### PR TITLE
fix(vision): avoid reloading gateway-attached images

### DIFF
--- a/agent/native_vision_context.py
+++ b/agent/native_vision_context.py
@@ -1,0 +1,51 @@
+"""Turn-local visibility for images already attached to the main model."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar
+from pathlib import Path
+from typing import Iterable, Iterator
+
+
+_NATIVE_IMAGE_REFS: ContextVar[frozenset[str]] = ContextVar(
+    "hermes_native_image_refs",
+    default=frozenset(),
+)
+
+
+def _normalize_ref(ref: str) -> str:
+    value = str(ref or "").strip()
+    if not value:
+        return ""
+    if value.startswith("file://"):
+        value = value[7:]
+    if value.startswith(("http://", "https://", "data:")):
+        return value
+    try:
+        return str(Path(value).expanduser().resolve(strict=False))
+    except Exception:
+        return value
+
+
+@contextmanager
+def scoped_native_image_refs(refs: Iterable[str]) -> Iterator[None]:
+    """Publish image references visible in the current parent agent turn."""
+    normalized = frozenset(filter(None, (_normalize_ref(ref) for ref in refs)))
+    token = _NATIVE_IMAGE_REFS.set(normalized)
+    try:
+        yield
+    finally:
+        _NATIVE_IMAGE_REFS.reset(token)
+
+
+def is_native_image_attached(ref: str) -> bool:
+    """Return whether *ref* is already visible to the current main model."""
+    # Children inherit ContextVars, but their user turn does not contain the
+    # parent's image parts. They must remain able to load the referenced image.
+    from agent.delegation_context import is_delegated_child_context
+
+    if is_delegated_child_context():
+        return False
+    normalized = _normalize_ref(ref)
+    return bool(normalized and normalized in _NATIVE_IMAGE_REFS.get())

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6913,6 +6913,7 @@ class TurnRunner:
             # content list. Consume-and-clear so subsequent turns on the same
             # runner instance don't re-attach stale images.
             _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
+            _attached_native_imgs = []
             if _native_imgs:
                 try:
                     from agent.image_routing import build_native_content_parts
@@ -6927,6 +6928,10 @@ class TurnRunner:
                         )
                     if any(p.get("type") == "image_url" for p in _parts):
                         _run_message: Any = _parts
+                        _skipped_set = set(_skipped)
+                        _attached_native_imgs = [
+                            path for path in _native_imgs if str(path) not in _skipped_set
+                        ]
                     else:
                         # All images failed to read — fall back to plain text.
                         _run_message = ctx.message
@@ -6971,7 +6976,10 @@ class TurnRunner:
             # inbound id (NOT event_message_id, which is the reply anchor).
             if ctx.inbound_message_id is not None:
                 _conversation_kwargs["persist_user_platform_id"] = str(ctx.inbound_message_id)
-            result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+            from agent.native_vision_context import scoped_native_image_refs
+
+            with scoped_native_image_refs(_attached_native_imgs):
+                result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
         finally:
             unregister_gateway_notify(_approval_session_key)
             # Cancel any pending clarify entries so blocked agent

--- a/tests/agent/test_native_vision_context.py
+++ b/tests/agent/test_native_vision_context.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent.delegation_context import delegated_child_context
+from agent.native_vision_context import (
+    is_native_image_attached,
+    scoped_native_image_refs,
+)
+
+
+def test_scope_normalizes_file_urls_and_resets_after_success(tmp_path):
+    image = tmp_path / "image.png"
+
+    with scoped_native_image_refs([f"file://{image}"]):
+        assert is_native_image_attached(str(image)) is True
+
+    assert is_native_image_attached(str(image)) is False
+
+
+def test_scope_resets_after_exception(tmp_path):
+    image = tmp_path / "image.png"
+
+    with pytest.raises(RuntimeError, match="turn failed"):
+        with scoped_native_image_refs([str(image)]):
+            assert is_native_image_attached(str(image)) is True
+            raise RuntimeError("turn failed")
+
+    assert is_native_image_attached(str(image)) is False
+
+
+def test_delegated_child_does_not_inherit_parent_attachment(tmp_path):
+    image = tmp_path / "image.png"
+
+    with scoped_native_image_refs([str(image)]):
+        assert is_native_image_attached(str(image)) is True
+        with delegated_child_context():
+            assert is_native_image_attached(str(image)) is False
+        assert is_native_image_attached(str(image)) is True
+
+
+def test_cancelled_task_does_not_leak_attachment(tmp_path):
+    image = tmp_path / "image.png"
+    entered = asyncio.Event()
+
+    async def cancelled_turn():
+        with scoped_native_image_refs([str(image)]):
+            entered.set()
+            await asyncio.Event().wait()
+
+    async def scenario():
+        task = asyncio.create_task(cancelled_turn())
+        await entered.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert is_native_image_attached(str(image)) is False
+
+    asyncio.run(scenario())
+
+
+def test_concurrent_turns_keep_attachment_refs_isolated(tmp_path):
+    first = tmp_path / "first.png"
+    second = tmp_path / "second.png"
+    both_entered = asyncio.Event()
+    entered = 0
+    lock = asyncio.Lock()
+
+    async def turn(own, other):
+        nonlocal entered
+        with scoped_native_image_refs([str(own)]):
+            async with lock:
+                entered += 1
+                if entered == 2:
+                    both_entered.set()
+            await both_entered.wait()
+            assert is_native_image_attached(str(own)) is True
+            assert is_native_image_attached(str(other)) is False
+
+    async def scenario():
+        await asyncio.gather(turn(first, second), turn(second, first))
+
+    asyncio.run(scenario())

--- a/tests/gateway/test_queued_native_image_session_key.py
+++ b/tests/gateway/test_queued_native_image_session_key.py
@@ -51,13 +51,20 @@ class CaptureAdapter(BasePlatformAdapter):
 
 class CaptureQueuedNativeImageAgent:
     calls = []
+    expected_native_refs = []
+    native_visibility = []
 
     def __init__(self, **kwargs):
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
 
     def run_conversation(self, message, conversation_history=None, task_id=None):
+        from agent.native_vision_context import is_native_image_attached
+
         type(self).calls.append(message)
+        type(self).native_visibility.append(
+            [is_native_image_attached(ref) for ref in type(self).expected_native_refs]
+        )
         return {
             "final_response": f"done-{len(type(self).calls)}",
             "messages": [],
@@ -93,6 +100,7 @@ def _make_runner(adapter):
 @pytest.mark.asyncio
 async def test_queued_followup_uses_pending_event_session_key_for_native_images(monkeypatch, tmp_path):
     CaptureQueuedNativeImageAgent.calls = []
+    CaptureQueuedNativeImageAgent.native_visibility = []
 
     fake_dotenv = types.ModuleType("dotenv")
     fake_dotenv.load_dotenv = lambda *args, **kwargs: None
@@ -111,6 +119,11 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
 
     image_path = tmp_path / "queued-image.png"
     image_path.write_bytes(_ONE_BY_ONE_PNG)
+    missing_path = tmp_path / "missing-image.png"
+    CaptureQueuedNativeImageAgent.expected_native_refs = [
+        str(image_path),
+        str(missing_path),
+    ]
 
     source = SessionSource(
         platform=Platform.TELEGRAM,
@@ -128,8 +141,8 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
         text="describe this",
         message_type=MessageType.PHOTO,
         source=pending_source,
-        media_urls=[str(image_path)],
-        media_types=["image/png"],
+        media_urls=[str(image_path), str(missing_path)],
+        media_types=["image/png", "image/png"],
         message_id="queued-1",
     )
 
@@ -149,3 +162,8 @@ async def test_queued_followup_uses_pending_event_session_key_for_native_images(
     assert queued_message[0]["type"] == "text"
     assert queued_message[0]["text"].startswith("describe this")
     assert any(part.get("type") == "image_url" for part in queued_message)
+    assert CaptureQueuedNativeImageAgent.native_visibility[-1] == [True, False]
+
+    from agent.native_vision_context import is_native_image_attached
+
+    assert is_native_image_attached(str(image_path)) is False

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -335,6 +335,59 @@ class TestVisionAnalyzeNative:
 class TestHandleVisionAnalyzeFastPath:
     """Verify the dispatcher chooses fast-path vs aux-LLM correctly."""
 
+    def test_gateway_native_attachment_is_not_embedded_twice(self, tmp_path):
+        """A gateway-attached image must not be returned again by the tool."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+
+        from agent.native_vision_context import scoped_native_image_refs
+
+        with scoped_native_image_refs([str(img)]), patch(
+            "tools.vision_tools._vision_analyze_native"
+        ) as native_analyze:
+            result = asyncio.run(
+                _handle_vision_analyze(
+                    {"image_url": str(img), "question": "describe it"}
+                )
+            )
+
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed["success"] is True
+        assert parsed["already_attached"] is True
+        assert "_multimodal" not in parsed
+        native_analyze.assert_not_called()
+
+    def test_attached_image_region_still_uses_native_crop(self, tmp_path):
+        """A region asks for new detail and must bypass whole-image dedupe."""
+        img = tmp_path / "x.png"
+        img.write_bytes(_TINY_PNG)
+        expected = {"_multimodal": True, "content": []}
+
+        from agent.native_vision_context import scoped_native_image_refs
+
+        with scoped_native_image_refs([str(img)]), patch(
+            "tools.vision_tools._should_use_native_vision_fast_path",
+            return_value=True,
+        ), patch(
+            "tools.vision_tools._vision_analyze_native",
+            return_value=expected,
+        ) as native_analyze:
+            result = asyncio.run(
+                _handle_vision_analyze(
+                    {
+                        "image_url": str(img),
+                        "question": "read the label",
+                        "region": [0, 0, 1, 1],
+                    }
+                )
+            )
+
+        assert result is expected
+        native_analyze.assert_awaited_once_with(
+            str(img), "read the label", task_id=None, region=[0, 0, 1, 1]
+        )
+
     def test_vision_capable_main_model_uses_fast_path(self, tmp_path, monkeypatch):
         """Main model supports native vision → fast path returns multimodal."""
         img = tmp_path / "x.png"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1854,6 +1854,29 @@ async def _handle_vision_analyze(args: Dict[str, Any], **kw: Any) -> str:
     region = args.get("region")
     task_id = kw.get("task_id")
 
