### PR TITLE
fix(desktop): show only Nous Portal in Providers connect-an-account view

### DIFF
--- a/apps/desktop/src/app/settings/providers-settings.test.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.test.tsx
@@ -93,6 +93,22 @@ async function renderProvidersSettings() {
 }
 
 describe('ProvidersSettings', () => {
+  it('shows only Nous Portal in the accounts view — no Fireworks row or Other providers disclosure', async () => {
+    // The Connect-an-account section exists for the Portal subscription; every
+    // other provider stays reachable via the API-keys tab. Regression: this
+    // surface used to mirror the full onboarding picker (Fireworks quick-key
+    // row + "Other providers" disclosure listing the whole catalog).
+    await renderProvidersSettings()
+
+    expect(await screen.findByText('Nous Portal')).toBeTruthy()
+    expect(screen.queryByText('Fireworks AI')).toBeNull()
+    expect(screen.queryByText(/Other providers/)).toBeNull()
+    expect(screen.queryByText('OpenRouter')).toBeNull()
+    // MiniMax (the second, logged-out mock provider) must not appear —
+    // the unconnected catalog is what the disclosure used to dump here.
+    expect(screen.queryByText('MiniMax')).toBeNull()
+  })
+
   it('disconnects a connected provider account and refreshes the accounts list', async () => {
     await renderProvidersSettings()
 

--- a/apps/desktop/src/app/settings/providers-settings.tsx
+++ b/apps/desktop/src/app/settings/providers-settings.tsx
@@ -1,25 +1,15 @@
 import { useStore } from '@nanostores/react'
-import type { ReactNode } from 'react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 import { runInTerminal } from '@/app/right-sidebar/store'
-import {
-  FEATURED_ID,
-  FeaturedProviderRow,
-  FireworksProviderRow,
-  OpenRouterProviderRow,
-  ProviderRow,
-  providerTitle,
-  sortProviders
-} from '@/components/onboarding'
+import { FEATURED_ID, FeaturedProviderRow, providerTitle } from '@/components/onboarding'
 import { Button } from '@/components/ui/button'
 import { RowButton } from '@/components/ui/row-button'
 import { SearchField } from '@/components/ui/search-field'
 import { disconnectOAuthProvider, listOAuthProviders } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { Check, ChevronDown, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
+import { Check, ChevronRight, KeyRound, Loader2, Terminal, Trash2 } from '@/lib/icons'
 import { normalize } from '@/lib/text'
-import { cn } from '@/lib/utils'
 import { confirm } from '@/store/confirm'
 import { notify, notifyError } from '@/store/notifications'
 import { $desktopOnboarding, startManualLocalEndpoint, startManualProviderOAuth } from '@/store/onboarding'
@@ -34,16 +24,6 @@ import { SettingsContent, SettingsSkeleton } from './primitives'
 // The embedded terminal (and thus the "run disconnect command" path) only
 // exists in the Electron desktop shell, not the web dashboard.
 const canRunInTerminal = () => typeof window !== 'undefined' && Boolean(window.hermesDesktop?.terminal)
-
-// Parallel group headers ("Connected", "Other providers") so the expanded list
-// reads as its own section instead of bleeding into the connected group.
-function GroupLabel({ children }: { children: ReactNode }) {
-  return (
-    <p className="mt-3 px-0.5 text-[length:var(--conversation-caption-font-size)] font-medium text-(--ui-text-tertiary)">
-      {children}
-    </p>
-  )
-}
 
 // Sub-views surfaced as a sidebar subnav: account sign-in vs raw API keys.
 export const PROVIDER_VIEWS = ['accounts', 'keys', 'custom-endpoints'] as const
@@ -115,15 +95,10 @@ function buildProviderKeyGroups(vars: Record<string, EnvVarInfo>): ProviderKeyGr
   return groups.sort((a, b) => a.priority - b.priority || a.name.localeCompare(b.name))
 }
 
-// Deliberately a near-1:1 replica of the first-run onboarding picker
-// (`Picker` in desktop-onboarding-overlay): same recommended card, same
-// Fireworks #2 quick-key row, same provider rows, same "Other providers"
-// disclosure, same OpenRouter quick-key row, and the same bottom-right
-// "I have an API key" affordance. The leaf cards are the exact shared
-// components, so the two surfaces stay visually identical. Selecting a
-// provider hands off to the shared onboarding overlay, which runs that
-// provider's real sign-in flow; the key affordances open the API-key
-// catalog below.
+// Nous-only accounts view: the section exists to sell the Portal subscription
+// (browser sign-in, no API key). Other providers remain reachable through the
+// sibling API-keys tab / "Have an API key instead?" affordance, so they are not
+// listed here — the featured card is the whole section.
 function OAuthPicker({
   disconnecting,
   onDisconnect,
@@ -139,24 +114,15 @@ function OAuthPicker({
 }) {
   const { t } = useI18n()
   const p = t.settings.providers
-  const [showAll, setShowAll] = useState(false)
-  const ordered = useMemo(() => sortProviders(providers), [providers])
 
-  if (ordered.length === 0) {
+  if (providers.length === 0) {
     return null
   }
 
   const select = (p: OAuthProvider) => startManualProviderOAuth(p.id)
 
-  const featured = ordered.find(p => p.id === FEATURED_ID && !p.status?.logged_in) ?? null
-  const rest = featured ? ordered.filter(p => p.id !== FEATURED_ID) : ordered
-  // Keep connected accounts grouped and always visible; only the unconnected
-  // providers hide behind the disclosure, so the page leads with what's set up.
-  // Both lists preserve `sortProviders` order (curated priority, then name).
-  const connected = rest.filter(p => p.status?.logged_in)
-  const others = rest.filter(p => !p.status?.logged_in)
-  const collapsible = others.length > 0
-  const showOthers = !collapsible || showAll
+  const nous = providers.find(p => p.id === FEATURED_ID) ?? null
+  const nousConnected = nous?.status?.logged_in === true
 
   return (
     <section className="mb-5 grid gap-2">
@@ -175,45 +141,29 @@ function OAuthPicker({
       <p className="-mt-2 mb-1 text-[length:var(--conversation-caption-font-size)] leading-(--conversation-caption-line-height) text-(--ui-text-tertiary)">
         {p.intro}
       </p>
-      {featured && <FeaturedProviderRow onSelect={select} provider={featured} />}
-      {/* Slot #2 — always visible, matching onboarding / CANONICAL_PROVIDERS. */}
-      <FireworksProviderRow onClick={onWantApiKey} />
-      {connected.length > 0 && (
-        <>
-          <GroupLabel>{p.connected}</GroupLabel>
-          {connected.map(p => (
-            <ConnectedProviderRow
-              disconnecting={disconnecting === p.id}
-              key={p.id}
-              onDisconnect={onDisconnect}
-              onSelect={select}
-              onTerminalDisconnect={onTerminalDisconnect}
-              provider={p}
-            />
-          ))}
-        </>
+      {nous && !nousConnected && <FeaturedProviderRow onSelect={select} provider={nous} />}
+      {nous && nousConnected && (
+        <ConnectedProviderRow
+          disconnecting={disconnecting === nous.id}
+          key={nous.id}
+          onDisconnect={onDisconnect}
+          onSelect={select}
+          onTerminalDisconnect={onTerminalDisconnect}
+          provider={nous}
+        />
       )}
-      {showOthers && (
-        <>
-          {connected.length > 0 && <GroupLabel>{p.otherProviders}</GroupLabel>}
-          {others.map(p => (
-            <ProviderRow key={p.id} onSelect={select} provider={p} />
-          ))}
-          <OpenRouterProviderRow onClick={onWantApiKey} />
-        </>
-      )}
-      {collapsible && (
-        <Button
-          className="py-1 text-[length:var(--conversation-caption-font-size)]"
-          onClick={() => setShowAll(v => !v)}
-          size="inline"
-          type="button"
-          variant="text"
-        >
-          {showAll ? p.collapse : connected.length > 0 ? p.connectAnother : p.otherProviders}
-          <ChevronDown className={cn('size-3.5 transition', showAll && 'rotate-180')} />
-        </Button>
-      )}
+      {providers
+        .filter(p => p.id !== FEATURED_ID && p.status?.logged_in)
+        .map(p => (
+          <ConnectedProviderRow
+            disconnecting={disconnecting === p.id}
+            key={p.id}
+            onDisconnect={onDisconnect}
+            onSelect={select}
+            onTerminalDisconnect={onTerminalDisconnect}
+            provider={p}
+          />
+        ))}
     </section>
   )
 }


### PR DESCRIPTION
## Summary

The desktop Settings → Providers → "Connect an account" section (the accounts view) was a near-1:1 replica of the first-run onboarding picker: below the Nous Portal card it always showed a Fireworks AI quick-key row, an expandable "Other providers" disclosure listing every provider in the catalog, and an OpenRouter quick-key row.

This PR makes that section Nous-only. It exists to sell the Portal subscription (browser sign-in, no API key to copy) — the featured card plus your connected accounts is the whole section now.

**Who/when:** desktop users opening Settings → Providers (Accounts tab) who currently see a wall of ~40 third-party providers under "Other providers" next to the one subscription Hermes actually recommends.

## Before / after

Before:
```
Connect an account                    Have an API key instead?
Sign in with a subscription — ...
[ Nous Portal  RECOMMENDED ]
[ Fireworks AI ]
Connected
  [ Qwen Code  Connected ]
Other providers                    ▾   (expandable)
  [ ChatGPT or Codex Subscription ]
  [ MiniMax (OAuth) ]
  [ xAI Grok OAuth ... ]
  [ Anthropic API Key ]
  ... every provider in the catalog ...
  [ OpenRouter ]
```

After:
```
Connect an account                    Have an API key instead?
Sign in with a subscription — ...
[ Nous Portal  RECOMMENDED ]     (or the connected row with Remove, when signed in)
```

Everything removed here is still reachable:
- Any provider's API key → the "Have an API key instead?" link still routes to the API-keys tab (unchanged).
- Disconnecting a connected account → connected rows still render with their Remove/disconnect controls.

## What changed

`OAuthPicker` in `apps/desktop/src/app/settings/providers-settings.tsx`:
- Dropped the always-visible Fireworks AI quick-key row, the "Other providers" disclosure + collapse toggle, the per-provider rows, and the OpenRouter quick-key row.
- Kept: the Nous Portal featured card (RECOMMENDED badge when signed out), the connected Nous row, and other *connected* account rows (so GUI disconnect still works).
- Removed now-dead imports/components (`GroupLabel`, `sortProviders`, `ProviderRow`, `FireworksProviderRow`, `OpenRouterProviderRow`).

The first-run onboarding picker is unchanged — it's the provider-selection flow, where the full list is the point.

## Test plan

- [x] New regression test: accounts view renders only Nous Portal — asserts no "Fireworks AI", no "Other providers", no "OpenRouter", and no unconnected provider rows (`providers-settings.test.tsx`)
- [x] Existing 7 tests in the file still pass (disconnect flow, external-provider hints, keys tab) — 8/8 green
- [x] A render probe replaying the full provider zoo (ChatGPT/Codex, MiniMax, Qwen, xAI, Anthropic...) confirmed only the Nous card renders; removed after coverage moved into the test file
- [x] `tsc --noEmit` clean, ESLint clean, Prettier clean
- [x] Onboarding component tests (5/5) unaffected

## Notes for reviewers

- Unconnected providers intentionally have no surface on the Accounts tab anymore. That is the requested behavior: the accounts tab sells one subscription; everything else is an API key and lives one click away on the keys tab.
- `settings.providers.{collapse,connectAnother,otherProviders}` i18n keys are now unreferenced from this component but are still used by the onboarding picker's copy shape; left in place to keep the locale files' key parity stable.
