### PR TITLE
fix(email): key sessions and reply threading by Gmail X-GM-THRID

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -33,7 +33,7 @@ from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from email.mime.base import MIMEBase
-from email.utils import formatdate
+from email.utils import formatdate, make_msgid
 from email import encoders
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -110,6 +110,110 @@ _AUTOMATED_HEADERS = {
 MAX_MESSAGE_LENGTH = 50_000
 
 SMTP_CONNECT_TIMEOUT = 30
+
+
+# Grep-able prefix for the one operationally visible new failure mode: a
+# message whose Gmail thread id could not be resolved after repeated attempts.
+THREAD_LOOKUP_FAILURE_LOG_PREFIX = "[Email][thread-lookup-failure]"
+
+# Matches the X-GM-THRID value in an IMAP FETCH response, e.g.
+#   b'1 (X-GM-THRID 1234567890123456789 UID 1)'
+_GM_THRID_RE = re.compile(rb"X-GM-THRID\s+(\d+)")
+
+# Matches the From: header line inside a BODY.PEEK[HEADER.FIELDS (FROM)]
+# payload. Anchored to the start of a line so the FETCH response preamble
+# ("... BODY[HEADER.FIELDS (FROM)] ...") cannot be mistaken for the header.
+_FROM_HEADER_RE = re.compile(r"^From:\s*(.+)$", re.IGNORECASE | re.MULTILINE)
+
+SMTP_CONNECT_TIMEOUT = 30
+
+# Gmail's IMAP capability advertising the X-GM-* extensions (X-GM-THRID et al).
+# https://developers.google.com/gmail/imap/imap-extensions
+GMAIL_IMAP_CAPABILITY = "X-GM-EXT-1"
+
+# RFC 5322 §3.6.4: msg-id = "<" id-left "@" id-right ">". Inbound Message-IDs
+# are attacker-controlled, so anything echoed back into In-Reply-To/References
+# must match this shape first. A value containing CR/LF would otherwise reach
+# the header setter and raise HeaderParseError at send time, which would make
+# every reply in that thread fail — a message-shaped denial of service.
+_MSG_ID_RE = re.compile(r"<[^<>@\s]+@[^<>@\s]+>")
+
+# RFC 5322 places no hard cap on References, but an unbounded chain eventually
+# trips server header-size limits. Common MUA practice is to keep the thread
+# root plus the most recent ancestors; we do the same.
+MAX_REFERENCES = 20
+
+
+def _sanitize_msg_id(raw: Optional[str]) -> str:
+    """Return ``raw`` as a single RFC 5322 msg-id, or "" when it isn't one.
+
+    Only the first well-formed ``<id-left@id-right>`` token is kept, so
+    injected headers, folded whitespace and bare tokens are all discarded
+    rather than propagated into our outgoing headers.
+    """
+    if not raw:
+        return ""
+    match = _MSG_ID_RE.search(str(raw))
+    return match.group(0) if match else ""
+
+
+def _parse_references(raw: Optional[str]) -> List[str]:
+    """Extract the msg-id chain from a References/In-Reply-To header value."""
+    if not raw:
+        return []
+    return _MSG_ID_RE.findall(str(raw))
+
+
+def _build_references(parent_references: Optional[str], parent_msg_id: str) -> str:
+    """Build a reply's References header per RFC 5322 §3.6.4.
+
+    The field is the parent's References followed by the parent's Message-ID —
+    preserving the ancestry a mail client needs to nest a deep thread. The
+    previous implementation emitted only the parent's Message-ID, discarding
+    every earlier ancestor.
+
+    Duplicates are dropped (order preserved) and the chain is capped by keeping
+    the thread root plus the most recent ancestors.
+    """
+    chain = _parse_references(parent_references)
+    parent = _sanitize_msg_id(parent_msg_id)
+    if parent:
+        chain.append(parent)
+
+    seen = set()
+    deduped = []
+    for mid in chain:
+        if mid not in seen:
+            seen.add(mid)
+            deduped.append(mid)
+
+    if len(deduped) > MAX_REFERENCES:
+        deduped = deduped[:1] + deduped[-(MAX_REFERENCES - 1):]
+    return " ".join(deduped)
+
+
+def _parse_gm_thrid(data: Any) -> Optional[str]:
+    """Extract the X-GM-THRID value from a raw IMAP FETCH response.
+
+    Gmail computes the thread id server-side, so it is stable and — unlike
+    ``References``/``In-Reply-To`` — not attacker-controlled.  imaplib hands
+    back a list whose items are either bytes or ``(header, payload)`` tuples
+    depending on the response shape, so both are scanned.
+
+    Returns ``None`` when no thread id is present; callers treat that
+    identically to a failed FETCH.
+    """
+    if not data:
+        return None
+    for item in data:
+        parts = item if isinstance(item, (tuple, list)) else (item,)
+        for part in parts:
+            if not isinstance(part, (bytes, bytearray)):
+                continue
+            match = _GM_THRID_RE.search(bytes(part))
+            if match:
+                return match.group(1).decode("ascii")
+    return None
 
 
 def _close_imap(imap: "imaplib.IMAP4") -> None:
@@ -529,6 +633,12 @@ def _extract_attachments(
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    # Consecutive failed X-GM-THRID lookups tolerated for a single UID before
+    # the message is reported to its sender and dropped.  A single transient
+    # IMAP hiccup must not cost a message, but retrying forever must not wedge
+    # the poll loop either.
+    _THRID_MAX_FAILURES = 5
+
     # Per-account snapshot of seen UIDs, surviving adapter recreation.
     # The gateway's reconnect watcher builds a FRESH adapter instance for
     # each retry; without this, connect(is_reconnect=True) would re-mark the
@@ -602,8 +712,31 @@ class EmailAdapter(BasePlatformAdapter):
         self._last_fetch_failed: bool = False
         self._last_fetch_error: str = ""
 
-        # Map chat_id (sender email) -> last subject + message-id for threading
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Map (sender email, thread_id) -> last subject + message-id for
+        # threading.  Keying on the address alone collapsed every thread with
+        # one correspondent into a single slot, so a reply — in particular a
+        # cron job's output — threaded onto whichever conversation with that
+        # sender had been touched most recently rather than the one it belonged
+        # to.  ``thread_id`` is Gmail's server-computed X-GM-THRID.
+        #
+        # Insertion order is maintained as recency order (see
+        # ``_remember_thread_context``) so a send that names no thread at all
+        # can still fall back to this correspondent's most recent one.
+        self._thread_context: Dict[Tuple[str, Optional[str]], Dict[str, str]] = {}
+
+        # Consecutive X-GM-THRID lookup failures, keyed by UID.  A message whose
+        # thread cannot be resolved is left UNSEEN and retried on the next poll
+        # cycle; after ``_THRID_MAX_FAILURES`` strikes it is reported to the
+        # sender, marked seen and dropped so one stuck message cannot wedge the
+        # poll loop forever.
+        self._thrid_failures: Dict[bytes, int] = {}
+
+        # Whether the IMAP server advertises Gmail's X-GM-EXT-1 capability.
+        # None until first probed. Per-thread sessions require the
+        # server-computed X-GM-THRID, so a server without the extension keeps
+        # the previous sender-keyed behaviour instead of failing every message.
+        self._has_gmail_ext: Optional[bool] = None
+        self._logged_no_gmail_ext = False
 
         logger.info("[Email] Adapter initialized for %s", self._address)
 
@@ -626,6 +759,106 @@ class EmailAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             # Fallback: just clear old entries if sort fails
             self._seen_uids = set(list(self._seen_uids)[-self._seen_uids_max // 2:])
+
+    def _remember_thread_context(
+        self,
+        addr: str,
+        thread_id: Optional[str],
+        subject: str,
+        message_id: str,
+        references: str = "",
+    ) -> None:
+        """Record the latest subject/message-id/References for one thread.
+
+        ``references`` is the inbound message's own References header; a reply
+        needs it to build a compliant chain (RFC 5322 §3.6.4) rather than
+        pointing only at its immediate parent.
+
+        The entry is re-inserted rather than updated in place so dict order
+        stays recency order, which ``_thread_ctx`` relies on for its
+        no-thread_id fallback.
+        """
+        key = (addr, thread_id)
+        self._thread_context.pop(key, None)
+        self._thread_context[key] = {
+            "subject": subject,
+            "message_id": message_id,
+            "references": references or "",
+        }
+
+    def _thread_ctx(
+        self, addr: str, thread_id: Optional[str] = None
+    ) -> Dict[str, str]:
+        """Return the reply context for one (address, thread) pair.
+
+        With a ``thread_id`` the lookup is exact: a reply destined for a thread
+        must carry that thread's own ``In-Reply-To``/``References`` or none at
+        all.  Returning some other thread's message-id is the bug this keying
+        exists to prevent, so an unknown thread yields an empty context.
+
+        Without a ``thread_id`` — a standalone/home-channel send, or a caller
+        that never had a thread to begin with — the most recent thread for that
+        correspondent is used.  That is a best effort for a send that named no
+        thread, not a fallback for one whose thread is simply unknown.
+        """
+        if thread_id is not None:
+            return self._thread_context.get((addr, thread_id), {})
+        for (ctx_addr, _), ctx in reversed(self._thread_context.items()):
+            if ctx_addr == addr:
+                return ctx
+        return {}
+
+    def _apply_threading_headers(
+        self,
+        msg: MIMEMultipart,
+        ctx: Dict[str, str],
+        reply_to_msg_id: Optional[str] = None,
+    ) -> None:
+        """Set RFC 5322 §3.6.4 In-Reply-To / References on a reply.
+
+        ``In-Reply-To`` names the parent; ``References`` carries the parent's
+        own chain plus the parent — which is what lets a client nest a reply
+        under a long thread instead of only under its immediate parent.
+
+        Both values pass through :func:`_sanitize_msg_id` first, so a malformed
+        or header-injecting inbound Message-ID is dropped rather than echoed
+        (or raised on) at send time.
+        """
+        parent_id = _sanitize_msg_id(reply_to_msg_id or ctx.get("message_id"))
+        if not parent_id:
+            return
+        msg["In-Reply-To"] = parent_id
+        references = _build_references(ctx.get("references", ""), parent_id)
+        if references:
+            msg["References"] = references
+
+    def _new_message_id(self) -> str:
+        """Generate a globally unique RFC 5322 Message-ID.
+
+        ``make_msgid`` folds in a timestamp, the pid and a random component,
+        which is a stronger uniqueness guarantee than the previous 48 bits of
+        UUID hex.
+        """
+        try:
+            return make_msgid(idstring="hermes", domain=self._message_id_domain())
+        except Exception:
+            # A pathological domain must not break sending.
+            return f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
+
+    @staticmethod
+    def _thread_id_from_metadata(metadata: Optional[Dict[str, Any]]) -> Optional[str]:
+        """Pull the delivery thread id out of send metadata.
+
+        The gateway's DeliveryRouter and the interactive reply path both put the
+        originating ``SessionSource.thread_id`` here, which for email is the
+        X-GM-THRID captured at ingestion.
+        """
+        if not metadata:
+            return None
+        raw = metadata.get("thread_id")
+        if raw is None or raw == "":
+            return None
+        return str(raw)
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """Create an SMTP connection, selecting the correct protocol for the port.
@@ -850,6 +1083,147 @@ class EmailAdapter(BasePlatformAdapter):
             )
             await self._notify_fatal_error()
 
+    def _probe_gmail_ext(self, imap: "imaplib.IMAP4") -> bool:
+        """Record whether this server advertises Gmail's X-GM-EXT-1 capability.
+
+        Per-thread session isolation is built on ``X-GM-THRID``, which only
+        Gmail/Workspace serves. Without this probe a non-Gmail deployment answers
+        every thread lookup with BAD, burns through the retry budget and drops
+        all inbound mail. Probing lets those servers degrade to the previous
+        sender-keyed behaviour instead.
+
+        Delegated mailboxes and some Workspace configurations also omit the
+        capability, so this is not purely a non-Gmail concern.
+        """
+        try:
+            caps = getattr(imap, "capabilities", None)
+            if not caps:
+                status, data = imap.capability()
+                if status != "OK" or not data:
+                    caps = ()
+                else:
+                    caps = tuple(
+                        part.decode("ascii", "replace") if isinstance(part, (bytes, bytearray)) else str(part)
+                        for item in data
+                        for part in (item.split() if isinstance(item, (bytes, bytearray)) else [item])
+                    )
+            names = {str(c).upper() for c in caps}
+            has_ext = GMAIL_IMAP_CAPABILITY.upper() in names
+        except Exception as e:
+            # Fail safe: without a definitive answer, keep the legacy behaviour
+            # rather than risk dropping mail.
+            logger.warning("[Email] IMAP capability probe failed: %s", e)
+            has_ext = False
+
+        self._has_gmail_ext = has_ext
+        if not has_ext and not self._logged_no_gmail_ext:
+            self._logged_no_gmail_ext = True
+            logger.warning(
+                "[Email] IMAP server does not advertise %s — per-thread session "
+                "isolation is unavailable; falling back to one session per "
+                "sender address. Gmail/Workspace mailboxes advertise this "
+                "capability; other providers are not yet supported.",
+                GMAIL_IMAP_CAPABILITY,
+            )
+        return has_ext
+
+    def _fetch_thread_id(self, imap: "imaplib.IMAP4", uid: bytes) -> Optional[str]:
+        """Fetch Gmail's server-computed thread id for one UID.
+
+        Returns ``None`` on any failure — a non-OK status, an empty response, or
+        a response carrying no X-GM-THRID.  The PRD treats all three identically:
+        the thread is unknown, so the message is not yet safe to process.
+        """
+        try:
+            status, data = imap.uid("fetch", uid, "(X-GM-THRID)")
+        except Exception as e:
+            logger.warning("[Email] X-GM-THRID fetch failed for UID %s: %s", uid, e)
+            return None
+        if status != "OK":
+            return None
+        return _parse_gm_thrid(data)
+
+    def _peek_sender(self, imap: "imaplib.IMAP4", uid: bytes) -> str:
+        """Best-effort sender lookup for a message we are about to give up on.
+
+        Uses BODY.PEEK so the probe itself does not set \\Seen — the give-up
+        path marks the message seen explicitly, and only after the notification
+        has been attempted.
+        """
+        try:
+            status, data = imap.uid(
+                "fetch", uid, "(BODY.PEEK[HEADER.FIELDS (FROM)])"
+            )
+            if status != "OK" or not data:
+                return ""
+            for item in data:
+                parts = item if isinstance(item, (tuple, list)) else (item,)
+                for part in parts:
+                    if not isinstance(part, (bytes, bytearray)):
+                        continue
+                    header = bytes(part).decode("utf-8", errors="replace")
+                    # Match a real From: header line, not the FETCH response
+                    # preamble — which itself contains the literal
+                    # "BODY[HEADER.FIELDS (FROM)]".
+                    match = _FROM_HEADER_RE.search(header)
+                    if match:
+                        return _extract_email_address(match.group(1))
+        except Exception as e:
+            logger.debug("[Email] Sender probe failed for UID %s: %s", uid, e)
+        return ""
+
+    def _give_up_on_thread_lookup(self, imap: "imaplib.IMAP4", uid: bytes) -> None:
+        """Report, mark seen and drop a message whose thread never resolved.
+
+        Called once the UID has burned through ``_THRID_MAX_FAILURES`` poll
+        cycles.  The body is never logged — only the UID and sender — so a
+        failure is discoverable without spilling message content into logs.
+        """
+        sender = self._peek_sender(imap, uid)
+        logger.error(
+            "%s UID %s (sender: %s) — X-GM-THRID unresolved after %d attempts; "
+            "notifying sender, marking seen and dropping",
+            THREAD_LOOKUP_FAILURE_LOG_PREFIX,
+            uid,
+            sender or "unknown",
+            self._THRID_MAX_FAILURES,
+        )
+
+        if sender:
+            try:
+                self._send_email(
+                    sender,
+                    "Hermes received your email but could not determine which "
+                    "conversation thread it belongs to, so it was not "
+                    "processed.\n\n"
+                    "Please try sending it again, ideally as a new message "
+                    "rather than a reply.",
+                    subject_override="Hermes could not process your message",
+                )
+            except Exception as e:
+                logger.error(
+                    "%s Failed to notify %s about UID %s: %s",
+                    THREAD_LOOKUP_FAILURE_LOG_PREFIX, sender, uid, e,
+                )
+        else:
+            logger.error(
+                "%s No sender resolvable for UID %s — dropping without notice",
+                THREAD_LOOKUP_FAILURE_LOG_PREFIX, uid,
+            )
+
+        # Mark seen last: until this succeeds the message is still eligible for
+        # another cycle, which is the safer way to fail.
+        try:
+            imap.uid("store", uid, "+FLAGS", "(\\Seen)")
+        except Exception as e:
+            logger.error(
+                "%s Failed to mark UID %s seen: %s",
+                THREAD_LOOKUP_FAILURE_LOG_PREFIX, uid, e,
+            )
+
+        self._thrid_failures.pop(uid, None)
+        self._seen_uids.add(uid)
+
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
         results = []
@@ -865,9 +1239,51 @@ class EmailAdapter(BasePlatformAdapter):
                 if status != "OK" or not data or not data[0]:
                     return results
 
-                for uid in data[0].split():
+                # Probe once per IMAP session: a server without the Gmail
+                # extension cannot answer X-GM-THRID at all, and must not be
+                # put through the retry-and-drop path below.
+                gmail_ext = self._probe_gmail_ext(imap)
+
+                unseen_uids = data[0].split()
+                # Drop strike counters for UIDs that are no longer unseen — the
+                # message was read elsewhere, moved, or deleted between cycles.
+                # Without this a mid-retry disappearance leaks an entry forever.
+                if self._thrid_failures:
+                    still_unseen = set(unseen_uids)
+                    for stale in [
+                        u for u in self._thrid_failures if u not in still_unseen
+                    ]:
+                        del self._thrid_failures[stale]
+
+                for uid in unseen_uids:
                     if uid in self._seen_uids:
                         continue
+
+                    # Resolve the Gmail thread id BEFORE the RFC822 fetch. That
+                    # fetch implicitly sets \Seen, which would strip the message
+                    # of the one flag that makes a retry possible — so the thread
+                    # lookup has to be the first thing that touches the UID.
+                    #
+                    # Without the Gmail extension there is no thread id to fetch:
+                    # process the message with thread_id=None, which reproduces
+                    # the previous sender-keyed behaviour exactly.
+                    thread_id = self._fetch_thread_id(imap, uid) if gmail_ext else None
+                    if gmail_ext and not thread_id:
+                        strikes = self._thrid_failures.get(uid, 0) + 1
+                        self._thrid_failures[uid] = strikes
+                        if strikes < self._THRID_MAX_FAILURES:
+                            # Transient: leave the message UNSEEN and untracked
+                            # so the next poll cycle picks it up again.
+                            logger.warning(
+                                "[Email] X-GM-THRID unresolved for UID %s "
+                                "(attempt %d/%d) — leaving unseen for retry",
+                                uid, strikes, self._THRID_MAX_FAILURES,
+                            )
+                            continue
+                        self._give_up_on_thread_lookup(imap, uid)
+                        continue
+
+                    self._thrid_failures.pop(uid, None)
 
                     status, msg_data = imap.uid("fetch", uid, "(RFC822)")
                     if status != "OK":
@@ -907,7 +1323,9 @@ class EmailAdapter(BasePlatformAdapter):
                     # batch or escalate to a reconnect — it is already marked
                     # seen above, so log the UID and move on (#80032 review).
                     try:
-                        parsed = self._parse_fetched_message(uid, raw_email)
+                        parsed = self._parse_fetched_message(
+                            uid, raw_email, thread_id=thread_id
+                        )
                     except Exception as parse_exc:
                         logger.error(
                             "[Email] Failed to process message UID %s, skipping: %s",
@@ -931,7 +1349,12 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_snapshot[self._address] = set(self._seen_uids)
         return results
 
-    def _parse_fetched_message(self, uid: bytes, raw_email: "bytes | bytearray") -> Optional[Dict[str, Any]]:
+    def _parse_fetched_message(
+        self,
+        uid: bytes,
+        raw_email: "bytes | bytearray",
+        thread_id: Optional[str] = None,
+    ) -> Optional[Dict[str, Any]]:
         """Parse one fetched RFC822 payload into a dispatchable dict.
 
         Returns ``None`` for messages that should be silently skipped
@@ -951,6 +1374,7 @@ class EmailAdapter(BasePlatformAdapter):
         subject = _decode_header_value(msg.get("Subject", "(no subject)"))
         message_id = msg.get("Message-ID", "")
         in_reply_to = msg.get("In-Reply-To", "")
+        references = msg.get("References", "")
         # Skip automated/noreply senders before any processing
         msg_headers = dict(msg.items())
         if _is_automated_sender(sender_addr, msg_headers):
@@ -972,11 +1396,13 @@ class EmailAdapter(BasePlatformAdapter):
 
         return {
             "uid": uid,
+            "thread_id": thread_id,
             "sender_addr": sender_addr,
             "sender_name": sender_name,
             "subject": subject,
             "message_id": message_id,
             "in_reply_to": in_reply_to,
+            "references": references,
             "body": body,
             "attachments": attachments,
             "date": msg.get("Date", ""),
@@ -1102,18 +1528,28 @@ class EmailAdapter(BasePlatformAdapter):
                 # only classification that surfaces both.
                 msg_type = MessageType.DOCUMENT
 
-        # Store thread context for reply threading
-        self._thread_context[sender_addr] = {
-            "subject": subject,
-            "message_id": msg_data["message_id"],
-        }
+        # Store thread context for reply threading, scoped to this thread so a
+        # second concurrent conversation with the same sender cannot overwrite
+        # it.
+        thread_id = msg_data.get("thread_id")
+        self._remember_thread_context(
+            sender_addr,
+            thread_id,
+            subject,
+            msg_data["message_id"],
+            msg_data.get("references", ""),
+        )
 
+        # thread_id flows from here into SessionSource -> build_session_key ->
+        # HERMES_SESSION_THREAD_ID -> cron origin, giving each Gmail thread its
+        # own session and its own cron delivery target.
         source = self.build_source(
             chat_id=sender_addr,
             chat_name=msg_data["sender_name"] or sender_addr,
             chat_type="dm",
             user_id=sender_addr,
             user_name=msg_data["sender_name"] or sender_addr,
+            thread_id=thread_id,
         )
 
         event = MessageEvent(
@@ -1136,11 +1572,17 @@ class EmailAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an email reply to the given address."""
+        """Send an email reply to the given address.
+
+        ``metadata["thread_id"]`` — set by the gateway's delivery router and by
+        the interactive reply path from ``SessionSource.thread_id`` — selects
+        which of this correspondent's threads the reply belongs to.
+        """
         try:
             loop = asyncio.get_running_loop()
+            thread_id = self._thread_id_from_metadata(metadata)
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, thread_id
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1162,27 +1604,38 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        thread_id: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
-        """Send an email via SMTP. Runs in executor thread."""
+        """Send an email via SMTP. Runs in executor thread.
+
+        ``thread_id`` scopes the reply-threading lookup so the outgoing
+        ``In-Reply-To``/``References`` name the thread this reply belongs to
+        rather than whichever thread with this correspondent was touched last.
+
+        ``subject_override`` sends a fresh subject instead of replying to a
+        stored one — used for the thread-lookup failure notice, which by
+        definition has no thread to reply into.
+        """
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
         # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        ctx = {} if subject_override else self._thread_ctx(to_addr, thread_id)
+        if subject_override:
+            subject = subject_override
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        # Threading headers
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        # Threading headers (RFC 5322 §3.6.4)
+        self._apply_threading_headers(msg, ctx, reply_to_msg_id)
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
+        msg_id = self._new_message_id()
         msg["Message-ID"] = msg_id
 
         msg.attach(MIMEText(body, "plain", "utf-8"))
@@ -1213,12 +1666,11 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an image URL as part of an email body.
 
-        ``metadata`` is accepted to honor the base-class contract; the
-        email body send doesn't use it.
+        ``metadata`` is forwarded so the send lands in the right thread.
         """
         text = caption or ""
         text += f"\n\nImage: {image_url}"
-        return await self.send(chat_id, text.strip(), reply_to)
+        return await self.send(chat_id, text.strip(), reply_to, metadata)
 
     async def send_multiple_images(
         self,
@@ -1267,6 +1719,7 @@ class EmailAdapter(BasePlatformAdapter):
                 chat_id,
                 body,
                 local_paths,
+                self._thread_id_from_metadata(metadata),
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1277,25 +1730,23 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_ctx(to_addr, thread_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        self._apply_threading_headers(msg, ctx)
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
+        msg_id = self._new_message_id()
         msg["Message-ID"] = msg_id
 
         if body:
@@ -1345,6 +1796,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                self._thread_id_from_metadata(kwargs.get("metadata")),
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1357,25 +1809,23 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        thread_id: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
+        ctx = self._thread_ctx(to_addr, thread_id)
         subject = ctx.get("subject", "Hermes Agent")
         if not subject.startswith("Re:"):
             subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        original_msg_id = ctx.get("message_id")
-        if original_msg_id:
-            msg["In-Reply-To"] = original_msg_id
-            msg["References"] = original_msg_id
+        self._apply_threading_headers(msg, ctx)
 
         msg["Date"] = formatdate(localtime=True)
-        msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
+        msg_id = self._new_message_id()
         msg["Message-ID"] = msg_id
 
         if body:
@@ -1405,7 +1855,7 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""
-        ctx = self._thread_context.get(chat_id, {})
+        ctx = self._thread_ctx(chat_id)
         return {
             "name": chat_id,
             "type": "dm",

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -364,7 +364,7 @@ class TestThreadContext(unittest.TestCase):
     def test_reply_uses_re_prefix(self):
         """Reply subject should have Re: prefix."""
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {
+        adapter._thread_context[("user@test.com", "T1")] = {
             "subject": "Project question",
             "message_id": "<original@test.com>",
         }
@@ -373,7 +373,9 @@ class TestThreadContext(unittest.TestCase):
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
-            adapter._send_email("user@test.com", "Here is the answer.", None)
+            adapter._send_email(
+                "user@test.com", "Here is the answer.", None, thread_id="T1"
+            )
 
             # Check the sent message
             send_call = mock_server.send_message.call_args[0][0]
@@ -436,7 +438,7 @@ class TestSendMethods(unittest.TestCase):
         """get_chat_info should return email address as chat info."""
         import asyncio
         adapter = self._make_adapter()
-        adapter._thread_context["user@test.com"] = {"subject": "Test", "message_id": "<m@t>"}
+        adapter._thread_context[("user@test.com", "T1")] = {"subject": "Test", "message_id": "<m@t>"}
 
         info = asyncio.run(
             adapter.get_chat_info("user@test.com")

--- a/tests/gateway/test_email_thread_isolation.py
+++ b/tests/gateway/test_email_thread_isolation.py
@@ -1,0 +1,817 @@
+"""Per-thread session isolation for the email adapter.
+
+Every email from one sender used to collapse into a single session keyed on the
+sender address alone, and outbound reply threading was sourced from a single
+per-sender slot holding "the last message received from this address". Two
+unrelated conversations with the same person therefore shared one context, and a
+cron job created in one thread delivered its result into whichever thread with
+that sender had been touched most recently.
+
+The fix keys both the session and the outbound reply context on Gmail's
+server-computed ``X-GM-THRID``. These tests mock only the IMAP/SMTP boundary —
+never adapter internals — and assert on observable outcomes.
+"""
+
+import os
+import unittest
+import uuid
+from email.mime.text import MIMEText
+from unittest.mock import MagicMock, patch
+
+
+def _make_adapter(address="hermes@test.com"):
+    from gateway.config import PlatformConfig
+
+    with patch.dict(os.environ, {
+        "EMAIL_ADDRESS": address,
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+    }):
+        from plugins.platforms.email.adapter import EmailAdapter
+
+        return EmailAdapter(PlatformConfig(enabled=True))
+
+
+def _raw_email(sender="user@test.com", subject="Hello", message_id=None):
+    msg = MIMEText("Test body", "plain", "utf-8")
+    msg["From"] = sender
+    msg["Subject"] = subject
+    msg["Message-ID"] = message_id or f"<{uuid.uuid4().hex[:8]}@test.com>"
+    return msg.as_bytes()
+
+
+def _is_thrid_fetch(args):
+    return any("X-GM-THRID" in str(a) for a in args)
+
+
+class TestThreadIdFetch(unittest.TestCase):
+    """X-GM-THRID is fetched over the existing IMAP connection and parsed."""
+
+    def _fetch(self, thrid_response):
+        adapter = _make_adapter()
+        raw = _raw_email()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                if _is_thrid_fetch(args):
+                    return thrid_response
+                return ("OK", [(b"1", raw)])
+            return ("NO", [])
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            return adapter, adapter._fetch_new_messages()
+
+    def test_well_formed_response_yields_thread_id(self):
+        _, results = self._fetch(
+            ("OK", [b"1 (X-GM-THRID 1795604436429434944 UID 1)"])
+        )
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["thread_id"], "1795604436429434944")
+
+    def test_error_status_is_a_failure(self):
+        """A non-OK FETCH leaves the message unprocessed and UNSEEN."""
+        adapter, results = self._fetch(("NO", [b"nope"]))
+        self.assertEqual(results, [])
+        self.assertNotIn(b"1", adapter._seen_uids)
+
+    def test_empty_response_is_a_failure(self):
+        adapter, results = self._fetch(("OK", []))
+        self.assertEqual(results, [])
+        self.assertNotIn(b"1", adapter._seen_uids)
+
+    def test_response_without_thrid_is_a_failure(self):
+        """A well-formed FETCH carrying no X-GM-THRID is treated as a failure."""
+        adapter, results = self._fetch(("OK", [b"1 (UID 1)"]))
+        self.assertEqual(results, [])
+        self.assertNotIn(b"1", adapter._seen_uids)
+
+    def test_thread_id_fetched_before_rfc822(self):
+        """The RFC822 fetch sets \\Seen, so the thread lookup must precede it.
+
+        Otherwise a message whose thread never resolves has already lost the
+        UNSEEN flag that makes a retry possible.
+        """
+        adapter = _make_adapter()
+        specs = []
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                specs.append(str(args[-1]))
+                if _is_thrid_fetch(args):
+                    return ("OK", [b"1 (X-GM-THRID 42 UID 1)"])
+                return ("OK", [(b"1", _raw_email())])
+            return ("NO", [])
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            adapter._fetch_new_messages()
+
+        self.assertIn("X-GM-THRID", specs[0])
+        self.assertIn("RFC822", specs[1])
+
+
+class TestThreadLookupRetryAndGiveUp(unittest.TestCase):
+    """Five strikes: retry, then notify the sender and drop."""
+
+    def _adapter_that_always_fails_thrid(self):
+        adapter = _make_adapter()
+        raw = _raw_email(sender="user@test.com")
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"7"])
+            if command == "fetch":
+                if _is_thrid_fetch(args):
+                    return ("NO", [])
+                if "HEADER.FIELDS" in str(args[-1]):
+                    return ("OK", [(b"7 (BODY[HEADER.FIELDS (FROM)]",
+                                    b"From: user@test.com\r\n\r\n")])
+                return ("OK", [(b"7", raw)])
+            if command == "store":
+                return ("OK", [b"7"])
+            return ("NO", [])
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.uid.side_effect = uid_handler
+        return adapter, mock_imap
+
+    def test_stays_unseen_through_first_four_failures(self):
+        adapter, mock_imap = self._adapter_that_always_fails_thrid()
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+                patch("smtplib.SMTP") as mock_smtp:
+            for cycle in range(1, 5):
+                results = adapter._fetch_new_messages()
+                self.assertEqual(results, [], f"cycle {cycle} should yield nothing")
+                self.assertNotIn(
+                    b"7", adapter._seen_uids,
+                    f"UID must stay retryable after failure {cycle}",
+                )
+                self.assertEqual(adapter._thrid_failures[b"7"], cycle)
+
+            # No notification and no \Seen store while still retrying.
+            mock_smtp.assert_not_called()
+            store_calls = [
+                c for c in mock_imap.uid.call_args_list if c[0][0] == "store"
+            ]
+            self.assertEqual(store_calls, [])
+
+    def test_fifth_failure_notifies_sender_marks_seen_and_drops(self):
+        adapter, mock_imap = self._adapter_that_always_fails_thrid()
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+                patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+
+            with self.assertLogs(
+                "plugins.platforms.email.adapter", level="ERROR"
+            ) as logs:
+                for _ in range(5):
+                    results = adapter._fetch_new_messages()
+
+            self.assertEqual(results, [])
+
+            # Sender was notified.
+            self.assertTrue(mock_server.send_message.called)
+            sent = mock_server.send_message.call_args[0][0]
+            self.assertEqual(sent["To"], "user@test.com")
+            self.assertNotIn("Re:", sent["Subject"])
+
+            # Marked seen on the server so it is not retried forever.
+            store_calls = [
+                c for c in mock_imap.uid.call_args_list if c[0][0] == "store"
+            ]
+            self.assertEqual(len(store_calls), 1)
+            self.assertEqual(store_calls[0][0][1], b"7")
+            self.assertIn("Seen", str(store_calls[0][0][3]))
+
+            # Dropped locally too.
+            self.assertIn(b"7", adapter._seen_uids)
+            self.assertNotIn(b"7", adapter._thrid_failures)
+
+        # Logged under a grep-able prefix, without the message body.
+        from plugins.platforms.email.adapter import (
+            THREAD_LOOKUP_FAILURE_LOG_PREFIX,
+        )
+        failure_logs = [
+            r for r in logs.output if THREAD_LOOKUP_FAILURE_LOG_PREFIX in r
+        ]
+        self.assertTrue(failure_logs)
+        self.assertIn("user@test.com", failure_logs[0])
+        self.assertNotIn("Test body", "\n".join(logs.output))
+
+    def test_success_after_transient_failure_clears_strikes(self):
+        """A recovered lookup must not carry its strikes forward."""
+        adapter = _make_adapter()
+        raw = _raw_email()
+        state = {"fail": True}
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"3"])
+            if command == "fetch":
+                if _is_thrid_fetch(args):
+                    if state["fail"]:
+                        return ("NO", [])
+                    return ("OK", [b"3 (X-GM-THRID 55 UID 3)"])
+                return ("OK", [(b"3", raw)])
+            return ("NO", [])
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            self.assertEqual(adapter._fetch_new_messages(), [])
+            self.assertEqual(adapter._thrid_failures[b"3"], 1)
+
+            state["fail"] = False
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["thread_id"], "55")
+        self.assertNotIn(b"3", adapter._thrid_failures)
+
+
+class TestSessionKeyIsolation(unittest.TestCase):
+    """The core regression test: one sender, two threads, two sessions."""
+
+    def test_distinct_threads_produce_distinct_session_keys(self):
+        from gateway.session import build_session_key
+        from gateway.config import Platform
+        from gateway.platforms.base import SessionSource
+
+        def source_for(thread_id):
+            return SessionSource(
+                platform=Platform.EMAIL,
+                chat_id="user@test.com",
+                chat_type="dm",
+                user_id="user@test.com",
+                thread_id=thread_id,
+            )
+
+        key_a = build_session_key(source_for("111"))
+        key_b = build_session_key(source_for("222"))
+
+        self.assertNotEqual(key_a, key_b)
+        self.assertIn("111", key_a)
+        self.assertIn("222", key_b)
+
+    def test_dispatch_populates_thread_id_on_the_session_source(self):
+        """thread_id must reach SessionSource — the rest of the pipeline
+        (build_session_key -> HERMES_SESSION_THREAD_ID -> cron origin) already
+        handles it when present."""
+        import asyncio
+
+        adapter = _make_adapter()
+        captured = []
+
+        async def capture(event):
+            captured.append(event)
+
+        adapter.handle_message = capture
+
+        msg_data = {
+            "uid": b"1",
+            "thread_id": "1795604436429434944",
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": "Quarterly report",
+            "message_id": "<a@test.com>",
+            "in_reply_to": "",
+            "body": "Hi",
+            "attachments": [],
+            "date": "",
+            "sender_authenticated": True,
+        }
+
+        with patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}):
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+        self.assertEqual(len(captured), 1)
+        self.assertEqual(
+            captured[0].source.thread_id, "1795604436429434944"
+        )
+
+    def test_two_threads_from_one_sender_do_not_share_a_session(self):
+        """End-to-end over the IMAP boundary: two concurrently open threads."""
+        import asyncio
+        from gateway.session import build_session_key
+
+        adapter = _make_adapter()
+        sources = []
+
+        async def capture(event):
+            sources.append(event.source)
+
+        adapter.handle_message = capture
+
+        bodies = {
+            b"1": _raw_email(subject="Invoice", message_id="<one@test.com>"),
+            b"2": _raw_email(subject="Lunch", message_id="<two@test.com>"),
+        }
+        thrids = {b"1": b"1000", b"2": b"2000"}
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1 2"])
+            if command == "fetch":
+                uid = args[0]
+                if _is_thrid_fetch(args):
+                    return ("OK", [b"%s (X-GM-THRID %s UID %s)"
+                                   % (uid, thrids[uid], uid)])
+                return ("OK", [(uid, bodies[uid])])
+            return ("NO", [])
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.uid.side_effect = uid_handler
+
+        async def drive():
+            with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                await adapter._check_inbox()
+
+        with patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}):
+            asyncio.run(drive())
+
+        self.assertEqual(len(sources), 2)
+        keys = {build_session_key(s) for s in sources}
+        self.assertEqual(len(keys), 2, f"threads shared a session: {keys}")
+
+
+class TestOutboundReplyThreading(unittest.TestCase):
+    """In-Reply-To/References must name the thread being replied to."""
+
+    def _adapter_with_two_threads(self):
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1000", "Invoice", "<one@test.com>"
+        )
+        adapter._remember_thread_context(
+            "user@test.com", "2000", "Lunch", "<two@test.com>"
+        )
+        return adapter
+
+    def _send(self, adapter, thread_id):
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            adapter._send_email(
+                "user@test.com", "Reply body", None, thread_id=thread_id
+            )
+            return mock_server.send_message.call_args[0][0]
+
+    def test_each_thread_gets_its_own_reply_anchor(self):
+        adapter = self._adapter_with_two_threads()
+
+        older = self._send(adapter, "1000")
+        self.assertEqual(older["Subject"], "Re: Invoice")
+        self.assertEqual(older["In-Reply-To"], "<one@test.com>")
+        self.assertEqual(older["References"], "<one@test.com>")
+
+        newer = self._send(adapter, "2000")
+        self.assertEqual(newer["Subject"], "Re: Lunch")
+        self.assertEqual(newer["In-Reply-To"], "<two@test.com>")
+
+    def test_reply_to_older_thread_is_not_captured_by_the_newer_one(self):
+        """The exact regression: the most-recently-touched thread used to win."""
+        adapter = self._adapter_with_two_threads()
+        sent = self._send(adapter, "1000")
+        self.assertNotEqual(sent["In-Reply-To"], "<two@test.com>")
+
+    def test_unknown_thread_does_not_borrow_another_threads_anchor(self):
+        adapter = self._adapter_with_two_threads()
+        sent = self._send(adapter, "9999")
+        self.assertIsNone(sent["In-Reply-To"])
+        self.assertEqual(sent["Subject"], "Re: Hermes Agent")
+
+    def test_send_reads_thread_id_from_delivery_metadata(self):
+        """The gateway delivery router passes thread_id in send metadata."""
+        import asyncio
+
+        adapter = self._adapter_with_two_threads()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            result = asyncio.run(
+                adapter.send(
+                    "user@test.com",
+                    "Cron output",
+                    metadata={"thread_id": "1000"},
+                )
+            )
+
+        self.assertTrue(result.success)
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent["In-Reply-To"], "<one@test.com>")
+        self.assertEqual(sent["Subject"], "Re: Invoice")
+
+    def test_send_without_thread_id_falls_back_to_most_recent_thread(self):
+        """A send that names no thread (standalone/home-channel) still threads."""
+        import asyncio
+
+        adapter = self._adapter_with_two_threads()
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(adapter.send("user@test.com", "Notice"))
+
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent["In-Reply-To"], "<two@test.com>")
+
+    def test_dispatch_does_not_overwrite_a_sibling_thread(self):
+        """A new message in thread A must leave thread B's anchor intact."""
+        import asyncio
+
+        adapter = self._adapter_with_two_threads()
+
+        async def noop(event):
+            pass
+
+        adapter.handle_message = noop
+
+        with patch.dict(os.environ, {"EMAIL_ALLOW_ALL_USERS": "true"}):
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"9",
+                "thread_id": "1000",
+                "sender_addr": "user@test.com",
+                "sender_name": "User",
+                "subject": "Re: Invoice",
+                "message_id": "<one-followup@test.com>",
+                "in_reply_to": "<one@test.com>",
+                "body": "ping",
+                "attachments": [],
+                "date": "",
+                "sender_authenticated": True,
+            }))
+
+        self.assertEqual(
+            adapter._thread_context[("user@test.com", "1000")]["message_id"],
+            "<one-followup@test.com>",
+        )
+        self.assertEqual(
+            adapter._thread_context[("user@test.com", "2000")]["message_id"],
+            "<two@test.com>",
+        )
+
+
+class TestCronOriginCapture(unittest.TestCase):
+    """An email-originated cron job records its thread and delivers back to it."""
+
+    def test_origin_captures_thread_id_for_an_email_session(self):
+        from tools.cronjob_tools import _origin_from_env
+
+        with patch.dict(os.environ, {
+            "HERMES_SESSION_PLATFORM": "email",
+            "HERMES_SESSION_CHAT_ID": "user@test.com",
+            "HERMES_SESSION_THREAD_ID": "1795604436429434944",
+        }):
+            origin = _origin_from_env()
+
+        self.assertIsNotNone(origin)
+        self.assertEqual(origin["platform"], "email")
+        self.assertIsNotNone(origin["thread_id"])
+        self.assertEqual(origin["thread_id"], "1795604436429434944")
+
+    def test_origin_delivery_nests_under_the_originating_thread(self):
+        """deliver="origin" routes through the delivery router, whose metadata
+        thread_id must select that thread's reply anchor."""
+        import asyncio
+        from gateway.delivery import DeliveryRouter, DeliveryTarget
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1000", "Invoice", "<one@test.com>"
+        )
+        # A later message in a different thread with the same sender — the
+        # slot that used to capture this delivery.
+        adapter._remember_thread_context(
+            "user@test.com", "2000", "Lunch", "<two@test.com>"
+        )
+
+        config = GatewayConfig()
+        config.platforms[Platform.EMAIL] = PlatformConfig(enabled=True)
+        router = DeliveryRouter(config, {Platform.EMAIL: adapter})
+
+        target = DeliveryTarget(
+            platform=Platform.EMAIL,
+            chat_id="user@test.com",
+            thread_id="1000",
+            is_explicit=True,
+        )
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            asyncio.run(
+                router._deliver_to_platform(target, "Job finished.", {})
+            )
+
+        sent = mock_server.send_message.call_args[0][0]
+        self.assertEqual(sent["In-Reply-To"], "<one@test.com>")
+        self.assertEqual(sent["References"], "<one@test.com>")
+        self.assertEqual(sent["Subject"], "Re: Invoice")
+
+
+class TestGmailCapabilityProbe(unittest.TestCase):
+    """X-GM-EXT-1 gates the thread-id path so non-Gmail servers keep working."""
+
+    def _run(self, capabilities, thrid_ok=True):
+        adapter = _make_adapter()
+        raw = _raw_email(sender="user@test.com")
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.capabilities = capabilities
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                if _is_thrid_fetch(args):
+                    if not thrid_ok:
+                        import imaplib
+                        raise imaplib.IMAP4.error("BAD Invalid system flag")
+                    return ("OK", [b"1 (X-GM-THRID 4242 UID 1)"])
+                if "HEADER.FIELDS" in str(args[-1]):
+                    return ("OK", [(b"1 (BODY[HEADER.FIELDS (FROM)]",
+                                    b"From: user@test.com\r\n\r\n")])
+                return ("OK", [(b"1", raw)])
+            return ("OK", [b"1"])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+                patch("smtplib.SMTP") as mock_smtp:
+            results = adapter._fetch_new_messages()
+        return adapter, results, mock_smtp
+
+    def test_gmail_server_gets_thread_ids(self):
+        adapter, results, _ = self._run(("IMAP4REV1", "X-GM-EXT-1"))
+        self.assertTrue(adapter._has_gmail_ext)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["thread_id"], "4242")
+
+    def test_non_gmail_server_still_delivers_mail(self):
+        """The regression this probe exists to prevent: without it, a server
+        that cannot answer X-GM-THRID loses every inbound message to the
+        retry-and-drop path."""
+        adapter, results, mock_smtp = self._run(("IMAP4REV1",), thrid_ok=False)
+
+        self.assertFalse(adapter._has_gmail_ext)
+        self.assertEqual(len(results), 1, "message must still be delivered")
+        self.assertIsNone(results[0]["thread_id"])
+        # No strike accumulated and no apology email sent.
+        self.assertEqual(adapter._thrid_failures, {})
+        mock_smtp.assert_not_called()
+
+    def test_non_gmail_falls_back_to_sender_keyed_session(self):
+        """thread_id=None reproduces the previous one-session-per-sender key."""
+        from gateway.session import build_session_key
+        from gateway.config import Platform
+        from gateway.platforms.base import SessionSource
+
+        key = build_session_key(SessionSource(
+            platform=Platform.EMAIL, chat_id="user@test.com",
+            chat_type="dm", user_id="user@test.com", thread_id=None,
+        ))
+        self.assertEqual(key, "agent:main:email:dm:user@test.com")
+
+    def test_probe_failure_fails_safe(self):
+        """An unusable capability response must not enable the THRID path."""
+        adapter = _make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.capabilities = ()
+        mock_imap.capability.side_effect = Exception("connection reset")
+        self.assertFalse(adapter._probe_gmail_ext(mock_imap))
+
+    def test_capability_queried_when_attribute_absent(self):
+        adapter = _make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.capabilities = None
+        mock_imap.capability.return_value = ("OK", [b"IMAP4REV1 X-GM-EXT-1 UIDPLUS"])
+        self.assertTrue(adapter._probe_gmail_ext(mock_imap))
+
+
+class TestRFC5322Compliance(unittest.TestCase):
+    """Outgoing headers follow RFC 5322 §3.6.4 (Identification Fields)."""
+
+    def _send(self, adapter, thread_id, reply_to=None):
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            mock_smtp.return_value = server
+            adapter._send_email("user@test.com", "Body", reply_to,
+                                thread_id=thread_id)
+            return server.send_message.call_args[0][0]
+
+    def test_references_carries_the_full_ancestor_chain(self):
+        """§3.6.4: References = parent's References + parent's Message-ID.
+
+        Emitting only the parent's Message-ID loses the ancestry a client
+        needs to nest a reply in a long thread.
+        """
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "Deep thread", "<p3@test.com>",
+            references="<root@test.com> <p1@test.com> <p2@test.com>",
+        )
+        msg = self._send(adapter, "1")
+        self.assertEqual(msg["In-Reply-To"], "<p3@test.com>")
+        self.assertEqual(
+            msg["References"],
+            "<root@test.com> <p1@test.com> <p2@test.com> <p3@test.com>",
+        )
+
+    def test_references_without_prior_chain_is_just_the_parent(self):
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "New thread", "<only@test.com>"
+        )
+        msg = self._send(adapter, "1")
+        self.assertEqual(msg["References"], "<only@test.com>")
+
+    def test_references_deduplicates(self):
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "S", "<p1@test.com>",
+            references="<root@test.com> <p1@test.com>",
+        )
+        msg = self._send(adapter, "1")
+        self.assertEqual(msg["References"], "<root@test.com> <p1@test.com>")
+
+    def test_references_chain_is_capped_keeping_root_and_recent(self):
+        from plugins.platforms.email.adapter import MAX_REFERENCES
+        chain = " ".join(f"<a{i}@test.com>" for i in range(50))
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "S", "<parent@test.com>", references=chain
+        )
+        msg = self._send(adapter, "1")
+        refs = msg["References"].split()
+        self.assertEqual(len(refs), MAX_REFERENCES)
+        self.assertEqual(refs[0], "<a0@test.com>", "thread root must survive")
+        self.assertEqual(refs[-1], "<parent@test.com>")
+
+    def test_header_injecting_message_id_is_sanitized(self):
+        """A CRLF-bearing inbound Message-ID must not reach the header setter.
+
+        Python raises HeaderParseError on such a value, which would make every
+        reply in that thread fail — so the value is trimmed to its msg-id.
+        """
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "S",
+            "<ok@test.com>\r\nBcc: attacker@evil.com\r\nX-Injected: yes",
+        )
+        msg = self._send(adapter, "1")
+        raw = msg.as_bytes()
+        self.assertEqual(msg["In-Reply-To"], "<ok@test.com>")
+        self.assertNotIn(b"Bcc:", raw)
+        self.assertNotIn(b"X-Injected", raw)
+
+    def test_malformed_message_id_is_dropped_not_echoed(self):
+        """§3.6.4 requires msg-id = '<' addr-spec '>'; a bare token is not one."""
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "S", "not-a-valid-msgid"
+        )
+        msg = self._send(adapter, "1")
+        self.assertIsNone(msg["In-Reply-To"])
+        self.assertIsNone(msg["References"])
+
+    def test_generated_message_id_is_well_formed(self):
+        adapter = _make_adapter()
+        msg = self._send(adapter, None)
+        mid = msg["Message-ID"]
+        self.assertTrue(mid.startswith("<") and mid.endswith(">"))
+        self.assertIn("@", mid)
+        self.assertNotIn(" ", mid)
+
+    def test_generated_message_ids_are_unique(self):
+        adapter = _make_adapter()
+        ids = {self._send(adapter, None)["Message-ID"] for _ in range(25)}
+        self.assertEqual(len(ids), 25)
+
+    def test_non_ascii_subject_is_rfc2047_encoded(self):
+        """§2.2: header field bodies are US-ASCII; non-ASCII needs RFC 2047."""
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "Uber Cafe \u4f60\u597d", "<p@test.com>"
+        )
+        raw = self._send(adapter, "1").as_bytes()
+        subject_lines = [l for l in raw.split(b"\n")
+                         if l.lower().startswith(b"subject")]
+        self.assertTrue(subject_lines)
+        for line in subject_lines:
+            self.assertTrue(all(b < 128 for b in line),
+                            "Subject must not contain raw 8-bit bytes")
+
+    def test_body_lines_within_rfc5322_limit(self):
+        """§2.1.1: no line may exceed 998 characters."""
+        adapter = _make_adapter()
+        adapter._remember_thread_context(
+            "user@test.com", "1", "S", "<p@test.com>"
+        )
+        with patch("smtplib.SMTP") as mock_smtp:
+            server = MagicMock()
+            mock_smtp.return_value = server
+            adapter._send_email("user@test.com", "x" * 50000, None, thread_id="1")
+            msg = server.send_message.call_args[0][0]
+        for line in msg.as_bytes().split(b"\n"):
+            self.assertLessEqual(len(line.rstrip(b"\r")), 998)
+
+    def test_inbound_references_captured_at_ingestion(self):
+        adapter = _make_adapter()
+        from email.mime.text import MIMEText as _MT
+        m = _MT("hi")
+        m["From"] = "user@test.com"
+        m["Subject"] = "S"
+        m["Message-ID"] = "<child@test.com>"
+        m["References"] = "<root@test.com> <mid@test.com>"
+
+        mock_imap = MagicMock()
+
+        mock_imap.capabilities = ("IMAP4REV1", "X-GM-EXT-1")
+        mock_imap.capabilities = ("X-GM-EXT-1",)
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                if _is_thrid_fetch(args):
+                    return ("OK", [b"1 (X-GM-THRID 9 UID 1)"])
+                return ("OK", [(b"1", m.as_bytes())])
+            return ("OK", [b"1"])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results[0]["references"],
+                         "<root@test.com> <mid@test.com>")
+
+
+class TestNotificationVolume(unittest.TestCase):
+    """Guard for #27804's second half: email must not emit progress chatter.
+
+    The isolation half is fixed by per-thread sessions; the 100-200 status
+    emails per request are already prevented by email's _TIER_MINIMAL display
+    defaults. These assertions pin those defaults so a future retier cannot
+    silently reintroduce the flood.
+    """
+
+    def test_email_progress_surfaces_are_all_off_by_default(self):
+        from gateway.display_config import resolve_display_setting
+
+        expected = {
+            "tool_progress": "off",
+            "interim_assistant_messages": False,
+            "long_running_notifications": False,
+            "streaming": False,
+            "busy_ack_detail": False,
+        }
+        for setting, want in expected.items():
+            with self.subTest(setting=setting):
+                self.assertEqual(
+                    resolve_display_setting({}, "email", setting, None), want,
+                    f"email must default {setting}={want!r} — every progress "
+                    "event costs a separate email (#27804)",
+                )
+
+    def test_operator_can_still_opt_in(self):
+        """The defaults are defaults, not a hard block."""
+        from gateway.display_config import resolve_display_setting
+
+        cfg = {"display": {"platforms": {"email": {"tool_progress": "all"}}}}
+        self.assertEqual(
+            resolve_display_setting(cfg, "email", "tool_progress", None), "all"
+        )
+
+    def test_typing_indicator_is_a_noop(self):
+        import asyncio
+        adapter = _make_adapter()
+        asyncio.run(adapter.send_typing("user@test.com"))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/gateway/test_send_multiple_images.py
+++ b/tests/gateway/test_send_multiple_images.py
@@ -382,6 +382,9 @@ class TestEmailMultiImage:
         a._smtp_host = "smtp.example.com"
         a._smtp_port = 587
         a._thread_context = {}
