### PR TITLE
fix(compaction): re-estimate post-tool pressure after native checkpoints

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -129,6 +129,33 @@ RUN_BUDGET_WRAPUP_NOTICE = (
 )
 
 
+def _native_responses_request_pressure_tokens(
+    agent: Any,
+    api_messages: List[Dict[str, Any]],
+    effective_system: str,
+) -> Optional[int]:
+    """Return the checkpoint-pruned next-request size when native is eligible."""
+    try:
+        from agent.codex_responses_adapter import (
+            estimate_native_responses_preflight_tokens,
+        )
+
+        native = estimate_native_responses_preflight_tokens(
+            agent,
+            api_messages,
+            system_prompt=effective_system or "",
+            tools=getattr(agent, "tools", None) or None,
+        )
+        if isinstance(native, int) and not isinstance(native, bool) and native >= 0:
+            return native
+    except Exception:
+        logger.debug(
+            "native Responses request estimate unavailable",
+            exc_info=True,
+        )
+    return None
+
+
 def _midturn_request_pressure_tokens(
     agent: Any,
     api_messages: List[Dict[str, Any]],
@@ -150,26 +177,54 @@ def _midturn_request_pressure_tokens(
     ``api_messages`` (which carries the system row) alongside
     ``effective_system`` counts the system prompt exactly once.
     """
-    try:
-        from agent.codex_responses_adapter import (
-            estimate_native_responses_preflight_tokens,
-        )
-
-        native = estimate_native_responses_preflight_tokens(
-            agent,
-            api_messages,
-            system_prompt=effective_system or "",
-            tools=getattr(agent, "tools", None) or None,
-        )
-        if isinstance(native, int) and not isinstance(native, bool) and native >= 0:
-            return native
-    except Exception:
-        logger.debug(
-            "native Responses mid-turn estimate unavailable; "
-            "using generic transcript estimate",
-            exc_info=True,
-        )
+    native = _native_responses_request_pressure_tokens(
+        agent,
+        api_messages,
+        effective_system,
+    )
+    if native is not None:
+        return native
     return approx_tokens + (
+        _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
+    )
+
+
+def _post_tool_request_pressure_tokens(
+    agent: Any,
+    messages: List[Dict[str, Any]],
+    effective_system: str,
+    *,
+    provider_prompt_tokens: int,
+) -> int:
+    """Measure the next request after tool results are appended.
+
+    Provider usage describes the request that just finished.  If it emitted a
+    native checkpoint, that pre-checkpoint count is stale for the next wire
+    payload and must not immediately trigger local compression.
+    """
+    overrides = getattr(agent, "request_overrides", None)
+    has_final_context_override = (
+        isinstance(overrides, dict) and "context_management" in overrides
+    )
+    native = None
+    if not has_final_context_override:
+        native = _native_responses_request_pressure_tokens(
+            agent,
+            messages,
+            effective_system,
+        )
+    if native is not None:
+        return native
+    if provider_prompt_tokens > 0:
+        return provider_prompt_tokens
+    # Preserve the existing no-usage fallback exactly: the post-tool path
+    # passed a full request estimate into the mid-turn helper, which then
+    # added its conservative tool-schema overhead separately.
+    fallback = estimate_request_tokens_rough(
+        messages,
+        tools=getattr(agent, "tools", None) or None,
+    )
+    return fallback + (
         _estimate_tools_tokens_rough(agent.tools) if agent.tools else 0
     )
 
@@ -7913,51 +7968,26 @@ def run_conversation(
                 if _tc_names == {"execute_code"}:
                     agent.iteration_budget.refund()
                 
-                # Use real token counts from the API response to decide
-                # compression.  prompt_tokens + completion_tokens is the
-                # actual context size the provider reported plus the
-                # assistant turn — a tight lower bound for the next prompt.
-                # Tool results appended above aren't counted yet, but the
-                # threshold (default 50%) leaves ample headroom; if tool
-                # results push past it, the next API call will report the
-                # real total and trigger compression then.
-                #
-                # If last_prompt_tokens is 0 (stale after API disconnect
-                # or provider returned no usage data), fall back to rough
-                # estimate to avoid missing compression.  Without this,
-                # a session can grow unbounded after disconnects because
-                # should_compress(0) never fires.  (#2153)
+                # Measure pressure on the next request, after tool results are
+                # appended. Provider usage is normally the tight lower bound,
+                # but it is stale when that response emitted a native checkpoint:
+                # the next Responses payload is checkpoint-pruned before send.
+                # Missing usage still falls back to the current rough request
+                # estimate so disconnects cannot let the session grow unbounded.
                 _compressor = agent.context_compressor
-                if _compressor.last_prompt_tokens > 0:
-                    # Only use prompt_tokens — completion/reasoning
-                    # tokens don't consume context window space.
-                    # Thinking models (GLM-5.1, QwQ, DeepSeek R1)
-                    # inflate completion_tokens with reasoning,
-                    # causing premature compression.  (#12026)
-                    _real_tokens = _compressor.last_prompt_tokens
-                elif _compressor.last_prompt_tokens == -1:
+                if _compressor.last_prompt_tokens == -1:
                     # Compression just ran and no API-reported prompt count
                     # has arrived yet. Avoid treating a schema-heavy rough
                     # post-compression estimate as real context pressure.
                     _real_tokens = 0
                 else:
-                    # Include tool schemas — with 50+ tools enabled
-                    # these add 20-30K tokens the messages-only
-                    # estimate misses, which can skip compression
-                    # past the configured threshold (#14695).
-                    # Route-aware (#96995/#97602 class): on a compacted
-                    # native-Codex session the generic durable-history
-                    # figure overstates the wire and would false-trigger
-                    # compression here exactly like the pre-API guard —
-                    # this fallback runs precisely when no provider usage
-                    # is available (post-disconnect / gateway restart),
-                    # the unanchored case from #97602's repro.
-                    _real_tokens = _midturn_request_pressure_tokens(
+                    _real_tokens = _post_tool_request_pressure_tokens(
                         agent,
                         messages,
                         active_system_prompt or "",
-                        estimate_request_tokens_rough(
-                            messages, tools=agent.tools or None
+                        provider_prompt_tokens=max(
+                            int(_compressor.last_prompt_tokens or 0),
+                            0,
                         ),
                     )
 

--- a/tests/agent/test_native_preflight_estimate.py
+++ b/tests/agent/test_native_preflight_estimate.py
@@ -146,3 +146,76 @@ def test_midturn_pressure_falls_back_to_generic_plus_tools_when_ineligible():
     assert _midturn_request_pressure_tokens(
         agent, messages, "be brief", approx
     ) == approx + _estimate_tools_tokens_rough(agent.tools)
+
+
+# ── Post-tool checkpoint pressure ──────────────────────────────────────────
+
+
+def test_post_tool_pressure_uses_checkpoint_pruned_next_request():
+    from agent.conversation_loop import _post_tool_request_pressure_tokens
+
+    agent = _codex_agent()
+    messages = _history_with_checkpoint()
+    expected = estimate_native_responses_preflight_tokens(
+        agent,
+        messages,
+        system_prompt="be brief",
+        tools=agent.tools,
+    )
+
+    assert isinstance(expected, int)
+    assert expected < 231_462
+    assert _post_tool_request_pressure_tokens(
+        agent,
+        messages,
+        "be brief",
+        provider_prompt_tokens=231_462,
+    ) == expected
+
+
+def test_post_tool_pressure_keeps_provider_usage_when_native_ineligible():
+    from agent.conversation_loop import _post_tool_request_pressure_tokens
+
+    agent = _codex_agent(model="gpt-5.2")
+    messages = [{"role": "user", "content": "hello"}]
+
+    assert _post_tool_request_pressure_tokens(
+        agent,
+        messages,
+        "be brief",
+        provider_prompt_tokens=231_462,
+    ) == 231_462
+
+
+def test_post_tool_pressure_keeps_provider_usage_for_final_context_override():
+    from agent.conversation_loop import _post_tool_request_pressure_tokens
+
+    agent = _codex_agent(request_overrides={"context_management": None})
+    messages = _history_with_checkpoint()
+
+    assert _post_tool_request_pressure_tokens(
+        agent,
+        messages,
+        "be brief",
+        provider_prompt_tokens=231_462,
+    ) == 231_462
+
+
+def test_post_tool_pressure_preserves_missing_usage_fallback():
+    from agent.conversation_loop import (
+        _estimate_tools_tokens_rough,
+        _post_tool_request_pressure_tokens,
+    )
+
+    tools = [{"type": "function", "function": {"name": "t", "parameters": {}}}]
+    agent = _codex_agent(api_mode="chat_completions", tools=tools)
+    messages = [{"role": "user", "content": "hello"}]
+    prior_fallback = estimate_request_tokens_rough(messages, tools=tools)
+    prior_fallback += _estimate_tools_tokens_rough(tools)
+
+    assert _post_tool_request_pressure_tokens(
+        agent,
+        messages,
+        "be brief",
+        provider_prompt_tokens=0,
+    ) == prior_fallback

--- a/tests/run_agent/test_post_tool_compression_attempt_cap.py
+++ b/tests/run_agent/test_post_tool_compression_attempt_cap.py
@@ -197,3 +197,39 @@ class TestPostToolCompressionAttemptCap:
 
         assert len(first) == 3
         assert len(second) == 3
+
+    def test_native_checkpoint_reestimates_post_tool_pressure(self, agent):
+        """Stale pre-checkpoint usage must not trigger local compression.
+
+        The provider usage belongs to the request that emitted the native
+        checkpoint.  The next request is checkpoint-pruned, so its live wire
+        estimate wins after the tool result is appended.
+        """
+        agent.context_compressor.should_compress.side_effect = (
+            lambda tokens: tokens >= 10_000
+        )
+
+        with patch(
+            "agent.codex_responses_adapter.estimate_native_responses_preflight_tokens",
+            return_value=5_000,
+        ):
+            result, compress_calls = _run_tool_loop(agent, n_tool_iterations=1)
+
+        assert result["completed"] is True
+        assert compress_calls == []
+
+    def test_final_context_override_keeps_local_post_tool_fallback(self, agent):
+        """A final-wire override must not leave the request ownerless."""
+        agent.request_overrides = {"context_management": None}
+        agent.context_compressor.should_compress.side_effect = (
+            lambda tokens: tokens >= 10_000
+        )
+
+        with patch(
+            "agent.codex_responses_adapter.estimate_native_responses_preflight_tokens",
+            return_value=5_000,
+        ):
+            result, compress_calls = _run_tool_loop(agent, n_tool_iterations=1)
+
+        assert result["completed"] is True
+        assert compress_calls == [3]


### PR DESCRIPTION
## Summary

- re-estimate post-tool context pressure from the checkpoint-pruned Responses wire when native compaction is eligible
- keep provider-reported prompt usage for non-native requests and whenever final `request_overrides` explicitly controls `context_management`
- preserve the existing no-usage fallback and local compression attempt budget
- remove the prior broad native-custody policy, request-boundary suppression, documentation changes, and unrelated rejection-matcher work

## Root cause

The post-tool compression gate normally uses the provider's last `prompt_tokens`. When that response emitted a native checkpoint, the count describes the **pre-checkpoint request**. After the tool result is appended, the next Responses request is checkpoint-pruned; reusing the old count can immediately trigger local compression against history that no longer reaches the wire.

This change reuses the existing checkpoint-aware estimator at that one post-tool seam. If native estimation is unavailable, native is ineligible, or a final `context_management` override could make policy disagree with the wire request, the existing provider/fallback accounting remains in force.

## Scope and overlap

- No change to the repository's native-first plus local-fallback ownership contract.
- No automatic-compression suppression at turn start, mid-turn, idle, or above-context pressure.
- No transport/request-building change.
- #99447 remains the owner of the broader final-wire override/custody reconciliation. This PR keeps only the distinct checkpoint-pruned post-tool pressure correction identified in review.

## Validation

Test-first production-seam regression:

- before: stale provider usage caused one local post-tool compression even though the next native wire estimate was `5,000` tokens
- after: that compression is skipped
- explicit `request_overrides={"context_management": None}` negative control keeps local fallback armed

Final exact-head checks:

```text
python -m pytest -q -o 'addopts=' \
  tests/agent/test_native_preflight_estimate.py \
  tests/run_agent/test_post_tool_compression_attempt_cap.py \
  tests/run_agent/test_native_compaction.py \
  tests/run_agent/test_preflight_compression_cap_e2e.py \
  tests/run_agent/test_compression_budget_refund.py
# 102 passed

ruff check <three changed Python files>
# All checks passed

python -m py_compile <three changed Python files>
git diff --check origin/main...HEAD
# passed
```

The full repository matrix remains CI-owned.
