### PR TITLE
fix(compression): accept reasoning_content as the summary (supersedes #95231, #98496)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -10814,7 +10814,38 @@ def _call_llm_impl(
         raise
 
 
-def extract_content_or_reasoning(response) -> str:
+def _coerce_llm_message(response):
+    """Pull a message (dict, object, or str) out of a response-or-message value.
+
+    Compression and some OpenAI-compatible proxies hand us a dict-shaped
+    response or a bare message; vision/oneshot callers pass a ChatCompletion
+    object. MagicMock ``reasoning_*`` attrs are not strings — callers that
+    want the empty-content failure path rely on that.
+    """
+    if response is None or isinstance(response, str):
+        return response
+    if isinstance(response, dict):
+        if "choices" not in response:
+            return response
+        choices = response.get("choices") or []
+        if not choices:
+            return None
+        first = choices[0]
+        return first.get("message") if isinstance(first, dict) else getattr(first, "message", None)
+    choices = getattr(response, "choices", None)
+    if not choices:
+        return response
+    first = choices[0]
+    return first.get("message") if isinstance(first, dict) else getattr(first, "message", None)
+
+
+def _message_field(msg, name):
+    if isinstance(msg, dict):
+        return msg.get(name)
+    return getattr(msg, name, None)
+
+
+def extract_content_or_reasoning(response, *, max_reasoning_chars: int | None = None) -> str:
     """Extract content from an LLM response, falling back to reasoning fields.
 
     Mirrors the main agent loop's behavior when a reasoning model (DeepSeek-R1,
@@ -10827,12 +10858,24 @@ def extract_content_or_reasoning(response) -> str:
          structured reasoning fields (DeepSeek, Moonshot, NovitaAI, etc.).
       3. ``message.reasoning_details`` — OpenRouter unified array format.
 
+    Accepts a full response or a bare message (dict or object). When
+    ``max_reasoning_chars`` is set, a reasoning-field fallback is truncated
+    so an unbounded chain-of-thought cannot become the compaction summary.
+
     Returns the best available text, or ``""`` if nothing found.
     """
     import re
 
-    msg = response.choices[0].message
-    content = (msg.content or "").strip()
+    msg = _coerce_llm_message(response)
+    if msg is None:
+        return ""
+    if isinstance(msg, str):
+        return msg.strip()
+
+    raw = _message_field(msg, "content")
+    if not isinstance(raw, str):
+        raw = str(raw) if raw else ""
+    content = raw.strip()
 
     if content:
         # Strip inline think/reasoning blocks (mirrors _strip_think_blocks)
@@ -10848,11 +10891,11 @@ def extract_content_or_reasoning(response) -> str:
     # Content is empty or reasoning-only — try structured reasoning fields
     reasoning_parts: list[str] = []
     for field in ("reasoning", "reasoning_content"):
-        val = getattr(msg, field, None)
+        val = _message_field(msg, field)
         if val and isinstance(val, str) and val.strip() and val not in reasoning_parts:
             reasoning_parts.append(val.strip())
 
-    details = getattr(msg, "reasoning_details", None)
+    details = _message_field(msg, "reasoning_details")
     if details and isinstance(details, list):
         for detail in details:
             if isinstance(detail, dict):
@@ -10864,10 +10907,18 @@ def extract_content_or_reasoning(response) -> str:
                 if summary and summary not in reasoning_parts:
                     reasoning_parts.append(summary.strip() if isinstance(summary, str) else str(summary))
 
-    if reasoning_parts:
-        return "\n\n".join(reasoning_parts)
+    if not reasoning_parts:
+        return ""
 
-    return ""
+    text = "\n\n".join(reasoning_parts)
+    if max_reasoning_chars is not None and len(text) > max_reasoning_chars:
+        logger.warning(
+            "fell back to reasoning fields (%d chars); truncating to %d",
+            len(text),
+            max_reasoning_chars,
+        )
+        return text[:max_reasoning_chars]
+    return text
 
 
 @_relay_auxiliary_call_async

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -33,6 +33,7 @@ from agent.auxiliary_client import (
     _is_connection_error,
     aux_interrupt_protection,
     call_llm,
+    extract_content_or_reasoning,
 )
 from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
@@ -5326,22 +5327,13 @@ This compaction should PRIORITISE preserving all information related to the focu
                 )
             if self._compression_cancelled():
                 raise AuxiliaryExplicitCancellation()
-            # ``_validate_llm_response`` only guarantees ``choices[0].message``
-            # exists, not that it's an object with ``.content``. Some
-            # OpenAI-compatible proxies / local backends return a dict- or
-            # str-shaped message; coerce defensively instead of crashing.
-            if isinstance(response, dict):
-                choices = response.get("choices") or [{}]
-                message = choices[0].get("message") if isinstance(choices[0], dict) else getattr(choices[0], "message", None)
-            else:
-                message = response.choices[0].message
-            if isinstance(message, dict):
-                content = message.get("content")
-            else:
-                content = getattr(message, "content", message)
-            # Handle cases where content is not a string (e.g., dict from llama.cpp)
-            if not isinstance(content, str):
-                content = str(content) if content else ""
+            # Dict/object/str messages + reasoning-field fallback (DeepSeek /
+            # Qwen / Kimi return content="" with the summary in
+            # reasoning_content). Cap the fallback so a CoT dump cannot
+            # become the compaction summary.
+            content = extract_content_or_reasoning(
+                response, max_reasoning_chars=8000
+            )
             # Some OpenAI-compatible proxies (e.g. cmkey.cn, one-api channels)
             # return a well-formed HTTP 200 with an empty or whitespace-only
             # ``content`` instead of an error or empty ``choices``. That payload