+    # Gateway-native routing may already have placed these pixels in the
+    # current user turn. Avoid returning the same base64 payload again, while
+    # preserving region requests because crops provide new high-resolution
+    # detail that is not visible in the original attachment.
+    if region is None:
+        try:
+            from agent.native_vision_context import is_native_image_attached
+
+            if is_native_image_attached(image_url):
+                return json.dumps(
+                    {
+                        "success": True,
+                        "already_attached": True,
+                        "message": (
+                            "This image is already attached to the current user message. "
+                            "Inspect it directly with built-in vision; do not load it again."
+                        ),
+                    },
+                    ensure_ascii=False,
+                )
+        except Exception:
+            logger.debug("Native image deduplication check failed", exc_info=True)
+
     # The fan-out cap lives inside the encode/resize step (offloaded to the
     # bounded _vision_cpu_executor), NOT around the whole analysis — so a
     # legitimate multi-image workflow keeps full request concurrency while the


### PR DESCRIPTION
## Summary

Gateway-native image routing already attaches inbound images to the current user message. If the model then calls `vision_analyze` with the same image reference, Hermes currently reads and embeds the pixels a second time.

This change tracks successfully attached image references for the lifetime of the parent agent turn and lets `vision_analyze` return an `already_attached` result instead of producing a duplicate multimodal payload.