+        a._thrid_failures = {}
+        a._has_gmail_ext = True
+        a._logged_no_gmail_ext = False
         return a
 
     def test_local_files_attached_in_single_email(self, adapter, tmp_path):
@@ -400,9 +403,12 @@ class TestEmailMultiImage:
             _run(adapter.send_multiple_images("user@example.com", images))
 
         mock_send.assert_called_once()
-        to_addr, body, file_paths = mock_send.call_args.args
+        to_addr, body, file_paths, thread_id = mock_send.call_args.args
         assert to_addr == "user@example.com"
         assert len(file_paths) == 3
         assert "alt 0" in body
+        # No metadata passed, so no thread is named — the SMTP layer falls back
+        # to this correspondent's most recent thread.
+        assert thread_id is None
 
 


### PR DESCRIPTION
> [!NOTE]
> **This change was written by an AI agent (Claude Opus 5, via Claude Code), including this
> description.** A human directed the work, supplied the requirements and approved opening the
> PR, but the code, tests and prose here are AI-authored. Please review accordingly — in
> particular the design decisions called out under *Open questions for maintainers*, which are
> judgement calls rather than mechanical changes.

## What does this PR do?

The email adapter never set `SessionSource.thread_id`, so `build_session_key()` collapsed **all**
mail from one address into a single session (`agent:main:email:dm:<sender>`). Two unrelated
conversations with the same person shared one context window.

