### PR TITLE
fix(api-server): keep persisted Responses history linear after repair

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -6998,7 +6998,55 @@ class APIServerAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _response_message_matches_current_user(
+        message: Any,
+        user_message: Any,
+    ) -> bool:
+        """Match the current user payload while ignoring persistence metadata.
+
+        Session persistence adds ``_row_id``, ``_db_persisted``, and
+        timestamps. Alternation repair may also merge an adjacent user message
+        ahead of the current payload, while preserving it as a delimited suffix.
+        """
+        if not isinstance(message, dict) or message.get("role") != "user":
+            return False
+        content = message.get("content")
+        if content == user_message:
+            return True
+        return (
+            isinstance(content, str)
+            and isinstance(user_message, str)
+            and content.endswith(f"\n\n{user_message}")
+        )
+
+    @classmethod
+    def _persisted_response_turn_start_index(
+        cls,
+        agent_messages: Any,
+        user_message: Any,
+    ) -> int:
+        """Find the current-turn suffix in an authoritative persisted transcript."""
+        if not isinstance(agent_messages, list) or not agent_messages:
+            return 0
+        if not any(
+            isinstance(message, dict)
+            and (
+                message.get("_db_persisted") is True
+                or message.get("_row_id") is not None
+            )
+            for message in agent_messages
+        ):
+            return 0
+        for index in range(len(agent_messages) - 1, -1, -1):
+            if cls._response_message_matches_current_user(
+                agent_messages[index], user_message
+            ):
+                return index + 1
+        return 0
+
+    @classmethod
     def _build_response_conversation_history(
+        cls,
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
         result: Dict[str, Any],
@@ -7019,7 +7067,16 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_messages = result.get("messages") if isinstance(result, dict) else None
 
         if isinstance(agent_messages, list) and agent_messages:
-            turn_start = APIServerAdapter._response_messages_turn_start_index(
+            if cls._persisted_response_turn_start_index(
+                agent_messages,
+                user_message,
+            ):
+                # AIAgent returned its durable full transcript. Persistence
+                # metadata and alternation repair can make its prefix differ
+                # from ``prior`` even though it already owns the whole history.
+                return list(agent_messages)
+
+            turn_start = cls._response_messages_turn_start_index(
                 conversation_history,
                 user_message,
                 result,
@@ -7047,8 +7104,9 @@ class APIServerAdapter(BasePlatformAdapter):
         full_history.append({"role": "assistant", "content": final_response})
         return full_history
 
-    @staticmethod
+    @classmethod
     def _response_messages_turn_start_index(
+        cls,
         conversation_history: List[Dict[str, Any]],
         user_message: Any,
         result: Dict[str, Any],
@@ -7057,6 +7115,13 @@ class APIServerAdapter(BasePlatformAdapter):
         agent_messages = result.get("messages") if isinstance(result, dict) else None
         if not isinstance(agent_messages, list) or not agent_messages:
             return 0
+
+        persisted_turn_start = cls._persisted_response_turn_start_index(
+            agent_messages,
+            user_message,
+        )
+        if persisted_turn_start:
+            return persisted_turn_start
 
         prior = list(conversation_history)
         current_user = {"role": "user", "content": user_message}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1425,6 +1425,113 @@ class TestResponsesEndpoint:
         assert stored_history == compressed_history
 
 
+    def test_persisted_repaired_transcript_is_stored_once(self, adapter):
+        prior = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        current = "new question"
+        transcript = [
+            {
+                "role": "user",
+                "content": "old question\n\nrepaired context",
+                "_row_id": 1,
+                "_db_persisted": True,
+            },
+            {
+                "role": "assistant",
+                "content": "old answer",
+                "timestamp": 1.0,
+                "_row_id": 2,
+                "_db_persisted": True,
+            },
+            {
+                "role": "user",
+                "content": f"adjacent user context\n\n{current}",
+                "timestamp": 2.0,
+                "_row_id": 3,
+                "_db_persisted": True,
+            },
+            {
+                "role": "assistant",
+                "content": "new answer",
+                "timestamp": 3.0,
+                "_row_id": 4,
+                "_db_persisted": True,
+            },
+        ]
+        result = {"messages": transcript}
+
+        assert adapter._response_messages_turn_start_index(
+            prior, current, result
+        ) == 3
+        assert adapter._build_response_conversation_history(
+            prior, current, result, "new answer"
+        ) == transcript
+        assert [
+            message["content"]
+            for message in adapter._turn_transcript_messages(
+                prior, current, result
+            )
+        ] == ["new answer"]
+
+    def test_persisted_response_history_grows_linearly(self, adapter):
+        history = []
+        for turn in range(8):
+            current = f"turn-{turn}"
+            transcript = [
+                {**message, "_db_persisted": True}
+                for message in history
+            ]
+            if transcript and turn % 2 == 0:
+                transcript[0] = {
+                    **transcript[0],
+                    "content": f"{transcript[0]['content']}\n\nrepaired-{turn}",
+                }
+            transcript.extend([
+                {
+                    "role": "user",
+                    "content": current,
+                    "_row_id": turn * 2 + 1,
+                    "_db_persisted": True,
+                },
+                {
+                    "role": "assistant",
+                    "content": f"answer-{turn}",
+                    "_row_id": turn * 2 + 2,
+                    "_db_persisted": True,
+                },
+            ])
+
+            stored = adapter._build_response_conversation_history(
+                history, current, {"messages": transcript}, f"answer-{turn}"
+            )
+
+            assert stored == transcript
+            assert len(stored) == len(history) + 2
+            history = stored
+
+        assert len(history) == 16
+
+    def test_unpersisted_turn_suffix_keeps_legacy_append_behavior(self, adapter):
+        prior = [
+            {"role": "user", "content": "old question"},
+            {"role": "assistant", "content": "old answer"},
+        ]
+        suffix = [{"role": "assistant", "content": "new answer"}]
+
+        stored = adapter._build_response_conversation_history(
+            prior,
+            "new question",
+            {"messages": suffix},
+            "new answer",
+        )
+
+        assert stored == prior + [
+            {"role": "user", "content": "new question"},
+            {"role": "assistant", "content": "new answer"},
+        ]
+
     @pytest.mark.asyncio
     async def test_previous_response_id_outputs_only_current_turn_items(self, adapter):
         """Response output must not replay previous tool artifacts."""


### PR DESCRIPTION
## Summary

This closes a remaining edge case in the chained `/v1/responses` history deduplication introduced by #18995 / #21185.

- Treat an AIAgent transcript carrying SessionDB persistence markers (`_db_persisted` or `_row_id`) as the authoritative full transcript.
- Locate the current turn from the last matching user payload while ignoring persistence metadata.
- Handle message-alternation repair, which can prepend adjacent user content while preserving the current payload as a `\n\n`-delimited suffix.
- Keep the existing append behavior for unpersisted legacy/mock turn-local suffixes.

Related: #56895.

## Root cause

`_response_messages_turn_start_index()` currently compares whole message dictionaries:

```python
agent_messages[:len(expected_prefix)] == expected_prefix
```

The caller-provided `conversation_history` contains plain role/content dictionaries, while a real persisted AIAgent transcript can contain fields such as `_row_id`, `_db_persisted`, and `timestamp`. Alternation repair may also rewrite the prefix by merging adjacent user messages.

The exact-prefix check then returns `0`, and `_build_response_conversation_history()` incorrectly stores:

```text
prior + current_user + full_agent_transcript
```

A minimal reproduction on current upstream `main` turns 2 prior messages plus a 4-message full transcript into 7 stored messages. Repeated chained turns can therefore grow close to exponentially and trigger unnecessary context compression.

## Compatibility

The new authoritative path is gated on both:

1. a persistence marker in the returned transcript; and
2. a user message matching the current request payload.

Unpersisted turn-local suffixes continue through the existing compatibility branch unchanged.

## Tests

- `uv run --extra dev --extra messaging pytest -q tests/gateway/test_api_server.py` - **113 passed**
- `uv run --extra dev ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py` - **passed**
- Added an 8-turn regression that asserts linear history growth: `2, 4, 6, 8, 10, 12, 14, 16`
- Added coverage for persistence metadata, alternation-repaired user content, current-turn output slicing, and the legacy suffix path

A downstream integration using the native Responses chain also reproduced linear growth over 8 test turns and 4 production canary turns after this change.