### PR TITLE
fix(gateway): deliver recovered MEDIA attachments, not text-only replays (#99846)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12963,26 +12963,80 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # + stale cutoff bound later retries.
                 continue
             content = row["content"]
-            if row.get("needs_marker"):
-                content = row.get("marker", RECOVERED_MARKER) + content
             metadata = (
                 {"thread_id": row["thread_id"]} if row.get("thread_id") else None
             )
 
+            # A recovered final must honor the same explicit media contract as
+            # live delivery (#99846): a persisted final containing a valid
+            # ``MEDIA:<path>`` directive is dispatched through the platform's
+            # native media senders, not replayed as raw text — otherwise the
+            # obligation is marked delivered without the attachment ever being
+            # uploaded. Extraction failure falls back to the legacy text-only
+            # replay for that row.
+            text_content = content
+            media_files: list = []
             try:
-                result = await adapter.send(
-                    chat_id=row["chat_id"],
-                    content=content,
-                    metadata=metadata,
+                from gateway.platforms.base import BasePlatformAdapter
+
+                media_files, text_content = BasePlatformAdapter.extract_media(
+                    content
                 )
-            except Exception as send_err:
-                logger.warning(
-                    "obligation %s: redelivery send raised: %s",
-                    row["obligation_id"], send_err,
+                media_files = BasePlatformAdapter.filter_media_delivery_paths(
+                    media_files, session_key=row.get("session_key") or ""
                 )
-                result = None
-            try:
+            except Exception:
+                logger.debug(
+                    "obligation %s: recovered media extraction failed; "
+                    "replaying as text",
+                    row["obligation_id"], exc_info=True,
+                )
+                media_files, text_content = [], content
+            if row.get("needs_marker"):
+                # Prepended to the cleaned text so the ambiguity marker can
+                # never interact with MEDIA parsing.
+                text_content = row.get("marker", RECOVERED_MARKER) + text_content
+
+            text_delivered = not text_content.strip()
+            send_error = ""
+            if not text_delivered:
+                try:
+                    result = await adapter.send(
+                        chat_id=row["chat_id"],
+                        content=text_content,
+                        metadata=metadata,
+                    )
+                except Exception as send_err:
+                    logger.warning(
+                        "obligation %s: redelivery send raised: %s",
+                        row["obligation_id"], send_err,
+                    )
+                    result = None
                 if result is not None and getattr(result, "success", False):
+                    text_delivered = True
+                else:
+                    send_error = str(
+                        getattr(result, "error", "") or "send failed"
+                    )
+            media_delivered = True
+            if media_files:
+                media_delivered, media_error = await self._deliver_recovered_media(
+                    adapter,
+                    platform,
+                    row["chat_id"],
+                    media_files,
+                    metadata,
+                    force_document="[[as_document]]" in content,
+                )
+                if media_error and not send_error:
+                    send_error = media_error
+
+            try:
+                if (
+                    text_delivered
+                    and media_delivered
+                    and (text_content.strip() or media_files)
+                ):
                     await asyncio.to_thread(mark_delivered, row["obligation_id"])
                     redelivered += 1
                     logger.info(
@@ -12995,11 +13049,125 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     await asyncio.to_thread(
                         mark_failed,
                         row["obligation_id"],
-                        str(getattr(result, "error", "") or "send failed"),
+                        send_error or "no deliverable content",
                     )
             except Exception:
                 logger.debug("delivery ledger update failed", exc_info=True)
         return redelivered
+
+    async def _deliver_recovered_media(
+        self,
+        adapter,
+        platform: Platform,
+        chat_id: str,
+        media_files: list,
+        metadata: Optional[Dict[str, Any]],
+        *,
+        force_document: bool = False,
+    ) -> Tuple[bool, str]:
+        """Dispatch recovered ``MEDIA:`` attachments for one obligation.
+
+        Mirrors the live delivery paths (``BasePlatformAdapter`` response
+        handling and the post-stream rescan): images go out as native photo
+        sends (batched when there are several), audio through the voice
+        sender, video through the video sender, everything else as a
+        document. Returns ``(all_delivered, first_error)`` — the caller marks
+        the obligation delivered only when every required send succeeded, so
+        a partial text/media failure stays retryable (#99846).
+        """
+        from pathlib import Path
+        from urllib.parse import quote as _quote
+
+        from gateway.platforms.base import should_send_media_as_audio
+
+        _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
+        _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
+
+        # Partition images out so several can be sent as a single native
+        # batch; ``[[as_document]]`` keeps image-extension files on the
+        # byte-preserving document path (mirrors live delivery).
+        image_paths: list = []
+        non_image_media: list = []
+        for media_path, is_voice in media_files:
+            ext = Path(media_path).suffix.lower()
+            if (
+                ext in _IMAGE_EXTS
+                and not is_voice
+                and not force_document
+            ):
+                image_paths.append(media_path)
+            else:
+                non_image_media.append((media_path, is_voice))
+
+        all_delivered = True
+        first_error = ""
+
+        if image_paths:
+            try:
+                if len(image_paths) == 1:
+                    result = await adapter.send_image_file(
+                        chat_id=chat_id,
+                        image_path=image_paths[0],
+                        metadata=metadata,
+                    )
+                else:
+                    batch = [
+                        (f"file://{_quote(p)}", "") for p in image_paths
+                    ]
+                    result = await adapter.send_multiple_images(
+                        chat_id=chat_id,
+                        images=batch,
+                        metadata=metadata,
+                    )
+                # ``send_multiple_images`` defaults to a None return (the
+                # default impl forwards item-by-item); only an explicit
+                # failure flag or an exception counts against delivery.
+                if result is not None and not getattr(result, "success", False):
+                    all_delivered = False
+                    first_error = first_error or str(
+                        getattr(result, "error", "") or "image delivery failed"
+                    )
+            except Exception as img_err:
+                logger.warning(
+                    "recovered obligation image delivery failed: %s", img_err,
+                )
+                all_delivered = False
+                first_error = first_error or str(img_err)
+
+        for media_path, is_voice in non_image_media:
+            try:
+                ext = Path(media_path).suffix.lower()
+                if should_send_media_as_audio(platform, ext, is_voice=is_voice):
+                    result = await adapter.send_voice(
+                        chat_id=chat_id,
+                        audio_path=media_path,
+                        metadata=metadata,
+                        is_voice=is_voice,
+                    )
+                elif ext in _VIDEO_EXTS:
+                    result = await adapter.send_video(
+                        chat_id=chat_id,
+                        video_path=media_path,
+                        metadata=metadata,
+                    )
+                else:
+                    result = await adapter.send_document(
+                        chat_id=chat_id,
+                        file_path=media_path,
+                        metadata=metadata,
+                    )
+                if result is not None and not getattr(result, "success", False):
+                    all_delivered = False
+                    first_error = first_error or str(
+                        getattr(result, "error", "") or "media delivery failed"
+                    )
+            except Exception as media_err:
+                logger.warning(
+                    "recovered obligation media delivery failed: %s", media_err,
+                )
+                all_delivered = False
+                first_error = first_error or str(media_err)
+        return all_delivered, first_error
 
     async def _redeliver_pending_obligations(self) -> int:
         """Claim + redeliver in one call — composition of

--- a/tests/gateway/test_delivery_ledger.py
+++ b/tests/gateway/test_delivery_ledger.py
@@ -720,3 +720,311 @@ class TestOwnerAlivePidProbe:
 
         monkeypatch.setattr(status, "_pid_exists", boom)
         assert dl._owner_alive(12345, 999) is False
+
+
+class TestRecoveredMediaDelivery:
+    """#99846: recovered finals must honor the same explicit media contract
+    as live delivery. A persisted final containing ``MEDIA:<path>`` used to be
+    replayed through ``adapter.send()`` as text only — the obligation was
+    marked delivered without the attachment ever being uploaded."""
+
+    @staticmethod
+    def _media_adapter(tmp_path, *, send_success=True):
+        """Adapter double whose media send methods record calls; the real
+        ``send_image_file``/``send_document``/... are never exercised because
+        the adapters in these tests are MagicMocks — what matters is that
+        redelivery dispatches to the RIGHT method with the RIGHT path."""
+        adapter = MagicMock()
+        adapter.name = "slack"
+        adapter.platform = "slack"
+        adapter.send = AsyncMock(
+            return_value=MagicMock(success=send_success, error="" if send_success else "nope")
+        )
+        for m in (
+            "send_image_file",
+            "send_document",
+            "send_voice",
+            "send_video",
+            "send_multiple_images",
+        ):
+            setattr(adapter, m, AsyncMock(return_value=MagicMock(success=True, error="")))
+        return adapter
+
+    @staticmethod
+    def _runner(adapter):
+        from gateway.config import Platform
+        from gateway.run import GatewayRunner
+
+        runner = object.__new__(GatewayRunner)
+        runner.adapters = {Platform.SLACK: adapter}
+        runner._profile_adapters = {}
+        runner._active_profile_name = lambda: "default"
+        _store = MagicMock()
+        _store.clear_resume_pending = AsyncMock()
+        _store._store = None
+        runner.session_store = None
+        runner._async_session_store = _store
+        return runner
+
+    @pytest.mark.asyncio
+    async def test_recovered_image_final_calls_send_image_file(self, tmp_path):
+        img = tmp_path / "proof.png"
+        img.write_bytes(b"\x89PNG fake")
+        _record(content=f"proof attached\nMEDIA:{img}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        # The text part is delivered WITHOUT the MEDIA: directive...
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"] == "proof attached"
+        # ...and the attachment goes out through the image sender.
+        adapter.send_image_file.assert_awaited_once()
+        img_kwargs = adapter.send_image_file.call_args.kwargs
+        assert img_kwargs["image_path"] == str(img)
+        assert img_kwargs["chat_id"] == "C1"
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_image_batch_uses_send_multiple_images(self, tmp_path):
+        img1 = tmp_path / "a.jpg"
+        img1.write_bytes(b"jpg1")
+        img2 = tmp_path / "b.png"
+        img2.write_bytes(b"png1")
+        _record(content=f"MEDIA:{img1}\nMEDIA:{img2}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        adapter.send_multiple_images.assert_awaited_once()
+        batch = adapter.send_multiple_images.call_args.kwargs["images"]
+        assert [u for u, _ in batch] == [f"file://{img1}", f"file://{img2}"]
+        adapter.send_image_file.assert_not_awaited()
+        # Text reduced to empty after extraction + no fallback send needed:
+        # the batch itself carries the delivery.
+        adapter.send.assert_not_awaited()
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_document_routes_to_send_document(self, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF fake")
+        _record(content=f"report ready\nMEDIA:{doc}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        adapter.send_document.assert_awaited_once()
+        assert adapter.send_document.call_args.kwargs["file_path"] == str(doc)
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_voice.assert_not_awaited()
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_video_routes_to_send_video(self, tmp_path):
+        vid = tmp_path / "clip.mp4"
+        vid.write_bytes(b"mp4 fake")
+        _record(content=f"MEDIA:{vid}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        adapter.send_video.assert_awaited_once()
+        assert adapter.send_video.call_args.kwargs["video_path"] == str(vid)
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_audio_routes_to_send_voice(self, tmp_path):
+        audio = tmp_path / "note.mp3"
+        audio.write_bytes(b"mp3 fake")
+        _record(content=f"MEDIA:{audio}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        # Non-Telegram platform: every audio ext routes through the audio sender.
+        adapter.send_voice.assert_awaited_once()
+        assert adapter.send_voice.call_args.kwargs["audio_path"] == str(audio)
+        adapter.send_document.assert_not_awaited()
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_voice_directive_sets_is_voice(self, tmp_path):
+        audio = tmp_path / "note.mp3"
+        audio.write_bytes(b"mp3 fake")
+        _record(
+            content=f"[[audio_as_voice]]\nMEDIA:{audio}",
+        )
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        adapter.send_voice.assert_awaited_once()
+        assert adapter.send_voice.call_args.kwargs["is_voice"] is True
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_unsafe_media_path_is_dropped_not_uploaded(self, tmp_path):
+        # Path does not exist → validate_media_delivery_path rejects it → no
+        # upload, and the directive must NOT leak into the delivered text.
+        _record(content=f"see file\nMEDIA:{tmp_path / 'missing.png'}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_multiple_images.assert_not_awaited()
+        sent = adapter.send.call_args.kwargs
+        assert "MEDIA:" not in sent["content"]
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_media_failure_marks_row_failed_not_delivered(self, tmp_path):
+        img = tmp_path / "proof.png"
+        img.write_bytes(b"\x89PNG fake")
+        _record(content=f"MEDIA:{img}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        # Text send succeeds but the attachment upload fails.
+        adapter.send_image_file = AsyncMock(
+            return_value=MagicMock(success=False, error="upload denied")
+        )
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        # Nothing was deliverable in full — the obligation must stay retryable.
+        assert n == 0
+        adapter.send_image_file.assert_awaited_once()
+        assert _row("ob-1")["state"] == "failed"
+        assert _row("ob-1")["last_error"]
+
+    @pytest.mark.asyncio
+    async def test_recovered_media_send_raises_marks_row_failed(self, tmp_path):
+        doc = tmp_path / "report.pdf"
+        doc.write_bytes(b"%PDF fake")
+        _record(content=f"MEDIA:{doc}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        adapter.send_document = AsyncMock(side_effect=RuntimeError("boom"))
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 0
+        assert _row("ob-1")["state"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_recovered_media_failure_with_text_still_marks_failed(self, tmp_path):
+        """Text + attachment where the attachment fails: the text may have
+        reached the user, but the obligation is NOT fully delivered — partial
+        delivery must not falsely acknowledge completion (#99846)."""
+        img = tmp_path / "proof.png"
+        img.write_bytes(b"\x89PNG fake")
+        _record(content=f"proof attached\nMEDIA:{img}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        adapter.send_image_file = AsyncMock(
+            return_value=MagicMock(success=False, error="flood wait")
+        )
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 0
+        adapter.send.assert_awaited_once()  # text went out first
+        assert _row("ob-1")["state"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_recovered_marker_prepend_survives_media_extraction(self, tmp_path):
+        """needs_marker rows (attempting/failed) carry the recovered-reply
+        marker — it must land on the cleaned TEXT, after extraction, so it can
+        never be eaten by MEDIA parsing."""
+        img = tmp_path / "proof.png"
+        img.write_bytes(b"\x89PNG fake")
+        _record(content=f"proof attached\nMEDIA:{img}")
+        dl.mark_attempting("ob-1")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"].startswith(dl.RECOVERED_MARKER)
+        assert sent["content"].endswith("proof attached")
+        assert "MEDIA:" not in sent["content"]
+        adapter.send_image_file.assert_awaited_once()
+        assert _row("ob-1")["state"] == "delivered"
+
+    @pytest.mark.asyncio
+    async def test_recovered_as_document_routes_image_to_send_document(self, tmp_path):
+        img = tmp_path / "big.png"
+        img.write_bytes(b"\x89PNG fake")
+        _record(content=f"[[as_document]]\nMEDIA:{img}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        await runner._redeliver_pending_obligations()
+
+        # [[as_document]] preserves bytes: image-ext files skip the photo path.
+        adapter.send_document.assert_awaited_once()
+        assert adapter.send_document.call_args.kwargs["file_path"] == str(img)
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_multiple_images.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_recovered_only_dangling_media_tag_is_not_falsely_acknowledged(self, tmp_path):
+        """Content whose every deliverable part evaporates (only a MEDIA tag
+        with a nonexistent path): send nothing (never echo host paths into
+        chat) and do NOT mark delivered — the obligation stays retryable and
+        the attempts cap retires it (#99846, mirroring the live path's refusal
+        to leak paths)."""
+        _record(content=f"MEDIA:{tmp_path / 'gone.png'}")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 0
+        adapter.send.assert_not_awaited()
+        adapter.send_image_file.assert_not_awaited()
+        assert _row("ob-1")["state"] == "failed"
+
+    @pytest.mark.asyncio
+    async def test_recovered_plain_text_final_unchanged(self, tmp_path):
+        """No media → behavior identical to the pre-fix redelivery path."""
+        _record(content="the final answer")
+        _orphan("ob-1")
+        adapter = self._media_adapter(tmp_path)
+        runner = self._runner(adapter)
+
+        n = await runner._redeliver_pending_obligations()
+
+        assert n == 1
+        sent = adapter.send.call_args.kwargs
+        assert sent["content"] == "the final answer"
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_document.assert_not_awaited()
+        adapter.send_voice.assert_not_awaited()
+        assert _row("ob-1")["state"] == "delivered"


### PR DESCRIPTION
## What

`GatewayRunner._redeliver_claimed_obligations()` replayed a recovered final through `adapter.send()` as text only. A persisted final containing a valid `MEDIA:<path>` directive was marked **delivered without the attachment ever being uploaded** — crash/restart recovery silently diverged from the live delivery contract.

## How

Recovery now honors the same explicit media contract as live delivery:

1. `extract_media(content)` → `(media_files, cleaned_text)`
2. `filter_media_delivery_paths(media_files, session_key=...)` — session-scoped, same unsafe-path rules as live delivery (missing/denylisted paths dropped, never echoed as raw directives)
3. The recovered-reply marker is prepended to the **cleaned text after extraction**, so it can never interact with `MEDIA:` parsing
4. Text is sent separately only when non-empty; attachments dispatch by type in `_deliver_recovered_media`: single image → `send_image_file`, multiple images → one `send_multiple_images` batch (`file://` URIs, like the live paths), audio → `send_voice` via `should_send_media_as_audio` (with `is_voice` propagation), video ext → `send_video`, everything else → `send_document`; `[[as_document]]` keeps image-ext files on the byte-preserving document path
5. Delivered only when **every** required send succeeds (`SendResult.success` honored for media sends, not just exceptions) — otherwise `mark_failed(...)` keeps the row retryable under the existing at-least-once contract; an empty-after-extraction row is never falsely acknowledged and never leaks host paths into chat
6. Extraction failure on a row degrades to legacy text-only replay (debug-logged) — redelivery is never lost

Both recovery paths are covered: startup sweep (`sweep_recoverable`) and reconnect sweep (`sweep_failed_for_runtime`) both route into `_redeliver_claimed_obligations` and both row shapes carry `session_key`.

## Verification

- **RED**: 12/14 regression tests fail on unmodified upstream/main (`b20cc5f787`, the commit named in the issue)
- **GREEN**: 50 passed in `tests/gateway/test_delivery_ledger.py` (14 new `TestRecoveredMediaDelivery` + 36 pre-existing) — re-verified independently at review time
- Post-rebase onto `e22f8a7fbd`: 62 passed across the ledger suite + neighbors (`test_delivery_ledger_fd_leak.py`, `test_delivery_ledger_producer.py`, `test_restart_redelivery_dedup.py`); additional neighbors `test_platform_reconnect.py` + `test_wire_voice_media.py` green at build time
- `ruff check`: clean; `git diff --check`: clean; exactly one focused commit (`0 1` vs upstream/main)
- New tests are production-path: they drive the real `_redeliver_pending_obligations()` → ledger state machine with a recording adapter double, asserting dispatched method + path + resulting row state

## Relationship to #99855

#99855 (opened during our build window) addresses the same symptom. Differences, per a quality-aware comparison at review time (competitor head `50aeda653`, unchanged since evaluation):

- `filter_media_delivery_paths()` called **without** `session_key` → loses session-scoped path validation (Docker-mount translation) that live delivery uses
- Media `SendResult.success` **ignored** (only exceptions fail) → a graceful platform rejection of the attachment still marks the obligation delivered, violating the issue's explicit "partial text/media failure remains retryable" requirement
- Empty text + all media filtered out → marked delivered having sent nothing
- No `[[as_document]]` byte-preserving routing, no `is_voice` propagation, no image batching (multiple images sent one-by-one)
- 4 tests vs 14 here; no coverage of marker ordering, batching, unsafe-path non-leak, or the dangling-tag corner

Happy to fold in anything useful from it — credit to @liuhao1024 for independently catching this.

Fixes #99846

Auto-published by Moonsong via Path B automated pipeline.