## Behavior

- Scope attachment visibility to the current turn with a `ContextVar`, including concurrent-turn and cancellation isolation.
- Normalize local paths and `file://` references while preserving HTTP(S) and data URL references.
- Publish only images that `build_native_content_parts()` actually attached; failed or skipped images remain loadable.
- Keep delegated child agents able to load the image because their user turn does not contain the parent's native attachment.
- Preserve `region` requests so crop/zoom analysis can still return new high-resolution detail.
- Reset attachment state after successful, failed, or cancelled turns.

## Test coverage

- `scripts/run_tests.sh` completed 88 image-routing and gateway tests: 88 passed, 0 failed.
- Coverage includes scope reset, exceptions, task cancellation, concurrent turns, delegated children, queued gateway images, skipped attachments, duplicate suppression, and region passthrough.
- Manual runtime smoke with `assets/banner.png` confirmed `already_attached=true`, no duplicate `_multimodal` payload, and scope reset after the turn.
- `scripts/check-windows-footguns.py --diff origin/main` passed for all 6 changed files.
- Ruff, Python bytecode compilation, and `git diff --check` pass.
- A no-filter full-suite run was also attempted (approximately 37,054 tests). It is not reported as passing: two unrelated LSP tests fail under this host's discovery state. Pytest temporary paths resolve inside a parent workspace, and the available TypeScript LSP makes a shell-linter fallback test skip that fallback. The affected files are unchanged by this PR.

## Platforms tested

- Linux x86_64, kernel 7.0.0-28-generic, Python 3.11.14: automated tests and manual runtime smoke.
- Windows and macOS: not runtime-tested. Cross-platform path/file handling was checked with the repository's Windows-footgun scanner; the implementation uses `pathlib.Path` and adds no process, signal, shell, or platform-specific code.

## Related issues

No matching existing issue was found.

## Pre-landing review

No issues found.

## Test plan

- [x] Run native vision context tests.
- [x] Run native vision fast-path tests.
- [x] Run image routing tests.
- [x] Run gateway turn isolation and queued-image tests.
- [x] Exercise duplicate suppression with a real repository image.
- [x] Run the Windows-footgun scanner for the complete diff.
