### PR TITLE
fix(slack): persist feedback-button clicks and emit feedback:received hook

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7638,21 +7638,80 @@ class SlackAdapter(BasePlatformAdapter):
                 exc_info=True,
             )
 
+    def _append_feedback_record(self, record: Dict[str, Any]) -> None:
+        """Persist a feedback-button click as one JSONL line under the home.
+
+        The rotating agent/gateway logs age feedback history out under real
+        traffic, so the durable sink lives in its own append-only file next
+        to them. Failures never break the click path — a lost record must
+        not cost the ack or the hook event.
+        """
+        try:
+            from hermes_constants import get_hermes_home, mkdir_under_hermes_home
+
+            log_dir = mkdir_under_hermes_home(get_hermes_home() / "logs")
+            with open(log_dir / "feedback.jsonl", "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except Exception:
+            logger.debug("[Slack] feedback record persist failed", exc_info=True)
+
     async def _handle_feedback_action(self, ack, body, action) -> None:
-        """Ack Slack AI feedback button clicks and log the choice."""
+        """Record Slack AI feedback button clicks for later analysis.
+
+        The click is acked immediately, appended to the durable feedback log
+        (``$HERMES_HOME/logs/feedback.jsonl``), and forwarded to the gateway
+        hook surface as ``feedback:received`` so operators can build their
+        own follow-ups — e.g. asking what went wrong on a negative click.
+        """
         await ack()
 
         value = str(action.get("value") or "")
         message = body.get("message", {}) or {}
         channel_id = (body.get("channel") or {}).get("id", "")
         user_id = (body.get("user") or {}).get("id", "")
+        msg_ts = str(message.get("ts") or "")
+        thread_ts = str(message.get("thread_ts") or "")
+        team_id = self._event_team_id({}, body)
+        record = {
+            "platform": "slack",
+            "value": value,
+            "user_id": user_id,
+            "channel_id": channel_id,
+            "message_ts": msg_ts,
+            "thread_ts": thread_ts,
+            "team_id": team_id,
+            "timestamp": time.time(),
+        }
+        self._append_feedback_record(record)
         logger.info(
             "[Slack] Feedback button clicked: value=%s user=%s channel=%s ts=%s",
             value,
             user_id,
             channel_id,
-            message.get("ts", ""),
+            msg_ts,
         )
+
+        # Forward through the shared gateway hook surface (the same one
+        # reaction:added/removed uses). getattr-guard: tests build adapters
+        # via object.__new__ without running __init__.
+        feedback_handler = getattr(self, "_reaction_handler", None)
+        if feedback_handler is not None:
+            try:
+                await feedback_handler(
+                    {
+                        "platform": "slack",
+                        "event_name": "feedback:received",
+                        "value": value,
+                        "user_id": user_id,
+                        "channel_id": channel_id,
+                        "message_ts": msg_ts,
+                        "thread_ts": thread_ts,
+                        "team_id": team_id,
+                        "raw_event": body,
+                    }
+                )
+            except Exception:  # pragma: no cover - hook contract is non-blocking
+                logger.debug("[Slack] feedback hook forwarding failed", exc_info=True)
 
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""

--- a/tests/gateway/test_slack_feedback_buttons.py
+++ b/tests/gateway/test_slack_feedback_buttons.py
@@ -1,0 +1,179 @@
+"""Durable sink + hook event for Slack AI feedback-button clicks (#99809)."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+handler_mod = MagicMock()
+handler_mod.AsyncSocketModeHandler = MagicMock
+sys.modules.setdefault("slack_bolt.adapter", MagicMock())
+sys.modules.setdefault("slack_bolt.adapter.socket_mode", MagicMock())
+sys.modules.setdefault(
+    "slack_bolt.adapter.socket_mode.async_handler", handler_mod
+)
+sdk_mod = MagicMock()
+sdk_mod.web = MagicMock()
+sdk_mod.web.async_client = MagicMock()
+sdk_mod.web.async_client.AsyncWebClient = MagicMock
+sys.modules.setdefault("slack_sdk", sdk_mod)
+sys.modules.setdefault("slack_sdk.web", sdk_mod.web)
+sys.modules.setdefault("slack_sdk.web.async_client", sdk_mod.web.async_client)
+bolt_mod = MagicMock()
+bolt_mod.async_app = MagicMock()
+bolt_mod.async_app.AsyncApp = MagicMock
+sys.modules.setdefault("slack_bolt", bolt_mod)
+sys.modules.setdefault("slack_bolt.async_app", bolt_mod.async_app)
+
+from gateway.config import PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="xoxb-test")
+    adapter = SlackAdapter(config)
+    adapter._app = MagicMock()
+    adapter._bot_user_id = "U_BOT"
+    adapter._team_clients = {"T1": AsyncMock()}
+    adapter._team_bot_user_ids = {"T1": "U_BOT"}
+    adapter._channel_team = {"C1": "T1"}
+    return adapter
+
+
+def _click_body(value="good", thread_ts=""):
+    message = {"ts": "1700.0002", "text": "Answer"}
+    if thread_ts:
+        message["thread_ts"] = thread_ts
+    return {
+        "team_id": "T1",
+        "channel": {"id": "C1"},
+        "user": {"id": "U1"},
+        "message": message,
+    }
+
+
+class TestFeedbackButtonsSink:
+    @pytest.mark.asyncio
+    async def test_click_appends_jsonl_record_under_home(self, tmp_path):
+        adapter = _make_adapter()
+        acked = []
+
+        async def _ack():
+            acked.append(True)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            await adapter._handle_feedback_action(
+                _ack, _click_body(thread_ts="1700.0001"), {"value": "good"}
+            )
+
+        assert acked == [True]
+        sink = tmp_path / "logs" / "feedback.jsonl"
+        assert sink.exists()
+        records = [json.loads(line) for line in sink.read_text().splitlines()]
+        assert len(records) == 1
+        record = records[0]
+        assert record["platform"] == "slack"
+        assert record["value"] == "good"
+        assert record["user_id"] == "U1"
+        assert record["channel_id"] == "C1"
+        assert record["message_ts"] == "1700.0002"
+        assert record["thread_ts"] == "1700.0001"
+        assert record["team_id"] == "T1"
+        assert isinstance(record["timestamp"], float)
+
+    @pytest.mark.asyncio
+    async def test_click_without_thread_records_empty_thread_ts(self, tmp_path):
+        adapter = _make_adapter()
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            await adapter._handle_feedback_action(
+                _noop_ack, _click_body(), {"value": "bad"}
+            )
+
+        record = json.loads(
+            (tmp_path / "logs" / "feedback.jsonl").read_text().splitlines()[0]
+        )
+        assert record["thread_ts"] == ""
+        assert record["value"] == "bad"
+
+    @pytest.mark.asyncio
+    async def test_persist_failure_does_not_break_ack(self, tmp_path):
+        adapter = _make_adapter()
+        acked = []
+
+        async def _ack():
+            acked.append(True)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with patch(
+                "plugins.platforms.slack.adapter.json.dumps",
+                side_effect=OSError("disk full"),
+            ):
+                await adapter._handle_feedback_action(
+                    _ack, _click_body(), {"value": "good"}
+                )
+
+        assert acked == [True]
+        sink = tmp_path / "logs" / "feedback.jsonl"
+        assert sink.read_text().strip() == ""
+
+
+class TestFeedbackButtonsHook:
+    @pytest.mark.asyncio
+    async def test_click_emits_feedback_received_hook(self):
+        adapter = _make_adapter()
+        hook_events = []
+
+        async def _hook(ctx):
+            hook_events.append(ctx)
+
+        adapter.set_reaction_handler(_hook)
+
+        await adapter._handle_feedback_action(
+            _noop_ack, _click_body(thread_ts="1700.0001"), {"value": "bad"}
+        )
+
+        assert len(hook_events) == 1
+        event = hook_events[0]
+        assert event["event_name"] == "feedback:received"
+        assert event["platform"] == "slack"
+        assert event["value"] == "bad"
+        assert event["user_id"] == "U1"
+        assert event["channel_id"] == "C1"
+        assert event["message_ts"] == "1700.0002"
+        assert event["thread_ts"] == "1700.0001"
+        assert event["team_id"] == "T1"
+        assert event["raw_event"]["user"]["id"] == "U1"
+
+    @pytest.mark.asyncio
+    async def test_click_without_handler_is_silent_noop(self, tmp_path):
+        adapter = _make_adapter()
+        assert adapter._reaction_handler is None
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            await adapter._handle_feedback_action(
+                _noop_ack, _click_body(), {"value": "good"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_hook_failure_does_not_raise(self, tmp_path):
+        adapter = _make_adapter()
+
+        async def _boom(ctx):
+            raise RuntimeError("hook consumer crashed")
+
+        adapter.set_reaction_handler(_boom)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            await adapter._handle_feedback_action(
+                _noop_ack, _click_body(), {"value": "good"}
+            )
+
+
+async def _noop_ack():
+    return None


### PR DESCRIPTION
Closes #99809.

## What

`_handle_feedback_action` acked the click and wrote one rotating-log line — the signal was effectively discarded. This wires both halves of the ask:

1. **Durable sink** — each click appends a JSONL record to `$HERMES_HOME/logs/feedback.jsonl` with `value`, `user_id`, `channel_id`, `message_ts`, `thread_ts`, `team_id`, `timestamp`. Persist failures log at debug and never break the ack/hook path.
2. **Hook event** — the click is forwarded through the existing `set_reaction_handler` gateway surface as `feedback:received` (same name scheme as `reaction:added`/`reaction:removed`), with the full normalized payload + `raw_event`, so operators can build follow-ups (e.g. "what went wrong?" on a negative click) without forking the adapter.

The handler is `getattr`-guarded exactly like the reaction path, so adapters built via `object.__new__` in tests stay unaffected.

## Tests

New `tests/gateway/test_slack_feedback_buttons.py` (6 tests): JSONL record shape incl. `thread_ts`/`team_id` capture, empty `thread_ts` for non-thread clicks, ack survives a persist failure, hook payload, silent no-op without a handler, hook-consumer crash doesn't propagate. Existing Slack suites still pass (264 passed, 1 skipped).