### PR TITLE
feat(kanban): add `reopen` verb to recover a task stuck in 'done'

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -770,6 +770,36 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit machine-readable JSON result",
     )
 
+    p_reopen = sub.add_parser(
+        "reopen",
+        help="Recover a task stuck in 'done' back to the active queue "
+             "(done -> ready/todo); requires --reason",
+    )
+    p_reopen.add_argument("task_id")
+    p_reopen.add_argument(
+        "--ids",
+        nargs="+",
+        default=None,
+        help="Additional 'done' task ids to reopen with the same reason (bulk mode)",
+    )
+    p_reopen.add_argument(
+        "--reason",
+        required=True,
+        help="Required audit reason — recorded on a 'reopened' event so the "
+             "recovery is not silent. Quote multi-word reasons.",
+    )
+    p_reopen.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Validate the reopen without mutating state",
+    )
+    p_reopen.add_argument(
+        "--json",
+        dest="json",
+        action="store_true",
+        help="Emit machine-readable JSON result",
+    )
+
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="*",
                            help="Task ids to archive (default mode)")
@@ -1172,6 +1202,7 @@ def kanban_command(args: argparse.Namespace) -> int:
             "request-changes": _cmd_request_changes,
             "reopen-review":  _cmd_reopen_review,
             "promote":  _cmd_promote,
+            "reopen":  _cmd_reopen,
             "archive":  _cmd_archive,
             "tail":     _cmd_tail,
             "dispatch": _cmd_dispatch,
@@ -2667,6 +2698,55 @@ def _cmd_promote(args: argparse.Namespace) -> int:
             print(f"{label} {r['task_id']} -> ready{tag}{suffix}")
         else:
             print(f"cannot promote {r['task_id']}: {r['error']}", file=sys.stderr)
