### PR TITLE
fix(voice): write auto TTS replies to audio cache

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,7 +15,6 @@ import re
 import socket as _socket
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -236,7 +235,7 @@ def should_send_media_as_audio(platform, ext: str, is_voice: bool = False) -> bo
 
 
 def build_auto_tts_output_path(platform) -> str:
-    """Return a unique temp output path for gateway auto-TTS synthesis.
+    """Return a unique audio-cache output path for gateway auto-TTS synthesis.
 
     Platform-awareness lives HERE (the caller knows its platform), not in the
     TTS tool's ``HERMES_SESSION_PLATFORM`` contextvar — that contextvar is
@@ -252,13 +251,7 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
-    audio_path = os.path.join(
-        tempfile.gettempdir(),
-        "hermes_voice",
-        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
-    )
-    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-    return audio_path
+    return str(get_audio_cache_dir() / f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}")
 
 
 def utf16_len(s: str) -> int:

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -12,6 +12,7 @@ voice bubble). The fix passes an explicit output path from
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -23,6 +24,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     build_auto_tts_output_path,
+    get_audio_cache_dir,
 )
 from gateway.session import SessionSource, build_session_key
 from tools.tts_tool import OPUS_VOICE_PLATFORMS
@@ -76,6 +78,19 @@ def _hold_typing():
 # ---------------------------------------------------------------------------
 # build_auto_tts_output_path: OPUS_VOICE_PLATFORMS is the single source of truth
 # ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("platform", "expected_suffix"),
+    [(Platform.TELEGRAM, ".ogg"), (Platform.DISCORD, ".mp3")],
+)
+def test_output_path_uses_audio_cache_with_platform_native_extension(
+    platform, expected_suffix
+):
+    path = Path(build_auto_tts_output_path(platform))
+
+    assert path.parent == get_audio_cache_dir()
+    assert path.suffix == expected_suffix
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- write gateway auto-TTS output under the established approved audio cache instead of `/tmp/hermes_voice`
- preserve UUID-derived filenames and `OPUS_VOICE_PLATFORMS` extension selection
- add regression coverage for Telegram `.ogg` and Discord `.mp3` output paths

Fixes #80386
Fixes #80436

## Validation
- `scripts/run_tests.sh tests/gateway/test_base_auto_tts_output_format.py tests/gateway/test_voice_command.py -q`
  - 77 passed, 7 skipped
- `uv run --extra dev --extra voice ruff check gateway/platforms/base.py tests/gateway/test_base_auto_tts_output_format.py`
- `git diff --check`

No config, provider, streaming-TTS, mixer, STT, or receiver changes.