### PR TITLE
fix(cli): strip public-dashboard OAuth env vars from SSH-isolated backends

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12000,6 +12000,25 @@ def cmd_dashboard(args):
     if not _headless_backend:
         os.environ.pop("HERMES_SERVE_HEADLESS", None)
 
+    # ── Strip public-dashboard OAuth config from SSH-spawned backends ──
+    # load_hermes_dotenv() (called once at module import, before this
+    # function runs) reloads ~/.hermes/.env into os.environ unconditionally
+    # — including HERMES_DASHBOARD_OAUTH_CLIENT_ID / HERMES_DASHBOARD_PUBLIC_URL,
+    # which are meant only for the real public-facing dashboard service
+    # (e.g. hermes-mission-control.service). A Desktop-SSH isolated backend
+    # re-reads the same .env itself regardless of how it was launched, so
+    # process-environment inheritance was never the vector — this is not a
+    # sandboxing gap, just a stale config value with no scope of its own.
+    # A --ssh-session-token-file backend has its own token-only auth
+    # contract (see _read_ssh_session_token_file) and must never engage
+    # Portal OAuth on a loopback-bound port. Confirmed via FF-CL-20260831-009
+    # (env-scrubbed canary + strace) that this .env reload, not inherited
+    # env, was the actual trigger for the 401 unauthenticated/no_cookie loop
+    # in Desktop's SSH reconnect path.
+    if _token_file:
+        os.environ.pop("HERMES_DASHBOARD_OAUTH_CLIENT_ID", None)
+        os.environ.pop("HERMES_DASHBOARD_PUBLIC_URL", None)
+
     # ── Unified profile launch routing ────────────────────────────────
     # The dashboard is a MACHINE management surface: it can read/write any
     # profile via the per-request ?profile= scoping. Running one dashboard
@@ -12244,6 +12263,17 @@ def cmd_dashboard(args):
         )
 
     from hermes_cli.web_server import start_server
+
+    # ── Re-strip OAuth vars: web_server imports tui_gateway.server, whose
+    # own module-level load_hermes_dotenv() call reloads ~/.hermes/.env and
+    # re-populates HERMES_DASHBOARD_OAUTH_CLIENT_ID / HERMES_DASHBOARD_PUBLIC_URL
+    # after the strip above. Re-clear here, immediately before the auth gate
+    # (_maybe_setup_dashboard_auth_interactively / start_server) reads them,
+    # so an SSH-spawned isolated backend never picks up the public-dashboard's
+    # Portal OAuth config. See FF-CL-20260831-009/010.
+    if _token_file:
+        os.environ.pop("HERMES_DASHBOARD_OAUTH_CLIENT_ID", None)
+        os.environ.pop("HERMES_DASHBOARD_PUBLIC_URL", None)
 
     # Interactive auth setup: if this bind will engage the auth gate but no
     # provider is registered yet, offer to configure one here (TTY only)


### PR DESCRIPTION
## Summary

Desktop's SSH-spawned isolated dashboard backend (`--ssh-session-token-file`) was picking up `HERMES_DASHBOARD_OAUTH_CLIENT_ID` / `HERMES_DASHBOARD_PUBLIC_URL` from `~/.hermes/.env`, forcing `should_require_dashboard_auth()` to engage Nous Portal OAuth on a loopback-bound, token-only backend. This produces a repeating `401 unauthenticated`/`no_cookie` loop on Desktop's SSH reconnect path (Desktop shows a generic 'SSH connection failed' since the raw error doesn't match a known pattern in `classifySshError()`).

This looks related to #94119 (Windows Desktop registered SSH gateway stuck connecting) and the auth/readiness issues it references (#61457, #71515) — same symptom class (SSH-spawned backend never reaches a usable session due to an auth/session mismatch), though I can't confirm it's the *same* root cause on Windows without reproducing there. Filing this as its own fix since I have hard evidence for the Linux path.

## Root cause

Process-environment inheritance from the real public-dashboard service was the first suspect, but that's ruled out: neither var appears in the SSH-isolated backend's `/proc/<pid>/environ`.

The actual cause is two separate `load_hermes_dotenv()` calls that repopulate `os.environ` from `~/.hermes/.env` **inside the SSH-isolated backend process itself**, regardless of `--isolated` mode:
1. `hermes_cli/main.py`'s own module-import-time call
2. A second call inside `tui_gateway/server.py` (module-level), triggered transitively when `hermes_cli.web_server` is imported later in `cmd_dashboard()`

Neither has an SSH-isolated-mode carve-out, so a public-dashboard-only OAuth config value leaks into a backend that should only ever use its own token-based auth contract (see `_read_ssh_session_token_file`).

## Fix

Pop both vars from `os.environ` at the two points where they get (re)populated, gated on `args.ssh_session_token_file` being set — the same signal `cmd_dashboard()` already uses elsewhere to identify an SSH-isolated backend. No behavior change for any other launch path (`dashboard`, `serve` without an SSH token, etc). 30-line diff, single file.

## How I tested it

- **Isolated canary**: reproduced Desktop's exact launch command (`hermes serve --isolated --host 127.0.0.1 --port 0 --ssh-session-token-file ... --ssh-owner-nonce ...`) in an `env -i`-scrubbed shell (confirmed clean via `/proc/<pid>/environ`).
  - Pre-fix: backend refused to bind — `Refusing to bind dashboard to 127.0.0.1 — dashboard.public_url is set to https://...`, `/api/status` would have reported `auth_required=true, auth_providers=['nous']`.
  - Post-fix: backend bound cleanly, `/api/status` reports `auth_required=false, auth_providers=[]`.
- **Real Desktop SSH reconnect**: confirmed the freshly-spawned backend from an actual Desktop reconnect also reports `auth_required=false`, and the foreman (end user) confirmed Desktop reached a working session with no repeat of the 401 loop.
- **Regression check**: existing Desktop-SSH lifecycle suite — `npx vitest run electron/remote-lifecycle.test.ts` — 91/91 passed, no regression.

## Platforms tested

Linux (Ubuntu, x86_64 VPS). Have not reproduced or tested on Windows/macOS — flagging in case this is related to #94119's Windows-specific report, but not claiming it's confirmed to be the same bug there.