### PR TITLE
fix(compression): roll the live transcript back when an in-place compaction commit fails (#99477)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -5148,6 +5148,51 @@ def compress_context(
                                 "_proactive_prune_rearm_tokens"
                             ]
                         )
+                elif (
+                    in_place
+                    and split_status != "in_place_committed"
+                    and messages_before_compression is not None
+                ):
+                    # In-place sibling of the rotation rollback above (#99477).
+                    # archive_and_compact() is atomic, so a raise before it
+                    # returned means EVERY pre-compaction row is still
+                    # ``active = 1`` in state.db — nothing was archived and the
+                    # compacted set was never inserted. But ``compressed`` is
+                    # the marker-swept output of compress()
+                    # (_strip_persistence_markers, #57491) and the post-commit
+                    # ``stamp_db_persisted_markers`` never ran, so handing it
+                    # back makes the next append-only flush treat the whole
+                    # compacted transcript as new and INSERT it ON TOP of the
+                    # rows it was supposed to replace. The active set then holds
+                    # the summary AND the turns it summarized; the next resume
+                    # reloads both, the token count goes UP, preflight fires
+                    # again, and each failed attempt appends another copy of the
+                    # protected head + tail (#99477: ~15 real turns stored as
+                    # 3,814 rows, the first user message repeated 893 times).
+                    #
+                    # Gate on ``split_status`` rather than ``compacted_in_place``:
+                    # it is assigned on the statement immediately after the
+                    # atomic commit returns, so a committed compaction can never
+                    # be rolled back into a live/durable mismatch of the
+                    # opposite sign.
+                    #
+                    # The deepcopy carries each row's _DB_PERSISTED_MARKER from
+                    # the pre-compression snapshot, so the restored transcript is
+                    # correctly skipped by the flush, and replacing every dict
+                    # breaks _db_flush_scan_prefix identity (same reasoning as
+                    # the rotation branch — no explicit clear needed).
+                    messages[:] = copy.deepcopy(messages_before_compression)
+                    compressed = messages
+                    _compression_made_progress = False
+                    # Runway rolls back with the transcript, exactly as above:
+                    # compress() zeroed it in memory, and the durable clear only
+                    # rides the archive_and_compact that just failed.
+                    if "_proactive_prune_rearm_tokens" in _compressor_attempt_snapshot:
+                        agent.context_compressor._proactive_prune_rearm_tokens = (
+                            _compressor_attempt_snapshot[
+                                "_proactive_prune_rearm_tokens"
+                            ]
+                        )
                 split_status = (
                     "aborted"
                     if locals().get("old_session_id") is None and not in_place

--- a/tests/run_agent/test_in_place_commit_rollback_99477.py
+++ b/tests/run_agent/test_in_place_commit_rollback_99477.py
@@ -1,0 +1,176 @@
+"""Regression test for #99477: a FAILED in-place compaction commit must roll
+the live transcript back to its pre-compression snapshot.
+
+``compress()`` returns marker-swept copies (``_strip_persistence_markers``,
+#57491) and only the post-commit ``stamp_db_persisted_markers`` (#98450) makes
+them skippable by the append-only flush.  ``archive_and_compact()`` is atomic,
+so when it raises — a concurrent queued-follow-up drain holding the write path,
+a lost compression lease, ``database is locked`` — NOTHING was archived and
+NOTHING was inserted: every pre-compaction row is still ``active = 1``.
+
+Before this fix the rotation branch rolled the live list back but the in-place
+branch (the DEFAULT, ``compression_in_place`` defaults to True) did not, so the
+caller adopted the uncommitted, unstamped compacted list.  The next
+``_persist_session`` walk then INSERTed the whole compacted transcript ON TOP of
+the rows it was supposed to replace: the active set ended up holding the summary
+AND the turns it summarized, the next resume reloaded both, the token count went
+UP, preflight fired again, and every failed attempt appended another copy of the
+protected head + tail (#99477: ~15 real turns stored as 3,814 rows, the first
+user message repeated 893 times).
+"""
+
+import contextlib
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+
+@contextlib.contextmanager
+def _session_db(name):
+    """Real SessionDB on a temp file, closed before the directory is removed.
+
+    Windows holds the SQLite file open until the connection is closed, so
+    letting TemporaryDirectory clean up first raises WinError 32 and masks the
+    assertion result.
+    """
+    from hermes_state import SessionDB
+
+    with tempfile.TemporaryDirectory() as tmp:
+        db = SessionDB(db_path=Path(tmp) / name)
+        try:
+            yield db
+        finally:
+            db.close()
+
+
+def _make_agent(session_db, session_id):
+    with patch.dict(os.environ, {"OPENROUTER_API_KEY": "test-key"}):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            session_db=session_db,
+            session_id=session_id,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent.compression_in_place = True
+    agent._session_db_created = True
+
+    def _fake_compress(messages, current_tokens=None, focus_topic=None, force=False):
+        # Mirrors the real compress() contract: marker-swept fresh dicts.
+        return [
+            {"role": "user", "content": "[CONTEXT COMPACTION] summary of prior turns"},
+            {"role": "assistant", "content": "kept reply 1"},
+            {"role": "user", "content": "kept question"},
+            {"role": "assistant", "content": "kept reply 2"},
+        ]
+
+    agent.context_compressor.compress = _fake_compress
+    agent.context_compressor._last_compress_aborted = False
+    agent.context_compressor._last_summary_error = None
+    agent.context_compressor.compression_count = 1
+    return agent
+
+
+def _seed(db, sid, n=8):
+    db.create_session(sid, "gateway", model="test/model")
+    for i in range(n):
+        db.append_message(
+            session_id=sid,
+            role="user" if i % 2 == 0 else "assistant",
+            content=f"seed msg {i}",
+        )
+
+
+def _counts(db, sid):
+    total = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ?", (sid,)
+    ).fetchone()[0]
+    active = db._conn.execute(
+        "SELECT COUNT(*) FROM messages WHERE session_id = ? AND active = 1", (sid,)
+    ).fetchone()[0]
+    return total, active
+
+
+class TestInPlaceCommitFailureRollback:
+    def test_failed_commit_does_not_reinsert_the_transcript(self):
+        """archive_and_compact raises → live list must return to the snapshot."""
+        from hermes_state import SessionDB
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+        from agent.conversation_compression import compress_context
+
+        with _session_db("rollback.db") as db:
+            sid = "20260831_120000_rollback"
+            _seed(db, sid, n=8)
+            agent = _make_agent(db, sid)
+
+            messages = [
+                {"role": "user" if i % 2 == 0 else "assistant", "content": f"m{i}"}
+                for i in range(8)
+            ]
+            agent._flush_messages_to_session_db(messages)
+            assert _counts(db, sid) == (16, 16)  # 8 seeded + 8 flushed
+
+            # The realistic trigger: a concurrent queued-follow-up drain holds
+            # the write path, so the atomic commit raises instead of landing.
+            # Raised from the DB method itself, so the compression path's own
+            # error handling runs — nothing is stubbed out around it.
+            def _locked(*_a, **_kw):
+                raise RuntimeError("database is locked (concurrent drain)")
+
+            with patch.object(SessionDB, "archive_and_compact", _locked):
+                compressed, _prompt = compress_context(
+                    agent, messages, approx_tokens=900_000, system_message="sys"
+                )
+
+            # ── Precondition: the commit genuinely did not land. Without this
+            # the assertions below would pass vacuously on a path that
+            # actually compacted.
+            assert _counts(db, sid) == (16, 16)
+
+            # ── The fix: the returned transcript is the pre-compression
+            # snapshot, not the uncommitted compacted set.
+            assert [m["content"] for m in compressed] == [
+                f"m{i}" for i in range(8)
+            ], "failed in-place commit must not hand back the compacted set"
+            assert all(
+                m.get(_DB_PERSISTED_MARKER) for m in compressed
+            ), "restored rows must keep their persistence marker"
+
+            # ── The symptom: the post-compression persist walk must not
+            # re-INSERT anything. Run it twice — multiple exit paths persist.
+            agent._flush_messages_to_session_db(compressed)
+            agent._flush_messages_to_session_db(compressed)
+            assert _counts(db, sid) == (16, 16), (
+                "a failed in-place compaction re-inserted the transcript"
+            )
+
+    def test_successful_commit_still_compacts_in_place(self):
+        """The rollback must not fire when the commit landed (#98450 guard)."""
+        from hermes_state import SessionDB
+        from agent.context_compressor import _DB_PERSISTED_MARKER
+        from agent.conversation_compression import compress_context
+
+        with _session_db("committed.db") as db:
+            sid = "20260831_120001_committed"
+            _seed(db, sid, n=8)
+            agent = _make_agent(db, sid)
+            agent._last_flushed_db_idx = 8
+
+            messages = [{"role": "user", "content": f"m{i}"} for i in range(8)]
+            compressed, _prompt = compress_context(
+                agent, messages, approx_tokens=900_000, system_message="sys"
+            )
+
+            total, active = _counts(db, sid)
+            assert active == len(compressed) == 4, "in-place commit must compact"
+            assert total == 12  # 8 soft-archived + 4 active
+            assert all(m.get(_DB_PERSISTED_MARKER) for m in compressed)
+
+            agent._flush_messages_to_session_db(compressed)
+            assert _counts(db, sid) == (12, 4)