+    return 0 if not failed else 1
+
+
+def _cmd_reopen(args: argparse.Namespace) -> int:
+    reason = (args.reason or "").strip()
+    author = _profile_author()
+    as_json = getattr(args, "json", False)
+    dry_run = bool(getattr(args, "dry_run", False))
+    extra_ids = list(getattr(args, "ids", None) or [])
+    # Dedupe while preserving order; positional task_id always first.
+    ids: list[str] = []
+    seen: set[str] = set()
+    for tid in [args.task_id, *extra_ids]:
+        if tid not in seen:
+            ids.append(tid)
+            seen.add(tid)
+
+    results: list[dict[str, object]] = []
+    with kb.connect_closing() as conn:
+        for tid in ids:
+            ok, err = kb.reopen_task(
+                conn,
+                tid,
+                actor=author,
+                reason=reason,
+                dry_run=dry_run,
+            )
+            results.append({
+                "task_id": tid,
+                "reopened": ok,
+                "dry_run": dry_run,
+                "reason": reason,
+                "error": err,
+            })
+
+    failed = [r for r in results if not r["reopened"]]
+    if as_json:
+        # Single-id stays a flat object for back-compat; bulk emits a list.
+        payload: object = results[0] if len(results) == 1 else results
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+        return 0 if not failed else 1
+
+    tag = " (dry)" if dry_run else ""
+    label = "Would reopen" if dry_run else "Reopened"
+    for r in results:
+        if r["reopened"]:
+            print(f"{label} {r['task_id']}{tag}: {reason}")
+        else:
+            print(f"cannot reopen {r['task_id']}: {r['error']}", file=sys.stderr)
     return 0 if not failed else 1
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7197,6 +7197,104 @@ def invalidate_descendants_for_parent_reopen(
     return {"invalidated": invalidated, "terminations": terminations}
 
 
+def reopen_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    actor: str,
+    reason: str,
+    dry_run: bool = False,
+) -> tuple[bool, Optional[str]]:
+    """Reopen a ``done`` task back into the active queue with an audit trail.
+
+    The recovery verb for a task that reached ``done`` in error — a reviewer
+    rejection that never got recorded, or a forged ``UPDATE ... SET
+    status='done'`` — where ``reopen-review`` / ``unblock`` / ``promote`` all
+    refuse because the task is not in their source lane (#99577). Without it
+    the only way back was a raw ``sqlite3`` write, leaving the board carrying a
+    bogus ``done`` with no path out.
+
+    Semantics mirror the dashboard drag-drop reopen (``_set_status_direct``):
+
+    * lands the task at its parent-gated status (``ready`` when every parent is
+      ``done``/``archived``, else ``todo``) via
+      :func:`_landing_status_after_parents`;
+    * closes any run still open under the bogus completion — the stale
+      dead-PID ``running`` run reported in the issue's follow-up — via
+      :func:`_reclaim_dangling_run`, restoring the runs invariant;
+    * clears ``completed_at`` and the claim fields (the task is no longer
+      complete) while preserving ``result`` as history;
+    * re-gates every descendant dispatched on the now-retracted result through
+      the single shared :func:`invalidate_descendants_for_parent_reopen`, so a
+      CLI reopen and a dashboard reopen can never drift.
+
+    The mandatory ``reason`` (recorded on a ``reopened`` event with ``actor``)
+    is the guard the issue asks for: a completed task cannot be reopened
+    silently or by accident.
+
+    Returns ``(True, None)`` on success, ``(False, message)`` when the task is
+    missing, not ``done``, or the reason is empty. ``dry_run=True`` validates
+    without mutating.
+    """
+    reason = (reason or "").strip()
+    if not reason:
+        return False, "a reason is required to reopen a completed task"
+    row = conn.execute(
+        "SELECT status FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None:
+        return False, f"task {task_id} not found"
+    if row["status"] != "done":
+        return False, (
+            f"task {task_id} is {row['status']!r}; reopen only applies to "
+            "'done' tasks (use unblock / reopen-review / promote for other lanes)"
+        )
+    if dry_run:
+        return True, None
+
+    now = int(time.time())
+    terminations: list[tuple[Optional[int], Optional[str]]] = []
+    with write_txn(conn):
+        # Close a run still open under the bogus completion before the status
+        # flip, restoring the ``current_run_id IS NULL`` <=> run-terminal
+        # invariant (mirrors reopen_review_task / unblock_task).
+        _reclaim_dangling_run(
+            conn, task_id, statuses=("done",), now=now,
+            note="invariant recovery on done reopen",
+        )
+        new_status = _landing_status_after_parents(conn, task_id)
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, completed_at = NULL, "
+            "current_run_id = NULL, claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL "
+            "WHERE id = ? AND status = 'done'",
+            (new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False, f"task {task_id} is no longer 'done'"
+        _append_event(
+            conn, task_id, "reopened",
+            {
+                "actor": actor,
+                "reason": reason,
+                "from_status": "done",
+                "status": new_status,
+            },
+        )
+        # Descendants dispatched on the retracted result must be re-gated —
+        # identical semantics to the dashboard reopen surface. Composes under
+        # this txn (allow_nested) and defers worker kills to us post-commit.
+        invalidation = invalidate_descendants_for_parent_reopen(
+            conn, task_id, author=actor,
+        )
+        terminations.extend(invalidation.get("terminations", []))
+    # Events are durable now — safe to kill the reclaimed/retracted workers.
+    for pid, claim_lock in terminations:
+        _terminate_reclaimed_worker(pid, claim_lock)
+    recompute_ready(conn)
+    return True, None
+
+
 def specify_triage_task(
     conn: sqlite3.Connection,
     task_id: str,

--- a/tests/hermes_cli/test_kanban_reopen_done.py
+++ b/tests/hermes_cli/test_kanban_reopen_done.py
@@ -1,0 +1,145 @@
+"""Regressions for ``kanban_db.reopen_task`` — the done-recovery verb (#99577).
+
+Before this, a task stuck in ``done`` (a reviewer rejection that never got
+recorded, or a forged ``UPDATE ... SET status='done'``) had no CLI path out:
+``reopen-review`` / ``unblock`` / ``promote`` all refuse because the task is
+not in their source lane, so operators reached for raw ``sqlite3``. These tests
+pin the recovery contract:
+
+* a ``done`` task reopens to its parent-gated landing status with an audited
+  ``reopened`` event carrying the required reason + actor,
+* the reason is mandatory (no silent/accidental reopen),
+* only ``done`` tasks are eligible,
+* descendants dispatched on the retracted result are re-gated (shared
+  ``invalidate_descendants_for_parent_reopen`` semantics),
+* a run left open under the forged completion (the issue's stale dead-PID
+  ``running`` run) is reclaimed, restoring the runs invariant,
+* ``dry_run`` validates without mutating.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def conn(tmp_path: Path):
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+def _done_task(conn, **kw) -> str:
+    tid = kb.create_task(conn, title=kw.pop("title", "t"), assignee="builder", **kw)
+    assert kb.complete_task(conn, tid)
+    return tid
+
+
+def _reopened_event(conn, task_id: str):
+    for ev in kb.list_events(conn, task_id):
+        if ev.kind == "reopened":
+            return ev
+    return None
+
+
+def test_reopen_done_moves_to_ready_and_writes_audited_event(conn):
+    tid = _done_task(conn)
+    assert kb.get_task(conn, tid).status == "done"
+
+    ok, err = kb.reopen_task(conn, tid, actor="alice", reason="reviewer rejected")
+    assert ok is True and err is None
+
+    task = kb.get_task(conn, tid)
+    assert task.status == "ready"          # no parents -> ready
+    assert task.completed_at is None        # no longer complete
+    assert task.current_run_id is None
+
+    ev = _reopened_event(conn, tid)
+    assert ev is not None, "a 'reopened' event must be recorded"
+    assert ev.payload["reason"] == "reviewer rejected"
+    assert ev.payload["actor"] == "alice"
+    assert ev.payload["from_status"] == "done"
+    assert ev.payload["status"] == "ready"
+
+
+def test_reopen_requires_a_reason(conn):
+    tid = _done_task(conn)
+    ok, err = kb.reopen_task(conn, tid, actor="alice", reason="   ")
+    assert ok is False
+    assert err and "reason" in err
+    # State untouched — the guard is the whole point (#99577).
+    assert kb.get_task(conn, tid).status == "done"
+    assert _reopened_event(conn, tid) is None
+
+
+def test_reopen_refuses_a_non_done_task(conn):
+    tid = kb.create_task(conn, title="t", assignee="builder")  # 'ready', not done
+    ok, err = kb.reopen_task(conn, tid, actor="alice", reason="oops")
+    assert ok is False
+    assert err and "done" in err
+    assert kb.get_task(conn, tid).status == "ready"
+
+
+def test_reopen_refuses_unknown_task(conn):
+    ok, err = kb.reopen_task(conn, "t_missing", actor="alice", reason="x")
+    assert ok is False
+    assert err and "not found" in err
+
+
+def test_reopen_dry_run_does_not_mutate(conn):
+    tid = _done_task(conn)
+    ok, err = kb.reopen_task(conn, tid, actor="alice", reason="peek", dry_run=True)
+    assert ok is True and err is None
+    assert kb.get_task(conn, tid).status == "done"
+    assert _reopened_event(conn, tid) is None
+
+
+def test_reopen_invalidates_done_descendants(conn):
+    parent = _done_task(conn, title="parent")
+    child = kb.create_task(conn, title="child", assignee="builder", parents=[parent])
+    assert kb.complete_task(conn, child)
+    assert kb.get_task(conn, child).status == "done"
+
+    ok, err = kb.reopen_task(conn, parent, actor="alice", reason="redo parent")
+    assert ok is True and err is None
+
+    # The child was built on the parent's now-retracted result -> re-gated.
+    child_task = kb.get_task(conn, child)
+    assert child_task.status == "todo"
+    assert child_task.completed_at is None
+
+
+def test_reopen_reclaims_a_run_left_open_by_a_forged_completion(conn):
+    # Simulate the issue's forged completion: a running claim raw-UPDATEd to
+    # 'done' without closing the run, leaving a dangling running run + claim.
+    tid = kb.create_task(conn, title="t", assignee="builder")
+    claimed = kb.claim_task(conn, tid)
+    assert claimed is not None and kb.get_task(conn, tid).status == "running"
+    with kb.write_txn(conn):
+        conn.execute("UPDATE tasks SET status = 'done' WHERE id = ?", (tid,))
+
+    # Precondition: the run is still open under the forged 'done'.
+    open_before = conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+        (tid,),
+    ).fetchone()[0]
+    assert open_before == 1
+
+    ok, err = kb.reopen_task(conn, tid, actor="alice", reason="dead worker")
+    assert ok is True and err is None
+
+    task = kb.get_task(conn, tid)
+    assert task.status in {"ready", "todo"}
+    assert task.current_run_id is None
+    assert task.claim_lock is None
+    # The dangling run is closed — no run left running/open for this task.
+    open_after = conn.execute(
+        "SELECT COUNT(*) FROM task_runs WHERE task_id = ? AND ended_at IS NULL",
+        (tid,),
+    ).fetchone()[0]
+    assert open_after == 0


### PR DESCRIPTION
## What does this PR do?

Once a task is `done`, no status verb can move it out: `reopen-review`,
`unblock`, and `promote` all refuse (wrong source lane) and `edit` only
backfills recovery fields. The only way back was a raw `sqlite3` UPDATE,
which leaves the board carrying a bogus `done` with no audit trail (#99577).

Add `hermes kanban reopen <id> --reason "..."` and the domain-layer
`kanban_db.reopen_task` behind it. It mirrors the dashboard drag-drop reopen
(`_set_status_direct`): lands the task at its parent-gated status
(`ready`/`todo`), closes any run left open under the forged completion via
`_reclaim_dangling_run` (the stale dead-PID `running` run reported in the
issue's follow-up), clears `completed_at` + claim fields, and re-gates
descendants through the shared `invalidate_descendants_for_parent_reopen` so
the CLI and dashboard reopen paths can't drift. The mandatory `--reason` is
recorded on a `reopened` event, so recovery is auditable, never silent.

## Related Issue

Fixes #99577 (both the missing done-recovery verb and the follow-up: a run
left `running` with a dead PID that `reclaim` couldn't clear).
## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
## Changes Made

- `hermes_cli/kanban_db.py` — new `reopen_task()`.
- `hermes_cli/kanban.py` — new `reopen` subcommand (`--ids` bulk, `--dry-run`, `--json`).
- `tests/hermes_cli/test_kanban_reopen_done.py` — landing status, mandatory
  reason, non-done refusal, descendant invalidation, dangling-run reclaim, dry-run.

## How to Test

    pytest tests/hermes_cli/test_kanban_reopen_done.py -q

7 pass.