### PR TITLE
fix(desktop): stop hidden session panes from yanking the visible chat (supersedes #81829)

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.test.ts
+++ b/apps/desktop/src/app/chat/composer/focus.test.ts
@@ -4,6 +4,7 @@ import { $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 
 import {
   blurComposerInput,
+  focusComposerInput,
   getActiveComposer,
   markActiveComposer,
   onComposerFocusRequest,
@@ -50,6 +51,39 @@ afterEach(() => {
   // would otherwise decide the next one.
   markActiveComposer('main')
   $hoveredTreeGroup.set(null)
+})
+
+describe('focusComposerInput', () => {
+  it('does not steal the caret from another live composer', () => {
+    const foreground = mountInput()
+    const background = mountInput()
+
+    foreground.focus()
+    focusComposerInput(background)
+
+    expect(document.activeElement).toBe(foreground)
+  })
+
+  it('still focuses when the caret is not already in a composer', () => {
+    const input = mountInput()
+    const outside = document.createElement('button')
+
+    document.body.append(outside)
+    outside.focus()
+    focusComposerInput(input)
+
+    expect(document.activeElement).toBe(input)
+  })
+
+  it('takes the caret from a hidden keep-alive composer on tab switch', () => {
+    const hidden = mountInput(true)
+    const visible = mountInput()
+
+    hidden.focus()
+    focusComposerInput(visible)
+
+    expect(document.activeElement).toBe(visible)
+  })
 })
 
 describe('blurComposerInput', () => {

--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -10,7 +10,7 @@
  * steal focus from the composer effect.
  */
 
-import { queryAllVisible, queryVisible } from '@/components/pane-shell/pane-visibility'
+import { isElementInHiddenPane, queryAllVisible, queryVisible } from '@/components/pane-shell/pane-visibility'
 import { $hoveredTreeGroup } from '@/components/pane-shell/tree/store'
 
 import type { InlineRefInput } from './inline-refs'
@@ -396,10 +396,25 @@ export const focusComposerInput = (el: HTMLElement | null) => {
   // Skip when already focused: focus() runs the full focusing steps (forcing
   // layout) even on the active element, and during a session switch the DOM is
   // large and dirty — the redundant retries were measurably expensive there.
+  // Also skip when another VISIBLE composer holds the caret — a keep-alive
+  // remount must not yank typing. A hidden tab that still has DOM focus must
+  // not block the pane the user just switched to.
   const focus = () => {
-    if (document.activeElement !== el) {
-      el.focus({ preventScroll: true })
+    if (document.activeElement === el) {
+      return
     }
+
+    const active = document.activeElement
+
+    if (
+      active instanceof HTMLElement &&
+      active.dataset.slot === RICH_INPUT_SLOT &&
+      !isElementInHiddenPane(active)
+    ) {
+      return
+    }
+
+    el.focus({ preventScroll: true })
   }
 
   focus()

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, render, waitFor } from '@testing-library/react'
 import { useLayoutEffect } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { PaneVisibleContext } from '@/components/pane-shell/pane-visibility'
 import { clearSessionDraft, type ComposerAttachment, mainComposerScope, stashSessionDraft } from '@/store/composer'
 import { $connection } from '@/store/session'
 
@@ -292,5 +293,61 @@ describe('useComposerDraft — a closing composer hands the focus-bus key back',
     unmount()
 
     expect(getActiveComposer()).toBe('tile:other')
+  })
+})
+
+describe('useComposerDraft — a hidden keep-alive tab never auto-focuses its composer', () => {
+  afterEach(() => {
+    cleanup()
+    mainComposerScope.clear()
+    markActiveComposer('main')
+  })
+
+  function renderScopedHidden(target: ComposerTarget, hidden: boolean) {
+    const scope: ComposerScope = { ...MAIN_COMPOSER_SCOPE, target }
+
+    return render(
+      <PaneVisibleContext.Provider value={!hidden}>
+        <ComposerScopeProvider value={scope}>
+          <ProbeHarness
+            activeQueueSessionKey="session-tile"
+            onLayoutSnapshot={() => undefined}
+            sessionId="session-tile"
+          />
+        </ComposerScopeProvider>
+      </PaneVisibleContext.Provider>
+    )
+  }
+
+  it('does not claim the focus bus when the composer mounts inside a hidden pane', () => {
+    renderScopedHidden('tile:bg', true)
+
+    expect(getActiveComposer()).toBe('main')
+  })
+
+  it('still claims the bus when the same composer becomes visible', () => {
+    const { rerender } = renderScopedHidden('tile:fg', true)
+
+    expect(getActiveComposer()).toBe('main')
+
+    rerender(
+      <PaneVisibleContext.Provider value={true}>
+        <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, target: 'tile:fg' }}>
+          <ProbeHarness
+            activeQueueSessionKey="session-tile"
+            onLayoutSnapshot={() => undefined}
+            sessionId="session-tile"
+          />
+        </ComposerScopeProvider>
+      </PaneVisibleContext.Provider>
+    )
+
+    expect(getActiveComposer()).toBe('tile:fg')
+  })
+
+  it('claims the bus on mount when visible', () => {
+    renderScopedHidden('tile:vis', false)
+
+    expect(getActiveComposer()).toBe('tile:vis')
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -9,6 +9,7 @@ import '@/store/suggestion-providers/skill'
 import { useAui, useAuiState, useComposerRuntime } from '@assistant-ui/react'
 import { type RefObject, useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react'
 
+import { usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { SLASH_COMMAND_RE } from '@/lib/chat-runtime'
 import { sanitizeComposerInput } from '@/lib/composer-input-sanitize'
 import {
@@ -75,6 +76,7 @@ export function useComposerDraft({
 }: UseComposerDraftArgs) {
   const aui = useAui()
   const composerRuntime = useComposerRuntime()
+  const paneVisible = usePaneVisible()
   // Which composer this is on the focus bus + which attachment set it owns.
   const { attachments: attachmentScope, target } = useComposerScope()
 
@@ -181,11 +183,15 @@ export function useComposerDraft({
     [paintDraft]
   )
 
+  // Keep-alive tabs keep this composer mounted. A background session whose
+  // turn finished or recovered from a reconnect would otherwise re-run this
+  // effect and steal the caret. usePaneVisible defaults true outside a tab
+  // stack, so tiles, pop-outs, and secondary windows still auto-focus.
   useEffect(() => {
-    if (!inputDisabled) {
+    if (!inputDisabled && paneVisible) {
       focusInput()
     }
-  }, [focusInput, focusKey, focusRequestId, inputDisabled])
+  }, [focusInput, focusKey, focusRequestId, inputDisabled, paneVisible])
 
   // The mirror of the `markActiveComposer` above: give the key back when this
   // composer goes away (a session tile closing, a pane unmounting). Covers both

--- a/apps/desktop/src/app/chat/index.tsx
+++ b/apps/desktop/src/app/chat/index.tsx
@@ -682,7 +682,7 @@ const ChatViewContent = memo(function ChatViewContent({
               </ErrorState>
             </div>
           )}
-          {showChatBar && <ScrollToBottomButton />}
+          {showChatBar && <ScrollToBottomButton sessionId={activeSessionId} />}
           {/* Vibe hearts rise from the composer only when no pet is out (else
               they play on the pet). Fired by the core `reaction` event. */}
           {!petPresent && (

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.test.tsx
@@ -23,14 +23,14 @@ afterEach(() => {
 // control's hidden (parked-at-bottom) state.
 describe('ScrollToBottomButton', () => {
   it('stays hidden while parked at the bottom', () => {
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.queryByRole('button')).toBeNull()
   })
 
   it('is a plain jump-to-bottom control when scrolled up with no approval', () => {
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.getByRole('button', { name: 'Scroll to bottom' })).toBeTruthy()
     expect(screen.queryByText('Approval needed')).toBeNull()
@@ -39,7 +39,7 @@ describe('ScrollToBottomButton', () => {
   it('morphs into the approval pill when scrolled up with a pending approval', () => {
     pendingApproval()
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     expect(screen.getByRole('button', { name: 'Approval needed' })).toBeTruthy()
     expect(screen.getByText('Approval needed')).toBeTruthy()
@@ -47,7 +47,7 @@ describe('ScrollToBottomButton', () => {
 
   it('does not morph while a pending approval is still in view (at bottom)', () => {
     pendingApproval()
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId={null} />)
 
     // Parked at bottom → control hidden, so it can't claim "approval needed".
     expect(screen.queryByRole('button')).toBeNull()
@@ -55,9 +55,9 @@ describe('ScrollToBottomButton', () => {
 
   it('re-arms sticky-bottom on click', () => {
     const handler = vi.fn()
-    const stop = onScrollToBottomRequest(handler)
+    const stop = onScrollToBottomRequest(handler, 'sess-1')
     setThreadAtBottom(false)
-    render(<ScrollToBottomButton />)
+    render(<ScrollToBottomButton sessionId="sess-1" />)
 
     fireEvent.click(screen.getByRole('button'))
 

--- a/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
+++ b/apps/desktop/src/app/chat/scroll-to-bottom-button.tsx
@@ -28,7 +28,7 @@ import { $threadJumpButtonVisible, requestScrollToBottom } from '@/store/thread-
  * `data-state`. `idle` (never-shown) stays silent so it can't flash on mount;
  * `in`/`out` only swap once it has actually appeared.
  */
-export function ScrollToBottomButton() {
+export function ScrollToBottomButton({ sessionId }: { sessionId: string | null }) {
   const { t } = useI18n()
   const visible = useStore($threadJumpButtonVisible)
   const request = useStore($approvalRequest)
@@ -59,7 +59,7 @@ export function ScrollToBottomButton() {
       data-state={state}
       onClick={() => {
         triggerHaptic('selection')
-        requestScrollToBottom()
+        requestScrollToBottom(sessionId)
       }}
       style={{
         bottom: 'calc(var(--composer-measured-height) + 0.625rem)'

--- a/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx
@@ -53,7 +53,7 @@ describe('clarify.request stream hydration', () => {
   beforeEach(() => {
     clearClarifyRequest()
     scrollToBottom.mockClear()
-    stopScrollListener = onScrollToBottomRequest(scrollToBottom)
+    stopScrollListener = onScrollToBottomRequest(scrollToBottom, SID)
   })
 
   afterEach(() => {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/input-requests.ts
@@ -94,7 +94,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 
@@ -142,7 +142,7 @@ export function handleInputRequestEvent(ctx: GatewayEventContext): boolean {
         })
 
         if (sessionId === activeSessionIdRef.current) {
-          requestScrollToBottom()
+          requestScrollToBottom(sessionId)
         }
       }
 

--- a/apps/desktop/src/components/assistant-ui/thread/index.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/index.tsx
@@ -175,6 +175,7 @@ export const Thread = memo(function Thread({
           components={messageComponents}
           emptyPlaceholder={emptyPlaceholder}
           loadingIndicator={loadingIndicator}
+          sessionId={sessionId}
           sessionKey={sessionKey}
         />
         {loading === 'session' && <CenteredThreadSpinner />}

--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -9,7 +9,10 @@ import {
   liveTailStart,
   type MessageGroup,
   resolveThreadScrollTarget,
+  RUN_START_SNAP_THRESHOLD_PX,
   shouldClampTranscriptBudget,
+  shouldRePinOnTranscriptReload,
+  shouldSnapOnRunStart,
   subscribeToThreadForeground,
   transcriptBackfillFrameCount,
   transcriptPaneBudget
@@ -327,5 +330,38 @@ describe('liveTailStart', () => {
 describe('transcriptBackfillFrameCount', () => {
   it('settles a full pane in at most three prepend commits', () => {
     expect(transcriptBackfillFrameCount()).toBeLessThanOrEqual(3)
+  })
+})
+
+describe('shouldSnapOnRunStart', () => {
+  it('snaps when the viewport is already at the bottom', () => {
+    expect(shouldSnapOnRunStart(0)).toBe(true)
+  })
+
+  it('snaps when the viewport is a line or two off the bottom', () => {
+    expect(shouldSnapOnRunStart(RUN_START_SNAP_THRESHOLD_PX - 1)).toBe(true)
+  })
+
+  it('leaves a reader who has scrolled into history alone', () => {
+    expect(shouldSnapOnRunStart(RUN_START_SNAP_THRESHOLD_PX)).toBe(false)
+    expect(shouldSnapOnRunStart(400)).toBe(false)
+  })
+})
+
+describe('shouldRePinOnTranscriptReload', () => {
+  it('pins on a session switch even before the transcript has settled', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: true, settledNonEmpty: false })).toBe(true)
+  })
+
+  it('pins on a session switch even when the prior session had settled', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: true, settledNonEmpty: true })).toBe(true)
+  })
+
+  it('preserves the reader position on a same-session refresh after settling', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: true })).toBe(false)
+  })
+
+  it('pins on a cold-load arrival (same session, never settled non-empty)', () => {
+    expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: false })).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -17,7 +17,7 @@ import {
 } from 'react'
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
-import { usePaneLifecycle } from '@/components/pane-shell/pane-visibility'
+import { usePaneLifecycle, usePaneVisible } from '@/components/pane-shell/pane-visibility'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
 import { cn } from '@/lib/utils'
@@ -25,8 +25,8 @@ import {
   onScrollToBottomRequest,
   onThreadEditClose,
   onThreadEditOpen,
-  resetThreadScroll,
-  setThreadAtBottom
+  publishThreadAtBottom,
+  resetPublishedThreadScroll
 } from '@/store/thread-scroll'
 import { isSecondaryWindow } from '@/store/windows'
 
@@ -138,6 +138,28 @@ export const resolveThreadScrollTarget: GetTargetScrollTop = (targetScrollTop, {
   return remaining >= 0 && remaining <= SCROLL_TARGET_EPSILON_PX ? currentScrollTop : targetScrollTop
 }
 
+/** Near-bottom slack for a run-start snap. Wider than the subpixel epsilon
+ *  use-stick-to-bottom uses for resize follow — a follow-up sent a line or two
+ *  off the bottom should still track, but a reader in history must not yank. */
+export const RUN_START_SNAP_THRESHOLD_PX = 64
+
+export function shouldSnapOnRunStart(
+  remainingPx: number,
+  thresholdPx = RUN_START_SNAP_THRESHOLD_PX
+): boolean {
+  return remainingPx < thresholdPx
+}
+
+// True when the pin-to-bottom settle should re-arm. A same-session refresh
+// (transcript briefly emptied and repopulated under the same key) must keep
+// the reader's position; only a session switch or a cold-load arrival re-pins.
+export function shouldRePinOnTranscriptReload(opts: {
+  sessionSwitched: boolean
+  settledNonEmpty: boolean
+}): boolean {
+  return opts.sessionSwitched || !opts.settledNonEmpty
+}
+
 export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
   let frameId: number | null = null
   let framePending = false
@@ -186,6 +208,7 @@ interface ThreadMessageListProps {
   components: ThreadMessageComponents
   emptyPlaceholder?: ReactNode
   loadingIndicator?: ReactNode
+  sessionId?: string | null
   sessionKey?: string | null
 }
 
@@ -375,6 +398,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   components,
   emptyPlaceholder,
   loadingIndicator,
+  sessionId = null,
   sessionKey
 }) => {
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
@@ -421,6 +445,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   const mountedPanes = useStore($mountedTranscriptPanes)
   const paneLifecycle = usePaneLifecycle()
+  const paneVisible = usePaneVisible()
   // Hidden panes retain only a live-tail budget. Visible panes share the normal
   // screen budget; a reveal backfills older rows in bounded transition steps.
   const paneBudget = transcriptPaneBudget(mountedPanes, paneLifecycle === 'hot-hidden')
@@ -469,6 +494,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // Session the settle loop last armed for, so a re-arm within the same load
   // is distinguishable from a switch to a different transcript.
   const settleKeyRef = useRef(sessionKey)
+  // True once the CURRENT session has settled with a non-empty transcript.
+  // A same-session refresh must keep the reader's position; only a switch or
+  // a cold-load arrival re-arms. Reset on switch so a mid-settle key change
+  // cannot inherit the outgoing session's settled flag.
+  const settledNonEmptyRef = useRef(false)
 
   // Record where the view should land once a prepend has grown the content,
   // measured from the BOTTOM so the added height doesn't invalidate it. Only a
@@ -575,11 +605,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     ? 'pt-[calc(var(--titlebar-height)+0.75rem)]'
     : 'pt-[calc(var(--titlebar-height)-0.5rem)]'
 
-  useEffect(() => setThreadAtBottom(isAtBottom), [isAtBottom])
-  useEffect(() => () => resetThreadScroll(), [])
+  useEffect(() => publishThreadAtBottom(isAtBottom, { paneVisible }), [isAtBottom, paneVisible])
+  useEffect(() => () => resetPublishedThreadScroll({ paneVisible }), [paneVisible])
 
   // Floating jump button (outside this subtree) → return to the bottom.
-  useEffect(() => onScrollToBottomRequest(() => void scrollToBottom()), [scrollToBottom])
+  useEffect(
+    () => onScrollToBottomRequest(() => void scrollToBottom(), sessionId),
+    [scrollToBottom, sessionId]
+  )
 
   // Waking from display: hidden (HUD mode hides the main window; OS hide does
   // the same to any window): rAF and ResizeObserver may have been frozen, so
@@ -620,8 +653,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   useEffect(() => onThreadEditOpen(beginEditHold), [beginEditHold])
   useEffect(() => onThreadEditClose(endEditHold), [endEditHold])
   useEffect(() => () => endEditHold(), [endEditHold])
-  // New run → snap to the latest turn.
-  useAuiEvent('thread.runStart', () => void scrollToBottom())
+  // New run → snap to the latest turn only when already near the bottom.
+  useAuiEvent('thread.runStart', () => {
+    const el = scrollRef.current
+
+    if (el && shouldSnapOnRunStart(el.scrollHeight - el.scrollTop - el.clientHeight)) {
+      scrollToBottom()
+    }
+  })
 
   // Reset the cap and pin to bottom on mount + every session switch (messages
   // swap in place on a long-lived runtime, so sessionKey is the only signal).
@@ -646,6 +685,19 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       return
     }
 
+    const sessionSwitched = settleKeyRef.current !== sessionKey
+
+    if (sessionSwitched) {
+      settledNonEmptyRef.current = false
+    }
+
+    // Same-session refresh (transcript briefly cleared and repopulated) must
+    // keep the reader's position. Run before stopScroll / scrollTop reset so
+    // a refresh neither yanks the view nor clears the settled flag.
+    if (!shouldRePinOnTranscriptReload({ sessionSwitched, settledNonEmpty: settledNonEmptyRef.current })) {
+      return
+    }
+
     stopScroll()
     el.scrollTop = el.scrollHeight
     loadSettledRef.current = false
@@ -653,7 +705,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     // An anchor captured for the OUTGOING transcript must not be applied to
     // this one — a switch owns the position outright. The empty→non-empty
     // re-arm is the SAME load, whose in-flight anchor is still correct.
-    if (settleKeyRef.current !== sessionKey) {
+    if (sessionSwitched) {
       settleKeyRef.current = sessionKey
       restoreFromBottomRef.current = null
     }
@@ -680,6 +732,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       // frames to minimize the settle-loop racing markdown paint on every switch.
       if (stableFrames >= 2 || ++frame > 15) {
         void scrollToBottom('instant')
+        settledNonEmptyRef.current = hasGroups
         loadSettledRef.current = true
 
         return

--- a/apps/desktop/src/store/thread-scroll.test.ts
+++ b/apps/desktop/src/store/thread-scroll.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $threadJumpButtonVisible,
+  $threadScrolledUp,
+  onScrollToBottomRequest,
+  publishThreadAtBottom,
+  requestScrollToBottom,
+  resetPublishedThreadScroll,
+  resetThreadScroll,
+  setThreadAtBottom
+} from './thread-scroll'
+
+afterEach(() => {
+  resetThreadScroll()
+})
+
+describe('publishThreadAtBottom', () => {
+  it('lets the visible pane flash the jump pill when the thread leaves the bottom', () => {
+    publishThreadAtBottom(false, { paneVisible: true })
+
+    expect($threadJumpButtonVisible.get()).toBe(true)
+    expect($threadScrolledUp.get()).toBe(true)
+  })
+
+  it('ignores stick-to-bottom misses from a hidden keep-alive pane', () => {
+    setThreadAtBottom(true)
+
+    publishThreadAtBottom(false, { paneVisible: false })
+
+    expect($threadJumpButtonVisible.get()).toBe(false)
+    expect($threadScrolledUp.get()).toBe(false)
+  })
+
+  it('keeps the visible pane\'s scrolled-up chrome when a hidden pane publishes', () => {
+    publishThreadAtBottom(false, { paneVisible: true })
+
+    publishThreadAtBottom(true, { paneVisible: false })
+
+    expect($threadJumpButtonVisible.get()).toBe(true)
+    expect($threadScrolledUp.get()).toBe(true)
+  })
+})
+
+describe('resetPublishedThreadScroll', () => {
+  it('clears the jump pill when the visible pane unmounts', () => {
+    setThreadAtBottom(false)
+
+    resetPublishedThreadScroll({ paneVisible: true })
+
+    expect($threadJumpButtonVisible.get()).toBe(false)
+    expect($threadScrolledUp.get()).toBe(false)
+  })
+
+  it('does not clear the visible pane when a hidden list unmounts', () => {
+    setThreadAtBottom(false)
+
+    resetPublishedThreadScroll({ paneVisible: false })
+
+    expect($threadJumpButtonVisible.get()).toBe(true)
+    expect($threadScrolledUp.get()).toBe(true)
+  })
+})
+
+describe('requestScrollToBottom', () => {
+  it('routes a scroll request only to its session', () => {
+    const sessionA = vi.fn()
+    const sessionB = vi.fn()
+    const stopA = onScrollToBottomRequest(sessionA, 'session-a')
+    const stopB = onScrollToBottomRequest(sessionB, 'session-b')
+
+    requestScrollToBottom('session-b')
+
+    expect(sessionA).not.toHaveBeenCalled()
+    expect(sessionB).toHaveBeenCalledOnce()
+    stopA()
+    stopB()
+  })
+
+  it('does not let a late unmount clear a newer session\'s handler', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const stopFirst = onScrollToBottomRequest(first, 'session-a')
+    const stopSecond = onScrollToBottomRequest(second, 'session-a')
+
+    stopFirst()
+    requestScrollToBottom('session-a')
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledOnce()
+    stopSecond()
+  })
+})

--- a/apps/desktop/src/store/thread-scroll.ts
+++ b/apps/desktop/src/store/thread-scroll.ts
@@ -8,6 +8,11 @@ import { atom, type WritableAtom } from 'nanostores'
 // `$threadScrolledUp` dims the composer / status stack; `$threadJumpButtonVisible`
 // shows the floating jump control. Both track `!isAtBottom` today, but stay
 // separate so their thresholds can diverge again without touching consumers.
+//
+// Keep-alive tabs stay mounted with a real layout box, so only the on-screen
+// pane may publish or reset this composer-facing mirror. Jump-to-bottom
+// requests are keyed by session so a click (or an input-request snap) cannot
+// scroll every mounted transcript.
 export const $threadScrolledUp = atom(false)
 export const $threadJumpButtonVisible = atom(false)
 
@@ -28,18 +33,45 @@ export const setThreadAtBottom = (isAtBottom: boolean) => {
 
 export const resetThreadScroll = () => setThreadAtBottom(true)
 
+export const publishThreadAtBottom = (isAtBottom: boolean, publisher: { paneVisible: boolean }): void => {
+  if (!publisher.paneVisible) {
+    return
+  }
+
+  setThreadAtBottom(isAtBottom)
+}
+
+export const resetPublishedThreadScroll = (publisher: { paneVisible: boolean }): void => {
+  if (!publisher.paneVisible) {
+    return
+  }
+
+  resetThreadScroll()
+}
+
 // Cross-component bridge: the jump button lives by the composer, the viewport's
 // `scrollToBottom` lives inside the thread. The bridge registers a handler; the
 // button fires it. Mirrors the composer focus/insert emitter pattern.
-const handlers = new Set<() => void>()
+const handlers = new Map<string | null, Set<() => void>>()
 
-export const onScrollToBottomRequest = (handler: () => void) => {
-  handlers.add(handler)
+export const onScrollToBottomRequest = (handler: () => void, sessionId: string | null = null) => {
+  const scoped = handlers.get(sessionId) ?? new Set<() => void>()
 
-  return () => void handlers.delete(handler)
+  scoped.add(handler)
+  handlers.set(sessionId, scoped)
+
+  return () => {
+    scoped.delete(handler)
+
+    if (scoped.size === 0) {
+      handlers.delete(sessionId)
+    }
+  }
 }
 
-export const requestScrollToBottom = () => handlers.forEach(handler => handler())
+export const requestScrollToBottom = (sessionId: string | null = null) => {
+  handlers.get(sessionId)?.forEach(handler => handler())
+}
 
 // Inline edit grows a sticky human bubble. Fire on pointerdown so the viewport
 // escapes stick-to-bottom before focus/layout; close clears the edit flag when


### PR DESCRIPTION
## What does this PR do?

Supersedes #81829, #98316, #98681, #95503, and #99370.

Desktop keeps inactive session panes mounted. Those panes were publishing stick-to-bottom into window-global atoms, every transcript listened to the same jump-to-bottom broadcast, and a hidden composer would steal the caret on remount. A brand-new chat still hit it because other tabs were alive in the background. Sending a follow-up or refreshing the transcript also snapped a scrolled-up reader to the bottom.

Only the visible session may move the viewport, publish scroll chrome, or take composer focus. A run start or same-session refresh leaves a reader in history where they were.

## Related Issue

Fixes #98680
Fixes #99338

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Gate `$threadScrolledUp` / `$threadJumpButtonVisible` publishes on pane visibility
- Key jump-to-bottom requests by session id
- Skip composer autofocus in hidden keep-alive tabs
- Refuse to steal the caret from another visible composer (a hidden one that still has DOM focus does not block a tab switch)
- Snap on `thread.runStart` only when already near the bottom
- Keep scroll position across a same-session transcript refresh

Dropped from the cluster: persist-across-switch from #69554, the HUD probe in #98408 (separate), and #98681's unscoped "any composer has focus" guard (that blocked tab-switch autofocus).

## How to Test

1. Open two session tabs. Type in the front composer while a buried tab is live. The jump pill should not flash and the caret should stay.
2. Scroll up in a long answer and send a follow-up. The viewport should stay put.
3. Trigger a same-session transcript refresh (reconnect / compact) while scrolled up. The reading position should stay.

- [x] Regressions added for publish isolation, request routing, hidden autofocus, caret steal, run-start snap, and same-session re-pin
- [ ] Manual two-tab + scrolled-up follow-up check above

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

Credit: @gamewocao, @mor44-AI, @d4rk-pri0r, @Jackal991, @DanBennettUK
