### PR TITLE
fix(desktop): scope bundle-skew detection to runtime paths

### DIFF
--- a/apps/desktop/electron/bundle-skew.test.ts
+++ b/apps/desktop/electron/bundle-skew.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterAll, describe, expect, it } from 'vitest'
 
 import { detectBundleSkew, isFallbackCommit, type RunGit } from './bundle-skew'
 
@@ -24,7 +29,7 @@ describe('detectBundleSkew', () => {
     expect(result).toEqual({ desktopCommitsBehind: 3, outOfSync: true })
   })
 
-  it('passes the stamp range scoped to apps/desktop', async () => {
+  it('counts only commits that touch runtime desktop paths', async () => {
     let seen: string[] = []
 
     const git: RunGit = async args => {
@@ -35,7 +40,19 @@ describe('detectBundleSkew', () => {
 
     await detectBundleSkew(STAMP, git, REPO)
 
-    expect(seen).toEqual(['rev-list', '--count', `${STAMP.commit}..HEAD`, '--', 'apps/desktop'])
+    expect(seen).toEqual([
+      'rev-list',
+      '--count',
+      `${STAMP.commit}..HEAD`,
+      '--',
+      'apps/desktop/src',
+      'apps/desktop/electron',
+      'apps/desktop/index.html',
+      'apps/desktop/public',
+      'apps/desktop/assets',
+      'apps/desktop/package.json',
+      'apps/desktop/vite.config.ts'
+    ])
   })
 
   it('is quiet when no desktop commits follow the stamp', async () => {
@@ -79,9 +96,104 @@ describe('detectBundleSkew', () => {
   })
 
   it('is quiet on unparsable rev-list output', async () => {
-    expect(await detectBundleSkew(STAMP, gitReturning('fatal: bad object'), REPO)).toEqual({
-      desktopCommitsBehind: null,
-      outOfSync: false
+    const result = await detectBundleSkew(STAMP, gitReturning('fatal: bad object'), REPO)
+
+    expect(result).toEqual({ desktopCommitsBehind: null, outOfSync: false })
+  })
+})
+
+// Real-git integration: proves the pathspec discriminates docs/e2e-only
+// commits from runtime commits in an actual repository, not just via mocks.
+const scratchRepos: string[] = []
+
+afterAll(() => {
+  for (const dir of scratchRepos) {
+    execFileSync('rm', ['-rf', dir])
+  }
+})
+
+function makeScratchRepo(): { repoRoot: string; base: string } {
+  const repoRoot = mkdtempSync(join(tmpdir(), 'bundle-skew-'))
+  scratchRepos.push(repoRoot)
+
+  const git = (...args: string[]) =>
+    execFileSync('git', ['-c', 'user.email=skew@test', '-c', 'user.name=skew', ...args], {
+      cwd: repoRoot,
+      stdio: ['ignore', 'pipe', 'pipe']
     })
+
+  git('init', '-q')
+  git('commit', '-q', '--allow-empty', '-m', 'base')
+  const base = git('rev-parse', 'HEAD').toString().trim()
+
+  return { repoRoot, base }
+}
+
+function realGitRun(root: string): RunGit {
+  return async (args, options) => {
+    try {
+      const stdout = execFileSync('git', args, {
+        cwd: options.cwd || root,
+        stdio: ['ignore', 'pipe', 'pipe']
+      }).toString()
+
+      return { code: 0, stderr: '', stdout }
+    } catch (error) {
+      const e = error as { stdout?: Buffer; stderr?: Buffer; status?: number }
+
+      return {
+        code: e.status ?? 1,
+        stderr: e.stderr?.toString() ?? '',
+        stdout: e.stdout?.toString() ?? ''
+      }
+    }
+  }
+}
+
+describe('detectBundleSkew against a real git repo', () => {
+  it('is quiet when only docs and e2e specs changed under apps/desktop', async () => {
+    const { repoRoot, base } = makeScratchRepo()
+
+    const git = (...args: string[]) =>
+      execFileSync('git', ['-c', 'user.email=skew@test', '-c', 'user.name=skew', ...args], {
+        cwd: repoRoot
+      })
+
+    execFileSync('mkdir', ['-p', join(repoRoot, 'apps/desktop/e2e')])
+    execFileSync('touch', [join(repoRoot, 'apps/desktop/AGENTS.md')])
+    execFileSync('touch', [join(repoRoot, 'apps/desktop/e2e/boot.spec.ts')])
+    git('add', '.')
+    git('commit', '-q', '-m', 'docs and e2e only')
+
+    const result = await detectBundleSkew(
+      { commit: base, source: 'local' },
+      realGitRun(repoRoot),
+      repoRoot
+    )
+
+    expect(result).toEqual({ desktopCommitsBehind: 0, outOfSync: false })
+  })
+
+  it('warns when a renderer file changed under apps/desktop', async () => {
+    const { repoRoot, base } = makeScratchRepo()
+
+    const git = (...args: string[]) =>
+      execFileSync('git', ['-c', 'user.email=skew@test', '-c', 'user.name=skew', ...args], {
+        cwd: repoRoot
+      })
+
+    execFileSync('mkdir', ['-p', join(repoRoot, 'apps/desktop/src/app')])
+    execFileSync('touch', [join(repoRoot, 'apps/desktop/src/app/new-feature.tsx')])
+    execFileSync('touch', [join(repoRoot, 'apps/desktop/README.md')])
+    git('add', '.')
+    git('commit', '-q', '-m', 'renderer change')
+
+    const result = await detectBundleSkew(
+      { commit: base, source: 'local' },
+      realGitRun(repoRoot),
+      repoRoot
+    )
+
+    expect(result).toEqual({ desktopCommitsBehind: 1, outOfSync: true })
   })
 })

--- a/apps/desktop/electron/bundle-skew.ts
+++ b/apps/desktop/electron/bundle-skew.ts
@@ -10,15 +10,16 @@
  * Bot Mode update" reports).
  *
  * Detection: the packaged build carries install-stamp.json with the commit
- * it was built from. If commits touching `apps/desktop/` exist in the source
- * tree AFTER that stamp commit, the running renderer is provably missing
- * desktop changes the installed runtime has:
+ * it was built from. If commits touching the runtime paths of apps/desktop
+ * exist in the source tree AFTER that stamp commit, the running renderer is
+ * provably missing desktop changes the installed runtime has:
  *
- *   git rev-list --count <stampCommit>..HEAD -- apps/desktop
+ *   git rev-list --count <stampCommit>..HEAD -- <RUNTIME_PATHS>
  *
- * Scoping to `apps/desktop/` keeps this quiet for the common case where the
- * repo advances with agent-only changes — a shell built before those is not
- * stale in any way the user can see.
+ * Scoping to runtime paths keeps this quiet for the common cases where the
+ * repo advances without user-visible desktop changes — agent-only commits
+ * elsewhere in the repo, or docs / e2e spec / config churn under
+ * apps/desktop that never reaches the shipped renderer or main process.
  *
  * Fail-quiet by design: no stamp (dev runs), a fallback all-zero stamp
  * (non-git build), an unknown commit (stamp predates a shallow clone's
@@ -35,7 +36,7 @@ export interface BundleSkewStamp {
 }
 
 export interface BundleSkewResult {
-  /** Commits under apps/desktop/ between the build stamp and HEAD (null = unknowable). */
+  /** Commits behind on runtime desktop paths between the build stamp and HEAD (null = unknowable). */
   desktopCommitsBehind: null | number
   /** True only on positive proof that the renderer predates desktop changes in the tree. */
   outOfSync: boolean
@@ -45,6 +46,22 @@ export type RunGit = (
   args: string[],
   options: { cwd: string }
 ) => Promise<{ code: number; stderr: string; stdout: string }>
+
+/**
+ * The apps/desktop paths that actually reach the user: renderer sources,
+ * main-process sources, the HTML entry, the public/ assets Vite copies into
+ * the bundle, app icons and the packaging config. Docs, e2e specs, scratch
+ * scripts and dev tooling never reach the shipped app.
+ */
+const RUNTIME_PATHS = [
+  'apps/desktop/src',
+  'apps/desktop/electron',
+  'apps/desktop/index.html',
+  'apps/desktop/public',
+  'apps/desktop/assets',
+  'apps/desktop/package.json',
+  'apps/desktop/vite.config.ts'
+] as const
 
 const NOT_STALE: BundleSkewResult = { desktopCommitsBehind: null, outOfSync: false }
 
@@ -63,9 +80,12 @@ export async function detectBundleSkew(
   }
 
   try {
-    const result = await runGit(['rev-list', '--count', `${stamp.commit}..HEAD`, '--', 'apps/desktop'], {
-      cwd: repoRoot
-    })
+    const result = await runGit(
+      ['rev-list', '--count', `${stamp.commit}..HEAD`, '--', ...RUNTIME_PATHS],
+      {
+        cwd: repoRoot
+      }
+    )
 
     if (result.code !== 0) {
       return NOT_STALE


### PR DESCRIPTION
## Problem

`detectBundleSkew` counts **every** commit under `apps/desktop/` since the build stamp:

```
git rev-list --count <stamp>..HEAD -- apps/desktop
```

so a delta that only adds docs (`AGENTS.md` / `DESIGN.md` / `README.md`) or Playwright e2e specs trips the **"App build out of date"** banner — telling the user their install is torn and promising "new interface features (like Bot Mode) will be missing" when zero renderer or main-process files changed. That directly violates the module's own invariant: *this warning must never false-positive*.

## Fix

Scope the rev-list pathspec to the paths that actually reach the shipped app:

- `apps/desktop/src` (renderer)
- `apps/desktop/electron` (main process)
- `apps/desktop/index.html`
- `apps/desktop/public` (Vite copies it into the bundle)
- `apps/desktop/assets` (app icons via extraResources)
- `apps/desktop/package.json`, `apps/desktop/vite.config.ts` (build inputs)

Docs, e2e specs, tsconfigs, dev scripts and scratch dirs stay out of the count. Genuinely torn installs still warn exactly as before.

## Tests

- updated the pathspec assertion to pin the runtime-path list
- added two integration tests that run against a **real scratch git repo**: a docs+e2e-only commit → quiet (`desktopCommitsBehind: 0`), and a renderer commit → warns (`outOfSync: true`) — the exact repro from the issue, verified by actual `git rev-list`, not mocks
- all existing fail-quiet cases unchanged (11/11 pass)

Closes #99832