### PR TITLE
fix(desktop): stop dead runtimes from stealing composer focus (supersedes #97874)

### DIFF
--- a/apps/desktop/src/app/chat/composer/status-stack/index.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/index.tsx
@@ -21,7 +21,6 @@ import {
   dismissBackgroundProcess,
   groupStatusItems,
   refreshBackgroundProcesses,
-  resetBackgroundPollingGuard,
   type StatusGroup,
   stopBackgroundProcess
 } from '@/store/composer-status'
@@ -103,13 +102,15 @@ export function ComposerStatusStack({ queue, sessionId }: ComposerStatusStackPro
   const groups = useMemo(() => groupStatusItems(items), [items])
 
   // Seed from the registry on session open; event-driven refreshes (terminal /
-  // process tool completions) live in use-message-stream.
+  // process tool completions) live in use-message-stream. This must NOT reset
+  // the gone-polling latch: a mount/remount is not proof of a fresh runtime
+  // binding (a boot-restored tile can remount repeatedly while still bound to
+  // a dead runtime id), so clearing it here re-arms an endless 4001 storm
+  // against that id. The latch is reset at the actual rebind seams instead —
+  // gateway reconnect and runtime re-mint (see resetBackgroundPollingGuard
+  // call sites in use-gateway-boot.ts and store/gateway.ts).
   useEffect(() => {
     if (sessionId) {
-      // Opening/rebinding a session is a fresh runtime binding: clear any
-      // gone-latch left by a previous runtime under this id so the poll below
-      // is allowed to run again (see resetBackgroundPollingGuard).
-      resetBackgroundPollingGuard(sessionId)
       void refreshBackgroundProcesses(sessionId)
       void refreshSessionGoal(sessionId)
     }

--- a/apps/desktop/src/app/chat/composer/status-stack/polling-guard.test.tsx
+++ b/apps/desktop/src/app/chat/composer/status-stack/polling-guard.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { resetBackgroundPollingGuard } from '@/store/composer-status'
+import { $gateway } from '@/store/gateway'
+
+import { ComposerStatusStack } from './index'
+
+// The stack measures itself into a surface var — jsdom has no ResizeObserver.
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+vi.stubGlobal('ResizeObserver', ResizeObserverStub)
+
+const SID = 'sess-dead-runtime'
+
+function renderStack() {
+  return render(
+    <MemoryRouter>
+      <I18nProvider configClient={null} initialLocale="en">
+        <ComposerStatusStack queue={null} sessionId={SID} />
+      </I18nProvider>
+    </MemoryRouter>
+  )
+}
+
+// #98434: a boot-restored tile can stay bound to a dead runtime id and remount
+// repeatedly (no genuine rebind ever happens). The mount effect used to clear
+// the gone-polling latch on every mount, so each remount re-armed the 4001
+// storm against that id forever.
+describe('ComposerStatusStack dead-runtime remount', () => {
+  beforeEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  afterEach(() => {
+    cleanup()
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('does not re-poll process.list after a remount once the session is latched gone', async () => {
+    const request = vi.fn(async (method: string) => {
+      if (method === 'process.list') {
+        throw new Error('session not found')
+      }
+
+      return {}
+    })
+
+    const processListCalls = () => request.mock.calls.filter(([method]) => method === 'process.list').length
+
+    $gateway.set({ request } as never)
+
+    const first = renderStack()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(processListCalls()).toBe(1)
+
+    first.unmount()
+
+    const second = renderStack()
+    await Promise.resolve()
+    await Promise.resolve()
+
+    // Before the fix: the mount effect cleared the latch, so this remount
+    // re-fired process.list against the same dead id.
+    expect(processListCalls()).toBe(1)
+
+    second.unmount()
+  })
+})

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -23,10 +23,16 @@ vi.mock('@/store/gateway', async importActual => ({
 }))
 
 const probe = vi.hoisted(() => ({ resolveSessionOwner: vi.fn(async () => undefined as unknown) }))
+const sessionMocks = vi.hoisted(() => ({ requestSessionResume: vi.fn() }))
 
 vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => ({
   ...(await importActual<Record<string, unknown>>()),
   resolveSessionOwner: probe.resolveSessionOwner
+}))
+
+vi.mock('@/store/session', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  requestSessionResume: sessionMocks.requestSessionResume
 }))
 
 const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
@@ -40,13 +46,16 @@ const { isSessionOwnerResolutionError } = await import('@/store/session-owner-re
 const { $sessionTiles } = await import('@/store/session-states')
 const { makeSessionInfo } = await import('@/test/session-info')
 
-function dispatcher(ambientRequest = vi.fn(async () => ({ ambient: true }))) {
+function dispatcher(
+  ambientRequest = vi.fn(async () => ({ ambient: true })),
+  selectedStoredSessionId: null | string = null
+) {
   return {
     ambientRequest,
     request: createSessionRpcDispatcher({
       ambientRequest: ambientRequest as never,
       runtimeIdByStoredSessionIdRef: { current: new Map([['stored-omar', 'rt-omar']]) },
-      selectedStoredSessionIdRef: { current: null },
+      selectedStoredSessionIdRef: { current: selectedStoredSessionId },
       sessionStateByRuntimeIdRef: { current: new Map() }
     })
   }
@@ -67,6 +76,7 @@ afterEach(() => {
   $sessionTiles.set([])
   $profiles.set([])
   _resetSessionOwnerHintsForTests({ storage: true })
+  sessionMocks.requestSessionResume.mockReset()
   vi.clearAllMocks()
 })
 
@@ -192,5 +202,60 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
       session_id: 'stored-tg',
       text: 'hi'
     })
+  })
+})
+
+describe('createSessionRpcDispatcher: stale runtime recovery', () => {
+  it('requests a durable rebind for the visible session after a structured 4001', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(
+      Object.assign(new Error('runtime was reaped'), { code: 4001 })
+    )
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow('runtime was reaped')
+
+    expect(sessionMocks.requestSessionResume).toHaveBeenCalledWith('stored-omar', {
+      connectionId: 'local',
+      profile: 'omar'
+    })
+  })
+
+  it('does not let a background 4001 pull a different session into the foreground', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(
+      Object.assign(new Error('session not found'), { code: 4001 })
+    )
+    const { request } = dispatcher(undefined, 'stored-other')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow('session not found')
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('does not interpret an unrelated coded RPC failure as a stale runtime', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(
+      Object.assign(new Error('tool output says session not found'), { code: 5007 })
+    )
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('process.list', { session_id: 'rt-omar' })).rejects.toThrow(
+      'tool output says session not found'
+    )
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
+  })
+
+  it('leaves the warm resume lifecycle to recover its own session.activate failure', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(
+      Object.assign(new Error('session not found'), { code: 4001 })
+    )
+    const { request } = dispatcher(undefined, 'stored-omar')
+
+    await expect(request('session.activate', { session_id: 'rt-omar' })).rejects.toThrow('session not found')
+
+    expect(sessionMocks.requestSessionResume).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -35,7 +35,8 @@ import type { MutableRefObject } from 'react'
 
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
-import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
+import { isSessionGoneForBackgroundPolling } from '@/store/runtime-gone'
+import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows, requestSessionResume } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
@@ -97,6 +98,26 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     // backend "session not found" on a backend that never held the runtime.
     assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
 