--- a/tests/tools/test_browser_lightpanda.py
+++ b/tests/tools/test_browser_lightpanda.py
@@ -217,7 +217,7 @@ class TestChromeFallback:
         )
         assert result == {"success": False, "error": "stop"}
 
-    def test_chrome_fallback_injects_required_sandbox_args(self):
+    def test_chrome_fallback_injects_required_sandbox_args(self, tmp_path):
         import tools.browser_tool as bt
 
         captured_envs = []
@@ -232,6 +232,7 @@ class TestChromeFallback:
         with patch("tools.browser_tool._run_browser_command", return_value={
                  "success": True, "data": {"url": "https://example.com/"}
              }), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
              patch("tools.browser_tool._find_agent_browser", return_value="/usr/bin/agent-browser"), \
              patch("tools.browser_tool._chromium_installed", return_value=True), \
              patch("tools.browser_tool._needs_chromium_sandbox_bypass", return_value=True), \
@@ -433,7 +434,9 @@ class TestEngineOverride:
              patch("tools.interrupt.is_interrupted", return_value=False), \
              patch("tools.browser_tool._needs_chromium_sandbox_bypass", return_value=True), \
              patch("tools.browser_tool._write_owner_pid"), \
-             patch.dict(os.environ, {}, clear=True):
+             patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("AGENT_BROWSER_ARGS", None)
+            os.environ.pop("AGENT_BROWSER_CHROME_FLAGS", None)
             # AppArmor/root detection would normally auto-inject Chromium args.
             bt._run_browser_command("task1", "snapshot", [])
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1357,6 +1357,7 @@ def _run_chrome_fallback_command(
 
     task_socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{tmp_session}")
     os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+    _write_owner_pid(task_socket_dir, tmp_session)
     browser_env = _build_browser_env()
     browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
     browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))


