### PR TITLE
fix(whatsapp): make mark_online configurable so send_read_receipts can work

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1720,6 +1720,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "send_read_receipts" in platform_cfg:
                     bridged["send_read_receipts"] = platform_cfg["send_read_receipts"]
+                if "mark_online" in platform_cfg:
+                    bridged["mark_online"] = platform_cfg["mark_online"]
                 if plat == Platform.TELEGRAM and "allowed_chats" in platform_cfg:
                     bridged["allowed_chats"] = platform_cfg["allowed_chats"]
                 if plat == Platform.TELEGRAM and "group_allowed_chats" in platform_cfg:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -441,6 +441,11 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
     - group_policy: "open" | "allowlist" | "disabled" | "pairing" — which groups are processed (default: "pairing")
     - group_allow_from: List of group JIDs allowed (when group_policy="allowlist")
     - send_read_receipts: Mark accepted inbound WhatsApp messages as read
+      (has no effect unless mark_online is true — WhatsApp only delivers
+      receipts for messages received while the socket is marked online)
+    - mark_online: Mark the Baileys socket online on connect (default: false).
+      Required for send_read_receipts to produce ticks; online presence is
+      visible to contacts, so it stays opt-in
 
     Behavior (gating, mention parsing, markdown conversion, chunking) is
     provided by ``WhatsAppBehaviorMixin`` so the Cloud API adapter can
@@ -495,6 +500,22 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             read_receipts if isinstance(read_receipts, bool)
             else str(read_receipts or "").strip().lower() in {"1", "true", "yes", "on"}
         )
+        mark_online = config.extra.get("mark_online", False)
+        self._mark_online = (
+            mark_online if isinstance(mark_online, bool)
+            else str(mark_online or "").strip().lower() in {"1", "true", "yes", "on"}
+        )
+        if self._send_read_receipts and not self._mark_online:
+            # WhatsApp only emits delivery/read receipts for messages received
+            # on an online-marked socket; with markOnlineOnConnect off the
+            # bridge's readMessages() call is silently discarded upstream.
+            print(
+                f"[{self.name}] warning: send_read_receipts=true has no effect "
+                "while mark_online is false (WhatsApp discards receipts for "
+                "offline-delivered messages). Set platforms.whatsapp.mark_online: "
+                "true to make read receipts work; note this makes the bot "
+                "visible as online to contacts."
+            )
         self._mention_patterns = self._compile_mention_patterns()
         self._message_queue: asyncio.Queue = asyncio.Queue()
         self._bridge_log_fh = None
@@ -688,7 +709,13 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 running_hash = data.get("scriptHash", "")
                                 disk_hash = _file_content_hash(bridge_path)
                                 running_read_receipts = bool(data.get("sendReadReceipts", False))
-                                config_matches = running_read_receipts == self._send_read_receipts
+                                running_mark_online = bool(data.get("markOnline", False))
+                                config_mismatches = []
+                                if running_read_receipts != self._send_read_receipts:
+                                    config_mismatches.append("send_read_receipts")
+                                if running_mark_online != self._mark_online:
+                                    config_mismatches.append("mark_online")
+                                config_matches = not config_mismatches
                                 if (
                                     running_hash
                                     and disk_hash
@@ -706,7 +733,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                                 stale_reason = (
                                     f"running={running_hash or 'unversioned'}, disk={disk_hash}"
                                     if running_hash != disk_hash
-                                    else "send_read_receipts config changed"
+                                    else f"{', '.join(config_mismatches)} config changed"
                                 )
                                 print(f"[{self.name}] Running bridge is stale ({stale_reason}), restarting")
                             else:
@@ -736,6 +763,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 bridge_env["WHATSAPP_REPLY_PREFIX"] = self._reply_prefix
             bridge_env["WHATSAPP_SEND_READ_RECEIPTS"] = (
                 "true" if self._send_read_receipts else "false"
+            )
+            bridge_env["WHATSAPP_MARK_ONLINE"] = (
+                "true" if self._mark_online else "false"
             )
             # Under multiplexing, the bridge subprocess runs with a copy of
             # os.environ that does NOT contain the secondary profile's .env

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -84,6 +84,16 @@ const SEND_READ_RECEIPTS =
   typeof process.env.WHATSAPP_SEND_READ_RECEIPTS === 'string' &&
   ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_SEND_READ_RECEIPTS.toLowerCase());
 
