### PR TITLE
feat(skills): busy-terminal — a joke screensaver that fakes a coding session

### DIFF
--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -23,13 +23,15 @@ about the user's actual work and should never be presented as if it did.
 
 ## When to Use
 
-- The user asks for a terminal screensaver, an idle animation, or "make this
-  terminal look busy"
+Trigger on any of these, without asking a follow-up question:
+
+- "pretend I'm working" / "make it look like I'm working" / "look busy"
+- "start the fake work screensaver" / "busy terminal" / "fake coding"
 - The user wants an ambient background pane during a stream, demo, or recording
-- The user names it directly ("busy terminal", "fake work screensaver")
 
 Do not reach for this when the user wants real build, test, or git output —
-run the real thing with `terminal` instead.
+run the real thing with `terminal` instead. Never describe its output as if it
+reflected real work; it is invented and reports nothing about the repository.
 
 ## Prerequisites
 
@@ -40,20 +42,29 @@ redirected degrades to plain text automatically, as does setting `NO_COLOR`.
 
 ## How to Run
 
-Use the `terminal` tool. It runs until Ctrl-C unless given a `--duration`.
+Always pass `--window`. Run it through the `terminal` tool:
 
 ```bash
-python3 ~/.hermes/skills/creative/busy-terminal/scripts/busy_terminal.py
+python3 ~/.hermes/skills/creative/busy-terminal/scripts/busy_terminal.py \
+  --window --duration 600
 ```
 
-Prefer a bounded run when starting it on the user's behalf, so it cannot
-outlive their attention:
+`--window` opens a fresh terminal window on the user's screen, then returns
+immediately. Without it the animation writes into the agent's captured pipe,
+where there is no TTY to animate and — at the default unbounded duration — the
+turn never ends.
+
+Pick a `--duration` so the window cannot outlive the user's attention. Ten
+minutes is a good default; they can Ctrl-C sooner.
+
+Variants worth offering:
 
 ```bash
-python3 .../busy_terminal.py --duration 300        # five minutes
-python3 .../busy_terminal.py --scene tests --speed 2
-python3 .../busy_terminal.py --seed 7 --no-color   # reproducible, plain
+... --window --scene tests --speed 2   # one scene, faster
+... --window --duration 300            # five minutes
 ```
+
+The user can also run it themselves in any terminal, without `--window`.
 
 ## Quick Reference
 
@@ -64,6 +75,7 @@ python3 .../busy_terminal.py --seed 7 --no-color   # reproducible, plain
 | `--scene` | cycle | Pin one of `code`, `build`, `tests`, `git` |
 | `--seed` | random | Reproducible run |
 | `--no-color` | off | Plain text, no ANSI escapes |
+| `--window` | off | Open a new terminal window and return — use this from an agent |
 
 | Scene | What it shows |
 |-------|---------------|
@@ -74,20 +86,25 @@ python3 .../busy_terminal.py --seed 7 --no-color   # reproducible, plain
 
 ## Procedure
 
-1. Confirm the terminal is one the user can watch and interrupt — this takes
-   over the pane it runs in.
-2. Pick a `--duration` unless the user explicitly wants it open-ended.
-3. Launch it with `terminal`. Tell the user Ctrl-C stops it.
+1. Run the script with `--window` and a `--duration` via `terminal`.
+2. Tell the user a new window opened and that Ctrl-C in it stops the show.
+3. Suggest full screen and a larger font if they want it to fill the display.
 
 Scenes never repeat back to back; `next_scene` excludes the one that just
 played, so the cycle reads as varied rather than random-looking.
 
 ## Pitfalls
 
-- It owns the pane. Start it in a terminal the user is not working in, or they
-  will have to Ctrl-C to get their prompt back.
-- Backgrounding it (`terminal(background=True)`) is pointless — the output is
-  the entire feature and a background process writes it nowhere visible.
+- **Forgetting `--window` hangs the turn.** The default duration is unbounded,
+  so a captured run never returns and the user sees nothing.
+- It owns the pane it runs in. `--window` gives it its own, which is why that
+  is the agent's path.
+- Backgrounding it (`terminal(background=True)`) is not a substitute — the
+  output is the entire feature and a background process writes it nowhere
+  visible.
+- On Linux `--window` needs a terminal emulator on PATH; it raises
+  `NoTerminalError` naming the ones it tried. Over plain SSH with no emulator,
+  fall back to telling the user to run it without `--window`.
 - Under 40 columns the editor pane and artifact table wrap badly. `Console`
   floors the width at 40, but a genuinely tiny terminal still looks cramped.
 - `--speed` scales pauses, not content. Very high values (>10) reduce it to a

--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: busy-terminal
+description: "Joke screensaver faking a live coding session."
+version: 1.0.0
+author: "Luke The Dev (@iamlukethedev), Hermes Agent"
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [creative, screensaver, terminal, ascii, fun, animation]
+    category: creative
+---
+
+# Busy Terminal Skill
+
+Fills a terminal with an invented coding session — an editor typing source, a
+build, a test run, and git activity — cycling at random until stopped. It is a
+screensaver in the `cmatrix` / `genact` tradition.
+
+Nothing it prints is real. It reads no files, runs no commands, and opens no
+sockets; every path, SHA, and byte count is generated. It reports no status
+about the user's actual work and should never be presented as if it did.
+
+## When to Use
+
+- The user asks for a terminal screensaver, an idle animation, or "make this
+  terminal look busy"
+- The user wants an ambient background pane during a stream, demo, or recording
+- The user names it directly ("busy terminal", "fake work screensaver")
+
+Do not reach for this when the user wants real build, test, or git output —
+run the real thing with `terminal` instead.
+
+## Prerequisites
+
+Python 3.9+. No third-party packages, no API keys, no network.
+
+Colour needs a terminal that understands ANSI escapes. Output that is piped or
+redirected degrades to plain text automatically, as does setting `NO_COLOR`.
+
+## How to Run
+
+Use the `terminal` tool. It runs until Ctrl-C unless given a `--duration`.
+
+```bash
+python3 ~/.hermes/skills/creative/busy-terminal/scripts/busy_terminal.py
+```
+
+Prefer a bounded run when starting it on the user's behalf, so it cannot
+outlive their attention:
+
+```bash
+python3 .../busy_terminal.py --duration 300        # five minutes
+python3 .../busy_terminal.py --scene tests --speed 2
+python3 .../busy_terminal.py --seed 7 --no-color   # reproducible, plain
+```
+
+## Quick Reference
+
+| Flag | Default | Effect |
+|------|---------|--------|
+| `--duration` | `0` | Seconds to run; `0` means until Ctrl-C |
+| `--speed` | `1.0` | Time multiplier — `2` is twice as fast |
+| `--scene` | cycle | Pin one of `code`, `build`, `tests`, `git` |
+| `--seed` | random | Reproducible run |
+| `--no-color` | off | Plain text, no ANSI escapes |
+
+| Scene | What it shows |
+|-------|---------------|
+| `code` | Editor pane, line numbers, source typed and highlighted |
+| `build` | Vite / Cargo / Docker output, progress bar, artifact sizes |
+| `tests` | Pytest-style dots, pass–fail summary, occasional flake retry |
+| `git` | Commit, push with delta compression, CI checks going green |
+
+## Procedure
+
+1. Confirm the terminal is one the user can watch and interrupt — this takes
+   over the pane it runs in.
+2. Pick a `--duration` unless the user explicitly wants it open-ended.
+3. Launch it with `terminal`. Tell the user Ctrl-C stops it.
+
+Scenes never repeat back to back; `next_scene` excludes the one that just
+played, so the cycle reads as varied rather than random-looking.
+
+## Pitfalls
+
+- It owns the pane. Start it in a terminal the user is not working in, or they
+  will have to Ctrl-C to get their prompt back.
+- Backgrounding it (`terminal(background=True)`) is pointless — the output is
+  the entire feature and a background process writes it nowhere visible.
+- Under 40 columns the editor pane and artifact table wrap badly. `Console`
+  floors the width at 40, but a genuinely tiny terminal still looks cramped.
+- `--speed` scales pauses, not content. Very high values (>10) reduce it to a
+  wall of text with no rhythm.
+
+## Verification
+
+- Output appears within a second and keeps scrolling
+- Over a few minutes all four scenes appear, none twice in a row
+- Ctrl-C exits cleanly and the cursor comes back (no invisible prompt)
+- `--no-color` output contains no `\033[` sequences
+- Two runs with the same `--seed` produce the same transcript

--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: busy-terminal
 description: "Joke screensaver: fake coding or Hollywood hacking."
-version: 1.2.0
+version: 1.3.0
 author: "Luke The Dev (@iamlukethedev), Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
@@ -95,7 +95,7 @@ The user can also run it themselves in any terminal, without `--window`.
 | `tests` | developer | Pytest-style dots, pass–fail summary, occasional flake retry |
 | `git` | developer | Commit, push with delta compression, CI checks going green |
 | `matrix` | hacker | Digital rain with bright heads and dimming trails |
-| `warroom` | hacker | Rain behind several live panes, password dialog floating on top |
+| `warroom` | hacker | Rain behind live panes (red/green accents), four floating dialogs |
 | `intrusion` | hacker | Port scan, brute-force, ACCESS GRANTED banner, exfil bar |
 | `crack` | hacker | Hex spray, then an AES key locking in byte by byte |
 
@@ -131,7 +131,9 @@ played, so the cycle reads as varied rather than random-looking.
 - The matrix rain and the war room need ANSI cursor addressing; piped or
   `--no-color` output degrades them to scrolling lines on purpose.
 - The war room shines at generous sizes — panes that would come out under
-  14×4 cells are dropped, so a tiny terminal shows fewer windows.
+  14×4 cells are dropped, and the three corner dialogs (perimeter alert,
+  proxy chain, exfil meter) only appear at 70×20 or larger. The password
+  centerpiece always shows.
 - The hacker profile is theatre, not technique — keep targets and loot inside
   the shipped fictional pools if you ever extend the pools.
 

--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: busy-terminal
 description: "Joke screensaver: fake coding or Hollywood hacking."
-version: 1.3.0
+version: 1.4.0
 author: "Luke The Dev (@iamlukethedev), Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
@@ -31,12 +31,13 @@ and should never be presented as if it did.
 Trigger on any of these, without asking a follow-up question:
 
 - "pretend I'm working" / "make it look like I'm working" / "look busy"
-  → `--profile developer`
+  / "fake coding" → `--profile developer`
 - "hacker mode" / "make me look like a movie hacker" / "Hollywood hacking"
-  / "matrix mode" / "digital rain" → `--profile hacker`
-- "start the fake work screensaver" / "busy terminal" / "fake coding"
-  → `--profile developer`, or `mixed` if they ask for everything
-- The user wants an ambient background pane during a stream, demo, or recording
+  / "matrix mode" / "digital rain" / "several windows" / "the screensaver"
+  / "busy terminal" → `--profile hacker`
+- Ambiguous, or the user is testing the feature → `--profile hacker` (the
+  war room opens first). Never launch a bare `--window --duration` and rely
+  on an old default — always pass `--profile` explicitly.
 
 Do not reach for this when the user wants real build, test, or git output —
 run the real thing with `terminal` instead. Never describe its output as if it
@@ -55,7 +56,7 @@ Always pass `--window`. Run it through the `terminal` tool:
 
 ```bash
 python3 ~/.hermes/skills/creative/busy-terminal/scripts/busy_terminal.py \
-  --window --duration 600
+  --window --profile hacker --duration 600
 ```
 
 `--window` opens a fresh terminal window on the user's screen, then returns
@@ -69,9 +70,9 @@ minutes is a good default; they can Ctrl-C sooner.
 Variants worth offering:
 
 ```bash
-... --window --profile hacker --duration 300   # five minutes of Hollywood
-... --window --scene matrix                    # just the rain, on repeat
-... --window --scene tests --speed 2           # one scene, faster
+... --window --profile developer --duration 600   # fake coding, no rain
+... --window --scene warroom --duration 180       # just the multi-window poster
+... --window --scene matrix                       # just the rain
 ```
 
 The user can also run it themselves in any terminal, without `--window`.
@@ -80,7 +81,7 @@ The user can also run it themselves in any terminal, without `--window`.
 
 | Flag | Default | Effect |
 |------|---------|--------|
-| `--profile` | `developer` | Scene set: `developer`, `hacker`, or `mixed` |
+| `--profile` | `hacker` | Scene set: `hacker`, `developer`, or `mixed` |
 | `--duration` | `0` | Seconds to run; `0` means until Ctrl-C |
 | `--speed` | `1.0` | Time multiplier — `2` is twice as fast |
 | `--scene` | cycle | Pin one scene on repeat (overrides the profile) |
@@ -102,9 +103,10 @@ The user can also run it themselves in any terminal, without `--window`.
 ## Procedure
 
 1. Pick the profile from the user's phrasing (see When to Use); default to
-   `developer` when it is ambiguous.
+   `hacker` when it is ambiguous. Always pass `--profile` on the command
+   line — do not omit it.
 2. Run the script with `--window`, the profile, and a `--duration` via
-   `terminal`.
+   `terminal`. The war room opens first on the hacker rotation.
 3. Tell the user a new window opened and that Ctrl-C in it stops the show.
 4. Suggest full screen and a larger font if they want it to fill the display —
    the matrix rain especially earns it.

--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: busy-terminal
 description: "Joke screensaver: fake coding or Hollywood hacking."
-version: 1.1.0
+version: 1.2.0
 author: "Luke The Dev (@iamlukethedev), Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
@@ -15,9 +15,10 @@ metadata:
 
 Fills a terminal with invented activity, cycling scenes at random until
 stopped. Two profiles: `developer` fakes honest work (editor, build, tests,
-git) and `hacker` fakes the movie kind (digital rain, an intrusion ending in
-ACCESS GRANTED, a key crack). `mixed` interleaves both. It is a screensaver in
-the `cmatrix` / `genact` / Hollywood-hacker tradition.
+git) and `hacker` fakes the movie kind (digital rain, a multi-window war room
+with a password-matching dialog, an intrusion ending in ACCESS GRANTED, a key
+crack). `mixed` interleaves both. It is a screensaver in the `cmatrix` /
+`genact` / Hollywood-hacker tradition.
 
 Nothing it prints is real. It reads no files, runs no commands, and opens no
 sockets; every path, SHA, and byte count is generated, and the hacker
@@ -94,6 +95,7 @@ The user can also run it themselves in any terminal, without `--window`.
 | `tests` | developer | Pytest-style dots, pass–fail summary, occasional flake retry |
 | `git` | developer | Commit, push with delta compression, CI checks going green |
 | `matrix` | hacker | Digital rain with bright heads and dimming trails |
+| `warroom` | hacker | Rain behind several live panes, password dialog floating on top |
 | `intrusion` | hacker | Port scan, brute-force, ACCESS GRANTED banner, exfil bar |
 | `crack` | hacker | Hex spray, then an AES key locking in byte by byte |
 
@@ -126,8 +128,10 @@ played, so the cycle reads as varied rather than random-looking.
   floors the width at 40, but a genuinely tiny terminal still looks cramped.
 - `--speed` scales pauses, not content. Very high values (>10) reduce it to a
   wall of text with no rhythm.
-- The matrix rain needs ANSI cursor addressing; piped or `--no-color` output
-  degrades it to scrolling glyph lines on purpose.
+- The matrix rain and the war room need ANSI cursor addressing; piped or
+  `--no-color` output degrades them to scrolling lines on purpose.
+- The war room shines at generous sizes — panes that would come out under
+  14×4 cells are dropped, so a tiny terminal shows fewer windows.
 - The hacker profile is theatre, not technique — keep targets and loot inside
   the shipped fictional pools if you ever extend the pools.
 

--- a/optional-skills/creative/busy-terminal/SKILL.md
+++ b/optional-skills/creative/busy-terminal/SKILL.md
@@ -1,32 +1,40 @@
 ---
 name: busy-terminal
