### PR TITLE
fix(slack): surface section.fields and context.elements in thread-parent text

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7959,6 +7959,23 @@ class SlackAdapter(BasePlatformAdapter):
                         section_text = (text_obj.get("text") or "").strip()
                         if section_text and section_text not in msg_text and all(section_text not in e for e in extras):
                             extras.append(section_text)
+                # ``section`` blocks can carry their content in ``fields``
+                # (e.g. webhook lead forms) and ``context`` blocks in
+                # ``elements`` — neither exposes a top-level ``text`` object,
+                # so both were silently dropped from thread-parent/context
+                # text. Surface them so the agent sees the full message.
+                sub_blocks = None
+                if block_type == "section":
+                    sub_blocks = block.get("fields")
+                elif block_type == "context":
+                    sub_blocks = block.get("elements")
+                if isinstance(sub_blocks, list):
+                    for sub in sub_blocks:
+                        if not isinstance(sub, dict):
+                            continue
+                        sub_text = (sub.get("text") or "").strip()
+                        if sub_text and sub_text not in msg_text and all(sub_text not in e for e in extras):
+                            extras.append(sub_text)
         # Legacy ``attachments`` (Alertmanager, Grafana, PagerDuty, CI bots):
         # apps often post with an empty ``text`` and the real content in
         # attachment fields or attachment-nested blocks.

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -4742,6 +4742,59 @@ class TestThreadImageContext:
 
         assert adapter._render_message_text(msg) == "run ```echo ok```"
 
+    def test_render_message_text_surfaces_section_fields_and_context_elements(
+        self, adapter
+    ):
+        """Webhook/bot lead forms put data in ``section.fields`` and
+        ``context.elements``, which have no top-level ``text`` object. Those
+        must not be dropped from thread-parent/context text."""
+        msg = {
+            "text": "New contact form submission — Dark Pro Shops",
+            "blocks": [
+                {
+                    "type": "header",
+                    "text": {
+                        "type": "plain_text",
+                        "text": "🎾 New Contact Form Submission — Dark Pro Shops",
+                        "emoji": True,
+                    },
+                },
+                {
+                    "type": "section",
+                    "fields": [
+                        {"type": "mrkdwn", "text": "*Site:*\nDark Pro Shops (darkproshops.com)"},
+                        {"type": "mrkdwn", "text": "*Business:*\nMartin Consulting"},
+                        {"type": "mrkdwn", "text": "*Email:*\nmvandiver@me.com"},
+                    ],
+                },
+                {
+                    "type": "section",
+                    "text": {
+                        "type": "mrkdwn",
+                        "text": "💬 *Message:*\nHi! I'd like to subscribe to weekly updates.",
+                    },
+                },
+                {
+                    "type": "context",
+                    "elements": [
+                        {
+                            "type": "mrkdwn",
+                            "text": "🌐 https://darkproshops.com/contact/\n⏰ 01/09/2026, 5:57:01 am  |  IP: 212.30.36.179",
+                        }
+                    ],
+                },
+            ],
+        }
+
+        rendered = adapter._render_message_text(msg)
+
+        assert "*Site:*\nDark Pro Shops (darkproshops.com)" in rendered
+        assert "*Business:*\nMartin Consulting" in rendered
+        assert "*Email:*\nmvandiver@me.com" in rendered
+        assert "💬 *Message:*" in rendered
+        assert "Hi! I'd like to subscribe to weekly updates." in rendered
+        assert "IP: 212.30.36.179" in rendered
+
     # -- integration: cold-start thread hydrate ----------------------------
 
     def _thread_event(self, text="<@U_BOT> what do you think of the chart?"):


### PR DESCRIPTION
## Problem

`SlackAdapter._render_message_text()` — used to render thread-parent and thread-context text for the agent — only read each block's top-level `text` object. Block Kit `section` blocks that carry content in `fields` (e.g. webhook lead/notification forms) and `context` blocks that carry content in `elements` (referrer/timestamp/IP metadata) have no top-level `text`, so their content was silently dropped.

Concretely: a Cloudflare Pages webhook posting a lead form (header + section with `fields` + section with `text` + context) rendered to the agent as only the `text` fallback + header + message section. The six form fields (Site/Business/Location/Contact/Phone/Email) and the context metadata were missing, so the agent triaging the thread never saw the lead's email or contact details.

## Fix

In `_render_message_text()`, additionally walk `section.fields` and `context.elements` (both arrays of `{type, text}` objects) and surface their text, with the same deduplication checks as the existing `text` handling.

## Test

Added `test_render_message_text_surfaces_section_fields_and_context_elements` reproducing the webhook lead-form block layout and asserting the field/element text is preserved. Verified RED before the fix (fields/elements dropped) and GREEN after.

## Scope

- `plugins/platforms/slack/adapter.py` — 17 insertions
- `tests/gateway/test_slack.py` — new unit test
