### PR TITLE
fix(providers): stop sending provider routing object to Nous endpoint

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -556,6 +556,11 @@ def _validated_openrouter_provider_sort(raw_sort: Any) -> Optional[str]:
 
 def _provider_preferences_for_agent(agent) -> Dict[str, Any]:
     """Build the validated provider-routing object shared by request paths."""
+    # OpenRouter-only. The Nous endpoint centrally decides routing and returns
+    # HTTP 400 if we send `only`/`ignore`/`order`/`data_collection`/`zdr`/
+    # `require_parameters`/`sort`. Never emit a `provider` object for Nous.
+    if getattr(agent, "provider", None) in {"nous", "nous-portal", "nousresearch"}:
+        return {}
     preferences: Dict[str, Any] = {}
     if agent.providers_allowed:
         preferences["only"] = agent.providers_allowed

--- a/plugins/model-providers/nous/__init__.py
+++ b/plugins/model-providers/nous/__init__.py
@@ -61,8 +61,9 @@ class NousProfile(ProviderProfile):
         if sticky_key:
             body["session_id"] = sticky_key
         provider_preferences = context.get("provider_preferences")
-        if provider_preferences:
-            body["provider"] = provider_preferences
+        # Nous centrally decides routing; sending a `provider` object returns
+        # HTTP 400. Never emit provider routing here (OpenRouter-only feature).
+        # Ignore any passed preferences defensively.
         return body
 
     @staticmethod


### PR DESCRIPTION
## What does this PR do?

Fixes the recurring HTTP 400 on the **Nous Portal** endpoint caused by forwarding OpenRouter-only `provider` routing preferences into the request body.

Reproduction (confirmed on a live gateway, `meituan/longcat-2.0:free` via Nous):

```
HTTP 400: This endpoint does not honor caller-supplied `provider` routing
preferences (e.g. `only`, `ignore`, `order`, `data_collection`, `zdr`,
`require_parameters`, `sort`). Routing is decided centrally per model, so
these fields are not enforced — sending them would give a false sense of
control. Remove the `provider` object from your request.
```

Root cause: `provider_routing` in `config.yaml` is OpenRouter-specific config, but it leaked onto the Nous wire in **two** places:

1. `agent/chat_completion_helpers.py::_provider_preferences_for_agent()` builds the routing dict unconditionally and it flows into the shared request path (main loop, summary, background, cron).
2. `plugins/model-providers/nous/__init__.py::build_extra_body()` re-emits `body["provider"]` from those preferences — copying OpenRouter behavior the Portal rejects.

The non-profile transport path already gates this behind `is_openrouter`, so both profiles (Nous + OpenRouter) should be consistent with the transport.

## Related Issue

Fixes #77564

Note: two overlapping PRs exist — #77593 (Nous profile only) and #89425 (auxiliary path only). This PR is the more complete fix: it guards **both** the shared helper choke-point and the Nous profile, so the bug is killed at every path (main loop, auxiliary, summary, cron, background). Happy to reconcile/merge scope with #77593 and #89425.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py`: `_provider_preferences_for_agent()` now returns `{}` for Nous providers (`nous`, `nous-portal`, `nousresearch`), so the shared builder never emits a `provider` routing object on the Nous wire.
- `plugins/model-providers/nous/__init__.py`: `build_extra_body()` no longer forwards `provider_preferences`; it returns only Portal tags + `session_id` sticky key. Added explanatory comment.
- OpenRouter profile unchanged — still forwards prefs.

## How to Test

1. Configure `model.provider: nous` and `model.default: meituan/longcat-2.0:free` (or any Nous route).
2. Keep the default `provider_routing` block in `config.yaml` (it is OpenRouter config but should not break Nous).
3. Send a message through the gateway (main loop) and trigger an auxiliary/summary call (e.g. context compression or a background task).
4. Confirm no `HTTP 400 ... does not honor caller-supplied provider routing preferences` in `~/.hermes/logs/errors.log`.

Without the fix, every turn 400s after the provider object reaches Nous. With it, turns complete normally and OpenRouter routing is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've verified the fix on a live gateway (see "How to Test"): the 400 is gone and Nous turns complete
- [x] I've tested on my platform: Ubuntu (Linux 6.8.0-138)

### Documentation & Housekeeping

- [x] N/A — no new config keys, no doc/architecture changes
- [x] N/A — no tool schemas changed

## Screenshots / Logs

Before (from `~/.hermes/logs/errors.log`):

```
ERROR agent.conversation_loop: Non-retryable client error: Error code: 400 - {'status': 400, 'message': 'This endpoint does not honor caller-supplied `provider` routing preferences ...'}
```

After: no 400; `model=meituan/longcat-2.0:free provider=nous` turns complete normally.