-description: "Joke screensaver faking a live coding session."
-version: 1.0.0
+description: "Joke screensaver: fake coding or Hollywood hacking."
+version: 1.1.0
 author: "Luke The Dev (@iamlukethedev), Hermes Agent"
 license: MIT
 platforms: [linux, macos, windows]
 metadata:
   hermes:
-    tags: [creative, screensaver, terminal, ascii, fun, animation]
+    tags: [creative, screensaver, terminal, ascii, fun, animation, matrix, hacker]
     category: creative
 ---
 
 # Busy Terminal Skill
 
-Fills a terminal with an invented coding session — an editor typing source, a
-build, a test run, and git activity — cycling at random until stopped. It is a
-screensaver in the `cmatrix` / `genact` tradition.
+Fills a terminal with invented activity, cycling scenes at random until
+stopped. Two profiles: `developer` fakes honest work (editor, build, tests,
+git) and `hacker` fakes the movie kind (digital rain, an intrusion ending in
+ACCESS GRANTED, a key crack). `mixed` interleaves both. It is a screensaver in
+the `cmatrix` / `genact` / Hollywood-hacker tradition.
 
 Nothing it prints is real. It reads no files, runs no commands, and opens no
-sockets; every path, SHA, and byte count is generated. It reports no status
-about the user's actual work and should never be presented as if it did.
+sockets; every path, SHA, and byte count is generated, and the hacker
+profile's "targets" are RFC 5737 documentation addresses on example.* hosts,
+unroutable by construction. It reports no status about the user's actual work
+and should never be presented as if it did.
 
 ## When to Use
 
 Trigger on any of these, without asking a follow-up question:
 
 - "pretend I'm working" / "make it look like I'm working" / "look busy"
+  → `--profile developer`
+- "hacker mode" / "make me look like a movie hacker" / "Hollywood hacking"
+  / "matrix mode" / "digital rain" → `--profile hacker`
 - "start the fake work screensaver" / "busy terminal" / "fake coding"
+  → `--profile developer`, or `mixed` if they ask for everything
 - The user wants an ambient background pane during a stream, demo, or recording
 
 Do not reach for this when the user wants real build, test, or git output —
@@ -60,8 +68,9 @@ minutes is a good default; they can Ctrl-C sooner.
 Variants worth offering:
 
 ```bash
-... --window --scene tests --speed 2   # one scene, faster
-... --window --duration 300            # five minutes
+... --window --profile hacker --duration 300   # five minutes of Hollywood
+... --window --scene matrix                    # just the rain, on repeat
+... --window --scene tests --speed 2           # one scene, faster
 ```
 
 The user can also run it themselves in any terminal, without `--window`.
@@ -70,25 +79,33 @@ The user can also run it themselves in any terminal, without `--window`.
 
 | Flag | Default | Effect |
 |------|---------|--------|
+| `--profile` | `developer` | Scene set: `developer`, `hacker`, or `mixed` |
 | `--duration` | `0` | Seconds to run; `0` means until Ctrl-C |
 | `--speed` | `1.0` | Time multiplier — `2` is twice as fast |
-| `--scene` | cycle | Pin one of `code`, `build`, `tests`, `git` |
+| `--scene` | cycle | Pin one scene on repeat (overrides the profile) |
 | `--seed` | random | Reproducible run |
 | `--no-color` | off | Plain text, no ANSI escapes |
 | `--window` | off | Open a new terminal window and return — use this from an agent |
 
-| Scene | What it shows |
-|-------|---------------|
-| `code` | Editor pane, line numbers, source typed and highlighted |
-| `build` | Vite / Cargo / Docker output, progress bar, artifact sizes |
-| `tests` | Pytest-style dots, pass–fail summary, occasional flake retry |
-| `git` | Commit, push with delta compression, CI checks going green |
+| Scene | Profile | What it shows |
+|-------|---------|---------------|
+| `code` | developer | Editor pane, line numbers, source typed and highlighted |
+| `build` | developer | Vite / Cargo / Docker output, progress bar, artifact sizes |
+| `tests` | developer | Pytest-style dots, pass–fail summary, occasional flake retry |
+| `git` | developer | Commit, push with delta compression, CI checks going green |
+| `matrix` | hacker | Digital rain with bright heads and dimming trails |
+| `intrusion` | hacker | Port scan, brute-force, ACCESS GRANTED banner, exfil bar |
+| `crack` | hacker | Hex spray, then an AES key locking in byte by byte |
 
 ## Procedure
 
-1. Run the script with `--window` and a `--duration` via `terminal`.
-2. Tell the user a new window opened and that Ctrl-C in it stops the show.
-3. Suggest full screen and a larger font if they want it to fill the display.
+1. Pick the profile from the user's phrasing (see When to Use); default to
+   `developer` when it is ambiguous.
+2. Run the script with `--window`, the profile, and a `--duration` via
+   `terminal`.
+3. Tell the user a new window opened and that Ctrl-C in it stops the show.
+4. Suggest full screen and a larger font if they want it to fill the display —
+   the matrix rain especially earns it.
 
 Scenes never repeat back to back; `next_scene` excludes the one that just
 played, so the cycle reads as varied rather than random-looking.
@@ -109,11 +126,17 @@ played, so the cycle reads as varied rather than random-looking.
   floors the width at 40, but a genuinely tiny terminal still looks cramped.
 - `--speed` scales pauses, not content. Very high values (>10) reduce it to a
   wall of text with no rhythm.
+- The matrix rain needs ANSI cursor addressing; piped or `--no-color` output
+  degrades it to scrolling glyph lines on purpose.
+- The hacker profile is theatre, not technique — keep targets and loot inside
+  the shipped fictional pools if you ever extend the pools.
 
 ## Verification
 
 - Output appears within a second and keeps scrolling