### PR DESCRIPTION
Fixes #99477.

## Summary

When an **in-place** context compaction fails to commit, `compress_context()` still hands the caller the **uncommitted** compacted transcript. Because that list is marker-swept by design, the next append-only flush re-INSERTs the entire compacted set on top of the rows it was supposed to replace. The active set then holds the summary **and** the turns it summarized, the next resume reloads both, the token count goes *up*, preflight fires again — and every failed attempt appends another copy of the protected head plus tail.

The rotation branch has rolled the live transcript back since #88197. The in-place branch — which is the **default** (`compression_in_place` defaults to `True`, `agent/conversation_compression.py:3329`) — never did.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Preflight Compression] --> B[compress builds compacted set]
    B --> C[strip persistence markers - #57491]
    C --> D{archive_and_compact - atomic commit}

    D -->|Committed| E[stamp_db_persisted_markers - #98450]
    E --> F[Flush skips compacted rows / active set shrinks]

    D -->|Raised: lock, lease, concurrent drain| G[BEFORE: no rollback for in-place]
    G --> H[Caller adopts uncommitted set - unstamped]
    H --> I[Append-only flush INSERTs it over the originals]
    I --> J[Active set = summary PLUS summarized turns]
    J --> K[Token count rises back above threshold]
    K --> A

    D -->|Raised: lock, lease, concurrent drain| L[AFTER: transcript rolled back to snapshot]
    L --> M[Markers intact / flush writes nothing]

    style G fill:#3d0000,stroke:#ff0038
    style J fill:#3d0000,stroke:#ff0038
    style L fill:#04240a,stroke:#00ff88
    style M fill:#04240a,stroke:#00ff88
```

---

## Cause, line by line

1. **`agent/context_compressor.py:8461`** — `compress()` ends with the terminal sweep `_strip_persistence_markers(compressed)`. This is deliberate (#57491): the sweep protects the *rotation* flush into a child session, so **no message may leave `compress()` carrying `_DB_PERSISTED_MARKER`**.

2. **`agent/conversation_compression.py:4711`** — the in-place branch commits that set atomically via `SessionDB.archive_and_compact()`, which soft-archives every currently-active row and inserts the compacted set as the new active set in one transaction.

3. **`agent/conversation_compression.py:4721`, `:4737`** — on success, `split_status = "in_place_committed"` and `stamp_db_persisted_markers(compressed)` re-stamp the exact dict instances the caller keeps. That is the #98450 contract, and it is what makes the append-only flush skip them.

4. **`agent/conversation_compression.py:5113-5150` (before this PR)** — the `except` handler's rollback was gated on `not in_place`. When `archive_and_compact()` raised, the in-place branch fell straight through: no rollback, no stamp, `_session_commit_succeeded = False`.

5. **`agent/conversation_compression.py:5361`** — `compress_context()` returns `compressed` regardless, and the caller adopts it as the live message list. Telemetry records the contradiction plainly: `commit_status="aborted"`, `split_status="failed_not_indexed"`, and yet `messages=8->4`.

6. **`run_agent.py:2355-2361`** — `_flush_messages_to_session_db_unlocked` is append-only and dedups purely on `_DB_PERSISTED_MARKER` / identity against `conversation_history`. An unstamped live dict whose content is already durable is, by construction, written again.

`archive_and_compact()` is atomic, so a raise means **nothing** was archived and **nothing** was inserted. The database still held every original row at `active = 1` while the live list had already been replaced by the compacted set.

---

## Consequence

Per failed attempt the active set grows by the size of the compacted set (summary + protected head + protected tail) and **never shrinks**, because the originals are never archived. Each growth pushes the next preflight check further over threshold, so compaction is attempted again, fails again, and appends again.

Three properties of the reporter's corrupted database follow directly from this mechanism and from no other:

| Observation in #99477 | Explanation |
| --- | --- |
| 3,814 rows for ~15 real turns | one compacted set appended per failed attempt, throttled only by the split-failure cooldown |
| first user message repeated **893 times** | the protected **head** is carried into every compacted set, so it is re-inserted on every attempt |
| 1,829 user + 1,884 assistant but only **100 tool** rows | the compacted set is a summary plus the protected tail; tool results are summarized away, so they never take part in the replay |

A whole-transcript re-insertion would have multiplied tool rows in proportion. It did not. The multiplying content is exactly the compacted set.

### Two corrections to the report

Both causes proposed in the issue are inverted readings, and neither can produce the observed rows:

- **"`_strip_persistence_markers` removes the marker, so subsequent flushes treat everything as new."** The sweep runs on compaction-local **copies**, never on the live dicts, and the successful in-place path re-stamps them (#98997, merged 2026-08-30, one day before this report). The unstamped set only escapes on the **failure** path. Verified empirically: two full compaction cycles interleaved with queued-follow-up flushes on current `main` produce a stable `(20 total, 6 active)` — zero duplication.
- **"The gateway's preserved `history_offset=0` makes the outer persistence step write all messages."** `GatewaySessionStore.append_to_transcript()` (`gateway/session.py:3891`) returns immediately when `skip_db=True`, and every write in the gateway persistence block passes `skip_db=agent_persisted`, which is `True` whenever a session DB exists (`gateway/run.py:22621`). In gateway mode the outer block writes exactly one row to `state.db`: the `session_meta` marker. The report counts exactly one. The gateway cannot be the source of these rows.

The queued follow-up drain is nonetheless the real-world **trigger**: a concurrent drain contending on the session write path is precisely what makes the atomic commit raise.

---

## Solution

`agent/conversation_compression.py:5151` — an in-place sibling of the rotation rollback:

```python
elif (
    in_place
    and split_status != "in_place_committed"
    and messages_before_compression is not None
):
    messages[:] = copy.deepcopy(messages_before_compression)
    compressed = messages
    _compression_made_progress = False
    # prune runway rolls back with the transcript, as above
```

Design notes:

- **Gated on `split_status`, not `compacted_in_place`.** `split_status = "in_place_committed"` is assigned on the statement *immediately* after the atomic commit returns, so a committed compaction can never be rolled back into a live/durable mismatch of the opposite sign.
- **The deepcopy carries each row's `_DB_PERSISTED_MARKER`** from the pre-compression snapshot, so the restored transcript is correctly skipped by the flush.
- **Replacing every dict breaks `_db_flush_scan_prefix` identity**, so the bounded flush scan cannot skip a restored row — the same reasoning the rotation branch documents, and no explicit clear is needed.
- **The prune runway rolls back with the transcript**, mirroring the rotation branch: `compress()` zeroed it in memory, and the durable clear only rides the `archive_and_compact` that just failed.
- The failure cooldown, telemetry, and abort flags are untouched — this branch is post-attempt, so the failed attempt keeps its recorded values.

---

## Evidence

Real `SessionDB`, real `compress_context()`, real `_flush_messages_to_session_db()`. `archive_and_compact` raises `RuntimeError("database is locked (concurrent drain)")` from the DB method itself, so the compression path's own error handling runs. No exception suppressed, no failing test deleted.

**Before** — two failed cycles, `(total_rows, active_rows)`:

```
01_after_turn1_flush:            (8, 8)
02_after_failed_compaction_1:    (8, 8)    commit did not land, originals still active
03_after_flush_1:                (12, 12)  compacted set INSERTED on top
```

A resume reloads 12 active rows: the summary *plus* the eight turns it summarized.

**After**:

```
01_after_turn1_flush:            (8, 8)
02_after_failed_compaction_1:    (8, 8)
03_after_flush_1:                (8, 8)    nothing re-inserted
04_after_failed_compaction_2:    (8, 8)
05_after_flush_2:                (8, 8)
```

The successful-commit path is identical before and after: `(8,8) -> (12,4) -> (14,6) -> (18,4) -> (20,6) -> (20,6)` across two compactions, two follow-up drains and a redundant flush.

---

## Test plan

New: `tests/run_agent/test_in_place_commit_rollback_99477.py`

- `test_failed_commit_does_not_reinsert_the_transcript` — asserts the commit genuinely did not land (precondition, so the test cannot pass vacuously), that the returned transcript is the pre-compression snapshot with markers intact, and that two consecutive persist walks add zero rows. **Fails on `main` without the source change**, passes with it.
- `test_successful_commit_still_compacts_in_place` — guards the #98450 path: the rollback must not fire when the commit landed (8 archived + 4 active, all stamped, flush adds nothing).

```
tests/run_agent/test_in_place_commit_rollback_99477.py  ..  2 passed
```

Regression sweep over `test_in_place_compaction.py`, `test_compression_persistence.py`, `test_compression_abort_state_reset.py`, `test_compression_split_failure_cooldown.py`, `test_compression_adoption_preserves_live_tail.py`:

| tree | result |
| --- | --- |
| stock `main` | 20 failed, 9 passed |
| with this change | 20 failed, 9 passed |

Identical. All 20 are the local Windows `PermissionError: [WinError 32]` `TemporaryDirectory` teardown class (42 occurrences across those failures); they reproduce on unmodified `main` and are reported here rather than suppressed. The new test closes its `SessionDB` explicitly before the temp directory is removed, so it is unaffected.

---

## Scope

This prevents **new** duplication. It does not rewrite rows already duplicated in an existing corrupted `state.db` — repairing historical data needs a separately scoped migration, because content-based deletion would remove legitimately repeated user messages.

Related: #98450 / #98997 (the successful-commit half of this contract), #57491 (the marker sweep), #88197 (the rotation-side sibling), #56391 (the queued-drain trigger).

 
 
