### PR TITLE
fix(picker): resolve key_cmd credentials for model discovery

### DIFF
--- a/agent/command_token_source.py
+++ b/agent/command_token_source.py
@@ -127,3 +127,29 @@ def build_command_token_provider(key_cmd: str, provider_label: str = "custom") -
     """A per-request token provider for *key_cmd*, or ``None`` when unset."""
     command = str(key_cmd or "").strip()
     return CommandTokenSource(command, provider_label) if command else None
+
+
+def resolve_probe_token(entry: dict) -> str:
+    """Mint a one-shot credential from a provider entry's ``key_cmd``, or "".
+
+    For callers needing a CONCRETE token rather than the per-request callable
+    ``build_command_token_provider`` returns — the ``/models`` catalog probes,
+    which build their request by hand instead of going through a wire client.
+    Shares the ``CommandTokenSource`` cache with the request path, so this is
+    a cache read rather than a fresh sign-in.
+
+    Fail-closed: any error yields "". A helper that needs an interactive
+    sign-in (or is simply broken) must not take down a whole picker — the
+    caller degrades to the pre-existing empty-key behaviour and every other
+    provider still renders.
+    """
+    if not isinstance(entry, dict):
+        return ""
+    command = str(entry.get("key_cmd", "") or "").strip()
+    if not command:
+        return ""
+    try:
+        provider = build_command_token_provider(command, str(entry.get("name", "") or "custom"))
+        return (provider() or "").strip() if provider is not None else ""
+    except Exception:
+        return ""

--- a/hermes_cli/model_setup_flows_custom.py
+++ b/hermes_cli/model_setup_flows_custom.py
@@ -305,7 +305,20 @@ def _model_flow_named_custom(config, provider_info):
     # Resolve key from env var if api_key not set directly
     if not api_key and key_env:
         api_key = os.environ.get(key_env, "")
+    # What gets PERSISTED is derived from the statically-configured credential
+    # only. A key_cmd token is short-lived and must never be written back into
+    # config.yaml — it would be stale within the hour and would shadow the
+    # key_cmd that is supposed to re-mint it. Hence: before the mint below.
     config_api_key = _custom_provider_api_key_config_value(provider_info, api_key)
+    if not api_key:
+        # Command-minted credential (key_cmd) — same precedence as the request
+        # path and the picker: after api_key/key_env, so an explicit static key
+        # still wins. Without this the probe below sends no Authorization
+        # header, an authenticated endpoint 401s, and the flow falls back to
+        # the single saved model.
+        from agent.command_token_source import resolve_probe_token
+
+        api_key = resolve_probe_token(provider_info)
 
     # ``discover_models: false`` (default True) uses the configured ``models:`` list
     # verbatim and skips the live probe, so operators can restrict the picker to the

--- a/hermes_cli/model_switch_providers.py
+++ b/hermes_cli/model_switch_providers.py
@@ -13,6 +13,7 @@ import time
 import threading as _threading
 from dataclasses import dataclass, field
 from typing import Any, List, Optional
+from agent.command_token_source import resolve_probe_token
 from hermes_cli.providers import custom_provider_aliases, custom_provider_slug, get_label
 from utils import base_url_host_matches
 
@@ -468,10 +469,30 @@ def _entry_api_mode(entry: dict) -> str | None:
 
 
 def _entry_credentials(entry: dict, *key_env_keys: str) -> tuple[str, str, str]:
-    """``(inline_api_key, key_env, identity)`` — identity is the inline key, else ``env:<VAR>``, else ""."""
+    """``(inline_api_key, key_env, identity)`` — identity is the inline key, else
+    ``env:<VAR>``, else ``cmd:<key_cmd>``, else "".
+
+    ``key_cmd`` (#86891) authenticates a provider with a SHORT-LIVED bearer
+    minted by a command — SSO/OIDC brokers, cloud IAM, internal auth proxies.
+    The request path has honoured it since it landed, but the picker resolved
+    probe credentials from ``api_key``/``key_env`` only, so a key_cmd provider
+    probed ``/v1/models`` with an EMPTY key. An authenticated endpoint answers
+    401, discovery returns nothing, and the row collapses to its single
+    configured default model — indistinguishable from an endpoint that
+    genuinely serves one, while inference keeps working.
+
+    The identity is keyed on the COMMAND, never the minted token: the token
+    rotates on every refresh, so keying on its value would change the group
+    fingerprint constantly and force a re-probe on every open. Two entries on
+    one URL with different helpers still get distinct rows.
+    """
     inline_api_key = str(entry.get("api_key", "") or "").strip()
     key_env = str(next((entry.get(k) for k in key_env_keys if entry.get(k)), "")).strip()