+// Mark the socket online on connect. WhatsApp only emits delivery/read
+// receipts for messages received on an online-marked socket, so read
+// receipts are inert while this stays false. Online presence is visible
+// to contacts — opt-in, default off (privacy-preserving).
+const MARK_ONLINE =
+  typeof process !== 'undefined' &&
+  process.env &&
+  typeof process.env.WHATSAPP_MARK_ONLINE === 'string' &&
+  ['1', 'true', 'yes', 'on'].includes(process.env.WHATSAPP_MARK_ONLINE.toLowerCase());
+
 const PORT = parseInt(getArg('port', '3000'), 10);
 const SESSION_DIR = getArg('session', path.join(process.env.HOME || '~', '.hermes', 'whatsapp', 'session'));
 // Cache directories: the Python gateway passes the profile-aware paths via
@@ -409,7 +419,7 @@ async function startSocket() {
     printQRInTerminal: false,
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
-    markOnlineOnConnect: false,
+    markOnlineOnConnect: MARK_ONLINE,
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)
     getMessage: async (key) => {
@@ -1111,6 +1121,7 @@ app.get('/health', (req, res) => {
     uptime: process.uptime(),
     scriptHash: SCRIPT_HASH,
     sendReadReceipts: SEND_READ_RECEIPTS,
+    markOnline: MARK_ONLINE,
   });
 });
 

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -54,6 +54,7 @@ def _make_adapter():
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._mark_online = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None

