### PR TITLE
fix(bot-mode): keep Bot Chat open on its compression lineage (supersedes #97416)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10679,7 +10679,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # the tip (== the row itself when uncompressed).
         tip = row
         try:
-            tip_id = self.resolve_resume_session_id(session_id) or session_id
+            tip_id = self.get_compression_tip(session_id) or session_id
             if tip_id != session_id:
                 tip = self.get_session(tip_id) or row
         except Exception:

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -334,7 +334,6 @@ def test_session_list_title_lookup_ignores_unmarked_normal_child(home, monkeypat
     assert len(sessions) == 1
     assert sessions[0]["id"] == "root2"
     assert sessions[0]["resolved_id"] == "root2"
-    assert "canonical click target" in sessions[0]["preview"]
     db.close()
 
 
@@ -353,7 +352,6 @@ def test_session_list_title_lookup_resolves_compression_tip(home, monkeypatch):
     assert len(sessions) == 1
     assert sessions[0]["id"] == "root3"
     assert sessions[0]["resolved_id"] == "tip3"
-    assert "post-compression click target" in sessions[0]["preview"]
     db.close()
 
 

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -161,6 +161,22 @@ def test_canonical_session_resolves_compression_tip(home):
     assert "post-compression content" in canonical["preview"]
 
 
+def test_canonical_session_ignores_unmarked_normal_child(home):
+    db = _db(home)
+    _add_session(db, "root1", title="Bot Chat", ts=1000,
+                 text="canonical bot content")
+    _add_session(db, "normal1", title="Friendly greeting", ts=3000,
+                 text="ordinary chat content", parent="root1")
+    db.close()
+
+    canonical = _row(_profiles({}), "default")["canonical_session"]
+
+    assert canonical["id"] == "root1"
+    assert canonical["resolved_id"] == "root1"
+    assert canonical["title"] == "Bot Chat"
+    assert "canonical bot content" in canonical["preview"]
+
+
 # ---------------------------------------------------------------------------
 # Recoverable-archive resurrection (#92687)
 # ---------------------------------------------------------------------------
@@ -301,6 +317,43 @@ def test_session_list_title_lookup_keeps_deliberate_archive_hidden(home, monkeyp
     envelope = srv._methods["session.list"](1, {"title": "Bot Chat"})
     assert envelope["result"]["sessions"] == []
     assert db.get_session("retired2")["archived"]
+    db.close()
+
+
+def test_session_list_title_lookup_ignores_unmarked_normal_child(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "root2", title="Bot Chat", ts=1000,
+                 text="canonical click target", hidden=True)
+    _add_session(db, "normal2", title="Friendly greeting", ts=3000,
+                 text="ordinary click target", parent="root2")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = srv._methods["session.list"](1, {"title": "Bot Chat"})
+    sessions = envelope["result"]["sessions"]
+
+    assert len(sessions) == 1
+    assert sessions[0]["id"] == "root2"
+    assert sessions[0]["resolved_id"] == "root2"
+    assert "canonical click target" in sessions[0]["preview"]
+    db.close()
+
+
+def test_session_list_title_lookup_resolves_compression_tip(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "root3", title="Bot Chat", ts=1000,
+                 text="pre-compression click target", hidden=True,
+                 end_reason="compression")
+    _add_session(db, "tip3", title="Bot Chat (continued)", ts=3000,
+                 text="post-compression click target", parent="root3")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = srv._methods["session.list"](1, {"title": "Bot Chat"})
+    sessions = envelope["result"]["sessions"]
+
+    assert len(sessions) == 1
+    assert sessions[0]["id"] == "root3"
+    assert sessions[0]["resolved_id"] == "tip3"
+    assert "post-compression click target" in sessions[0]["preview"]
     db.close()
 
 

--- a/tests/tui_gateway/test_profiles_list_canonical_session.py
+++ b/tests/tui_gateway/test_profiles_list_canonical_session.py
@@ -76,6 +76,23 @@ def _row(profiles, name):
     return next(p for p in profiles if p["name"] == name)
 
 
+def _resume(params, monkeypatch):
+    """Cold resume far enough to read the remapped stored id, no agent build."""
+    monkeypatch.setattr(srv, "_schedule_resume_hydration", lambda *a, **k: None)
+    monkeypatch.setattr(srv, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(srv, "_enable_gateway_prompts", lambda: None)
+    known = set(srv._sessions)
+    try:
+        return srv._methods["session.resume"](1, {
+            **params,
+            "defer_history": True,
+            "omit_messages": True,
+        })
+    finally:
+        for sid in [s for s in srv._sessions if s not in known]:
+            srv._sessions.pop(sid, None)
+
+
 # ---------------------------------------------------------------------------
 # canonical_session resolution
 # ---------------------------------------------------------------------------
@@ -352,6 +369,73 @@ def test_session_list_title_lookup_resolves_compression_tip(home, monkeypatch):
     assert len(sessions) == 1
     assert sessions[0]["id"] == "root3"
     assert sessions[0]["resolved_id"] == "tip3"
+    db.close()
+
+
+def test_canonical_session_resurrects_despite_unmarked_normal_child(home):
+    # Recoverability is judged at the compression tip, not the legacy resume
+    # walker. An unmarked side chat must not hide a reaped Bot Chat.
+    db = _db(home)
+    _add_session(db, "reaped3", title="Bot Chat", ts=1000,
+                 text="surviving forever chat", hidden=True,
+                 end_reason="ws_orphan_reap", archived=True)
+    _add_session(db, "normal3", title="Friendly greeting", ts=3000,
+                 text="ordinary chat content", parent="reaped3")
+    db.close()
+
+    canonical = _row(_profiles({}), "default")["canonical_session"]
+    assert canonical is not None
+    assert canonical["id"] == "reaped3"
+    assert canonical["resolved_id"] == "reaped3"
+
+    db = _db(home)
+    try:
+        assert not db.get_session("reaped3")["archived"]
+    finally:
+        db.close()
+
+
+def test_session_resume_bot_chat_ignores_unmarked_normal_child(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "root4", title="Bot Chat", ts=1000,
+                 text="canonical resume target", hidden=True)
+    _add_session(db, "normal4", title="Friendly greeting", ts=3000,
+                 text="ordinary resume target", parent="root4")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = _resume({"session_id": "root4"}, monkeypatch)
+    assert "error" not in envelope, envelope
+    assert envelope["result"]["resumed"] == "root4"
+    assert envelope["result"]["session_key"] == "root4"
+    db.close()
+
+
+def test_session_resume_bot_chat_resolves_compression_tip(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "root5", title="Bot Chat", ts=1000,
+                 text="pre-compression resume target", hidden=True,
+                 end_reason="compression")
+    _add_session(db, "tip5", title="Bot Chat (continued)", ts=3000,
+                 text="post-compression resume target", parent="root5")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = _resume({"session_id": "root5"}, monkeypatch)
+    assert "error" not in envelope, envelope
+    assert envelope["result"]["resumed"] == "tip5"
+    assert envelope["result"]["session_key"] == "tip5"
+    db.close()
+
+
+def test_session_resume_ordinary_chat_still_follows_unmarked_child(home, monkeypatch):
+    db = _db(home)
+    _add_session(db, "plain-root", title="Scratch", ts=1000, text="parent chat")
+    _add_session(db, "plain-child", title="Follow-up", ts=3000,
+                 text="child chat", parent="plain-root")
+    monkeypatch.setattr(srv, "_get_db", lambda: db)
+
+    envelope = _resume({"session_id": "plain-root"}, monkeypatch)
+    assert "error" not in envelope, envelope
+    assert envelope["result"]["resumed"] == "plain-child"
     db.close()
 
 

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -125,7 +125,11 @@ def _(rid, params: dict) -> dict:
                 if not _resurrect_recoverable_canonical(db, profile_path, session_id):
                     return None
             try:
-                tip = db.resolve_resume_session_id(session_id) or session_id
+                # Canonical Bot Chat identity may advance only across a proven
+                # compression edge.  The generic resume resolver also carries
+                # a legacy unmarked-child fallback, which is intentionally too
+                # broad for this exact-title registry lookup.
+                tip = db.get_compression_tip(session_id) or session_id
             except Exception:
                 tip = session_id
             tip_row = db.get_session(tip) or row

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -95,10 +95,13 @@ def _(rid, params: dict) -> dict:
 
         Exact-lookup semantics, deliberately different from the listing:
         hidden rows still resolve (canonical chats are always hidden),
-        compression lineages resolve to the live tip with the same resolver
-        ``session.resume`` uses, and denied internal sources (tool/kanban)
-        count as absent. The reported ``id`` stays the durable registry row
-        while ``resolved_id`` names the live tip. Best-effort: any failure
+        compression lineages resolve to the live tip via
+        ``get_compression_tip`` (not the generic resume walker, whose
+        unmarked-child fallback can select an ordinary child).
+        ``session.resume`` uses that same tip resolver when the target is
+        titled ``Bot Chat``. Denied internal sources (tool/kanban) count as
+        absent. The reported ``id`` stays the durable registry row while
+        ``resolved_id`` names the live tip. Best-effort: any failure
         degrades to None rather than failing the whole profiles.list call.
         """
         if db is None:
@@ -172,7 +175,7 @@ def _(rid, params: dict) -> dict:
                 return False
             tip = row
             try:
-                tip_id = db.resolve_resume_session_id(session_id) or session_id
+                tip_id = db.get_compression_tip(session_id) or session_id
                 if tip_id != session_id:
                     tip = db.get_session(tip_id) or row
             except Exception:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -560,10 +560,18 @@ def _(rid, params: dict) -> dict:
         # here also re-anchors the fast path below so a still-live rotated session
         # is reused (by its new key) instead of rebuilding a duplicate agent on the
         # stale parent. Skipped for lazy watch windows, which intentionally attach
-        # to the exact child branch they were opened on.
+        # to the exact child branch they were opened on. Bot Chat is a named
+        # registry row — stay on a proven compression edge so an unmarked
+        # side chat cannot steal the open (the title-lookup / profiles.list
+        # contract). Other sessions keep the legacy unmarked-child walker.
         if found and not is_truthy_value(params.get("lazy", False)):
             try:
-                tip = db.resolve_resume_session_id(target)
+                from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+                if (found.get("title") or "").strip() == BOT_CHAT_TITLE:
+                    tip = db.get_compression_tip(target) or target
+                else:
+                    tip = db.resolve_resume_session_id(target)
             except Exception:
                 tip = target
             if tip and tip != target:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -217,7 +217,12 @@ def _(rid, params: dict) -> dict:
                 ):
                     return _ok(rid, {"sessions": []})
                 try:
-                    tip = db.resolve_resume_session_id(row["id"]) or row["id"]
+                    # A named-session registry lookup must resolve only a real
+                    # compression continuation.  The generic resume resolver
+                    # retains a legacy unmarked-child fallback for historical
+                    # sessions; using it here can redirect the canonical Bot
+                    # Chat to an unrelated normal child.
+                    tip = db.get_compression_tip(row["id"]) or row["id"]
                 except Exception:
                     tip = row["id"]
                 tip_row = (db.get_session(tip) or row) if tip != row["id"] else row


### PR DESCRIPTION
## What does this PR do?

Supersedes #97416.

Opening the canonical Bot Chat could land in an ordinary child session such as "Friendly greeting". `session.list(title=)` and `profiles.list` found the Bot Chat row, then `resolve_resume_session_id()` followed an unmarked child that had messages even though nothing was compressed.

#97416 switched those two lookups to `get_compression_tip()`. Desktop then opens that id with `forceResume: true`, and `session.resume` still used the legacy walker, so the same child won again. Recoverable-archive resurrection used the same walker, so a reaped Bot Chat with a side-chat child could fail to come back.

This keeps Gille's lookup switches and uses `get_compression_tip()` on `session.resume` when the target is titled `Bot Chat`, on `_resurrect_recoverable_canonical`, and in `SessionDB.unarchive_recoverable_session`. Ordinary chats still use the unmarked-child fallback.

## Related Issue

Supersedes #97416. No public issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_session.py`: exact-title lookup and Bot Chat `session.resume` resolve only a proven compression tip.
- `tui_gateway/methods_profiles.py`: same tip resolver for `canonical_session` and resurrection.
- `hermes_state.py`: `unarchive_recoverable_session` judges recoverability at the compression tip, matching its own comment.
- `tests/tui_gateway/test_profiles_list_canonical_session.py`: unmarked child cannot steal lookup, resume, or resurrection; a real compression continuation still advances; ordinary resume still follows an unmarked child.

## How to Test

1. Bot Chat plus an unmarked child titled something else with messages: `session.list(title="Bot Chat")` and `profiles.list` `canonical_session` stay on Bot Chat. `session.resume` of that Bot Chat id stays there too.
2. Bot Chat ended with `end_reason='compression'` and a continuation child: both lookups and `session.resume` resolve to the continuation.
3. Ordinary titled session with an unmarked child: `session.resume` still follows the child.
4. `scripts/run_tests.sh tests/tui_gateway/test_profiles_list_canonical_session.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (targeted `scripts/run_tests.sh` for this file)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Credit: @helix4u (primary). Related: #97416