### PR TITLE
fix(agent): recover compression at emergency context pressure

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1306,6 +1306,10 @@ _SUMMARY_FAILURE_COOLDOWN_SECONDS = 600
 _FALLBACK_SUMMARY_MAX_CHARS = 8_000
 _FALLBACK_PREVIOUS_SUMMARY_MAX_CHARS = 3_000
 _FALLBACK_TURN_MAX_CHARS = 700
+# A transient summary outage should preserve the transcript while there is
+# still room to retry.  At this boundary, however, preserving every message
+# can strand the session beyond the provider window before the next retry.
+_EMERGENCY_FALLBACK_CONTEXT_RATIO = 0.95
 _AUTO_FOCUS_MAX_TURNS = 3
 _AUTO_FOCUS_TURN_MAX_CHARS = 260
 _AUTO_FOCUS_MAX_CHARS = 700
@@ -8044,18 +8048,33 @@ This compaction should PRIORITISE preserving all information related to the focu
         #           surface a warning.
         # Default is False (historical behavior).
         #
-        # EXCEPTION — terminal access/quota, transient network failures, and
-        # empty-content provider degradation always abort. Missing credentials,
+        # EXCEPTION — terminal access/quota and empty-content provider
+        # degradation always abort. Transient network failures abort while the
+        # request remains below the emergency pressure boundary; at 95% of the
+        # model window the existing deterministic handoff is safer than
+        # preserving a transcript that may no longer fit on the next turn.
+        # Missing credentials,
         # 401/402/403 access failures, confirmed non-resetting quota exhaustion,
         # and HTTP 200 empty responses from degraded channels cannot be repaired
         # by immediately generating a static placeholder. In all of these cases,
         # rotating into a child session with a placeholder summary degrades the
         # conversation for zero benefit. Preserve it unchanged until access or
         # provider health is restored (#29559, #25585, #94448).
+        emergency_network_fallback = bool(
+            self._last_summary_network_failure
+            and display_tokens
+            >= int(self.context_length * _EMERGENCY_FALLBACK_CONTEXT_RATIO)
+        )
+        if emergency_network_fallback:
+            telemetry["failure_class"] = "summary_network_emergency_fallback"
+
         if not summary and not feasibility_skip and (
             self.abort_on_summary_failure
             or self._last_summary_auth_failure
-            or self._last_summary_network_failure
+            or (
+                self._last_summary_network_failure
+                and not emergency_network_fallback
+            )
             or self._last_summary_empty_content_failure
             or self._last_summary_truncated_failure
         ):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -3001,18 +3001,59 @@ class TestCooldownReentryAbort:
             "agent.context_compressor.call_llm",
             side_effect=ConnectionError("Connection error."),
         ):
-            first = c.compress(msgs, current_tokens=999999, force=True)
+            first = c.compress(msgs, current_tokens=94_000, force=True)
         assert first == msgs
         assert c._last_compress_aborted is True
         assert c._last_summary_network_failure is True
 
-        second = c.compress(msgs, current_tokens=999999)
+        second = c.compress(msgs, current_tokens=94_000)
         assert second == msgs, (
             "Second compress during cooldown must abort (preserve messages), "
             "not drop the middle window via static-fallback"
         )
         assert c._last_compress_aborted is True
         assert c._last_summary_fallback_used is False