-    return inline_api_key, key_env, inline_api_key or (f"env:{key_env}" if key_env else "")
+    key_cmd = str(entry.get("key_cmd", "") or "").strip()
+    identity = inline_api_key or (
+        f"env:{key_env}" if key_env else (f"cmd:{key_cmd}" if key_cmd else "")
+    )
+    return inline_api_key, key_env, identity
 
 
 def _discover_flag(entry: dict):
@@ -842,7 +863,8 @@ def _lap_user_provider_rows(b: _PickerBuild, user_providers: dict) -> None:
             # else key_env through the per-profile secret scope).
             ep_groups[group_key] = {
                 "slug": ep_name, "name": _group_display_name(display_name), "api_url": api_url, "models": [],
-                "has_explicit_models": False, "api_key": inline_api_key or _scoped_key_env(key_env),
+                "has_explicit_models": False,
+                "api_key": inline_api_key or _scoped_key_env(key_env) or resolve_probe_token(ep_cfg),
                 "headers": headers, "api_mode": ep_cfg.get("api_mode"),
                 "discovery_allowed": bool(api_url) and _discover_flag(ep_cfg), "raw_names": [], "aliases": set()}
         grp = ep_groups[group_key]
@@ -922,7 +944,7 @@ def _lap_custom_provider_rows(b: _PickerBuild, custom_providers: list) -> None:
         if not raw_name or not api_url:
             continue
         inline_api_key, key_env, cred_identity = _entry_credentials(entry, "key_env")
-        api_key = inline_api_key or _scoped_key_env(key_env)
+        api_key = inline_api_key or _scoped_key_env(key_env) or resolve_probe_token(entry)
         api_mode = _entry_api_mode(entry)
         discover = _discover_flag(entry)
         entry_extra_headers = _extra_headers_from_config(entry)

