### PR TITLE
fix(desktop): route /btw through prompt.btw so the answer reaches the chat (supersedes #99078)

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
@@ -1,0 +1,66 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { RpcEvent } from '@/types/hermes'
+
+import { type MessageStreamHarness, renderMessageStream } from './test-harness'
+
+const SID = 'session-1'
+const OTHER_SID = 'session-2'
+
+let stream: MessageStreamHarness
+
+function mountStream() {
+  stream = renderMessageStream(SID)
+}
+
+function emit(type: RpcEvent['type'], payload: RpcEvent['payload'] = {}, sessionId = SID) {
+  act(() => stream.handleEvent({ payload, session_id: sessionId, type }))
+}
+
+function lastMessage(id = SID) {
+  return stream.state(id).messages.at(-1)
+}
+
+describe('btw.complete event', () => {
+  beforeEach(() => {
+    mountStream()
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #99065: prompt.btw delivers the answer here. The slash-worker route
+  // printed it after the stdout capture window closed, so only the ack rendered.
+  it('appends the answer to the originating session as a system message', () => {
+    emit('btw.complete', { task_id: 'btw_ab12cd', question: 'which file was that error in?', text: 'src/main.ts' })
+
+    const message = lastMessage()
+
+    expect(message?.role).toBe('system')
+    expect(message?.id).toBe('btw-complete-btw_ab12cd')
+    expect(stream.text()).toBe('[btw "which file was that error in?" (btw_ab12cd)]\nsrc/main.ts')
+  })
+
+  it('keeps another session untouched when the event targets this one', () => {
+    emit('btw.complete', { task_id: 'btw_1', text: 'for the other chat' }, OTHER_SID)
+
+    expect(lastMessage()).toBeUndefined()
+    expect(stream.text(OTHER_SID)).toBe('[btw (btw_1)]\nfor the other chat')
+  })
+
+  it('omits the question and task-id header bits when the backend omits them', () => {
+    emit('btw.complete', { text: 'the answer' })
+
+    expect(stream.text()).toBe('[btw]\nthe answer')
+  })
+
+  it('drops an empty completion instead of appending a blank line', () => {
+    emit('btw.complete', { task_id: 'btw_1', question: 'q', text: '   ' })
+
+    expect(lastMessage()).toBeUndefined()
+  })
+})
+)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx
@@ -63,4 +63,3 @@ describe('btw.complete event', () => {
     expect(lastMessage()).toBeUndefined()
   })
 })
-)

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/status.ts
@@ -41,6 +41,35 @@ export function handleStatusEvent(ctx: GatewayEventContext): boolean {
     return true
   }
 
+  if (event.type === 'btw.complete') {
+    // prompt.btw answers a side question and emits this on the originating
+    // session. Persistent transcript line, matching the TUI's `[btw "q"]`
+    // — without it Desktop only ever showed the acknowledgement (#99065).
+    const text = coerceGatewayText(payload?.text).trim()
+
+    if (text && sessionId) {
+      const taskId = String(payload?.task_id ?? '').trim()
+      const question = coerceGatewayText(payload?.question).trim()
+      const header = `[btw${question ? ` "${question}"` : ''}${taskId ? ` (${taskId})` : ''}]`
+
+      flushQueuedDeltas(sessionId)
+      updateSessionState(sessionId, state => ({
+        ...state,
+        messages: [
+          ...state.messages,
+          {
+            id: `btw-complete-${taskId || Date.now()}`,
+            role: 'system',
+            parts: [textPart(`${header}\n${text}`, occurredAt)],
+            timestamp: occurredAt
+          }
+        ]
+      }))
+    }
+
+    return true
+  }
+
   if (event.type === 'review.summary') {
     // Self-improvement background review saved something to memory/skills
     // and emitted a persistent summary (Python formats it as

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1002,6 +1002,99 @@ describe('usePromptActions /compress', () => {
   })
 })
 
