### PR TITLE
fix(desktop): fence composer actions during session convergence

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-committed-action-scope.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-committed-action-scope.test.tsx
@@ -1,0 +1,41 @@
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { Suspense } from 'react'
+import { describe, expect, it, vi } from 'vitest'
+
+import { useCommittedActionScope } from './use-committed-action-scope'
+
+describe('useCommittedActionScope', () => {
+  it('keeps the committed handler current when a different-scope render suspends', () => {
+    const called = vi.fn()
+    const suspended = new Promise<void>(() => undefined)
+
+    function Probe({ scope, suspend = false }: { scope: string; suspend?: boolean }) {
+      const actionIsCurrent = useCommittedActionScope(scope, false)
+
+      if (suspend) {
+        throw suspended
+      }
+
+      return <button onClick={() => actionIsCurrent() && called(scope)}>Run {scope}</button>
+    }
+
+    const view = render(
+      <Suspense fallback={<div>Loading</div>}>
+        <Probe scope="session-a" />
+      </Suspense>
+    )
+
+    act(() => {
+      view.rerender(
+        <Suspense fallback={<div>Loading</div>}>
+          <Probe scope="session-b" suspend />
+        </Suspense>
+      )
+    })
+
+    fireEvent.click(screen.getByText('Run session-a'))
+
+    expect(called).toHaveBeenCalledOnce()
+    expect(called).toHaveBeenCalledWith('session-a')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-committed-action-scope.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-committed-action-scope.ts
@@ -1,0 +1,29 @@
+import { useCallback, useLayoutEffect, useRef } from 'react'
+
+/**
+ * Commit-safe lifecycle generation for session-bound actions.
+ *
+ * A work-in-progress React render must never mutate refs read by the currently
+ * committed UI. We calculate the generation the candidate render will own, but
+ * publish it only from a layout effect. If React abandons the render, visible
+ * handlers keep matching the last committed generation.
+ */
+export function useCommittedActionScope(scopeKey: string | null, disabled: boolean): () => boolean {
+  const committedRef = useRef({ disabled, epoch: 0, key: scopeKey })
+
+  const renderEpoch =
+    committedRef.current.key === scopeKey ? committedRef.current.epoch : committedRef.current.epoch + 1
+
+  useLayoutEffect(() => {
+    const current = committedRef.current
+    const epoch = current.key === scopeKey ? current.epoch : Math.max(renderEpoch, current.epoch + 1)
+
+    committedRef.current = { disabled, epoch, key: scopeKey }
+  }, [disabled, renderEpoch, scopeKey])
+
+  return useCallback(() => {
+    const committed = committedRef.current
+
+    return committed.key === scopeKey && committed.epoch === renderEpoch && !committed.disabled
+  }, [renderEpoch, scopeKey])
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.test.tsx
@@ -1,0 +1,70 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { type PropsWithChildren } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
+import { useComposerBranch } from './use-composer-branch'
+
+const mocks = vi.hoisted(() => ({
+  listRepoBranches: vi.fn(async () => []),
+  requestStartWorkSession: vi.fn(),
+  startWorkInRepo: vi.fn(),
+  switchBranchInRepo: vi.fn(async () => undefined)
+}))
+
+vi.mock('@/store/projects', () => mocks)
+
+function Wrapper({ children }: PropsWithChildren) {
+  return <ComposerScopeProvider value={MAIN_COMPOSER_SCOPE}>{children}</ComposerScopeProvider>
+}
+
+describe('useComposerBranch session-transition lifecycle', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('does not clear B or open a session when an A worktree request resolves late', async () => {
+    let resolveWorktree: ((result: { path: string }) => void) | undefined
+
+    const pendingWorktree = new Promise<{ path: string }>(resolve => {
+      resolveWorktree = resolve
+    })
+
+    mocks.startWorkInRepo.mockReturnValueOnce(pendingWorktree)
+    const clearDraft = vi.fn()
+    const draftRef = { current: 'draft from A' }
+
+    const hook = renderHook(
+      ({ actionsDisabled, sessionKey }: { actionsDisabled: boolean; sessionKey: string }) =>
+        useComposerBranch({
+          actionsDisabled,
+          clearDraft,
+          cwd: `/repo/${sessionKey}`,
+          draftRef,
+          sessionKey
+        }),
+      { initialProps: { actionsDisabled: false, sessionKey: 'session-a' }, wrapper: Wrapper }
+    )
+
+    let branchPromise: Promise<void> | undefined
+
+    act(() => {
+      branchPromise = hook.result.current.handleBranchOff('feature-a')
+    })
+
+    hook.rerender({ actionsDisabled: true, sessionKey: 'session-b' })
+    draftRef.current = 'draft from B'
+    hook.rerender({ actionsDisabled: false, sessionKey: 'session-b' })
+
+    await act(async () => {
+      resolveWorktree?.({ path: '/worktrees/feature-a' })
+      await branchPromise
+    })
+
+    expect(clearDraft).not.toHaveBeenCalled()
+    expect(mocks.requestStartWorkSession).not.toHaveBeenCalled()
+    expect(draftRef.current).toBe('draft from B')
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-branch.ts
@@ -1,13 +1,17 @@
-import { type MutableRefObject, useCallback } from 'react'
+import { type MutableRefObject, useCallback, useLayoutEffect, useRef } from 'react'
 
 import { listRepoBranches, requestStartWorkSession, startWorkInRepo, switchBranchInRepo } from '@/store/projects'
 
 import { useComposerScope } from '../scope'
 
+import { useCommittedActionScope } from './use-committed-action-scope'
+
 interface UseComposerBranchOptions {
+  actionsDisabled: boolean
   clearDraft: () => void
   cwd: null | string | undefined
   draftRef: MutableRefObject<string>
+  sessionKey: string | null
 }
 
 /**
@@ -17,20 +21,38 @@ interface UseComposerBranchOptions {
  * instead of getting stashed under this one. Backend coupling (cwd + the
  * projects store) is the only dependency; nothing about ChatBar's render.
  */
-export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBranchOptions) {
+export function useComposerBranch({
+  actionsDisabled,
+  clearDraft,
+  cwd,
+  draftRef,
+  sessionKey
+}: UseComposerBranchOptions) {
   const scope = useComposerScope()
+  const actionIsCurrent = useCommittedActionScope(sessionKey, actionsDisabled)
+  const actionStateRef = useRef({ actionsDisabled, clearDraft, cwd, draftRef })
+
+  useLayoutEffect(() => {
+    actionStateRef.current = { actionsDisabled, clearDraft, cwd, draftRef }
+  }, [actionsDisabled, clearDraft, cwd, draftRef])
 
   // Hand a worktree off to the controller: open a fresh session anchored there,
   // carrying the composer draft as its first turn. Clearing here means the draft
   // travels to the new session instead of getting stashed under this one.
   const openInWorktree = useCallback(
     (path: string) => {
-      const text = draftRef.current
-      clearDraft()
+      if (!actionIsCurrent()) {
+        return
+      }
+
+      const action = actionStateRef.current
+      const text = action.draftRef.current
+
+      action.clearDraft()
       scope.attachments.clear()
       requestStartWorkSession(path, text)
     },
-    [clearDraft, draftRef]
+    [actionIsCurrent, scope.attachments]
   )
 
   // Branch off into a NEW worktree (base = branch name, or current HEAD). A
@@ -38,14 +60,18 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
   // draft; a missing cwd / remote backend no-ops (the row hides the affordance).
   const handleBranchOff = useCallback(
     async (branch: string, base?: string) => {
-      const repoPath = cwd?.trim()
+      if (!actionIsCurrent()) {
+        return
+      }
+
+      const repoPath = actionStateRef.current.cwd?.trim()
       const result = repoPath && (await startWorkInRepo(repoPath, { base, branch, name: branch }))
 
       if (result) {
         openInWorktree(result.path)
       }
     },
-    [cwd, openInWorktree]
+    [actionIsCurrent, openInWorktree]
   )
 
   // Convert an EXISTING branch into a fresh worktree + session (no new branch).
@@ -53,13 +79,17 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
   // anchored there carrying the draft.
   const handleConvertBranch = useCallback(
     async (branch: string, path?: null | string, isDefault?: boolean) => {
+      if (!actionIsCurrent()) {
+        return
+      }
+
       if (path?.trim()) {
         openInWorktree(path)
 
         return
       }
 
-      const repoPath = cwd?.trim()
+      const repoPath = actionStateRef.current.cwd?.trim()
 
       if (repoPath && isDefault) {
         await switchBranchInRepo(repoPath, branch)
@@ -74,24 +104,32 @@ export function useComposerBranch({ clearDraft, cwd, draftRef }: UseComposerBran
         openInWorktree(result.path)
       }
     },
-    [cwd, openInWorktree]
+    [actionIsCurrent, openInWorktree]
   )
 
   const handleListBranches = useCallback(async () => {
-    const repoPath = cwd?.trim()
+    if (!actionIsCurrent()) {
+      return []
+    }
+
+    const repoPath = actionStateRef.current.cwd?.trim()
 
     return repoPath ? listRepoBranches(repoPath) : []
-  }, [cwd])
+  }, [actionIsCurrent])
 
   const handleSwitchBranch = useCallback(
     async (branch: string) => {
-      const repoPath = cwd?.trim()
+      if (!actionIsCurrent()) {
+        return
+      }
+
+      const repoPath = actionStateRef.current.cwd?.trim()
 
       if (repoPath) {
         await switchBranchInRepo(repoPath, branch)
       }
     },
-    [cwd]
+    [actionIsCurrent]
   )
 
   return { handleBranchOff, handleConvertBranch, handleListBranches, handleSwitchBranch, openInWorktree }

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.test.tsx
@@ -23,22 +23,37 @@ import { useComposerQueue } from './use-composer-queue'
 
 const SESSION_KEY = 'stored-session-queue-hook'
 
-function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onSteer?: ChatBarProps['onSteer'] } = {}) {
+function renderQueueHook(
+  overrides: {
+    actionsDisabled?: boolean
+    busy?: boolean
+    onCancel?: () => void
+    onSteer?: ChatBarProps['onSteer']
+  } = {}
+) {
   const onSubmit = vi.fn<ChatBarProps['onSubmit']>(async () => true)
   const onCancel = overrides.onCancel ?? vi.fn()
   const onSteer = overrides.onSteer
   const queueEditRef: { current: QueueEditState | null } = { current: null }
+  const draftRef = { current: '' }
+  const loadIntoComposer = vi.fn()
+
+  const initialProps: { actionsDisabled?: boolean; busy: boolean } = {
+    actionsDisabled: overrides.actionsDisabled,
+    busy: overrides.busy ?? false
+  }
 
   const hook = renderHook(
-    ({ busy }: { busy: boolean }) =>
+    ({ actionsDisabled, busy }: { actionsDisabled?: boolean; busy: boolean }) =>
       useComposerQueue({
+        actionsDisabled: actionsDisabled ?? overrides.actionsDisabled ?? false,
         activeQueueSessionKey: SESSION_KEY,
         attachments: [],
         busy,
         clearDraft: () => undefined,
-        draftRef: { current: '' },
+        draftRef,
         focusInput: () => undefined,
-        loadIntoComposer: () => undefined,
+        loadIntoComposer,
         onCancel,
         onSteer,
         onSubmit,
@@ -46,10 +61,10 @@ function renderQueueHook(overrides: { busy?: boolean; onCancel?: () => void; onS
         queueSessionKey: SESSION_KEY,
         sessionId: 'rt-session-queue-hook'
       }),
-    { initialProps: { busy: overrides.busy ?? false } }
+    { initialProps }
   )
 
-  return { hook, onCancel, onSubmit }
+  return { draftRef, hook, loadIntoComposer, onCancel, onSubmit }
 }
 
 describe('useComposerQueue park integration', () => {
@@ -73,6 +88,52 @@ describe('useComposerQueue park integration', () => {
 
     await waitFor(() => expect(onSubmit).toHaveBeenCalledTimes(1))
     expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(0)
+  })
+
+  it('holds every queued action while route and active session disagree', async () => {
+    const entry = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'belongs to the new route' })
+    const onSteer = vi.fn(async () => true)
+    const { hook, onCancel, onSubmit } = renderQueueHook({ actionsDisabled: true, busy: true, onSteer })
+
+    act(() => {
+      expect(hook.result.current.sendQueuedNow(entry!.id)).toBe(false)
+    })
+
+    await act(async () => {
+      expect(await hook.result.current.steerQueuedNow(entry!.id)).toBe(false)
+      expect(await hook.result.current.drainNextQueued()).toBe(false)
+      hook.rerender({ busy: false })
+      await Promise.resolve()
+    })
+
+    expect(onCancel).not.toHaveBeenCalled()
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(getQueuedPrompts(SESSION_KEY)).toHaveLength(1)
+  })
+
+  it('blocks queue edit, save, cancel, and stepping while identities disagree', () => {
+    const first = enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'first queued draft' })!
+    enqueueQueuedPrompt(SESSION_KEY, { attachments: [], text: 'second queued draft' })
+    const { draftRef, hook, loadIntoComposer } = renderQueueHook({ busy: true })
+
+    act(() => hook.result.current.beginQueuedEdit(first))
+    expect(hook.result.current.queueEdit?.entryId).toBe(first.id)
+
+    loadIntoComposer.mockClear()
+    draftRef.current = 'draft typed during transition'
+    hook.rerender({ actionsDisabled: true, busy: true })
+
+    act(() => {
+      expect(hook.result.current.stepQueuedEdit(1)).toBe(false)
+      expect(hook.result.current.exitQueuedEdit('save')).toBe(false)
+      expect(hook.result.current.exitQueuedEdit('cancel')).toBe(false)
+      hook.result.current.beginQueuedEdit(first)
+    })
+
+    expect(getQueuedPrompts(SESSION_KEY)[0]?.text).toBe('first queued draft')
+    expect(hook.result.current.queueEdit?.entryId).toBe(first.id)
+    expect(loadIntoComposer).not.toHaveBeenCalled()
   })
 
   it('holds a parked queue at the idle settle (the Stop edge)', async () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-queue.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { type RefObject, useCallback, useEffect, useRef, useState } from 'react'
+import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
@@ -28,6 +28,7 @@ import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
 interface UseComposerQueueArgs {
+  actionsDisabled: boolean
   activeQueueSessionKey: string | null
   attachments: ComposerAttachment[]
   busy: boolean
@@ -53,6 +54,7 @@ interface UseComposerQueueArgs {
  * without a back-reference. Behaviour-identical to the inline original.
  */
 export function useComposerQueue({
+  actionsDisabled,
   activeQueueSessionKey,
   attachments,
   busy,
@@ -82,7 +84,10 @@ export function useComposerQueue({
   const queueParked = Boolean(activeQueueSessionKey && parkedSessions[activeQueueSessionKey])
 
   const [queueEdit, setQueueEdit] = useState<QueueEditState | null>(null)
-  queueEditRef.current = queueEdit
+
+  useLayoutEffect(() => {
+    queueEditRef.current = queueEdit
+  }, [queueEdit, queueEditRef])
 
   const setQueueEditSnapshot = useCallback(
     (next: QueueEditState | null) => {
@@ -99,7 +104,7 @@ export function useComposerQueue({
   const drainFailuresRef = useRef(new Map<string, number>())
 
   const beginQueuedEdit = (entry: QueuedPromptEntry) => {
-    if (!activeQueueSessionKey || queueEdit) {
+    if (actionsDisabled || !activeQueueSessionKey || queueEdit) {
       return
     }
 
@@ -120,7 +125,7 @@ export function useComposerQueue({
   // saving the in-progress edit on each step. Stepping newer past the last
   // entry exits edit mode and restores the pre-edit draft.
   const stepQueuedEdit = (direction: -1 | 1) => {
-    if (!queueEdit) {
+    if (actionsDisabled || !queueEdit) {
       return false
     }
 
@@ -153,7 +158,7 @@ export function useComposerQueue({
   }
 
   const exitQueuedEdit = (action: 'cancel' | 'save'): boolean => {
-    if (!queueEdit) {
+    if (actionsDisabled || !queueEdit) {
       return false
     }
 
@@ -181,7 +186,7 @@ export function useComposerQueue({
   const queueCurrentDraft = useCallback(() => {
     const text = draftRef.current
 
-    if (!activeQueueSessionKey || (!text.trim() && attachments.length === 0)) {
+    if (actionsDisabled || !activeQueueSessionKey || (!text.trim() && attachments.length === 0)) {
       return false
     }
 
@@ -194,13 +199,13 @@ export function useComposerQueue({
     triggerHaptic('selection')
 
     return true
-  }, [activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments])
+  }, [actionsDisabled, activeQueueSessionKey, attachments, clearDraft, draftRef, scope.attachments])
 
   // All queue drain paths share one lock + send-then-remove sequence.
   // `pickEntry` lets each caller choose head, by-id, or skip-edited.
   const runDrain = useCallback(
     async (pickEntry: (entries: QueuedPromptEntry[]) => QueuedPromptEntry | undefined): Promise<boolean> => {
-      if (drainingQueueRef.current || !activeQueueSessionKey) {
+      if (actionsDisabled || drainingQueueRef.current || !activeQueueSessionKey) {
         return false
       }
 
@@ -243,7 +248,7 @@ export function useComposerQueue({
         drainingQueueRef.current = false
       }
     },
-    [activeQueueSessionKey, onSubmit, sessionId]
+    [actionsDisabled, activeQueueSessionKey, onSubmit, sessionId]
   )
 
   const pickDrainHead = useCallback(
@@ -259,7 +264,7 @@ export function useComposerQueue({
 
   const sendQueuedNow = useCallback(
     (id: string) => {
-      if (!activeQueueSessionKey || id === queueEdit?.entryId) {
+      if (actionsDisabled || !activeQueueSessionKey || id === queueEdit?.entryId) {
         return false
       }
 
@@ -283,7 +288,7 @@ export function useComposerQueue({
 
       return runDrain(entries => entries.find(e => e.id === id))
     },
-    [activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
+    [actionsDisabled, activeQueueSessionKey, busy, onCancel, queueEdit, runDrain]
   )
 
   // Deliver a queued entry as a mid-turn redirect — the queue-panel sibling of
@@ -294,7 +299,7 @@ export function useComposerQueue({
   // busy — idle has no turn to redirect, and `sendQueuedNow` already covers it.
   const steerQueuedNow = useCallback(
     async (id: string): Promise<boolean> => {
-      if (!onSteer || !busy || !activeQueueSessionKey || id === queueEditRef.current?.entryId) {
+      if (actionsDisabled || !onSteer || !busy || !activeQueueSessionKey || id === queueEditRef.current?.entryId) {
         return false
       }
 
@@ -323,7 +328,7 @@ export function useComposerQueue({
 
       return true
     },
-    [activeQueueSessionKey, busy, onSteer, queueEditRef]
+    [actionsDisabled, activeQueueSessionKey, busy, onSteer, queueEditRef]
   )
 
   // Edge-independent auto-drain: send the head whenever the session is idle and
@@ -331,7 +336,7 @@ export function useComposerQueue({
   // a stale-session 404) can't strand the entry permanently nor spin-loop. The
   // drain lock serializes sends; a remount/reconnect resets the failure counts.
   const autoDrainNext = useCallback(() => {
-    if (busy || queueParked || drainingQueueRef.current || !activeQueueSessionKey) {
+    if (actionsDisabled || busy || queueParked || drainingQueueRef.current || !activeQueueSessionKey) {
       return
     }
 
@@ -362,7 +367,7 @@ export function useComposerQueue({
         }
       })
       .catch(onFail)
-  }, [activeQueueSessionKey, busy, pickDrainHead, queueParked, queuedPrompts, runDrain, t])
+  }, [actionsDisabled, activeQueueSessionKey, busy, pickDrainHead, queueParked, queuedPrompts, runDrain, t])
 
   // Re-key on a runtime session-id change. A stable stored id (queueSessionKey)
   // never churns, so a change there is a real session switch and must NOT

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.test.tsx
@@ -20,6 +20,7 @@ import { ComposerScopeProvider, ComposerSurfaceProvider, MAIN_COMPOSER_SCOPE } f
 import { useComposerSubmit } from './use-composer-submit'
 
 interface SubmitHarnessOptions {
+  actionsDisabled?: boolean
   attachments?: ComposerAttachment[]
   busy?: boolean
   compacting?: boolean
@@ -35,6 +36,7 @@ interface SubmitHarnessOptions {
 let surfaceSequence = 0
 
 function renderSubmitHook({
+  actionsDisabled = false,
   attachments = [],
   busy = false,
   compacting = false,
@@ -52,10 +54,13 @@ function renderSubmitHook({
   editor.dataset.slot = 'composer-rich-input'
   editor.textContent = text
   const editorRef = { current: editor }
+  const activeQueueSessionKeyRef = { current: sessionKey }
   const onCancel = vi.fn()
   const onSteer = vi.fn(async () => true)
   const onSubmit = vi.fn(async () => true)
   const queueCurrentDraft = vi.fn(() => true)
+  const loadIntoComposer = vi.fn()
+  const stashAt = vi.fn()
   let updatePaneVisible: Dispatch<SetStateAction<boolean>> | undefined
 
   const clearDraft = vi.fn(() => {
@@ -93,8 +98,9 @@ function renderSubmitHook({
   const hook = renderHook(
     () =>
       useComposerSubmit({
+        actionsDisabled,
         activeQueueSessionKey: sessionKey,
-        activeQueueSessionKeyRef: { current: sessionKey },
+        activeQueueSessionKeyRef,
         attachments,
         busy,
         compacting,
@@ -106,7 +112,7 @@ function renderSubmitHook({
         exitQueuedEdit: vi.fn(() => false),
         focusInput: vi.fn(),
         inputDisabled,
-        loadIntoComposer: vi.fn(),
+        loadIntoComposer,
         onCancel,
         onSteer,
         onSubmit,
@@ -115,18 +121,21 @@ function renderSubmitHook({
         queuedPrompts: [],
         sessionId: 'runtime-session',
         setComposerText: vi.fn(),
-        stashAt: vi.fn()
+        stashAt
       }),
     { wrapper: Wrapper }
   )
 
   return {
+    activeQueueSessionKeyRef,
     clearDraft,
     hook,
+    loadIntoComposer,
     onCancel,
     onSteer,
     onSubmit,
     queueCurrentDraft,
+    stashAt,
     composerSurfaceId: resolvedSurfaceId,
     setPaneVisible(nextVisible: boolean) {
       if (!updatePaneVisible) {
@@ -137,6 +146,37 @@ function renderSubmitHook({
     }
   }
 }
+
+describe('useComposerSubmit rejection restoration', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  it('stashes a rejected A submission without overwriting the visible B draft', async () => {
+    let settle: ((accepted: boolean) => void) | undefined
+
+    const pending = new Promise<boolean>(resolve => {
+      settle = resolve
+    })
+
+    const { activeQueueSessionKeyRef, hook, loadIntoComposer, onSubmit, stashAt } = renderSubmitHook({
+      sessionKey: 'session-a'
+    })
+
+    onSubmit.mockImplementationOnce(() => pending)
+
+    act(() => {
+      hook.result.current.dispatchSubmit('draft from A')
+      activeQueueSessionKeyRef.current = 'session-b'
+    })
+
+    await act(async () => settle?.(false))
+
+    expect(stashAt).toHaveBeenCalledWith('session-a', 'draft from A', [])
+    expect(loadIntoComposer).not.toHaveBeenCalled()
+  })
+})
 
 describe('useComposerSubmit external request routing', () => {
   afterEach(() => {
@@ -262,6 +302,14 @@ describe('useComposerSubmit external request routing', () => {
 
     expect(disabled.onSubmit).not.toHaveBeenCalled()
   })
+
+  it('does not externally submit through a route-transitioning composer', () => {
+    const transitioning = renderSubmitHook({ actionsDisabled: true })
+
+    requestComposerSubmit('do not cross the session boundary', { target: 'main' })
+
+    expect(transitioning.onSubmit).not.toHaveBeenCalled()
+  })
 })
 
 describe('useComposerSubmit busy-turn routing', () => {
@@ -284,6 +332,24 @@ describe('useComposerSubmit busy-turn routing', () => {
     expect(queueCurrentDraft).not.toHaveBeenCalled()
     expect(onCancel).not.toHaveBeenCalled()
     expect(onSubmit).not.toHaveBeenCalled()
+  })
+
+  it('keeps a busy draft untouched while route and active session disagree', () => {
+    const { clearDraft, hook, onCancel, onSteer, onSubmit, queueCurrentDraft } = renderSubmitHook({
+      actionsDisabled: true,
+      busy: true,
+      text: 'this belongs to session B'
+    })
+
+    act(() => {
+      hook.result.current.submitDraft()
+    })
+
+    expect(clearDraft).not.toHaveBeenCalled()
+    expect(onSteer).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(queueCurrentDraft).not.toHaveBeenCalled()
+    expect(onCancel).not.toHaveBeenCalled()
   })
 
   it('queues a plain-text follow-up while the active turn is compacting', () => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-submit.ts
@@ -18,6 +18,7 @@ import { useComposerScope, useComposerSurfaceId } from '../scope'
 import type { ChatBarProps } from '../types'
 
 interface UseComposerSubmitArgs {
+  actionsDisabled: boolean
   activeQueueSessionKey: string | null
   activeQueueSessionKeyRef: RefObject<string | null>
   attachments: ComposerAttachment[]
@@ -53,6 +54,7 @@ interface UseComposerSubmitArgs {
  * external-submit listener ref.
  */
 export function useComposerSubmit({
+  actionsDisabled,
   activeQueueSessionKey,
   activeQueueSessionKeyRef,
   attachments,
@@ -88,7 +90,13 @@ export function useComposerSubmit({
     const submittedAttachments = attachments ?? []
 
     const restore = () => {
-      loadIntoComposer(text, submittedAttachments)
+      // The mounted composer may now be showing another route. Preserve the
+      // rejected payload in A's stash, but never paint it over B's visible
+      // editor or attachments after a session switch.
+      if (activeQueueSessionKeyRef.current === submittedScope) {
+        loadIntoComposer(text, submittedAttachments)
+      }
+
       // Use the scope captured at dispatch, not whatever session is focused
       // now — the gateway can reject well after the user has switched away,
       // and re-stashing into the currently-focused session would overwrite
@@ -110,7 +118,10 @@ export function useComposerSubmit({
   // and the exact visible surface captured at click time — every tile stays
   // mounted, and a session can be rendered in more than one pane.
   const dispatchSubmitRef = useRef(dispatchSubmit)
-  dispatchSubmitRef.current = dispatchSubmit
+
+  useLayoutEffect(() => {
+    dispatchSubmitRef.current = dispatchSubmit
+  })
 
   useLayoutEffect(
     () =>
@@ -120,16 +131,17 @@ export function useComposerSubmit({
           surfaceId !== null &&
           requestedSurfaceId === surfaceId &&
           paneVisible &&
-          !inputDisabled
+          !inputDisabled &&
+          !actionsDisabled
         ) {
           dispatchSubmitRef.current(text, undefined, displayKind)
         }
       }),
-    [inputDisabled, paneVisible, scope.target, surfaceId]
+    [actionsDisabled, inputDisabled, paneVisible, scope.target, surfaceId]
   )
 
   const submitDraft = () => {
-    if (disabled) {
+    if (disabled || actionsDisabled) {
       return
     }
 
@@ -241,7 +253,7 @@ export function useComposerSubmit({
 
     // Guard on live editor state, not the render-lagged `canSteer`: a redirect
     // fired on a fast Enter must not be dropped because state hasn't synced.
-    if (!onSteer || !text || attachments.length > 0 || SLASH_COMMAND_RE.test(text)) {
+    if (actionsDisabled || !onSteer || !text || attachments.length > 0 || SLASH_COMMAND_RE.test(text)) {
       return
     }
 
@@ -256,7 +268,7 @@ export function useComposerSubmit({
   }
 
   const queueDraft = () => {
-    if (disabled || !busy) {
+    if (disabled || actionsDisabled || !busy) {
       return
     }
 

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-lifecycle.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice-lifecycle.test.tsx
@@ -1,0 +1,125 @@
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { type PropsWithChildren } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
+
+import { useComposerVoice } from './use-composer-voice'
+
+interface ConversationOptions {
+  enabled: boolean
+  onFatalError?: () => void
+  onInterrupt?: () => Promise<void> | void
+  onStopWord?: () => void
+  onSubmit: (text: string) => Promise<void> | void
+}
+
+interface RecorderOptions {
+  onTranscript: (text: string) => void
+}
+
+const mocks = vi.hoisted(() => ({
+  conversationOptions: null as ConversationOptions | null,
+  recorderCancel: vi.fn(),
+  recorderOptions: null as RecorderOptions | null
+}))
+
+vi.mock('./use-auto-speak-replies', () => ({ useAutoSpeakReplies: vi.fn() }))
+vi.mock('./use-voice-conversation', () => ({
+  useVoiceConversation: vi.fn((options: ConversationOptions) => {
+    mocks.conversationOptions = options
+
+    return {
+      end: vi.fn(),
+      level: 0,
+      muted: false,
+      start: vi.fn(),
+      status: 'idle',
+      stopTurn: vi.fn(),
+      toggleMute: vi.fn()
+    }
+  })
+}))
+vi.mock('./use-voice-recorder', () => ({
+  useVoiceRecorder: vi.fn((options: RecorderOptions) => {
+    mocks.recorderOptions = options
+
+    return {
+      cancel: mocks.recorderCancel,
+      dictate: vi.fn(),
+      voiceActivityState: { elapsedSeconds: 0, level: 0, status: 'idle' },
+      voiceStatus: 'idle'
+    }
+  })
+}))
+
+function Wrapper({ children }: PropsWithChildren) {
+  return <ComposerScopeProvider value={MAIN_COMPOSER_SCOPE}>{children}</ComposerScopeProvider>
+}
+
+describe('useComposerVoice session-transition lifecycle', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+    mocks.conversationOptions = null
+    mocks.recorderCancel.mockReset()
+    mocks.recorderOptions = null
+  })
+
+  it('drops A callbacks that finish after the composer has converged on B', async () => {
+    const clearDraft = vi.fn()
+    const focusInput = vi.fn()
+    const insertText = vi.fn()
+    const onInterrupt = vi.fn()
+    const onSubmit = vi.fn(async () => true)
+    const onTranscribeAudio = vi.fn(async () => 'transcript')
+
+    const hook = renderHook(
+      ({ disabled, submissionKey }: { disabled: boolean; submissionKey: string }) =>
+        useComposerVoice({
+          busy: false,
+          clearDraft,
+          disabled,
+          focusInput,
+          insertText,
+          maxRecordingSeconds: 120,
+          onInterrupt,
+          onSubmit,
+          onTranscribeAudio,
+          sessionId: `runtime-${submissionKey}`,
+          submissionKey,
+          target: 'main'
+        }),
+      { initialProps: { disabled: false, submissionKey: 'session-a' }, wrapper: Wrapper }
+    )
+
+    act(() => hook.result.current.startConversation())
+    expect(mocks.conversationOptions?.enabled).toBe(true)
+
+    const conversationA = mocks.conversationOptions!
+    const recorderA = mocks.recorderOptions!
+
+    hook.rerender({ disabled: true, submissionKey: 'session-b' })
+    expect(mocks.recorderCancel).toHaveBeenCalledOnce()
+    expect(mocks.conversationOptions?.enabled).toBe(false)
+    hook.rerender({ disabled: false, submissionKey: 'session-b' })
+
+    act(() => hook.result.current.startConversation())
+    expect(mocks.conversationOptions?.enabled).toBe(true)
+
+    await act(async () => {
+      recorderA.onTranscript('dictation from A')
+      await conversationA.onSubmit('spoken turn from A')
+      await conversationA.onInterrupt?.()
+      conversationA.onFatalError?.()
+      conversationA.onStopWord?.()
+    })
+
+    expect(insertText).not.toHaveBeenCalled()
+    expect(clearDraft).not.toHaveBeenCalled()
+    expect(onSubmit).not.toHaveBeenCalled()
+    expect(onInterrupt).not.toHaveBeenCalled()
+    expect(focusInput).not.toHaveBeenCalled()
+    expect(mocks.conversationOptions?.enabled).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import { canSubmitVoiceTurn } from './use-composer-voice'
+
+describe('canSubmitVoiceTurn', () => {
+  it('fails closed while composer actions are disabled for a route transition', () => {
+    expect(canSubmitVoiceTurn({ busy: false, disabled: true })).toBe(false)
+  })
+
+  it('still rejects a transcript while the active turn is busy', () => {
+    expect(canSubmitVoiceTurn({ busy: true, disabled: false })).toBe(false)
+  })
+
+  it('allows an idle matched-session transcript', () => {
+    expect(canSubmitVoiceTurn({ busy: false, disabled: false })).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
@@ -19,6 +19,7 @@ import { useComposerScope } from '../scope'
 import type { ChatBarProps } from '../types'
 
 import { useAutoSpeakReplies } from './use-auto-speak-replies'
+import { useCommittedActionScope } from './use-committed-action-scope'
 import { useVoiceConversation } from './use-voice-conversation'
 import { useVoiceRecorder } from './use-voice-recorder'
 
@@ -35,9 +36,15 @@ interface UseComposerVoiceArgs {
   onSubmit: ChatBarProps['onSubmit']
   onTranscribeAudio: ChatBarProps['onTranscribeAudio']
   sessionId: string | null | undefined
+  /** Durable identity for the route-scoped draft this callback belongs to. */
+  submissionKey: string | null
   /** This composer's focus-bus key — voice toggles targeting another
    *  composer (or the active one, when not us) are ignored. */
   target: ComposerTarget
+}
+
+export function canSubmitVoiceTurn({ busy, disabled }: Pick<UseComposerVoiceArgs, 'busy' | 'disabled'>): boolean {
+  return !busy && !disabled
 }
 
 /**
@@ -57,6 +64,7 @@ export function useComposerVoice({
   onSubmit,
   onTranscribeAudio,
   sessionId,
+  submissionKey,
   target
 }: UseComposerVoiceArgs) {
   const { t } = useI18n()
@@ -66,12 +74,65 @@ export function useComposerVoice({
   const ownsWakeIndicatorRef = useRef(false)
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
-  const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
+  // Voice transcription completes asynchronously. The composer intentionally
+  // stays mounted across route switches, so a callback created for A can finish
+  // after the same editor is showing B. Invalidate every callback generation on
+  // a durable draft-scope change and read all action dependencies live.
+  const voiceScopeIsCurrent = useCommittedActionScope(submissionKey, disabled)
+
+  const voiceActionStateRef = useRef({
+    busy,
+    clearDraft,
+    disabled,
     focusInput,
+    insertText,
+    onInterrupt,
+    onSubmit,
+    sessionId
+  })
+
+  useLayoutEffect(() => {
+    voiceActionStateRef.current = {
+      busy,
+      clearDraft,
+      disabled,
+      focusInput,
+      insertText,
+      onInterrupt,
+      onSubmit,
+      sessionId
+    }
+  }, [busy, clearDraft, disabled, focusInput, insertText, onInterrupt, onSubmit, sessionId])
+
+  const insertVoiceTranscript = (text: string) => {
+    if (voiceScopeIsCurrent()) {
+      voiceActionStateRef.current.insertText(text)
+    }
+  }
+
+  const focusAfterVoice = () => {
+    if (voiceScopeIsCurrent()) {
+      voiceActionStateRef.current.focusInput()
+    }
+  }
+
+  const {
+    cancel: cancelDictation,
+    dictate,
+    voiceActivityState,
+    voiceStatus
+  } = useVoiceRecorder({
+    focusInput: focusAfterVoice,
     maxRecordingSeconds,
-    onTranscript: insertText,
+    onTranscript: insertVoiceTranscript,
     onTranscribeAudio
   })
+
+  const cancelDictationRef = useRef(cancelDictation)
+
+  useLayoutEffect(() => {
+    cancelDictationRef.current = cancelDictation
+  }, [cancelDictation])
 
   /** Auto-speak selector: the latest unspoken reply only — a backlog collapses to the newest. */
   const pendingResponse = () => {
@@ -117,14 +178,24 @@ export function useComposerVoice({
   }
 
   const submitVoiceTurn = async (text: string) => {
-    if (busy) {
+    const action = voiceActionStateRef.current
+
+    if (!voiceScopeIsCurrent() || !canSubmitVoiceTurn(action)) {
       return
     }
 
     triggerHaptic('submit')
-    resetBrowseState(sessionId)
-    clearDraft()
-    await onSubmit(text)
+    resetBrowseState(action.sessionId)
+    action.clearDraft()
+    await action.onSubmit(text)
+  }
+
+  const interruptVoiceTurn = async () => {
+    if (!voiceScopeIsCurrent()) {
+      return
+    }
+
+    await voiceActionStateRef.current.onInterrupt?.()
   }
 
   const wakePausedRef = useRef(false)
@@ -138,17 +209,25 @@ export function useComposerVoice({
   const conversation = useVoiceConversation({
     busy,
     consumePendingResponse,
-    enabled: voiceConversationActive,
-    onFatalError: () => setVoiceConversationActive(false),
+    enabled: voiceConversationActive && !disabled,
+    onFatalError: () => {
+      if (voiceScopeIsCurrent()) {
+        setVoiceConversationActive(false)
+      }
+    },
     // Speaking over the model mid-generation interrupts the in-flight turn —
     // the same seam as the Stop button — so the interjection becomes the next
     // turn instead of waiting behind a reply the user already rejected.
-    onInterrupt,
+    onInterrupt: interruptVoiceTurn,
     // A spoken stop command ("stop", "never mind", "goodbye", …) ends the
     // hands-free conversation. Flipping the flag is the authoritative off
     // switch — the enabled=false prop + effect below drive conversation.end()
     // teardown (mic close, wake re-arm).
-    onStopWord: () => setVoiceConversationActive(false),
+    onStopWord: () => {
+      if (voiceScopeIsCurrent()) {
+        setVoiceConversationActive(false)
+      }
+    },
     onSubmit: submitVoiceTurn,
     onTranscribeAudio,
     pendingResponse: pendingTurnResponse,
@@ -156,6 +235,26 @@ export function useComposerVoice({
     // to finish releasing the capture device (see wakePauseBarrierRef).
     beforeMicOpen: () => wakePauseBarrierRef.current ?? undefined
   })
+
+  const mountedVoiceScopeKeyRef = useRef(submissionKey)
+  const mountedVoiceDisabledRef = useRef(disabled)
+
+  // eslint-disable-next-line no-restricted-syntax -- local lifecycle token, not an atom mirror
+  useEffect(() => {
+    const scopeChanged = mountedVoiceScopeKeyRef.current !== submissionKey
+    const becameDisabled = disabled && !mountedVoiceDisabledRef.current
+
+    mountedVoiceScopeKeyRef.current = submissionKey
+    mountedVoiceDisabledRef.current = disabled
+
+    if (!scopeChanged && !becameDisabled) {
+      return
+    }
+
+    cancelDictationRef.current()
+    setVoiceConversationActive(false)
+    void conversation.end()
+  }, [conversation, disabled, submissionKey])
 
   // eslint-disable-next-line no-restricted-syntax -- ownership token used only by unmount cleanup
   useEffect(() => {

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.test.tsx
@@ -1,0 +1,146 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type MicRecorderErrorCopy, useMicRecorder } from './use-mic-recorder'
+
+const copy: MicRecorderErrorCopy = {
+  microphoneAccessDenied: 'denied',
+  microphoneConstraintsUnsupported: 'constraints',
+  microphoneInUse: 'in use',
+  microphonePermissionDenied: 'permission',
+  microphoneStartFailed: 'failed',
+  microphoneUnsupported: 'unsupported',
+  noMicrophone: 'missing'
+}
+
+class FakeMediaRecorder {
+  static instances: FakeMediaRecorder[] = []
+  static isTypeSupported = () => false
+  static startError: Error | null = null
+
+  mimeType = 'audio/webm'
+  ondataavailable: ((event: { data: Blob }) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onstop: (() => void) | null = null
+  state: RecordingState = 'inactive'
+
+  constructor(_stream: MediaStream) {
+    FakeMediaRecorder.instances.push(this)
+  }
+
+  start() {
+    if (FakeMediaRecorder.startError) {
+      throw FakeMediaRecorder.startError
+    }
+
+    this.state = 'recording'
+  }
+
+  stop() {
+    this.state = 'inactive'
+  }
+}
+
+const stream = () => {
+  const stop = vi.fn()
+
+  return { media: { getTracks: () => [{ stop }] } as unknown as MediaStream, stop }
+}
+
+describe('useMicRecorder generations', () => {
+  const originalMediaRecorder = globalThis.MediaRecorder
+  const originalMediaDevices = navigator.mediaDevices
+
+  beforeEach(() => {
+    FakeMediaRecorder.instances = []
+    FakeMediaRecorder.startError = null
+    Object.defineProperty(globalThis, 'MediaRecorder', { configurable: true, value: FakeMediaRecorder })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'MediaRecorder', { configurable: true, value: originalMediaRecorder })
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: originalMediaDevices })
+  })
+
+  it('stop cancels a pending microphone acquisition', async () => {
+    let resolveStream: ((value: MediaStream) => void) | undefined
+
+    const pendingStream = new Promise<MediaStream>(resolve => {
+      resolveStream = resolve
+    })
+
+    const acquired = stream()
+
+    const getUserMedia = vi.fn(() => pendingStream)
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia }
+    })
+
+    const hook = renderHook(() => useMicRecorder(copy))
+    let starting: Promise<void> | undefined
+
+    act(() => {
+      starting = hook.result.current.handle.start()
+    })
+    await waitFor(() => expect(getUserMedia).toHaveBeenCalledOnce())
+    await expect(hook.result.current.handle.stop()).resolves.toBeNull()
+    resolveStream?.(acquired.media)
+    await act(async () => starting)
+
+    expect(acquired.stop).toHaveBeenCalledOnce()
+    expect(hook.result.current.recording).toBe(false)
+  })
+
+  it('releases the microphone and permits retry when MediaRecorder.start throws', async () => {
+    const failed = stream()
+    const retry = stream()
+    const getUserMedia = vi.fn().mockResolvedValueOnce(failed.media).mockResolvedValueOnce(retry.media)
+
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: { getUserMedia } })
+    FakeMediaRecorder.startError = new DOMException('cannot start', 'InvalidStateError')
+
+    const hook = renderHook(() => useMicRecorder(copy))
+
+    await expect(act(async () => hook.result.current.handle.start())).rejects.toThrow('failed')
+
+    expect(failed.stop).toHaveBeenCalledOnce()
+    expect(hook.result.current.recording).toBe(false)
+
+    FakeMediaRecorder.startError = null
+    await act(async () => hook.result.current.handle.start())
+
+    expect(getUserMedia).toHaveBeenCalledTimes(2)
+    expect(FakeMediaRecorder.instances).toHaveLength(2)
+    expect(hook.result.current.recording).toBe(true)
+    expect(retry.stop).not.toHaveBeenCalled()
+  })
+
+  it('ignores a stale onstop after a replacement recorder starts', async () => {
+    const first = stream()
+    const second = stream()
+    const getUserMedia = vi.fn().mockResolvedValueOnce(first.media).mockResolvedValueOnce(second.media)
+
+    Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: { getUserMedia } })
+
+    const hook = renderHook(() => useMicRecorder(copy))
+
+    await act(async () => hook.result.current.handle.start())
+    const firstRecorder = FakeMediaRecorder.instances[0]!
+    const staleOnStop = firstRecorder.onstop
+    const firstStop = hook.result.current.handle.stop()
+
+    act(() => hook.result.current.handle.cancel())
+    await expect(firstStop).resolves.toBeNull()
+    expect(firstRecorder.onstop).toBeNull()
+
+    await act(async () => hook.result.current.handle.start())
+    expect(hook.result.current.recording).toBe(true)
+
+    act(() => staleOnStop?.())
+
+    expect(second.stop).not.toHaveBeenCalled()
+    expect(hook.result.current.recording).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-mic-recorder.ts
@@ -77,6 +77,9 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   const silenceTriggeredRef = useRef(false)
   const silenceStartedAtRef = useRef<number | null>(null)
   const stopResolverRef = useRef<((recording: MicRecording | null) => void) | null>(null)
+  const startEpochRef = useRef(0)
+  const startingRef = useRef(false)
+  const recorderGenerationRef = useRef(0)
 
   const cleanup = () => {
     if (animationRef.current) {
@@ -94,7 +97,15 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     silenceTriggeredRef.current = false
   }
 
-  useEffect(() => () => cleanup(), [])
+  useEffect(
+    () => () => {
+      startEpochRef.current += 1
+      recorderGenerationRef.current += 1
+      startingRef.current = false
+      cleanup()
+    },
+    []
+  )
 
   const startMeter = (stream: MediaStream, options: MicRecorderOptions) => {
     const audioWindow = window as Window & { webkitAudioContext?: BrowserAudioContext }
@@ -167,7 +178,7 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
   }
 
   const start: MicRecorderHandle['start'] = async (options = {}) => {
-    if (recorderRef.current) {
+    if (recorderRef.current || startingRef.current) {
       return
     }
 
@@ -175,95 +186,154 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
       throw new Error(copy.microphoneUnsupported)
     }
 
-    const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
+    const startEpoch = startEpochRef.current + 1
 
-    if (permitted === false) {
-      throw new Error(copy.microphoneAccessDenied)
-    }
-
-    let stream: MediaStream
+    startEpochRef.current = startEpoch
+    startingRef.current = true
 
     try {
-      stream = await navigator.mediaDevices.getUserMedia({
-        audio: { echoCancellation: true, noiseSuppression: true }
-      })
-    } catch (error) {
-      throw micError(error, copy)
-    }
+      const permitted = await window.hermesDesktop?.requestMicrophoneAccess?.()
 
-    const mimeType =
-      ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus', 'audio/ogg', 'audio/wav'].find(
-        type => MediaRecorder.isTypeSupported(type)
-      ) ?? ''
-
-    let recorder: MediaRecorder
-
-    try {
-      recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
-    } catch (error) {
-      stream.getTracks().forEach(track => track.stop())
-      throw micError(error, copy)
-    }
-
-    chunksRef.current = []
-    streamRef.current = stream
-    recorderRef.current = recorder
-    heardSpeechRef.current = false
-    silenceTriggeredRef.current = false
-    silenceStartedAtRef.current = null
-    startedAtRef.current = Date.now()
-
-    recorder.ondataavailable = event => {
-      if (event.data.size > 0) {
-        chunksRef.current.push(event.data)
+      if (startEpochRef.current !== startEpoch) {
+        return
       }
-    }
 
-    recorder.onstop = () => {
-      const chunks = chunksRef.current
-      const recordingType = recorder.mimeType || mimeType || 'audio/webm'
-      const durationMs = Date.now() - startedAtRef.current
-      const heardSpeech = heardSpeechRef.current
+      if (permitted === false) {
+        throw new Error(copy.microphoneAccessDenied)
+      }
 
-      chunksRef.current = []
-      cleanup()
+      let stream: MediaStream
 
-      const resolver = stopResolverRef.current
-      stopResolverRef.current = null
+      try {
+        stream = await navigator.mediaDevices.getUserMedia({
+          audio: { echoCancellation: true, noiseSuppression: true }
+        })
+      } catch (error) {
+        throw micError(error, copy)
+      }
 
-      if (!chunks.length) {
-        resolver?.(null)
+      if (startEpochRef.current !== startEpoch) {
+        stream.getTracks().forEach(track => track.stop())
 
         return
       }
 
-      resolver?.({
-        audio: new Blob(chunks, { type: recordingType }),
-        durationMs,
-        heardSpeech
-      })
-    }
+      const mimeType =
+        ['audio/webm;codecs=opus', 'audio/webm', 'audio/mp4', 'audio/ogg;codecs=opus', 'audio/ogg', 'audio/wav'].find(
+          type => MediaRecorder.isTypeSupported(type)
+        ) ?? ''
 
-    recorder.onerror = event => {
-      const error = micError((event as Event & { error?: unknown }).error, copy)
-      const resolver = stopResolverRef.current
-      stopResolverRef.current = null
-      cleanup()
-      options.onError?.(error)
-      resolver?.(null)
-    }
+      let recorder: MediaRecorder
 
-    recorder.start()
-    setRecording(true)
-    startMeter(stream, options)
+      try {
+        recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined)
+      } catch (error) {
+        stream.getTracks().forEach(track => track.stop())
+        throw micError(error, copy)
+      }
+
+      if (startEpochRef.current !== startEpoch) {
+        stream.getTracks().forEach(track => track.stop())
+
+        return
+      }
+
+      const recorderGeneration = ++recorderGenerationRef.current
+
+      chunksRef.current = []
+      streamRef.current = stream
+      recorderRef.current = recorder
+      heardSpeechRef.current = false
+      silenceTriggeredRef.current = false
+      silenceStartedAtRef.current = null
+      startedAtRef.current = Date.now()
+
+      recorder.ondataavailable = event => {
+        if (
+          recorderGenerationRef.current === recorderGeneration &&
+          recorderRef.current === recorder &&
+          event.data.size > 0
+        ) {
+          chunksRef.current.push(event.data)
+        }
+      }
+
+      recorder.onstop = () => {
+        if (recorderGenerationRef.current !== recorderGeneration || recorderRef.current !== recorder) {
+          return
+        }
+
+        const chunks = chunksRef.current
+        const recordingType = recorder.mimeType || mimeType || 'audio/webm'
+        const durationMs = Date.now() - startedAtRef.current
+        const heardSpeech = heardSpeechRef.current
+
+        chunksRef.current = []
+        cleanup()
+
+        const resolver = stopResolverRef.current
+        stopResolverRef.current = null
+
+        if (!chunks.length) {
+          resolver?.(null)
+
+          return
+        }
+
+        resolver?.({
+          audio: new Blob(chunks, { type: recordingType }),
+          durationMs,
+          heardSpeech
+        })
+      }
+
+      recorder.onerror = event => {
+        if (recorderGenerationRef.current !== recorderGeneration || recorderRef.current !== recorder) {
+          return
+        }
+
+        const error = micError((event as Event & { error?: unknown }).error, copy)
+        const resolver = stopResolverRef.current
+        stopResolverRef.current = null
+        cleanup()
+        options.onError?.(error)
+        resolver?.(null)
+      }
+
+      try {
+        recorder.start()
+      } catch (error) {
+        recorderGenerationRef.current += 1
+        recorder.ondataavailable = null
+        recorder.onerror = null
+        recorder.onstop = null
+        cleanup()
+        throw micError(error, copy)
+      }
+
+      setRecording(true)
+      startMeter(stream, options)
+    } finally {
+      if (startEpochRef.current === startEpoch) {
+        startingRef.current = false
+      }
+    }
   }
 
   const stop: MicRecorderHandle['stop'] = () =>
     new Promise<MicRecording | null>(resolve => {
       const recorder = recorderRef.current
 
-      if (!recorder || recorder.state === 'inactive') {
+      if (!recorder) {
+        startEpochRef.current += 1
+        startingRef.current = false
         cleanup()
+        resolve(null)
+
+        return
+      }
+
+      if (recorder.state === 'inactive') {
         resolve(null)
 
         return
@@ -274,15 +344,21 @@ export function useMicRecorder(copy: MicRecorderErrorCopy): {
     })
 
   const cancel: MicRecorderHandle['cancel'] = () => {
+    startEpochRef.current += 1
+    recorderGenerationRef.current += 1
+    startingRef.current = false
     const recorder = recorderRef.current
     const resolver = stopResolverRef.current
     stopResolverRef.current = null
 
-    if (recorder && recorder.state !== 'inactive') {
+    if (recorder) {
       recorder.ondataavailable = null
       recorder.onerror = null
       recorder.onstop = null
-      recorder.stop()
+
+      if (recorder.state !== 'inactive') {
+        recorder.stop()
+      }
     }
 
     cleanup()

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.test.tsx
@@ -1,0 +1,189 @@
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mic = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  recording: false,
+  start: vi.fn<() => Promise<void>>(),
+  stop: vi.fn<() => Promise<{ audio: Blob; durationMs: number; heardSpeech: boolean } | null>>()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      notifications: {
+        voice: {
+          noSpeechDetected: 'No speech',
+          recordingFailed: 'Recording failed',
+          transcriptionFailed: 'Transcription failed',
+          transcriptionUnavailable: 'Unavailable',
+          tryRecordingAgain: 'Try again',
+          unavailable: 'Unavailable'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('./use-mic-recorder', () => ({
+  useMicRecorder: () => ({
+    handle: { cancel: mic.cancel, start: mic.start, stop: mic.stop },
+    level: 0,
+    recording: mic.recording
+  })
+}))
+
+import { useVoiceRecorder } from './use-voice-recorder'
+
+describe('useVoiceRecorder lifecycle', () => {
+  beforeEach(() => {
+    mic.cancel.mockReset()
+    mic.start.mockReset()
+    mic.stop.mockReset()
+    mic.recording = false
+  })
+
+  it('serializes rapid Dictate starts while microphone acquisition is pending', async () => {
+    let resolveStart: (() => void) | undefined
+    mic.start.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveStart = resolve
+        })
+    )
+
+    const hook = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 120,
+        onTranscribeAudio: vi.fn(async () => ''),
+        onTranscript: vi.fn()
+      })
+    )
+
+    act(() => {
+      hook.result.current.dictate()
+      hook.result.current.dictate()
+    })
+
+    expect(mic.start).toHaveBeenCalledOnce()
+
+    await act(async () => resolveStart?.())
+  })
+
+  it('uses a second Dictate toggle to cancel pending microphone acquisition', async () => {
+    let resolveStart: (() => void) | undefined
+    mic.start.mockImplementation(
+      () =>
+        new Promise<void>(resolve => {
+          resolveStart = resolve
+        })
+    )
+
+    const hook = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 120,
+        onTranscribeAudio: vi.fn(async () => 'transcript'),
+        onTranscript: vi.fn()
+      })
+    )
+
+    act(() => hook.result.current.dictate())
+    act(() => hook.result.current.dictate())
+
+    expect(mic.cancel).toHaveBeenCalledOnce()
+    await act(async () => resolveStart?.())
+    expect(hook.result.current.voiceStatus).toBe('idle')
+  })
+
+  it('does not let stale start A cancel newer start B', async () => {
+    let resolveFirstStart: (() => void) | undefined
+    mic.start
+      .mockImplementationOnce(
+        () =>
+          new Promise<void>(resolve => {
+            resolveFirstStart = resolve
+          })
+      )
+      .mockResolvedValueOnce()
+
+    const hook = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 120,
+        onTranscribeAudio: vi.fn(async () => 'transcript'),
+        onTranscript: vi.fn()
+      })
+    )
+
+    act(() => hook.result.current.dictate())
+    act(() => hook.result.current.dictate())
+    act(() => hook.result.current.dictate())
+
+    expect(mic.start).toHaveBeenCalledTimes(2)
+    expect(mic.cancel).toHaveBeenCalledOnce()
+
+    await act(async () => resolveFirstStart?.())
+
+    expect(mic.cancel).toHaveBeenCalledOnce()
+  })
+
+  it('shares one stop operation across rapid Dictate toggles', async () => {
+    mic.recording = true
+    let resolveStop: ((value: null) => void) | undefined
+    mic.stop.mockImplementation(
+      () =>
+        new Promise<null>(resolve => {
+          resolveStop = resolve
+        })
+    )
+
+    const hook = renderHook(() =>
+      useVoiceRecorder({
+        focusInput: vi.fn(),
+        maxRecordingSeconds: 120,
+        onTranscribeAudio: vi.fn(async () => 'transcript'),
+        onTranscript: vi.fn()
+      })
+    )
+
+    act(() => hook.result.current.dictate())
+    act(() => hook.result.current.dictate())
+
+    expect(mic.stop).toHaveBeenCalledOnce()
+
+    await act(async () => resolveStop?.(null))
+  })
+
+  it('cancels and invalidates transcription when unmounted', async () => {
+    mic.recording = true
+    mic.stop.mockResolvedValue({ audio: new Blob(['audio']), durationMs: 10, heardSpeech: true })
+    let resolveTranscription: ((text: string) => void) | undefined
+
+    const onTranscribeAudio = vi.fn(
+      () =>
+        new Promise<string>(resolve => {
+          resolveTranscription = resolve
+        })
+    )
+
+    const onTranscript = vi.fn()
+    const focusInput = vi.fn()
+
+    const hook = renderHook(() =>
+      useVoiceRecorder({ focusInput, maxRecordingSeconds: 120, onTranscribeAudio, onTranscript })
+    )
+
+    act(() => hook.result.current.dictate())
+    await waitFor(() => expect(onTranscribeAudio).toHaveBeenCalledOnce())
+
+    hook.unmount()
+    expect(mic.cancel).toHaveBeenCalledOnce()
+
+    await act(async () => resolveTranscription?.('stale transcript'))
+
+    expect(onTranscript).not.toHaveBeenCalled()
+    expect(focusInput).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-recorder.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useLayoutEffect, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { notify, notifyError } from '@/store/notifications'
@@ -23,11 +23,19 @@ export function useVoiceRecorder({
   const { t } = useI18n()
   const voiceCopy = t.notifications.voice
   const { handle, level, recording } = useMicRecorder(voiceCopy)
+  const handleRef = useRef(handle)
   const [voiceStatus, setVoiceStatus] = useState<VoiceStatus>('idle')
   const [elapsedSeconds, setElapsedSeconds] = useState(0)
   const startedAtRef = useRef(0)
   const intervalRef = useRef<number | null>(null)
   const timeoutRef = useRef<number | null>(null)
+  const recordingEpochRef = useRef(0)
+  const startingRef = useRef(false)
+  const stopPromiseRef = useRef<Promise<void> | null>(null)
+
+  useLayoutEffect(() => {
+    handleRef.current = handle
+  }, [handle])
 
   const clearTimers = () => {
     if (intervalRef.current) {
@@ -41,51 +49,103 @@ export function useVoiceRecorder({
     }
   }
 
-  useEffect(() => () => clearTimers(), [])
+  useEffect(
+    () => () => {
+      recordingEpochRef.current += 1
+      startingRef.current = false
+      clearTimers()
+      handleRef.current.cancel()
+    },
+    [] // recorder handle methods close over stable refs; cleanup must run once
+  )
 
-  const stop = async () => {
+  const stop = (): Promise<void> => {
+    if (stopPromiseRef.current) {
+      return stopPromiseRef.current
+    }
+
+    const recordingEpoch = recordingEpochRef.current
+
     clearTimers()
-    const result = await handle.stop()
+    let stopPromise: Promise<void>
 
-    if (!result) {
-      setVoiceStatus('idle')
+    stopPromise = (async () => {
+      const result = await handle.stop()
 
-      return
-    }
-
-    if (!onTranscribeAudio) {
-      setVoiceStatus('idle')
-
-      return
-    }
-
-    setVoiceStatus('transcribing')
-
-    try {
-      const transcript = (await onTranscribeAudio(result.audio)).trim()
-
-      if (!transcript) {
-        notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
-      } else {
-        onTranscript(transcript)
+      if (recordingEpochRef.current !== recordingEpoch) {
+        return
       }
-    } catch (error) {
-      notifyError(error, voiceCopy.transcriptionFailed)
-    } finally {
-      setVoiceStatus('idle')
-      focusInput()
-    }
+
+      if (!result) {
+        setVoiceStatus('idle')
+
+        return
+      }
+
+      if (!onTranscribeAudio) {
+        setVoiceStatus('idle')
+
+        return
+      }
+
+      setVoiceStatus('transcribing')
+
+      try {
+        const transcript = (await onTranscribeAudio(result.audio)).trim()
+
+        if (recordingEpochRef.current !== recordingEpoch) {
+          return
+        }
+
+        if (!transcript) {
+          notify({ kind: 'warning', title: voiceCopy.noSpeechDetected, message: voiceCopy.tryRecordingAgain })
+        } else {
+          onTranscript(transcript)
+        }
+      } catch (error) {
+        if (recordingEpochRef.current === recordingEpoch) {
+          notifyError(error, voiceCopy.transcriptionFailed)
+        }
+      } finally {
+        if (recordingEpochRef.current === recordingEpoch) {
+          setVoiceStatus('idle')
+          focusInput()
+        }
+      }
+    })().finally(() => {
+      if (stopPromiseRef.current === stopPromise) {
+        stopPromiseRef.current = null
+      }
+    })
+
+    stopPromiseRef.current = stopPromise
+
+    return stopPromise
   }
 
   const start = async () => {
+    if (startingRef.current || recording || voiceStatus !== 'idle') {
+      return
+    }
+
     if (!onTranscribeAudio) {
       notify({ kind: 'warning', title: voiceCopy.unavailable, message: voiceCopy.transcriptionUnavailable })
 
       return
     }
 
+    const recordingEpoch = recordingEpochRef.current + 1
+
+    recordingEpochRef.current = recordingEpoch
+    startingRef.current = true
+
     try {
       await handle.start({ onError: error => notifyError(error, voiceCopy.recordingFailed) })
+
+      if (recordingEpochRef.current !== recordingEpoch) {
+        return
+      }
+
       startedAtRef.current = Date.now()
       setElapsedSeconds(0)
       setVoiceStatus('recording')
@@ -93,13 +153,31 @@ export function useVoiceRecorder({
       const cap = Math.max(1, Math.min(Math.trunc(maxRecordingSeconds), 600))
       timeoutRef.current = window.setTimeout(() => void stop(), cap * 1000)
     } catch (error) {
-      setVoiceStatus('idle')
-      notifyError(error, voiceCopy.recordingFailed)
+      if (recordingEpochRef.current === recordingEpoch) {
+        setVoiceStatus('idle')
+        notifyError(error, voiceCopy.recordingFailed)
+      }
+    } finally {
+      if (recordingEpochRef.current === recordingEpoch) {
+        startingRef.current = false
+      }
     }
   }
 
+  const cancel = () => {
+    recordingEpochRef.current += 1
+    startingRef.current = false
+    stopPromiseRef.current = null
+    clearTimers()
+    handle.cancel()
+    setElapsedSeconds(0)
+    setVoiceStatus('idle')
+  }
+
   const dictate = () => {
-    if (recording) {
+    if (startingRef.current) {
+      cancel()
+    } else if (recording) {
       void stop()
     } else if (voiceStatus === 'idle') {
       void start()
@@ -112,5 +190,5 @@ export function useVoiceRecorder({
     status: voiceStatus
   }
 
-  return { dictate, voiceActivityState, voiceStatus }
+  return { cancel, dictate, voiceActivityState, voiceStatus }
 }

--- a/apps/desktop/src/app/chat/composer/index.test.tsx
+++ b/apps/desktop/src/app/chat/composer/index.test.tsx
@@ -1,0 +1,132 @@
+import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ThreadRuntime } from '@/components/assistant-ui/test-utils'
+
+import type { ChatBarProps } from './types'
+
+import { ChatBar } from './index'
+
+const mocks = vi.hoisted(() => ({
+  runComposerMiddleware: vi.fn(async draft => draft)
+}))
+
+vi.mock('./contrib', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  runComposerMiddleware: mocks.runComposerMiddleware
+}))
+
+function props(overrides: Partial<ChatBarProps> = {}): ChatBarProps {
+  return {
+    actionsDisabled: false,
+    busy: false,
+    cwd: null,
+    disabled: false,
+    onCancel: vi.fn(),
+    onSubmit: vi.fn(async () => true),
+    queueSessionKey: 'session-a',
+    sessionId: 'runtime-a',
+    state: {
+      model: { canSwitch: false, model: 'test-model', provider: 'test-provider' },
+      tools: { enabled: false, label: 'Tools' },
+      voice: { active: false, enabled: false }
+    },
+    ...overrides
+  }
+}
+
+describe('ChatBar transition focus', () => {
+  afterEach(() => {
+    cleanup()
+    window.localStorage.clear()
+    vi.restoreAllMocks()
+    mocks.runComposerMiddleware.mockReset()
+    mocks.runComposerMiddleware.mockImplementation(async draft => draft)
+  })
+
+  it('keeps the real contenteditable, draft, focus, and caret while actions become fenced', () => {
+    const view = render(
+      <MemoryRouter>
+        <ThreadRuntime messages={[]}>
+          <ChatBar {...props()} />
+        </ThreadRuntime>
+      </MemoryRouter>
+    )
+
+    const editor = view.container.querySelector<HTMLElement>('[data-slot="composer-rich-input"]')!
+
+    editor.focus()
+    editor.textContent = 'draft in progress'
+    fireEvent.input(editor)
+
+    const range = globalThis.document.createRange()
+    const selection = window.getSelection()!
+
+    range.setStart(editor.firstChild!, 5)
+    range.collapse(true)
+    selection.removeAllRanges()
+    selection.addRange(range)
+
+    view.rerender(
+      <MemoryRouter>
+        <ThreadRuntime messages={[]}>
+          <ChatBar {...props({ actionsDisabled: true })} />
+        </ThreadRuntime>
+      </MemoryRouter>
+    )
+
+    const editorAfterTransition = view.container.querySelector<HTMLElement>('[data-slot="composer-rich-input"]')!
+
+    expect(editorAfterTransition).toBe(editor)
+    expect(globalThis.document.activeElement).toBe(editor)
+    expect(editorAfterTransition.textContent).toBe('draft in progress')
+    expect(selection.anchorNode).toBe(editor.firstChild)
+    expect(selection.anchorOffset).toBe(5)
+  })
+
+  it('rejects middleware output after the committed submit scope changes', async () => {
+    let resolveMiddleware: ((draft: { attachments: never[]; text: string }) => void) | undefined
+    const middleware = new Promise<{ attachments: never[]; text: string }>(resolve => {
+      resolveMiddleware = resolve
+    })
+    const onSubmit = vi.fn(async () => true)
+    const view = render(
+      <MemoryRouter>
+        <ThreadRuntime messages={[]}>
+          <ChatBar {...props({ onSubmit })} />
+        </ThreadRuntime>
+      </MemoryRouter>
+    )
+    const editor = view.container.querySelector<HTMLElement>('[data-slot="composer-rich-input"]')!
+
+    mocks.runComposerMiddleware.mockReturnValueOnce(middleware)
+    editor.textContent = 'message from session A'
+    fireEvent.input(editor)
+    fireEvent.keyDown(editor, { key: 'Enter' })
+
+    await waitFor(() => expect(mocks.runComposerMiddleware).toHaveBeenCalledOnce())
+
+    view.rerender(
+      <MemoryRouter>
+        <ThreadRuntime messages={[]}>
+          <ChatBar
+            {...props({
+              actionsDisabled: true,
+              onSubmit,
+              queueSessionKey: 'session-b',
+              sessionId: 'runtime-b'
+            })}
+          />
+        </ThreadRuntime>
+      </MemoryRouter>
+    )
+
+    await act(async () => {
+      resolveMiddleware?.({ attachments: [], text: 'message from session A' })
+      await middleware
+    })
+
+    expect(onSubmit).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -1,6 +1,15 @@
 import { ComposerPrimitive } from '@assistant-ui/react'
 import { useStore } from '@nanostores/react'
-import { type ClipboardEvent, type FormEvent, type KeyboardEvent, useCallback, useEffect, useMemo, useRef } from 'react'
+import {
+  type ClipboardEvent,
+  type FormEvent,
+  type KeyboardEvent,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef
+} from 'react'
 
 import { useTourMarker } from '@/app/chat/tour-marker'
 import { useHudComposerDrag } from '@/app/hud/composer-drag'
@@ -45,6 +54,7 @@ import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-aff
 import { markActiveComposer, onComposerAttachImagesRequest } from './focus'
 import { HelpHint } from './help-hint'
 import { useAtCompletions } from './hooks/use-at-completions'
+import { useCommittedActionScope } from './hooks/use-committed-action-scope'
 import { useComposerBranch } from './hooks/use-composer-branch'
 import { useComposerDraft } from './hooks/use-composer-draft'
 import { useComposerDrop } from './hooks/use-composer-drop'
@@ -87,6 +97,7 @@ import { chipTypedUrlOnSpace, linkifyUrls } from './url-refs'
 import { VoiceActivity, VoicePlaybackActivity } from './voice-activity'
 
 export function ChatBar({
+  actionsDisabled = false,
   busy,
   cwd,
   disabled,
@@ -124,12 +135,18 @@ export function ChatBar({
   // end control. Populated after useComposerVoice below (the submit wrapper
   // is created first); render-time assignment keeps the ref current.
   const voiceStopRef = useRef<{ active: boolean; end: () => void }>({ active: false, end: () => {} })
+  const submitScopeKey = queueSessionKey === undefined ? (sessionId ?? null) : queueSessionKey
+  const submitActionIsCurrent = useCommittedActionScope(submitScopeKey, actionsDisabled)
 
   // Every send (typed, queued, voice) passes through the contributed
   // middleware chain first — rewrite / pass-through / cancel. Empty chain =
   // exact pass-through, so surfaces without contributions are byte-identical.
   const onSubmit = useCallback<ChatBarProps['onSubmit']>(
     async (value, options) => {
+      if (!submitActionIsCurrent()) {
+        return false
+      }
+
       // Bare stop phrase typed while the voice conversation is live: end the
       // conversation (mic off, pill dismissed) instead of sending "stop" to
       // the agent. Spoken transcripts are already stop-checked inside
@@ -147,13 +164,13 @@ export function ChatBar({
 
       const draft = await runComposerMiddleware({ text: value, attachments: options?.attachments })
 
-      if (!draft) {
+      if (!draft || !submitActionIsCurrent()) {
         return false
       }
 
       return onSubmitProp(draft.text, { ...options, attachments: draft.attachments })
     },
-    [onSubmitProp]
+    [onSubmitProp, submitActionIsCurrent]
   )
 
   // Which live composer this instance IS (main | tile) — its attachment set,
@@ -172,7 +189,7 @@ export function ChatBar({
   // busy submit routes text to the queue instead of a steer (which would sit
   // undelivered behind the blocked tool batch). Drives the button affordance.
   const blockingPrompt = useStore(useMemo(() => sessionBlockingPrompt(sessionId ?? null), [sessionId]))
-  const activeQueueSessionKey = queueSessionKey || sessionId || null
+  const activeQueueSessionKey = submitScopeKey
 
   // Status items (subagents, background processes) are keyed by the RUNTIME
   // session id — gateway events and process.list both speak that id. Only the
@@ -222,6 +239,7 @@ export function ChatBar({
   const gatewayState = useStore($gatewayState)
   const reconnecting = gatewayState === 'closed' || gatewayState === 'error'
   const inputDisabled = disabled && !reconnecting
+  const actionDisabled = disabled || actionsDisabled
 
   // The draft engine — detached source of truth (DOM + draftRef + edge
   // selectors); typing never re-renders the chrome. ChatBar owns `queueEditRef`
@@ -302,6 +320,7 @@ export function ChatBar({
     steerQueuedNow,
     stepQueuedEdit
   } = useComposerQueue({
+    actionsDisabled,
     activeQueueSessionKey,
     attachments,
     busy,
@@ -317,7 +336,7 @@ export function ChatBar({
     sessionId
   })
 
-  const statusStackVisible = queuedPrompts.length > 0 || statusPresent
+  const statusStackVisible = !actionsDisabled && (queuedPrompts.length > 0 || statusPresent)
 
   // Halt vs. reach-the-queue: every interrupt lands on onCancel, but only the
   // gestures that MEAN "stop working" (Stop button, Esc) go through this
@@ -328,10 +347,14 @@ export function ChatBar({
   // busy) call the raw onCancel and keep draining on settle. Parked entries
   // stay in the panel until resumed, sent, edited, or deleted.
   const haltRun = useCallback(() => {
+    if (actionsDisabled) {
+      return
+    }
+
     parkQueuedPrompts(activeQueueSessionKeyRef.current)
 
     return onCancel()
-  }, [activeQueueSessionKeyRef, onCancel])
+  }, [actionsDisabled, activeQueueSessionKeyRef, onCancel])
 
   const { compactPill, foldVoice, minimal, stacked } = useComposerMetrics({
     composerDockRef,
@@ -342,7 +365,7 @@ export function ChatBar({
   })
 
   const hasComposerPayload = hasText || attachments.length > 0
-  const canSubmit = busy || hasComposerPayload
+  const canSubmit = !actionsDisabled && (busy || hasComposerPayload)
 
   // Steer only makes sense mid-turn, text-only (the gateway can't carry images
   // into a tool result) and never for a slash command (those execute inline).
@@ -361,6 +384,7 @@ export function ChatBar({
   // The submit engine — the orchestration seam where draft + queue meet. Owns
   // the submit decision tree, the send-with-restore primitive, and steer.
   const { queueDraft, steerDraft, submitDraft } = useComposerSubmit({
+    actionsDisabled,
     activeQueueSessionKey,
     activeQueueSessionKeyRef,
     attachments,
@@ -662,7 +686,7 @@ export function ChatBar({
     if ((event.metaKey || event.ctrlKey) && !event.altKey && event.shiftKey && event.key.toLowerCase() === 'k') {
       event.preventDefault()
 
-      if (!busy) {
+      if (!actionsDisabled && !busy) {
         void drainNextQueued()
       }
 
@@ -673,14 +697,14 @@ export function ChatBar({
     // Tab must not fall through to the browser — it would move focus out of
     // the composer mid-completion, which reads as the popover "eating" the
     // keypress. Swallow it; the refresh lands with the items.
-    if (trigger && triggerLoading && triggerItems.length === 0 && event.key === 'Tab') {
+    if (!actionsDisabled && trigger && triggerLoading && triggerItems.length === 0 && event.key === 'Tab') {
       event.preventDefault()
       triggerKeyConsumedRef.current = true
 
       return
     }
 
-    if (trigger && triggerItems.length > 0) {
+    if (!actionsDisabled && trigger && triggerItems.length > 0) {
       if (event.key === 'ArrowDown') {
         event.preventDefault()
         triggerKeyConsumedRef.current = true
@@ -765,6 +789,7 @@ export function ChatBar({
     // `/personality creative`. Space/Tab still commit what's typed as a single
     // directive chip; Enter falls through to submit (send it as-is).
     if (
+      !actionsDisabled &&
       trigger?.kind === '/' &&
       !triggerItems.length &&
       (event.key === ' ' || event.key === 'Tab') &&
@@ -782,7 +807,7 @@ export function ChatBar({
     // ArrowUp/ArrowDown navigate, in priority order: the queue (edit entries in
     // place) then sent-message history. The history ring is derived from live
     // session messages each press — single source of truth, no mirror.
-    if (event.key === 'ArrowUp') {
+    if (!actionsDisabled && event.key === 'ArrowUp') {
       const currentDraft = draftRef.current
 
       // Editing a queued turn → walk to the older entry.
@@ -823,7 +848,7 @@ export function ChatBar({
       return
     }
 
-    if (event.key === 'ArrowDown') {
+    if (!actionsDisabled && event.key === 'ArrowDown') {
       // Editing a queued turn → walk to the newer entry (past the newest exits).
       if (queueEdit) {
         event.preventDefault()
@@ -854,7 +879,7 @@ export function ChatBar({
     if (event.key === 'Enter' && (event.metaKey || event.ctrlKey) && !event.shiftKey) {
       event.preventDefault()
 
-      if (busy && !disabled) {
+      if (busy && !actionDisabled) {
         // As with plain Enter, source the just-typed content from the DOM so a
         // fast keypress cannot queue a stale draft.
         const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
@@ -882,7 +907,7 @@ export function ChatBar({
       const editorText = editorRef.current ? composerPlainText(editorRef.current) : draftRef.current
       const hasLivePayload = editorText.trim().length > 0 || attachments.length > 0
 
-      if (disabled) {
+      if (actionDisabled) {
         return
       }
 
@@ -917,7 +942,7 @@ export function ChatBar({
 
     if (event.key === 'Escape') {
       // Editing a queued turn → Esc cancels the edit, restoring the prior draft.
-      if (queueEdit) {
+      if (!actionsDisabled && queueEdit) {
         event.preventDefault()
         exitQueuedEdit('cancel')
 
@@ -927,7 +952,7 @@ export function ChatBar({
       // Otherwise Esc interrupts the running turn (Stop-button parity) — unless
       // the turn is parked waiting on the user, where Esc must not discard the
       // pending prompt. An explicit halt, so it parks the queue too.
-      if (busy && !awaitingInput) {
+      if (!actionsDisabled && busy && !awaitingInput) {
         event.preventDefault()
         triggerHaptic('cancel')
         void Promise.resolve(haltRun())
@@ -958,11 +983,11 @@ export function ChatBar({
   // Branch / worktree hand-offs (CodingStatusRow). Owns the worktree open +
   // branch-off/convert/list/switch actions; draft travels into the new session.
   const { handleBranchOff, handleConvertBranch, handleListBranches, handleSwitchBranch, openInWorktree } =
-    useComposerBranch({ clearDraft, cwd, draftRef })
+    useComposerBranch({ actionsDisabled, clearDraft, cwd, draftRef, sessionKey: activeQueueSessionKey })
 
   // Global Esc-to-cancel when the chat (not the composer input) has focus.
   // Same explicit-halt semantics as the Stop button: park the queue.
-  useComposerEscCancel({ awaitingInput, busy, onCancel: haltRun, target: scope.target })
+  useComposerEscCancel({ awaitingInput, busy: actionsDisabled ? false : busy, onCancel: haltRun, target: scope.target })
 
   const {
     conversation,
@@ -976,7 +1001,7 @@ export function ChatBar({
   } = useComposerVoice({
     busy,
     clearDraft,
-    disabled,
+    disabled: actionDisabled,
     focusInput,
     insertText,
     maxRecordingSeconds,
@@ -985,13 +1010,15 @@ export function ChatBar({
     onSubmit,
     onTranscribeAudio,
     sessionId,
+    submissionKey: activeQueueSessionKey,
     target: scope.target
   })
 
-  // Keep the typed-stop interceptor (see onSubmit above) in sync with the
-  // live conversation state. Render-time ref assignment, same pattern as
-  // dispatchSubmitRef — no effect needed for a plain mirror.
-  voiceStopRef.current = { active: voiceConversationActive, end: endConversation }
+  // Publish only committed conversation state so an abandoned concurrent
+  // render cannot redirect typed Stop into another session's voice lifecycle.
+  useLayoutEffect(() => {
+    voiceStopRef.current = { active: voiceConversationActive, end: endConversation }
+  }, [endConversation, voiceConversationActive])
 
   const contextMenu = (
     <ContextMenu
@@ -1022,7 +1049,7 @@ export function ChatBar({
         onToggleMute: conversation.toggleMute,
         status: conversation.status
       }}
-      disabled={disabled}
+      disabled={actionDisabled}
       foldVoice={foldVoice}
       hasComposerPayload={hasComposerPayload}
       minimal={minimal}
@@ -1186,43 +1213,45 @@ export function ChatBar({
               5px transparent grab margin — so both strips carry the same inset
               and share one left edge with it. */}
           <div className={cn(composerFloatingStrip, 'px-[5px] pb-1.5 empty:hidden')}>
-            <ActionBadges sessionId={statusSessionId} />
-            <SuggestionPills sessionId={statusSessionId} />
+            {!actionsDisabled && <ActionBadges sessionId={statusSessionId} />}
+            {!actionsDisabled && <SuggestionPills sessionId={statusSessionId} />}
           </div>
           {/* Session-scoped status stack (todos, subagents, background tasks,
               queue). An in-flow dock child: the dock is bottom-anchored, so it
               grows upward over the thread and the dock's own measurement covers
               it. Collapses to nothing when every status is empty. */}
-          <ComposerStatusStack
-            queue={
-              activeQueueSessionKey && queuedPrompts.length > 0 ? (
-                <QueuePanel
-                  busy={busy}
-                  editingId={queueEdit?.entryId ?? null}
-                  entries={queuedPrompts}
-                  onDelete={id => {
-                    if (removeQueuedPrompt(activeQueueSessionKey, id) && queueEdit?.entryId === id) {
-                      exitQueuedEdit('cancel')
-                    }
-                  }}
-                  onEdit={beginQueuedEdit}
-                  onResume={() => {
-                    unparkQueuedPrompts(activeQueueSessionKey)
+          {!actionsDisabled && (
+            <ComposerStatusStack
+              queue={
+                activeQueueSessionKey && queuedPrompts.length > 0 ? (
+                  <QueuePanel
+                    busy={busy}
+                    editingId={queueEdit?.entryId ?? null}
+                    entries={queuedPrompts}
+                    onDelete={id => {
+                      if (removeQueuedPrompt(activeQueueSessionKey, id) && queueEdit?.entryId === id) {
+                        exitQueuedEdit('cancel')
+                      }
+                    }}
+                    onEdit={beginQueuedEdit}
+                    onResume={() => {
+                      unparkQueuedPrompts(activeQueueSessionKey)
 
-                    // Idle → kick the head immediately; busy → the settle drain
-                    // takes over now that the park is lifted.
-                    if (!busy) {
-                      void drainNextQueued()
-                    }
-                  }}
-                  onSendNow={id => void sendQueuedNow(id)}
-                  onSteerNow={id => void steerQueuedNow(id)}
-                  parked={queueParked}
-                />
-              ) : null
-            }
-            sessionId={statusSessionId}
-          />
+                      // Idle → kick the head immediately; busy → the settle drain
+                      // takes over now that the park is lifted.
+                      if (!busy) {
+                        void drainNextQueued()
+                      }
+                    }}
+                    onSendNow={id => void sendQueuedNow(id)}
+                    onSteerNow={id => void steerQueuedNow(id)}
+                    parked={queueParked}
+                  />
+                ) : null
+              }
+              sessionId={statusSessionId}
+            />
+          )}
           <ComposerPrimitive.Root
             className={cn(
               'group/composer relative w-full overflow-visible rounded-2xl',
@@ -1260,7 +1289,7 @@ export function ChatBar({
             ref={composerRef}
           >
             {isHelpHint && <HelpHint />}
-            {trigger && !argStageEmpty && (
+            {!actionsDisabled && trigger && !argStageEmpty && (
               <ComposerTriggerPopover
                 activeIndex={triggerActive}
                 items={triggerItems}
@@ -1316,21 +1345,23 @@ export function ChatBar({
                     composerSurfaceGlass
                   )}
                 />
-                <CodingStatusRow
-                  onBranchOff={handleBranchOff}
-                  onConvertBranch={handleConvertBranch}
-                  onListBranches={handleListBranches}
-                  // A tile's rail reviews ITS worktree: pin the pane's scope to
-                  // this surface's cwd. Main keeps the classic follow-the-
-                  // active-session scope (null).
-                  onOpen={() => toggleReview(scope.target === 'main' ? null : (cwd ?? null), scope.target)}
-                  onOpenWorktree={openInWorktree}
-                  onSwitchBranch={handleSwitchBranch}
-                  // Blank in a bot chat: the row hides itself without a repo,
-                  // and stops probing git / GitHub for a surface that has no
-                  // branch to show. Cheaper than a second composer.
-                  repoPath={botChat ? undefined : cwd}
-                />
+                {!actionsDisabled && (
+                  <CodingStatusRow
+                    onBranchOff={handleBranchOff}
+                    onConvertBranch={handleConvertBranch}
+                    onListBranches={handleListBranches}
+                    // A tile's rail reviews ITS worktree: pin the pane's scope to
+                    // this surface's cwd. Main keeps the classic follow-the-
+                    // active-session scope (null).
+                    onOpen={() => toggleReview(scope.target === 'main' ? null : (cwd ?? null), scope.target)}
+                    onOpenWorktree={openInWorktree}
+                    onSwitchBranch={handleSwitchBranch}
+                    // Blank in a bot chat: the row hides itself without a repo,
+                    // and stops probing git / GitHub for a surface that has no
+                    // branch to show. Cheaper than a second composer.
+                    repoPath={botChat ? undefined : cwd}
+                  />
+                )}
                 <div
                   className={cn(
                     'relative z-1 flex min-h-0 w-full flex-col gap-(--composer-row-gap) overflow-hidden rounded-[inherit] px-(--composer-surface-pad-x) py-(--composer-surface-pad-y) transition-opacity duration-200 ease-out',
@@ -1343,10 +1374,10 @@ export function ChatBar({
                   {/* Contribution seams: banners above, a row below, inline
                     additions beside the "+" menu and before the controls.
                     All four render nothing until something contributes. */}
-                  <ContribSlot area={COMPOSER_AREAS.top} />
+                  {!actionsDisabled && <ContribSlot area={COMPOSER_AREAS.top} />}
                   <VoiceActivity state={voiceActivityState} />
                   <VoicePlaybackActivity />
-                  {queueEdit && editingQueuedPrompt && (
+                  {!actionsDisabled && queueEdit && editingQueuedPrompt && (
                     <div className="flex items-center justify-between gap-2 rounded-lg border border-[color-mix(in_srgb,var(--dt-composer-ring)_32%,transparent)] bg-accent/18 px-2 py-1">
                       <div className="min-w-0 text-[0.7rem] text-muted-foreground/88">
                         {t.composer.editingQueuedInComposer}
@@ -1380,16 +1411,16 @@ export function ChatBar({
                     )}
                   >
                     <div className="flex translate-y-[3px] items-start gap-(--composer-control-gap) self-start [grid-area:menu]">
-                      {contextMenu}
-                      <ContribSlot area={COMPOSER_AREAS.leading} />
+                      {!actionsDisabled && contextMenu}
+                      {!actionsDisabled && <ContribSlot area={COMPOSER_AREAS.leading} />}
                     </div>
                     <div className="min-w-0 [grid-area:input]">{input}</div>
                     <div className="flex min-w-0 items-center justify-end gap-(--composer-control-gap) [grid-area:controls]">
-                      <ContribSlot area={COMPOSER_AREAS.actions} />
+                      {!actionsDisabled && <ContribSlot area={COMPOSER_AREAS.actions} />}
                       {controls}
                     </div>
                   </div>
-                  <ContribSlot area={COMPOSER_AREAS.bottom} />
+                  {!actionsDisabled && <ContribSlot area={COMPOSER_AREAS.bottom} />}
                 </div>
               </div>
             </div>

--- a/apps/desktop/src/app/chat/composer/types.ts
+++ b/apps/desktop/src/app/chat/composer/types.ts
@@ -32,6 +32,7 @@ export interface ChatBarState {
 }
 
 export interface ChatBarProps {
+  actionsDisabled?: boolean
   busy: boolean
   disabled: boolean
   focusKey?: string | null

--- a/apps/desktop/src/app/chat/index.test.tsx
+++ b/apps/desktop/src/app/chat/index.test.tsx
@@ -1,10 +1,11 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { useState } from 'react'
-import { MemoryRouter } from 'react-router'
+import { MemoryRouter, useNavigate } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -19,6 +20,7 @@ import {
   $selectedStoredSessionId,
   $sessions
 } from '@/store/session'
+import { $sessionStates } from '@/store/session-states'
 
 const threadRenderCount = vi.hoisted(() => ({ current: 0 }))
 
@@ -48,7 +50,19 @@ vi.mock('@/lib/model-options', () => ({
 }))
 vi.mock('./chat-drop-overlay', () => ({ ChatDropOverlay: () => null }))
 vi.mock('./chat-swap-overlay', () => ({ ChatSwapOverlay: () => null, ChatSyncBadge: () => null }))
-vi.mock('./composer', () => ({ ChatBar: () => null, ChatBarFallback: () => null }))
+vi.mock('./composer', async () => {
+  const React = await import('react')
+
+  return {
+    ChatBar: ({ actionsDisabled, busy }: { actionsDisabled?: boolean; busy: boolean }) =>
+      React.createElement('textarea', {
+        'data-actions-disabled': actionsDisabled ? 'true' : 'false',
+        'data-busy': busy ? 'true' : 'false',
+        'data-testid': 'composer'
+      }),
+    ChatBarFallback: () => null
+  }
+})
 vi.mock('./hooks/use-file-drop-zone', () => ({
   useFileDropZone: () => ({ dragKind: null, dropHandlers: {} })
 }))
@@ -61,7 +75,7 @@ vi.mock('./sidebar/session-actions-menu', async () => {
   }
 })
 
-const { ChatView } = await import('./index')
+const { ChatView, shouldShowChatBar } = await import('./index')
 
 function assistantMessage(id: string, text: string): ChatMessage {
   return {
@@ -70,6 +84,74 @@ function assistantMessage(id: string, text: string): ChatMessage {
     role: 'assistant'
   }
 }
+
+function chatViewProps() {
+  return {
+    gateway: null,
+    maxVoiceRecordingSeconds: 120,
+    onAddContextRef: vi.fn(),
+    onAddUrl: vi.fn(),
+    onAttachDroppedItems: vi.fn(),
+    onAttachImageBlob: vi.fn(),
+    onBranchInNewChat: vi.fn(),
+    onCancel: vi.fn(),
+    onDeleteSelectedSession: vi.fn(),
+    onEdit: vi.fn(),
+    onPasteClipboardImage: vi.fn(),
+    onPickFiles: vi.fn(),
+    onPickFolders: vi.fn(),
+    onPickImages: vi.fn(),
+    onReload: vi.fn(),
+    onRemoveAttachment: vi.fn(),
+    onRetryResume: vi.fn(),
+    onSteer: vi.fn(),
+    onSubmit: vi.fn(),
+    onThreadMessagesChange: vi.fn(),
+    onToggleSelectedPin: vi.fn(),
+    onTranscribeAudio: vi.fn()
+  }
+}
+
+describe('shouldShowChatBar', () => {
+  it('preserves initial-loading, exhausted, watch, and normal visibility', () => {
+    expect(
+      shouldShowChatBar({
+        activeSessionId: null,
+        isRoutedSessionView: true,
+        messagesEmpty: true,
+        resumeExhausted: false,
+        watchWindow: false
+      })
+    ).toBe(false)
+    expect(
+      shouldShowChatBar({
+        activeSessionId: 'runtime-a',
+        isRoutedSessionView: true,
+        messagesEmpty: false,
+        resumeExhausted: true,
+        watchWindow: false
+      })
+    ).toBe(false)
+    expect(
+      shouldShowChatBar({
+        activeSessionId: 'runtime-a',
+        isRoutedSessionView: true,
+        messagesEmpty: false,
+        resumeExhausted: false,
+        watchWindow: true
+      })
+    ).toBe(false)
+    expect(
+      shouldShowChatBar({
+        activeSessionId: 'runtime-a',
+        isRoutedSessionView: true,
+        messagesEmpty: false,
+        resumeExhausted: false,
+        watchWindow: false
+      })
+    ).toBe(true)
+  })
+})
 
 describe('ChatView render isolation', () => {
   beforeEach(() => {
@@ -83,8 +165,16 @@ describe('ChatView render isolation', () => {
     $currentProvider.set('test-provider')
     $freshDraftReady.set(false)
     $gatewayState.set('closed')
-    $messages.set([assistantMessage('assistant-1', 'Stable historical answer')])
+    const initialMessages = [assistantMessage('assistant-1', 'Stable historical answer')]
+
+    $messages.set(initialMessages)
     $selectedStoredSessionId.set('stored-1')
+    $sessionStates.set({
+      'runtime-1': {
+        ...createClientSessionState('stored-1'),
+        messages: initialMessages
+      }
+    })
     $sessions.set([{ id: 'stored-1', message_count: 1, title: 'Stable chat' } as never])
   })
 
@@ -102,34 +192,12 @@ describe('ChatView render isolation', () => {
     $gatewayState.set('idle')
     $messages.set([])
     $selectedStoredSessionId.set(null)
+    $sessionStates.set({})
     $sessions.set([])
   })
 
   it('does not re-render chat history when an unrelated parent idle tick updates', () => {
-    const props = {
-      gateway: null,
-      maxVoiceRecordingSeconds: 120,
-      onAddContextRef: vi.fn(),
-      onAddUrl: vi.fn(),
-      onAttachDroppedItems: vi.fn(),
-      onAttachImageBlob: vi.fn(),
-      onBranchInNewChat: vi.fn(),
-      onCancel: vi.fn(),
-      onDeleteSelectedSession: vi.fn(),
-      onEdit: vi.fn(),
-      onPasteClipboardImage: vi.fn(),
-      onPickFiles: vi.fn(),
-      onPickFolders: vi.fn(),
-      onPickImages: vi.fn(),
-      onReload: vi.fn(),
-      onRemoveAttachment: vi.fn(),
-      onRetryResume: vi.fn(),
-      onSteer: vi.fn(),
-      onSubmit: vi.fn(),
-      onThreadMessagesChange: vi.fn(),
-      onToggleSelectedPin: vi.fn(),
-      onTranscribeAudio: vi.fn()
-    }
+    const props = chatViewProps()
 
     const queryClient = new QueryClient({
       defaultOptions: { queries: { retry: false } }
@@ -160,5 +228,128 @@ describe('ChatView render isolation', () => {
     // memo(ChatView) with stable props must absorb the parent's idle tick —
     // the transcript (Thread) must not re-render. This is PR #38470's contract.
     expect(threadRenderCount.current).toBe(1)
+  })
+
+  it('keeps the focused composer mounted but action-blocked through a transient route-session mismatch', () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    const props = chatViewProps()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/stored-1']}>
+          <ChatView {...props} />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    const composer = screen.getByTestId('composer') as HTMLTextAreaElement
+    composer.value = 'draft in progress'
+    composer.focus()
+    composer.setSelectionRange(5, 5)
+
+    act(() => {
+      $sessions.set([
+        { id: 'stored-1', message_count: 1, title: 'Stable chat' } as never,
+        { id: 'stored-2', message_count: 1, title: 'Incoming update' } as never
+      ])
+      $selectedStoredSessionId.set('stored-2')
+    })
+
+    const composerAfterMismatch = screen.getByTestId('composer') as HTMLTextAreaElement
+
+    expect(composerAfterMismatch).toBe(composer)
+    expect(globalThis.document.activeElement).toBe(composer)
+    expect(composerAfterMismatch.value).toBe('draft in progress')
+    expect(composerAfterMismatch.selectionStart).toBe(5)
+    expect(composerAfterMismatch.selectionEnd).toBe(5)
+    expect(composerAfterMismatch.dataset.actionsDisabled).toBe('true')
+  })
+
+  it('blocks busy session A actions during a route-first navigation to session B', () => {
+    $sessionStates.set({
+      'runtime-1': {
+        ...createClientSessionState('stored-1'),
+        busy: true,
+        messages: [assistantMessage('assistant-a', 'A is still running')]
+      }
+    })
+    $sessions.set([
+      { id: 'stored-1', message_count: 1, title: 'Busy A' } as never,
+      { id: 'stored-2', message_count: 1, title: 'Target B' } as never
+    ])
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } }
+    })
+
+    const props = chatViewProps()
+
+    function RouteFirstHarness() {
+      const navigate = useNavigate()
+
+      return (
+        <>
+          <button onClick={() => navigate('/stored-2')} type="button">
+            Navigate to B
+          </button>
+          <ChatView {...props} />
+        </>
+      )
+    }
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <MemoryRouter initialEntries={['/stored-1']}>
+          <RouteFirstHarness />
+        </MemoryRouter>
+      </QueryClientProvider>
+    )
+
+    const composer = screen.getByTestId('composer') as HTMLTextAreaElement
+    expect(composer.dataset.busy).toBe('true')
+    expect(composer.dataset.actionsDisabled).toBe('false')
+    composer.value = 'draft for B'
+    composer.focus()
+    composer.setSelectionRange(7, 7)
+
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate to B' }))
+
+    const composerDuringMismatch = screen.getByTestId('composer') as HTMLTextAreaElement
+
+    expect(composerDuringMismatch).toBe(composer)
+    expect(composerDuringMismatch.dataset.busy).toBe('true')
+    expect(composerDuringMismatch.dataset.actionsDisabled).toBe('true')
+    expect(globalThis.document.activeElement).toBe(composer)
+
+    // Selected B can publish before runtime A is replaced. Route-vs-selected is
+    // now clean, but the active runtime still owns busy/session actions for A —
+    // the fence must remain until runtime identity converges too.
+    act(() => $selectedStoredSessionId.set('stored-2'))
+
+    const composerAfterSelectionConverges = screen.getByTestId('composer') as HTMLTextAreaElement
+
+    expect(composerAfterSelectionConverges).toBe(composer)
+    expect(composerAfterSelectionConverges.dataset.busy).toBe('true')
+    expect(composerAfterSelectionConverges.dataset.actionsDisabled).toBe('true')
+
+    act(() => {
+      $sessionStates.set({
+        ...$sessionStates.get(),
+        'runtime-2': {
+          ...createClientSessionState('stored-2'),
+          messages: [assistantMessage('assistant-b', 'B is ready')]
+        }
+      })
+      $activeSessionId.set('runtime-2')
+    })
+
+    const composerAfterRuntimeConverges = screen.getByTestId('composer') as HTMLTextAreaElement
+
+    expect(composerAfterRuntimeConverges).toBe(composer)
+    expect(composerAfterRuntimeConverges.dataset.busy).toBe('false')
+    expect(composerAfterRuntimeConverges.dataset.actionsDisabled).toBe('false')
   })
 })

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -48,7 +48,7 @@ import {
   sessionPinId,
   shouldMigrateComposerScope
 } from '@/store/session'
-import { $focusedStoredSessionId, sessionTileDelegate } from '@/store/session-states'
+import { $focusedStoredSessionId, $sessionStates, sessionTileDelegate } from '@/store/session-states'
 import { $transcriptTailBySessionId, transcriptTailState } from '@/store/transcript-tail'
 import { isAuxiliaryWindow, isWatchWindow } from '@/store/windows'
 import type { ModelOptionsResponse } from '@/types/hermes'
@@ -107,6 +107,22 @@ interface ChatViewProps extends Omit<React.ComponentProps<'div'>, 'onSubmit'> {
   onRetryResume: (sessionId: string) => void
   onTranscribeAudio?: (audio: Blob) => Promise<string>
   onDismissError?: (messageId: string) => void
+}
+
+export function shouldShowChatBar({
+  activeSessionId,
+  isRoutedSessionView,
+  messagesEmpty,
+  resumeExhausted,
+  watchWindow
+}: {
+  activeSessionId: null | string | undefined
+  isRoutedSessionView: boolean
+  messagesEmpty: boolean
+  resumeExhausted: boolean
+  watchWindow: boolean
+}): boolean {
+  return !(isRoutedSessionView && messagesEmpty && !activeSessionId) && !resumeExhausted && !watchWindow
 }
 
 interface ChatHeaderProps {
@@ -393,6 +409,11 @@ const ChatViewContent = memo(function ChatViewContent({
   const composerSurfaceId = useComposerSurfaceId()
   const isPrimary = view.kind === 'primary'
   const activeSessionId = useStore(view.$runtimeId)
+
+  const activeRuntimeStoredId = useStoreSelector($sessionStates, states =>
+    activeSessionId ? (states[activeSessionId]?.storedSessionId ?? null) : null
+  )
+
   const storedId = useStore(view.$storedId)
   // Multi-pane dimming: only the focused surface paints at full strength, so
   // two sessions side by side read as "this one, and that one over there".
@@ -488,6 +509,15 @@ const ChatViewContent = memo(function ChatViewContent({
   // waiting for the resume effect (which paints a frame later) to clear them.
   const routeSessionMismatch = isPrimary ? isRouteSessionMismatch(routedSessionId, selectedSessionId, sessions) : false
 
+  const activeRuntimeRouteMismatch =
+    isPrimary && isRoutedSessionView
+      ? !activeSessionId ||
+        !activeRuntimeStoredId ||
+        isRouteSessionMismatch(routedSessionId, activeRuntimeStoredId, sessions)
+      : false
+
+  const sessionTransitioning = routeSessionMismatch || activeRuntimeRouteMismatch
+
   // The compact new-session pop-out skips the wordmark/tagline intro — it's a
   // scratch window, not the full-height empty state. The Appearance toggle
   // turns it off everywhere else.
@@ -526,22 +556,26 @@ const ChatViewContent = memo(function ChatViewContent({
     knownHistory: routedHasHistory,
     messagesEmpty,
     resumeExhausted,
-    routeSessionMismatch,
+    routeSessionMismatch: sessionTransitioning,
     routedSessionView: isRoutedSessionView
   })
 
   const threadLoading = threadLoadingState(loadingSession, busy, awaitingResponse, lastVisibleIsUser)
-  // The composer mount deliberately does NOT follow `routeSessionMismatch`.
-  // That flag is a transient split-write flicker during session switches (the
-  // routed id and the active id land in two separate store writes), and
-  // unmounting the composer mid-typing destroys DOM focus and the caret — the
-  // #88621 class of "it stopped letting me type" bugs. The transcript still
-  // shows the loader; the composer stays mounted and the draft-swap layout
-  // effect handles the session transition. Hide it only when there is
-  // genuinely no session yet (route not resumed), the resume gave up (no live
-  // runtime to send to), or the window is a read-only watch spectator.
-  const showChatBar =
-    !(isRoutedSessionView && messagesEmpty && !activeSessionId) && !resumeExhausted && !isWatchWindow()
+
+  // Keep the DOM/editor mounted through the transient route ↔ selected-session
+  // split write so focus, draft, and selection survive. A mismatch is also a
+  // genuine navigation seam, though: the route/draft can already mean B while
+  // busy/session actions still point at A. ChatBar receives an independent
+  // action fence below — typing stays enabled, every submit/steer/cancel/queue
+  // path fails closed until the identities converge.
+  const showChatBar = shouldShowChatBar({
+    activeSessionId,
+    isRoutedSessionView,
+    messagesEmpty,
+    resumeExhausted,
+    watchWindow: isWatchWindow()
+  })
+
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({
@@ -654,7 +688,7 @@ const ChatViewContent = memo(function ChatViewContent({
         onEdit={onEdit}
         onReload={onReload}
         onThreadMessagesChange={onThreadMessagesChange}
-        suppressMessages={routeSessionMismatch}
+        suppressMessages={sessionTransitioning}
       >
         <div
           className="relative min-h-0 max-w-full flex-1 overflow-hidden bg-(--ui-chat-surface-background) contain-[layout_paint]"
@@ -721,6 +755,7 @@ const ChatViewContent = memo(function ChatViewContent({
         {showChatBar && (
           <Suspense fallback={<ChatBarFallback />}>
             <ChatBar
+              actionsDisabled={sessionTransitioning}
               busy={busy}
               cwd={currentCwd}
               disabled={!gatewayOpen}

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -531,10 +531,17 @@ const ChatViewContent = memo(function ChatViewContent({
   })
 
   const threadLoading = threadLoadingState(loadingSession, busy, awaitingResponse, lastVisibleIsUser)
-  // Hide the composer in the exhausted error state too: there's no live runtime
-  // to send to until a retry rebinds one. Watch windows are pure spectators of a
-  // subagent run driven elsewhere — no composer, transcript is read-only.
-  const showChatBar = !loadingSession && !resumeExhausted && !isWatchWindow()
+  // The composer mount deliberately does NOT follow `routeSessionMismatch`.
+  // That flag is a transient split-write flicker during session switches (the
+  // routed id and the active id land in two separate store writes), and
+  // unmounting the composer mid-typing destroys DOM focus and the caret — the
+  // #88621 class of "it stopped letting me type" bugs. The transcript still
+  // shows the loader; the composer stays mounted and the draft-swap layout
+  // effect handles the session transition. Hide it only when there is
+  // genuinely no session yet (route not resumed), the resume gave up (no live
+  // runtime to send to), or the window is a read-only watch spectator.
+  const showChatBar =
+    !(isRoutedSessionView && messagesEmpty && !activeSessionId) && !resumeExhausted && !isWatchWindow()
   const threadKey = selectedSessionId || activeSessionId || (isRoutedSessionView ? location.pathname : 'new')
 
   const modelOptionsQuery = useQuery<ModelOptionsResponse>({


### PR DESCRIPTION
## Summary

- add a fail-closed convergence fence around the mounted composer introduced by #95227, preventing transient route/selection/runtime disagreement from sending actions to the outgoing session
- suppress stale transcript rendering and fence submit, steer, cancel, queue, branch/worktree, and voice callbacks during the transition
- publish session-bound action generations and callback mirrors only after React commits, so an abandoned concurrent render cannot invalidate or redirect the visible composer's handlers

## Scope

This is the first reviewable extraction from draft umbrella #95880 and is intentionally stacked on #95227. It contains only the composer convergence/action fence and its commit-safe asynchronous callbacks. Until #95227 merges, GitHub will also display that prerequisite's one-file mount change in this Draft PR; the branch will be rebased onto `main` immediately after the prerequisite lands.

Intentionally excluded for follow-up child PRs:

- owner-scoped draft/storage migrations and New Chat handoffs
- cross-window queue persistence and drain arbitration
- exact-owner tile, HUD, Quick Entry, delete/resume, unread, and todo lifecycle routing
- broader voice ownership and Bot/read-only transcript recovery

## Verification

- focused composer/chat/recorder suite: 59 passed
- full Desktop UI suite under `LC_ALL=C.UTF-8 LANG=C.UTF-8 NODE_ENV=test`: 6,828 passed
- renderer/Electron/E2E TypeScript typecheck: passed
- ESLint (`--quiet`): passed
- changed-file Prettier check and `git diff --check`: passed
- added-line secret/shell/eval/unsafe-deserialization scan: clean
- review footprint: 20 files / approximately 118 KB, split into four independently reviewed sub-cap groups

Depends on #95227

Related context: #88621

Umbrella: #95880