--- a/tests/agent/test_context_compressor_reasoning_fallback.py
+++ b/tests/agent/test_context_compressor_reasoning_fallback.py
@@ -1,0 +1,81 @@
+"""Reasoning-model summaries must not trip the empty-content failure path.
+
+Local / thinking backends (DeepSeek, Qwen, Kimi) often return content=""
+with the usable text in reasoning / reasoning_content. _generate_summary
+should accept that via extract_content_or_reasoning, bound the fallback
+so a CoT dump cannot grow the transcript, and still fail closed when
+both fields are empty (#11978).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.context_compressor import ContextCompressor, SUMMARY_PREFIX
+
+
+def _compressor(**overrides):
+    kwargs = dict(model="test/model", quiet_mode=True, tail_mode="legacy")
+    kwargs.update(overrides)
+    with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+        return ContextCompressor(**kwargs)
+
+
+def _turns():
+    return [
+        {"role": "user", "content": "do something"},
+        {"role": "assistant", "content": "ok"},
+    ]
+
+
+def test_empty_content_uses_reasoning_content():
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(
+            content="",
+            reasoning_content="kept reasoning summary",
+        ))]
+    )
+    with patch("agent.context_compressor.call_llm", return_value=response):
+        out = _compressor()._generate_summary(_turns())
+    assert out is not None
+    assert "kept reasoning summary" in out
+    assert out.startswith(SUMMARY_PREFIX)
+
+
+def test_whitespace_content_falls_back_for_dict_and_object():
+    class _Msg:
+        content = " "
+        reasoning_content = "object reasoning"
+
+    for message, needle in (
+        ({"content": " ", "reasoning_content": "dict reasoning"}, "dict reasoning"),
+        (_Msg(), "object reasoning"),
+    ):
+        response = {"choices": [{"message": message}]}
+        with patch("agent.context_compressor.call_llm", return_value=response):
+            out = _compressor()._generate_summary(_turns())
+        assert out is not None
+        assert needle in out
+
+
+def test_oversized_reasoning_fallback_is_truncated():
+    reasoning = "t" * 20_000
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(
+            content="",
+            reasoning_content=reasoning,
+        ))]
+    )
+    with patch("agent.context_compressor.call_llm", return_value=response):
+        out = _compressor()._generate_summary(_turns())
+    assert out is not None
+    assert reasoning not in out
+    assert len(out) < 15_000
+
+
+def test_empty_content_without_reasoning_still_fails():
+    mock_response = MagicMock()
+    mock_response.choices = [MagicMock()]
+    mock_response.choices[0].message.content = None
+    with patch("agent.context_compressor.call_llm", return_value=mock_response):
+        out = _compressor()._generate_summary(_turns())
+    assert out is None

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -177,3 +177,29 @@ class TestExtractContentOrReasoning:
         """When both content and reasoning exist, content wins."""
         response = _make_response("Actual answer", reasoning="Internal reasoning")
         assert extract_content_or_reasoning(response) == "Actual answer"
+
+    def test_dict_message_and_whitespace_fall_back(self):
+        assert extract_content_or_reasoning(
+            {"content": " ", "reasoning_content": "dict reasoning"}
+        ) == "dict reasoning"
+        assert extract_content_or_reasoning(
+            {"choices": [{"message": {"content": "", "reasoning": "from response"}}]}
+        ) == "from response"
+
+    def test_string_message_passthrough(self):
+        response = types.SimpleNamespace(
+            choices=[types.SimpleNamespace(message="plain summary text")]
+        )
+        assert extract_content_or_reasoning(response) == "plain summary text"
+
+    def test_reasoning_fallback_respects_max_chars(self):
+        huge = "t" * 20_000
+        text = extract_content_or_reasoning(
+            {"content": "", "reasoning_content": huge},
+            max_reasoning_chars=8000,
+        )
+        assert text == huge[:8000]
+        assert extract_content_or_reasoning(
+            {"content": "", "reasoning_content": "short"},
+            max_reasoning_chars=8000,
+        ) == "short"


### PR DESCRIPTION
## Summary

Supersedes #95231 and #98496.

Local and thinking summarizers (DeepSeek, Qwen, Kimi) often return `content=""` with the usable text in `reasoning` / `reasoning_content`. Compression treated that as empty, raised, and burned another 100s+ retry — the loop Alex hit after four failed compressions.

This reuses `extract_content_or_reasoning` (widened for dict/object messages) instead of a second extractor, and truncates a reasoning fallback so a chain-of-thought dump cannot become the compaction summary. The wire-level `max_tokens` omit on the summary call stays: that cap is what produced truncated/thinking-only summaries and compaction loops. Growth at commit is already refused by the anti-growth guard.

`_build_chunk_digests` from #98496 is gone on current main, so that half is dropped.

### What was dropped from #95231
- Remaining-context `max_tokens` on the fallback-to-main path (fights the documented NO max_tokens invariant)

## Test plan
- [x] `pytest tests/agent/test_context_compressor_reasoning_fallback.py` — 4 passed
- [x] `pytest tests/tools/test_llm_content_none_guard.py` + empty-content / string-message / no-max-tokens regressions — 11 passed

Credit: @cdepuy (primary). Related: @papxiong6688-bot.