### PR TITLE
fix(gateway): keep the drain-marker read off the event loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9876,7 +9876,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         while self._running:
             try:
-                if drain_requested():
+                # drain_requested() does a synchronous read_text() on the
+                # marker file. At this 1s cadence that puts a blocking disk
+                # read on the event loop ~86k times a day; when the host is
+                # under I/O pressure a single read can stall for 30s+ and
+                # take every platform heartbeat down with it. Off-thread it.
+                if await asyncio.to_thread(drain_requested):
                     self._enter_external_drain()
                     # API and cron work live outside messaging's
                     # _running_agents map. Refresh the aggregate while an


### PR DESCRIPTION
`_drain_control_watcher` polls `drain_requested()` every second, and that does a synchronous
`Path.read_text()` on the marker file. It runs on the event loop, so it's roughly 86k blocking
reads a day on the loop thread.

Normally the read comes out of page cache and nobody notices. On a host under I/O pressure it
doesn't, and a single read can block for 30+ seconds. discord.py's heartbeat shares that loop, so
the heartbeat misses its window and the socket drops.

I hit this on a self-hosted gateway that started swapping. For several hours:

```
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 10 seconds.
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 30 seconds.
WARNING hermes_plugins.discord_platform.adapter: [Discord] Discord Gateway WebSocket unhealthy (socket_clo...)
```

Every blocked-loop traceback ended in the same place:

```
File "gateway/run.py", line 9879, in _drain_control_watcher
    if drain_requested():
File "gateway/drain_control.py", line 317, in drain_requested
    body = read_drain_request(home=home)
File "gateway/drain_control.py", line 360, in read_drain_request
    raw = path.read_text(encoding="utf-8")
```

Every bot went quiet while systemd still reported the service active, which made it hard to
attribute.

The marker is usually absent, so the common path is an `open()` that raises `FileNotFoundError`.
It still hits the filesystem and still blocks.

Fix:

```python
if await asyncio.to_thread(drain_requested):
```

Semantics are unchanged. `drain_control` still never raises and the existing `try/except` still
covers it. The `await` is sequential inside the `while self._running` loop, so only one probe is
ever in flight. Cancellation still reaches the existing handler, and the poll cadence and the
epoch/expiry staleness checks are untouched.

Same fix as #60794, where `build_channel_directory` blocked the loop with synchronous SQLite and
produced the same heartbeat symptom. `asyncio.to_thread` is already used across the tree,
including `channel_directory.py` and `kanban_watchers.py`.

Tested: `py_compile` clean, and the patched gateway has logged zero `heartbeat blocked` and zero
`Drain-control watcher tick error` since restart, against one every 5-10s before.

Happy to add a regression test, or to cache the marker's `stat()` instead if you'd prefer that.
