### PR TITLE
fix(gateway): prevent Feishu websocket shutdown hangs

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -220,6 +220,8 @@ _MAX_TEXT_INJECT_BYTES = 100 * 1024
 _FEISHU_CONNECT_ATTEMPTS = 3
 _FEISHU_SEND_ATTEMPTS = 3
 _FEISHU_APP_LOCK_SCOPE = "feishu-app-id"
+_FEISHU_WS_CLOSE_TIMEOUT_SECONDS = 1.0
+_FEISHU_WS_STOP_TIMEOUT_SECONDS = 1.0
 _DEFAULT_TEXT_BATCH_DELAY_SECONDS = 0.6
 _DEFAULT_TEXT_BATCH_MAX_MESSAGES = 8
 _DEFAULT_TEXT_BATCH_MAX_CHARS = 4000
@@ -1322,14 +1324,118 @@ def _strip_edge_self_mentions(
             return remaining
 
 
-def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
+@dataclass
+class _FeishuWSRuntime:
+    """Ownership record for one official-SDK websocket worker."""
+
+    client: Any
+    loop: Optional[asyncio.AbstractEventLoop] = None
+    thread: Optional[threading.Thread] = None
+    loop_ready: threading.Event = field(default_factory=threading.Event)
+    stop_requested: threading.Event = field(default_factory=threading.Event)
+    stopped: threading.Event = field(default_factory=threading.Event)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+def _abort_cancel_and_stop_feishu_ws_loop(
+    loop: asyncio.AbstractEventLoop,
+    ws_client: Any,
+) -> None:
+    """Run on the websocket thread to abort I/O and stop its event loop."""
+    # A loop.stop() alone cannot wake a selector blocked inside some websocket
+    # implementations. Abort whichever transport shape the installed
+    # lark/websockets version exposes, then stop the loop.
+    connection = getattr(ws_client, "_conn", None)
+    for candidate in (connection, getattr(connection, "protocol", None)):
+        transport = getattr(candidate, "transport", None)
+        if transport is None:
+            continue
+        try:
+            transport.abort()
+        except Exception:
+            logger.debug(
+                "[Feishu] Failed to abort websocket transport",
+                exc_info=True,
+            )
+        break
+    tasks = [task for task in asyncio.all_tasks(loop) if not task.done()]
+    logger.debug("[Feishu] Found %d pending websocket tasks", len(tasks))
+    for task in tasks:
+        task.cancel()
+    loop.stop()
+
+
+def _request_feishu_ws_loop_stop(
+    loop: Optional[asyncio.AbstractEventLoop],
+    ws_client: Any,
+) -> None:
+    """Abort the socket, cancel loop tasks, and stop without awaiting I/O."""
+    if loop is None or loop.is_closed():
+        return
+
+    try:
+        loop.call_soon_threadsafe(
+            _abort_cancel_and_stop_feishu_ws_loop,
+            loop,
+            ws_client,
+        )
+    except RuntimeError:
+        # The worker may have closed the loop between is_closed() and this
+        # call.  Its finally block has already completed the required cleanup.
+        pass
+
+
+def _arm_feishu_ws_loop_hard_stop(
+    loop: Optional[asyncio.AbstractEventLoop],
+    ws_client: Any,
+    delay: float,
+) -> None:
+    """Guarantee WS teardown even if a graceful CLOSE await never unwinds."""
+    if loop is None or loop.is_closed():
+        return
+
+    def _arm() -> None:
+        loop.call_later(
+            max(0.0, delay),
+            _abort_cancel_and_stop_feishu_ws_loop,
+            loop,
+            ws_client,
+        )
+
+    try:
+        loop.call_soon_threadsafe(_arm)
+    except RuntimeError:
+        pass
+
+
+def _request_feishu_ws_runtime_stop(runtime: _FeishuWSRuntime) -> None:
+    runtime.stop_requested.set()
+    with runtime.lock:
+        loop = runtime.loop
+    _request_feishu_ws_loop_stop(loop, runtime.client)
+
+
+def _run_official_feishu_ws_client(
+    ws_client: Any,
+    adapter: Any,
+    runtime: Optional[_FeishuWSRuntime] = None,
+) -> None:
     """Run the official Lark WS client in its own thread-local event loop."""
     import lark_oapi.ws.client as ws_client_module
 
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
+    original_module_loop = getattr(ws_client_module, "loop", None)
     ws_client_module.loop = loop
-    adapter._ws_thread_loop = loop
+    if runtime is None:
+        adapter._ws_thread_loop = loop
+    else:
+        with runtime.lock:
+            runtime.loop = loop
+        runtime.loop_ready.set()
+        publish_loop = getattr(adapter, "_publish_ws_runtime_loop", None)
+        if callable(publish_loop):
+            publish_loop(runtime, loop)
 
     original_connect = ws_client_module.websockets.connect
     original_configure = getattr(ws_client, "_configure", None)
@@ -1362,18 +1468,30 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
         setattr(ws_client, "_configure", _configure_with_overrides)
     _apply_runtime_ws_overrides()
     try:
-        ws_client.start()
+        # disconnect() can win the race before this daemon publishes its loop.
+        # In that case never enter the SDK's permanent run_forever() call.
+        if runtime is None or not runtime.stop_requested.is_set():
+            ws_client.start()
     except Exception:
-        pass
+        logger.debug("[Feishu] Websocket worker exited", exc_info=True)
     finally:
-        ws_client_module.websockets.connect = original_connect
-        if original_configure is not None:
+        if ws_client_module.websockets.connect is _connect_with_overrides:
+            ws_client_module.websockets.connect = original_connect
+        if (
+            original_configure is not None
+            and getattr(ws_client, "_configure", None) is _configure_with_overrides
+        ):
             setattr(ws_client, "_configure", original_configure)
+        if getattr(ws_client_module, "loop", None) is loop:
+            ws_client_module.loop = original_module_loop
         pending = [t for t in asyncio.all_tasks(loop) if not t.done()]
         for task in pending:
             task.cancel()
         if pending:
-            loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+            # One bounded loop turn delivers cancellation without allowing a
+            # task that swallows CancelledError to wedge worker teardown.
+            loop.call_soon(loop.stop)
+            loop.run_forever()
         try:
             loop.stop()
         except Exception:
@@ -1382,7 +1500,15 @@ def _run_official_feishu_ws_client(ws_client: Any, adapter: Any) -> None:
             loop.close()
         except Exception:
             pass
-        adapter._ws_thread_loop = None
+        if runtime is None:
+            adapter._ws_thread_loop = None
+        else:
+            with runtime.lock:
+                runtime.loop = None
+            runtime.stopped.set()
+            finish_runtime = getattr(adapter, "_finish_ws_runtime", None)
+            if callable(finish_runtime):
+                finish_runtime(runtime)
 
 
 def _load_lark_oapi() -> bool:
@@ -1516,6 +1642,19 @@ class FeishuAdapter(BasePlatformAdapter):
         # by the recreate-on-shutdown path; cleared on connect for reconnects.
         self._sdk_executor_closing = False
         self._ws_client: Optional[Any] = None
+        # The official Lark websocket client owns a permanent event loop.  It
+        # must run in a raw daemon thread rather than asyncio's default
+        # executor: asyncio.run() joins default-executor workers at exit and a
+        # wedged client would otherwise prevent gateway restart indefinitely.
+        self._ws_lifecycle_lock = threading.Lock()
+        self._ws_operation_lock = asyncio.Lock()
+        self._ws_lifecycle_epoch = 0
+        self._ws_connect_epoch: Optional[int] = None
+        self._ws_runtime: Optional[_FeishuWSRuntime] = None
+        self._ws_thread: Optional[threading.Thread] = None
+        self._ws_disconnect_count = 0
+        # Kept for compatibility with adapters/tests created by older code.
+        # New websocket workers are tracked by _ws_runtime, not this future.
         self._ws_future: Optional[asyncio.Future] = None
         self._ws_thread_loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
@@ -1771,7 +1910,115 @@ class FeishuAdapter(BasePlatformAdapter):
         except TypeError:
             executor.shutdown(wait=False)
 
+    def _publish_ws_runtime_loop(
+        self,
+        runtime: _FeishuWSRuntime,
+        loop: asyncio.AbstractEventLoop,
+    ) -> None:
+        """Publish a worker loop only if it still belongs to this adapter."""
+        with self._ws_lifecycle_lock:
+            if self._ws_runtime is runtime:
+                self._ws_thread_loop = loop
+
+    def _finish_ws_runtime(self, runtime: _FeishuWSRuntime) -> None:
+        """Drop a completed worker without clearing a newer generation."""
+        with self._ws_lifecycle_lock:
+            if self._ws_runtime is not runtime:
+                return
+            self._ws_thread_loop = None
+            if self._ws_disconnect_count == 0:
+                self._ws_runtime = None
+                self._ws_thread = None
+
+    def _start_ws_runtime(self, ws_client: Any) -> _FeishuWSRuntime:
+        """Start one daemon-owned Lark websocket runtime."""
+        with self._ws_lifecycle_lock:
+            if self._ws_disconnect_count > 0:
+                raise RuntimeError("Feishu websocket disconnect is still in progress")
+            if (
+                self._ws_connect_epoch is not None
+                and self._ws_connect_epoch != self._ws_lifecycle_epoch
+            ):
+                raise RuntimeError("Feishu connect was superseded by disconnect")
+            previous = self._ws_runtime
+            # Runtime ownership starts before Thread.start().  is_alive() is
+            # false in that small publication window, so using it here would
+            # allow two concurrent connects to start SDK workers that share
+            # module-global loop/monkeypatch state.
+            if previous is not None and not previous.stopped.is_set():
+                raise RuntimeError("Previous Feishu websocket worker is still stopping")
+
+            runtime = _FeishuWSRuntime(client=ws_client)
+            thread = threading.Thread(
+                target=_run_official_feishu_ws_client,
+                args=(ws_client, self, runtime),
+                name="hermes-feishu-ws",
+                daemon=True,
+            )
+            runtime.thread = thread
+            self._ws_runtime = runtime
+            self._ws_thread = thread
+            self._ws_thread_loop = None
+            self._ws_future = None
+            self._ws_client = ws_client
+
+        try:
+            thread.start()
+        except BaseException:
+            with self._ws_lifecycle_lock:
+                if self._ws_runtime is runtime:
+                    self._ws_runtime = None
+                    self._ws_thread = None
+                    self._ws_client = None
+            raise
+        return runtime
+
+    async def _wait_for_ws_runtime_stop(
+        self,
+        runtime: _FeishuWSRuntime,
+        timeout: float,
+    ) -> bool:
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + max(0.0, timeout)
+        while not runtime.stopped.is_set() and loop.time() < deadline:
+            await asyncio.sleep(0.01)
+        return runtime.stopped.is_set()
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
+        """Serialize transport publication against every disconnect request."""
+        with self._ws_lifecycle_lock:
+            if self._ws_disconnect_count > 0:
+                logger.warning("[Feishu] Connect rejected while disconnect is pending")
+                return False
+            connect_epoch = self._ws_lifecycle_epoch
+        async with self._ws_operation_lock:
+            with self._ws_lifecycle_lock:
+                if (
+                    self._ws_disconnect_count > 0
+                    or connect_epoch != self._ws_lifecycle_epoch
+                ):
+                    logger.warning(
+                        "[Feishu] Connect rejected while disconnect is pending"
+                    )
+                    return False
+                runtime = self._ws_runtime
+                if runtime is not None and not runtime.stopped.is_set():
+                    logger.warning("[Feishu] Connect rejected: websocket already active")
+                    return False
+                self._ws_connect_epoch = connect_epoch
+            if self._running:
+                with self._ws_lifecycle_lock:
+                    if self._ws_connect_epoch == connect_epoch:
+                        self._ws_connect_epoch = None
+                return True
+            try:
+                return await self._connect_impl(is_reconnect=is_reconnect)
+            finally:
+                with self._ws_lifecycle_lock:
+                    if self._ws_connect_epoch == connect_epoch:
+                        self._ws_connect_epoch = None
+
+    async def _connect_impl(self, *, is_reconnect: bool = False) -> bool:
         """Connect to Feishu/Lark."""
         # A fresh connect (or reconnect) re-arms the SDK executor after a prior
         # disconnect set the closing flag.
@@ -1814,6 +2061,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            with self._ws_lifecycle_lock:
+                if (
+                    self._ws_disconnect_count > 0
+                    or self._ws_connect_epoch != self._ws_lifecycle_epoch
+                ):
+                    raise RuntimeError("Feishu disconnect requested during connect")
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             # Plugin-registered native handlers (lark_oapi client).
@@ -1827,89 +2080,165 @@ class FeishuAdapter(BasePlatformAdapter):
             return False
 
     async def disconnect(self) -> None:
-        """Disconnect from Feishu/Lark."""
-        self._running = False
-        await self._cancel_pending_tasks(self._pending_text_batch_tasks)
-        await self._cancel_pending_tasks(self._pending_media_batch_tasks)
-        self._reset_batch_buffers()
-
-        # Send a WebSocket CLOSE frame to Feishu BEFORE tearing down the
-        # thread loop. Without this, Feishu's server never learns the
-        # connection is dead and continues routing messages to the stale
-        # endpoint — the channel goes silent until the server-side
-        # CLOSE-WAIT expires (minutes to hours). See issue #10202.
-        #
-        # ``_disable_websocket_auto_reconnect()`` nils ``self._ws_client``,
-        # so capture the client reference first.
-        ws_client = self._ws_client
-        ws_thread_loop = self._ws_thread_loop
-        self._disable_websocket_auto_reconnect()
-        await self._stop_webhook_server()
-
-        if (
-            ws_client is not None
-            and ws_thread_loop is not None
-            and not ws_thread_loop.is_closed()
-            and hasattr(ws_client, "_disconnect")
-        ):
-            try:
-                future = asyncio.run_coroutine_threadsafe(
-                    ws_client._disconnect(), ws_thread_loop
+        """Queue one teardown and keep connect closed until all callers exit."""
+        with self._ws_lifecycle_lock:
+            self._ws_disconnect_count += 1
+            self._ws_lifecycle_epoch += 1
+        try:
+            async with self._ws_operation_lock:
+                await self._disconnect_impl()
+        finally:
+            with self._ws_lifecycle_lock:
+                self._ws_disconnect_count = max(
+                    0,
+                    self._ws_disconnect_count - 1,
                 )
-                # 5s is generous — the CLOSE frame is a single WebSocket
-                # control frame. If it takes longer than that the
-                # connection is already wedged and we gain nothing by
-                # waiting further.
-                await asyncio.wait_for(asyncio.wrap_future(future), timeout=5.0)
-                logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
+
+    async def _disconnect_impl(self) -> None:
+        """Disconnect from Feishu/Lark with a bounded WS hard-stop path."""
+        self._running = False
+        with self._ws_lifecycle_lock:
+            runtime = self._ws_runtime
+            ws_client = runtime.client if runtime is not None else self._ws_client
+            legacy_ws_loop = self._ws_thread_loop
+        # Publish shutdown intent before the first await.  If disconnect wins
+        # the startup race, the worker observes this after creating its loop
+        # and exits without entering the SDK's permanent run_forever().
+        if runtime is not None:
+            runtime.stop_requested.set()
+        self._disable_websocket_auto_reconnect()
+
+        if runtime is not None:
+            with runtime.lock:
+                ws_thread_loop = runtime.loop
+        else:
+            # Compatibility path for an adapter started by an older build or
+            # a focused test that still provides _ws_future directly.
+            ws_thread_loop = legacy_ws_loop
+
+        # Arm the hard boundary before the first await.  Task.cancel() can get
+        # stuck propagating into a child that swallows CancelledError, which
+        # means a coroutine finally block is not by itself a timely shutdown
+        # guarantee.  The WS loop owns this timer and will stop independently.
+        _arm_feishu_ws_loop_hard_stop(
+            ws_thread_loop,
+            ws_client,
+            _FEISHU_WS_CLOSE_TIMEOUT_SECONDS,
+        )
+
+        try:
+            # Best-effort CLOSE before the hard stop prevents Feishu from
+            # routing messages to a stale endpoint (#10202).  Keep this inner
+            # budget below the gateway runner's 5s outer disconnect deadline;
+            # otherwise outer cancellation can interrupt before loop cleanup.
+            try:
+                if (
+                    ws_client is not None
+                    and ws_thread_loop is not None
+                    and not ws_thread_loop.is_closed()
+                    and hasattr(ws_client, "_disconnect")
+                ):
+                    close_future = asyncio.run_coroutine_threadsafe(
+                        ws_client._disconnect(), ws_thread_loop
+                    )
+                    # Do not bridge this cross-loop future with
+                    # asyncio.wrap_future().  wait_for() cancels the wrapped
+                    # concurrent future on timeout; if the independently
+                    # armed hard-stop has just closed the WS loop, that
+                    # cancellation tries to callback into the closed loop and
+                    # logs RuntimeError("Event loop is closed").  Polling is
+                    # still bounded and deliberately leaves cancellation to
+                    # the WS loop's hard-stop path.
+                    gateway_loop = asyncio.get_running_loop()
+                    close_deadline = (
+                        gateway_loop.time()
+                        + _FEISHU_WS_CLOSE_TIMEOUT_SECONDS
+                    )
+                    while not close_future.done():
+                        remaining = close_deadline - gateway_loop.time()
+                        if remaining <= 0:
+                            raise asyncio.TimeoutError
+                        await asyncio.sleep(min(0.01, remaining))
+                    close_future.result()
+                    logger.debug("[Feishu] Sent WebSocket CLOSE frame to Feishu")
             except asyncio.TimeoutError:
                 logger.warning(
-                    "[Feishu] CLOSE frame not acknowledged within 5s — "
-                    "Feishu may briefly route messages to the stale "
-                    "connection until server-side timeout"
+                    "[Feishu] CLOSE frame not acknowledged within %.1fs — "
+                    "forcing websocket shutdown",
+                    _FEISHU_WS_CLOSE_TIMEOUT_SECONDS,
                 )
+            except asyncio.CancelledError:
+                raise
             except Exception as exc:
                 logger.debug(
                     "[Feishu] Could not send WebSocket CLOSE frame: %s",
                     exc,
                     exc_info=True,
                 )
+            finally:
+                # Synchronous and ahead of every batch/webhook await: even if
+                # those tasks swallow cancellation, they cannot retain the WS
+                # worker and wedge asyncio.run() during process exit.
+                if runtime is not None:
+                    _request_feishu_ws_runtime_stop(runtime)
+                else:
+                    _request_feishu_ws_loop_stop(ws_thread_loop, ws_client)
 
-        if ws_thread_loop is not None and not ws_thread_loop.is_closed():
-            logger.debug("[Feishu] Cancelling websocket thread tasks and stopping loop")
+            if runtime is not None:
+                if not await self._wait_for_ws_runtime_stop(
+                    runtime,
+                    _FEISHU_WS_STOP_TIMEOUT_SECONDS,
+                ):
+                    logger.warning(
+                        "[Feishu] Websocket worker did not exit within %.1fs; "
+                        "leaving its daemon thread detached",
+                        _FEISHU_WS_STOP_TIMEOUT_SECONDS,
+                    )
+            else:
+                ws_future = self._ws_future
+                if ws_future is not None:
+                    try:
+                        await asyncio.wait_for(
+                            asyncio.shield(ws_future),
+                            timeout=_FEISHU_WS_STOP_TIMEOUT_SECONDS,
+                        )
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "[Feishu] Legacy websocket worker did not exit "
+                            "within %.1fs",
+                            _FEISHU_WS_STOP_TIMEOUT_SECONDS,
+                        )
 
-            def cancel_all_tasks() -> None:
-                tasks = [t for t in asyncio.all_tasks(ws_thread_loop) if not t.done()]
-                logger.debug("[Feishu] Found %d pending tasks in websocket thread", len(tasks))
-                for task in tasks:
-                    task.cancel()
-                ws_thread_loop.call_later(0.1, ws_thread_loop.stop)
+            await self._cancel_pending_tasks(self._pending_text_batch_tasks)
+            await self._cancel_pending_tasks(self._pending_media_batch_tasks)
+            self._reset_batch_buffers()
+            await self._stop_webhook_server()
+        finally:
+            # Belt-and-suspenders for exceptions outside the CLOSE stage.
+            if runtime is not None:
+                _request_feishu_ws_runtime_stop(runtime)
+            else:
+                _request_feishu_ws_loop_stop(legacy_ws_loop, ws_client)
 
-            ws_thread_loop.call_soon_threadsafe(cancel_all_tasks)
-
-        ws_future = self._ws_future
-        if ws_future is not None:
+            self._ws_future = None
+            self._loop = None
+            self._event_handler = None
+            self._shutdown_sdk_executor()
             try:
-                logger.debug("[Feishu] Waiting for websocket thread to exit (timeout=10s)")
-                await asyncio.wait_for(asyncio.shield(ws_future), timeout=10.0)
-                logger.debug("[Feishu] Websocket thread exited cleanly")
-            except asyncio.TimeoutError:
-                logger.warning("[Feishu] Websocket thread did not exit within 10s - may be stuck")
-            except asyncio.CancelledError:
-                logger.debug("[Feishu] Websocket thread cancelled during disconnect")
-            except Exception as exc:
-                logger.debug("[Feishu] Websocket thread exited with error: %s", exc, exc_info=True)
+                self._persist_seen_message_ids()
+            except Exception:
+                logger.debug("[Feishu] Failed to persist dedup state", exc_info=True)
+            await self._release_app_lock()
+            self._mark_disconnected()
 
-        self._ws_future = None
-        self._ws_thread_loop = None
-        self._loop = None
-        self._event_handler = None
-        self._shutdown_sdk_executor()
-        self._persist_seen_message_ids()
-        await self._release_app_lock()
-
-        self._mark_disconnected()
-        logger.info("[Feishu] Disconnected")
+            with self._ws_lifecycle_lock:
+                if self._ws_runtime is runtime and (
+                    runtime is None or runtime.stopped.is_set()
+                ):
+                    self._ws_runtime = None
+                    self._ws_thread = None
+                    self._ws_thread_loop = None
+            logger.info("[Feishu] Disconnected")
 
     async def _cancel_pending_tasks(self, tasks: Dict[str, asyncio.Task]) -> None:
         pending = [task for task in tasks.values() if task and not task.done()]
@@ -4934,6 +5263,16 @@ class FeishuAdapter(BasePlatformAdapter):
                 self._disable_websocket_auto_reconnect()
                 self._ws_future = None
                 await self._stop_webhook_server()
+                with self._ws_lifecycle_lock:
+                    superseded = (
+                        self._ws_disconnect_count > 0
+                        or (
+                            self._ws_connect_epoch is not None
+                            and self._ws_connect_epoch != self._ws_lifecycle_epoch
+                        )
+                    )
+                if superseded:
+                    raise
                 if attempt >= _FEISHU_CONNECT_ATTEMPTS - 1:
                     raise
                 wait_seconds = 2 ** attempt
@@ -4958,7 +5297,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if loop is None or loop.is_closed():
             raise RuntimeError("adapter loop is not ready")
         await self._hydrate_bot_identity()
-        self._ws_client = FeishuWSClient(
+        ws_client = FeishuWSClient(
             app_id=self._app_id,
             app_secret=self._app_secret,
             log_level=lark.LogLevel.INFO,
@@ -4971,12 +5310,7 @@ class FeishuAdapter(BasePlatformAdapter):
             # See https://github.com/NousResearch/hermes-agent/issues/50656
             extra_ua_tags=["channel"],
         )
-        self._ws_future = loop.run_in_executor(
-            None,
-            _run_official_feishu_ws_client,
-            self._ws_client,
-            self,
-        )
+        self._start_ws_runtime(ws_client)
 
     async def _connect_webhook(self) -> None:
         if not FEISHU_WEBHOOK_AVAILABLE:

--- a/tests/gateway/test_bounded_adapter_teardown.py
+++ b/tests/gateway/test_bounded_adapter_teardown.py
@@ -14,19 +14,38 @@ which wraps each await in the existing per-adapter timeout budget
 """
 
 import asyncio
+import concurrent.futures
 import logging
+import threading
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 from gateway.run import GatewayRunner
+from plugins.platforms.feishu.adapter import FeishuAdapter
 
 
 @pytest.fixture
 def bare_runner():
     """A GatewayRunner shell that only needs _bounded_adapter_teardown."""
     return object.__new__(GatewayRunner)
+
+
+async def _eventually_ws_worker_stops(
+    stopped: threading.Event,
+    worker_future: asyncio.Future,
+    *,
+    timeout: float,
+) -> bool:
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if stopped.is_set() and worker_future.done():
+            return True
+        await asyncio.sleep(0.01)
+    return stopped.is_set() and worker_future.done()
 
 
 @pytest.mark.asyncio
@@ -94,3 +113,427 @@ async def test_teardown_continues_after_cancellation_swallowing_background_cance
         await asyncio.wait_for(finished.wait(), timeout=0.2)
 
 
+@pytest.mark.asyncio
+async def test_feishu_timeout_reaps_ws_default_executor_worker(
+    bare_runner, monkeypatch
+):
+    """An outer disconnect deadline must not orphan Feishu's WS worker.
+
+    The gateway event loop historically owned ``_ws_future`` through its
+    default executor.  If cancellation landed while Feishu awaited the CLOSE
+    acknowledgement, ``asyncio.run()`` later hung in
+    ``shutdown_default_executor()`` waiting for this worker forever.
+    """
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.05")
+    adapter = FeishuAdapter(PlatformConfig())
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+
+    ws_loop = asyncio.new_event_loop()
+    ws_started = threading.Event()
+    ws_stopped = threading.Event()
+
+    def run_ws_loop() -> None:
+        asyncio.set_event_loop(ws_loop)
+        ws_started.set()
+        try:
+            ws_loop.run_forever()
+        finally:
+            try:
+                pending = [
+                    task for task in asyncio.all_tasks(ws_loop) if not task.done()
+                ]
+                for task in pending:
+                    task.cancel()
+                if pending:
+                    # Multiple hard-stop callbacks can still be queued. One
+                    # bounded turn delivers cancellation without letting a
+                    # later loop.stop() break run_until_complete().
+                    ws_loop.call_soon(ws_loop.stop)
+                    ws_loop.run_forever()
+            finally:
+                ws_loop.close()
+                ws_stopped.set()
+
+    gateway_loop = asyncio.get_running_loop()
+    ws_future = gateway_loop.run_in_executor(None, run_ws_loop)
+    assert ws_started.wait(timeout=1.0)
+
+    close_started = threading.Event()
+
+    async def never_ack_close() -> None:
+        close_started.set()
+        await asyncio.Future()
+
+    adapter._ws_client = SimpleNamespace(
+        _disconnect=never_ack_close,
+        _auto_reconnect=True,
+    )
+    adapter._ws_thread_loop = ws_loop
+    adapter._ws_future = ws_future
+
+    try:
+        await bare_runner._bounded_adapter_teardown(adapter, Platform.FEISHU)
+
+        assert close_started.is_set()
+        assert await _eventually_ws_worker_stops(
+            ws_stopped, ws_future, timeout=0.5
+        ), (
+            "gateway teardown returned while Feishu's default-executor WS "
+            "worker was still alive; shutdown_default_executor would block"
+        )
+    finally:
+        # Keep the old implementation's expected red result from leaking a
+        # live executor worker into the rest of the test process.
+        if not ws_stopped.is_set() and not ws_loop.is_closed():
+            ws_loop.call_soon_threadsafe(ws_loop.stop)
+        assert await _eventually_ws_worker_stops(
+            ws_stopped, ws_future, timeout=1.0
+        )
+
+
+@pytest.mark.asyncio
+async def test_feishu_ws_worker_does_not_use_loop_default_executor(monkeypatch):
+    """The permanent WS loop must not become an asyncio.run exit dependency."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    gateway_loop = asyncio.get_running_loop()
+
+    class GatewayLoopSpy:
+        def is_closed(self) -> bool:
+            return False
+
+        def run_in_executor(self, *_args, **_kwargs):
+            pytest.fail("Feishu WS worker must not use the loop default executor")
+
+    adapter._loop = GatewayLoopSpy()
+    adapter._hydrate_bot_identity = AsyncMock()
+    adapter._build_lark_client = MagicMock(return_value=SimpleNamespace())
+    adapter._build_event_handler = MagicMock(return_value=object())
+
+    started = threading.Event()
+    release = threading.Event()
+
+    def blocking_ws_worker(*_args) -> None:
+        started.set()
+        release.wait(timeout=2.0)
+
+    class FakeWSClient:
+        def __init__(self, **_kwargs):
+            pass
+
+    monkeypatch.setattr(feishu_module, "FEISHU_WEBSOCKET_AVAILABLE", True)
+    monkeypatch.setattr(feishu_module, "FEISHU_DOMAIN", object())
+    monkeypatch.setattr(
+        feishu_module,
+        "lark",
+        SimpleNamespace(LogLevel=SimpleNamespace(INFO="INFO")),
+    )
+    monkeypatch.setattr(feishu_module, "FeishuWSClient", FakeWSClient)
+    monkeypatch.setattr(
+        feishu_module,
+        "_run_official_feishu_ws_client",
+        blocking_ws_worker,
+    )
+
+    try:
+        await adapter._connect_websocket()
+        deadline = gateway_loop.time() + 1.0
+        while not started.is_set() and gateway_loop.time() < deadline:
+            await asyncio.sleep(0.01)
+        assert started.is_set()
+        runtime = getattr(adapter, "_ws_runtime", None)
+        assert runtime is not None
+        assert runtime.thread is not None and runtime.thread.daemon
+    finally:
+        release.set()
+        ws_future = adapter._ws_future
+        if ws_future is not None:
+            await asyncio.wait_for(asyncio.shield(ws_future), timeout=1.0)
+        runtime = getattr(adapter, "_ws_runtime", None)
+        thread = getattr(runtime, "thread", None)
+        deadline = gateway_loop.time() + 1.0
+        while thread is not None and thread.is_alive() and gateway_loop.time() < deadline:
+            await asyncio.sleep(0.01)
+        assert thread is None or not thread.is_alive()
+
+
+@pytest.mark.asyncio
+async def test_feishu_close_timeout_does_not_cancel_cross_loop_future(monkeypatch):
+    """A CLOSE timeout must not callback into an already-closed WS loop.
+
+    ``asyncio.wait_for(asyncio.wrap_future(...))`` cancels the underlying
+    concurrent future on timeout.  The future returned by
+    ``run_coroutine_threadsafe`` then tries to forward that cancellation to
+    its source loop, which may already have been closed by the independently
+    armed hard-stop timer.
+    """
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+    monkeypatch.setattr(feishu_module, "_FEISHU_WS_CLOSE_TIMEOUT_SECONDS", 0.01)
+    monkeypatch.setattr(feishu_module, "_arm_feishu_ws_loop_hard_stop", lambda *_args: None)
+    monkeypatch.setattr(feishu_module, "_request_feishu_ws_loop_stop", lambda *_args: None)
+
+    class CloseFuture(concurrent.futures.Future):
+        cancel_requested = False
+
+        def cancel(self) -> bool:
+            self.cancel_requested = True
+            return super().cancel()
+
+    close_future = CloseFuture()
+
+    def fake_run_coroutine_threadsafe(coro, _loop):
+        coro.close()
+        return close_future
+
+    monkeypatch.setattr(
+        feishu_module.asyncio,
+        "run_coroutine_threadsafe",
+        fake_run_coroutine_threadsafe,
+    )
+    adapter._ws_client = SimpleNamespace(
+        _disconnect=lambda: asyncio.sleep(0),
+        _auto_reconnect=True,
+    )
+    adapter._ws_thread_loop = SimpleNamespace(is_closed=lambda: False)
+
+    await adapter.disconnect()
+
+    assert not close_future.cancel_requested
+
+
+@pytest.mark.asyncio
+async def test_overlapping_feishu_disconnects_keep_reconnect_closed(monkeypatch):
+    """A second teardown must not reopen connect while the first is pending."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+    monkeypatch.setattr(
+        feishu_module,
+        "_run_official_feishu_ws_client",
+        lambda *_args: None,
+    )
+
+    first_entered = asyncio.Event()
+    release_first = asyncio.Event()
+    first_task = None
+
+    async def controlled_cancel(_tasks) -> None:
+        if asyncio.current_task() is first_task:
+            first_entered.set()
+            await release_first.wait()
+
+    monkeypatch.setattr(adapter, "_cancel_pending_tasks", controlled_cancel)
+    first_task = asyncio.create_task(adapter.disconnect())
+    await asyncio.wait_for(first_entered.wait(), timeout=1.0)
+    second_task = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+
+    try:
+        assert adapter._ws_disconnect_count == 2
+        with pytest.raises(
+            RuntimeError,
+            match="disconnect is still in progress",
+        ):
+            adapter._start_ws_runtime(SimpleNamespace())
+    finally:
+        release_first.set()
+        await asyncio.wait_for(
+            asyncio.gather(first_task, second_task),
+            timeout=1.0,
+        )
+
+    assert adapter._ws_disconnect_count == 0
+
+
+def test_pending_feishu_ws_runtime_blocks_a_second_start(monkeypatch):
+    """Published-but-not-started ownership must still block another worker."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    pending = feishu_module._FeishuWSRuntime(client=SimpleNamespace())
+    pending.thread = SimpleNamespace(is_alive=lambda: False)
+    adapter._ws_runtime = pending
+
+    def forbidden_thread(*_args, **_kwargs):
+        pytest.fail("a second websocket thread was constructed")
+
+    monkeypatch.setattr(feishu_module.threading, "Thread", forbidden_thread)
+    with pytest.raises(
+        RuntimeError,
+        match="Previous Feishu websocket worker is still stopping",
+    ):
+        adapter._start_ws_runtime(SimpleNamespace())
+
+
+@pytest.mark.asyncio
+async def test_gateway_cancel_reaps_new_feishu_ws_runtime(
+    bare_runner, monkeypatch
+):
+    """The production runtime path must survive cancellation during CLOSE."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    assert feishu_module._load_lark_oapi()
+    monkeypatch.setenv("HERMES_GATEWAY_ADAPTER_DISCONNECT_TIMEOUT", "0.05")
+    adapter = FeishuAdapter(PlatformConfig())
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+
+    started = threading.Event()
+    close_started = threading.Event()
+
+    class FakeClient:
+        _auto_reconnect = True
+
+        def start(self) -> None:
+            import lark_oapi.ws.client as ws_client_module
+
+            started.set()
+            ws_client_module.loop.run_forever()
+
+        async def _disconnect(self) -> None:
+            close_started.set()
+            await asyncio.Future()
+
+    gateway_loop = asyncio.get_running_loop()
+    executor_before = getattr(gateway_loop, "_default_executor", None)
+    runtime = adapter._start_ws_runtime(FakeClient())
+    deadline = gateway_loop.time() + 1.0
+    while not started.is_set() and gateway_loop.time() < deadline:
+        await asyncio.sleep(0.01)
+    assert started.is_set() and runtime.loop_ready.is_set()
+
+    await bare_runner._bounded_adapter_teardown(adapter, Platform.FEISHU)
+
+    deadline = gateway_loop.time() + 1.0
+    while not runtime.stopped.is_set() and gateway_loop.time() < deadline:
+        await asyncio.sleep(0.01)
+    assert close_started.is_set()
+    assert runtime.stopped.is_set()
+    assert runtime.thread is not None and not runtime.thread.is_alive()
+    assert getattr(gateway_loop, "_default_executor", None) is executor_before
+
+
+@pytest.mark.asyncio
+async def test_stubborn_batch_cancel_cannot_retain_feishu_ws_worker(monkeypatch):
+    """WS stop is armed before awaiting a child that swallows cancellation."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+
+    ws_loop = asyncio.new_event_loop()
+    ws_started = threading.Event()
+    ws_stopped = threading.Event()
+    runtime = feishu_module._FeishuWSRuntime(client=SimpleNamespace())
+
+    def run_ws_loop() -> None:
+        asyncio.set_event_loop(ws_loop)
+        with runtime.lock:
+            runtime.loop = ws_loop
+        runtime.loop_ready.set()
+        ws_started.set()
+        try:
+            ws_loop.run_forever()
+        finally:
+            ws_loop.close()
+            with runtime.lock:
+                runtime.loop = None
+            runtime.stopped.set()
+            ws_stopped.set()
+
+    thread = threading.Thread(target=run_ws_loop, daemon=True)
+    runtime.thread = thread
+    adapter._ws_runtime = runtime
+    adapter._ws_thread = thread
+    adapter._ws_client = runtime.client
+    thread.start()
+    assert ws_started.wait(timeout=1.0)
+
+    release_child = asyncio.Event()
+    child_cancelled = asyncio.Event()
+
+    async def stubborn_child() -> None:
+        while not release_child.is_set():
+            try:
+                await release_child.wait()
+            except asyncio.CancelledError:
+                child_cancelled.set()
+
+    child = asyncio.create_task(stubborn_child())
+    adapter._pending_text_batch_tasks["stubborn"] = child
+    operation = asyncio.create_task(adapter.disconnect())
+    await asyncio.wait_for(child_cancelled.wait(), timeout=1.0)
+    operation.cancel()
+
+    try:
+        deadline = asyncio.get_running_loop().time() + 1.0
+        while not ws_stopped.is_set() and asyncio.get_running_loop().time() < deadline:
+            await asyncio.sleep(0.01)
+        assert ws_stopped.is_set()
+        assert runtime.stopped.is_set()
+        assert not operation.done()
+    finally:
+        release_child.set()
+        try:
+            await asyncio.wait_for(operation, timeout=1.0)
+        except asyncio.CancelledError:
+            pass
+        await asyncio.wait_for(child, timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_cancelled_disconnect_invalidates_inflight_connect(monkeypatch):
+    """Shutdown intent survives cancellation while waiting for connect's lock."""
+    import plugins.platforms.feishu.adapter as feishu_module
+
+    adapter = FeishuAdapter(PlatformConfig())
+    adapter._app_id = "cli_test"
+    adapter._app_secret = "secret_test"
+    monkeypatch.setattr(feishu_module, "_load_lark_oapi", lambda: True)
+    monkeypatch.setattr(
+        feishu_module,
+        "acquire_scoped_lock",
+        lambda *_args, **_kwargs: (True, None),
+    )
+    monkeypatch.setattr(feishu_module, "release_scoped_lock", lambda *_args: None)
+    monkeypatch.setattr(adapter, "_persist_seen_message_ids", lambda: None)
+    monkeypatch.setattr(adapter, "_mark_disconnected", lambda: None)
+    monkeypatch.setattr(adapter, "_set_fatal_error", lambda *_args, **_kwargs: None)
+
+    async def direct_to_thread(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(feishu_module.asyncio, "to_thread", direct_to_thread)
+    connect_paused = asyncio.Event()
+    release_connect = asyncio.Event()
+
+    async def paused_connect_with_retry() -> None:
+        connect_paused.set()
+        await release_connect.wait()
+
+    monkeypatch.setattr(adapter, "_connect_with_retry", paused_connect_with_retry)
+    connect_task = asyncio.create_task(adapter.connect())
+    await asyncio.wait_for(connect_paused.wait(), timeout=1.0)
+    disconnect_task = asyncio.create_task(adapter.disconnect())
+    await asyncio.sleep(0)
+    assert adapter._ws_disconnect_count == 1
+    disconnect_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await disconnect_task
+    assert adapter._ws_disconnect_count == 0
+
+    release_connect.set()
+    connected = await asyncio.wait_for(connect_task, timeout=1.0)
+
+    assert connected is False
+    assert adapter._ws_runtime is None
+    assert adapter._ws_disconnect_count == 0


### PR DESCRIPTION
## What does this PR do?

Prevents planned Gateway restarts from hanging when the Feishu/Lark WebSocket does not acknowledge shutdown promptly.

The official SDK's permanent `run_forever()` worker was submitted to the Gateway event loop's default executor. If the Gateway's 5-second adapter teardown deadline cancelled `FeishuAdapter.disconnect()` before that worker stopped, `asyncio.run()` later joined the default executor and kept the old process alive indefinitely. Clearing adapter references or calling `executor.shutdown(wait=False)` does not remove that process-exit dependency.

This change:

- owns the SDK WebSocket in a named raw daemon thread instead of the event loop's default executor;
- gives graceful CLOSE and worker exit separate 1-second inner budgets, with an independently armed transport abort/task cancel/loop stop fallback;
- publishes shutdown intent before the first await, so cancellation-swallowing batch or webhook tasks cannot retain the WebSocket worker;
- serializes connect/disconnect lifecycle publication and uses an epoch guard so a late connect cannot resurrect or overwrite a newer runtime;
- avoids cancelling the cross-loop CLOSE future on timeout, which previously could callback into an already-closed loop and log `RuntimeError("Event loop is closed")`;
- preserves the old `_ws_future` path for compatibility with already-created adapters and focused tests.

#96809 correctly protects trailing adapter cleanup when cancellation lands during CLOSE. The Ubuntu reproduction exposed an additional process-exit dependency: that approach retains both the default-executor worker and the incompatible 5-second CLOSE + 10-second worker wait inside the Gateway's 5-second outer deadline. This PR keeps the same cancellation-safe intent while removing the executor dependency and covering worker ownership and connect/disconnect races.

The daemon flag is a final process-exit safety net; normal teardown still actively closes the socket, aborts lingering transport I/O, cancels loop tasks, stops the loop, and waits for the runtime to report that it stopped.

## Related Issue

Fixes #96801

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/feishu/adapter.py`
  - add explicit WebSocket runtime ownership, bounded graceful shutdown, and hard-stop helpers;
  - move the permanent SDK worker off the default executor;
  - serialize connect/disconnect and reject stale lifecycle publication;
  - keep local cleanup and app-lock release in the disconnect finalizer.
- `tests/gateway/test_bounded_adapter_teardown.py`
  - add behavior regressions for default-executor shutdown hangs, outer cancellation, CLOSE timeout callback races, disconnect-before-loop-ready, overlapping disconnects, stale connects, duplicate workers, and cancellation-swallowing child tasks.

No configuration keys, public schemas, or Gateway-wide timeout behavior are changed.

## How to Test

1. Run the Feishu suites on a clean `upstream/main` worktree with this commit:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/gateway/test_feishu.py \
     tests/gateway/test_feishu_approval_buttons.py -q
   ```

   Result: **98 passed**.

2. Run the shutdown/lifecycle suites:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/gateway/test_safe_adapter_disconnect.py \
     tests/gateway/test_bounded_adapter_teardown.py \
     tests/gateway/test_gateway_shutdown.py -q
   ```

   Result: **29 passed**.

3. Run lint on the changed files:

   ```bash
   ruff check \
     plugins/platforms/feishu/adapter.py \
     tests/gateway/test_bounded_adapter_teardown.py
   ```

   Result: **all checks passed**; `git diff --check` also passed.

4. Manual production-path verification on an idle Ubuntu Gateway:

   - Before the fix, `hermes gateway restart` logged `feishu disconnect timed out after 5.0s`; the old PID remained alive until an exact-PID `SIGKILL`, and the command completed in **253.04s**.
   - With the fix loaded, an unassisted restart completed in **28.05s**, including systemd's 5-second restart delay and full Gateway startup. The PID changed normally, Feishu reconnected, and the verification window contained **0** adapter disconnect timeouts, **0** closed-loop callback errors, and **0** tracebacks.
   - Feishu did not acknowledge CLOSE within 1 second in that run; the new hard-stop path fired and the process still exited promptly, which exercises the intended failure path.

5. The full installed-runtime suite was also attempted. The host's release/test venv does not contain all `[all,dev]` dependencies (notably `anthropic`), so unrelated `tests/agent` cases were not green; the run was stopped after approximately 6,593 passes and 8 failures outside the changed area. The targeted clean-worktree suites above are green, and the PR CI matrix should provide the authoritative full-extra run.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (see the full-suite environment note above; changed-area canonical suites are 127/127)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04.4 LTS x86_64, Python 3.11.16, Hermes 0.21.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; implementation comments and regression docstrings describe the lifecycle contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the implementation uses Python threading/asyncio primitives and no platform-specific process APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changed

## Screenshots / Logs

Before:

```text
feishu disconnect timed out after 5.0s - forcing continue
```

After:

```text
CLOSE frame not acknowledged within 1.0s — forcing websocket shutdown
clean_verification_restart_elapsed=28.05 exit=0
```
