### PR TITLE
feat(whatsapp): 8-digit phone pairing-code login for the bridge

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -17,9 +17,10 @@
  *
  * Usage:
  *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session
+ *   node bridge.js --port 3000 --session ~/.hermes/whatsapp/session --phone 15551234567   (pairing-code login, no QR)
  */
 
-import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser } from '@whiskeysockets/baileys';
+import { makeWASocket, useMultiFileAuthState, DisconnectReason, fetchLatestBaileysVersion, downloadMediaMessage, getAggregateVotesInPollMessage, decryptPollVote, getKeyAuthor, jidNormalizedUser, Browsers } from '@whiskeysockets/baileys';
 import express from 'express';
 import { Boom } from '@hapi/boom';
 import pino from 'pino';
@@ -407,7 +408,7 @@ async function startSocket() {
     auth: state,
     logger,
     printQRInTerminal: false,
-    browser: ['Hermes Agent', 'Chrome', '120.0'],
+    browser: Browsers.macOS('Safari'),
     syncFullHistory: false,
     markOnlineOnConnect: false,
     // Required for Baileys 7.x: without this, incoming messages that need
@@ -418,6 +419,25 @@ async function startSocket() {
       return { conversation: '' };
     },
   });
+
+  const pairPhone = getArg('phone', null);
+  if (pairPhone && !sock.authState.creds.registered) {
+    setTimeout(async () => {
+      try {
+        const cleanPhone = pairPhone.replace(/[^0-9]/g, '');
+        const code = await sock.requestPairingCode(cleanPhone);
+        const formattedCode = code?.match(/.{1,4}/g)?.join('-') || code;
+        if (!PAIR_JSON) {
+          console.log(`\n==============================================`);
+          console.log(`📱 YOUR 8-DIGIT WHATSAPP PAIRING CODE: ${formattedCode}`);
+          console.log(`==============================================\n`);
+        }
+        emitPairEvent({ event: 'pairing_code', code: formattedCode });
+      } catch (err) {
+        console.error('Failed to request pairing code:', err);
+      }
+    }, 2500);
+  }
 
   sock.ev.on('creds.update', () => { saveCreds(); lidToPhone = buildLidMap(); });
 


### PR DESCRIPTION
## What

Adds phone pairing-code login to `scripts/whatsapp-bridge/bridge.js` as an alternative to QR pairing, via a new `--phone <number>` argument.

## Why

QR pairing needs a phone camera pointed at a terminal or dashboard, which is painful for headless installs, remote servers, and Windows service setups. WhatsApp's **Link with phone number** flow (8-digit pairing code) removes that requirement; Baileys has supported it via `sock.requestPairingCode()` since well before the currently pinned `7.0.0-rc13`.

## How

- Import `Browsers` and switch the socket identity to `Browsers.macOS('Safari')` — Baileys rejects pairing-code requests from non-vendor browser signatures, so the custom `['Hermes Agent', 'Chrome', '120.0']` identity cannot use this flow.
- When `--phone` is passed and the session is unregistered, request a pairing code ~2.5 s after socket creation (gives the WebSocket time to open), print it formatted `XXXX-XXXX`, and emit a `pairing_code` event through the existing `emitPairEvent` mechanism.
- The human-readable banner is gated on `!PAIR_JSON`, matching the file's convention that `--pair-json` mode emits only JSON lines on stdout; JSON consumers get the code via the `pairing_code` event instead.

## Verification

- `node --check` passes.
- `Browsers` export and `sock.requestPairingCode` verified present in the pinned `@whiskeysockets/baileys 7.0.0-rc13` (`lib/Socket/socket.js`).
- Flow exercised on a Windows 11 install of Hermes (the pairing-code path is how that install's WhatsApp session was linked).

## Notes for reviewers

- No dependency changes — rc13 already ships everything needed.
- `adapter.py` / dashboard plumbing for passing `--phone` through the platform layer would make this end-to-end from `hermes whatsapp`; happy to follow up if there's interest, but the bridge capability stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)