+
+    def test_network_failure_at_emergency_pressure_uses_static_fallback(self):
+        """A failed summarizer must not strand a session at the context limit.
+
+        Below the emergency boundary the existing preserve-and-retry behavior
+        remains safer.  Once the rendered request reaches 95% of the model
+        window, preserving the oversized transcript makes every later turn
+        less recoverable.  The local redacted handoff must win at that point.
+        """
+        with patch(
+            "agent.context_compressor.get_model_context_length",
+            return_value=100_000,
+        ):
+            c = ContextCompressor(
+                model="test",
+                quiet_mode=True,
+                protect_first_n=2,
+                protect_last_n=2,
+                abort_on_summary_failure=False,
+            )
+            _ = c.context_length
+        msgs = self._msgs(12)
+
+        with patch(
+            "agent.context_compressor.call_llm",
+            side_effect=ConnectionError("Connection error."),
+        ):
+            result = c.compress(msgs, current_tokens=95_000, force=True)
+
+        assert result != msgs
+        assert c._last_compress_aborted is False
+        assert c._last_summary_fallback_used is True
+        assert c._last_summary_dropped_count > 0
+        assert (
+            c._last_compression_telemetry["failure_class"]
+            == "summary_network_emergency_fallback"
+        )
+        assert any(
+            "deterministic fallback" in str(message.get("content", ""))
+            for message in result
+        )
 
     def test_auth_failure_cooldown_reentry_still_aborts(self):
         """Same re-entry hole for auth failures: a 401 sets the flag, cooldown


### PR DESCRIPTION
## What does this PR do?

Prevents a transient summarizer outage from permanently stranding a Hermes session beyond its model context window.

Today, network/stream failures always preserve the full transcript. That is safe while there is room to retry, but a repeatedly failing session can grow past the model window and then cannot answer or compact. This change keeps the existing preserve-and-retry behavior below 95% context pressure. At or above 95%, a network summary failure uses Hermes's existing bounded, redacted deterministic handoff instead.

Terminal authentication/quota failures, empty provider responses, truncated summaries, and `compression.abort_on_summary_failure=true` remain fail-closed and preserve the transcript.

The emergency path is reported as `summary_network_emergency_fallback` in compression telemetry.

## Related Issue

No public issue. Reproduced from a live Telegram Hermes session whose repeated 300-second compression timeouts left approximately 445k tokens against a 272k model window.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_compressor.py`
  - Preserve transient network failures below 95% of the active model window.
  - Use the existing local deterministic handoff at or above 95%.
  - Emit a distinct emergency-fallback telemetry class.
- `tests/agent/test_context_compressor.py`
  - Prove a network failure at 94% still preserves the transcript, including cooldown re-entry.
  - Prove a network failure at 95% compacts with the deterministic fallback and records the emergency telemetry class.
  - Preserve the existing fail-closed authentication behavior.

## How to Test

1. Run `scripts/run_tests.sh tests/agent/test_context_compressor.py -q`.
2. Run the adjacent continuity, fallback-budget, in-place compaction, and gateway command suites listed below.
3. Simulate `ConnectionError` with a 100k context window at 94k and 95k rendered tokens; verify preservation at 94k and bounded fallback at 95k.

## Verification

Exact head: `8039497d27d062ce2ba5fe22bed20a07b9770680`

- Full context-compressor file: 151 passed, 0 failed.
- Adjacent continuity/fallback/in-place/gateway suites: 31 passed, 0 failed.
- Targeted red/green regression: failed before the source change, then 3 passed, 0 failed after it.
- Ruff: passed for both changed files.
- Python bytecode compilation: passed for both changed files.
- Windows footgun scan: passed for both changed files.
- `git diff --check`: passed.
- Platform: Windows 11 host with WSL2 test runner.

One unrelated pre-existing wall-clock test, `test_hygiene_does_not_wait_ceiling_after_fence_cancel`, exceeded its two-second timing bound on this NTFS/WSL checkout. It does not execute the changed compressor branch; it failed both in the grouped run and alone. The compressor, gateway command, and continuity tests above are green.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing PRs and issues for this failure class.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the entire repository test suite. (Focused and adjacent suites above passed; full suite was not run.)
- [x] I've added behavior tests for the bug fix.
- [x] I've tested on Windows 11 / WSL2.

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and rationale are documented inline and in tests.
- [x] `cli-config.yaml.example` changes are N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A.
- [x] Cross-platform impact was considered; no file, process, shell, or platform-specific behavior changed.
- [x] Tool description/schema changes are N/A.

## Screenshots / Logs

Before the fix, the emergency-pressure regression returned the original oversized message list and failed its assertion. At this exact head, 182 focused and adjacent tests pass.