+describe('usePromptActions /btw', () => {
+  afterEach(() => {
+    cleanup()
+    vi.restoreAllMocks()
+  })
+
+  // #99065: slash.exec only captured the ack; the answer prints after the
+  // worker's stdout window. prompt.btw + btw.complete is the TUI path.
+  it('routes through prompt.btw (not slash.exec) and renders the start notice', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        return { task_id: 'btw_ab12cd' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw which file was that error in?')
+
+    expect(requestGateway).toHaveBeenCalledWith('prompt.btw', {
+      session_id: RUNTIME_SESSION_ID,
+      text: 'which file was that error in?'
+    })
+    expect(requestGateway).not.toHaveBeenCalledWith('slash.exec', expect.anything())
+    expect(requestGateway).not.toHaveBeenCalledWith('command.dispatch', expect.anything())
+    expect(renderedSeedTexts(seeds).some(text => text.includes('btw_ab12cd'))).toBe(true)
+  })
+
+  it('shows usage when no question is typed', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async () => ({} as never))
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw')
+
+    expect(requestGateway).not.toHaveBeenCalled()
+    expect(renderedSeedTexts(seeds).some(text => text.includes('Usage: /btw'))).toBe(true)
+  })
+
+  it('falls back to the slash worker when an older gateway lacks prompt.btw', async () => {
+    const seeds: Record<string, unknown>[] = []
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.btw') {
+        throw new Error('method not found: prompt.btw')
+      }
+
+      if (method === 'slash.exec') {
+        return { output: 'Side question started by legacy gateway' } as never
+      }
+
+      throw new Error(`unexpected method: ${method}`)
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        onReady={h => (handle = h)}
+        onSeedState={s => seeds.push(s)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/btw anything')
+
+    expect(requestGateway).toHaveBeenCalledWith('slash.exec', expect.objectContaining({ command: 'btw anything' }))
+    expect(renderedSeedTexts(seeds).some(text => text.includes('legacy gateway'))).toBe(true)
+  })
+})
+
 describe('usePromptActions exec fallback error reporting', () => {
   beforeEach(() => {
     setSessions(() => [sessionInfo()])

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -497,6 +497,52 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         branch: async () => {
           await branchCurrentSession()
         },
+        // /btw uses prompt.btw (the TUI's path). It must NOT go through
+        // runExec: the slash worker prints the answer after process_command
+        // returns, past the stdout capture window (#99065). The RPC replies
+        // with a task id; the answer arrives later as btw.complete.
+        btw: async ctx => {
+          const question = ctx.arg.trim()
+
+          const resolved = await withSlashOutput(ctx)
+
+          if (!resolved) {
+            return
+          }
+
+          const { render: renderSlashOutput, sessionId } = resolved
+
+          if (!question) {
+            renderSlashOutput(
+              'Usage: /btw <question> — answered from a snapshot of this conversation without interrupting it.'
+            )
+
+            return
+          }
+
+          try {
+            const result = await requestGateway<{ task_id?: string }>('prompt.btw', {
+              session_id: sessionId,
+              text: question
+            })
+
+            renderSlashOutput(
+              result.task_id
+                ? `btw ${result.task_id} — answering from a conversation snapshot`
+                : 'btw — answering from a conversation snapshot'
+            )
+          } catch (err) {
+            // Older gateways without the dedicated RPC still have the
+            // slash-worker route — same compatibility fallback as runRpc.
+            if (isMissingRpcMethod(err)) {
+              await runExec(ctx)
+
+              return
+            }
+
+            renderSlashOutput(`error: ${err instanceof Error ? err.message : String(err)}`)
+          }
+        },
         // /compress (alias /compact) runs the gateway's dedicated
         // session.compress RPC — the TUI's path
         // (ui-tui/src/app/slash/commands/session.ts). It must NOT go through

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -94,6 +94,8 @@ export type GatewayEventPayload = {
   // clarify.request
   request_id?: string
   question?: string
+  // btw.complete / background.complete — id of the side/background task
+  task_id?: string
   choices?: string[] | null
   multi_select?: boolean
   // clarify.request batch form: questions replaces question/choices, and

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -232,9 +232,9 @@ describe('desktop slash command curation', () => {
   })
 
   it('still routes commands without dedicated RPCs through exec()', () => {
+    // /btw is an action (prompt.btw) — the slash-worker print never reached Desktop.
     const execNames = [
       '/bg',
-      '/btw',
       '/debug',
       '/goal',
       '/personality',
@@ -249,6 +249,13 @@ describe('desktop slash command curation', () => {
     for (const name of execNames) {
       expect(resolveDesktopCommand(name)?.surface).toEqual({ kind: 'exec' })
     }
+  })
+
+  it('routes /btw to the prompt.btw side-question action', () => {
+    expect(resolveDesktopCommand('/btw')?.surface).toEqual({ kind: 'action', action: 'btw' })
+    expect(isDesktopSlashCommand('/btw')).toBe(true)
+    expect(isDesktopSlashSuggestion('/btw')).toBe(true)
+    expect(desktopSlashUnavailableMessage('/btw')).toBeNull()
   })
 
   it('distinguishes free prose from finite slash option lists', () => {

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -55,6 +55,7 @@ export interface DesktopThemeCommandOption {
 export type DesktopActionId =
   | 'branch'
   | 'browser'
+  | 'btw'
   | 'compress'
   | 'handoff'
   | 'hatch'
@@ -238,6 +239,15 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     description: 'Compress this conversation context',
     aliases: ['/compact'],
     surface: action('compress'),
+    argumentMode: 'text'
+  },
+  // /btw must be an action (prompt.btw RPC), not exec: the slash worker
+  // prints the answer after process_command returns, so Desktop only ever
+  // saw the acknowledgement (#99065). The answer arrives as btw.complete.
+  {
+    name: '/btw',
+    description: 'Ask a side question about this conversation without interrupting it',
+    surface: action('btw'),
     argumentMode: 'text'
   },
   {


### PR DESCRIPTION
## What does this PR do?

`/btw` in Desktop printed the side-question acknowledgement and never showed the answer. Switching chats dropped that line.

Desktop sent `/btw` through `slash.exec` / the slash worker. The CLI handler prints the answer from a thread after `process_command` returns, past the worker's stdout capture window. The TUI already uses `prompt.btw` and renders `btw.complete`. This PR does the same on Desktop: `/btw` is a local action that calls `prompt.btw`, and `btw.complete` appends the answer onto the originating session so a chat switch does not lose it. Older gateways without the RPC still fall back to the slash worker.

Supersedes #99078, #99088, #99360.

### What this PR does
- Route `/btw` through `prompt.btw` (same path as the TUI)
- Persist `btw.complete` on the session that asked
- Fall back to the slash worker when the RPC is missing

### What was dropped from the cluster
- Extra `formatBtw*` helpers and a `slash:` wrap on the answer line
- A dedicated `PromptBtwResponse` type with no other callers

## Related Issue

Fixes #99065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

- [x] From `apps/desktop`: `npx vitest run src/app/session/hooks/use-message-stream/btw-complete-event.test.tsx src/lib/desktop-slash-commands.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx` (164 passed)
- [ ] In Desktop, `/btw hello` in a chat with history shows the start notice, then the answer in that same chat
- [ ] Switch to another session and back — the answer is still on the original chat
- [ ] Bare `/btw` prints usage and does not call the model

Credit: @Sirfetch-d (primary). Related: @kokhlo, @xxxigm.