### PR TITLE
fix(desktop): restore the transcript when regenerate is rejected (supersedes #95848)

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -2,12 +2,16 @@ import { renderHook } from '@testing-library/react'
 import { act } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
 import { MAIN_COMPOSER_SCOPE } from './composer/scope'
 
 const requestGatewayMock = vi.hoisted(() => vi.fn())
 
 const { $activeSessionId, $sessions, setSessions } = await import('@/store/session')
-const { $sessionTiles, setSessionTileDelegate } = await import('@/store/session-states')
+const { $sessionStates, $sessionTiles, clearAllSessionStates, publishSessionState, setSessionTileDelegate } =
+  await import('@/store/session-states')
 const { listTileSessionRow, useSessionTileActions } = await import('./session-tile-actions')
 
 const RUNTIME_SESSION_ID = 'rt-tile-current'
@@ -204,5 +208,74 @@ describe('useSessionTileActions sleep/wake session recovery', () => {
     expect(calls[2]?.params).toMatchObject({ session_id: RECOVERED_SESSION_ID })
     expect($sessionTiles.get()[0]?.runtimeId).toBe(RECOVERED_SESSION_ID)
     expect($activeSessionId.get()).toBe('foreground-runtime')
+  })
+})
+
+describe('useSessionTileActions reloadFromMessage failed-submit rollback (#95745)', () => {
+  const seed = [
+    { id: 'u1', parts: [textPart('first')], role: 'user' as const, timestamp: 0 },
+    { id: 'a1', parts: [textPart('reply')], role: 'assistant' as const, timestamp: 1 },
+    { id: 'u2', parts: [textPart('later')], role: 'user' as const, timestamp: 2 },
+    { id: 'a2', parts: [textPart('later reply')], role: 'assistant' as const, timestamp: 3 }
+  ]
+
+  beforeEach(() => {
+    $activeSessionId.set('foreground-runtime')
+    setSessions([])
+    $sessionTiles.set([{ runtimeId: RUNTIME_SESSION_ID, storedSessionId: STORED_SESSION_ID }])
+    publishSessionState(RUNTIME_SESSION_ID, createClientSessionState(STORED_SESSION_ID, seed as never))
+    setSessionTileDelegate({
+      archiveSession: vi.fn(async () => undefined),
+      branchSession: vi.fn(async () => undefined),
+      deleteSession: vi.fn(async () => undefined),
+      executeSlash: vi.fn(async () => undefined),
+      interruptSession: vi.fn(async () => undefined),
+      resumeTile: vi.fn(async () => RUNTIME_SESSION_ID),
+      submitToSession: vi.fn(async () => undefined),
+      updateSession: vi.fn((_runtimeId, updater) => {
+        const current = $sessionStates.get()[RUNTIME_SESSION_ID]
+
+        if (!current) {
+          return undefined
+        }
+
+        const next = updater(current)
+
+        publishSessionState(RUNTIME_SESSION_ID, next)
+
+        return next
+      })
+    })
+  })
+
+  afterEach(() => {
+    $activeSessionId.set(null)
+    setSessions([])
+    $sessionTiles.set([])
+    clearAllSessionStates()
+    requestGatewayMock.mockReset()
+    vi.restoreAllMocks()
+  })
+
+  it('restores the full tile transcript when regenerate is rejected', async () => {
+    requestGatewayMock.mockImplementation(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new Error('target user message is no longer in session history')
+      }
+
+      return {}
+    })
+
+    const { result } = renderTileActions()
+
+    await act(async () => {
+      await result.current.reloadFromMessage('u1')
+    })
+
+    const rolledBack = $sessionStates.get()[RUNTIME_SESSION_ID]?.messages
+
+    expect(rolledBack?.map(m => m.id)).toEqual(['u1', 'a1', 'u2', 'a2'])
+    expect(rolledBack?.some(m => m.hidden)).toBe(false)
+    expect($sessionStates.get()[RUNTIME_SESSION_ID]?.busy).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -504,6 +504,8 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
         return
       }
 
+      const messages = state.messages
+
       update(current => applyReloadOptimistic(current, plan))
 
       try {
@@ -518,11 +520,20 @@ export function useSessionTileActions({ requestGateway, runtimeId, scope, stored
             plan.truncateMessageId,
             plan.truncateRowId,
             plan.sourceText,
-            durableRowIdsForRebind(state.messages)
+            durableRowIdsForRebind(messages)
           )
         )
       } catch (err) {
-        update(current => ({ ...current, busy: false, awaitingResponse: false, turnLive: false, turnStartedAt: null }))
+        // Mirror the primary-chat reload catch: optimistic hide/truncate
+        // must roll back when the submit is rejected (#95745).
+        update(current => ({
+          ...current,
+          busy: false,
+          awaitingResponse: false,
+          turnLive: false,
+          turnStartedAt: null,
+          messages
+        }))
         notifyError(err, copy.regenerateFailed)
       }
     },

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -5706,3 +5706,67 @@ describe('usePromptActions editMessage stale-target recovery (#82462)', () => {
     ).toBeUndefined()
   })
 })