-- Over a few minutes all four scenes appear, none twice in a row
+- Over a few minutes every scene in the chosen profile appears, none twice in
+  a row
+- `--profile hacker` reaches the ACCESS GRANTED banner and a fully locked key
 - Ctrl-C exits cleanly and the cursor comes back (no invisible prompt)
 - `--no-color` output contains no `\033[` sequences
 - Two runs with the same `--seed` produce the same transcript

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -1,0 +1,667 @@
+#!/usr/bin/env python3
+"""Fake a busy coding session in the terminal.
+
+Four scenes cycle in random order: an editor typing source, a build, a test
+run, and git activity. Every byte is invented — no file is read or written, no
+command runs, nothing touches the network. This is a joke screensaver in the
+`cmatrix` tradition, not a tool.
+
+    python3 busy_terminal.py                 # until Ctrl-C
+    python3 busy_terminal.py --duration 120  # two minutes, then exit
+    python3 busy_terminal.py --scene tests   # one scene on repeat
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import random
+import re
+import shutil
+import sys
+import time
+from typing import Callable, Sequence, TextIO
+
+SCENES = ("code", "build", "tests", "git")
+
+RESET = "\033[0m"
+BOLD = "\033[1m"
+GREY = "\033[38;5;244m"
+RED = "\033[38;5;203m"
+GREEN = "\033[38;5;114m"
+YELLOW = "\033[38;5;180m"
+BLUE = "\033[38;5;75m"
+MAGENTA = "\033[38;5;176m"
+CYAN = "\033[38;5;80m"
+ORANGE = "\033[38;5;215m"
+
+CLEAR_SCREEN = "\033[2J\033[H"
+HIDE_CURSOR = "\033[?25l"
+SHOW_CURSOR = "\033[?25h"
+
+
+# ── Console ──────────────────────────────────────────────────────────────────
+
+
+class Console:
+    """The only surface a scene is allowed to touch.
+
+    Output and timing are injected rather than hardcoded to stdout and
+    ``time.sleep`` so a test can drive an entire scene against a fake clock and
+    capture the frames instead of sleeping through them.
+    """
+
+    def __init__(
+        self,
+        *,
+        width: int = 100,
+        height: int = 30,
+        color: bool = True,
+        speed: float = 1.0,
+        write: Callable[[str], None] | None = None,
+        sleep: Callable[[float], None] | None = None,
+    ) -> None:
+        self.width = max(40, width)
+        self.height = max(10, height)
+        self.color = color
+        self.speed = speed if speed > 0 else 1.0
+        self._write = write if write is not None else _stdout_writer
+        self._sleep = sleep if sleep is not None else time.sleep
+
+    def paint(self, text: str = "") -> None:
+        """Emit text with no trailing newline."""
+        self._write(text)
+
+    def line(self, text: str = "") -> None:
+        self._write(text + "\n")
+
+    def pause(self, seconds: float) -> None:
+        """Sleep, scaled by --speed. Never negative, never a busy-wait."""
+        self._sleep(max(0.0, seconds) / self.speed)
+
+    def tint(self, text: str, code: str) -> str:
+        return f"{code}{text}{RESET}" if self.color else text
+
+    def clear(self) -> None:
+        if self.color:
+            self._write(CLEAR_SCREEN)
+
+
+def _stdout_writer(text: str) -> None:
+    sys.stdout.write(text)
+    sys.stdout.flush()
+
+
+# ── Pure formatters ──────────────────────────────────────────────────────────
+
+
+def progress_bar(done: float, total: float, width: int = 28) -> str:
+    """A fixed-width bar. Out-of-range input clamps instead of overflowing."""
+    width = max(1, width)
+    fraction = 0.0 if total <= 0 else done / total
+    fraction = min(1.0, max(0.0, fraction))
+    filled = round(fraction * width)
+
+    return "█" * filled + "░" * (width - filled)
+
+
+def human_bytes(count: float) -> str:
+    """Byte count as a short human string (1536 -> '1.5 KiB')."""
+    step = 1024.0
+    for unit in ("B", "KiB", "MiB", "GiB"):
+        if abs(count) < step or unit == "GiB":
+            return f"{count:.0f} {unit}" if unit == "B" else f"{count:.1f} {unit}"
+        count /= step
+
+    return f"{count:.1f} GiB"
+
+
+def next_scene(rng: random.Random, last: str = "", scenes: Sequence[str] = SCENES) -> str:
+    """Pick the next scene, never the one that just played.
+
+    Back-to-back repeats are what make a shuffle look broken, so they are
+    excluded rather than left to chance. A one-scene catalog still returns
+    that scene — the rule yields rather than looping forever.
+    """
+    options = [scene for scene in scenes if scene != last] or list(scenes)
+
+    return rng.choice(options)
+
+
+def test_summary(passed: int, failed: int, skipped: int, seconds: float) -> str:
+    """The pytest-style tail line. Failures lead when there are any."""
+    parts = []
+    if failed:
+        parts.append(f"{failed} failed")
+    parts.append(f"{passed} passed")
+    if skipped:
+        parts.append(f"{skipped} skipped")
+
+    return f"{', '.join(parts)} in {seconds:.2f}s"
+
+
+# ── Syntax highlighting ──────────────────────────────────────────────────────
+
+KEYWORDS = {
+    "python": {
+        "async", "await", "class", "def", "elif", "else", "except", "finally",
+        "for", "from", "if", "import", "in", "is", "not", "raise", "return",
+        "try", "while", "with", "yield", "None", "True", "False",
+    },
+    "ts": {
+        "async", "await", "const", "export", "function", "if", "import",
+        "interface", "let", "new", "return", "type", "useEffect", "useState",
+        "from", "null", "true", "false",
+    },
+    "go": {
+        "defer", "err", "for", "func", "if", "import", "nil", "package",
+        "range", "return", "struct", "type", "var",
+    },
+    "rust": {
+        "as", "enum", "fn", "impl", "let", "match", "mod", "mut", "pub",
+        "return", "self", "struct", "use", "while", "Some", "None", "Ok", "Err",
+    },
+}
+
+_TOKEN = re.compile(
+    r"(?P<comment>#.*$|//.*$)"
+    r"|(?P<string>\"(?:[^\"\\]|\\.)*\"|'(?:[^'\\]|\\.)*')"
+    r"|(?P<number>\b\d+(?:\.\d+)?\b)"
+    r"|(?P<word>[A-Za-z_][A-Za-z_0-9]*)"
+)
+
+
+def highlight(line: str, language: str, color: bool = True) -> str:
+    """Tint keywords, strings, comments, and numbers. A no-op without color."""
+    if not color:
+        return line
+
+    keywords = KEYWORDS.get(language, set())
+
+    def paint(match: re.Match[str]) -> str:
+        text = match.group(0)
+        kind = match.lastgroup
+        if kind == "comment":
+            return f"{GREY}{text}{RESET}"
+        if kind == "string":
+            return f"{GREEN}{text}{RESET}"
+        if kind == "number":
+            return f"{ORANGE}{text}{RESET}"
+        if kind == "word" and text in keywords:
+            return f"{MAGENTA}{text}{RESET}"
+
+        return text
+
+    return _TOKEN.sub(paint, line)
+
+
+# ── Content ──────────────────────────────────────────────────────────────────
+
+REPO = "~/work/atlas"
+
+BRANCHES = ("feat/ingest-backoff", "fix/session-leak", "feat/live-query", "chore/deps")
+
+SOURCES: tuple[tuple[str, str, tuple[str, ...]], ...] = (
+    (
+        "services/ingest/retry.py",
+        "python",
+        (
+            "import asyncio",
+            "import random",
+            "from typing import Awaitable, Callable, TypeVar",
+            "",
+            'T = TypeVar("T")',
+            "",
+            "",
+            "async def with_backoff(",
+            "    call: Callable[[], Awaitable[T]],",
+            "    attempts: int = 5,",
+            "    base: float = 0.25,",
+            ") -> T:",
+            '    """Retry an awaitable with jittered exponential backoff."""',
+            "    last = None",
+            "    for attempt in range(attempts):",
+            "        try:",
+            "            return await call()",
+            "        except TransientError as exc:",
+            "            last = exc",
+            "            delay = base * 2 ** attempt",
+            "            # Jitter keeps a thundering herd from resynchronising.",
+            "            await asyncio.sleep(delay + random.random() * base)",
+            "    raise RetryExhausted(attempts) from last",
+        ),
+    ),
+    (
+        "web/src/hooks/use-live-query.ts",
+        "ts",
+        (
+            "import { useEffect, useState } from 'react'",
+            "",
+            "interface LiveQuery<T> {",
+            "  data: T | null",
+            "  error: Error | null",
+            "  stale: boolean",
+            "}",
+            "",
+            "export function useLiveQuery<T>(key: string): LiveQuery<T> {",
+            "  const [data, setData] = useState<T | null>(null)",
+            "  const [error, setError] = useState<Error | null>(null)",
+            "",
+            "  useEffect(() => {",
+            "    let cancelled = false",
+            "    subscribe(key, next => {",
+            "      // A late frame must never overwrite newer intent.",
+            "      if (!cancelled) setData(next)",
+            "    }).catch(setError)",
+            "",
+            "    return () => {",
+            "      cancelled = true",
+            "    }",
+            "  }, [key])",
+            "",
+            "  return { data, error, stale: data === null }",
+            "}",
+        ),
+    ),
+    (
+        "internal/api/handler.go",
+        "go",
+        (
+            "package api",
+            "",
+            "import (",
+            '    "encoding/json"',
+            '    "net/http"',
+            '    "time"',
+            ")",
+            "",
+            "func (s *Server) handleSnapshot(w http.ResponseWriter, r *http.Request) {",
+            "    ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)",
+            "    defer cancel()",
+            "",
+            "    snap, err := s.store.Snapshot(ctx, chi.URLParam(r, \"id\"))",
+            "    if err != nil {",
+            "        s.fail(w, http.StatusBadGateway, err)",
+            "        return",
+            "    }",
+            "",
+            "    w.Header().Set(\"Cache-Control\", \"no-store\")",
+            "    json.NewEncoder(w).Encode(snap)",
+            "}",
+        ),
+    ),
+    (
+        "crates/parser/src/lexer.rs",
+        "rust",
+        (
+            "use std::str::Chars;",
+            "",
+            "pub struct Lexer<'a> {",
+            "    chars: Chars<'a>,",
+            "    offset: usize,",
+            "}",
+            "",
+            "impl<'a> Lexer<'a> {",
+            "    pub fn next_token(&mut self) -> Option<Token> {",
+            "        let start = self.offset;",
+            "        match self.bump()? {",
+            "            c if c.is_whitespace() => self.next_token(),",
+            "            // A bare '-' is a minus; '->' is an arrow.",
+            "            '-' if self.peek() == Some('>') => Some(Token::Arrow),",
+            "            c if c.is_ascii_digit() => Some(self.number(start)),",
+            "            _ => Some(Token::Unknown(start)),",
+            "        }",
+            "    }",
+            "}",
+        ),
+    ),
+)
+
+BUILDS = (
+    (
+        "npm run build",
+        "vite v5.4.11 building for production...",
+        (
+            "web/assets/index-4f21ac.js",
+            "web/assets/vendor-9cb0e1.js",
+            "web/assets/index-0b7714.css",
+        ),
+    ),
+    (
+        "cargo build --release",
+        "   Compiling atlas-parser v0.9.3",
+        (
+            "target/release/atlas",
+            "target/release/atlas-parser.rlib",
+        ),
+    ),
+    (
+        "docker build -t atlas/ingest:dev .",
+        "=> [internal] load build definition from Dockerfile",
+        (
+            "layer sha256:9c1b4f2a",
+            "layer sha256:2fd0aa71",
+        ),
+    ),
+)
+
+TEST_FILES = (
+    "tests/ingest/test_backoff.py",
+    "tests/api/test_snapshot.py",
+    "tests/store/test_lineage.py",
+    "tests/web/use-live-query.test.ts",
+    "tests/parser/test_lexer.py",
+)
+
+COMMIT_SUBJECTS = (
+    "fix(ingest): jitter the backoff so retries stop resynchronising",
+    "feat(api): cache-bust snapshot responses behind a short timeout",
+    "refactor(parser): fold the arrow case into next_token",
+    "fix(web): drop a late frame instead of overwriting newer state",
+    "test(store): pin the lineage invariant across compression",
+)
+
+CI_CHECKS = (
+    "lint / ruff",
+    "tests / python 3.12",
+    "tests / node 22",
+    "build / linux-amd64",
+    "supply-chain / audit",
+)
+
+
+# ── Scenes ───────────────────────────────────────────────────────────────────
+
+
+def type_out(
+    console: Console,
+    text: str,
+    *,
+    prefix: str = "",
+    language: str = "",
+    rng: random.Random,
+) -> None:
+    """Type a line a character at a time, then repaint it highlighted.
+
+    Highlighting a partial line would recolor tokens as they grow, which reads
+    as flicker; typing plain and repainting once at the end looks like an
+    editor catching up. The repaint returns to column 0, so it has to redraw
+    `prefix` (the line-number gutter) or the code slides left over it.
+    """
+    if prefix:
+        console.paint(prefix)
+
+    for char in text:
+        console.paint(char)
+        console.pause(rng.uniform(0.004, 0.028) if char != " " else 0.006)
+
+    if language and console.color:
+        console.paint("\r" + prefix + highlight(text, language, console.color))
+    console.line()
+
+
+def prompt(console: Console, command: str, rng: random.Random) -> None:
+    """The shell prompt plus a typed-out command."""
+    console.paint(console.tint(REPO, BLUE) + console.tint(" ❯ ", GREEN))
+    for char in command:
+        console.paint(char)
+        console.pause(rng.uniform(0.012, 0.05))
+    console.line()
+    console.pause(0.35)
+
+
+def scene_code(console: Console, rng: random.Random) -> None:
+    """An editor pane filling with source, line numbers and all."""
+    path, language, lines = rng.choice(SOURCES)
+
+    console.clear()
+    console.line(console.tint(f"  {path}", BOLD) + console.tint("   ● unsaved", ORANGE))
+    console.line(console.tint("  " + "─" * (console.width - 4), GREY))
+
+    for number, text in enumerate(lines, start=1):
+        gutter = console.tint(f"{number:>4} │ ", GREY)
+        type_out(console, text, prefix=gutter, language=language, rng=rng)
+
+        # Every so often, stop and stare at it like a person would.
+        if rng.random() < 0.12:
+            console.pause(rng.uniform(0.4, 1.1))
+
+    console.line()
+    console.pause(0.5)
+    console.line(console.tint("  saved", GREEN) + console.tint(f"  {path}", GREY))
+    console.pause(1.2)
+
+
+def scene_build(console: Console, rng: random.Random) -> None:
+    """A build with staged progress and an artifact table."""
+    command, banner, artifacts = rng.choice(BUILDS)
+
+    console.line()
+    prompt(console, command, rng)
+    console.line(console.tint(banner, GREY))
+
+    total = rng.randint(180, 940)
+    step = max(1, total // rng.randint(12, 20))
+    done = 0
+    while done < total:
+        done = min(total, done + step)
+        bar = progress_bar(done, total)
+        console.paint(f"\r{console.tint(bar, CYAN)} {done}/{total} modules")
+        console.pause(rng.uniform(0.05, 0.16))
+
+    console.line()
+    console.line()
+    for artifact in artifacts:
+        size = rng.uniform(12_000, 940_000)
+        gzip = size / rng.uniform(2.8, 4.1)
+        console.line(
+            console.tint(f"  {artifact:<34}", GREY)
+            + console.tint(f"{human_bytes(size):>10}", YELLOW)
+            + console.tint(f"  │ gzip: {human_bytes(gzip):>9}", GREY)
+        )
+        console.pause(0.14)
+
+    console.line()
+    console.line(console.tint(f"  ✓ built in {rng.uniform(3.2, 24.0):.2f}s", GREEN))
+    console.pause(1.4)
+
+
+def scene_tests(console: Console, rng: random.Random) -> None:
+    """A test run that mostly passes, occasionally retries a flake."""
+    console.line()
+    prompt(console, "pytest -q", rng)
+
+    passed = 0
+    failed = 0
+    skipped = 0
+    for path in rng.sample(TEST_FILES, k=rng.randint(3, len(TEST_FILES))):
+        console.paint(console.tint(f"  {path:<38}", GREY))
+        for _ in range(rng.randint(6, 26)):
+            roll = rng.random()
+            if roll < 0.02:
+                failed += 1
+                console.paint(console.tint("F", RED))
+            elif roll < 0.05:
+                skipped += 1
+                console.paint(console.tint("s", YELLOW))
+            else:
+                passed += 1
+                console.paint(console.tint(".", GREEN))
+            console.pause(rng.uniform(0.01, 0.07))
+        console.line()
+
+    seconds = rng.uniform(1.8, 19.4)
+    console.line()
+    summary = test_summary(passed, failed, skipped, seconds)
+    console.line(console.tint(f"  {summary}", RED if failed else GREEN))
+
+    if failed:
+        console.pause(0.8)
+        console.line(console.tint("  rerunning the failure in isolation…", GREY))
+        console.pause(rng.uniform(1.0, 2.0))
+        console.line(console.tint("  ✓ passed on retry — flake, not a break", GREEN))
+
+    console.pause(1.4)
+
+
+def scene_git(console: Console, rng: random.Random) -> None:
+    """Commit, push, then CI checks going green one at a time."""
+    branch = rng.choice(BRANCHES)
+    subject = rng.choice(COMMIT_SUBJECTS)
+    sha = "".join(rng.choice("0123456789abcdef") for _ in range(7))
+
+    console.line()
+    prompt(console, f'git commit -am "{subject}"', rng)
+    files = rng.randint(2, 9)
+    console.line(console.tint(f"[{branch} {sha}]", GREY) + f" {subject}")
+    console.line(
+        console.tint(
+            f" {files} files changed, "
+            f"{rng.randint(18, 240)} insertions(+), {rng.randint(3, 90)} deletions(-)",
+            GREY,
+        )
+    )
+    console.pause(0.9)
+
+    prompt(console, f"git push origin {branch}", rng)
+    objects = rng.randint(14, 61)
+    for label, count in (("Counting objects", objects), ("Compressing objects", objects // 2)):
+        for index in range(1, count + 1):
+            percent = round(index / count * 100)
+            console.paint(f"\r{console.tint(label, GREY)}: {percent:>3}% ({index}/{count})")
+            console.pause(0.012)
+        console.line(", done.")
+
+    written = rng.uniform(2_000, 96_000)
+    console.line(
+        console.tint("Writing objects", GREY)
+        + f": 100% ({objects}/{objects}), {human_bytes(written)}, done."
+    )
+    console.pause(0.6)
+    console.line(console.tint(f"remote: Resolving deltas: 100% ({objects}/{objects}), done.", GREY))
+    console.line("To github.com:atlas/atlas.git")
+    console.line(console.tint(f"   {sha}..{sha[::-1]}  {branch} -> {branch}", GREY))
+    console.line()
+
+    console.pause(0.8)
+    console.line(console.tint("  CI", BOLD))
+    for check in rng.sample(CI_CHECKS, k=rng.randint(3, len(CI_CHECKS))):
+        console.paint(console.tint(f"    ● {check}", YELLOW))
+        console.pause(rng.uniform(0.5, 1.6))
+        console.paint("\r" + console.tint(f"    ✓ {check}", GREEN) + "\n")
+
+    console.pause(1.4)
+
+
+SCENE_RUNNERS: dict[str, Callable[[Console, random.Random], None]] = {
+    "code": scene_code,
+    "build": scene_build,
+    "tests": scene_tests,
+    "git": scene_git,
+}
+
+
+def run(
+    console: Console,
+    rng: random.Random,
+    *,
+    scene: str = "",
+    duration: float = 0.0,
+    now: Callable[[], float] = time.monotonic,
+) -> int:
+    """Cycle scenes until `duration` elapses. Returns how many ran.
+
+    `duration <= 0` means forever, so the caller (not this loop) owns the exit
+    condition — Ctrl-C in the CLI, a fixed scene count in a test.
+    """
+    started = now()
+    played = 0
+    last = ""
+
+    while True:
+        last = scene or next_scene(rng, last)
+        SCENE_RUNNERS[last](console, rng)
+        played += 1
+
+        if duration > 0 and now() - started >= duration:
+            return played
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def supports_color(stream: TextIO, requested: bool) -> bool:
+    """Colour when asked for it, the stream is a TTY, and NO_COLOR is unset."""
+    if not requested or os.environ.get("NO_COLOR"):
+        return False
+
+    return bool(getattr(stream, "isatty", lambda: False)())
+
+
+def _enable_windows_ansi() -> None:
+    """Turn on VT processing so the escapes mean something on Windows."""
+    if sys.platform != "win32":
+        return
+
+    try:
+        import ctypes
+
+        kernel32 = ctypes.windll.kernel32
+        kernel32.SetConsoleMode(kernel32.GetStdHandle(-11), 7)
+    except Exception:
+        # An old console just gets no colour; the animation still runs.
+        pass
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="busy_terminal.py",
+        description="A joke screensaver that fakes a busy coding session.",
+    )
+    parser.add_argument(
+        "--duration", type=float, default=0.0,
+        help="Seconds to run. 0 (default) runs until Ctrl-C.",
+    )
+    parser.add_argument(
+        "--speed", type=float, default=1.0,
+        help="Time multiplier. 2 is twice as fast, 0.5 half.",
+    )
+    parser.add_argument(
+        "--scene", choices=SCENES, default="",
+        help="Play one scene on repeat instead of cycling.",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Seed for a reproducible run.")
+    parser.add_argument("--no-color", action="store_true", help="Plain text, no ANSI escapes.")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    _enable_windows_ansi()
+
+    size = shutil.get_terminal_size(fallback=(100, 30))
+    console = Console(
+        width=size.columns,
+        height=size.lines,
+        color=supports_color(sys.stdout, not args.no_color),
+        speed=args.speed,
+    )
+    rng = random.Random(args.seed)
+
+    if console.color:
+        console.paint(HIDE_CURSOR)
+    try:
+        run(console, rng, scene=args.scene, duration=args.duration)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if console.color:
+            console.paint(SHOW_CURSOR + RESET)
+        console.line()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -2,13 +2,18 @@
 """Fake a busy coding session in the terminal.
 
 Four scenes cycle in random order: an editor typing source, a build, a test
-run, and git activity. Every byte is invented — no file is read or written, no
-command runs, nothing touches the network. This is a joke screensaver in the
-`cmatrix` tradition, not a tool.
+run, and git activity. Every byte the scenes print is invented — no file is
+read or written, no command runs, nothing touches the network. This is a joke
+screensaver in the `cmatrix` tradition, not a tool.
 
     python3 busy_terminal.py                 # until Ctrl-C
     python3 busy_terminal.py --duration 120  # two minutes, then exit
     python3 busy_terminal.py --scene tests   # one scene on repeat