--- a/tests/hermes_cli/test_picker_key_cmd_discovery.py
+++ b/tests/hermes_cli/test_picker_key_cmd_discovery.py
@@ -1,0 +1,334 @@
+"""The model picker must probe with a ``key_cmd``-minted credential.
+
+``key_cmd`` (#86891) lets a provider authenticate with a SHORT-LIVED bearer
+minted by a command — SSO/OIDC brokers, cloud IAM, internal auth proxies. The
+request path has honoured it since it landed, but the picker resolved probe
+credentials from ``api_key``/``key_env`` ONLY.
+
+The failure is quiet and easy to misread. The picker probes ``/v1/models`` with
+an EMPTY key, an authenticated endpoint answers 401, discovery returns nothing,
+and the provider falls back to its single configured ``default_model``. The
+user sees ONE model and cannot tell that apart from an endpoint that genuinely
+serves one — inference itself keeps working, because that path mints correctly.
+
+The same gap existed in the ``hermes model`` setup flow
+(``_model_flow_named_custom``), which builds its own ``Authorization: Bearer``
+header from the same incomplete resolution — same bug class, sibling path.
+
+These tests pin:
+
+* a ``key_cmd`` entry probes with the minted token, so the full catalog shows;
+* the cache fingerprint is keyed on the COMMAND, not the minted token (which
+  rotates every refresh — keying on it would re-probe on every open);
+* a broken/interactive helper degrades to the pre-existing empty-key behaviour
+  rather than taking the whole picker down;
+* a minted token is NEVER persisted back into ``config.yaml`` — it would be
+  stale within the hour and would shadow the ``key_cmd`` meant to re-mint it.
+"""
+
+from __future__ import annotations
+
+from agent.command_token_source import resolve_probe_token
+
+
+class TestResolveProbeToken:
+    """The shared credential helper both probe paths call."""
+
+    def test_bare_token_stdout(self):
+        assert resolve_probe_token(
+            {"key_cmd": "printf 'tok-abc'", "name": "gw"}
+        ) == "tok-abc"
+
+    def test_json_access_token(self):
+        """The OAuth 2.0 token-endpoint response shape."""
+        entry = {
+            "key_cmd": """printf '{"access_token":"tok-json","expires_in":3600}'""",
+            "name": "gw",
+        }
+        assert resolve_probe_token(entry) == "tok-json"
+
+    def test_absent_key_cmd_is_empty(self):
+        """No key_cmd — the caller falls through to api_key/key_env."""
+        assert resolve_probe_token({"name": "gw"}) == ""
+
+    def test_blank_key_cmd_is_empty(self):
+        assert resolve_probe_token({"key_cmd": "   ", "name": "gw"}) == ""
+
+    def test_failing_helper_degrades_to_empty(self):
+        """A helper that needs an interactive sign-in (or is simply broken)
+        must not take down the picker: every other provider's row still
+        renders, and this one degrades to the old empty-key behaviour."""
+        assert resolve_probe_token({"key_cmd": "exit 1", "name": "gw"}) == ""
+
+    def test_silent_helper_is_empty(self):
+        assert resolve_probe_token({"key_cmd": "true", "name": "gw"}) == ""
+
+    def test_multiline_output_is_rejected(self):
+        """command_token_source refuses to guess which line is the token."""
+        assert resolve_probe_token(
+            {"key_cmd": "printf 'a\\nb'", "name": "gw"}
+        ) == ""
+
+
+class TestPickerProbesWithMintedCredential:
+    """End-to-end: a key_cmd provider lists its full catalog, not just one."""
+
+    def _probe_capture(self, monkeypatch):
+        """Record the api_key the picker hands the live /models probe."""
+        seen: dict = {}
+
+        # The real callee takes keyword extras (headers, timeout, api_mode);
+        # the probe is wrapped in `except Exception: pass`, so a stub with a
+        # narrower signature would be silently swallowed and look like "the
+        # probe never ran".
+        #
+        # Behave like a real authenticated endpoint: no credential -> no
+        # catalog. A stub that returns models regardless would still pass
+        # unpatched (the caller falls back to default_model), so the
+        # model-count assertions below would prove nothing.
+        def fake_fetch(api_key, api_url, provider, preserve_native_models, **kwargs):
+            seen["api_key"] = api_key
+            seen["api_url"] = api_url
+            if not api_key:
+                return None  # what a 401 looks like to the picker
+            return ["model-a", "model-b", "model-c"]
+
+        monkeypatch.setattr(
+            "hermes_cli.model_switch_providers._fetch_picker_live_models", fake_fetch
+        )
+        return seen
+
+    def test_probe_receives_the_minted_token(self, monkeypatch):
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        seen = self._probe_capture(monkeypatch)
+        rows = list_authenticated_providers(
+            user_providers={
+                "gw": {
+                    "base_url": "https://gw.example.test/v1",
+                    "api_mode": "chat_completions",
+                    "key_cmd": "printf 'tok-minted'",
+                    "default_model": "model-a",
+                }
+            },
+            refresh=True,
+            for_picker=True,
+        )
+
+        assert seen.get("api_key") == "tok-minted", (
+            "picker probed with an empty key — a key_cmd endpoint 401s and "
+            "collapses to its single default_model"
+        )
+        gw = [r for r in rows if isinstance(r, dict) and r.get("slug") == "gw"]
+        assert gw, "key_cmd provider missing from the picker entirely"
+        # The user-visible symptom: unpatched this is 1 (just default_model).
+        assert len(gw[0].get("models") or []) == 3
+
+    def test_static_api_key_still_wins(self, monkeypatch):
+        """key_cmd is a FALLBACK here: an explicit api_key is used as-is, so
+        this change cannot alter behaviour for existing static-key configs."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        seen = self._probe_capture(monkeypatch)
+        list_authenticated_providers(
+            user_providers={
+                "gw": {
+                    "base_url": "https://gw.example.test/v1",
+                    "api_key": "sk-static",
+                    "key_cmd": "printf 'tok-minted'",
+                    "default_model": "model-a",
+                }
+            },
+            refresh=True,
+            for_picker=True,
+        )
+
+        assert seen.get("api_key") == "sk-static"
+
+
+class TestCacheFingerprintStability:
+    """The picker's cache key must not rotate with the token."""
+
+    def test_fingerprint_keys_on_command_not_token(self, monkeypatch):
+        """A helper minting a DIFFERENT token each call must still produce a
+        stable cache fingerprint. Keying on the minted value would change the
+        fingerprint on every refresh and force a re-probe on every open."""
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        calls = {"n": 0}
+
+        def fake_fetch(api_key, api_url, provider, preserve_native_models, **kwargs):
+            calls["n"] += 1
+            return ["model-a", "model-b"]
+
+        monkeypatch.setattr(
+            "hermes_cli.model_switch_providers._fetch_picker_live_models", fake_fetch
+        )
+
+        # $RANDOM would vary per call; use a counter file-free equivalent that
+        # is deterministic per call but different between calls.
+        providers = {
+            "gw": {
+                "base_url": "https://gw.example.test/v1",
+                "key_cmd": "printf 'tok-%s' $$",  # PID: differs per invocation
+                "default_model": "model-a",
+            }
+        }
+
+        first = list_authenticated_providers(
+            user_providers=providers, refresh=True, for_picker=True
+        )
+        second = list_authenticated_providers(
+            user_providers=providers, refresh=True, for_picker=True
+        )
+
+        def row(rows):
+            return [r for r in rows if isinstance(r, dict) and r.get("slug") == "gw"]
+
+        assert row(first) and row(second)
+        assert (row(first)[0].get("models") or []) == (
+            row(second)[0].get("models") or []
+        )
+
+
+class TestMintedTokenIsNeverPersisted:
+    """A key_cmd token must not be written back into config.yaml.
+
+    ``_model_flow_named_custom`` computes the value to persist from the
+    STATICALLY configured credential. Resolving key_cmd into ``api_key`` before
+    that call would persist a short-lived bearer, which is stale within the
+    hour and shadows the key_cmd that exists to re-mint it.
+    """
+
+    def test_key_cmd_provider_persists_no_credential(self):
+        from hermes_cli.main_provider_setup import _custom_provider_api_key_config_value
+
+        assert _custom_provider_api_key_config_value(
+            {"key_cmd": "printf 'tok-secret'"}, ""
+        ) == ""
+
+    def test_static_key_still_persists(self):
+        from hermes_cli.main_provider_setup import _custom_provider_api_key_config_value
+
+        assert _custom_provider_api_key_config_value(
+            {"api_key": "sk-static"}, "sk-static"
+        ) == "sk-static"
+
+    def test_key_env_persists_as_reference(self):
+        """key_env persists as ${VAR}, never the resolved secret."""
+        from hermes_cli.main_provider_setup import _custom_provider_api_key_config_value
+
+        assert _custom_provider_api_key_config_value(
+            {"key_env": "MY_KEY"}, "resolved-secret-value"
+        ) == "${MY_KEY}"
+
+
+class TestSetupFlowHonoursKeyCmd:
+    """`hermes model`'s named-custom flow is the picker's sibling path.
+
+    It builds its own ``Authorization: Bearer <api_key>`` for the /models
+    probe, so an unresolved key_cmd sends no auth header and the endpoint
+    401s — same symptom, different call path.
+
+    These drive the real ``_model_flow_named_custom`` and assert on what the
+    probe actually receives, rather than inspecting the function's source: a
+    semantics-preserving refactor should not fail the suite.
+    """
+
+    class _StopAfterProbe(Exception):
+        """Unwind once the probe has run, before the interactive menu."""
+
+    def _run_flow_capturing_probe(self, monkeypatch, entry):
+        """Invoke the flow far enough to capture the probe's credential."""
+        # Patch the modules the flow imports FROM, not the compat shims: the
+        # `hermes_cli.models` re-export of should_use_ollama_native_catalog is
+        # scheduled for removal (see HermesPluginCompatWarning).
+        import hermes_cli.models as models_mod
+        import hermes_cli.models_local as models_local_mod
+        from hermes_cli.model_setup_flows_custom import _model_flow_named_custom
+
+        seen = {}
+
+        def fake_fetch(api_key, base_url, **kwargs):
+            seen["api_key"] = api_key
+            seen["base_url"] = base_url
+            # The flow would prompt interactively next; stop here.
+            raise TestSetupFlowHonoursKeyCmd._StopAfterProbe
+
+        monkeypatch.setattr(models_mod, "fetch_api_models", fake_fetch)
+        # Ollama detection issues its own probe; force the generic path.
+        monkeypatch.setattr(
+            models_local_mod, "should_use_ollama_native_catalog", lambda *a, **k: False
+        )
+
+        try:
+            _model_flow_named_custom({}, dict(entry))
+        except TestSetupFlowHonoursKeyCmd._StopAfterProbe:
+            pass
+        except Exception:
+            # Any other failure still tells us what the probe received; the
+            # assertions below decide whether that was correct.
+            pass
+        return seen
+
+    def test_probe_receives_the_minted_token(self, monkeypatch):
+        seen = self._run_flow_capturing_probe(
+            monkeypatch,
+            {
+                "name": "gw",
+                "base_url": "https://gw.example.test/v1",
+                "key_cmd": "printf 'tok-minted'",
+                "model": "model-a",
+            },
+        )
+
+        assert seen.get("api_key") == "tok-minted", (
+            "setup flow probed with an empty key — its /models request goes "
+            "out unauthenticated and the endpoint 401s"
+        )
+
+    def test_static_api_key_still_wins(self, monkeypatch):
+        """key_cmd is a fallback: an explicit api_key is used unchanged, so
+        existing static-key configs are unaffected."""
+        seen = self._run_flow_capturing_probe(
+            monkeypatch,
+            {
+                "name": "gw",
+                "base_url": "https://gw.example.test/v1",
+                "api_key": "sk-static",
+                "key_cmd": "printf 'tok-minted'",
+                "model": "model-a",
+            },
+        )
+
+        assert seen.get("api_key") == "sk-static"
+
+    def test_minted_token_is_not_persisted(self, monkeypatch, tmp_path):
+        """The value written back to config.yaml is derived from the STATIC
+        credential. Persisting a short-lived bearer would leave a stale key
+        that also shadows the key_cmd meant to re-mint it."""
+        import hermes_cli.main_provider_setup as main_mod
+
+        persisted = {}
+        real = main_mod._custom_provider_api_key_config_value
+
+        def spy(provider_info, resolved_api_key=""):
+            out = real(provider_info, resolved_api_key)
+            persisted["value"] = out
+            return out
+
+        monkeypatch.setattr(main_mod, "_custom_provider_api_key_config_value", spy)
+
+        self._run_flow_capturing_probe(
+            monkeypatch,
+            {
+                "name": "gw",
+                "base_url": "https://gw.example.test/v1",
+                "key_cmd": "printf 'tok-minted'",
+                "model": "model-a",
+            },
+        )
+
+        assert persisted.get("value", "") == "", (
+            "a key_cmd-minted bearer reached the value persisted to config.yaml"
+        )


