### PR TITLE
fix(auth): keep dead credentials out of pool fallback

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -764,19 +764,27 @@ def _resolve_api_key_provider_secret(
 
     # Fallback: try credential pool (e.g. zai key stored via auth.json)
     try:
-        from agent.credential_pool import load_pool
+        from agent.credential_pool import STATUS_EXHAUSTED, STATUS_OK, load_pool
         pool = load_pool(provider_id)
         if pool and pool.has_credentials():
-            # Prefer the pool's own selection (peek), but iterate the rest of
-            # the entries too so one malformed entry doesn't block a valid one.
+            # Prefer healthy entries.  Only explicitly exhausted entries may
+            # bypass pool availability so the real upstream 429/402 surfaces;
+            # dead and unknown states must never re-enter rotation here.
             candidates = []
             entry = pool.peek()
-            if entry is not None:
+            if entry is not None and getattr(entry, "last_status", None) in (
+                None,
+                STATUS_OK,
+            ):
                 candidates.append(entry)
             try:
-                for extra in pool.entries():
-                    if extra is not None and all(extra is not c for c in candidates):
-                        candidates.append(extra)
+                entries = pool.entries()
+                for status in (None, STATUS_OK, STATUS_EXHAUSTED):
+                    for extra in entries:
+                        if getattr(extra, "last_status", None) != status:
+                            continue
+                        if all(extra is not candidate for candidate in candidates):
+                            candidates.append(extra)
             except Exception:
                 pass
             for entry in candidates:

--- a/tests/hermes_cli/test_auth_key_prefix_skip.py
+++ b/tests/hermes_cli/test_auth_key_prefix_skip.py
@@ -19,6 +19,7 @@ The fix:
 
 import logging
 import os
+import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -48,7 +49,7 @@ def isolated_hermes_home(tmp_path, monkeypatch):
 
 def _write_env_file(home: Path, **kwargs) -> None:
     lines = [f"{k}={v}" for k, v in kwargs.items()]
-    (home / ".env").write_text("\n".join(lines) + "\n")
+    (home / ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
 
 def _mock_pool(*entries):
@@ -63,6 +64,7 @@ def _entry(token):
     e = MagicMock()
     e.access_token = token
     e.runtime_api_key = ""
+    e.last_status = None
     return e
 
 
@@ -87,6 +89,47 @@ class TestMalformedEnvKeySkipped:
         warnings = [r for r in caplog.records if "OPENROUTER_API_KEY" in r.getMessage()]
         assert warnings, "expected a WARNING naming the malformed env var"
         assert "sk-or-" in warnings[0].getMessage()
+
+    @pytest.mark.parametrize(
+        "status,expected_key,expected_source",
+        [
+            ("exhausted", "sk-or-v1-exhausted-key", "credential_pool:openrouter"),
+            ("dead", "", ""),
+        ],
+    )
+    def test_raw_pool_fallback_only_reuses_exhausted_entries(
+        self,
+        isolated_hermes_home,
+        status,
+        expected_key,
+        expected_source,
+    ):
+        """Exhausted keys may surface the upstream error; dead keys stay dead."""
+        from agent.credential_pool import CredentialPool, PooledCredential
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+
+        entry = PooledCredential(
+            provider="openrouter",
+            id=f"{status}-entry",
+            label=status,
+            auth_type="api_key",
+            priority=0,
+            source="manual",
+            access_token=f"sk-or-v1-{status}-key",
+            last_status=status,
+            last_status_at=time.time(),
+            last_error_reset_at=time.time() + 3600,
+        )
+        pool = CredentialPool("openrouter", [entry])
+
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            key, source = _resolve_api_key_provider_secret(
+                provider_id="openrouter",
+                pconfig=_make_pconfig("openrouter"),
+            )
+
+        assert key == expected_key
+        assert source == expected_source
 
     def test_malformed_env_key_with_empty_pool_returns_empty(
         self, isolated_hermes_home, caplog


### PR DESCRIPTION
## What does this PR do?

Keeps API-key credential-pool fallback from reviving permanently dead credentials.

The current resolver scans raw pool entries when `peek()` has no usable result. That is useful for explicitly exhausted credentials because retrying the stored key lets the provider surface its real 429/402 response instead of Hermes reporting a missing API key. However, the same scan also accepted `dead` and unknown credential states.

This change keeps healthy credentials first, allows the raw-entry fallback only for `exhausted`, and excludes `dead` or unknown states.

## Related Issue

Refs #40960

This is narrower than #40961 and #57137: current `main` already includes a raw-entry fallback, while this PR closes the remaining status boundary so terminal credentials do not re-enter rotation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/auth.py`: order healthy pool candidates before exhausted fallback entries and exclude dead/unknown states.
- `tests/hermes_cli/test_auth_key_prefix_skip.py`: cover exhausted-versus-dead fallback behavior with real `CredentialPool` entries; make the test fixture's `.env` write explicitly UTF-8.

## How to Test

1. Resolve a pool whose sole entry is explicitly `exhausted` and still in cooldown; the stored key should be returned so the upstream status can surface.
2. Resolve the same pool with the entry marked `dead`; resolution should return an empty key/source.
3. Run:

   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_auth_key_prefix_skip.py tests/hermes_cli/test_api_key_providers.py tests/agent/test_credential_pool.py -q
   ```

   Result: 176 passed, 0 failed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 under WSL2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused test suite: 176 passed, 0 failed.