+    python3 busy_terminal.py --window        # open a new terminal, return now
+
+`--window` is the one thing here that starts a process: it re-launches this
+script inside a fresh terminal window and exits. An agent needs it, because a
+captured pipe has no TTY to animate and an unbounded run would never return.
 """
 
 from __future__ import annotations
@@ -17,9 +22,12 @@ import argparse
 import os
 import random
 import re
+import shlex
 import shutil
+import subprocess
 import sys
 import time
+from pathlib import Path
 from typing import Callable, Sequence, TextIO
 
 SCENES = ("code", "build", "tests", "git")
@@ -587,6 +595,85 @@ def run(
             return played
 
 
+# ── Launching a visible window ───────────────────────────────────────────────
+
+LINUX_TERMINALS = (
+    ("x-terminal-emulator", ("-e",)),
+    ("gnome-terminal", ("--",)),
+    ("konsole", ("-e",)),
+    ("xfce4-terminal", ("-e",)),
+    ("alacritty", ("-e",)),
+    ("kitty", ("--",)),
+    ("xterm", ("-e",)),
+)
+
+
+class NoTerminalError(RuntimeError):
+    """No terminal emulator on this machine can host the screensaver."""
+
+
+def applescript_string(text: str) -> str:
+    """Quote text as an AppleScript string literal."""
+    return '"' + text.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def window_argv(
+    command: str,
+    platform: str,
+    which: Callable[[str], str | None] = shutil.which,
+) -> list[str]:
+    """Build the argv that runs `command` in a NEW visible terminal window.
+
+    Takes the platform as data rather than reading `sys.platform`, so all three
+    branches are checkable from one host.
+    """
+    if platform == "darwin":
+        return [
+            "osascript",
+            "-e", f"tell application \"Terminal\" to do script {applescript_string(command)}",
+            "-e", 'tell application "Terminal" to activate',
+        ]
+
+    if platform == "win32":
+        return ["cmd", "/c", "start", "", "cmd", "/k", command]
+
+    for emulator, flags in LINUX_TERMINALS:
+        if which(emulator):
+            # `sh -c` normalises the argument shape across emulators.
+            return [emulator, *flags, "sh", "-c", command]
+
+    raise NoTerminalError(
+        "no terminal emulator found (tried: "
+        + ", ".join(name for name, _ in LINUX_TERMINALS)
+        + ")"
+    )
+
+
+def relaunch_command(argv: Sequence[str], script: str = "", python: str = "") -> str:
+    """The shell command that re-runs this script without `--window`."""
+    parts = [
+        python or sys.executable,
+        script or str(Path(__file__).resolve()),
+        *[arg for arg in argv if arg != "--window"],
+    ]
+
+    return " ".join(shlex.quote(part) for part in parts)
+
+
+def open_in_window(
+    argv: Sequence[str],
+    *,
+    platform: str = sys.platform,
+    spawn: Callable[..., object] = subprocess.Popen,
+    which: Callable[[str], str | None] = shutil.which,
+) -> int:
+    """Start the screensaver in its own window and return immediately."""
+    command = window_argv(relaunch_command(argv), platform, which)
+    spawn(command)
+
+    return 0
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 
@@ -632,12 +719,21 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--seed", type=int, default=None, help="Seed for a reproducible run.")
     parser.add_argument("--no-color", action="store_true", help="Plain text, no ANSI escapes.")
+    parser.add_argument(
+        "--window", action="store_true",
+        help="Open a new terminal window running this, then exit. Use this from an agent.",
+    )
 
     return parser
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    args = build_parser().parse_args(argv)
+    raw = list(sys.argv[1:] if argv is None else argv)
+    args = build_parser().parse_args(raw)
+
+    if args.window:
+        return open_in_window(raw)
+
     _enable_windows_ansi()
 
     size = shutil.get_terminal_size(fallback=(100, 30))

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -35,11 +35,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Sequence, TextIO
 
-SCENES = ("code", "build", "tests", "git", "matrix", "intrusion", "crack")
+SCENES = ("code", "build", "tests", "git", "matrix", "warroom", "intrusion", "crack")
 
 PROFILES: dict[str, tuple[str, ...]] = {
     "developer": ("code", "build", "tests", "git"),
-    "hacker": ("matrix", "intrusion", "crack"),
+    "hacker": ("matrix", "warroom", "intrusion", "crack"),
     "mixed": SCENES,
 }
 
@@ -419,6 +419,8 @@ LOOT = (
     "/opt/mainframe/schematics.zip",
 )
 
+PASSWORDS = ("Tr1n1ty-1999", "sw0rdf1sh", "Z10N-4cc3ss", "m0rph3us#7")
+
 
 # ── Scenes ───────────────────────────────────────────────────────────────────
 
@@ -611,6 +613,43 @@ def move_to(row: int, col: int) -> str:
     return f"\033[{row};{col}H"
 
 
+def fit(text: str, width: int) -> str:
+    """Clip or pad to exactly `width` — pane content must never spill out."""
+    if width <= 0:
+        return ""
+
+    return text[:width].ljust(width)
+
+
+@dataclass(frozen=True)
+class Rect:
+    """A window rectangle in 1-based terminal cells, borders included."""
+
+    top: int
+    left: int
+    width: int
+    height: int
+
+    @property
+    def bottom(self) -> int:
+        return self.top + self.height - 1
+
+    @property
+    def right(self) -> int:
+        return self.left + self.width - 1
+
+    def contains(self, row: int, col: int) -> bool:
+        return self.top <= row <= self.bottom and self.left <= col <= self.right
+
+    def overlaps(self, other: "Rect") -> bool:
+        return not (
+            self.right < other.left
+            or other.right < self.left
+            or self.bottom < other.top
+            or other.bottom < self.top
+        )
+
+
 @dataclass
 class Drop:
     """One falling column of digital rain."""
@@ -635,12 +674,22 @@ def spawn_drop(col: int, height: int, rng: random.Random) -> Drop:
     )
 
 
-def rain_step(drops: list[Drop], height: int, rng: random.Random) -> str:
+def rain_step(
+    drops: list[Drop],
+    height: int,
+    rng: random.Random,
+    avoid: Sequence[Rect] = (),
+) -> str:
     """Advance every drop one tick and return the whole frame as one string.
 
     One write per frame is the point: per-cell writes flicker and swamp the
-    terminal with flushes.
+    terminal with flushes. Cells inside `avoid` are never touched, so the rain
+    flows around the war-room windows instead of scribbling through them.
     """
+
+    def open_cell(row: int, col: int) -> bool:
+        return 1 <= row <= height and not any(rect.contains(row, col) for rect in avoid)
+
     parts = [MATRIX_BODY]
     for index, drop in enumerate(drops):
         prev = int(drop.row)
@@ -648,16 +697,16 @@ def rain_step(drops: list[Drop], height: int, rng: random.Random) -> str:
         head = int(drop.row)
 
         if head != prev:
-            if 1 <= head <= height:
+            if open_cell(head, drop.col):
                 parts.append(
                     move_to(head, drop.col)
                     + MATRIX_HEAD + rng.choice(MATRIX_GLYPHS) + RESET + MATRIX_BODY
                 )
             # The old head dims into the trail body.
-            if 1 <= prev <= height:
+            if open_cell(prev, drop.col):
                 parts.append(move_to(prev, drop.col) + rng.choice(MATRIX_GLYPHS))
             tail = head - drop.trail
-            if 1 <= tail <= height:
+            if open_cell(tail, drop.col):
                 parts.append(move_to(tail, drop.col) + " ")
 
         if drop.row - drop.trail > height:
@@ -700,6 +749,225 @@ def scene_matrix(console: Console, rng: random.Random) -> None:
         console.pause(0.9)
     console.paint(RESET)
     console.pause(1.2)
+
+
+# ── The war room: several live windows over the rain ────────────────────────
+
+
+def warroom_layout(width: int, height: int) -> dict[str, Rect]:
+    """Window rectangles scaled to the terminal.
+
+    Panes never overlap each other — none of them re-stamps on the others'
+    cadence, so overlap would scribble. The dialog is the one exception: it
+    floats over everything because it is re-stamped into every frame, last.
+    Panes that would come out too small to read are dropped rather than
+    squeezed.
+    """
+    rects: dict[str, Rect] = {}
+    left_w = (width - 6) // 2
+    right_w = width - 6 - left_w
+    top_h = (height - 5) // 2
+    bottom_h = height - 5 - top_h
+
+    candidates = {
+        "memdump": Rect(top=2, left=2, width=left_w, height=top_h),
+        "uplink": Rect(top=2, left=left_w + 4, width=right_w, height=height - 3),
+        "intercept": Rect(top=top_h + 3, left=2, width=left_w, height=bottom_h),
+    }
+    for name, rect in candidates.items():
+        if rect.width >= 14 and rect.height >= 4:
+            rects[name] = rect
+
+    dialog_width = min(36, width - 4)
+    rects["dialog"] = Rect(
+        top=max(1, height // 2 - 2),
+        left=max(1, (width - dialog_width) // 2),
+        width=dialog_width,
+        height=5,
+    )
+
+    return rects
+
+
+@dataclass
+class Pane:
+    """One live window: a box, a text tone, and a feed that fills it."""
+
+    rect: Rect
+    title: str
+    tone: str
+    feed: Callable[[random.Random, int], str]
+    period: int
+    reveal: int
+    lines: list[str]
+
+
+def feed_hex(rng: random.Random, width: int) -> str:
+    """A memdump row: offset, then as many hex pairs as fit."""
+    pairs = max(1, (width - 7) // 3)
+    body = " ".join(f"{rng.randrange(256):02x}" for _ in range(pairs))
+
+    return f"{rng.randrange(0x10000):04x}: {body}"
+
+
+def feed_intercept(rng: random.Random, width: int) -> str:
+    return (
+        f"pkt {rng.randrange(10000):04d} ▸ 203.0.113.{rng.randrange(1, 255)}:443"
+        f" · TLS1.3 · {rng.uniform(0.2, 9.9):.1f} KiB"
+    )
+
+
+def feed_trace(rng: random.Random, width: int) -> str:
+    return (
+        f"hop {rng.randrange(2, 15):02d}  {rng.uniform(4.0, 240.0):6.1f} ms"
+        f"  relay-{rng.randrange(10):02d}.example.net"
+    )
+
+
+def box_stamp(console: Console, rect: Rect, title: str, tone: str) -> str:
+    """Paint a window frame with a blank interior, in one string."""
+    label = title[: max(0, rect.width - 6)]
+    top = "┌─ " + label + " " + "─" * (rect.width - len(label) - 5) + "┐"
+    parts = [move_to(rect.top, rect.left) + console.tint(top, tone)]
+    for row in range(rect.top + 1, rect.bottom):
+        parts.append(
+            move_to(row, rect.left)
+            + console.tint("│" + " " * (rect.width - 2) + "│", tone)
+        )
+    parts.append(
+        move_to(rect.bottom, rect.left)
+        + console.tint("└" + "─" * (rect.width - 2) + "┘", tone)
+    )
+
+    return "".join(parts)
+
+
+def interior_stamp(console: Console, pane: Pane) -> str:
+    """Repaint a pane's content area, bottom-aligned like a scrolling log."""
+    inner_rows = pane.rect.height - 2
+    inner_width = pane.rect.width - 4
+    visible = pane.lines[-inner_rows:]
+    padded = [""] * (inner_rows - len(visible)) + visible
+
+    parts = []
+    for offset, line in enumerate(padded):
+        parts.append(
+            move_to(pane.rect.top + 1 + offset, pane.rect.left + 2)
+            + console.tint(fit(line, inner_width), pane.tone)
+        )
+
+    return "".join(parts)
+
+
+def dialog_stamp(
+    console: Console,
+    rect: Rect,
+    password: str,
+    locked: int,
+    rng: random.Random,
+) -> str:
+    """The floating centerpiece: masked characters locking in one by one."""
+    granted = locked >= len(password)
+    tone = GREEN if granted else CYAN
+    title = "ACCESS GRANTED" if granted else "MATCHING PASSWORD"
+
+    cells = []
+    for index, char in enumerate(password):
+        if index < locked:
+            cells.append(console.tint(char, BOLD + GREEN))
+        elif rng.random() < 0.14:
+            cells.append(console.tint(rng.choice("0123456789ABCDEF"), CYAN))
+        else:
+            cells.append(console.tint("▪", GREY))
+
+    inner_width = rect.width - 4
+    row = " ".join(cells)
+    pad = max(0, (inner_width - (len(password) * 2 - 1)) // 2)
+    status = f"{locked}/{len(password)} matched" if not granted else "session key accepted"
+
+    return (
+        box_stamp(console, rect, title, BOLD + tone if granted else tone)
+        + move_to(rect.top + 2, rect.left + 2) + " " * pad + row
+        + move_to(rect.top + 3, rect.left + 2)
+        + console.tint(fit(status.center(inner_width), inner_width), GREY)
+    )
+
+
+def scene_warroom(console: Console, rng: random.Random) -> None:
+    """The full movie set: rain behind several live panes, dialog on top."""
+    if not console.color:
+        # No cursor addressing — interleave the feeds as a flat log instead.
+        for _ in range(rng.randint(24, 40)):
+            roll = rng.random()
+            if roll < 0.4:
+                console.line(feed_intercept(rng, console.width - 2))
+            elif roll < 0.7:
+                console.line(feed_hex(rng, console.width - 2))
+            else:
+                console.line(feed_trace(rng, console.width - 2))
+            console.pause(0.06)
+        console.line(f"[dialog] password matched ({rng.randint(6, 14)} candidates)")
+        console.pause(1.0)
+
+        return
+
+    console.clear()
+    layout = warroom_layout(console.width, console.height)
+    dialog_rect = layout.pop("dialog")
+
+    dressing = {
+        "memdump": (feed_hex, GREY),
+        "uplink": (feed_intercept, GREEN),
+        "intercept": (feed_trace, CYAN),
+    }
+    panes = []
+    for index, name in enumerate(sorted(layout)):
+        feed, tone = dressing[name]
+        panes.append(
+            Pane(
+                rect=layout[name],
+                title=name,
+                tone=tone,
+                feed=feed,
+                period=rng.randint(3, 6),
+                reveal=6 + index * rng.randint(6, 10),
+                lines=[],
+            )
+        )
+
+    drops = [spawn_drop(col, console.height, rng) for col in range(1, console.width, 2)]
+    password = rng.choice(PASSWORDS)
+    dialog_at = rng.randint(40, 60)
+    lock_every = rng.randint(7, 11)
+    locked = 0
+    total = dialog_at + lock_every * len(password) + 24
+
+    for tick in range(total):
+        parts = []
+        shown = [pane.rect for pane in panes if tick >= pane.reveal]
+        if tick >= dialog_at:
+            shown.append(dialog_rect)
+        parts.append(rain_step(drops, console.height, rng, avoid=shown))
+
+        for pane in panes:
+            if tick == pane.reveal:
+                parts.append(box_stamp(console, pane.rect, pane.title, pane.tone))
+            elif tick > pane.reveal and (tick - pane.reveal) % pane.period == 0:
+                pane.lines.append(pane.feed(rng, pane.rect.width - 4))
+                pane.lines = pane.lines[-(pane.rect.height - 2):]
+                parts.append(interior_stamp(console, pane))
+
+        if tick >= dialog_at:
+            if locked < len(password) and tick > dialog_at and (tick - dialog_at) % lock_every == 0:
+                locked += 1
+            # Stamped last, every tick — that is what lets it float over panes.
+            parts.append(dialog_stamp(console, dialog_rect, password, locked, rng))
+
+        console.paint("".join(parts))
+        console.pause(0.05)
+
+    console.clear()
+    console.pause(0.5)
 
 
 def scene_intrusion(console: Console, rng: random.Random) -> None:
@@ -812,6 +1080,7 @@ SCENE_RUNNERS: dict[str, Callable[[Console, random.Random], None]] = {
     "tests": scene_tests,
     "git": scene_git,
     "matrix": scene_matrix,
+    "warroom": scene_warroom,
     "intrusion": scene_intrusion,
     "crack": scene_crack,
 }

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -786,12 +786,23 @@ def warroom_layout(width: int, height: int) -> dict[str, Rect]:
         height=5,
     )
 
+    # The three corner dialogs only exist on generous terminals, in bands the
+    # password dialog never reaches, so the four floaters stay readable.
+    if width >= 70 and height >= 20:
+        rects["alert"] = Rect(top=3, left=width - 28, width=24, height=4)
+        rects["proxy"] = Rect(top=height - 5, left=4, width=26, height=4)
+        rects["exfil"] = Rect(top=height - 5, left=width - 32, width=26, height=4)
+
     return rects
 
 
 @dataclass
 class Pane:
-    """One live window: a box, a text tone, and a feed that fills it."""
+    """One live window: a box, a text tone, and a feed that fills it.
+
+    Lines carry their own tone so an accent rolled at append time survives
+    every repaint — re-rolling on repaint would make old rows flicker.
+    """
 
     rect: Rect
     title: str
@@ -799,7 +810,18 @@ class Pane:
     feed: Callable[[random.Random, int], str]
     period: int
     reveal: int
-    lines: list[str]
+    lines: list[tuple[str, str]]
+    accent: str = ""
+    accent_chance: float = 0.0
+
+
+def roll_tone(rng: random.Random, pane: Pane) -> str:
+    """The tone for a freshly appended line — usually the pane's, sometimes
+    its accent."""
+    if pane.accent and rng.random() < pane.accent_chance:
+        return pane.accent
+
+    return pane.tone
 
 
 def feed_hex(rng: random.Random, width: int) -> str:
@@ -847,13 +869,13 @@ def interior_stamp(console: Console, pane: Pane) -> str:
     inner_rows = pane.rect.height - 2
     inner_width = pane.rect.width - 4
     visible = pane.lines[-inner_rows:]
-    padded = [""] * (inner_rows - len(visible)) + visible
+    padded = [("", pane.tone)] * (inner_rows - len(visible)) + visible
 
     parts = []
-    for offset, line in enumerate(padded):
+    for offset, (line, tone) in enumerate(padded):
         parts.append(
             move_to(pane.rect.top + 1 + offset, pane.rect.left + 2)
-            + console.tint(fit(line, inner_width), pane.tone)
+            + console.tint(fit(line, inner_width), tone)
         )
 
     return "".join(parts)
@@ -893,6 +915,55 @@ def dialog_stamp(
     )
 
 
