### PR TITLE
fix(gateway): gate systemd timeout probe on LoadState (salvage #34734)

### DIFF
--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -372,30 +372,47 @@ def check_systemd_timing_alignment(
     # Query systemctl for TimeoutStopUSec.  Use --user OR system depending
     # on which manager actually owns the unit.  Try user first since
     # that's the common case for hermes.
+    #
+    # `systemctl --user show <unit>` answers with built-in defaults (e.g.
+    # TimeoutStopUSec=1min 30s) and exit code 0 even when that manager has
+    # never heard of the unit, so the returned value alone cannot tell us
+    # who owns it.  Gate on LoadState=loaded before trusting the timeout:
+    # otherwise a system-managed unit is judged against the user manager's
+    # phantom 90s default and we warn about a mismatch that does not exist.
     timeout_us: Optional[int] = None
     for flag in (["--user"], []):
         try:
             result = subprocess.run(
-                ["systemctl", *flag, "show", unit_name, "--property=TimeoutStopUSec"],
+                [
+                    "systemctl", *flag, "show", unit_name,
+                    "--property=LoadState",
+                    "--property=TimeoutStopUSec",
+                ],
                 capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=2.0,
             )
         except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
             continue
         if result.returncode != 0:
             continue
-        # Output: "TimeoutStopUSec=1min 30s" or "TimeoutStopUSec=90000000"
+        # Output: "LoadState=loaded" plus "TimeoutStopUSec=1min 30s" or
+        # "TimeoutStopUSec=90000000".  Property order is not guaranteed, so
+        # collect both before deciding whether to trust this manager.
+        load_state: Optional[str] = None
+        candidate_us: Optional[int] = None
         for line in result.stdout.splitlines():
-            if line.startswith("TimeoutStopUSec="):
+            if line.startswith("LoadState="):
+                load_state = line.split("=", 1)[1].strip()
+            elif line.startswith("TimeoutStopUSec="):
                 value = line.split("=", 1)[1].strip()
                 # Try numeric microseconds first
                 if value.isdigit():
-                    timeout_us = int(value)
+                    candidate_us = int(value)
                 else:
-                    timeout_us = parse_systemd_duration_to_us(value)
-                if timeout_us is not None:
-                    break
-        if timeout_us is not None:
-            break
+                    candidate_us = parse_systemd_duration_to_us(value)
+        if load_state != "loaded" or candidate_us is None:
+            continue
+        timeout_us = candidate_us
+        break
 
     if timeout_us is None:
         return None

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import builtins
+import io
 import json
 import os
 import signal
@@ -142,3 +144,127 @@ class TestCheckSystemdTimingAlignment:
         # for whatever unit pytest IS in.  Both are valid; we just ensure
         # the function doesn't raise.
         assert result is None or isinstance(result, dict)
+
+
+# ---------------------------------------------------------------------------
+# check_systemd_timing_alignment — systemd manager scope
+# ---------------------------------------------------------------------------
+
+class _FakeCompleted:
+    """Minimal stand-in for subprocess.CompletedProcess."""
+
+    def __init__(self, stdout: str, returncode: int = 0):
+        self.stdout = stdout
+        self.returncode = returncode
+        self.stderr = ""
+
+
+def _show_output(load_state: str, timeout: str) -> str:
+    return f"LoadState={load_state}\nTimeoutStopUSec={timeout}\n"
+
+
+@pytest.fixture
+def systemd_unit(monkeypatch):
+    """Make the checker believe it runs under ``hermes-gateway.service``.
+
+    Fakes INVOCATION_ID and the ``/proc/self/cgroup`` read so these tests
+    are hermetic and stay valid on macOS and Windows, where /proc is absent.
+    """
+    monkeypatch.setenv("INVOCATION_ID", "test-invocation")
+    real_open = builtins.open
+
+    def fake_open(path, *args, **kwargs):
+        if str(path) == "/proc/self/cgroup":
+            return io.StringIO("0::/system.slice/hermes-gateway.service\n")
+        return real_open(path, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+    return "hermes-gateway.service"
+
+
+def _patch_systemctl(monkeypatch, user, system):
+    """Serve canned ``systemctl show`` output and record the scopes probed.
+
+    Pass ``None`` for a manager that fails outright (exit 1), e.g. a server
+    with no user bus.
+    """
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        scope = "user" if "--user" in cmd else "system"
+        calls.append(scope)
+        payload = user if scope == "user" else system
+        if payload is None:
+            return _FakeCompleted("", returncode=1)
+        return _FakeCompleted(payload)
+
+    monkeypatch.setattr(sf.subprocess, "run", fake_run)
+    return calls
+
+
+class TestCheckSystemdTimingAlignmentManagerScope:
+    """``systemctl --user`` answers for units it does not own.
+
+    ``systemctl --user show <unit>`` exits 0 and reports built-in defaults
+    (``TimeoutStopUSec=1min 30s``) even when the user manager has never
+    heard of the unit.  Trusting that value made a system-managed gateway
+    warn about a phantom 90s stop timeout on every startup, so the checker
+    gates on ``LoadState=loaded`` before believing a manager.
+    """
+
+    def test_ignores_phantom_default_from_unloaded_user_manager(
+        self, systemd_unit, monkeypatch
+    ):
+        calls = _patch_systemctl(
+            monkeypatch,
+            user=_show_output("not-found", "1min 30s"),  # phantom 90s default
+            system=_show_output("loaded", "300s"),       # the unit we actually run
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls == ["user", "system"]
+        assert result is not None
+        assert result["timeout_stop_sec"] == 300.0
+        # The phantom 90s sits below expected_min (210s) and would have been
+        # reported as a mismatch; the real unit's 300s clears it.
+        assert result["mismatch"] is False
+
+    def test_uses_user_manager_when_it_owns_the_unit(
+        self, systemd_unit, monkeypatch
+    ):
+        calls = _patch_systemctl(
+            monkeypatch,
+            user=_show_output("loaded", "300s"),
+            system=_show_output("loaded", "999s"),
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert calls == ["user"], "a loaded user unit must not fall through"
+        assert result is not None
+        assert result["timeout_stop_sec"] == 300.0
+
+    def test_returns_none_when_no_manager_has_the_unit(
+        self, systemd_unit, monkeypatch
+    ):
+        _patch_systemctl(
+            monkeypatch,
+            user=_show_output("not-found", "1min 30s"),
+            system=_show_output("not-found", "1min 30s"),
+        )
+
+        assert sf.check_systemd_timing_alignment(180.0) is None
+
+    def test_property_order_is_not_assumed(self, systemd_unit, monkeypatch):
+        # systemd does not guarantee the order of --property output.
+        _patch_systemctl(
+            monkeypatch,
+            user=None,  # no user bus at all
+            system="TimeoutStopUSec=300s\nLoadState=loaded\n",
+        )
+
+        result = sf.check_systemd_timing_alignment(180.0)
+
+        assert result is not None
+        assert result["timeout_stop_sec"] == 300.0


### PR DESCRIPTION
## What does this PR do?

`check_systemd_timing_alignment()` trusts the first systemd manager that answers, but `systemctl --user show <unit>` **exits 0 and returns built-in defaults** — including `TimeoutStopUSec=1min 30s` — even when the user manager has never heard of the unit. There is no way to tell that phantom answer apart from a real one by value alone.

So on a system-managed gateway (`/etc/systemd/system/hermes-gateway.service`, the standard server install), the check measured the *user* manager's phantom 90s against the real stop budget and logged a stop-timeout mismatch warning on every single startup. The unit was correctly sized the whole time.

The fix asks for `LoadState` alongside `TimeoutStopUSec` and skips any manager that does not report `LoadState=loaded`. Probe order is unchanged — user first, then system — so user-scope installs keep their current fast path.

This **salvages #34734 by @rp-keeran**, which diagnosed the same root cause and chose the same `LoadState` guard. That PR has gone stale and no longer merges: it predates the `cron_drain_timeout` parameter and the `_parse_systemd_duration_to_us` → `parse_systemd_duration_to_us` rename. This is that fix rebased onto current `main`, plus the regression tests its review asked for. Credit for the diagnosis is theirs.

## Related Issue

No open issue — the bug was found in production and traced to #34734.

Supersedes #34734 · also addressed in passing by the unfocused bundle #43195

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_forensics.py` — request `--property=LoadState` next to `--property=TimeoutStopUSec`; skip a manager unless it reports `LoadState=loaded`. Both properties are collected before the decision because systemd does not guarantee `--property` output order.
- `tests/gateway/test_shutdown_forensics.py` — four tests in a new `TestCheckSystemdTimingAlignmentManagerScope` class, using a hermetic `systemd_unit` fixture that fakes `INVOCATION_ID` and the `/proc/self/cgroup` read so they also run on macOS and Windows.

The review on #34734 asked for "an unloaded `--user` result followed by a loaded system result, plus a loaded user-scope happy path", and that the selected timeout come only from the loaded manager. All three are covered, plus a property-order guard.

Two of the four fail without the source change (verified by reverting it):

```
FAILED ...::test_ignores_phantom_default_from_unloaded_user_manager
FAILED ...::test_returns_none_when_no_manager_has_the_unit
E  AssertionError: assert {'timeout_stop_sec': 90.0, ...} is None
```

That `90.0` is the phantom default being trusted — the bug, reproduced in a test. The other two (user-scope happy path, property-order) pass either way by design: they pin behavior that must not regress rather than behavior being changed.

## How to Test

1. Install the gateway as a **system** unit (`/etc/systemd/system/hermes-gateway.service`) — i.e. any normal headless/server install — and start it.
2. Before this change: every startup logs a `TimeoutStopSec` mismatch warning, reporting `timeout_stop_sec: 90.0`, regardless of what the unit actually sets. Confirm the unit is in fact sized correctly with `systemctl show hermes-gateway.service --property=TimeoutStopUSec`, then note that `systemctl --user show hermes-gateway.service --property=TimeoutStopUSec` returns `1min 30s` for a unit the user manager does not own — that is the phantom.
3. After this change: no warning, because the user manager's answer is discarded as `LoadState=not-found`.
4. Unit tests: `pytest tests/gateway/test_shutdown_forensics.py -q` → 14 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #34734 and #43195; this supersedes the former rather than competing with it
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** I ran `tests/gateway/test_shutdown_forensics.py` (14 passed) and `ruff check` on both changed files (clean). The full suite needs the complete dev install, which I did not stand up; CI coverage would be appreciated here.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: bug observed and reproduced on Ubuntu/systemd (system-scope unit); unit tests run on macOS, Python 3.11.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, the behavior change is explained in an in-function comment
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — the code path is gated on `INVOCATION_ID` and `/proc/self/cgroup`, so it is Linux-only in practice; the new tests fake both and therefore stay green on macOS and Windows
