### PR TITLE
fix(update): restart launchd-supervised dashboards instead of raw-killing them (two-supervisor port race on macOS)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8695,16 +8695,22 @@ def _restart_managed_dashboard_service(
     reason: str,
     unit: str = _DASHBOARD_SYSTEMD_UNIT,
 ) -> bool:
-    """Restart a systemd-managed dashboard instead of raw-killing its PID.
+    """Restart a managed dashboard instead of raw-killing its PID.
 
-    Returns True when a dashboard unit was found and handled (successfully or
-    with a printed actionable failure).  Returning True deliberately prevents
-    the caller from falling back to ``os.kill``: systemd treats a direct
-    SIGTERM of the service's main PID as a clean stop, so ``Restart=on-failure``
-    will not bring the dashboard back.
+    Returns True when a managed dashboard was found and handled (successfully
+    or with a printed actionable failure).  Returning True deliberately
+    prevents the caller from falling back to ``os.kill``: systemd treats a
+    direct SIGTERM of the service's main PID as a clean stop, so
+    ``Restart=on-failure`` will not bring the dashboard back — and on macOS,
+    raw-killing a launchd ``KeepAlive`` agent just makes launchd respawn it
+    while the update path's own detached respawn races it for the port
+    (two supervisors, one job).
     """
     if sys.platform == "win32":
         return False
+
+    if sys.platform == "darwin":
+        return _restart_launchd_dashboard_after_update(reason)
 
     def _systemctl(*args: str, timeout: int = 10) -> subprocess.CompletedProcess:
         return subprocess.run(
@@ -8947,6 +8953,94 @@ def _dashboard_cmdline_for_pid(pid: int) -> list[str] | None:
         return argv or None
     except (OSError, ValueError, subprocess.TimeoutExpired):
         return None
+
+
+def _restart_launchd_dashboard_after_update(reason: str) -> bool:
+    """Restart the launchd-supervised ``ai.hermes.dashboard`` agent (macOS).
+
+    Mirrors the gateway's launchd contract (#88848 via
+    ``_restart_launchd_gateway_after_update``): plist existence classifies a
+    launchd install, ``launchctl kickstart -k`` owns the restart, and the
+    function only reports success when launchd reports a fresh supervised
+    PID. Returning True keeps the caller from raw-killing the agent's PID —
+    killing a ``KeepAlive`` agent just makes launchd respawn it, and the
+    update path's own detached ``Popen`` respawn then races launchd for
+    :9119/:9120 (the loser exit-75s and crash-loops every ~30s).
+
+    Returns False when no dashboard plist exists (not a launchd install —
+    the systemd branch or the manual-respawn path handles those).
+    """
+    if sys.platform != "darwin":
+        return False
+
+    def _launchctl(*args: str, timeout: int = 15) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["launchctl", *args],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=timeout,
+        )
+
+    label = "ai.hermes.dashboard"
+    uid = os.getuid()
+    domain = f"gui/{uid}"
+    plist = (
+        Path.home() / "Library" / "LaunchAgents" / f"{label}.plist"
+    )
+    if not plist.exists():
+        return False
+
+    def _supervised_pid():
+        try:
+            result = _launchctl("print", f"{domain}/{label}")
+        except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+            return None
+        if result.returncode != 0:
+            return None
+        for line in (result.stdout or "").splitlines():
+            line = line.strip()
+            if line.startswith("pid ="):
+                value = line.split("=", 1)[1].strip()
+                try:
+                    pid = int(value)
+                except ValueError:
+                    return None
+                return pid or None
+        return None
+
+    print()
+    print(f"⟲ Restarting launchd-supervised dashboard ({reason})")
+    try:
+        result = _launchctl("kickstart", "-k", f"{domain}/{label}", timeout=30)
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError) as e:
+        print(
+            f"  ⚠ Could not restart {label} ({e.__class__.__name__}: {e}).\n"
+            f"    Recover manually: launchctl kickstart -k {domain}/{label}"
+        )
+        return True
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        print(
+            f"  ⚠ launchctl kickstart failed for {label}: {stderr}\n"
+            f"    Recover manually: launchctl kickstart -k {domain}/{label}"
+        )
+        return True
+
+    # kickstart returning is only "restart REQUESTED" — verify supervision,
+    # same contract as the gateway path (#88848: "the call returned" is not
+    # "the service is supervised").
+    deadline = _time.monotonic() + 20.0
+    while _time.monotonic() < deadline:
+        pid = _supervised_pid()
+        if pid:
+            print(f"  ✓ restarted {label} (launchd pid {pid})")
+            return True
+        _time.sleep(1.0)
+    print(
+        f"  ✗ {label} kickstarted but launchd is not supervising it.\n"
+        f"    Check: launchctl print {domain}/{label}  |  logs: ~/.hermes/logs/dashboard.error.log"
+    )
+    return True
 
 
 def _respawn_dashboard_processes(commands: list[list[str]]) -> list[list[str]]:

--- a/tests/hermes_cli/test_update_dashboard_launchd.py
+++ b/tests/hermes_cli/test_update_dashboard_launchd.py
@@ -1,0 +1,155 @@
+"""Tests for the launchd-aware dashboard restart on macOS.
+
+Background: on macOS the dashboard can be supervised by launchd
+(``ai.hermes.dashboard``, KeepAlive). ``hermes update`` used to
+raw-kill its PID and then respawn a detached copy itself — two supervisors
+racing for :9119/:9120, the loser exit-75 crash-looping every ~30s.
+The fix routes the darwin path through ``launchctl kickstart -k`` and
+never falls back to ``os.kill`` for supervised agents.
+"""
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli.main import (
+    _kill_stale_dashboard_processes,
+    _restart_launchd_dashboard_after_update,
+    _restart_managed_dashboard_service,
+)
+
+
+@pytest.fixture
+def _refresh_bindings():
+    """Re-import live bindings (xdist pollution guard, mirrors this file's
+    siblings)."""
+    global _kill_stale_dashboard_processes
+    global _restart_managed_dashboard_service
+    import importlib
+
+    live = sys.modules.get("hermes_cli.main")
+    if live is None:
+        live = importlib.import_module("hermes_cli.main")
+    _kill_stale_dashboard_processes = live._kill_stale_dashboard_processes
+    _restart_managed_dashboard_service = live._restart_managed_dashboard_service
+    yield
+
+
+def _plist_exists(monkeypatch, tmp_path, exists=True):
+    plist_dir = tmp_path / "Library" / "LaunchAgents"
+    plist_dir.mkdir(parents=True, exist_ok=True)
+    plist = plist_dir / "ai.hermes.dashboard.plist"
+    if exists:
+        plist.write_text("<plist/>")
+    monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path)
+    return plist
+
+
+class TestRestartLaunchdDashboardAfterUpdate:
+    def test_kickstart_success_reports_pid(self, tmp_path, monkeypatch, capsys):
+        _plist_exists(monkeypatch, tmp_path)
+        printed_pid = {"n": 0}
+
+        def fake_run(args, *a, **kw):
+            if args[:2] == ["launchctl", "kickstart"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if args[:2] == ["launchctl", "print"]:
+                # first probe: not yet registered; second: supervised
+                printed_pid["n"] += 1
+                if printed_pid["n"] < 2:
+                    return MagicMock(returncode=0, stdout="state = not running\n")
+                return MagicMock(
+                    returncode=0, stdout="state = running\n\tpid = 4242\n"
+                )
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch("time.sleep") as sleep:
+            ok = _restart_launchd_dashboard_after_update("test")
+
+        assert ok is True
+        out = capsys.readouterr().out
+        assert "launchd-supervised dashboard" in out
+        assert "4242" in out
+        # sleep calls in the supervision wait loop are mocked short
+        assert sleep.called
+
+    def test_kickstart_failure_is_loud_but_handled(self, tmp_path, monkeypatch, capsys):
+        _plist_exists(monkeypatch, tmp_path)
+
+        def fake_run(args, *a, **kw):
+            if args[:2] == ["launchctl", "kickstart"]:
+                return MagicMock(returncode=1, stdout="", stderr="bootstrap failed")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            ok = _restart_launchd_dashboard_after_update("test")
+
+        assert ok is True  # handled: caller must not raw-kill
+        out = capsys.readouterr().out
+        assert "launchctl kickstart failed" in out
+        assert "launchctl kickstart -k" in out  # manual recovery hint
+
+    def test_no_plist_returns_false(self, tmp_path, monkeypatch):
+        _plist_exists(monkeypatch, tmp_path, exists=False)
+        with patch("subprocess.run", side_effect=AssertionError("must not run")):
+            assert _restart_launchd_dashboard_after_update("test") is False
+
+    def test_supervision_timeout_is_loud(self, tmp_path, monkeypatch, capsys):
+        _plist_exists(monkeypatch, tmp_path)
+
+        def fake_run(args, *a, **kw):
+            if args[:2] == ["launchctl", "kickstart"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if args[:2] == ["launchctl", "print"]:
+                return MagicMock(returncode=1, stdout="", stderr="not found")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        monotonic_values = iter([0.0, 100.0])
+        monkeypatch.setattr("hermes_cli.main._time.monotonic",
+                            lambda: next(monotonic_values))
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch("time.sleep"):
+            ok = _restart_launchd_dashboard_after_update("test")
+
+        assert ok is True
+        out = capsys.readouterr().out
+        assert "not supervising" in out
+
+
+class TestManagedDashboardDispatch:
+    def test_darwin_routes_to_launchd_path(self, monkeypatch):
+        calls = []
+        monkeypatch.setattr(sys, "platform", "darwin")
+        with patch("hermes_cli.main._restart_launchd_dashboard_after_update",
+                   side_effect=lambda reason: calls.append(reason) or True):
+            got = _restart_managed_dashboard_service("unit-test")
+        assert got is True
+        assert calls == ["unit-test"]
+
+    def test_supervised_agent_is_never_raw_killed(self, tmp_path, monkeypatch,
+                                                  capsys):
+        """The race that started this: update finds a launchd-supervised
+        dashboard PID; the correct outcome is a kickstart, not os.kill +
+        detached respawn."""
+        _plist_exists(monkeypatch, tmp_path)
+
+        def fake_run(args, *a, **kw):
+            if args[:2] == ["launchctl", "kickstart"]:
+                return MagicMock(returncode=0, stdout="", stderr="")
+            if args[:2] == ["launchctl", "print"]:
+                return MagicMock(returncode=0, stdout="state = running\n\tpid = 777\n")
+            raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+        with patch("subprocess.run", side_effect=fake_run), \
+             patch("hermes_cli.main._find_stale_dashboard_pids",
+                   return_value=[777]) as find_pids, \
+             patch("os.kill") as kill:
+            _kill_stale_dashboard_processes(restart_managed=True)
+
+        find_pids.assert_not_called()
+        kill.assert_not_called()
+        out = capsys.readouterr().out
+        assert "777" in out

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -230,8 +230,12 @@ class TestKillStaleDashboardPosix:
 
 
 
-    def test_user_scope_restart_never_falls_back_to_system_or_sudo(self, capsys):
+    def test_user_scope_restart_never_falls_back_to_system_or_sudo(self, capsys, monkeypatch):
         """A user unit is discovered and restarted through ``systemctl --user``."""
+        # This test exercises the systemd branch; pin Linux so hosts running
+        # the suite on macOS take the launchd branch (their own tests live in
+        # test_update_dashboard_launchd.py).
+        monkeypatch.setattr(sys, "platform", "linux")
         calls: list[list[str]] = []
 
         def fake_run(args, *a, **kw):


### PR DESCRIPTION
## `hermes update` raw-kills launchd-supervised dashboards, then races launchd with its own detached respawn

### The failure (observed repeatedly in production)

On a macOS host where the dashboard is a launchd agent (`ai.hermes.dashboard`, `KeepAlive`), every `hermes update` produced the same wedge:

1. `_kill_stale_dashboard_processes(restart_managed=True)` finds no systemd unit and raw-kills the dashboard PID.
2. launchd's `KeepAlive` immediately respawns it (launchd is doing its job).
3. The update path's `_respawn_dashboard_processes` also spawns a detached `Popen` copy (PPID 1).
4. Two supervisors race for :9119/:9120. The loser exits 75; launchd retries it every ~30s — forever — while a dashboard actually answers on the port. `launchctl list` shows `75` + no PID while `lsof` shows a listener.

Every operator workaround since has been "find the orphan (the process whose PPID is 1), kill it, `launchctl kickstart`" — including agents diagnosing this box, who kept applying the documented bandaid instead of the cause. The dashboard_procs docstring even asserts "The dashboard has no service manager", which is true on Linux and false on macOS.

### The fix

`_restart_managed_dashboard_service` already owns the "managed service instead of raw-kill" contract — for systemd. This PR gives it the darwin branch:

- `_restart_launchd_dashboard_after_update()`: plist existence classifies a launchd install (`~/Library/LaunchAgents/ai.hermes.dashboard.plist`), `launchctl kickstart -k gui/<uid>/<label>` owns the restart, and success **requires** launchd to report a fresh supervised PID — mirroring the gateway's launchd contract from #88848 ("the call returned" is not "the service is supervised").
- Returning True keeps the caller on the managed path, so the supervised agent is never offered to `os.kill` (killing a `KeepAlive` job just respawns it into the race) and never reaches the detached `Popen` respawn.
- No plist → `False` → the existing systemd/manual paths behave exactly as before. Linux/Windows behavior unchanged; the systemd branch's test now pins `sys.platform=linux` explicitly (it previously relied on the dev host's OS, which breaks once darwin has its own branch), with the launchd path covered by its own tests.

### Tests (`tests/hermes_cli/test_update_dashboard_launchd.py`)

- kickstart success: restart requested, supervision verified via `launchctl print` pid, PID reported
- kickstart failure: loud output with the exact manual recovery command, still returns True (handled — never raw-kill)
- supervision timeout: loud "not supervising" report with diagnostic pointers
- no plist: returns False without touching launchd (non-launchd installs unaffected)
- dispatch: darwin routes to the launchd path; **the core guarantee — a supervised agent is never raw-killed** (`_find_stale_dashboard_pids` and `os.kill` never called when the launchd path handles it)

Full lifecycle suite: 58 passed, 3 skipped (`test_update_stale_dashboard.py`, `test_dashboard_lifecycle_flags.py`, `test_lazy_command_exports.py`, plus the new file). Ruff clean.

### Notes for reviewers

- The restart actually ran on the production host that exhibited the bug (kickstart → fresh supervised PID verified via `launchctl print`), so the contract is exercised against the real launchd, not only mocks.
- Known unrelated: `test_lazy_reexports_resolve_to_real_objects` fails when run in the same shard as `test_update_stale_dashboard.py` even on clean `main` (module-reload pollution between those files) — reproducible without this PR; happy to split into its own issue.