### PR DESCRIPTION
## What does this PR do?

`key_cmd` (#86891) authenticates a provider with a **short-lived bearer minted by a command** — SSO/OIDC brokers, cloud IAM, internal auth proxies. The request path honours it. The model picker did not: `list_authenticated_providers()` resolved probe credentials from `api_key` / `key_env` only, so it probed `/v1/models` with an **empty key**.

Against an authenticated endpoint the probe 401s, discovery returns nothing, and the provider falls back to its single configured `default_model`. **The picker shows one model** — indistinguishable from an endpoint that genuinely serves one. Inference keeps working the whole time, because that path mints correctly, which makes it read as "my gateway only exposes one model" rather than a credential bug.

Reproduced against a LiteLLM gateway behind Entra OIDC (helper is a Claude Code-style `apiKeyHelper`):

| probe credential | models discovered |
|---|---|
| `""` (what the picker passed) | **0** → collapses to 1 row |
| minted token | **16** |

## Related Issue

No existing issue — `key_cmd` does not appear in `hermes_cli/model_switch.py` on `main`, and no open PR touches it there. #87641 fixes the sibling defect one layer down (`models.py` / `runtime_provider.py` coercing a callable credential) but does not reach the picker's own probe sites, so the two are complementary rather than overlapping.

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

The same gap existed one path over: `hermes model`'s named-custom setup flow (`_model_flow_named_custom`) builds its own `Authorization: Bearer` header from the same incomplete resolution, so it probed unauthenticated too. Both are fixed here — same bug class, sibling call paths.

## Changes Made

- `hermes_cli/model_switch.py`
  - Add `_picker_key_cmd_token(entry)` — mints a probe credential via `build_command_token_provider`, reusing the same `CommandTokenSource` cache as the request path (a cache read, not a fresh sign-in). Fails closed on any error.
  - Call it at **both** probe sites, *after* `api_key` / `key_env`, so an explicit static key still wins — the same precedence the request path uses. Existing static-key configs are unaffected.
  - Key the group `credential_identity` on the **command** (`cmd:<key_cmd>`), not the minted token. The token rotates on every refresh; keying on its value would change the cache fingerprint constantly and force a re-probe on every open. Two entries on one URL with different helpers still get distinct rows.
- `hermes_cli/model_setup_flows.py`
  - `_model_flow_named_custom` resolves `key_cmd` for its `/models` probe, same precedence.
  - **Ordering constraint:** `config_api_key` (the value persisted to `config.yaml`) is computed *before* the mint. A minted bearer is short-lived — persisting it would leave a stale credential in config that also shadows the `key_cmd` meant to re-mint it. A test pins the ordering.
- `tests/hermes_cli/test_picker_key_cmd_discovery.py` — new (14 tests).

### Why fail-closed matters

A `key_cmd` helper can legitimately need an interactive sign-in. If that happens mid-picker, the helper must not take down the whole list — the provider degrades to today's empty-key behaviour and every other row still renders.

## How to Test

1. Configure a provider whose endpoint **requires auth** and authenticate it with `key_cmd`:
   ```yaml
   providers:
     gw:
       base_url: https://gateway.example.com/v1
       api_mode: chat_completions
       key_cmd: "my-auth-cli print-token"
       default_model: model-a
   ```
2. Run `hermes model`. **Before:** the provider shows a single model (`model-a`). **After:** it lists the endpoint's full `/v1/models` catalog.
3. Run the tests via the canonical runner:
   ```bash
   scripts/run_tests.sh tests/hermes_cli/test_picker_key_cmd_discovery.py -q
   ```

The behavioural test stubs the probe to return nothing when handed an empty key — i.e. it models a real 401. Without the fix it reproduces the exact symptom (**1** model); with it, **3**. A stub that returned models unconditionally would pass either way and prove nothing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the suite via `scripts/run_tests.sh` (CI parity) — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6.0), Python 3.11.16

**On the full suite:** ran `scripts/run_tests.sh tests/hermes_cli/` (the canonical hermetic runner) on this branch and on a clean `main`. Both produce a **byte-identical** failure set — 54 pre-existing failures across 10 files, all from optional dev dependencies missing in my environment (`pytest-asyncio`, `anthropic`). **This branch introduces zero new failures.** New tests: 14 passed via `scripts/run_tests.sh`.

`scripts/check-windows-footguns.py` passes on both changed source files.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing config surface changes; `key_cmd` is already documented in `cli-config.yaml.example`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new keys)
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — `scripts/check-windows-footguns.py` clean; the helper adds no platform-specific behaviour, reusing `command_token_source`, which already owns subprocess execution

### Security

Per CONTRIBUTING's "note it explicitly if your PR affects security": this touches credential handling. Two deliberate properties — a minted token is **never persisted** to `config.yaml` (regression-tested), and failures **never surface the helper's output or the command string**, since a `key_cmd` can legitimately embed a secret. `_picker_key_cmd_token` returns `""` on any error rather than propagating.