+
+describe('usePromptActions reloadFromMessage failed-submit rollback (#95745)', () => {
+  afterEach(() => {
+    cleanup()
+    clearNotifications()
+    setMessages([])
+    $busy.set(false)
+  })
+
+  it('restores the full transcript when regenerate is rejected', async () => {
+    $busy.set(false)
+
+    const seed = [
+      { id: 'u1', parts: [textPart('first')], role: 'user' as const, timestamp: 0 },
+      { id: 'a1', parts: [textPart('reply')], role: 'assistant' as const, timestamp: 1 },
+      { id: 'u2', parts: [textPart('later')], role: 'user' as const, timestamp: 2 },
+      { id: 'a2', parts: [textPart('later reply')], role: 'assistant' as const, timestamp: 3 }
+    ]
+
+    setMessages(seed as never)
+
+    let latest: Record<string, unknown> | undefined
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'prompt.submit') {
+        throw new JsonRpcGatewayError('target user message is no longer in session history', {
+          code: 4018,
+          data: {
+            ordinal: 0,
+            prefix_user_count: 1,
+            segment_ordinal: -1,
+            user_turn_count: 2
+          }
+        })
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | undefined
+
+    await actRender(
+      <Harness
+        onReady={h => {
+          handle = h
+        }}
+        onSeedState={next => {
+          latest = next
+        }}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        seedMessages={seed}
+      />
+    )
+
+    await handle!.reloadFromMessage('u1')
+
+    const rolledBack = latest?.messages as Array<{ hidden?: boolean; id: string }> | undefined
+
+    expect(rolledBack?.map(m => m.id)).toEqual(['u1', 'a1', 'u2', 'a2'])
+    expect(rolledBack?.some(m => m.hidden)).toBe(false)
+    expect(latest?.busy).toBe(false)
+    expect(latest?.awaitingResponse).toBe(false)
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -932,12 +932,16 @@ export function usePromptActions({
 
         applySurvivorRowIds(sessionId, survivorRowIds)
       } catch (err) {
+        // Same rollback as restoreToMessage below: applyReloadOptimistic
+        // already hid/truncated the transcript, and leaving that in place
+        // after a rejected submit is what blanked the chat (#95745).
         updateSessionState(sessionId, state => ({
           ...state,
           busy: false,
           awaitingResponse: false,
           turnLive: false,
-          turnStartedAt: null
+          turnStartedAt: null,
+          messages
         }))
         notifyError(err, copy.regenerateFailed)
       }


### PR DESCRIPTION
## Summary

Supersedes #95848. Closes #95745.

Desktop hid/truncated the transcript for an optimistic regenerate, then on a rejected submit (provider error, or "target user message is no longer in session history") reset only the busy flags. The saved chat was fine; switching away and back reloaded it. `restoreToMessage` already rolled `messages` back in the same file.

Same restore on the session-tile `reloadFromMessage` path, which the old PR missed. The mirror-of-the-merge-object test is dropped in favor of driving the real catch.

## Test plan
- [x] Hook test: `reloadFromMessage` + rejected `prompt.submit` restores the pre-optimistic message ids
- [x] Tile test: same rollback through `useSessionTileActions`

Credit: @ygd58 (primary).