### PR TITLE
fix(desktop): skip cold process probes for dead backend-ownership PIDs (supersedes #92897)

### DIFF
--- a/apps/desktop/electron/backend-claim.test.ts
+++ b/apps/desktop/electron/backend-claim.test.ts
@@ -66,9 +66,15 @@ test('processStartMarker resolves a real marker for the current process', async 
   assert.match(marker, /^(linux|win|winms|ps):.+/)
 })
 
-test('processStartMarker rejects for a PID that does not exist', async () => {
+test('a missing PID is classified as ESRCH so reapOrphans can drop the record', async () => {
   // Largest PIDs are bounded well below this on every supported platform.
-  await assert.rejects(processStartMarker(2 ** 30 + 12345))
+  // Windows Get-Process / macOS `ps -p` used to surface exit code 1, which
+  // the identity matchers treated as "unknown" and kept forever. The native
+  // gate throws ESRCH — the errno those catch blocks already map to gone.
+  await assert.rejects(
+    processStartMarker(2 ** 30 + 12345),
+    (error: NodeJS.ErrnoException) => error?.code === 'ESRCH'
+  )
 })
 
 // --- PID-only marker helpers --------------------------------------------------

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -21,6 +21,7 @@ import { execFile } from 'node:child_process'
 import fs from 'node:fs'
 
 import { electronProcessStartMarker } from './parent-process-identity'
+import { isPidAlive } from './update-marker'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 export function execText(command: string, args: string[], { timeout = 3000 } = {}): Promise<string> {
@@ -42,6 +43,15 @@ export function execText(command: string, args: string[], { timeout = 3000 } = {
  * `claimDecision` / `probeStartMarker`).
  */
 export async function processStartMarker(pid: number): Promise<string> {
+  // Cheap native dead-PID gate. Windows Get-Process / macOS `ps -p` exit 1
+  // on a missing PID (not ESRCH), so the identity matchers used to keep the
+  // orphan and re-probe it every launch (#92875). ESRCH is the code those
+  // catch blocks already map to "gone". Alive or uninspectable (EPERM) PIDs
+  // still fall through to the platform probe.
+  if (!isPidAlive(pid)) {
+    throw Object.assign(new Error(`PID ${pid} no longer exists`), { code: 'ESRCH' })
+  }
+
   if (process.platform === 'linux') {
     const stat = await fs.promises.readFile(`/proc/${pid}/stat`, 'utf8')
 


### PR DESCRIPTION
## Summary

Supersedes #92897, #95178, and #97892.

Windows Desktop was blowing the 45s backend wait on serial orphan probes: closing the app force-kills the backend, `releaseBackendChild` never runs, and stale `backend-ownership.json` entries accumulate. Each dead PID was probed with a cold PowerShell `Get-Process` that exits 1 (not ESRCH), so `reapOrphans` kept the record. macOS `ps -p` had the same exit-1 hole.

`processStartMarker` now asks the existing `isPidAlive` helper first. A dead PID throws ESRCH, the code the identity/parent matchers already treat as gone, so the sweep drops the record without spawning PowerShell or `ps`. Live or uninspectable (EPERM) PIDs still go through the platform probe.

### What this PR does
- Gate `processStartMarker` with `isPidAlive` from `update-marker.ts`
- Pin that a missing PID rejects with `code === 'ESRCH'`

### What was dropped from #92897 / #95178 / #97892
- New `process-liveness.ts` (duplicated `isPidAlive` with opposite invalid-PID policy)
- PowerShell `SilentlyContinue` sentinel (still paid the 2–8s spawn)
- Darwin-only `processProbeConfirmsMissing` exit-1 mapper

## Test plan
- [x] `npx vitest run --project electron electron/backend-claim.test.ts electron/backend-ownership.test.ts electron/update-marker.test.ts` → 48 passed
- [ ] Windows: close Desktop a few times, reopen — connecting screen should not sit for tens of seconds on stale ownership records

Closes #92875

Credit: @Jackal991 (primary). Related: @jonotonfoto, @foras910521-lab