### PR TITLE
fix(desktop): offer a retry when the model catalog fails to load

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -593,3 +593,24 @@ describe('ModelSettings MoA preset editor', () => {
     }
   })
 })
+
+describe('ModelSettings failed initial load', () => {
+  // #99843: a failed initial catalog fetch (e.g. the /api/model/options
+  // code-skew guard 503ing until the remote dashboard restarts) parked the
+  // panel on a '—' provider row with inline error text and no recovery path —
+  // the panel stays mounted, so the stale error view survived even after the
+  // backend was healthy again.
+  it('surfaces a retry that refetches after the initial fetch fails', async () => {
+    getGlobalModelOptions.mockRejectedValueOnce(new Error('503: Restart required: stale-module revision'))
+    await renderModelSettings()
+
+    expect(await screen.findByText('Settings failed to load')).toBeTruthy()
+    expect(screen.getByText(/Restart required/)).toBeTruthy()
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry' }))
+
+    await waitFor(() => expect(getGlobalModelOptions).toHaveBeenCalledTimes(2))
+    expect(await screen.findByText('Vision')).toBeTruthy()
+    expect(screen.queryByText('Settings failed to load')).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/settings/model-settings.tsx
+++ b/apps/desktop/src/app/settings/model-settings.tsx
@@ -33,6 +33,7 @@ import { startManualLocalEndpoint, startManualOnboarding, startManualProviderOAu
 
 import { hermesConfigCacheWriter, invalidateHermesConfig, useHermesConfigRecord } from '../hooks/use-config-record'
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
+import { PanelEmpty } from '../overlays/panel'
 
 import { CONTROL_TEXT } from './constants'
 import { getNested, setNested } from './helpers'
@@ -784,6 +785,26 @@ export function ModelSettings({ onMainModelChanged, scopeProfile }: ModelSetting
 
   if (loading && !mainModel) {
     return <ModelSettingsSkeleton />
+  }
+
+  // A failed initial fetch (e.g. the /api/model/options code-skew guard
+  // 503ing until the remote dashboard restarts) must surface a retry, not a
+  // '—' provider row with inline error text — the panel stays mounted while
+  // the user sits on it, so without an explicit recovery path the stale
+  // error view survives even after the backend is healthy again (#99843).
+  if (!loading && !mainModel && error) {
+    return (
+      <PanelEmpty
+        action={
+          <Button onClick={() => void refresh({ replaceSelection: true })} size="sm">
+            {t.common.retry}
+          </Button>
+        }
+        description={error}
+        icon="error"
+        title={t.settings.config.failedLoad}
+      />
+    )
   }
 
   return (


### PR DESCRIPTION
## What does this PR do?

The ModelSettings panel fetched its provider/model catalog exactly once on mount. When that initial fetch failed — most visibly the `/api/model/options` code-skew guard returning 503 "Restart required" until the remote dashboard restarts — the panel parked on a `—` provider row with inline error text and **no recovery path**. Because the panel stays mounted while the user sits on it, the stale error view survived even after the backend was healthy again, which is exactly the "Settings → Models stays desynced after the code-skew error is fixed" report in #99843 (backend state verified correct, new sessions honoring the right default, yet Settings still showing `--` and the old error).

This adds the same failed-load pattern the config page already uses (`config-settings.tsx`): when the initial catalog fetch fails and no data was ever painted, render an empty state showing the backend error plus a **Retry** button that refetches and repaints the real provider/model state. Later per-action failures on an already-loaded panel keep the existing inline error display.

## Related Issue

Fixes #99843

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.tsx`: render a `PanelEmpty` with the backend error and a Retry button (calls `refresh({ replaceSelection: true })`) when the initial load failed and no model data exists, instead of a `—` provider row with unrecoverable inline error text.
- `apps/desktop/src/app/settings/model-settings.test.tsx`: regression test — initial `getGlobalModelOptions` rejection shows the failed-load state, and Retry refetches and restores the working panel.

## How to Test

1. `cd apps/desktop && npx vitest run src/app/settings/model-settings.test.tsx` — all 23 tests pass, including the new `ModelSettings failed initial load > surfaces a retry that refetches after the initial fetch fails`.
2. Observed result: with the initial options fetch mocked to reject (503 "Restart required"), the panel shows "Settings failed to load" with the backend error; clicking Retry triggers a second fetch and paints the provider/auxiliary UI again — the pre-fix code had no retry affordance at all.
3. `npx tsc --noEmit -p tsconfig.json` and `npx eslint src/app/settings/model-settings.tsx src/app/settings/model-settings.test.tsx` both pass clean.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: renderer-only change; the desktop vitest suite linked in How to Test covers it
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (renderer logic is platform-independent; failure mode reproduced via component test)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (report was on Windows Desktop; fix is renderer-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill added.

## Screenshots / Logs

Not applicable — behavior verified via the component test described in How to Test.