### PR TITLE
feat(providers): unofficial Grok Bot ConnectRPC transport

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -720,7 +720,7 @@ def init_agent(
     agent._credential_pool = credential_pool
     agent.acp_command = acp_command or command
     agent.acp_args = list(acp_args or args or [])
-    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server"}:
+    if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse", "codex_app_server", "grokbot"}:
         agent.api_mode = api_mode
     elif agent.provider == "openai-codex":
         agent.api_mode = "codex_responses"

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -2732,6 +2732,28 @@ def create_openai_client(agent, client_kwargs: dict, *, reason: str, shared: boo
     if (getattr(agent, "provider", "") or "").strip().lower() == "moa":
         from agent.moa_loop import build_moa_facade
         return build_moa_facade(agent, getattr(agent, "model", None) or "default")
+    grokbot_facade = None
+    try:
+        from agent.transports.grokbot import grokbot_runtime_active, build_grokbot_client
+        _gb_url = str(client_kwargs.get("base_url") or "")
+        if grokbot_runtime_active(agent, base_url=_gb_url):
+            grokbot_facade = build_grokbot_client
+    except Exception as exc:
+        _ra().logger.warning("Grok Bot facade import/build probe failed: %s", exc)
+    if grokbot_facade is not None:
+        return grokbot_facade(agent)
+    from urllib.parse import urlparse
+    _gb_url = str(client_kwargs.get("base_url") or getattr(agent, "base_url", "") or "")
+    _gb_prov = (getattr(agent, "provider", "") or "").strip().lower()
+    try:
+        _gb_host = (urlparse(_gb_url).hostname or "").lower()
+    except Exception:
+        _gb_host = ""
+    if _gb_prov in {"grokbot", "grok-bot"} or _gb_host == "api2.cursor.sh":
+        raise RuntimeError(
+            "Grok Bot facade unavailable; refusing OpenAI /chat/completions "
+            "against api2.cursor.sh (that route 404s and retries for minutes)."
+        )
     ssl_ca_cert = client_kwargs.pop("ssl_ca_cert", None)
     ssl_verify_cfg = client_kwargs.pop("ssl_verify", None)
     httpx_verify = resolve_httpx_verify(ca_bundle=ssl_ca_cert, ssl_verify=ssl_verify_cfg)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -272,6 +272,9 @@ def _create_openai_client(*, api_key: str, base_url: str, **kwargs: Any) -> Any:
         # Availability probe: credentials/base_url resolved — that is the
         # answer. Skip the openai import + httpx/SSL construction entirely.
         return _AuxProbeClientStub(api_key=api_key, base_url=base_url)
+    from agent.transports.grokbot import grokbot_runtime_active, build_grokbot_client
+    if grokbot_runtime_active(base_url=base_url):
+        return build_grokbot_client()
     kwargs = {**_openai_http_client_kwargs(base_url), **kwargs}
     # OpenCode Zen free tier: the keyless placeholder must never reach the
     # wire — the Zen relay serves free models anonymously but 401s any

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1337,6 +1337,14 @@ def _classify_by_status(
                 retryable=False,
                 should_fallback=True,
             )
+        # Cursor/Grok Bot has no OpenAI /chat/completions route. Retrying
+        # that 404 sleeps ~60s x 15 and looks like a hang with no tokens.
+        if "route post:/chat/completions not found" in error_msg:
+            return result_fn(
+                FailoverReason.unknown,
+                retryable=False,
+                should_fallback=False,
+            )
         # Generic 404 with no "model not found" signal — could be a wrong
         # endpoint path (common with local llama.cpp / Ollama / vLLM when
         # the URL is slightly misconfigured), a proxy routing glitch, or

--- a/agent/grokbot/__init__.py
+++ b/agent/grokbot/__init__.py
@@ -1,0 +1,1 @@
+"""Unofficial Grok Bot (Cursor sand) ConnectRPC client."""

--- a/agent/grokbot/client.py
+++ b/agent/grokbot/client.py
@@ -1,0 +1,427 @@
+#!/usr/bin/env python3
+"""Working Grok Bot (Cursor/sand backend) chat client.
+
+Route:  POST https://api2.cursor.sh/aiserver.v1.InferenceService/Stream
+Body:   Connect streaming envelope + protobuf InferenceStreamRequest
+
+Reverse-engineered from /Applications/Grok Bot.app:
+  - dist/host/host-main.cjs  -> InferenceService/Stream, InferenceStreamRequest (UC)
+  - dist/electron-main/main.cjs -> auth, checksum, PKCE login
+
+Verified live 2026-08-29: model "grok-4.6" replied "PONG" to "Reply with exactly: PONG".
+
+Usage:
+    python3 grokbot_client.py chat "hello" [--model grok-4.6] [--tools]
+    python3 grokbot_client.py models
+    python3 grokbot_client.py probe          # try each model id, report which work
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import struct
+import urllib.error
+import urllib.request
+import uuid
+
+from agent.grokbot import login as _g
+
+API_BASE = _g.API_BASE
+CHAT_URL = f"{API_BASE}/aiserver.v1.InferenceService/Stream"
+CT = "application/connect+proto"
+
+# Model ids verified against this account (see `probe`).
+DEFAULT_MODEL = "grok-4.6"
+KNOWN_MODELS = ["grok-4.6", "grok-4.5", "default", "composer-2.5"]
+
+
+# ------------------------------------------------------------ protobuf ------
+
+def vi(n: int) -> bytes:
+    """Varint."""
+    b = bytearray()
+    while True:
+        x = n & 0x7F
+        n >>= 7
+        b.append(x | 0x80 if n else x)
+        if not n:
+            return bytes(b)
+
+
+def tag(f: int, w: int) -> bytes:
+    return vi((f << 3) | w)
+
+
+def s(f: int, v: str) -> bytes:
+    e = v.encode()
+    return tag(f, 2) + vi(len(e)) + e
+
+
+def m(f: int, p: bytes) -> bytes:
+    return tag(f, 2) + vi(len(p)) + p
+
+
+def envelope(proto: bytes) -> bytes:
+    """Connect streaming envelope: 1 flag byte + 4-byte BE length + payload."""
+    return b"\x00" + struct.pack(">I", len(proto)) + proto
+
+
+# ---------------------------------------------------------- request ---------
+
+# InferenceStreamRequest (UC):
+#   1  messages        (vb)   repeated
+#   2  tools           (TD)
+#   5  model_id        string
+#   6  invocation_id   string
+#   7  requested_model (FQ)   required
+#   8  conversation_id string
+#
+# message (vb):   1 role(enum) 2 text
+# requested_model (FQ): 1 model_id  2 max_mode  4 built_in_model
+
+ROLE_USER = 1
+ROLE_ASSISTANT = 2
+ROLE_TOOL = 3
+ROLE_SYSTEM = 4
+
+
+def _content_text(content) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        bits = []
+        for p in content:
+            if isinstance(p, dict):
+                bits.append(p.get("text") or p.get("content") or "")
+            else:
+                bits.append(str(p))
+        return "".join(bits)
+    return str(content)
+
+
+def openai_messages_to_history(msgs: list[dict]) -> tuple[str, list[tuple[int, str]]]:
+    """Flatten OpenAI chat messages into proto (role, text) + last user prompt.
+
+    Native proto tool-result encoding still errors. Tool results become extra
+    user text. Assistant ``tool_calls`` are NOT serialized as ``Called tools:``
+    (that leaked into the model transcript and got imitated).
+    """
+    history: list[tuple[int, str]] = []
+    pending_user = ""
+    for m in msgs or []:
+        role = (m.get("role") or "user").lower()
+        text = _content_text(m.get("content"))
+        if role == "system":
+            history.append((ROLE_USER, f"[SYSTEM]\n{text}"))
+        elif role == "user":
+            if pending_user:
+                history.append((ROLE_USER, pending_user))
+            pending_user = text
+        elif role == "assistant":
+            if pending_user:
+                history.append((ROLE_USER, pending_user))
+                pending_user = ""
+            if text:
+                history.append((ROLE_ASSISTANT, text))
+        elif role == "tool":
+            name = m.get("name") or "tool"
+            pending_user = (
+                (pending_user + "\n" if pending_user else "")
+                + f"TOOL_RESULT {name}: {text}"
+            )
+    return pending_user, history
+
+
+def message(role: int, text: str) -> bytes:
+    return tag(1, 0) + vi(role) + s(2, text)
+
+
+def encode_tool_def(name: str, description: str = "", parameters=None) -> bytes:
+    """InferenceStreamRequest.tools item (live-verified 2026-08-29).
+
+    field 1 name, field 2 description, field 5 parameters JSON schema.
+    """
+    body = s(1, name)
+    if description:
+        body += s(2, description)
+    if parameters is not None:
+        if not isinstance(parameters, str):
+            parameters = json.dumps(parameters)
+        body += s(5, parameters)
+    return body
+
+
+def build_request(prompt: str, model: str = DEFAULT_MODEL,
+                  conversation_id: str | None = None,
+                  history: list[tuple[int, str]] | None = None,
+                  tools: list[dict] | None = None) -> bytes:
+    msgs = list(history or []) + ([(ROLE_USER, prompt)] if prompt else [])
+    body = b"".join(m(1, message(r, t)) for r, t in msgs)
+    for t in tools or []:
+        fn = t.get("function") if t.get("type") == "function" or "function" in t else t
+        if not isinstance(fn, dict):
+            continue
+        name = fn.get("name") or t.get("name")
+        if not name:
+            continue
+        body += m(2, encode_tool_def(name, fn.get("description") or "",
+                                     fn.get("parameters") or t.get("parameters")))
+    body += m(7, s(1, model))                                  # requested_model
+    body += s(6, str(uuid.uuid4()))                            # invocation_id
+    body += s(8, conversation_id or str(uuid.uuid4()))         # conversation_id
+    return body
+
+
+# ------------------------------------------------------------ response ------
+
+def _walk(buf: bytes):
+    """Minimal protobuf walker -> list of (field_no, wire_type, value)."""
+    i, out = 0, []
+    while i < len(buf):
+        try:
+            key, i = _read_varint(buf, i)
+        except Exception:
+            break
+        f, w = key >> 3, key & 7
+        if w == 0:
+            v, i = _read_varint(buf, i)
+            out.append((f, w, v))
+        elif w == 2:
+            ln, i = _read_varint(buf, i)
+            out.append((f, w, buf[i:i + ln]))
+            i += ln
+        elif w == 5:
+            out.append((f, w, buf[i:i + 4])); i += 4
+        elif w == 1:
+            out.append((f, w, buf[i:i + 8])); i += 8
+        else:
+            break
+    return out
+
+
+def _read_varint(buf: bytes, i: int) -> tuple[int, int]:
+    n = shift = 0
+    while True:
+        b = buf[i]; i += 1
+        n |= (b & 0x7F) << shift
+        if not b & 0x80:
+            return n, i
+        shift += 7
+
+
+_UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", re.I)
+_B64_RE = re.compile(r"^[A-Za-z0-9+/=_-]{32,}$")
+
+
+def _looks_like_text(t: str) -> bool:
+    if not t or len(t.strip()) < 1:
+        return False
+    if _UUID_RE.match(t):                      # request/conversation ids
+        return False
+    if _B64_RE.match(t):                       # opaque blobs
+        return False
+    if t.startswith("http") or t.startswith("{"):
+        return False
+    # must contain at least one letter or digit and mostly printable
+    if not re.search(r"[A-Za-z0-9]", t):
+        return False
+    printable = sum(1 for ch in t if ch == "\n" or ch == "\t" or 32 <= ord(ch) < 0x110000)
+    return printable / len(t) > 0.95
+
+
+_LEAK_RE = re.compile(r"\\confidence\{\d+\}")
+
+
+def _clean(t: str) -> str:
+    """Strip leaked system-prompt scaffolding from model output."""
+    t = _LEAK_RE.sub("", t)
+    t = re.sub(r"^[\x00-\x1f]+", "", t)          # leading control byte = length prefix
+    return t.strip()
+
+
+def _parse_event(chunk: bytes) -> dict:
+    """Parse one InferenceStreamResponse frame into a dict.
+
+    Observed shape (verified live 2026-08-29):
+      field 1 -> streamed text event  -> nested field 1 = text
+      field 3 -> usage/telemetry
+      field 4 -> model routing info   (nested: 1=?, 2=model_id, ...)
+      field 5 -> timing
+      field 7 -> request/conversation id (nested field 1 = uuid)
+      field 9 -> opaque blob
+    """
+    out: dict = {}
+    for f, w, v in _walk(chunk):
+        if f == 1 and w == 2 and isinstance(v, bytes):
+            sub = dict((sf, sv) for sf, sw, sv in _walk(v) if sw == 2)
+            txt = sub.get(1)
+            if isinstance(txt, bytes):
+                try:
+                    out.setdefault("text", "")
+                    out["text"] += txt.decode("utf-8")
+                except UnicodeDecodeError:
+                    pass
+        elif f == 2 and w == 2 and isinstance(v, bytes):
+            # tool_call_part: 1=id, 2=name, 3=arguments JSON (streamed), 4=is_final
+            inner = {}
+            for sf, sw, sv in _walk(v):
+                if sw == 2 and isinstance(sv, bytes):
+                    inner[sf] = sv.decode("utf-8", "replace")
+                elif sw == 0:
+                    inner[sf] = sv
+            out.setdefault("tool_parts", []).append(inner)
+        elif f == 4 and w == 2 and isinstance(v, bytes):
+            sub = dict((sf, sv) for sf, sw, sv in _walk(v) if sw == 2)
+            mid = sub.get(2)
+            if isinstance(mid, bytes):
+                out.setdefault("model", mid.decode("utf-8", "replace"))
+        elif f == 7 and w == 2 and isinstance(v, bytes):
+            sub = dict((sf, sv) for sf, sw, sv in _walk(v) if sw == 2)
+            rid = sub.get(1)
+            if isinstance(rid, bytes):
+                out.setdefault("request_id", rid.decode("utf-8", "replace"))
+    return out
+
+
+def _extract_text(blob: bytes) -> str:
+    """Pull human-readable text out of a response chunk."""
+    parts = []
+    for f, w, v in _walk(blob):
+        if w == 2 and isinstance(v, bytes):
+            try:
+                t = v.decode("utf-8")
+            except UnicodeDecodeError:
+                continue
+            if _looks_like_text(t):
+                parts.append(t)
+    return "".join(parts)
+
+
+def _merge_tool_parts(parts: list[dict]) -> list[dict]:
+    """Accumulate streamed tool_call_part frames into final OpenAI tool_calls."""
+    by_id: dict[str, dict] = {}
+    order: list[str] = []
+    for p in parts:
+        raw_id = str(p.get(1) or "")
+        oid = raw_id.split("\n", 1)[0] or raw_id
+        if oid not in by_id:
+            by_id[oid] = {"id": oid or f"call_{uuid.uuid4().hex[:12]}",
+                          "name": "", "arguments": ""}
+            order.append(oid)
+        rec = by_id[oid]
+        if p.get(2):
+            rec["name"] = p[2]
+        if p.get(3):
+            frag = str(p[3])
+            cur = rec["arguments"]
+            # Prefer a complete JSON object over concatenated stream fragments.
+            def _ok(x):
+                try:
+                    json.loads(x); return True
+                except Exception:
+                    return False
+            if not cur:
+                rec["arguments"] = frag
+            elif _ok(frag) and (not _ok(cur) or len(frag) >= len(cur)):
+                rec["arguments"] = frag
+            elif not _ok(cur):
+                rec["arguments"] = cur + frag
+    out = []
+    for oid in order:
+        rec = by_id[oid]
+        args = rec["arguments"] or "{}"
+        # streamed args sometimes arrive as '{' then '"k":"v"}' then full json
+        try:
+            json.loads(args)
+        except json.JSONDecodeError:
+            # keep last complete-looking object
+            m = re.search(r"\{.*\}", args)
+            args = m.group(0) if m else "{}"
+        if not rec["name"]:
+            continue
+        out.append({
+            "id": rec["id"] if rec["id"].startswith("call") else f"call_{uuid.uuid4().hex[:12]}",
+            "type": "function",
+            "function": {"name": rec["name"], "arguments": args},
+        })
+    return out
+
+
+def infer(prompt: str, model: str = DEFAULT_MODEL, token: str | None = None,
+          conversation_id: str | None = None, history=None,
+          tools: list[dict] | None = None, on_chunk=None) -> dict:
+    """Run InferenceService/Stream. Returns {text, tool_calls, model}."""
+    routed_model = ""
+    def _post(tok: str) -> bytes:
+        body = envelope(build_request(prompt, model, conversation_id, history, tools=tools))
+        h = _g.headers(tok)
+        h["Content-Type"] = CT
+        h["Accept"] = CT
+        req = urllib.request.Request(CHAT_URL, data=body, headers=h, method="POST")
+        try:
+            resp = urllib.request.urlopen(req, timeout=180)
+            return resp.read()
+        except urllib.error.HTTPError as e:
+            raw = e.read()
+            raise RuntimeError(f"HTTP {e.code}: {raw[:400]!r}") from None
+
+    tok = token or (_g._load() or {}).get("accessToken")
+    if not tok:
+        raise RuntimeError("No Grok Bot session. Run: python3 grokbot_login.py login")
+    try:
+        raw = _post(tok)
+    except RuntimeError as e:
+        if token is None and str(e).startswith("HTTP 401"):
+            sess = _g.refresh_session()
+            raw = _post(sess["accessToken"])
+        else:
+            raise
+
+    text_parts = []
+    tool_parts = []
+    i = 0
+    while i + 5 <= len(raw):
+        flags = raw[i]
+        (ln,) = struct.unpack(">I", raw[i + 1:i + 5])
+        i += 5
+        chunk = raw[i:i + ln]
+        i += ln
+        if flags & 0x02:
+            try:
+                err = json.loads(chunk)
+                if "error" in err:
+                    raise RuntimeError(json.dumps(err["error"])[:600])
+            except json.JSONDecodeError:
+                pass
+            continue
+        ev = _parse_event(chunk)
+        if ev.get("model"):
+            routed_model = ev["model"]
+        if ev.get("tool_parts"):
+            tool_parts.extend(ev["tool_parts"])
+        t = ev.get("text", "")
+        if t:
+            t = _clean(t)
+            if t:
+                text_parts.append(t)
+                if on_chunk:
+                    on_chunk(t)
+    result_text = "".join(text_parts)
+    if routed_model:
+        stream.last_model = routed_model
+    return {"text": result_text, "tool_calls": _merge_tool_parts(tool_parts),
+            "model": routed_model}
+
+
+def stream(prompt: str, model: str = DEFAULT_MODEL, token: str | None = None,
+           conversation_id: str | None = None, history=None,
+           on_chunk=None, tools=None) -> str:
+    return infer(prompt, model, token, conversation_id, history, tools, on_chunk)["text"]
+
+
+stream.last_model = ""
+
+

--- a/agent/grokbot/login.py
+++ b/agent/grokbot/login.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Grok Bot (Cursor/sand) PKCE login — browser OAuth, no app modification.
+
+Reverse-engineered from /Applications/Grok Bot.app (dist/electron-main/main.cjs).
+
+Flow (matches the app's own LoginManager):
+  1. Generate PKCE verifier (32 random bytes, base64url) + challenge (S256).
+  2. Build https://cursor.com/loginDeepControl?challenge=..&uuid=..&mode=login
+     &redirectTarget=sand&supportsSelectedTeamLogin=true
+  3. User signs in in the browser.
+  4. Poll {apiBaseUrl}/auth/poll?uuid=..&verifier=..  (404 = keep waiting)
+  5. On success -> {"accessToken", "refreshToken"}  (plaintext, usable directly).
+
+Writes (mode 0600, never printed):
+  ~/.grokbot/session.json   {accessToken, refreshToken, authId, email, expiresAt}
+
+Library used by hermes_cli.grokbot_oauth. Tokens stay in ~/.grokbot/session.json mode 0600.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import secrets
+import sys
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+API_BASE = "https://api2.cursor.sh"
+WEBSITE = "https://cursor.com"
+CLIENT_TYPE = "sand"
+CLIENT_VERSION = "0.24.0"
+HOME = Path(os.environ.get("GROKBOT_HOME", Path.home() / ".grokbot"))
+
+
+# ---------------------------------------------------------------- storage ----
+
+def _save(obj: dict, name: str = "session.json") -> Path:
+    HOME.mkdir(mode=0o700, parents=True, exist_ok=True)
+    p = HOME / name
+    p.write_text(json.dumps(obj, indent=2))
+    p.chmod(0o600)
+    return p
+
+
+def _load() -> dict | None:
+    p = HOME / "session.json"
+    if not p.is_file():
+        return None
+    return json.loads(p.read_text())
+
+
+# ------------------------------------------------------------- checksum -----
+
+def _b2s(b: bytes) -> bytes:
+    """Rolling XOR obfuscation lifted verbatim from main.cjs (function b2s)."""
+    e = 165
+    out = bytearray()
+    for i, v in enumerate(b):
+        v = (v ^ e) + i % 256
+        e = v
+        out.append(v & 0xFF)
+    return bytes(out)
+
+
+def checksum(machine_id: str) -> str:
+    """x-cursor-checksum = obfuscated 6-byte coarse timestamp + machine id."""
+    n = int(time.time() * 1000) // 1_000_000
+    ts = bytes([n >> 40 & 255, n >> 32 & 255, n >> 24 & 255,
+                n >> 16 & 255, n >> 8 & 255, n & 255])
+    return base64.urlsafe_b64encode(_b2s(ts)).decode().rstrip("=") + machine_id
+
+
+def machine_id() -> str:
+    """Reuse the app's own machine id when present; else random (server tolerates it)."""
+    store = Path.home() / "Library/Application Support/Grok Bot/sand-secrets.json"
+    try:
+        d = json.loads(store.read_text())
+        mid = d.get("cursor-machine-id")
+        if isinstance(mid, str) and mid:
+            return mid
+    except Exception:
+        pass
+    return "djEw" + secrets.token_urlsafe(16)
+
+
+def headers(token: str | None = None) -> dict[str, str]:
+    h = {
+        "Content-Type": "application/json",
+        "x-cursor-checksum": checksum(machine_id()),
+        "x-cursor-client-type": CLIENT_TYPE,
+        "x-cursor-client-version": CLIENT_VERSION,
+        "x-ghost-mode": "true",
+        "x-request-id": secrets.token_urlsafe(8),
+        "connect-protocol-version": "1",
+    }
+    if token:
+        h["authorization"] = f"Bearer {token}"
+    return h
+
+
+# ----------------------------------------------------------------- http -----
+
+def _req(url: str, body: bytes | None = None, hdrs: dict | None = None,
+         method: str = "POST", timeout: int = 30):
+    r = urllib.request.Request(url, data=body, headers=hdrs or {}, method=method)
+    try:
+        resp = urllib.request.urlopen(r, timeout=timeout)
+        return resp.status, resp.read()
+    except urllib.error.HTTPError as e:
+        return e.code, e.read()
+
+
+# --------------------------------------------------------------- pkce -------
+
+def _b64u(raw: bytes) -> str:
+    return base64.urlsafe_b64encode(raw).decode().rstrip("=")
+
+
+def start_login() -> dict:
+    verifier = _b64u(secrets.token_bytes(32))
+    challenge = _b64u(hashlib.sha256(verifier.encode()).digest())
+    uuid = secrets.token_urlsafe(16)
+    u = f"{WEBSITE}/loginDeepControl"
+    qs = (f"?challenge={challenge}&uuid={uuid}&mode=login"
+          f"&redirectTarget=sand&supportsSelectedTeamLogin=true")
+    return {"uuid": uuid, "verifier": verifier,
+            "challenge": challenge, "loginUrl": u + qs}
+
+
+def poll(uuid: str, verifier: str, seconds: float = 300.0) -> dict | None:
+    url = f"{API_BASE}/auth/poll?uuid={uuid}&verifier={verifier}"
+    deadline = time.time() + seconds
+    delay = 1.0
+    while time.time() < deadline:
+        code, body = _req(url, b"", headers(), method="GET")
+        # 404 == not yet completed -> keep waiting (per main.cjs c5i)
+        if code == 404:
+            time.sleep(min(delay, 10.0))
+            delay *= 1.2
+            continue
+        if code == 200:
+            try:
+                j = json.loads(body)
+            except Exception:
+                return None
+            if isinstance(j, dict) and "accessToken" in j:
+                return j
+        time.sleep(min(delay, 10.0))
+        delay *= 1.2
+    return None
+
+
+def login_session(open_browser: bool = True, timeout: float = 300.0) -> dict:
+    """PKCE login. Raises RuntimeError on timeout. Never prints tokens."""
+    s = start_login()
+    print("Open this URL and sign in:\n")
+    print(f"  {s['loginUrl']}\n")
+    if open_browser:
+        try:
+            import webbrowser
+            webbrowser.open(s["loginUrl"], new=2)
+        except Exception:
+            pass
+    print("Waiting for authorization", end="", flush=True)
+    res = poll(s["uuid"], s["verifier"], seconds=timeout)
+    print()
+    if not res:
+        raise RuntimeError("Grok Bot PKCE timed out or failed. Re-run and finish the browser sign-in.")
+    out = {"accessToken": res["accessToken"],
+           "refreshToken": res.get("refreshToken", ""),
+           "authId": res.get("authId"), "email": res.get("email"),
+           "expiresAt": res.get("expiresAt"), "obtainedAt": int(time.time())}
+    p = _save(out)
+    print(f"Saved -> {p} (mode 0600)")
+    return out
+
+
+def do_login(open_browser: bool = True) -> dict:
+    try:
+        return login_session(open_browser=open_browser)
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+
+# ------------------------------------------------------------- refresh ------
+
+def refresh_session() -> dict:
+    """Rotate the access token. Raises RuntimeError; never prints secrets."""
+    sess = _load()
+    if not sess or not sess.get("refreshToken"):
+        raise RuntimeError("No Grok Bot session. Run: python3 grokbot_login.py login")
+    body = json.dumps({"client_id": "KbZUR41cY7W6zRSdpSUJ7I7mLYBKOCmB",
+                       "grant_type": "refresh_token",
+                       "refresh_token": sess["refreshToken"]}).encode()
+    code, raw = _req(f"{API_BASE}/oauth/token", body, headers())
+    if code != 200:
+        raise RuntimeError(f"refresh HTTP {code}")
+    j = json.loads(raw)
+    if not j.get("access_token"):
+        raise RuntimeError("refresh returned empty access_token")
+    sess["accessToken"] = j["access_token"]
+    if j.get("refresh_token"):
+        sess["refreshToken"] = j["refresh_token"]
+    sess["obtainedAt"] = int(time.time())
+    _save(sess)
+    return sess
+
+
+def do_refresh() -> dict:
+    try:
+        sess = refresh_session()
+    except RuntimeError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+    print("Access token refreshed.")
+    return sess
+
+
+# --------------------------------------------------------------- calls ------
+
+def _tok() -> str:
+    s = _load()
+    if not s:
+        print("No session. Run: login", file=sys.stderr)
+        sys.exit(1)
+    return s["accessToken"]
+
+
+def rpc(service_method: str, payload_obj: dict) -> tuple[int, bytes]:
+    url = f"{API_BASE}/aiserver.v1.{service_method}"
+    body = json.dumps(payload_obj).encode()
+    return _req(url, body, headers(_tok()))
+
+
+def do_models() -> None:
+    code, raw = rpc("AiService/AvailableModels", {})
+    print(f"HTTP {code}  ({len(raw)} bytes)")
+    if code != 200:
+        print(raw[:400])
+        return
+    try:
+        j = json.loads(raw)
+    except Exception:
+        print(raw[:400])
+        return
+    models = j.get("models") or []
+    if not models:
+        print(json.dumps(j, indent=2)[:1200])
+        return
+    for m in models:
+        name = m.get("name") or m.get("modelId") or m.get("id") or "?"
+        extra = []
+        if m.get("vendor"):
+            extra.append(str(m["vendor"]))
+        if m.get("maxRequestTokens"):
+            extra.append(f"{m['maxRequestTokens']}tok")
+        print(f"  {name}" + (f"  ({', '.join(extra)})" if extra else ""))
+
+
+def do_chat(text: str, model: str = "grok-4.6") -> None:
+    """Minimal StreamChat probe. Proto field numbers are best-effort."""
+    body = {"model": model,
+            "messages": [{"role": "user", "content": text}]}
+    code, raw = rpc("AiService/StreamChat", body)
+    print(f"HTTP {code} ({len(raw)} bytes)")
+    print(raw[:800])
+
+
+# ----------------------------------------------------------------- cli ------
+
+def cmd_status() -> None:
+    s = _load()
+    if not s:
+        print("No session at", HOME / "session.json")
+        return
+    import hashlib as _h
+    red = lambda v: (_h.sha256(v.encode()).hexdigest()[:12] if v else "(none)")
+    print(f"session file : {HOME / 'session.json'}")
+    print(f"mode         : {oct((HOME / 'session.json').stat().st_mode & 0o777)}")
+    print(f"email        : {s.get('email') or '(unknown)'}")
+    print(f"authId       : {str(s.get('authId'))[:8]}..." if s.get("authId") else "authId       : (none)")
+    print(f"accessToken  : len={len(s.get('accessToken') or '')} sha256:{red(s.get('accessToken',''))}")
+    print(f"refreshToken : len={len(s.get('refreshToken') or '')} sha256:{red(s.get('refreshToken',''))}")
+    print(f"obtainedAt   : {s.get('obtainedAt')}")
+    code, raw = _req(f"{API_BASE}/aiserver.v1.AiService/GetUserInfo", b"{}",
+                     headers(s.get("accessToken")))
+    print(f"\nGetUserInfo  : HTTP {code}")
+    if code == 200:
+        print(raw[:500].decode("utf-8", "replace"))
+    else:
+        print(raw[:240].decode("utf-8", "replace"))
+
+
+def main() -> None:
+    cmd = sys.argv[1] if len(sys.argv) > 1 else "login"
+    if cmd == "login":
+        do_login()
+    elif cmd == "status":
+        cmd_status()
+    elif cmd == "refresh":
+        do_refresh()
+    elif cmd == "models":
+        do_models()
+    elif cmd == "chat":
+        if len(sys.argv) < 3:
+            print('usage: chat "message" [model]', file=sys.stderr)
+            sys.exit(1)
+        do_chat(sys.argv[2], sys.argv[3] if len(sys.argv) > 3 else "grok-4.6")
+    else:
+        print(__doc__)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/agent/grokbot/login.py
+++ b/agent/grokbot/login.py
@@ -41,9 +41,22 @@ HOME = Path(os.environ.get("GROKBOT_HOME", Path.home() / ".grokbot"))
 
 def _save(obj: dict, name: str = "session.json") -> Path:
     HOME.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(HOME, 0o700)
+    except OSError:
+        pass
     p = HOME / name
-    p.write_text(json.dumps(obj, indent=2))
-    p.chmod(0o600)
+    payload = json.dumps(obj, indent=2)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(p), flags, 0o600)
+    with os.fdopen(fd, "w") as f:
+        f.write(payload)
+        f.flush()
+        os.fsync(f.fileno())
+    try:
+        os.chmod(p, 0o600)
+    except OSError:
+        pass
     return p
 
 
@@ -51,7 +64,19 @@ def _load() -> dict | None:
     p = HOME / "session.json"
     if not p.is_file():
         return None
-    return json.loads(p.read_text())
+    try:
+        mode = p.stat().st_mode & 0o777
+    except OSError:
+        return None
+    if mode & 0o077:
+        return None
+    try:
+        data = json.loads(p.read_text())
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
 
 
 # ------------------------------------------------------------- checksum -----
@@ -137,7 +162,7 @@ def poll(uuid: str, verifier: str, seconds: float = 300.0) -> dict | None:
     deadline = time.time() + seconds
     delay = 1.0
     while time.time() < deadline:
-        code, body = _req(url, b"", headers(), method="GET")
+        code, body = _req(url, None, headers(), method="GET")
         # 404 == not yet completed -> keep waiting (per main.cjs c5i)
         if code == 404:
             time.sleep(min(delay, 10.0))

--- a/agent/grokbot/native.py
+++ b/agent/grokbot/native.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Native Hermes OpenAI-client facade over Grok Bot InferenceService/Stream.
+
+This is the in-process adapter (no localhost proxy). Hermes loads it from
+``agent.transports.grokbot`` and treats ``api_mode: grokbot`` like MoA:
+the facade *is* ``client.chat.completions.create``.
+
+Wire: POST https://api2.cursor.sh/aiserver.v1.InferenceService/Stream
+      Content-Type: application/connect+proto
+Auth: ~/.grokbot/session.json (PKCE). Never print tokens.
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from typing import Any, Iterator
+
+from agent.grokbot import client as gc
+
+
+def openai_tool_calls(raw: list[dict] | None) -> list[SimpleNamespace]:
+    out = []
+    for tc in raw or []:
+        fn = tc.get("function") or {}
+        out.append(SimpleNamespace(
+            id=tc.get("id") or f"call_{uuid.uuid4().hex[:12]}",
+            type="function",
+            index=len(out),
+            function=SimpleNamespace(
+                name=fn.get("name") or "",
+                arguments=fn.get("arguments") or "{}",
+            ),
+        ))
+    return out
+
+
+class _Usage:
+    prompt_tokens = 0
+    completion_tokens = 0
+    total_tokens = 0
+    prompt_tokens_details = None
+    prompt_cache_hit_tokens = 0
+
+
+class _Message:
+    def __init__(self, content: str | None, tool_calls: list | None):
+        self.role = "assistant"
+        self.content = content
+        self.tool_calls = tool_calls or None
+        self.refusal = None
+        self.reasoning_content = None
+        self.reasoning = None
+
+
+class _Choice:
+    def __init__(self, *, message=None, delta=None, finish_reason=None):
+        self.index = 0
+        self.message = message
+        self.delta = delta
+        self.finish_reason = finish_reason
+
+
+class _Response:
+    def __init__(self, model: str, content: str | None, tool_calls: list | None,
+                 finish_reason: str):
+        self.id = f"grokbot-{uuid.uuid4().hex[:16]}"
+        self.object = "chat.completion"
+        self.model = model or "grok-4.6"
+        self.choices = [_Choice(
+            message=_Message(content, tool_calls),
+            finish_reason=finish_reason,
+        )]
+        self.usage = _Usage()
+
+
+class _Delta:
+    def __init__(self, content=None, tool_calls=None):
+        self.content = content
+        self.tool_calls = tool_calls
+        self.role = "assistant"
+        self.reasoning_content = None
+
+
+class _Chunk:
+    def __init__(self, model: str, *, content=None, tool_calls=None,
+                 finish_reason=None, usage=None):
+        self.id = f"grokbot-chunk-{uuid.uuid4().hex[:12]}"
+        self.object = "chat.completion.chunk"
+        self.model = model or "grok-4.6"
+        self.usage = usage
+        delta = _Delta(content=content, tool_calls=tool_calls)
+        self.choices = [_Choice(delta=delta, finish_reason=finish_reason)]
+
+
+class GrokbotStream:
+    """Iterator that looks enough like an OpenAI streaming response."""
+
+    def __init__(self, chunks: list):
+        self._chunks = chunks
+        self.response = None
+        self.final_response = None
+
+    def __iter__(self) -> Iterator:
+        return iter(self._chunks)
+
+    def close(self) -> None:
+        return None
+
+
+def _run_infer(messages: list[dict], model: str, tools: list | None) -> dict:
+    prompt, history = gc.openai_messages_to_history(messages)
+    if not prompt and not history:
+        prompt = "hello"
+    return gc.infer(
+        prompt,
+        model or gc.DEFAULT_MODEL,
+        history=history or None,
+        tools=tools or None,
+    )
+
+
+def _to_response(result: dict, model: str) -> _Response:
+    tcs = openai_tool_calls(result.get("tool_calls"))
+    text = (result.get("text") or "") or None
+    if tcs:
+        finish = "tool_calls"
+    else:
+        finish = "stop"
+    routed = result.get("model") or model
+    return _Response(routed, text, tcs or None, finish)
+
+
+def _to_stream(result: dict, model: str) -> GrokbotStream:
+    routed = result.get("model") or model or "grok-4.6"
+    chunks: list = []
+    text = result.get("text") or ""
+    if text:
+        chunks.append(_Chunk(routed, content=text))
+    tcs = openai_tool_calls(result.get("tool_calls"))
+    if tcs:
+        chunks.append(_Chunk(routed, tool_calls=tcs))
+        chunks.append(_Chunk(routed, finish_reason="tool_calls", usage=_Usage()))
+    else:
+        chunks.append(_Chunk(routed, finish_reason="stop", usage=_Usage()))
+    return GrokbotStream(chunks)
+
+
+class _Completions:
+    def create(self, **kwargs: Any) -> Any:
+        messages = kwargs.get("messages") or []
+        model = kwargs.get("model") or gc.DEFAULT_MODEL
+        tools = kwargs.get("tools") or []
+        stream = bool(kwargs.get("stream"))
+        result = _run_infer(messages, model, tools)
+        if stream:
+            return _to_stream(result, model)
+        return _to_response(result, model)
+
+
+class GrokBotClient:
+    """Drop-in for ``openai.OpenAI`` on the chat.completions.create path."""
+
+    def __init__(self, agent: Any = None):
+        self._agent = agent
+        self.chat = SimpleNamespace(completions=_Completions())
+        self._closed = False
+
+    def close(self) -> None:
+        self._closed = True
+
+    def is_closed(self) -> bool:
+        return self._closed
+
+
+def build_grokbot_client(agent: Any = None) -> GrokBotClient:
+    return GrokBotClient(agent=agent)
+
+
+class GrokbotTransport:
+    """Hermes ProviderTransport for api_mode=grokbot.
+
+    Kwargs stay OpenAI-shaped; the facade owns Connect/protobuf. Normalization
+    reuses ChatCompletionsTransport so the agent loop sees the usual objects.
+    """
+
+    @property
+    def api_mode(self) -> str:
+        return "grokbot"
+
+    def convert_messages(self, messages, **kwargs):
+        return messages
+
+    def convert_tools(self, tools):
+        return tools
+
+    def build_kwargs(self, model, messages, tools=None, **params):
+        out = {"model": model, "messages": messages}
+        if tools:
+            out["tools"] = tools
+        return out
+
+    def _cc(self):
+        from agent.transports.chat_completions import ChatCompletionsTransport
+        return ChatCompletionsTransport()
+
+    def normalize_response(self, response, **kwargs):
+        return self._cc().normalize_response(response, **kwargs)
+
+    def validate_response(self, response) -> bool:
+        return self._cc().validate_response(response)
+
+    def extract_cache_stats(self, response):
+        return None
+
+    def map_finish_reason(self, raw_reason: str) -> str:
+        return raw_reason

--- a/agent/transports/__init__.py
+++ b/agent/transports/__init__.py
@@ -66,3 +66,7 @@ def _discover_transports() -> None:
         import agent.transports.bedrock  # noqa: F401
     except ImportError:
         pass
+    try:
+        import agent.transports.grokbot  # noqa: F401
+    except ImportError:
+        pass

--- a/agent/transports/grokbot.py
+++ b/agent/transports/grokbot.py
@@ -1,0 +1,107 @@
+"""Native Grok Bot (Cursor/sand) Hermes transport. No OpenAI proxy.
+
+``api_mode: grokbot`` talks ConnectRPC protobuf in-process via
+``agent.grokbot.native``. Auth is ``~/.grokbot/session.json``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+from urllib.parse import urlparse
+
+from agent.transports.base import ProviderTransport
+from agent.transports import register_transport
+
+logger = logging.getLogger(__name__)
+
+_CURSOR_HOST = "api2.cursor.sh"
+
+
+def load_native():
+    from agent.grokbot import native
+
+    return native
+
+
+def build_grokbot_client(agent: Any = None):
+    return load_native().build_grokbot_client(agent)
+
+
+def _hostname(url: str) -> str:
+    raw = (url or "").strip()
+    if not raw:
+        return ""
+    try:
+        return (urlparse(raw).hostname or "").lower()
+    except Exception:
+        return ""
+
+
+def grokbot_runtime_active(
+    agent: Any = None,
+    *,
+    api_mode: str = "",
+    provider: str = "",
+    base_url: str = "",
+) -> bool:
+    """True when this agent/request should use the Grok Bot facade.
+
+    Matches explicit api_mode/provider, or the exact Cursor inference host.
+    Substring matching is not used. ``https://evil-api2.cursor.sh.example``
+    must not hijack.
+    """
+    mode = (api_mode or getattr(agent, "api_mode", "") or "").strip().lower()
+    if mode == "grokbot":
+        return True
+    prov = (
+        provider
+        or getattr(agent, "provider", "")
+        or getattr(agent, "requested_provider", "")
+        or ""
+    ).strip().lower()
+    if prov in {"grokbot", "grok-bot"}:
+        return True
+    url = (base_url or getattr(agent, "base_url", "") or "").strip()
+    if _hostname(url) == _CURSOR_HOST:
+        return True
+    kwargs = getattr(agent, "_client_kwargs", None) or {}
+    if isinstance(kwargs, dict) and _hostname(str(kwargs.get("base_url") or "")) == _CURSOR_HOST:
+        return True
+    return False
+
+
+class GrokbotTransport(ProviderTransport):
+    def __init__(self):
+        self._inner = load_native().GrokbotTransport()
+
+    @property
+    def api_mode(self) -> str:
+        return "grokbot"
+
+    def convert_messages(self, messages, **kwargs):
+        return self._inner.convert_messages(messages, **kwargs)
+
+    def convert_tools(self, tools):
+        return self._inner.convert_tools(tools)
+
+    def build_kwargs(self, model, messages, tools=None, **params):
+        return self._inner.build_kwargs(model, messages, tools=tools, **params)
+
+    def normalize_response(self, response, **kwargs):
+        return self._inner.normalize_response(response, **kwargs)
+
+    def validate_response(self, response) -> bool:
+        return self._inner.validate_response(response)
+
+    def extract_cache_stats(self, response):
+        return self._inner.extract_cache_stats(response)
+
+    def map_finish_reason(self, raw_reason: str) -> str:
+        return self._inner.map_finish_reason(raw_reason)
+
+
+try:
+    register_transport("grokbot", GrokbotTransport)
+except Exception:
+    logger.debug("Grokbot transport not registered", exc_info=True)

--- a/agent/transports/grokbot.py
+++ b/agent/transports/grokbot.py
@@ -6,14 +6,11 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 from urllib.parse import urlparse
 
 from agent.transports.base import ProviderTransport
 from agent.transports import register_transport
-
-logger = logging.getLogger(__name__)
 
 _CURSOR_HOST = "api2.cursor.sh"
 
@@ -101,7 +98,4 @@ class GrokbotTransport(ProviderTransport):
         return self._inner.map_finish_reason(raw_reason)
 
 
-try:
-    register_transport("grokbot", GrokbotTransport)
-except Exception:
-    logger.debug("Grokbot transport not registered", exc_info=True)
+register_transport("grokbot", GrokbotTransport)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -282,6 +282,12 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
         auth_type="oauth_external",
         inference_base_url=DEFAULT_QWEN_BASE_URL,
     ),
+    "grokbot": ProviderConfig(
+        id="grokbot",
+        name="Grok Bot (Cursor sand)",
+        auth_type="oauth_external",
+        inference_base_url="https://api2.cursor.sh",
+    ),
     "lmstudio": ProviderConfig(
         id="lmstudio",
         name="LM Studio",
@@ -2253,6 +2259,7 @@ def resolve_provider(
         "opencode": "opencode-zen", "zen": "opencode-zen",
         "free": "opencode-free", "opencode_free": "opencode-free",
         "qwen-portal": "qwen-oauth", "qwen-cli": "qwen-oauth", "qwen-oauth": "qwen-oauth",
+        "grok-bot": "grokbot", "grokbot": "grokbot",
         "hf": "huggingface", "hugging-face": "huggingface", "huggingface-hub": "huggingface",
         "mimo": "xiaomi", "xiaomi-mimo": "xiaomi",
         "tencent": "tencent-tokenhub", "tokenhub": "tencent-tokenhub",

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -35,7 +35,7 @@ from hermes_cli.secret_prompt import masked_secret_prompt
 
 
 # Providers that support OAuth login in addition to API keys.
-_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth"}
+_OAUTH_CAPABLE_PROVIDERS = {"anthropic", "nous", "openai-codex", "xai-oauth", "qwen-oauth", "minimax-oauth", "grokbot"}
 
 
 def _get_custom_provider_entries() -> list[dict]:
@@ -114,6 +114,8 @@ def _normalize_provider(provider: str) -> str:
         return "openrouter"
     if normalized in {"grok-oauth", "xai-oauth", "x-ai-oauth", "xai-grok-oauth"}:
         return "xai-oauth"
+    if normalized in {"grokbot", "grok-bot"}:
+        return "grokbot"
     # Check if it matches a custom provider name
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:
@@ -261,6 +263,11 @@ def auth_add_command(args) -> None:
             requested_type = AUTH_TYPE_API_KEY
         else:
             requested_type = AUTH_TYPE_OAUTH if provider in _OAUTH_CAPABLE_PROVIDERS else AUTH_TYPE_API_KEY
+
+    if provider == "grokbot" and requested_type == AUTH_TYPE_API_KEY:
+        raise SystemExit(
+            "Grok Bot uses PKCE, not an API key. Run: hermes auth add grokbot --type oauth"
+        )
 
     pool = load_pool(provider)
 
@@ -471,6 +478,39 @@ def auth_add_command(args) -> None:
         if first_credential:
             auth_mod.mark_provider_active_if_unset(provider)
         print(f'Added {provider} OAuth credential #{len(pool.entries())}: "{entry.label}"')
+        return
+
+    if provider == "grokbot":
+        from hermes_cli.grokbot_oauth import existing_session, run_pkce_login, session_label
+
+        sess = existing_session()
+        imported = False
+        if sess is not None:
+            imported = True
+            print("Using existing ~/.grokbot/session.json (PKCE).")
+        else:
+            try:
+                sess = run_pkce_login(
+                    open_browser=not getattr(args, "no_browser", False),
+                    timeout=float(getattr(args, "timeout", None) or 300.0),
+                )
+            except RuntimeError as exc:
+                raise SystemExit(str(exc)) from None
+        label = (getattr(args, "label", None) or "").strip() or session_label(sess)
+        entry = PooledCredential(
+            provider=provider,
+            id=uuid.uuid4().hex[:6],
+            label=label,
+            auth_type=AUTH_TYPE_OAUTH,
+            priority=0,
+            source=f"{SOURCE_MANUAL}:grokbot_pkce",
+            access_token=sess.get("accessToken") or "",
+            refresh_token=sess.get("refreshToken") or "",
+            base_url="https://api2.cursor.sh",
+        )
+        pool.add_entry(entry)
+        verb = "Imported" if imported else "Added"
+        print(f'{verb} {provider} PKCE credential #{len(pool.entries())}: "{entry.label}"')
         return
 
     if provider == "qwen-oauth":

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1510,6 +1510,8 @@ _API_MODE_ALIASES = {
     "messages": "anthropic_messages",
     "bedrock": "bedrock_converse",
     "bedrock-converse": "bedrock_converse",
+    "connect_inference": "grokbot",
+    "grok-bot": "grokbot",
 }
 
 

--- a/hermes_cli/grokbot_oauth.py
+++ b/hermes_cli/grokbot_oauth.py
@@ -1,0 +1,35 @@
+"""Grok Bot PKCE for `hermes auth add grokbot`.
+
+Cursor sand loginDeepControl poller. Tokens stay in ~/.grokbot/session.json
+(mode 0600). The credential pool stores a listable copy so `hermes auth list`
+shows grokbot as oauth, not a dummy yaml api_key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.grokbot import login as grokbot_login
+
+
+def existing_session() -> dict[str, Any] | None:
+    sess = grokbot_login._load()
+    if not isinstance(sess, dict):
+        return None
+    if not sess.get("accessToken") or not sess.get("refreshToken"):
+        return None
+    return sess
+
+
+def run_pkce_login(*, open_browser: bool = True, timeout: float = 300.0) -> dict[str, Any]:
+    return grokbot_login.login_session(open_browser=open_browser, timeout=timeout)
+
+
+def session_label(sess: dict[str, Any]) -> str:
+    auth_id = str(sess.get("authId") or "")
+    email = str(sess.get("email") or "")
+    if email:
+        return email
+    if auth_id:
+        return auth_id.split("|", 1)[0] + "|…"
+    return "grokbot-pkce"

--- a/hermes_cli/grokbot_oauth.py
+++ b/hermes_cli/grokbot_oauth.py
@@ -13,7 +13,10 @@ from agent.grokbot import login as grokbot_login
 
 
 def existing_session() -> dict[str, Any] | None:
-    sess = grokbot_login._load()
+    try:
+        sess = grokbot_login._load()
+    except Exception:
+        return None
     if not isinstance(sess, dict):
         return None
     if not sess.get("accessToken") or not sess.get("refreshToken"):

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3341,15 +3341,41 @@ def list_authenticated_providers(
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
                 if hermes_slug in _MODELS_DEV_PREFERRED:
                     model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+        overlay_yaml = None
+        if isinstance(user_providers, dict):
+            overlay_yaml = user_providers.get(hermes_slug) or user_providers.get(pid)
+            if not isinstance(overlay_yaml, dict):
+                overlay_yaml = None
+        if overlay_yaml:
+            yaml_models = _declared_model_ids(overlay_yaml.get("models"))
+            yaml_default = str(
+                overlay_yaml.get("default_model") or overlay_yaml.get("model") or ""
+            ).strip()
+            model_ids = list(dict.fromkeys(
+                ([yaml_default] if yaml_default else []) + yaml_models + list(model_ids or [])
+            ))
+        if not model_ids:
+            # Overlay with no catalog must not claim the slug. Otherwise a
+            # providers.<slug> yaml row is skipped and the picker drops this
+            # empty hermes row.
+            continue
         total = len(model_ids)
         if hermes_slug in _UNCAPPED_PICKER_PROVIDERS:
             top = model_ids  # Aggregator: show full catalog regardless of max_models
         else:
             top = model_ids[:max_models] if max_models is not None else model_ids
 
+        overlay_label = get_label(hermes_slug)
+        if overlay_yaml:
+            overlay_label = coerce_provider_id(overlay_yaml.get("name")) or overlay_label
+        if overlay_label == hermes_slug:
+            _reg = _auth_registry.get(hermes_slug) or _auth_registry.get(pid)
+            if _reg and getattr(_reg, "name", None):
+                overlay_label = _reg.name
+
         results.append({
             "slug": hermes_slug,
-            "name": get_label(hermes_slug),
+            "name": overlay_label,
             "is_current": hermes_slug == current_provider or pid == current_provider,
             "is_user_defined": False,
             "models": top,

--- a/hermes_cli/providers.py
+++ b/hermes_cli/providers.py
@@ -82,6 +82,11 @@ HERMES_OVERLAYS: Dict[str, HermesOverlay] = {
         base_url_override="https://portal.qwen.ai/v1",
         base_url_env_var="HERMES_QWEN_BASE_URL",
     ),
+    "grokbot": HermesOverlay(
+        transport="grokbot",
+        auth_type="oauth_external",
+        base_url_override="https://api2.cursor.sh",
+    ),
     "lmstudio": HermesOverlay(
         transport="openai_chat",
         auth_type="api_key",
@@ -470,6 +475,7 @@ TRANSPORT_TO_API_MODE: Dict[str, str] = {
     "anthropic_messages": "anthropic_messages",
     "codex_responses": "codex_responses",
     "bedrock_converse": "bedrock_converse",
+    "grokbot": "grokbot",
 }
 
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -438,6 +438,8 @@ _VALID_API_MODES = {
     # `model.openai_runtime == "codex_app_server"` AND provider in
     # {"openai", "openai-codex"}. Default is unchanged.
     "codex_app_server",
+    # Unofficial Cursor sand ConnectRPC. Opt-in via providers.grokbot api_mode.
+    "grokbot",
 }
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -5608,6 +5608,9 @@ class AIAgent:
             from agent.moa_loop import build_moa_facade
 
             return build_moa_facade(self, self.model)
+        from agent.transports.grokbot import grokbot_runtime_active, build_grokbot_client
+        if grokbot_runtime_active(self):
+            return build_grokbot_client(self)
         return self._create_openai_client(
             self._client_kwargs,
             reason=reason,
@@ -5730,6 +5733,9 @@ class AIAgent:
 
         primary_client = self._ensure_primary_openai_client(reason=reason)
         if self.provider == "moa":
+            return primary_client
+        from agent.transports.grokbot import grokbot_runtime_active
+        if grokbot_runtime_active(self) or type(primary_client).__name__ in {"GrokBotClient", "GrokbotClient"}:
             return primary_client
         if isinstance(primary_client, Mock):
             return primary_client

--- a/tests/agent/transports/test_grokbot.py
+++ b/tests/agent/transports/test_grokbot.py
@@ -1,0 +1,89 @@
+"""Offline Grok Bot transport tests. No network."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from agent.error_classifier import classify_api_error
+from agent.grokbot.client import openai_messages_to_history, ROLE_ASSISTANT, ROLE_USER
+from agent.transports import get_transport
+from agent.transports.grokbot import grokbot_runtime_active
+from hermes_cli.config import _canonical_api_mode
+from hermes_cli.runtime_provider import _parse_api_mode, _VALID_API_MODES
+
+
+def test_grokbot_is_a_valid_api_mode():
+    assert "grokbot" in _VALID_API_MODES
+    assert _parse_api_mode("grokbot") == "grokbot"
+    assert _canonical_api_mode("grok-bot") == "grokbot"
+    assert _canonical_api_mode("connect_inference") == "grokbot"
+
+
+def test_get_transport_grokbot():
+    t = get_transport("grokbot")
+    assert t is not None
+    assert t.api_mode == "grokbot"
+
+
+def test_runtime_active_by_api_mode_and_provider():
+    assert grokbot_runtime_active(SimpleNamespace(api_mode="grokbot", provider="x", base_url=""))
+    assert grokbot_runtime_active(SimpleNamespace(api_mode="", provider="grokbot", base_url=""))
+    assert grokbot_runtime_active(SimpleNamespace(api_mode="", provider="grok-bot", base_url=""))
+    assert not grokbot_runtime_active(SimpleNamespace(api_mode="chat_completions", provider="openai", base_url=""))
+
+
+def test_runtime_active_exact_hostname_only():
+    assert grokbot_runtime_active(
+        SimpleNamespace(api_mode="", provider="custom", base_url="https://api2.cursor.sh")
+    )
+    assert grokbot_runtime_active(
+        SimpleNamespace(api_mode="", provider="custom", base_url="https://api2.cursor.sh/v1")
+    )
+    assert not grokbot_runtime_active(
+        SimpleNamespace(
+            api_mode="",
+            provider="custom",
+            base_url="https://evil-api2.cursor.sh.example",
+        )
+    )
+    assert not grokbot_runtime_active(
+        SimpleNamespace(api_mode="", provider="custom", base_url="https://api.cursor.com")
+    )
+
+
+def test_openai_history_does_not_stuff_called_tools():
+    prompt, history = openai_messages_to_history(
+        [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "write_file", "arguments": "{}"},
+                    }
+                ],
+            },
+            {"role": "tool", "name": "write_file", "content": "ok"},
+        ]
+    )
+    assert "Called tools:" not in prompt
+    assert "Called tools:" not in "".join(t for _, t in history)
+    assert any(role == ROLE_USER and t.startswith("[SYSTEM]") for role, t in history)
+    assert prompt.startswith("TOOL_RESULT write_file:")
+    assert ROLE_ASSISTANT not in {r for r, t in history if not t}
+
+
+def test_cursor_chat_completions_404_is_not_retried():
+    class Err(Exception):
+        def __init__(self):
+            super().__init__("Error code: 404")
+            self.status_code = 404
+            self.body = {"message": "Route POST:/chat/completions not found", "error": "Not Found"}
+            self.response = SimpleNamespace(headers={})
+
+    classified = classify_api_error(Err(), provider="grokbot", model="grok-4.6")
+    assert classified.retryable is False

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4790,7 +4790,7 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
 
         # Explicit delegation.api_mode in config always wins. Lets users force
         # a transport for non-standard endpoints the URL heuristic can't detect.
-        if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages"}:
+        if configured_api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "grokbot"}:
             api_mode = configured_api_mode
 
         # A provider configured ALONGSIDE base_url means the user wants that


### PR DESCRIPTION
## What does this PR do?

Hermes can talk to Grok Bot's real wire, Cursor sand ConnectRPC, without a localhost OpenAI proxy.

Pointing a stock OpenAI client at `https://api2.cursor.sh` 404s on `/chat/completions` and then retries for minutes. This adds `api_mode: grokbot`. The OpenAI-shaped `client.chat.completions.create` facade packs `POST /aiserver.v1.InferenceService/Stream` with `application/connect+proto`. Auth is PKCE via `hermes auth add grokbot --type oauth`. Tokens stay in `~/.grokbot/session.json` mode 0600.

This is unofficial. It is not xAI and it is not the Cursor Agent SDK. I ran it. If you do not want reverse-engineered Cursor sand in core, close it and I will split the protocol into a plugin. The facade hook in `create_openai_client` still has to live somewhere.

## Related Issue

Fixes #99886

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `agent/grokbot/` vendored Connect client, PKCE login, OpenAI facade
- `agent/transports/grokbot.py` plus `api_mode: grokbot` in the usual registration spots
- `hermes auth add grokbot --type oauth`. API keys are rejected.
- Picker keeps yaml `models:` on the overlay row so an empty models.dev catalog does not hide grokbot
- Cursor `/chat/completions` 404 is not retryable
- Offline tests for api_mode, hostname matching (exact host only), history flatten, and that 404

## How to Test

1. `pytest tests/agent/transports/test_grokbot.py tests/hermes_cli/test_api_mode_aliases.py -o addopts= -q`
2. `hermes auth add grokbot --type oauth`
3. Config:

```yaml
providers:
  grokbot:
    api_mode: grokbot
    base_url: https://api2.cursor.sh
    default_model: grok-4.6
    discover_models: false
    models: [grok-4.6, grok-4.5, default, composer-2.5]
```

4. `hermes chat --provider grokbot --model grok-4.6 --oneshot -q "Reply with exactly: NATIVE_OK"`
5. Quit and relaunch the desktop app after pulling this. A live `hermes serve` will not pick up the transport.

I ran 4 on macOS 27. Session `20260831_174158_592707` returned `NATIVE_RESTART_OK` in 4s. A tool spawn wrote `NATIVE_SPAWN_OK` and returned `DONE`. Nothing listened on `:8931`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (open #91719 is Grok Bot data migration into Bot Mode, a different product)
- [x] My PR contains only changes related to this feature
- [x] Targeted pytest on the new tests plus api_mode aliases: 31 passed
- [x] I've added tests
- [x] I've tested on macOS 27 (desktop + CLI). Did not run the full `pytest tests/ -q` suite in this clone.

### Documentation & Housekeeping

- [ ] Docs. N/A unless you want a provider page after this is accepted
- [ ] `cli-config.yaml.example`. N/A, yaml snippet is in How to Test
- [ ] CONTRIBUTING.md / AGENTS.md. N/A
- [x] Cross-platform: protocol is stdlib urllib. PKCE opens a browser. Session path uses `Path.home() / ".grokbot"`
- [ ] Tool schemas. N/A

## Screenshots / Logs

CLI oneshot, provider=grokbot, base_url=https://api2.cursor.sh, finish_reason=stop, no `/chat/completions` 404.
