### PR TITLE
fix(skills): classify root skills under general

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1511,9 +1511,9 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 32
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
-# org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3: root-level entries now use the general category; v2 snapshots may encode
+# them as <name>/<name> and must be rebuilt.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1633,7 +1633,7 @@ def _build_snapshot_entry(
 
     if len(parts) >= 2:
         skill_name = parts[-2]
-        category = "/".join(parts[:-2]) if len(parts) > 2 else parts[0]
+        category = "/".join(parts[:-2]) or "general"
     else:
         category = "general"
         skill_name = skill_file.parent.name

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -2,6 +2,7 @@
 
 import builtins
 import importlib
+import json
 import logging
 import os
 import sys
@@ -304,7 +305,43 @@ class TestBuildSkillsSystemPrompt:
         yield
         clear_skills_system_prompt_cache(clear_snapshot=True)
 
+    def test_root_level_skill_is_not_repeated_as_its_category(
+        self, monkeypatch, tmp_path
+    ):
+        from agent.prompt_builder import _build_skills_manifest
 
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skills_root = tmp_path / "skills"
+        skill_dir = skills_root / "git-worktree-discipline"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: git-worktree-discipline\n"
+            "description: Keep worktrees safe\n"
+            "---\n"
+        )
+        (tmp_path / ".skills_prompt_snapshot.json").write_text(
+            json.dumps({
+                "version": 2,
+                "manifest": _build_skills_manifest(skills_root),
+                "skills": [
+                    {
+                        "skill_name": "git-worktree-discipline",
+                        "category": "git-worktree-discipline",
+                        "frontmatter_name": "git-worktree-discipline",
+                        "description": "Keep worktrees safe",
+                        "platforms": [],
+                        "conditions": {},
+                    }
+                ],
+                "category_descriptions": {},
+            })
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "\n  general:\n    - git-worktree-discipline:" in result
+        assert "\n  git-worktree-discipline:\n" not in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -320,6 +320,11 @@ class TestBuildSkillsSystemPrompt:
             "description: Keep worktrees safe\n"
             "---\n"
         )
+        (skill_dir / "DESCRIPTION.md").write_text(
+            "---\n"
+            "description: Misleading same-name category\n"
+            "---\n"
+        )
         (tmp_path / ".skills_prompt_snapshot.json").write_text(
             json.dumps({
                 "version": 2,
@@ -342,6 +347,7 @@ class TestBuildSkillsSystemPrompt:
 
         assert "\n  general:\n    - git-worktree-discipline:" in result
         assert "\n  git-worktree-discipline:\n" not in result
+        assert "Misleading same-name category" not in result
 
     def test_deduplicates_skills(self, monkeypatch, tmp_path):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## Summary

- Classify root-level local skills under `general` instead of repeating each skill name as its own category.
- Advance the skill-prompt snapshot version so cached self-qualified entries are rebuilt.
- Cover the observed same-name `DESCRIPTION.md` collision in the regression test.

## Motivation

A root-level skill such as `research/SKILL.md` was rendered in `<available_skills>` as a `research` category containing a `research` skill. That pseudo-namespaced shape encouraged invalid lookups such as `skill_view("research:research")`. If a bundled `research/DESCRIPTION.md` also existed, its category description was incorrectly attached to the unrelated root skill.

The skills tool already treats root-level skills as uncategorized and the banner groups them under `general`. This change makes the system-prompt builder follow the same contract while preserving nested and plugin-qualified skill behavior.

## Existing PR overlap

- #26467 corrects root-level category assignment but does not invalidate version-2 snapshots.
- #81338 contains the category correction and cache migration used here. Its implementation commit is cherry-picked with the original author preserved.
- This PR rebases that complete fix onto current `main` and adds coverage for the same-name category-description collision observed in a live skill catalog.

## Related Issue

No dedicated issue was found. The overlapping PRs are linked above.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `_build_snapshot_entry()` to place root-level skills under `general` while preserving nested categories.
- Increment `_SKILLS_SNAPSHOT_VERSION` from 2 to 3.
- Add a regression proving a stale version-2 snapshot is rebuilt without a self-qualified category or same-name category description.

## How to Test

```bash
scripts/run_tests.sh \
  tests/agent/test_prompt_builder.py \
  tests/tools/test_skills_tool.py \
  tests/test_plugin_skills.py \
  tests/agent/test_org_skill_namespace.py -q
```

Observed: 166 passed, 1 skipped.

```bash
ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py
python3 -m compileall -q agent/prompt_builder.py tests/agent/test_prompt_builder.py
git diff --check upstream/main...HEAD
```

Observed: all checks passed. An independent branch review reported no actionable findings.

## Risk and Exclusions

- The behavioral change is limited to two-part root skill paths. Nested category paths are unchanged.
- Version-2 prompt snapshots rebuild once as version 3. They are disposable caches, not user data.
- No tool resolution, plugin namespace, configuration, schema, or persistent-data behavior changes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing issues and PRs; #26467 and #81338 overlap and are disclosed above
- [x] My PR contains only changes related to this fix
- [ ] I ran the full repository test suite; focused coverage passed as documented above
- [x] I've added tests for the change
- [x] I've tested on macOS 26.5.2

### Documentation & Housekeeping

- [x] Documentation changes are not required
- [x] `cli-config.yaml.example` changes are not required
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are not required
- [x] Cross-platform impact was considered; the change uses platform-independent `Path.parts` output
- [x] Tool descriptions and schemas are unchanged

## Screenshots / Logs

Not applicable. The regression test captures the prompt-index failure and corrected output.
