### PR TITLE
fix(desktop): pin spoken-reply ownership to the live HUD renderer

### DIFF
--- a/apps/desktop/electron/ambient-speech-claim.test.ts
+++ b/apps/desktop/electron/ambient-speech-claim.test.ts
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { hudScopedSpeechOwnership } from './ambient-speech-claim'
+
+// Renderer id 10 is the hidden main window, 42 the live HUD window.
+test('with a live HUD, the hidden main renderer is denied speech ownership', () => {
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-1', senderId: 10, hudSenderId: 42 }), false)
+})
+
+test('with a live HUD, the HUD renderer owns speech even if the main window claimed first', () => {
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-1', senderId: 42, hudSenderId: 42 }), true)
+})
+
+test('speech pinning is time-independent, so claims far apart resolve identically', () => {
+  // Ownership is decided by sender identity alone; nothing reads a clock, so a
+  // claim arriving after the 1s dedupe interval cannot flip the outcome (#99717).
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-1', senderId: 10, hudSenderId: 42 }), false)
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-1', senderId: 42, hudSenderId: 42 }), true)
+})
+
+test('no live HUD: returns null so the first-caller-wins deduper decides speech too', () => {
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-1', senderId: 10, hudSenderId: null }), null)
+})
+
+test('non-speech cues keep the existing dedupe path even with a live HUD', () => {
+  assert.equal(hudScopedSpeechOwnership({ key: 'sound:turn:s1', senderId: 10, hudSenderId: 42 }), null)
+})
+
+test('after the HUD closes, the main renderer can own new speech claims again', () => {
+  // hudSenderId null models a destroyed/closed HUD window at claim time.
+  assert.equal(hudScopedSpeechOwnership({ key: 'speak:msg-2', senderId: 10, hudSenderId: null }), null)
+})

--- a/apps/desktop/electron/ambient-speech-claim.ts
+++ b/apps/desktop/electron/ambient-speech-claim.ts
@@ -1,0 +1,31 @@
+// HUD-scoped ownership for spoken replies (#99717). The ambient-cue claim IPC
+// backs both turn-end sounds and spoken replies with the same 1s event deduper,
+// which fits near-simultaneous cues but not message-level speech: a long reply
+// can play for minutes, and once the dedupe window expires a second renderer's
+// delayed claim wins and replays the same reply. While a HUD window is live it
+// is the surface the user is looking at, so speech ownership is pinned to it by
+// sender identity instead of wall-clock racing.
+
+export interface AmbientSpeechClaim {
+  key: string
+  senderId: number
+  hudSenderId: number | null
+}
+
+/**
+ * Decide `speak:*` cue ownership when a HUD window is live: true/false pins the
+ * claim to (or away from) the HUD renderer. Returns null when the generic
+ * first-caller-wins deduper should decide instead — non-speech cues, or no live
+ * HUD — so `sound:*` cues and normal multi-window behavior are unchanged.
+ */
+export function hudScopedSpeechOwnership({
+  key,
+  senderId,
+  hudSenderId
+}: AmbientSpeechClaim): boolean | null {
+  if (!key.startsWith('speak:') || hudSenderId === null) {
+    return null
+  }
+
+  return senderId === hudSenderId
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { hudScopedSpeechOwnership } from './ambient-speech-claim'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
@@ -16060,7 +16061,24 @@ const claimedAmbientCue = createEventDeduper()
 
 // A window asks "do I own this ambient cue (turn-end sound / spoken reply)?".
 // The first caller within the window gets true; peers get false and stay quiet.
-ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
+// Speech while a HUD window is live is the exception (#99717): the 1s dedupe
+// window expires mid-playback, so ownership is pinned to the HUD renderer by
+// sender identity — the hidden main renderer is denied even if it claims late.
+ipcMain.handle('hermes:ambient:claim', (event, rawKey) => {
+  const key = String(rawKey ?? '')
+  const liveHud = hudWindow && !hudWindow.isDestroyed() ? hudWindow : null
+
+  const hudSenderId =
+    liveHud && !liveHud.webContents.isDestroyed() ? liveHud.webContents.id : null
+
+  const hudDecision = hudScopedSpeechOwnership({ key, senderId: event.sender.id, hudSenderId })
+
+  if (hudDecision !== null) {
+    return hudDecision
+  }
+
+  return !claimedAmbientCue(key)
+})
 
 ipcMain.handle('hermes:notify', (_event, payload) => {
   if (!Notification.isSupported()) {


### PR DESCRIPTION
## What does this PR do?

Fixes duplicate auto-TTS playback in HUD mode (#99717). The `hermes:ambient:claim` IPC backs both turn-end sounds and spoken replies with the same 1-second event deduper (`createEventDeduper`). That interval fits near-simultaneous cues but not message-level speech: a long reply can play for minutes, so once the dedupe window expires, the hidden main renderer's delayed claim for the same `speak:<message-id>` key wins and the reply is spoken twice.

While a HUD window is live, this PR pins `speak:*` cue ownership to the HUD renderer by sender identity (`event.sender.id === hudWindow.webContents.id`) instead of wall-clock racing. The hidden main renderer is denied even when its claim arrives late. Non-speech cues (e.g. `sound:*`) and the no-HUD case keep the existing first-caller-wins deduper unchanged, and after the HUD closes the main renderer can own new speech claims again.

## Related Issue

Fixes #99717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/ambient-speech-claim.ts` (new): pure, clock-free helper `hudScopedSpeechOwnership()` — returns true/false when a live HUD should pin/deny a `speak:*` claim, `null` when the generic deduper should decide (non-speech keys or no live HUD).
- `apps/desktop/electron/main.ts`: the `hermes:ambient:claim` handler now consults that helper with the live `hudWindow`'s `webContents.id` (guarding `isDestroyed()` on both the window and its webContents) before falling back to the existing deduper.
- `apps/desktop/electron/ambient-speech-claim.test.ts` (new): regression tests covering the issue's acceptance list (see below).

## How to Test

1. `cd apps/desktop && ../../node_modules/.bin/vitest run --project electron electron/ambient-speech-claim.test.ts` — Observed result: 6/6 pass, covering: (a) live HUD denies the hidden main renderer, (b) live HUD grants the HUD renderer even if the main window claimed first, (c) decisions are time-independent so claims more than one second apart cannot flip the outcome, (d) no live HUD → falls through to the first-caller-wins deduper, (e) `sound:*` cues are untouched, (f) after the HUD closes the main renderer can own new claims. A denied claim never reaches `playSpeechText` — the renderer hook already gates on the claim result (`if (owns)` in `use-auto-speak-replies.ts`).
2. `../../node_modules/.bin/vitest run --project electron` — Observed result: 1987 passed, 1 failed (`managed-ssh-update.test.ts` POSIX launcher, exit 127/command-not-found). That failure is pre-existing and unrelated: it reproduces identically on a clean unmodified checkout on this host.
3. `../../node_modules/.bin/tsc -p tsconfig.electron.json --noEmit` — should pass with no errors.
4. Manual (needs a desktop build with HUD): enable Read replies aloud, open HUD mode, send a prompt — the reply should be spoken exactly once, with no replay after the first playback completes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (pure Electron/TypeScript layer; no Python touched; equivalent `vitest run --project electron` run instead)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64); the fix is OS-independent Electron main-process logic

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (main-process IPC logic, no platform-specific APIs)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A