-    return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    try {
+      return await requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    } catch (error) {
+      // A missed session.reclaimed leaves later RPCs answering 4001 against a
+      // still-resumable stored row. Prompt actions already retry their own
+      // calls; this seam covers the other session-scoped callers and wakes
+      // route-resume for the visible main session only. Do not retry the
+      // failing RPC — it may be destructive, and a fresh binding is async.
+      if (
+        method !== 'session.resume' &&
+        method !== 'session.activate' &&
+        paramSessionId &&
+        routingSessionId &&
+        routingSessionId === selectedStoredSessionIdRef.current &&
+        isSessionGoneForBackgroundPolling(error)
+      ) {
+        requestSessionResume(routingSessionId, typeof owner === 'object' && owner ? owner : undefined)
+      }
+
+      throw error
+    }
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/lifecycle.ts
@@ -9,6 +9,7 @@ import {
   type PetChangeMeta,
   setChangeEventsAvailable
 } from '@/store/live-sync'
+import { markRuntimeGone } from '@/store/runtime-gone'
 import { dropSessionState, unbindTileRuntime } from '@/store/session-states'
 // Leaf import (not the `@/themes` barrel) to avoid pulling the ThemeProvider
 // module graph into the gateway event hot path.
@@ -80,6 +81,8 @@ export function handleLifecycleEvent(ctx: GatewayEventContext): boolean {
     const reclaimedRuntimeId = String((payload as { session_id?: string } | undefined)?.session_id ?? '')
 
     if (reclaimedRuntimeId) {
+      // Heal while the cached stored-id mapping is still intact, then drop.
+      markRuntimeGone(reclaimedRuntimeId)
       dropSessionState(reclaimedRuntimeId)
       // A tile bound to the reclaimed runtime would otherwise render an
       // empty transcript forever: its view reads $sessionStates[runtime]

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import type { ClientSessionState } from '@/app/types'
+import { createClientSessionState } from '@/lib/chat-runtime'
 import {
   $currentCwd,
   $selectedStoredSessionId,
@@ -104,5 +106,44 @@ describe('handleSessionInfoEvent workspace ownership', () => {
 
     expect($currentCwd.get()).toBe('/repo/mine')
     expect($workspaceCwdOwner.get()).toBe('selected-session')
+  })
+
+  it('keeps runtime state identity when a heartbeat only restates cached fields', () => {
+    const original = {
+      ...createClientSessionState('stored-1'),
+      cwd: '/repo/mine',
+      fast: true,
+      model: 'model-1',
+      provider: 'provider-1'
+    }
+
+    const ctx = sessionInfoEvent({
+      activeSessionId: 'runtime-1',
+      cwd: '/repo/mine',
+      explicitSid: 'runtime-1',
+      storedSessionId: 'stored-1'
+    })
+
+    let next: ClientSessionState | undefined
+
+    ctx.payload = {
+      ...ctx.payload,
+      fast: true,
+      model: 'model-1',
+      provider: 'provider-1'
+    }
+    ctx.deps.sessionStateByRuntimeIdRef.current.set('runtime-1', original)
+    ctx.deps.updateSessionState = vi.fn(
+      (_sessionId: string, updater: (state: ClientSessionState) => ClientSessionState) => {
+        const updated = updater(original)
+        next = updated
+
+        return updated
+      }
+    )
+
+    handleSessionInfoEvent(ctx)
+
+    expect(next).toBe(original)
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/session-info.ts
@@ -28,7 +28,12 @@ import {
 import { reportInstallMethodWarning } from '@/store/updates'
 
 import { finalizeInterruptedMessages } from '../../use-prompt-actions/rewind'
-import { hasSessionInfoStatePatch, PRE_TURN_LIVE_SETTLE_GRACE_MS, sessionInfoStatePatch } from '../utils'
+import {
+  applySessionInfoStatePatch,
+  hasSessionInfoStatePatch,
+  PRE_TURN_LIVE_SETTLE_GRACE_MS,
+  sessionInfoStatePatch
+} from '../utils'
 
 import type { GatewayEventContext } from './types'
 
@@ -253,12 +258,7 @@ export function handleSessionInfoEvent(ctx: GatewayEventContext): boolean {
     if (sessionId && hasStatePatch) {
       updateSessionState(
         sessionId,
-        state => ({
-          ...state,
-          ...statePatch,
-          branch: statePatch.branch ?? state.branch,
-          cwd: statePatch.cwd ?? state.cwd
-        }),
+        state => applySessionInfoStatePatch(state, statePatch),
         payload?.stored_session_id || undefined
       )
     }

--- a/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx
@@ -4,6 +4,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type { ClientSessionState } from '@/app/types'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { resetRuntimeGoneHealing } from '@/store/runtime-gone'
+import { $activeSessionId, $sessionResumeRequest } from '@/store/session'
 import { $sessionStates, $sessionTiles, publishSessionState } from '@/store/session-states'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -36,14 +38,20 @@ const reclaim = (sessionId: string, reason = 'ws_orphan_reap') =>
 
 beforeEach(() => {
   queryClient = new QueryClient()
+  resetRuntimeGoneHealing()
   $sessionStates.set({})
   $sessionTiles.set([])
+  $activeSessionId.set(null)
+  $sessionResumeRequest.set(null)
 })
 
 afterEach(() => {
   cleanup()
+  resetRuntimeGoneHealing()
   $sessionStates.set({})
   $sessionTiles.set([])
+  $activeSessionId.set(null)
+  $sessionResumeRequest.set(null)
   vi.restoreAllMocks()
 })
 
@@ -128,5 +136,26 @@ describe('session.reclaimed', () => {
 
     expect(wiringCache.has('live-gone')).toBe(false)
     expect(wiringCache.has('live-kept')).toBe(true)
+  })
+
+  it('requests a durable resume when the reclaimed runtime is the active chat', () => {
+    mountStream()
+    $activeSessionId.set('live-gone')
+    publishSessionState('live-gone', createClientSessionState('stored-1'))
+
+    reclaim('live-gone')
+
+    expect($sessionResumeRequest.get()?.sessionId).toBe('stored-1')
+  })
+
+  it('does not navigate the primary chat when a background runtime is reclaimed', () => {
+    mountStream()
+    $activeSessionId.set('live-kept')
+    publishSessionState('live-gone', createClientSessionState('stored-1'))
+    publishSessionState('live-kept', createClientSessionState('stored-2'))
+
+    reclaim('live-gone')
+
+    expect($sessionResumeRequest.get()).toBeNull()
   })
 })

--- a/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/utils.ts
@@ -56,6 +56,30 @@ export function hasSessionInfoStatePatch(patch: SessionRuntimeStatePatch): boole
   return Object.keys(patch).length > 0
 }
 
+/** Keep the runtime-state object when a heartbeat only restates cached fields.
+ *  `$sessionStates` feeds every mounted session surface, so an equivalent spread
+ *  re-renders them all at the heartbeat cadence. */
+export function applySessionInfoStatePatch(
+  state: ClientSessionState,
+  patch: SessionRuntimeStatePatch
+): ClientSessionState {
+  if (
+    (patch.branch === undefined || patch.branch === state.branch) &&
+    (patch.cwd === undefined || patch.cwd === state.cwd) &&
+    (patch.fast === undefined || patch.fast === state.fast) &&
+    (patch.model === undefined || patch.model === state.model) &&
+    (patch.personality === undefined || patch.personality === state.personality) &&
+    (patch.provider === undefined || patch.provider === state.provider) &&
+    (patch.reasoningEffort === undefined || patch.reasoningEffort === state.reasoningEffort) &&
+    (patch.serviceTier === undefined || patch.serviceTier === state.serviceTier) &&
+    (patch.yolo === undefined || patch.yolo === state.yolo)
+  ) {
+    return state
+  }
+
+  return { ...state, ...patch }
+}
+
 // Minimum gap between two assistant-text flushes during a stream. Was 16ms
 // (rAF only), which at typical LLM token rates of ~30-80 tok/sec meant every
 // token got its own React commit + Streamdown markdown re-parse, scaling

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -1891,14 +1891,12 @@ describe('usePromptActions submit / queue drain semantics', () => {
     )
 
     expect(await handle!.submitText('continue remotely')).toBe(true)
-    expect(requestGatewayForAgent).toHaveBeenCalledWith(
-      'hermes01',
-      'default',
+    expect(ambientRequest).toHaveBeenCalledWith(
       'prompt.submit',
       { session_id: 'runtime-remote', text: 'continue remotely' },
       1_800_000
     )
-    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(requestGatewayForAgent).not.toHaveBeenCalled()
   })
 
   it('clears a leftover interrupted flag on a fresh submit (so the new turn streams)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -22,17 +22,14 @@ import {
   updateComposerAttachment
 } from '@/store/composer'
 import { resetSessionBackground } from '@/store/composer-status'
-import { requestGatewayForAgent } from '@/store/gateway'
 import { clearNotifications, notify, notifyError } from '@/store/notifications'
 import { clearPreviewArtifacts } from '@/store/preview-status'
 import { clearAllPrompts } from '@/store/prompts'
 import {
   $busy,
-  $connection,
   $currentCwd,
   $messages,
   $terminalBackend,
-  getSessionOwnerHint,
   setActiveSessionId,
   setAwaitingResponse,
   setBusy,
@@ -486,30 +483,6 @@ export function usePromptActions({
     }
   }, [activeSessionId, composerAttachments, eagerlyUploadAttachment])
 
-  // Session resume can be routed through a registry connection while the
-  // render-time requestGateway still points at the local default socket. Keep
-  // every follow-up session RPC on the same composite owner; otherwise resume
-  // succeeds on HERMES01 and prompt.submit immediately fails locally with
-  // "session not found".
-  const requestForPromptSession = useCallback<GatewayRequest>(
-    (method, params = {}, timeoutMs) => {
-      const storedSessionId = selectedStoredSessionIdRef.current
-      const owner = storedSessionId ? getSessionOwnerHint(storedSessionId) : undefined
-      const ambientConnection = $connection.get()
-
-      const connectionId =
-        owner?.connectionId ||
-        (ambientConnection?.mode === 'remote' ? ambientConnection.connectionId?.trim() || '' : '')
-
-      if (connectionId) {
-        return requestGatewayForAgent(connectionId, owner?.profile || 'default', method, params, timeoutMs)
-      }
-
-      return timeoutMs === undefined ? requestGateway(method, params) : requestGateway(method, params, timeoutMs)
-    },
-    [requestGateway, selectedStoredSessionIdRef]
-  )
-
   const submitPromptText = useSubmitPrompt({
     activeSessionIdRef,
     busyRef,
@@ -518,7 +491,9 @@ export function usePromptActions({
     getRoutedStoredSessionId,
     getRuntimeIdForStoredSession,
     getRouteToken,
-    requestGateway: requestForPromptSession,
+    // Window dispatcher: exact owner + turn lease through the terminal event.
+    // A private requestGatewayForAgent wrapper released the only client at ACK.
+    requestGateway,
     runtimeIdByStoredSessionIdRef,
     resumeStoredSession,
     selectedStoredSessionIdRef,

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -1,4 +1,3 @@
-import { JsonRpcGatewayError } from '@hermes/shared'
 import { atom, computed } from 'nanostores'
 
 import { translateNow } from '@/i18n'
@@ -9,11 +8,18 @@ import { $gateway } from './gateway'
 import { $goalsBySession, type GoalStatus } from './goals'
 import { dispatchNativeNotification } from './native-notifications'
 import { notifyError } from './notifications'
-import { markRuntimeGone, noteRuntimeAlive } from './runtime-gone'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone, noteRuntimeAlive } from './runtime-gone'
 import { $sessions, lineageAliases } from './session'
 import { $sessionStates } from './session-states'
 import { $subagentsBySession, type SubagentProgress } from './subagents'
 import { $todosBySession } from './todos'
+
+export {
+  isSessionGone,
+  isSessionGoneForBackgroundPolling,
+  markSessionGone,
+  resetBackgroundPollingGuard
+} from './runtime-gone'
 
 /** Composer status stack feed — merged todos, subagents, background per session. */
 export type StatusItemState = 'done' | 'failed' | 'running'
@@ -386,55 +392,11 @@ export function reconcileBackgroundProcesses(sid: string, procs: GatewayProcessE
   writeBackground(sid, next)
 }
 
-/** Session ids the gateway has told us are gone. A session-scoped RPC against a
- *  runtime the gateway no longer holds fails 4001 "session not found" — a
- *  TERMINAL condition, not the transient socket loss the catch below assumes.
- *
- *  The status stack re-polls `process.list` every 5s while a running row is on
- *  screen, so treating 4001 as transient meant re-sending the same dead id
- *  forever: one runtime id accumulated 18,614 gateway rejections in a single day
- *  (#94219 fallout). Latch the id here and skip it until something rebinds it. */
-const goneSessions = new Set<string>()
-
-/** Gateway JSON-RPC code for "session not found" (tui_gateway _sess_nowait). */
-const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
-
-/** A gone session is unrecoverable for THIS runtime id; a timeout or transport
- *  blip is not. Only the former may stop the poll — misclassifying a transient
- *  failure would silently freeze the status stack on a healthy session.
- *
- *  Match the gateway's 4001 code when the error carries one (JsonRpcGatewayError
- *  from a structured RPC rejection) — a message substring alone could latch on
- *  an unrelated error class that merely mentions "session not found" (e.g. a
- *  wrapped tool/report string). The message fallback survives only for errors
- *  with no numeric code at all, where the frame's structure was lost. */
-export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
-  if (error instanceof JsonRpcGatewayError && typeof error.code === 'number') {
-    return error.code === GATEWAY_SESSION_NOT_FOUND_CODE
-  }
-
-  const message = error instanceof Error ? error.message : String(error ?? '')
-
-  return /session not found/i.test(message)
-}
-
-/** Clear the gone-latch. Called with a session id when a fresh runtime binds to
- *  it (so polling resumes), or with no argument to reset everything (tests). */
-export function resetBackgroundPollingGuard(sid?: string): void {
-  if (sid) {
-    goneSessions.delete(sid)
-
-    return
-  }
-
-  goneSessions.clear()
-}
-
 /** Pull the session's live process snapshot from the gateway. */
 export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
-  if (!sid || !gateway || goneSessions.has(sid)) {
+  if (!sid || !gateway || isSessionGone(sid)) {
     return
   }
 
@@ -449,12 +411,7 @@ export async function refreshBackgroundProcesses(sid: string): Promise<void> {
     // A gone session never comes back under this runtime id: stop polling it,
     // or the 5s timer hammers the gateway with 4001s for the window's lifetime.
     if (isSessionGoneForBackgroundPolling(error)) {
-      goneSessions.add(sid)
-      // Latching stops the storm; it does not make the window usable again.
-      // This poll is the only caller that runs while the user is idle, so it is
-      // the only one that can carry the gateway's "resume the stored session"
-      // verdict to the view before the user types into a dead binding.
-      markRuntimeGone(sid)
+      markSessionGone(sid)
 
       return
     }

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1225,6 +1225,13 @@ export async function retainGatewayForSessionTurn(
   profile: string,
   sessionId: string
 ): Promise<() => void> {
+  // Primary events do not flow through a Secondary's terminal-event listener.
+  // Registering a no-op lease here would leave a phantom key that can suppress
+  // the real hold if this route is later re-homed as a secondary.
+  if (isPrimaryRegistryRoute(connectionId, normKey(profile))) {
+    return () => undefined
+  }
+
   const scope = registryBackendScopeKey(connectionId, normKey(profile))
   const key = turnLeaseKey(scope, sessionId)
 

--- a/apps/desktop/src/store/goals.test.ts
+++ b/apps/desktop/src/store/goals.test.ts
@@ -1,6 +1,8 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { $goalsBySession, applyGoalStatusText, clearSessionGoal } from './goals'
+import { $gateway } from './gateway'
+import { $goalsBySession, applyGoalStatusText, clearSessionGoal, refreshSessionGoal } from './goals'
+import { resetBackgroundPollingGuard } from './runtime-gone'
 
 describe('goal store', () => {
   afterEach(() => {
@@ -106,5 +108,39 @@ describe('goal store', () => {
     applyGoalStatusText('s2', '⏸ Goal (paused, 20/20 turns): other work', { hydrate: true })
 
     expect($goalsBySession.get().s2).toMatchObject({ status: 'paused', title: 'other work' })
+  })
+})
+
+describe('refreshSessionGoal dead-session guard', () => {
+  afterEach(() => {
+    $gateway.set(null as never)
+    resetBackgroundPollingGuard()
+  })
+
+  it('stops re-asking a runtime the gateway no longer holds', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('session not found')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshSessionGoal('dead-1')
+    await refreshSessionGoal('dead-1')
+    await refreshSessionGoal('dead-1')
+
+    expect(request).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not latch on a transient failure', async () => {
+    const request = vi.fn(async () => {
+      throw new Error('request timed out after 30s: slash.exec')
+    })
+
+    $gateway.set({ request } as never)
+
+    await refreshSessionGoal('s1')
+    await refreshSessionGoal('s1')
+
+    expect(request).toHaveBeenCalledTimes(2)
   })
 })

--- a/apps/desktop/src/store/goals.ts
+++ b/apps/desktop/src/store/goals.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import { keyedTimeouts } from '@/lib/keyed-timeouts'
 
 import { $gateway } from './gateway'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './runtime-gone'
 
 export type GoalStatus = 'active' | 'done' | 'paused' | 'waiting'
 
@@ -163,7 +164,7 @@ export function applyGoalStatusText(sid: string, text: string, opts?: { hydrate?
 export async function refreshSessionGoal(sid: string): Promise<void> {
   const gateway = $gateway.get()
 
-  if (!sid || !gateway) {
+  if (!sid || !gateway || isSessionGone(sid)) {
     return
   }
 
@@ -171,7 +172,13 @@ export async function refreshSessionGoal(sid: string): Promise<void> {
     const result = await gateway.request<{ output?: string }>('slash.exec', { command: 'goal status', session_id: sid })
 
     applyGoalStatusText(sid, result?.output ?? '', { hydrate: true })
-  } catch {
-    // Best-effort: older gateways or detached sessions simply won't hydrate it.
+  } catch (error) {
+    if (isSessionGoneForBackgroundPolling(error)) {
+      markSessionGone(sid)
+
+      return
+    }
+
+    // Best-effort: older gateways or a transport blip simply won't hydrate it.
   }
 }

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -16,6 +16,7 @@ import {
   setSecretRequest,
   setSudoRequest
 } from './prompts'
+import { resetBackgroundPollingGuard } from './runtime-gone'
 import { $activeSessionId } from './session'
 
 // Prompts are parked per-session; the exported $*Request views are scoped to the
@@ -216,5 +217,94 @@ describe('$activeSessionAwaitingInput', () => {
 
     $activeSessionId.set('s2')
     expect($activeSessionAwaitingInput.get()).toBe(true)
+  })
+})
+
+describe('pending approval replay backoff', () => {
+  afterEach(() => {
+    resetBackgroundPollingGuard()
+  })
+
+  it('stops polling a runtime the gateway no longer holds', async () => {
+    const calls: string[] = []
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+        throw new Error('4001: session not found')
+      }
+    }
+
+    for (let i = 0; i < 5; i++) {
+      await replayPendingApproval(gateway, 'dead-1')
+    }
+
+    expect(calls).toEqual(['approval.pending'])
+  })
+
+  it('keeps polling every other runtime', async () => {
+    const calls: string[] = []
+
+    const gateway = {
+      request: async (_method: string, params: Record<string, unknown>) => {
+        calls.push(String(params.session_id))
+
+        if (params.session_id === 'dead-1') {
+          throw new Error('4001: session not found')
+        }
+
+        return { approvals: [] }
+      }
+    }
+
+    await replayPendingApproval(gateway, 'dead-1')
+    await replayPendingApproval(gateway, 'dead-1')
+    await replayPendingApproval(gateway, 'alive-1')
+    await replayPendingApproval(gateway, 'alive-1')
+
+    expect(calls).toEqual(['dead-1', 'alive-1', 'alive-1'])
+  })
+
+  it('does not latch on a transient failure', async () => {
+    const calls: string[] = []
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+        throw new Error('websocket disconnected')
+      }
+    }
+
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+    await replayPendingApproval(gateway, 's1').catch(() => undefined)
+
+    expect(calls).toHaveLength(2)
+  })
+
+  it('polls again once the gone-latch is cleared', async () => {
+    const calls: string[] = []
+    let dead = true
+
+    const gateway = {
+      request: async (method: string) => {
+        calls.push(method)
+
+        if (dead) {
+          throw new Error('4001: session not found')
+        }
+
+        return { approvals: [] }
+      }
+    }
+
+    await replayPendingApproval(gateway, 's1')
+    await replayPendingApproval(gateway, 's1')
+    expect(calls).toHaveLength(1)
+
+    dead = false
+    resetBackgroundPollingGuard()
+    await replayPendingApproval(gateway, 's1')
+
+    expect(calls).toHaveLength(2)
   })
 })

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -1,6 +1,7 @@
 import { atom, computed, type ReadableAtom } from 'nanostores'
 
 import { $clarifyRequest, $clarifyRequests } from './clarify'
+import { isSessionGone, isSessionGoneForBackgroundPolling, markSessionGone } from './runtime-gone'
 import { $activeSessionId } from './session'
 
 // Blocking interactive prompts the gateway raises mid-turn. Each maps to a
@@ -127,13 +128,25 @@ export async function receiveApprovalRequest(gateway: ApprovalGateway | null, re
 }
 
 export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
-  if (!gateway || !sessionId) {
+  if (!gateway || !sessionId || isSessionGone(sessionId)) {
     return
   }
 
-  const rawResult = await gateway.request('approval.pending', {
-    session_id: sessionId
-  })
+  let rawResult: unknown
+
+  try {
+    rawResult = await gateway.request('approval.pending', {
+      session_id: sessionId
+    })
+  } catch (error) {
+    if (isSessionGoneForBackgroundPolling(error)) {
+      markSessionGone(sessionId)
+
+      return
+    }
+
+    throw error
+  }
 
   const result =
     rawResult && typeof rawResult === 'object' ? (rawResult as { approvals?: PendingApprovalPayload[] }) : {}

--- a/apps/desktop/src/store/runtime-gone.ts
+++ b/apps/desktop/src/store/runtime-gone.ts
@@ -1,15 +1,74 @@
 import { $activeSessionId, requestSessionResume } from './session'
 import { $sessionStates, $sessionTiles, unbindTileRuntime } from './session-states'
 
+/** Session ids the gateway has told us are gone. A session-scoped RPC against a
+ *  runtime the gateway no longer holds fails 4001 "session not found" — terminal
+ *  for THIS runtime id, not a transient socket loss.
+ *
+ *  Shared by every background poller (process.list, approval.pending, goal
+ *  status). One set, one clear path: a fresh-runtime rebind calls
+ *  {@link resetBackgroundPollingGuard} and every poller resumes. */
+const goneSessions = new Set<string>()
+
+/** Gateway JSON-RPC code for "session not found" (tui_gateway `_sess_nowait`). */
+const GATEWAY_SESSION_NOT_FOUND_CODE = 4001
+
+/** A gone session is unrecoverable for THIS runtime id; a timeout or transport
+ *  blip is not. Only the former may stop a poll — misclassifying a transient
+ *  failure would silently freeze a healthy session.
+ *
+ *  Match the gateway's 4001 code when the error carries one. The message
+ *  fallback survives only for errors with no numeric code at all. */
+export function isSessionGoneForBackgroundPolling(error: unknown): boolean {
+  const code =
+    error && typeof error === 'object' && typeof (error as { code?: unknown }).code === 'number'
+      ? (error as { code: number }).code
+      : undefined
+
+  if (code !== undefined) {
+    return code === GATEWAY_SESSION_NOT_FOUND_CODE
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+
+  return /session not found/i.test(message)
+}
+
+export function isSessionGone(sid: string): boolean {
+  return goneSessions.has(sid)
+}
+
+/** Latch `sid` off and heal the bound view. Safe to call on every 4001. */
+export function markSessionGone(sid: string): void {
+  if (!sid) {
+    return
+  }
+
+  goneSessions.add(sid)
+  markRuntimeGone(sid)
+}
+
+/** Clear the gone-latch. Called with a session id when a fresh runtime binds to
+ *  it (so polling resumes), or with no argument to reset everything (tests /
+ *  gateway reconnect). */
+export function resetBackgroundPollingGuard(sid?: string): void {
+  if (sid) {
+    goneSessions.delete(sid)
+
+    return
+  }
+
+  goneSessions.clear()
+}
+
 /** Heal a session view whose bound runtime id the gateway no longer holds.
  *
- *  The desktop learns a runtime is gone through two channels, and only one of
- *  them ever repaired anything:
+ *  The desktop learns a runtime is gone through two channels:
  *
- *  - PUSH — `session.reclaimed`. `gateway-event/lifecycle.ts` drops the cached
- *    state and calls `unbindTileRuntime`, which re-arms SessionTilePane's
- *    resume effect (gated on `!runtimeId`) so the tile rebinds a fresh runtime
- *    from the intact stored row.
+ *  - PUSH — `session.reclaimed`. `gateway-event/lifecycle.ts` calls
+ *    {@link markRuntimeGone} (same levers as the pull path) before dropping
+ *    the cached state, so the primary chat resumes instead of sitting on the
+ *    dead runtime until the user types.
  *  - PULL — a session-scoped RPC rejected `4001 "session not found"`. The
  *    gateway logs "client should resume the stored session" precisely because
  *    this is the terminal verdict; `_sess_nowait` has no other way to say it.
@@ -21,14 +80,9 @@ import { $sessionStates, $sessionTiles, unbindTileRuntime } from './session-stat
  *  id forever or (with the gone-latch) went silent against it, and in both cases
  *  the view stayed bound to a phantom runtime for the rest of its life.
  *
- *  That gap is only reachable through the pull channel. The push channel cannot
- *  cover a runtime that died with a previous app process (boot-restore), was
- *  reaped while this client was disconnected, or was reaped by a remote gateway
- *  this renderer had not yet dialled — the broadcast has no live listener. In
- *  those cases the 4001 is the *only* notice that ever arrives.
- *
- *  So route it to the same recovery the broadcast drives. Both surfaces that can
- *  hold a binding get their existing re-arm lever pulled:
+ *  The pull channel is the only notice when the client missed the broadcast
+ *  (boot-restore, disconnect, remote gateway). Both surfaces that can hold a
+ *  binding get their existing re-arm lever pulled:
  *
  *  - Tiles: `unbindTileRuntime` (SessionTilePane's resume effect refires).
  *  - The primary chat: `requestSessionResume`, the explicit-request lever. Its


### PR DESCRIPTION
## Summary

Supersedes #97874, #98455, #98568, #98629, and #97887.

When a Desktop runtime is reaped, the UI kept addressing the old id. `process.list`, `approval.pending`, and `goal status` 4001s remounted the status stack and stole the composer. `session.reclaimed` dropped cache without putting the visible chat back on a live runtime. `prompt.submit` used a private gateway wrapper that dropped the turn lease at ACK.

[#99664](https://github.com/NousResearch/hermes-agent/pull/99664) already latches `process.list` 4001s. This leftover is the rest of that class: keep the remount from clearing the latch, share it with approval and goal polls, skip equivalent `session.info` republishes, heal reclaim, resume the visible session on 4001, and send `prompt.submit` through the window dispatcher.

### What this PR does
- Status-stack remount no longer clears the gone-latch for the current session
- `approval.pending` and `goal status` share `runtime-gone` (4001 / session-not-found)
- `session.info` heartbeats reuse the same state object when nothing changed
- `session.reclaimed` calls `markRuntimeGone` before dropping cache
- Dispatcher 4001 on the visible session requests a durable resume
- `prompt.submit` uses the window dispatcher; primary routes skip a phantom turn lease

### What was dropped
- 98568's new `session-gone.ts` — latch lives in `runtime-gone.ts`
- 98629's private `detachedApprovalSessions` set
- 97874's reclaim-owner route / alias-ref plumbing and the 1100-line session-states rewrite
- Anything aimed at #88621 (`contentEditable` / `connecting`). That is a different bug.

## Test plan
- [ ] `npx vitest run --project ui` on `src/store/prompts.test.ts`, `src/store/goals.test.ts`, `src/store/composer-status.test.ts`, `src/store/runtime-gone.test.ts`, `src/app/chat/composer/status-stack/polling-guard.test.tsx`, `src/app/session/hooks/use-message-stream/gateway-event/session-info.test.ts`, `src/app/session/hooks/use-message-stream/session-reclaimed.test.tsx`, `src/app/contrib/session-rpc-dispatcher.test.ts`, `src/app/session/hooks/use-prompt-actions/index.test.tsx` (local worktree `node_modules` was broken; CI is the run)
- [ ] Kill a runtime behind an open chat: composer stays focused, no 4001 poll storm
- [ ] Reclaim the visible session: chat resumes; a background reclaim does not navigate

Fixes #97764, #98434, #98554

Credit: @chelsealong, @liuhao1024, @Dolverin, @lesterlxt, @wz-heng. Related salvage already on main: [#99664](https://github.com/NousResearch/hermes-agent/pull/99664) (from [#98876](https://github.com/NousResearch/hermes-agent/pull/98876) / @JoaoMarcos44).