The same root cause produced a second, more visible symptom: outbound `In-Reply-To`/`References`
were sourced from `_thread_context[to_addr]` — one slot per sender, holding "the last message
received from this address". A cron job created in thread A delivered its result into whichever
thread with that sender had been touched most recently.

This keys both the session and the outbound reply context on Gmail's server-computed
`X-GM-THRID`, bringing email to parity with the per-thread isolation Telegram/Discord/Slack
already have.

## Related Issue

Fixes #11422

This implements Revision 2 of an internal PRD; the revision's substance — the capability-probe
reconciliation with #11422, the RFC 5322 audit, and the scope calls on #26277 / #27804 — is
reproduced inline below rather than linked, so review needs nothing external.

Relates to #26277 (same user need, subject-based mechanism — see *Scope* below)
Relates to #27804 (this fixes the session-isolation half; the notification-volume half is
already fixed in-tree)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

**`plugins/platforms/email/adapter.py`**

- **Thread identity.** `_fetch_thread_id()` issues `UID FETCH (X-GM-THRID)` over the existing
  `imaplib` connection. It runs *before* the `RFC822` fetch, because that fetch implicitly sets
  `\Seen` — doing it second would strip the message of the one flag that makes a retry possible.
- **Capability probe** (per #11422). `_probe_gmail_ext()` records whether the server advertises
  `X-GM-EXT-1` once per IMAP session. Without it there is no thread id to fetch, so the adapter
  keeps the previous sender-keyed behaviour and logs one warning. Without this probe, a
  non-Gmail mailbox answers every thread lookup with `BAD`, burns the retry budget, and drops
  **all** inbound mail. Delegated mailboxes and some Workspace configs also omit the capability.
- **Bounded retry.** With the capability present, a failed lookup leaves the message `UNSEEN`
  for the next poll cycle. After 5 consecutive failures on one UID: log under the grep-able
  prefix `[Email][thread-lookup-failure]` (UID and sender only — never the body), reply to the
  sender, mark seen, drop. Strike counters are pruned when a UID leaves the `UNSEEN` set.
- **Pipeline.** `thread_id` flows through the existing
  `build_source()` → `SessionSource.thread_id` → `build_session_key()` →
  `HERMES_SESSION_THREAD_ID` → cron `origin` path. **No changes to `session.py` or
  `cronjob_tools.py`** — that logic already handled `thread_id`; only the email adapter failed
  to populate it.
- **Outbound threading.** `_thread_context` rekeyed from `sender_addr` to
  `(sender_addr, thread_id)`. A send naming no thread (standalone/home-channel) resolves to the
  correspondent's most recent thread; a send naming an *unknown* thread returns empty context
  rather than borrowing another thread's anchor — borrowing is the bug being fixed.

**RFC 5322 conformance** (same file)

- **§3.6.4 `References`** — was emitting only the parent's `Message-ID`, discarding all earlier
  ancestry, so clients could not nest a reply in a long thread. Now builds the full chain
  (parent's `References` + parent's `Message-ID`), deduplicated, capped at 20 by keeping the
  thread root plus the most recent ancestors.
- **§3.6.4 msg-id shape** — inbound `Message-ID` is attacker-controlled and was echoed verbatim
  into `In-Reply-To`/`References`. A value containing CRLF reached Python's header setter and
  raised `HeaderParseError` *at send time*, meaning every reply in that thread would fail
  permanently. Header injection was never possible (Python blocks it), but the availability bug
  was real. Values are now trimmed to their first well-formed `<id-left@id-right>` token, or
  dropped.
- **§3.6.4 uniqueness** — `Message-ID` generation moved from 48 bits of UUID hex to
  `email.utils.make_msgid()`.
- §2.2 (RFC 2047 header encoding) and §2.1.1 (998-char lines) were audited and are already
  compliant; no change, but both now have regression tests.

**Tests** — `tests/gateway/test_email_thread_isolation.py` (new, 817 lines / 38 tests), plus
8 lines each in `test_email.py` and `test_send_multiple_images.py`.

> **Reviewer note:** the two existing-test edits are not cosmetic. `_thread_context` is now
> keyed `(sender, thread_id)` rather than `sender`, and `_send_email_with_attachments` takes a
> `thread_id` argument — tests that construct or unpack either need updating. Any IMAP mock
> that neither advertises `X-GM-EXT-1` nor answers the `X-GM-THRID` fetch will exercise the
> non-Gmail fallback path rather than fail, which is the intended degradation.

## Scope

**#27804 has two halves and they have different owners.** The session-isolation half is fixed
here. The notification-volume half (100–200 status emails per request) is **already fixed
in-tree**: `gateway/display_config.py` assigns email `_TIER_MINIMAL`, verified at runtime:

```
email.tool_progress                = 'off'
email.interim_assistant_messages   = False
email.long_running_notifications   = False
email.streaming                    = False
email.busy_ack_detail              = False
```

Re-implementing throttling in the adapter would duplicate working behaviour and add dead code,
so this PR adds a **regression guard** pinning those defaults instead, while asserting an
operator can still opt back in per-platform.

**#26277 is related but not fixed.** It asks for opt-in isolation by *normalized subject*, on any
IMAP provider. This is Gmail-only, always-on where supported, and treats a mid-thread subject
rename as the *same* thread (`X-GM-THRID` is stable) where #26277 wants it to start a new one.
Those are coherent but different products, so #26277 should stay open for non-Gmail providers.

## Open questions for maintainers

1. **Opt-in vs. clean cut.** #11422 specifies this behind
   `platforms.email.extra.session_keying`, default `sender`, so existing installs see zero
   change. This PR applies it automatically wherever `X-GM-EXT-1` is advertised. The capability
   probe removes the correctness argument for a flag, but not the compatibility argument — on a
   Gmail mailbox, existing senders get a one-time session fragmentation (old sessions remain at
   their old keys and simply stop accumulating). Happy to add the flag if preferred.
2. **Session key shape.** #11422 suggests `…:dm:<addr>:gthr-<digits>`; this emits bare digits.
   Trivial to change.
3. **There are five other open PRs in this area** (#11185, #11418, #23999, #63659, #73189,
   #90482), none merged. If a maintainer would rather see this folded into one of those, say so
   and I'll close this in favour of it.

## How to Test

1. `scripts/run_tests.sh tests/gateway/test_email_thread_isolation.py tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_send_multiple_images.py -q`
2. Two concurrently open Gmail threads with the same sender produce two distinct session keys
   (`agent:main:email:dm:<addr>:<thrid>`); replying in one leaves the other's context untouched.
3. A cron job created inside thread A and delivered with `deliver="origin"` nests under thread A,
   not under whichever thread was most recently touched.
4. Against a non-Gmail IMAP server, mail is still delivered (sender-keyed), with one
   `does not advertise X-GM-EXT-1` warning — this is the regression the capability probe exists
   to prevent.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see *Open questions* #3
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` on the affected surface (1117 passed, 0 failed); whole-repo run in flight — see *Logs*
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A, no platform-specific code paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

**The regression the capability probe prevents** — simulated non-Gmail IMAP server, before vs after:

```
BEFORE                                  AFTER
cycle 1: delivered=0  dropped=False     delivered=1  thread_id=None
cycle 2: delivered=0  dropped=False     (sender-keyed session, mail intact)
cycle 3: delivered=0  dropped=False
cycle 4: delivered=0  dropped=False
cycle 5: delivered=0  dropped=True
error emails sent to: ['user@t.com']
```

**RFC 5322 §3.6.4 References chain:**

```
before  References: <p3@example.com>
after   References: <root@example.com> <p1@example.com> <p2@example.com> <p3@example.com>
```

**Header-injecting inbound Message-ID is now sanitized rather than fatal:**

```
<ok@x.com>\r\nBcc: attacker@evil.com   ->  In-Reply-To: <ok@x.com>   (Bcc not emitted)
not-a-valid-msgid                      ->  In-Reply-To: omitted
```

All figures below were measured on this commit, rebased onto current `main`, using
`scripts/run_tests.sh` (the canonical CI-equivalent runner with per-file isolation).

**Email surface — the four files this touches:**

```
tests/gateway/test_email.py
tests/gateway/test_email_robustness.py
tests/gateway/test_send_multiple_images.py
tests/gateway/test_email_thread_isolation.py     88 passed
```

**Everything importing the changed code** — 76 files referencing the email adapter,
`build_session_key`, `DeliveryRouter` or the cron scheduler:

```
=== Summary: 76 files, 1117 tests passed, 0 failed, 2 skipped in 140.2s (8 workers) ===
```

> **In flight:** the whole-repo `scripts/run_tests.sh` run on this rebased commit is still
> executing at the time of opening; I'll post the result as a comment. An earlier whole-repo run
> of the same change against an older base gave 39,210 passed / 10 failed, where all 10 were
> pre-existing flakes verified by stashing the change and re-running each (mostly
> mtime-granularity cache-invalidation tests — e.g. `test_skill_utils.py` failed 3/6 baseline
> runs and 5/6 with the change). That run is **not** this commit and is offered only as context.

Note: the project's declared dev extra was incomplete in my environment — `pytest-asyncio` was
missing, which fails every `@pytest.mark.asyncio` test repo-wide. Installing the `[dev]` pins
from `pyproject.toml` was required to get a meaningful run.
