### PR TITLE
fix(desktop): show Files tree when workspace ownership lock is stale

### DIFF
--- a/apps/desktop/src/app/right-sidebar/index.test.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.test.tsx
@@ -2,13 +2,40 @@ import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/re
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { HermesReadDirResult } from '@/global'
-import { $connection, $selectedStoredSessionId, $workspaceCwdOwner, setCurrentCwd } from '@/store/session'
+import {
+  $connection,
+  $selectedStoredSessionId,
+  $sessions,
+  $workspaceCwdOwner,
+  setCurrentCwd
+} from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
 
 import { resetProjectTreeState } from './files/use-project-tree'
 
 import { RightSidebarPane } from './index'
 
 const readDir = vi.fn<(path: string) => Promise<HermesReadDirResult>>()
+
+function listedSession(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    ended_at: null,
+    id: 'new-session',
+    input_tokens: 0,
+    is_active: true,
+    last_active: 1,
+    message_count: 1,
+    model: null,
+    output_tokens: 0,
+    preview: null,
+    profile: 'default',
+    source: 'desktop',
+    started_at: 1,
+    title: 'Ops chat',
+    tool_call_count: 0,
+    ...overrides
+  }
+}
 
 function installBridge() {
   ;(window as unknown as { hermesDesktop: { readDir: typeof readDir } }).hermesDesktop = { readDir }
@@ -19,6 +46,7 @@ describe('RightSidebarPane', () => {
     $connection.set(null)
     $selectedStoredSessionId.set(null)
     $workspaceCwdOwner.set(null)
+    $sessions.set([])
     resetProjectTreeState()
     readDir.mockReset()
     readDir.mockResolvedValue({ entries: [{ isDirectory: false, name: 'README.md', path: '/repo/README.md' }] })
@@ -30,6 +58,7 @@ describe('RightSidebarPane', () => {
     $connection.set(null)
     $selectedStoredSessionId.set(null)
     $workspaceCwdOwner.set(null)
+    $sessions.set([])
     setCurrentCwd('')
     resetProjectTreeState()
     delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
@@ -68,5 +97,19 @@ describe('RightSidebarPane', () => {
 
     await waitFor(() => expect(screen.queryByRole('button', { name: 'Refresh tree' })).toBeNull())
     expect(readDir).not.toHaveBeenCalled()
+  })
+
+  it('reads the selected session listed cwd when the ownership lock is stale', async () => {
+    $selectedStoredSessionId.set('new-session')
+    $workspaceCwdOwner.set('previous-session')
+    setCurrentCwd('/home/doug/default-profile-workspace')
+    $sessions.set([listedSession({ cwd: '/repo/ops' })])
+
+    render(<RightSidebarPane onActivateFile={vi.fn()} onActivateFolder={vi.fn()} />)
+
+    const refresh = await screen.findByRole('button', { name: 'Refresh tree' })
+    readDir.mockClear()
+    fireEvent.click(refresh)
+    await waitFor(() => expect(readDir).toHaveBeenCalledWith('/repo/ops'))
   })
 })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -13,7 +13,7 @@ import { cn } from '@/lib/utils'
 import { $panesFlipped } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
-import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
+import { $filesPaneWorkspaceCwd } from '@/store/session'
 
 import { SidebarPanelLabel } from '../shell/sidebar-label'
 
@@ -29,14 +29,11 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
   const { t } = useI18n()
   const r = t.rightSidebar
   const panesFlipped = useStore($panesFlipped)
-  const currentCwd = useStore($currentCwd).trim()
-  const selectedStoredSessionId = useStore($selectedStoredSessionId)
-  const workspaceCwdOwner = useStore($workspaceCwdOwner)
+  const currentCwd = useStore($filesPaneWorkspaceCwd)
 
-  // A transition intentionally retains the old CWD until the new session
-  // confirms its workspace. Do not issue a filesystem read against that path:
-  // under a gateway switch it may belong to a different remote machine.
-  const hasWorkspace = Boolean(currentCwd) && (workspaceCwdOwner ?? null) === (selectedStoredSessionId ?? null)
+  // Owned live cwd, else the selected session's listed folder. A stale
+  // ownership lock must not blank the tree when the open chat has a cwd.
+  const hasWorkspace = Boolean(currentCwd)
 
   const {
     collapseAll,
@@ -49,7 +46,7 @@ export function RightSidebarPane({ onActivateFile, onActivateFolder }: RightSide
     rootError,
     rootLoading,
     setNodeOpen
-  } = useProjectTree(hasWorkspace ? currentCwd : '')
+  } = useProjectTree(currentCwd)
 
   const cwdName =
     effectiveCwd

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1261,6 +1261,34 @@ export const commitWorkspaceCwdForSelectedSession = (cwd: string) => {
 export const workspaceCwdBelongsToSelectedSession = (): boolean =>
   ($workspaceCwdOwner.get() ?? null) === ($selectedStoredSessionId.get() ?? null)
 
+/**
+ * Folder the Files pane should read.
+ *
+ * Ownership (#71254) still wins when the live path is claimed for the open
+ * chat — that is the path the agent may have `cd`'d into. If the lock is
+ * still released or names a previous chat, fall back to the selected
+ * session's listed `cwd` instead of painting "No project open". Tab switches
+ * across projects routinely miss the `session.info` re-claim; the sidebar
+ * row already knows the folder.
+ *
+ * A previous conversation's retained path stays hidden when the selected
+ * row has no cwd (genuinely detached).
+ */
+export const $filesPaneWorkspaceCwd = computed(
+  [$currentCwd, $selectedStoredSessionId, $workspaceCwdOwner, $sessions],
+  (cwd, selected, owner, sessions) => {
+    const current = cwd.trim()
+    if (current && (owner ?? null) === (selected ?? null)) {
+      return current
+    }
+    if (!selected) {
+      return ''
+    }
+    const row = sessions.find(session => sessionMatchesStoredId(session, selected))
+    return row?.cwd?.trim() || ''
+  }
+)
+
 export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number => {
   const generation = $newChatWorkspaceTargetGeneration.get() + 1
   $newChatWorkspaceTarget.set(next)


### PR DESCRIPTION
## Bug Description

In Hermes Desktop, the Files pane often shows **No project open** for a chat that clearly has a project folder. The only reliable workaround was fully quitting the app, which also interrupts every running turn.

Reproduced on remote Desktop: many tabs across projects. The open chat's session row had a `cwd`; the global active project was a different one; Files stayed empty until a project switch re-bound ownership.

## Root Cause

The Files pane only draws when `$currentCwd` is owned by the selected session (`$workspaceCwdOwner === $selectedStoredSessionId`). That lock was added so a tab switch does not flash the **previous** chat's tree (#71254).

On switch the lock is **released** until `session.info` re-claims it. With several project tabs that packet is often missed (or ignored by the lineage/active-event guards). The lock stays released, so Files paints empty forever even though the sidebar row already knows the folder.

## Fix

- Add `$filesPaneWorkspaceCwd`: if the live path is owned by the open chat, use it (agent `cd` still wins). Otherwise use the selected session's listed `cwd`.
- Files pane reads that value. A previous chat's retained path still stays hidden when the selected row has no `cwd` (genuinely detached).

## How to Verify

1. Open two Desktop chats in different projects.
2. Switch between them until Files shows **No project open** while the chat is under a real project.
3. With this change, Files should show that chat's folder without quitting Desktop.
4. A chat with no `cwd` should still show **No project open**.

## Test Plan

- [x] Added regression test: stale owner + listed cwd → tree reads the listed folder
- [x] Existing cases kept: owned cwd still shows; previous-session retained cwd without a listed folder stays hidden; detached chat stays empty
- [ ] `apps/desktop` vitest — this host cannot load `vite.config.ts` (`@rolldown/plugin-babel` missing in the install). CI should run `src/app/right-sidebar/index.test.tsx`.

## Risk Assessment

Low — display-only fallback for the Files tree. Git/status rails still use the existing ownership helper. Does not change session membership, resume, or the #71254 "don't show the previous repo" rule when the selected row has no cwd.