--- a/tests/gateway/test_whatsapp_mark_online.py
+++ b/tests/gateway/test_whatsapp_mark_online.py
@@ -1,0 +1,329 @@
+"""Tests for the whatsapp mark_online config (#99829).
+
+``send_read_receipts`` was dead config: the Baileys bridge hardwired
+``markOnlineOnConnect: false``, so inbound messages arrived via the
+offline-notification path, WhatsApp emitted no delivery receipt for them,
+and the bridge's ``readMessages()`` call was discarded before a read
+receipt could ever render (messages stuck at one grey tick, #27198).
+
+These tests pin the fix: ``platforms.whatsapp.mark_online`` (default
+``false`` — online presence is visible to contacts, so it stays opt-in)
+flows config.yaml → ``PlatformConfig.extra`` → ``WhatsAppAdapter`` →
+``WHATSAPP_MARK_ONLINE`` env → ``bridge.js markOnlineOnConnect``, with a
+startup warning when ``send_read_receipts`` is enabled while presence is
+off, and a stale-bridge restart when the running bridge's presence mode
+no longer matches the config.
+"""
+
+import asyncio
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+
+
+class _AsyncCM:
+    """Minimal async context manager returning a fixed value."""
+
+    def __init__(self, value):
+        self.value = value
+
+    async def __aenter__(self):
+        return self.value
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+def _mock_health(json_data):
+    """Mock aiohttp.ClientSession whose GET returns 200 + *json_data*."""
+    mock_resp = MagicMock()
+    mock_resp.status = 200
+    mock_resp.json = AsyncMock(return_value=json_data)
+    mock_session = MagicMock()
+    mock_session.get = MagicMock(return_value=_AsyncCM(mock_resp))
+    mock_session.close = AsyncMock()
+    return MagicMock(return_value=_AsyncCM(mock_session))
+
+
+def _setup_bridge_dir(tmp_path: Path) -> Path:
+    bridge_dir = tmp_path / "whatsapp-bridge"
+    bridge_dir.mkdir()
+    (bridge_dir / "bridge.js").write_text("// current bridge code\n")
+    (bridge_dir / "package.json").write_text('{"name": "bridge"}\n')
+    session_path = tmp_path / "session"
+    session_path.mkdir()
+    (session_path / "creds.json").write_text("{}")
+    return bridge_dir
+
+
+def _fresh_node_modules(bridge_dir: Path) -> None:
+    from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+    nm = bridge_dir / "node_modules"
+    nm.mkdir()
+    (nm / ".hermes-pkg-hash").write_text(
+        _file_content_hash(bridge_dir / "package.json")
+    )
+
+
+def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
+                  session_path: Path = Path("/tmp/test-wa-session")):
+    """Create a WhatsAppAdapter with test attributes (bypass __init__)."""
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter.__new__(WhatsAppAdapter)
+    adapter.platform = Platform.WHATSAPP
+    adapter.config = MagicMock()
+    adapter._bridge_port = 19876
+    adapter._bridge_script = bridge_script
+    adapter._session_path = session_path
+    adapter._bridge_log_fh = None
+    adapter._bridge_log = None
+    adapter._bridge_process = None
+    adapter._reply_prefix = None
+    adapter._send_read_receipts = False
+    adapter._mark_online = False
+    adapter._running = False
+    adapter._message_handler = None
+    adapter._fatal_error_code = None
+    adapter._fatal_error_message = None
+    adapter._fatal_error_retryable = True
+    adapter._fatal_error_handler = None
+    adapter._active_sessions = {}
+    adapter._pending_messages = {}
+    adapter._background_tasks = set()
+    adapter._auto_tts_disabled_chats = set()
+    adapter._message_queue = asyncio.Queue()
+    adapter._http_session = None
+    return adapter
+
+
+# ---------------------------------------------------------------------------
+# Config bridging from config.yaml
+# ---------------------------------------------------------------------------
+
+
+class TestConfigYamlBridging:
+    """whatsapp.mark_online in config.yaml flows into PlatformConfig.extra."""
+
+    def test_mark_online_bridged_from_yaml(self, tmp_path):
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("whatsapp:\n  mark_online: true\n")
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+            with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+                config = load_gateway_config()
+
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert wa_config.extra.get("mark_online") is True
+
+    def test_mark_online_absent_by_default(self, tmp_path):
+        config_yaml = tmp_path / "config.yaml"
+        config_yaml.write_text("whatsapp:\n  reply_prefix: \"Bot\"\n")
+
+        with patch("gateway.config.get_hermes_home", return_value=tmp_path):
+            from gateway.config import load_gateway_config
+            with patch.dict("os.environ", {"WHATSAPP_ENABLED": "true"}, clear=False):
+                config = load_gateway_config()
+
+        wa_config = config.platforms.get(Platform.WHATSAPP)
+        assert wa_config is not None
+        assert "mark_online" not in wa_config.extra
+
+
+# ---------------------------------------------------------------------------
+# WhatsAppAdapter __init__ parsing + startup warning
+# ---------------------------------------------------------------------------
+
+
+class TestAdapterInit:
+    def test_mark_online_true(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"mark_online": True}))
+        assert adapter._mark_online is True
+
+    def test_mark_online_default_false(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._mark_online is False
+
+    def test_mark_online_truthy_string(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={"mark_online": "yes"}))
+        assert adapter._mark_online is True
+
+    def test_warns_when_receipts_enabled_without_presence(self, capsys):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        WhatsAppAdapter(PlatformConfig(enabled=True, extra={"send_read_receipts": True}))
+        out = capsys.readouterr().out
+        assert "send_read_receipts=true has no effect" in out
+        assert "mark_online" in out
+
+    def test_no_warning_when_presence_enabled(self, capsys):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        WhatsAppAdapter(PlatformConfig(enabled=True, extra={
+            "send_read_receipts": True, "mark_online": True,
+        }))
+        out = capsys.readouterr().out
+        assert "has no effect" not in out
+
+    def test_no_warning_when_receipts_disabled(self, capsys):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+        out = capsys.readouterr().out
+        assert "has no effect" not in out
+
+
+# ---------------------------------------------------------------------------
+# Bridge subprocess env bridging
+# ---------------------------------------------------------------------------
+
+
+class TestBridgeEnvBridging:
+    @pytest.mark.asyncio
+    async def test_bridge_env_carries_mark_online(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._mark_online = True
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["WHATSAPP_MARK_ONLINE"] == "true"
+
+    @pytest.mark.asyncio
+    async def test_bridge_env_defaults_mark_online_false(self, tmp_path):
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", _mock_health({"status": "disconnected"})), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        env = mock_popen.call_args.kwargs["env"]
+        assert env["WHATSAPP_MARK_ONLINE"] == "false"
+
+
+# ---------------------------------------------------------------------------
+# Stale-bridge handshake: presence mismatch restarts, match reuses
+# ---------------------------------------------------------------------------
+
+
+class TestStaleBridgeHandshake:
+
+    @pytest.mark.asyncio
+    async def test_restarts_bridge_when_mark_online_config_changed(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._mark_online = True
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        # Running bridge: same code hash, receipts match, but offline mode.
+        mock_client = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "sendReadReceipts": False,
+            "markOnline": False,
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True):
+            await adapter.connect()
+
+        mock_popen.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_reuses_bridge_when_mark_online_matches(self, tmp_path):
+        from plugins.platforms.whatsapp.adapter import _file_content_hash
+
+        bridge_dir = _setup_bridge_dir(tmp_path)
+        _fresh_node_modules(bridge_dir)
+        adapter = _make_adapter(
+            bridge_script=str(bridge_dir / "bridge.js"),
+            session_path=tmp_path / "session",
+        )
+        adapter._send_read_receipts = True
+        adapter._mark_online = True
+        disk_hash = _file_content_hash(bridge_dir / "bridge.js")
+        # Running bridge: same code hash and both flags match the config.
+        mock_client = _mock_health({
+            "status": "connected",
+            "scriptHash": disk_hash,
+            "sendReadReceipts": True,
+            "markOnline": True,
+        })
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = 1
+        mock_proc.returncode = 1
+
+        with patch("plugins.platforms.whatsapp.adapter.check_whatsapp_requirements", return_value=True), \
+             patch("aiohttp.ClientSession", mock_client), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.sleep", new_callable=AsyncMock), \
+             patch("plugins.platforms.whatsapp.adapter._kill_stale_bridge_by_pidfile"), \
+             patch("plugins.platforms.whatsapp.adapter._kill_port_process"), \
+             patch("subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch.object(adapter, "_acquire_platform_lock", return_value=True, create=True), \
+             patch.object(adapter, "_mark_connected", create=True), \
+             patch.object(adapter, "_wire_plugin_handlers", create=True), \
+             patch("plugins.platforms.whatsapp.adapter.asyncio.create_task"):
+            result = await adapter.connect()
+
+        assert result is True
+        mock_popen.assert_not_called()
+        assert adapter._bridge_process is None  # reused, not managed by us

--- a/tests/gateway/test_whatsapp_stale_bridge.py
+++ b/tests/gateway/test_whatsapp_stale_bridge.py
@@ -54,6 +54,7 @@ def _make_adapter(bridge_script: str = "/tmp/test-bridge.js",
     adapter._bridge_process = None
     adapter._reply_prefix = None
     adapter._send_read_receipts = False
+    adapter._mark_online = False
     adapter._running = False
     adapter._message_handler = None
     adapter._fatal_error_code = None

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -181,9 +181,12 @@ whatsapp:
   reply_prefix: ""                          # Empty string disables the header
   # reply_prefix: "🤖 *My Bot*\n──────\n"  # Custom prefix (supports \n for newlines)
   send_read_receipts: false                 # Mark accepted inbound messages as read (blue ticks)
+  mark_online: false                        # Mark the socket online so receipts can be delivered
 ```
 
 When `send_read_receipts` is `true`, the adapter marks policy-accepted inbound messages as read after DM/group/mention filtering passes. Rejected messages (e.g., from non-allowlisted senders) are not marked read. Disabled by default for privacy. Changing this setting automatically restarts the bridge subprocess on the next connection.
+
+`send_read_receipts` only works when `mark_online` is also `true`: WhatsApp delivers messages down the offline-notification path on a socket that is not marked online, and it emits no delivery receipt (the first grey tick's counterpart) for offline-delivered messages — so `readMessages()` is discarded before a read receipt can ever render. `mark_online` therefore gates both ticks and stays opt-in (default: `false`), because online presence is visible to your contacts. When `send_read_receipts: true` is set while `mark_online` is `false`, the adapter logs a warning at startup. Changing `mark_online` restarts the bridge subprocess on the next connection, same as `send_read_receipts`.
 
 ---
 


### PR DESCRIPTION
## What does this PR do?

`platforms.whatsapp.send_read_receipts` is dead config: `bridge.js` hardwired `markOnlineOnConnect: false`, so the Baileys socket connects in offline mode, inbound messages are delivered down the offline-notification path, and WhatsApp emits **no delivery receipt** for offline-delivered messages. Without a delivery receipt the sender never sees the second grey tick — and WhatsApp will not render a blue tick for a message it has not first marked delivered — so the bridge's `readMessages()` call is discarded no matter what the config says (the user-visible symptom in #27198).

This makes presence configurable instead of a literal, exactly as `send_read_receipts` already is: a new `platforms.whatsapp.mark_online` key (default `false`, preserving today's behavior and privacy — online presence is visible to contacts and stays opt-in) flows config.yaml → `PlatformConfig.extra` → `WhatsAppAdapter` → `WHATSAPP_MARK_ONLINE` env → `markOnlineOnConnect`. Defaulting to `true` unconditionally was explicitly considered and rejected in the issue (permanent online presence is a real privacy cost).

Two accompanying guardrails:

- **Startup warning** when `send_read_receipts: true` is set while `mark_online` is false, so the next person doesn't lose an evening to the coupling.
- **Stale-bridge handshake**: the running bridge now reports `markOnline` in `/health`, and the adapter restarts the bridge when the presence mode no longer matches the config (same as the existing `sendReadReceipts` handshake), so flipping the key takes effect without manually killing the subprocess.

## Related Issue

Fixes #99829

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js` — read `WHATSAPP_MARK_ONLINE` (same truthy-set parsing as `WHATSAPP_SEND_READ_RECEIPTS`), pass it to `makeWASocket({ markOnlineOnConnect })` instead of the hardcoded `false`, and report it as `markOnline` in `/health`.
- `plugins/platforms/whatsapp/adapter.py` — parse `mark_online` from `config.extra` (default `false`, bool or truthy string), warn at startup when `send_read_receipts` is enabled while presence is off, include `markOnline` in the stale-bridge config handshake (restart on mismatch), and pass `WHATSAPP_MARK_ONLINE` to the bridge subprocess env.
- `gateway/config.py` — bridge `whatsapp.mark_online` from config.yaml into `PlatformConfig.extra`, next to the existing `send_read_receipts` bridge.
- `tests/gateway/test_whatsapp_mark_online.py` — new: config.yaml bridging (present + absent), adapter parsing (bool/string/default), startup warning (fires only for the receipts-without-presence combination), env bridging (`"true"`/`"false"`), stale-bridge restart on presence mismatch, and bridge reuse when hash + both flags match.
- `tests/gateway/test_whatsapp_stale_bridge.py`, `tests/gateway/test_whatsapp_connect.py` — test adapters built via `__new__` now set `_mark_online` alongside `_send_read_receipts`.
- `website/docs/user-guide/messaging/whatsapp.md` — document `mark_online`, why it gates both ticks, and the startup warning.

## How to Test

1. `python -m pytest tests/gateway/test_whatsapp_mark_online.py tests/gateway/test_whatsapp_stale_bridge.py tests/gateway/test_whatsapp_connect.py tests/gateway/test_whatsapp_reply_prefix.py -q` — Observed result: **100 passed, 5 skipped** on upstream/main + this change.
2. Verified red→green: with only the adapter change stashed, 7 of the 12 new tests fail (`AttributeError` on `_mark_online`, missing warning, missing env key); with it applied all 12 pass.
3. `node --check scripts/whatsapp-bridge/bridge.js` — Observed result: passes.
4. Manual end-to-end (requires a paired WhatsApp): set `platforms.whatsapp.mark_online: true` and `send_read_receipts: true` in `~/.hermes/config.yaml`, restart the gateway, confirm the bridge env carries `WHATSAPP_MARK_ONLINE=true` and that a DM from an allowlisted number now goes two-grey-ticks → blue (per the issue reporter's flip-line-412 experiment; this PR turns that experiment into config).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (the example file doesn't enumerate per-platform whatsapp keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-Compatibility) — or N/A (env-var bridging is platform-neutral; no path/process changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