+def alert_stamp(console: Console, rect: Rect, age: int) -> str:
+    """The red corner alarm: a countdown that reads like consequences."""
+    urgent = (age // 6) % 2 == 0
+    tone = BOLD + RED if urgent else RED
+    seconds = max(0, 45 - age // 18)
+    inner = rect.width - 4
+
+    return (
+        box_stamp(console, rect, "PERIMETER", tone)
+        + move_to(rect.top + 1, rect.left + 2)
+        + console.tint(fit("⚠ trace detected", inner), RED)
+        + move_to(rect.top + 2, rect.left + 2)
+        + console.tint(fit(f"lockout in 00:{seconds:02d}", inner), tone)
+    )
+
+
+def proxy_stamp(console: Console, rect: Rect, age: int) -> str:
+    """The green corner status: relay hops securing one by one."""
+    hops = min(5, 1 + age // 22)
+    chain = " ▸ ".join(f"{relay:02d}" for relay in (3, 7, 12, 19, 22)[:hops])
+    secured = hops == 5
+    status = "chain secured" if secured else f"{hops}/5 hops secured"
+    inner = rect.width - 4
+
+    return (
+        box_stamp(console, rect, "PROXY CHAIN", GREEN)
+        + move_to(rect.top + 1, rect.left + 2)
+        + console.tint(fit(f"relay {chain}", inner), GREEN)
+        + move_to(rect.top + 2, rect.left + 2)
+        + console.tint(fit(status, inner), BOLD + GREEN if secured else GREY)
+    )
+
+
+def exfil_stamp(console: Console, rect: Rect, age: int, total: float) -> str:
+    """The amber corner meter: bytes leaving the building."""
+    fraction = min(1.0, age / 90.0)
+    inner = rect.width - 4
+    bar = progress_bar(fraction, 1.0, max(6, inner - 6))
+    counter = f"{human_bytes(total * fraction)} / {human_bytes(total)}"
+
+    return (
+        box_stamp(console, rect, "EXFIL", ORANGE)
+        + move_to(rect.top + 1, rect.left + 2)
+        + console.tint(bar, ORANGE) + console.tint(f" {int(fraction * 100):>3}%", GREY)
+        + move_to(rect.top + 2, rect.left + 2)
+        + console.tint(fit(counter, inner), GREY)
+    )
+
+
 def scene_warroom(console: Console, rng: random.Random) -> None:
     """The full movie set: rain behind several live panes, dialog on top."""
     if not console.color:
@@ -914,15 +985,18 @@ def scene_warroom(console: Console, rng: random.Random) -> None:
     console.clear()
     layout = warroom_layout(console.width, console.height)
     dialog_rect = layout.pop("dialog")
+    alert_rect = layout.pop("alert", None)
+    proxy_rect = layout.pop("proxy", None)
+    exfil_rect = layout.pop("exfil", None)
 
     dressing = {
-        "memdump": (feed_hex, GREY),
-        "uplink": (feed_intercept, GREEN),
-        "intercept": (feed_trace, CYAN),
+        "memdump": (feed_hex, GREY, RED, 0.22),
+        "uplink": (feed_intercept, GREEN, BOLD + GREEN, 0.12),
+        "intercept": (feed_trace, CYAN, GREEN, 0.30),
     }
     panes = []
     for index, name in enumerate(sorted(layout)):
-        feed, tone = dressing[name]
+        feed, tone, accent, chance = dressing[name]
         panes.append(
             Pane(
                 rect=layout[name],
@@ -932,6 +1006,8 @@ def scene_warroom(console: Console, rng: random.Random) -> None:
                 period=rng.randint(3, 6),
                 reveal=6 + index * rng.randint(6, 10),
                 lines=[],
+                accent=accent,
+                accent_chance=chance,
             )
         )
 
@@ -940,11 +1016,18 @@ def scene_warroom(console: Console, rng: random.Random) -> None:
     dialog_at = rng.randint(40, 60)
     lock_every = rng.randint(7, 11)
     locked = 0
+    alert_at = rng.randint(18, 26)
+    proxy_at = rng.randint(28, 38)
+    exfil_at = rng.randint(46, 58)
+    exfil_total = rng.uniform(2e7, 8e7)
     total = dialog_at + lock_every * len(password) + 24
 
     for tick in range(total):
         parts = []
         shown = [pane.rect for pane in panes if tick >= pane.reveal]
+        for rect, since in ((alert_rect, alert_at), (proxy_rect, proxy_at), (exfil_rect, exfil_at)):
+            if rect is not None and tick >= since:
+                shown.append(rect)
         if tick >= dialog_at:
             shown.append(dialog_rect)
         parts.append(rain_step(drops, console.height, rng, avoid=shown))
@@ -953,14 +1036,20 @@ def scene_warroom(console: Console, rng: random.Random) -> None:
             if tick == pane.reveal:
                 parts.append(box_stamp(console, pane.rect, pane.title, pane.tone))
             elif tick > pane.reveal and (tick - pane.reveal) % pane.period == 0:
-                pane.lines.append(pane.feed(rng, pane.rect.width - 4))
+                pane.lines.append((pane.feed(rng, pane.rect.width - 4), roll_tone(rng, pane)))
                 pane.lines = pane.lines[-(pane.rect.height - 2):]
                 parts.append(interior_stamp(console, pane))
 
+        # Floaters re-stamp every tick; the password dialog goes last, on top.
+        if alert_rect is not None and tick >= alert_at:
+            parts.append(alert_stamp(console, alert_rect, tick - alert_at))
+        if proxy_rect is not None and tick >= proxy_at:
+            parts.append(proxy_stamp(console, proxy_rect, tick - proxy_at))
+        if exfil_rect is not None and tick >= exfil_at:
+            parts.append(exfil_stamp(console, exfil_rect, tick - exfil_at, exfil_total))
         if tick >= dialog_at:
             if locked < len(password) and tick > dialog_at and (tick - dialog_at) % lock_every == 0:
                 locked += 1
-            # Stamped last, every tick — that is what lets it float over panes.
             parts.append(dialog_stamp(console, dialog_rect, password, locked, rng))
 
         console.paint("".join(parts))

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -1,15 +1,19 @@
 #!/usr/bin/env python3
 """Fake a busy coding session in the terminal.
 
-Four scenes cycle in random order: an editor typing source, a build, a test
-run, and git activity. Every byte the scenes print is invented — no file is
-read or written, no command runs, nothing touches the network. This is a joke
-screensaver in the `cmatrix` tradition, not a tool.
+Scenes cycle in random order, grouped into profiles: `developer` fakes honest
+work (an editor typing source, a build, a test run, git activity) and `hacker`
+fakes the movie kind (digital rain, an intrusion, a key crack). Every byte the
+scenes print is invented — no file is read or written, no command runs,
+nothing touches the network. The "targets" are RFC 5737 documentation
+addresses and example.* hosts, so the theatre cannot point at anything real.
+This is a joke screensaver in the `cmatrix` tradition, not a tool.
 
-    python3 busy_terminal.py                 # until Ctrl-C
-    python3 busy_terminal.py --duration 120  # two minutes, then exit
-    python3 busy_terminal.py --scene tests   # one scene on repeat
-    python3 busy_terminal.py --window        # open a new terminal, return now
+    python3 busy_terminal.py                   # developer profile, until Ctrl-C
+    python3 busy_terminal.py --profile hacker  # full Hollywood
+    python3 busy_terminal.py --duration 120    # two minutes, then exit
+    python3 busy_terminal.py --scene matrix    # one scene on repeat
+    python3 busy_terminal.py --window          # open a new terminal, return now
 
 `--window` is the one thing here that starts a process: it re-launches this
 script inside a fresh terminal window and exits. An agent needs it, because a
@@ -27,10 +31,17 @@ import shutil
 import subprocess
 import sys
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable, Sequence, TextIO
 
-SCENES = ("code", "build", "tests", "git")
+SCENES = ("code", "build", "tests", "git", "matrix", "intrusion", "crack")
+
+PROFILES: dict[str, tuple[str, ...]] = {
+    "developer": ("code", "build", "tests", "git"),
+    "hacker": ("matrix", "intrusion", "crack"),
+    "mixed": SCENES,
+}
 
 RESET = "\033[0m"
 BOLD = "\033[1m"
@@ -377,6 +388,37 @@ CI_CHECKS = (
     "supply-chain / audit",
 )
 
+# The hacker profile's props. Hosts are RFC 2606 example domains and the
+# addresses RFC 5737 reserves for documentation — unroutable by construction.
+MATRIX_GLYPHS = "ﾊﾐﾋｰｳｼﾅﾓﾆｻﾜﾂｵﾘｱﾎﾃﾏｹﾒｴｶｷﾑﾕﾗｾﾈｽﾀﾇ0123456789Z:･.=*+-<>"
+MATRIX_HEAD = "\033[1m\033[38;5;157m"
+MATRIX_BODY = "\033[38;5;41m"
+
+TARGETS = (
+    ("vault.example.net", "203.0.113.42"),
+    ("mainframe.example.org", "198.51.100.17"),
+    ("archive.example.com", "203.0.113.208"),
+)
+
+PORTS = (
+    (22, "ssh"),
+    (25, "smtp"),
+    (80, "http"),
+    (443, "https"),
+    (3306, "mysql"),
+    (5432, "postgres"),
+    (6379, "redis"),
+    (8443, "https-alt"),
+)
+
+USERS = ("admin", "root", "operator", "dispatch", "jmoriarty", "svc_legacy")
+
+LOOT = (
+    "/srv/vault/blueprints.tar.gz",
+    "/srv/vault/ledger-2026.db",
+    "/opt/mainframe/schematics.zip",
+)
+
 
 # ── Scenes ───────────────────────────────────────────────────────────────────
 
@@ -561,11 +603,217 @@ def scene_git(console: Console, rng: random.Random) -> None:
     console.pause(1.4)
 
 
+# ── Hacker profile scenes ────────────────────────────────────────────────────
+
+
+def move_to(row: int, col: int) -> str:
+    """ANSI cursor move, 1-based."""
+    return f"\033[{row};{col}H"
+
+
+@dataclass
+class Drop:
+    """One falling column of digital rain."""
+
+    col: int
+    row: float
+    speed: float
+    trail: int
+
+
+def spawn_drop(col: int, height: int, rng: random.Random) -> Drop:
+    """A fresh drop, staggered above the screen so columns trickle in.
+
+    Speed stays at or below one cell per tick — faster drops skip rows and
+    leave holes in their own trail.
+    """
+    return Drop(
+        col=col,
+        row=-rng.uniform(0.0, height),
+        speed=rng.uniform(0.35, 1.0),
+        trail=rng.randint(4, max(5, height // 2)),
+    )
+
+
+def rain_step(drops: list[Drop], height: int, rng: random.Random) -> str:
+    """Advance every drop one tick and return the whole frame as one string.
+
+    One write per frame is the point: per-cell writes flicker and swamp the
+    terminal with flushes.
+    """
+    parts = [MATRIX_BODY]
+    for index, drop in enumerate(drops):
+        prev = int(drop.row)
+        drop.row += drop.speed
+        head = int(drop.row)
+
+        if head != prev:
+            if 1 <= head <= height:
+                parts.append(
+                    move_to(head, drop.col)
+                    + MATRIX_HEAD + rng.choice(MATRIX_GLYPHS) + RESET + MATRIX_BODY
+                )
+            # The old head dims into the trail body.
+            if 1 <= prev <= height:
+                parts.append(move_to(prev, drop.col) + rng.choice(MATRIX_GLYPHS))
+            tail = head - drop.trail
+            if 1 <= tail <= height:
+                parts.append(move_to(tail, drop.col) + " ")
+
+        if drop.row - drop.trail > height:
+            drops[index] = spawn_drop(drop.col, height, rng)
+
+    parts.append(RESET)
+
+    return "".join(parts)
+
+
+def scene_matrix(console: Console, rng: random.Random) -> None:
+    """Digital rain, then a word from the machine."""
+    if not console.color:
+        # No ANSI means no cursor addressing — degrade to scrolling glyphs.
+        for _ in range(rng.randint(24, 40)):
+            line = "".join(
+                rng.choice(MATRIX_GLYPHS) if rng.random() < 0.28 else " "
+                for _ in range(console.width - 2)
+            )
+            console.line(line)
+            console.pause(0.05)
+
+        return
+
+    console.clear()
+    drops = [spawn_drop(col, console.height, rng) for col in range(1, console.width, 2)]
+    for _ in range(rng.randint(150, 230)):
+        console.paint(rain_step(drops, console.height, rng))
+        console.pause(0.045)
+
+    console.clear()
+    console.pause(0.7)
+    console.paint(MATRIX_BODY + BOLD)
+    for message in ("wake up…", "your build finished hours ago"):
+        console.paint("  ")
+        for char in message:
+            console.paint(char)
+            console.pause(rng.uniform(0.05, 0.14))
+        console.line()
+        console.pause(0.9)
+    console.paint(RESET)
+    console.pause(1.2)
+
+
+def scene_intrusion(console: Console, rng: random.Random) -> None:
+    """The movie hack: scan, brute-force, ACCESS GRANTED, exfiltrate."""
+    host, addr = rng.choice(TARGETS)
+
+    console.line()
+    prompt(console, f"./ghost --target {addr} --stealth", rng)
+    console.line(console.tint(f"[ghost] resolving target… {host} ({addr})", GREY))
+    console.pause(0.6)
+
+    console.paint(console.tint("[ghost] mapping 1024 ports ", GREY))
+    for _ in range(rng.randint(18, 30)):
+        console.paint(console.tint(".", CYAN))
+        console.pause(rng.uniform(0.02, 0.09))
+    console.line()
+
+    for port, service in sorted(rng.sample(PORTS, k=rng.randint(3, 5))):
+        console.line(
+            f"  {port:>5}/tcp  " + console.tint("open", GREEN) + f"   {service}"
+        )
+        console.pause(0.18)
+    console.line(console.tint("[ghost] stack: nginx/1.27 · openssh 9.8 · debian 13", GREY))
+    console.pause(0.7)
+
+    console.line(console.tint("[ghost] trying credentials", GREY))
+    attempt = rng.randint(120, 400)
+    for _ in range(rng.randint(4, 7)):
+        attempt += rng.randint(7, 60)
+        user = rng.choice(USERS)
+        console.paint(
+            f"\r  attempt {attempt:04d}  {user:<12} {'•' * 10}  "
+            + console.tint("DENIED  ", RED)
+        )
+        console.pause(rng.uniform(0.2, 0.5))
+    attempt += rng.randint(7, 60)
+    console.paint(
+        f"\r  attempt {attempt:04d}  {'svc_backup':<12} {'•' * 10}  "
+        + console.tint("ACCEPTED", GREEN) + "\n"
+    )
+    console.pause(0.5)
+
+    inner = "   ACCESS GRANTED   "
+    console.line()
+    console.line(console.tint("  ╔" + "═" * len(inner) + "╗", GREEN))
+    console.line(console.tint("  ║" + inner + "║", BOLD + GREEN))
+    console.line(console.tint("  ╚" + "═" * len(inner) + "╝", GREEN))
+    console.line()
+    console.pause(0.9)
+
+    total = rng.uniform(6e6, 9e7)
+    done = 0.0
+    console.line(console.tint(f"[ghost] pulling {rng.choice(LOOT)}", GREY))
+    while done < total:
+        done = min(total, done + total * rng.uniform(0.04, 0.12))
+        console.paint(
+            "\r  " + console.tint(progress_bar(done, total), CYAN)
+            + f" {human_bytes(done):>9} / {human_bytes(total)}"
+        )
+        console.pause(rng.uniform(0.08, 0.2))
+    console.line()
+    console.line(console.tint("[ghost] wiping session logs… done", GREY))
+    console.line(console.tint("connection closed by remote host.", GREY))
+    console.pause(1.4)
+
+
+def scene_crack(console: Console, rng: random.Random) -> None:
+    """Hollywood decryption: hex spray, then the key locks in byte by byte."""
+    console.line()
+    prompt(console, "./decrypt blueprints.tar.gz.aes --gpu", rng)
+    console.line(console.tint("[decrypt] cipher: aes-256-gcm · key schedule unknown", GREY))
+    console.pause(0.4)
+
+    pairs = min(24, (console.width - 6) // 3)
+    for _ in range(rng.randint(4, 8)):
+        dump = " ".join(f"{rng.randrange(256):02x}" for _ in range(pairs))
+        console.line(console.tint(f"  {dump}", GREY))
+        console.pause(rng.uniform(0.05, 0.15))
+
+    console.line(console.tint("[decrypt] brute-forcing key segments", GREY))
+    key = [f"{rng.randrange(256):02X}" for _ in range(16)]
+    locked = [False] * 16
+    order = list(range(16))
+    rng.shuffle(order)
+    for step, target in enumerate(order, start=1):
+        # The trope itself: unlocked bytes flicker, then one locks in.
+        for _ in range(rng.randint(2, 5)):
+            cells = [
+                console.tint(key[i], GREEN) if locked[i]
+                else console.tint(f"{rng.randrange(256):02X}", GREY)
+                for i in range(16)
+            ]
+            console.paint("\r  KEY ▸ " + " ".join(cells) + f"  {step - 1:>2}/16")
+            console.pause(rng.uniform(0.03, 0.09))
+        locked[target] = True
+    console.paint(
+        "\r  KEY ▸ " + " ".join(console.tint(byte, GREEN) for byte in key) + "  16/16"
+    )
+    console.line()
+    console.pause(0.5)
+
+    console.line(console.tint("[decrypt] key recovered · verifying MAC… ok", GREEN))
+    console.line(console.tint("[decrypt] plaintext written to ./blueprints.tar.gz", GREY))
+    console.pause(1.4)
+
+
 SCENE_RUNNERS: dict[str, Callable[[Console, random.Random], None]] = {
     "code": scene_code,
     "build": scene_build,
     "tests": scene_tests,
     "git": scene_git,
+    "matrix": scene_matrix,
+    "intrusion": scene_intrusion,
+    "crack": scene_crack,
 }
 
 
@@ -574,20 +822,22 @@ def run(
     rng: random.Random,
     *,
     scene: str = "",
+    scenes: Sequence[str] = PROFILES["developer"],
     duration: float = 0.0,
     now: Callable[[], float] = time.monotonic,
 ) -> int:
-    """Cycle scenes until `duration` elapses. Returns how many ran.
+    """Cycle `scenes` until `duration` elapses. Returns how many ran.
 
-    `duration <= 0` means forever, so the caller (not this loop) owns the exit
-    condition — Ctrl-C in the CLI, a fixed scene count in a test.
+    A pinned `scene` beats the profile's rotation. `duration <= 0` means
+    forever, so the caller (not this loop) owns the exit condition — Ctrl-C in
+    the CLI, a fixed scene count in a test.
     """
     started = now()
     played = 0
     last = ""
 
     while True:
-        last = scene or next_scene(rng, last)
+        last = scene or next_scene(rng, last, scenes)
         SCENE_RUNNERS[last](console, rng)
         played += 1
 
@@ -714,8 +964,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="Time multiplier. 2 is twice as fast, 0.5 half.",
     )
     parser.add_argument(
+        "--profile", choices=sorted(PROFILES), default="developer",
+        help="Scene set: developer (fake work), hacker (full Hollywood), mixed (both).",
+    )
+    parser.add_argument(
         "--scene", choices=SCENES, default="",
-        help="Play one scene on repeat instead of cycling.",
+        help="Play one scene on repeat instead of cycling the profile.",
     )
     parser.add_argument("--seed", type=int, default=None, help="Seed for a reproducible run.")
     parser.add_argument("--no-color", action="store_true", help="Plain text, no ANSI escapes.")
@@ -748,7 +1002,13 @@ def main(argv: Sequence[str] | None = None) -> int:
     if console.color:
         console.paint(HIDE_CURSOR)
     try:
-        run(console, rng, scene=args.scene, duration=args.duration)
+        run(
+            console,
+            rng,
+            scene=args.scene,
+            scenes=PROFILES[args.profile],
+            duration=args.duration,
+        )
     except KeyboardInterrupt:
         pass
     finally:

--- a/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
+++ b/optional-skills/creative/busy-terminal/scripts/busy_terminal.py
@@ -9,11 +9,11 @@ nothing touches the network. The "targets" are RFC 5737 documentation
 addresses and example.* hosts, so the theatre cannot point at anything real.
 This is a joke screensaver in the `cmatrix` tradition, not a tool.
 
-    python3 busy_terminal.py                   # developer profile, until Ctrl-C
-    python3 busy_terminal.py --profile hacker  # full Hollywood
-    python3 busy_terminal.py --duration 120    # two minutes, then exit
-    python3 busy_terminal.py --scene matrix    # one scene on repeat
-    python3 busy_terminal.py --window          # open a new terminal, return now
+    python3 busy_terminal.py                      # hacker profile, until Ctrl-C
+    python3 busy_terminal.py --profile developer  # fake coding session
+    python3 busy_terminal.py --duration 120       # two minutes, then exit
+    python3 busy_terminal.py --scene warroom      # the multi-window poster
+    python3 busy_terminal.py --window             # open a new terminal, return now
 
 `--window` is the one thing here that starts a process: it re-launches this
 script inside a fresh terminal window and exits. An agent needs it, because a
@@ -1180,7 +1180,7 @@ def run(
     rng: random.Random,
     *,
     scene: str = "",
-    scenes: Sequence[str] = PROFILES["developer"],
+    scenes: Sequence[str] = PROFILES["hacker"],
     duration: float = 0.0,
     now: Callable[[], float] = time.monotonic,
 ) -> int:
@@ -1193,9 +1193,18 @@ def run(
     started = now()
     played = 0
     last = ""
+    # Open on the war room when it is in the rotation — that is the
+    # multi-window poster, and a random first pick often hides it for minutes.
+    pending_opener = "warroom" if (not scene and "warroom" in scenes) else ""
 
     while True:
-        last = scene or next_scene(rng, last, scenes)
+        if scene:
+            last = scene
+        elif pending_opener:
+            last = pending_opener
+            pending_opener = ""
+        else:
+            last = next_scene(rng, last, scenes)
         SCENE_RUNNERS[last](console, rng)
         played += 1
 
@@ -1236,10 +1245,18 @@ def window_argv(
     branches are checkable from one host.
     """
     if platform == "darwin":
+        # Size the new window for the war room (panes + four dialogs). A
+        # default 80x24 Terminal clips the corners and looks like one pane.
+        quoted = applescript_string(command)
         return [
             "osascript",
-            "-e", f"tell application \"Terminal\" to do script {applescript_string(command)}",
-            "-e", 'tell application "Terminal" to activate',
+            "-e",
+            "tell application \"Terminal\"\n"
+            f"  set w to do script {quoted}\n"
+            "  set number of columns of front window to 140\n"
+            "  set number of rows of front window to 42\n"
+            "  activate\n"
+            "end tell",
         ]
 
     if platform == "win32":
@@ -1322,8 +1339,8 @@ def build_parser() -> argparse.ArgumentParser:
         help="Time multiplier. 2 is twice as fast, 0.5 half.",
     )
     parser.add_argument(
-        "--profile", choices=sorted(PROFILES), default="developer",
-        help="Scene set: developer (fake work), hacker (full Hollywood), mixed (both).",
+        "--profile", choices=sorted(PROFILES), default="hacker",
+        help="Scene set: hacker (Hollywood, default), developer (fake work), mixed (both).",
     )
     parser.add_argument(
         "--scene", choices=SCENES, default="",

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -1,0 +1,321 @@
+"""Tests for optional-skills/creative/busy-terminal/scripts/busy_terminal.py"""
+
+import random
+import re
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+# Add the scripts dir so we can import the module directly
+SCRIPTS_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "creative"
+    / "busy-terminal"
+    / "scripts"
+)
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import busy_terminal
+
+ANSI = re.compile(r"\033\[[0-9;?]*[A-Za-z]")
+
+
+class Recorder:
+    """Captures what a scene paints and how long it asked to sleep."""
+
+    def __init__(self) -> None:
+        self.chunks: list[str] = []
+        self.slept = 0.0
+
+    def write(self, text: str) -> None:
+        self.chunks.append(text)
+
+    def sleep(self, seconds: float) -> None:
+        assert seconds >= 0, "a scene must never ask for a negative sleep"
+        self.slept += seconds
+
+    @property
+    def text(self) -> str:
+        return "".join(self.chunks)
+
+
+def make_console(color: bool = False, speed: float = 1.0) -> tuple[busy_terminal.Console, Recorder]:
+    rec = Recorder()
+    console = busy_terminal.Console(
+        width=100, height=30, color=color, speed=speed, write=rec.write, sleep=rec.sleep
+    )
+    return console, rec
+
+
+def ticking_clock(step: float = 1.0):
+    """A monotonic clock that advances a fixed step per call."""
+    state = {"t": 0.0}
+
+    def now() -> float:
+        state["t"] += step
+        return state["t"] - step
+
+    return now
+
+
+# ── Pure formatters ──────────────────────────────────────────────────────────
+
+
+class TestProgressBar:
+    def test_width_is_fixed_regardless_of_progress(self):
+        widths = {len(busy_terminal.progress_bar(done, 10, width=20)) for done in range(0, 11)}
+        assert widths == {20}
+
+    def test_endpoints_are_empty_and_full(self):
+        assert busy_terminal.progress_bar(0, 10, width=8) == "░" * 8
+        assert busy_terminal.progress_bar(10, 10, width=8) == "█" * 8
+
+    def test_out_of_range_clamps_instead_of_overflowing(self):
+        assert busy_terminal.progress_bar(-5, 10, width=8) == "░" * 8
+        assert busy_terminal.progress_bar(50, 10, width=8) == "█" * 8
+
+    def test_zero_total_does_not_divide_by_zero(self):
+        assert len(busy_terminal.progress_bar(3, 0, width=6)) == 6
+
+    def test_fill_never_shrinks_as_progress_grows(self):
+        fills = [busy_terminal.progress_bar(d, 20, width=12).count("█") for d in range(21)]
+        assert fills == sorted(fills)
+
+
+class TestHumanBytes:
+    @pytest.mark.parametrize(
+        "count,expected_unit",
+        [(512, "B"), (2048, "KiB"), (5 * 1024**2, "MiB"), (3 * 1024**3, "GiB")],
+    )
+    def test_unit_matches_magnitude(self, count, expected_unit):
+        assert busy_terminal.human_bytes(count).endswith(expected_unit)
+
+    def test_larger_counts_never_read_as_smaller_units(self):
+        assert busy_terminal.human_bytes(1024**4).endswith("GiB")
+
+
+class TestNextScene:
+    def test_never_repeats_the_scene_that_just_played(self):
+        rng = random.Random(0)
+        last = "code"
+        for _ in range(200):
+            chosen = busy_terminal.next_scene(rng, last)
+            assert chosen != last
+            last = chosen
+
+    def test_always_returns_a_known_scene(self):
+        rng = random.Random(1)
+        assert {busy_terminal.next_scene(rng, "build") for _ in range(50)} <= set(
+            busy_terminal.SCENES
+        )
+
+    def test_single_scene_catalog_yields_rather_than_looping(self):
+        rng = random.Random(2)
+        assert busy_terminal.next_scene(rng, "only", scenes=("only",)) == "only"
+
+    def test_no_prior_scene_can_pick_any_of_them(self):
+        rng = random.Random(3)
+        seen = {busy_terminal.next_scene(rng, "") for _ in range(200)}
+        assert seen == set(busy_terminal.SCENES)
+
+
+class TestTestSummary:
+    def test_failures_lead_the_line(self):
+        assert busy_terminal.test_summary(10, 2, 0, 1.0).startswith("2 failed")
+
+    def test_clean_run_omits_failed_and_skipped(self):
+        line = busy_terminal.test_summary(10, 0, 0, 1.5)
+        assert "failed" not in line and "skipped" not in line
+
+    def test_always_reports_passed_and_duration(self):
+        line = busy_terminal.test_summary(7, 1, 3, 2.25)
+        assert "7 passed" in line and "3 skipped" in line and "2.25s" in line
+
+
+# ── Highlighting ─────────────────────────────────────────────────────────────
+
+
+class TestHighlight:
+    def test_is_a_no_op_without_color(self):
+        line = 'def go(x):  # note'
+        assert busy_terminal.highlight(line, "python", color=False) == line
+
+    def test_stripping_escapes_recovers_the_original_line(self):
+        line = 'return "ok"  # 42'
+        painted = busy_terminal.highlight(line, "python", color=True)
+        assert ANSI.sub("", painted) == line
+
+    def test_every_opened_color_is_closed(self):
+        painted = busy_terminal.highlight('async def f(): return "x"  # 1', "python", color=True)
+        assert painted.count(busy_terminal.RESET) == len(re.findall(r"\033\[38;5;\d+m", painted))
+
+    def test_keywords_are_tinted_and_bare_identifiers_are_not(self):
+        painted = busy_terminal.highlight("import widget", "python", color=True)
+        assert busy_terminal.MAGENTA + "import" in painted
+        assert busy_terminal.MAGENTA + "widget" not in painted
+
+    def test_unknown_language_still_returns_the_line_intact(self):
+        line = "some :: unknown ++ syntax"
+        assert ANSI.sub("", busy_terminal.highlight(line, "cobol", color=True)) == line
+
+
+class TestTypeOut:
+    def test_repaint_redraws_the_prefix_so_the_gutter_survives(self):
+        """The repaint returns to column 0 and must not land on the line numbers."""
+        console, rec = make_console(color=True)
+        busy_terminal.type_out(
+            console, "return None", prefix="  12 │ ", language="python", rng=random.Random(1)
+        )
+        repaint = rec.text.split("\r")[-1]
+        assert repaint.startswith("  12 │ ")
+
+    def test_the_typed_characters_spell_the_whole_line(self):
+        console, rec = make_console(color=False)
+        busy_terminal.type_out(console, "import asyncio", rng=random.Random(1))
+        assert rec.text.strip() == "import asyncio"
+
+    def test_without_color_there_is_no_repaint_to_get_wrong(self):
+        console, rec = make_console(color=False)
+        busy_terminal.type_out(
+            console, "return None", prefix="  12 │ ", language="python", rng=random.Random(1)
+        )
+        assert "\r" not in rec.text
+
+
+# ── Scenes ───────────────────────────────────────────────────────────────────
+
+
+class TestScenes:
+    @pytest.mark.parametrize("name", busy_terminal.SCENES)
+    def test_every_scene_paints_something_and_asks_to_wait(self, name):
+        console, rec = make_console()
+        busy_terminal.SCENE_RUNNERS[name](console, random.Random(11))
+        assert rec.text.strip()
+        assert rec.slept > 0
+
+    @pytest.mark.parametrize("name", busy_terminal.SCENES)
+    def test_no_scene_emits_ansi_when_color_is_off(self, name):
+        console, rec = make_console(color=False)
+        busy_terminal.SCENE_RUNNERS[name](console, random.Random(12))
+        assert not ANSI.search(rec.text)
+
+    @pytest.mark.parametrize("name", busy_terminal.SCENES)
+    def test_speed_scales_the_wait_down(self, name):
+        _, slow = make_console(speed=1.0)
+        _, fast = make_console(speed=10.0)
+        slow_console = busy_terminal.Console(color=False, speed=1.0, write=slow.write, sleep=slow.sleep)
+        fast_console = busy_terminal.Console(color=False, speed=10.0, write=fast.write, sleep=fast.sleep)
+
+        busy_terminal.SCENE_RUNNERS[name](slow_console, random.Random(13))
+        busy_terminal.SCENE_RUNNERS[name](fast_console, random.Random(13))
+
+        assert fast.slept == pytest.approx(slow.slept / 10.0, rel=1e-6)
+
+    @pytest.mark.parametrize("name", busy_terminal.SCENES)
+    def test_same_seed_replays_the_same_transcript(self, name):
+        console_a, rec_a = make_console(color=True)
+        console_b, rec_b = make_console(color=True)
+        busy_terminal.SCENE_RUNNERS[name](console_a, random.Random(99))
+        busy_terminal.SCENE_RUNNERS[name](console_b, random.Random(99))
+        assert rec_a.text == rec_b.text
+
+    def test_scenes_touch_no_process_socket_or_file(self):
+        """The premise of the skill: none of this output is real."""
+        console, _ = make_console()
+        with (
+            mock.patch("subprocess.run") as run,
+            mock.patch("subprocess.Popen") as popen,
+            mock.patch("socket.socket") as sock,
+            mock.patch("builtins.open") as opened,
+        ):
+            for runner in busy_terminal.SCENE_RUNNERS.values():
+                runner(console, random.Random(14))
+
+        run.assert_not_called()
+        popen.assert_not_called()
+        sock.assert_not_called()
+        opened.assert_not_called()
+
+
+# ── Run loop ─────────────────────────────────────────────────────────────────
+
+
+class TestRunLoop:
+    def test_stops_once_the_duration_has_elapsed(self):
+        console, _ = make_console()
+        played = busy_terminal.run(
+            console, random.Random(5), duration=3.0, now=ticking_clock(1.0)
+        )
+        assert played == 3
+
+    def test_a_pinned_scene_is_the_only_one_that_plays(self):
+        console, _ = make_console()
+        seen: list[str] = []
+        runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
+
+        with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
+            busy_terminal.run(
+                console, random.Random(6), scene="tests", duration=4.0, now=ticking_clock(1.0)
+            )
+
+        assert set(seen) == {"tests"}
+
+    def test_cycling_covers_every_scene_without_adjacent_repeats(self):
+        console, _ = make_console()
+        seen: list[str] = []
+        runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
+
+        with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
+            busy_terminal.run(console, random.Random(7), duration=40.0, now=ticking_clock(1.0))
+
+        assert set(seen) == set(busy_terminal.SCENES)
+        assert all(a != b for a, b in zip(seen, seen[1:]))
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+class TestColorDetection:
+    def test_a_tty_that_was_asked_for_color_gets_it(self):
+        stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        assert busy_terminal.supports_color(stream, requested=True) is True
+
+    def test_a_pipe_never_gets_color(self):
+        stream = mock.Mock(isatty=mock.Mock(return_value=False))
+        assert busy_terminal.supports_color(stream, requested=True) is False
+
+    def test_no_color_env_wins_over_a_tty(self, monkeypatch):
+        monkeypatch.setenv("NO_COLOR", "1")
+        stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        assert busy_terminal.supports_color(stream, requested=True) is False
+
+    def test_opting_out_wins_over_a_tty(self):
+        stream = mock.Mock(isatty=mock.Mock(return_value=True))
+        assert busy_terminal.supports_color(stream, requested=False) is False
+
+
+class TestCli:
+    def test_defaults_run_forever_and_cycle(self):
+        args = busy_terminal.build_parser().parse_args([])
+        assert args.duration == 0.0
+        assert args.scene == ""
+
+    def test_scene_is_restricted_to_known_scenes(self):
+        with pytest.raises(SystemExit):
+            busy_terminal.build_parser().parse_args(["--scene", "nope"])
+
+    def test_a_bounded_run_exits_zero_and_prints(self, capsys):
+        code = busy_terminal.main(
+            ["--scene", "build", "--duration", "0.001", "--speed", "5000", "--no-color"]
+        )
+        out = capsys.readouterr().out
+        assert code == 0
+        assert out.strip()
+        assert not ANSI.search(out)
+
+    def test_interrupting_restores_the_cursor_and_exits_cleanly(self):
+        with mock.patch.object(busy_terminal, "run", side_effect=KeyboardInterrupt):
+            assert busy_terminal.main(["--no-color"]) == 0

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -275,6 +275,97 @@ class TestRunLoop:
         assert all(a != b for a, b in zip(seen, seen[1:]))
 
 
+# ── Launching a visible window ───────────────────────────────────────────────
+
+
+class TestApplescriptString:
+    def test_wraps_in_quotes(self):
+        assert busy_terminal.applescript_string("hi") == '"hi"'
+
+    def test_escapes_quotes_and_backslashes_so_the_literal_cannot_break_out(self):
+        quoted = busy_terminal.applescript_string('a "b" c\\d')
+        assert quoted == '"a \\"b\\" c\\\\d"'
+        assert quoted.startswith('"') and quoted.endswith('"')
+        assert '\\"b\\"' in quoted
+
+
+class TestWindowArgv:
+    def test_macos_drives_terminal_app_and_brings_it_forward(self):
+        argv = busy_terminal.window_argv("run me", "darwin")
+        assert argv[0] == "osascript"
+        assert any("do script" in part for part in argv)
+        assert any("activate" in part for part in argv)
+
+    def test_macos_embeds_the_command_as_an_escaped_applescript_literal(self):
+        argv = busy_terminal.window_argv('say "hi"', "darwin")
+        assert any('\\"hi\\"' in part for part in argv)
+
+    def test_windows_starts_a_detached_console(self):
+        argv = busy_terminal.window_argv("run me", "win32")
+        assert argv[:3] == ["cmd", "/c", "start"]
+        assert argv[-1] == "run me"
+
+    def test_linux_uses_the_first_emulator_that_exists(self):
+        installed = {"konsole": "/usr/bin/konsole", "xterm": "/usr/bin/xterm"}
+        argv = busy_terminal.window_argv("run me", "linux", which=installed.get)
+        assert argv[0] == "konsole"
+
+    def test_linux_normalises_every_emulator_through_sh_c(self):
+        for emulator, _ in busy_terminal.LINUX_TERMINALS:
+            argv = busy_terminal.window_argv(
+                "run me", "linux", which=lambda name, e=emulator: "/bin/x" if name == e else None
+            )
+            assert argv[0] == emulator
+            assert argv[-3:] == ["sh", "-c", "run me"]
+
+    def test_linux_without_any_emulator_says_so(self):
+        with pytest.raises(busy_terminal.NoTerminalError) as excinfo:
+            busy_terminal.window_argv("run me", "linux", which=lambda _name: None)
+        assert "xterm" in str(excinfo.value)
+
+
+class TestRelaunchCommand:
+    def test_drops_the_window_flag_so_the_child_actually_animates(self):
+        command = busy_terminal.relaunch_command(
+            ["--window", "--duration", "60"], script="/s/busy.py", python="/py"
+        )
+        assert "--window" not in command
+        assert command == "/py /s/busy.py --duration 60"
+
+    def test_quotes_paths_with_spaces(self):
+        command = busy_terminal.relaunch_command([], script="/a b/busy.py", python="/py")
+        assert "'/a b/busy.py'" in command
+
+    def test_other_flags_survive_the_round_trip(self):
+        command = busy_terminal.relaunch_command(
+            ["--window", "--scene", "git", "--seed", "3"], script="/s.py", python="/py"
+        )
+        assert command.endswith("--scene git --seed 3")
+
+
+class TestOpenInWindow:
+    def test_spawns_the_window_and_returns_without_animating(self):
+        spawned: list[list[str]] = []
+        code = busy_terminal.open_in_window(
+            ["--window", "--duration", "30"],
+            platform="darwin",
+            spawn=lambda argv: spawned.append(argv),
+        )
+        assert code == 0
+        assert len(spawned) == 1
+        assert spawned[0][0] == "osascript"
+
+    def test_the_command_it_hands_off_still_carries_the_options(self):
+        spawned: list[list[str]] = []
+        busy_terminal.open_in_window(
+            ["--window", "--scene", "build"],
+            platform="win32",
+            spawn=lambda argv: spawned.append(argv),
+        )
+        assert "--scene build" in spawned[0][-1]
+        assert "--window" not in spawned[0][-1]
+
+
 # ── CLI ──────────────────────────────────────────────────────────────────────
 
 
@@ -315,6 +406,17 @@ class TestCli:
         assert code == 0
         assert out.strip()
         assert not ANSI.search(out)
+
+    def test_window_hands_off_and_returns_instead_of_animating(self):
+        """An agent calls this; it must come back immediately, not block the turn."""
+        with (
+            mock.patch.object(busy_terminal, "open_in_window", return_value=0) as handoff,
+            mock.patch.object(busy_terminal, "run") as animate,
+        ):
+            assert busy_terminal.main(["--window", "--duration", "60"]) == 0
+
+        handoff.assert_called_once()
+        animate.assert_not_called()
 
     def test_interrupting_restores_the_cursor_and_exits_cleanly(self):
         with mock.patch.object(busy_terminal, "run", side_effect=KeyboardInterrupt):

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -269,10 +269,120 @@ class TestRunLoop:
         runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
 
         with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
-            busy_terminal.run(console, random.Random(7), duration=40.0, now=ticking_clock(1.0))
+            busy_terminal.run(
+                console,
+                random.Random(7),
+                scenes=busy_terminal.SCENES,
+                duration=60.0,
+                now=ticking_clock(1.0),
+            )
 
         assert set(seen) == set(busy_terminal.SCENES)
         assert all(a != b for a, b in zip(seen, seen[1:]))
+
+    @pytest.mark.parametrize("profile", sorted(busy_terminal.PROFILES))
+    def test_a_profile_only_plays_its_own_scenes(self, profile):
+        console, _ = make_console()
+        seen: list[str] = []
+        runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
+
+        with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
+            busy_terminal.run(
+                console,
+                random.Random(8),
+                scenes=busy_terminal.PROFILES[profile],
+                duration=60.0,
+                now=ticking_clock(1.0),
+            )
+
+        assert set(seen) == set(busy_terminal.PROFILES[profile])
+
+    def test_the_default_rotation_is_the_developer_profile(self):
+        """'Pretend I'm working' must not open with digital rain."""
+        console, _ = make_console()
+        seen: list[str] = []
+        runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
+
+        with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
+            busy_terminal.run(console, random.Random(9), duration=60.0, now=ticking_clock(1.0))
+
+        assert set(seen) == set(busy_terminal.PROFILES["developer"])
+
+
+class TestProfiles:
+    def test_every_profile_is_a_non_empty_subset_of_the_catalog(self):
+        for name, scenes in busy_terminal.PROFILES.items():
+            assert scenes, name
+            assert set(scenes) <= set(busy_terminal.SCENES), name
+
+    def test_every_scene_in_the_catalog_has_a_runner(self):
+        assert set(busy_terminal.SCENE_RUNNERS) == set(busy_terminal.SCENES)
+
+    def test_mixed_covers_the_union_of_all_profiles(self):
+        union = set().union(*busy_terminal.PROFILES.values())
+        assert set(busy_terminal.PROFILES["mixed"]) == union
+
+
+class TestRain:
+    def test_a_fresh_drop_starts_above_the_screen(self):
+        rng = random.Random(20)
+        for _ in range(100):
+            drop = busy_terminal.spawn_drop(col=5, height=30, rng=rng)
+            assert drop.row <= 0
+            assert drop.trail >= 4
+            assert 0 < drop.speed <= 1.0, "faster than a cell per tick leaves trail holes"
+
+    def test_a_step_advances_every_drop_by_its_own_speed(self):
+        rng = random.Random(21)
+        drops = [busy_terminal.spawn_drop(col, 30, rng) for col in (1, 3, 5)]
+        before = [(drop.row, drop.speed) for drop in drops]
+        busy_terminal.rain_step(drops, height=30, rng=rng)
+        for drop, (row, speed) in zip(drops, before):
+            assert drop.row == pytest.approx(row + speed)
+
+    def test_a_frame_is_one_write_and_never_scrolls(self):
+        rng = random.Random(22)
+        drops = [busy_terminal.spawn_drop(col, 30, rng) for col in range(1, 60, 2)]
+        for _ in range(80):
+            frame = busy_terminal.rain_step(drops, height=30, rng=rng)
+            assert "\n" not in frame
+
+    def test_a_drop_that_left_the_screen_respawns_above_it(self):
+        rng = random.Random(23)
+        drops = [busy_terminal.Drop(col=1, row=100.0, speed=1.0, trail=4)]
+        busy_terminal.rain_step(drops, height=30, rng=rng)
+        assert drops[0].row < 1
+
+
+class TestSceneArcs:
+    """Each hacker scene must reach its climax — that IS the scene."""
+
+    def test_the_intrusion_always_gets_in_and_always_gets_out(self):
+        console, rec = make_console()
+        busy_terminal.scene_intrusion(console, random.Random(30))
+        assert "ACCESS GRANTED" in rec.text
+        assert "connection closed by remote host." in rec.text
+        assert rec.text.index("ACCESS GRANTED") < rec.text.index("connection closed")
+
+    def test_the_intrusion_only_ever_touches_documentation_targets(self):
+        for seed in range(12):
+            console, rec = make_console()
+            busy_terminal.scene_intrusion(console, random.Random(seed))
+            assert any(host in rec.text for host, _addr in busy_terminal.TARGETS)
+            assert ".example." in rec.text
+
+    def test_the_crack_locks_all_sixteen_bytes(self):
+        console, rec = make_console()
+        busy_terminal.scene_crack(console, random.Random(31))
+        assert "16/16" in rec.text
+        assert "key recovered" in rec.text
+
+    def test_the_matrix_fallback_fits_the_terminal_width(self):
+        console, rec = make_console(color=False)
+        busy_terminal.scene_matrix(console, random.Random(32))
+        lines = [line for line in rec.text.splitlines() if line]
+        assert lines
+        assert all(len(line) <= console.width for line in lines)
 
 
 # ── Launching a visible window ───────────────────────────────────────────────
@@ -389,14 +499,28 @@ class TestColorDetection:
 
 
 class TestCli:
-    def test_defaults_run_forever_and_cycle(self):
+    def test_defaults_run_forever_on_the_developer_profile(self):
         args = busy_terminal.build_parser().parse_args([])
         assert args.duration == 0.0
         assert args.scene == ""
+        assert args.profile == "developer"
 
     def test_scene_is_restricted_to_known_scenes(self):
         with pytest.raises(SystemExit):
             busy_terminal.build_parser().parse_args(["--scene", "nope"])
+
+    def test_profile_is_restricted_to_known_profiles(self):
+        with pytest.raises(SystemExit):
+            busy_terminal.build_parser().parse_args(["--profile", "villain"])
+
+    def test_a_bounded_hacker_run_exits_zero_and_prints(self, capsys):
+        code = busy_terminal.main(
+            ["--profile", "hacker", "--duration", "0.001", "--speed", "5000", "--no-color"]
+        )
+        out = capsys.readouterr().out
+        assert code == 0
+        assert out.strip()
+        assert not ANSI.search(out)
 
     def test_a_bounded_run_exits_zero_and_prints(self, capsys):
         code = busy_terminal.main(

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -297,8 +297,8 @@ class TestRunLoop:
 
         assert set(seen) == set(busy_terminal.PROFILES[profile])
 
-    def test_the_default_rotation_is_the_developer_profile(self):
-        """'Pretend I'm working' must not open with digital rain."""
+    def test_the_default_rotation_is_the_hacker_profile(self):
+        """A bare launch must open the Hollywood set, not fake pytest."""
         console, _ = make_console()
         seen: list[str] = []
         runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
@@ -306,7 +306,25 @@ class TestRunLoop:
         with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
             busy_terminal.run(console, random.Random(9), duration=60.0, now=ticking_clock(1.0))
 
-        assert set(seen) == set(busy_terminal.PROFILES["developer"])
+        assert set(seen) == set(busy_terminal.PROFILES["hacker"])
+        assert seen[0] == "warroom"
+
+    def test_developer_does_not_open_on_the_war_room(self):
+        console, _ = make_console()
+        seen: list[str] = []
+        runners = {name: (lambda c, r, n=name: seen.append(n)) for name in busy_terminal.SCENES}
+
+        with mock.patch.object(busy_terminal, "SCENE_RUNNERS", runners):
+            busy_terminal.run(
+                console,
+                random.Random(9),
+                scenes=busy_terminal.PROFILES["developer"],
+                duration=8.0,
+                now=ticking_clock(1.0),
+            )
+
+        assert seen[0] != "warroom"
+        assert set(seen) <= set(busy_terminal.PROFILES["developer"])
 
 
 class TestProfiles:
@@ -560,9 +578,12 @@ class TestApplescriptString:
 class TestWindowArgv:
     def test_macos_drives_terminal_app_and_brings_it_forward(self):
         argv = busy_terminal.window_argv("run me", "darwin")
+        script = " ".join(argv)
         assert argv[0] == "osascript"
-        assert any("do script" in part for part in argv)
-        assert any("activate" in part for part in argv)
+        assert "do script" in script
+        assert "activate" in script
+        assert "number of columns of front window to 140" in script
+        assert "number of rows of front window to 42" in script
 
     def test_macos_embeds_the_command_as_an_escaped_applescript_literal(self):
         argv = busy_terminal.window_argv('say "hi"', "darwin")
@@ -657,11 +678,11 @@ class TestColorDetection:
 
 
 class TestCli:
-    def test_defaults_run_forever_on_the_developer_profile(self):
+    def test_defaults_run_forever_on_the_hacker_profile(self):
         args = busy_terminal.build_parser().parse_args([])
         assert args.duration == 0.0
         assert args.scene == ""
-        assert args.profile == "developer"
+        assert args.profile == "hacker"
 
     def test_scene_is_restricted_to_known_scenes(self):
         with pytest.raises(SystemExit):

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -354,6 +354,72 @@ class TestRain:
         assert drops[0].row < 1
 
 
+class TestFit:
+    def test_always_returns_exactly_the_requested_width(self):
+        for text in ("", "short", "x" * 500):
+            for width in (1, 7, 40):
+                assert len(busy_terminal.fit(text, width)) == width
+
+    def test_zero_or_negative_width_collapses_to_empty(self):
+        assert busy_terminal.fit("anything", 0) == ""
+        assert busy_terminal.fit("anything", -3) == ""
+
+
+class TestWarroomLayout:
+    SIZES = [(w, h) for w in (40, 60, 80, 100, 140, 200) for h in (10, 16, 24, 40, 60)]
+
+    @pytest.mark.parametrize("width,height", SIZES)
+    def test_every_window_stays_inside_the_terminal(self, width, height):
+        for name, rect in busy_terminal.warroom_layout(width, height).items():
+            assert rect.top >= 1 and rect.left >= 1, name
+            assert rect.bottom <= height, name
+            assert rect.right <= width, name
+
+    @pytest.mark.parametrize("width,height", SIZES)
+    def test_panes_never_overlap_each_other(self, width, height):
+        """Only the dialog may float — nothing re-stamps on the panes' cadence."""
+        layout = busy_terminal.warroom_layout(width, height)
+        layout.pop("dialog")
+        panes = list(layout.items())
+        for i, (name_a, rect_a) in enumerate(panes):
+            for name_b, rect_b in panes[i + 1:]:
+                assert not rect_a.overlaps(rect_b), f"{name_a} overlaps {name_b}"
+
+    @pytest.mark.parametrize("width,height", SIZES)
+    def test_the_dialog_is_always_present_and_readable(self, width, height):
+        dialog = busy_terminal.warroom_layout(width, height)["dialog"]
+        assert dialog.width >= 30
+        assert dialog.height == 5
+
+    def test_a_generous_terminal_gets_all_three_panes(self):
+        assert set(busy_terminal.warroom_layout(120, 35)) == {
+            "memdump", "uplink", "intercept", "dialog",
+        }
+
+
+class TestRainAvoidance:
+    MOVE = re.compile(r"\033\[(\d+);(\d+)H")
+
+    def test_rain_never_writes_inside_an_avoided_window(self):
+        rng = random.Random(40)
+        window = busy_terminal.Rect(top=5, left=5, width=20, height=10)
+        drops = [busy_terminal.spawn_drop(col, 30, rng) for col in range(1, 60, 2)]
+
+        for _ in range(300):
+            frame = busy_terminal.rain_step(drops, height=30, rng=rng, avoid=[window])
+            for row, col in self.MOVE.findall(frame):
+                assert not window.contains(int(row), int(col))
+
+    def test_the_drops_keep_falling_behind_the_window(self):
+        """Avoidance blocks the writes, not the motion."""
+        rng = random.Random(41)
+        window = busy_terminal.Rect(top=1, left=1, width=60, height=30)
+        drops = [busy_terminal.spawn_drop(col, 30, rng) for col in (1, 3)]
+        rows = [drop.row for drop in drops]
+        busy_terminal.rain_step(drops, height=30, rng=rng, avoid=[window])
+        assert all(drop.row > row for drop, row in zip(drops, rows))
+
+
 class TestSceneArcs:
     """Each hacker scene must reach its climax — that IS the scene."""
 
@@ -383,6 +449,27 @@ class TestSceneArcs:
         lines = [line for line in rec.text.splitlines() if line]
         assert lines
         assert all(len(line) <= console.width for line in lines)
+
+    def test_the_warroom_dialog_always_finishes_matching(self):
+        console, rec = make_console(color=True)
+        busy_terminal.scene_warroom(console, random.Random(33))
+        assert "MATCHING PASSWORD" in rec.text
+        assert "ACCESS GRANTED" in rec.text
+        assert rec.text.index("MATCHING PASSWORD") < rec.text.index("ACCESS GRANTED")
+
+    def test_the_warroom_opens_every_pane_the_layout_grants(self):
+        console, rec = make_console(color=True)
+        busy_terminal.scene_warroom(console, random.Random(34))
+        layout = busy_terminal.warroom_layout(console.width, console.height)
+        layout.pop("dialog")
+        for name in layout:
+            assert name in rec.text
+
+    def test_the_warroom_fallback_still_tells_the_story(self):
+        console, rec = make_console(color=False)
+        busy_terminal.scene_warroom(console, random.Random(35))
+        assert "password matched" in rec.text
+        assert not ANSI.search(rec.text)
 
 
 # ── Launching a visible window ───────────────────────────────────────────────

--- a/tests/skills/test_busy_terminal_skill.py
+++ b/tests/skills/test_busy_terminal_skill.py
@@ -375,14 +375,25 @@ class TestWarroomLayout:
             assert rect.bottom <= height, name
             assert rect.right <= width, name
 
+    FLOATERS = ("dialog", "alert", "proxy", "exfil")
+
     @pytest.mark.parametrize("width,height", SIZES)
     def test_panes_never_overlap_each_other(self, width, height):
-        """Only the dialog may float — nothing re-stamps on the panes' cadence."""
+        """Only floaters may overlap panes — nothing re-stamps on the panes'
+        cadence."""
         layout = busy_terminal.warroom_layout(width, height)
-        layout.pop("dialog")
-        panes = list(layout.items())
+        panes = [(n, r) for n, r in layout.items() if n not in self.FLOATERS]
         for i, (name_a, rect_a) in enumerate(panes):
             for name_b, rect_b in panes[i + 1:]:
+                assert not rect_a.overlaps(rect_b), f"{name_a} overlaps {name_b}"
+
+    @pytest.mark.parametrize("width,height", SIZES)
+    def test_the_four_dialogs_never_cover_each_other(self, width, height):
+        """Floaters may sit on panes, but every dialog must stay readable."""
+        layout = busy_terminal.warroom_layout(width, height)
+        floaters = [(n, layout[n]) for n in self.FLOATERS if n in layout]
+        for i, (name_a, rect_a) in enumerate(floaters):
+            for name_b, rect_b in floaters[i + 1:]:
                 assert not rect_a.overlaps(rect_b), f"{name_a} overlaps {name_b}"
 
     @pytest.mark.parametrize("width,height", SIZES)
@@ -391,10 +402,15 @@ class TestWarroomLayout:
         assert dialog.width >= 30
         assert dialog.height == 5
 
-    def test_a_generous_terminal_gets_all_three_panes(self):
+    def test_a_generous_terminal_gets_every_window(self):
         assert set(busy_terminal.warroom_layout(120, 35)) == {
-            "memdump", "uplink", "intercept", "dialog",
+            "memdump", "uplink", "intercept", "dialog", "alert", "proxy", "exfil",
         }
+
+    def test_a_small_terminal_drops_the_corner_dialogs_not_the_centerpiece(self):
+        layout = busy_terminal.warroom_layout(60, 16)
+        assert "dialog" in layout
+        assert not set(layout) & {"alert", "proxy", "exfil"}
 
 
 class TestRainAvoidance:
@@ -461,9 +477,64 @@ class TestSceneArcs:
         console, rec = make_console(color=True)
         busy_terminal.scene_warroom(console, random.Random(34))
         layout = busy_terminal.warroom_layout(console.width, console.height)
-        layout.pop("dialog")
+        for floater in ("dialog", "alert", "proxy", "exfil"):
+            layout.pop(floater, None)
         for name in layout:
             assert name in rec.text
+
+    def test_the_warroom_shows_all_four_dialogs_on_a_roomy_terminal(self):
+        console, rec = make_console(color=True)
+        assert console.width >= 70 and console.height >= 20
+        busy_terminal.scene_warroom(console, random.Random(36))
+        for title in ("MATCHING PASSWORD", "PERIMETER", "PROXY CHAIN", "EXFIL"):
+            assert title in rec.text
+
+    def test_an_accented_line_keeps_its_tone_across_repaints(self):
+        """The accent is rolled once at append time, not re-rolled per frame."""
+        console, rec = make_console(color=True)
+        pane = busy_terminal.Pane(
+            rect=busy_terminal.Rect(top=2, left=2, width=20, height=4),
+            title="memdump",
+            tone=busy_terminal.GREY,
+            feed=busy_terminal.feed_hex,
+            period=3,
+            reveal=0,
+            lines=[("corrupt row", busy_terminal.RED), ("normal row", busy_terminal.GREY)],
+        )
+        for _ in range(2):
+            rec.chunks.clear()
+            console.paint(busy_terminal.interior_stamp(console, pane))
+            assert busy_terminal.RED + "corrupt row" in rec.text
+            assert busy_terminal.GREY + "normal row" in rec.text
+
+
+class TestRollTone:
+    def test_a_certain_accent_always_lands_and_a_zero_chance_never_does(self):
+        pane_kwargs = dict(
+            rect=busy_terminal.Rect(top=1, left=1, width=20, height=4),
+            title="x", tone=busy_terminal.GREY, feed=busy_terminal.feed_hex,
+            period=3, reveal=0, lines=[],
+        )
+        always = busy_terminal.Pane(accent=busy_terminal.RED, accent_chance=1.0, **pane_kwargs)
+        never = busy_terminal.Pane(accent=busy_terminal.RED, accent_chance=0.0, **pane_kwargs)
+        plain = busy_terminal.Pane(**pane_kwargs)
+
+        rng = random.Random(50)
+        for _ in range(50):
+            assert busy_terminal.roll_tone(rng, always) == busy_terminal.RED
+            assert busy_terminal.roll_tone(rng, never) == busy_terminal.GREY
+            assert busy_terminal.roll_tone(rng, plain) == busy_terminal.GREY
+
+    def test_a_partial_chance_produces_both_tones(self):
+        pane = busy_terminal.Pane(
+            rect=busy_terminal.Rect(top=1, left=1, width=20, height=4),
+            title="x", tone=busy_terminal.CYAN, feed=busy_terminal.feed_trace,
+            period=3, reveal=0, lines=[],
+            accent=busy_terminal.GREEN, accent_chance=0.3,
+        )
+        rng = random.Random(51)
+        tones = {busy_terminal.roll_tone(rng, pane) for _ in range(200)}
+        assert tones == {busy_terminal.CYAN, busy_terminal.GREEN}
 
     def test_the_warroom_fallback_still_tells_the_story(self):
         console, rec = make_console(color=False)


### PR DESCRIPTION
## Summary

Adds `busy-terminal`, an optional creative skill in the `cmatrix` / `genact` / Hollywood tradition: a terminal screensaver that fakes activity, in two flavours picked by `--profile`:

- **developer** (default) — an editor typing source, a build, a test run, and git activity, with plausible output, timings, and progress bars.
- **hacker** — digital rain; a multi-window **war room** (rain flowing behind live memdump/uplink/intercept panes with red and green accent rows, plus four floating dialogs: the MATCHING PASSWORD centerpiece, a red PERIMETER countdown, a green PROXY CHAIN, and an amber EXFIL meter); a movie intrusion ending in an ACCESS GRANTED banner and an exfil bar; and an AES key cracking itself byte by byte.
- **mixed** — everything in one rotation. A pinned `--scene` overrides the profile.

Nothing it prints is real. It reads no files, runs no commands, and opens no sockets; every path, SHA, and byte count is generated. A test pins that premise directly by patching `subprocess.run`, `subprocess.Popen`, `socket.socket`, and `open` and asserting none of them are called across a full run of every scene. The hacker profile's "targets" are RFC 5737 documentation addresses on RFC 2606 example.* hosts — unroutable by construction — and the skill prose tells the agent never to present any of the output as if it reflected real work.

## Footprint

Rung 2 of the footprint ladder — a skill plus a stdlib-only script, zero model-tool surface. It lands in `optional-skills/` rather than `skills/` because it is niche by definition, so it ships without being active by default.

Three new files, nothing existing is touched:

- `optional-skills/creative/busy-terminal/SKILL.md`
- `optional-skills/creative/busy-terminal/scripts/busy_terminal.py`
- `tests/skills/test_busy_terminal_skill.py`

## Design notes

**`--window` is what makes it usable from an agent.** Running the script through the `terminal` tool directly does not work: a captured pipe has no TTY to animate, and the default duration is unbounded, so the turn never returns. `--window` re-launches the script inside a fresh terminal window and exits immediately. `window_argv` takes the platform as data rather than reading `sys.platform`, so the macOS (`osascript` → Terminal.app), Windows (`cmd start`), and Linux (first emulator on `PATH`, normalised through `sh -c`) branches are all covered from a single host, per the "don't fake the host OS" rule.

**Every animated frame is one write.** The rain composes the whole frame via cursor addressing (per-cell writes flicker); `rain_step` takes avoid-rects so the rain flows around the war-room windows instead of scribbling through them. War-room panes never overlap each other — nothing re-stamps on their cadence, and the layout invariant is tested across a 30-size sweep. The dialog is the one floater, legal because it is re-stamped into every frame, last. Piped or `--no-color` output degrades the rain and the war room to scrolling lines, so the no-ANSI contract holds for every scene.

**Output and clock are injected into `Console`**, so tests drive whole scenes against a fake clock and capture frames instead of sleeping through them. No test sleeps.

**Tests assert invariants, not snapshots** — bar width is fixed regardless of input, out-of-range progress clamps, stripping ANSI from a highlighted line recovers the original exactly, scenes never repeat back to back, each profile plays exactly its own scene set, drops advance by their own speed and respawn above the screen, rain never writes inside an avoided rect, war-room panes stay inside the terminal and pairwise disjoint at every size, the same seed replays the same transcript, and each hacker scene reaches its climax (the banner, the closing line, the fully locked key, the dialog flipping to ACCESS GRANTED). No test reads source text.

## Test plan

- [x] `scripts/run_tests.sh tests/skills/test_busy_terminal_skill.py -q` — 233 passed
- [x] All scenes verified visually in a real terminal (rain + war room verified live on macOS Terminal.app)
- [x] `--window` verified end to end on macOS: hands off and returns in ~200ms
- [x] `--no-color` and piped output emit no ANSI escapes in any scene
- [x] Skill loads through the real discovery path — `hermes skills list` shows it enabled under creative

## Note for reviewers

This is a toy, and I have no strong feelings about whether it belongs in the tree. Happy to publish it as a standalone skill repo instead if that is the preference.