### PR TITLE
fix(gateway): honor plugin-platform allowlists when resolving unauthorized DMs

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -984,7 +984,8 @@ class GatewayAuthorizationMixin:
            or ``GATEWAY_ALLOWED_USERS``) is configured, default to ``"ignore"`` —
            the allowlist signals that the owner has deliberately restricted
            access; spamming unknown contacts with pairing codes is both noisy
-           and a potential info-leak. (#9337)
+           and a potential info-leak. (#9337) Plugin-provided platforms resolve
+           their allowlist env var through the platform registry.
         6. No allowlist and no explicit config → ``"pair"`` (open-gateway default).
         """
         config = getattr(self, "config", None)
@@ -1057,6 +1058,21 @@ class GatewayAuthorizationMixin:
                 ),
                 Platform.QQBOT: ("QQ_GROUP_ALLOWED_USERS",),
             }
+            # Plugin-provided platforms are not in the static map above, so ask
+            # the registry for the allowlist env var they declared. Without this
+            # a plugin platform with a configured allowlist falls through to the
+            # "pair" default and SMSes/DMs pairing codes to unknown senders —
+            # the same failure #9337 fixed for built-in platforms. Mirrors the
+            # registry lookup ``is_authorized()`` already performs.
+            if platform not in platform_env_map:
+                try:
+                    from gateway.platform_registry import platform_registry
+
+                    entry = platform_registry.get(platform.value)
+                    if entry and entry.allowed_users_env:
+                        platform_env_map[platform] = entry.allowed_users_env
+                except Exception:
+                    pass
             if _platform_gate_env(platform_env_map.get(platform, "")).strip():
                 return "ignore"
             for env_key in platform_group_env_map.get(platform, ()):

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -396,3 +396,93 @@ def test_qqbot_with_allowlist_ignores_unauthorized_dm(monkeypatch):
 
     behavior = runner._get_unauthorized_dm_behavior(Platform.QQBOT)
     assert behavior == "ignore"
+
+
+def test_plugin_platform_with_allowlist_ignores_unauthorized_dm(monkeypatch):
+    """Plugin platforms must honor the allowlist-aware default too.
+
+    Regression guard, same class of bug as the QQBOT case above but for
+    plugin-provided platforms.  ``_get_unauthorized_dm_behavior`` resolved the
+    allowlist env var from a hardcoded map of BUILT-IN platforms only, so a
+    plugin platform (registered via ``platform_registry`` with its own
+    ``allowed_users_env``) missed the lookup and fell through to the ``"pair"``
+    default -- even with its allowlist configured.
+
+    Found in production on an SMS plugin platform: unknown senders were
+    answered with a pairing-code text.  On SMS that is billable outbound to
+    strangers and discloses that the number fronts an AI gateway, which is
+    exactly the outcome #9337 set out to prevent for built-in platforms.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("PLUGINSMS_ALLOWED_USERS", raising=False)
+    monkeypatch.setenv("PLUGINSMS_ALLOWED_USERS", "+15550001111")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="pluginsms",
+        label="Plugin SMS",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="PLUGINSMS_ALLOWED_USERS",
+        allow_all_env="PLUGINSMS_ALLOW_ALL_USERS",
+    ))
+
+    pluginsms = Platform("pluginsms")
+    config = GatewayConfig(platforms={pluginsms: PlatformConfig(enabled=True)})
+    runner, _adapter = _make_runner(pluginsms, config)
+
+    assert runner._get_unauthorized_dm_behavior(pluginsms) == "ignore"
+
+
+def test_plugin_platform_without_allowlist_still_pairs(monkeypatch):
+    """The registry lookup must not turn every plugin platform into "ignore".
+
+    With no allowlist configured, a plugin platform keeps the open-gateway
+    ``"pair"`` default (rule 6) exactly like a built-in one.
+    """
+    _clear_auth_env(monkeypatch)
+    monkeypatch.delenv("PLUGINOPEN_ALLOWED_USERS", raising=False)
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="pluginopen",
+        label="Plugin Open",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="PLUGINOPEN_ALLOWED_USERS",
+        allow_all_env="PLUGINOPEN_ALLOW_ALL_USERS",
+    ))
+
+    pluginopen = Platform("pluginopen")
+    config = GatewayConfig(platforms={pluginopen: PlatformConfig(enabled=True)})
+    runner, _adapter = _make_runner(pluginopen, config)
+
+    assert runner._get_unauthorized_dm_behavior(pluginopen) == "pair"
+
+
+def test_plugin_platform_without_declared_env_still_pairs(monkeypatch):
+    """A plugin that declares no ``allowed_users_env`` must resolve, not explode.
+
+    The registry lookup is best-effort: an entry with an empty
+    ``allowed_users_env`` contributes nothing to the map and the platform falls
+    through to the documented default rather than raising out of the
+    authorization path.
+
+    (A platform missing from the registry entirely is unreachable here --
+    ``Platform("...")`` rejects unknown names before this code runs.)
+    """
+    _clear_auth_env(monkeypatch)
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="pluginnoenv",
+        label="Plugin No Env",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+    ))
+
+    pluginnoenv = Platform("pluginnoenv")
+    config = GatewayConfig(platforms={pluginnoenv: PlatformConfig(enabled=True)})
+    runner, _adapter = _make_runner(pluginnoenv, config)
+
+    assert runner._get_unauthorized_dm_behavior(pluginnoenv) == "pair"


### PR DESCRIPTION
## What does this PR do?

`_get_unauthorized_dm_behavior()` resolves a platform's allowlist env var from a hardcoded map that contains **only built-in platforms**. Plugin-provided platforms declare their own `allowed_users_env` through the platform registry, so the lookup misses and resolution falls through to the `"pair"` default — **even when the operator has configured an allowlist**.

The result: unknown senders get answered with a pairing code. That is the exact behavior #9337 removed for built-in platforms, still reachable through any plugin platform.

The two authorization paths currently disagree. `is_authorized()` *already* consults the registry for the very same env var:

```python
# gateway/authz_mixin.py:560-572
# Plugin platforms: check the registry for auth env var names
if source.platform not in platform_env_map:
    entry = platform_registry.get(source.platform.value)
    if entry and entry.allowed_users_env:
        platform_env_map[source.platform] = entry.allowed_users_env
```

…but rule 5 in `_get_unauthorized_dm_behavior()` does not. So a plugin platform's sender is correctly judged unauthorized, and then replied to anyway. This PR applies the same registry lookup in rule 5, making the two paths agree.

**Why this matters beyond noise:** I hit it in production on an SMS plugin platform (Telnyx). `TELNYX_SMS_ALLOWED_USERS` was set and the resolved behavior was still `pair`, so any stranger texting the number would have received a pairing-code SMS — billable outbound to an arbitrary phone number, unsolicited traffic on a registered 10DLC campaign, and a disclosure that the number fronts an AI gateway.

## Related Issue

Same class of bug as #9337 (Signal pairing spam despite a configured allowlist), which fixed built-in platforms only. The QQBOT regression test already in `test_unauthorized_dm_behavior.py` covers a second instance of the same omission; this generalizes the fix to plugin platforms rather than adding a third hardcoded entry.

No existing issue filed for the plugin-platform case — searched open and closed PRs/issues for `unauthorized_dm_behavior` and pairing-code duplicates first. Nearest neighbors are all distinct: #32833 (global explicit `pair` *should* win over allowlists — opposite direction), #34791 (group policy), #85311 (WhatsApp self-chat).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `gateway/authz_mixin.py` — in `_get_unauthorized_dm_behavior()`, fall back to `platform_registry` for a plugin platform's `allowed_users_env` before the rule-5 allowlist check. Best-effort and wrapped in `try/except`, mirroring the existing lookup in `is_authorized()`.
- `gateway/authz_mixin.py` — docstring: note that plugin platforms resolve their allowlist env var through the registry.
- `tests/gateway/test_unauthorized_dm_behavior.py` — three tests (below).

Scoped deliberately: rule 5 only. No change to rules 1–4 or 6, no new config keys, and no change to any built-in platform's resolution.

## How to Test

1. `pytest tests/gateway/test_unauthorized_dm_behavior.py -q` → 16 passed.
2. Revert `gateway/authz_mixin.py` only, re-run: `test_plugin_platform_with_allowlist_ignores_unauthorized_dm` **fails** (resolves `pair`, expected `ignore`). The other two pass with and without the fix — they assert behavior that must *not* change.
3. Regression sweep across the auth-adjacent suites:
   ```
   pytest tests/gateway/test_unauthorized_dm_behavior.py \
          tests/gateway/test_config_driven_access_policy.py \
          tests/gateway/test_multiplex_profile_authz.py \
          tests/gateway/test_telegram_auth_check.py \
          tests/gateway/test_buzz_authz.py \
          tests/gateway/test_plugin_platform_interface.py -q
   ```
   → **107 passed, 2 skipped**.

Tests added:

| Test | Asserts |
|---|---|
| `test_plugin_platform_with_allowlist_ignores_unauthorized_dm` | plugin platform + allowlist → `ignore` (the fix; fails without it) |
| `test_plugin_platform_without_allowlist_still_pairs` | plugin platform, no allowlist → `pair` (rule 6 intact; the lookup must not blanket-convert plugin platforms to `ignore`) |
| `test_plugin_platform_without_declared_env_still_pairs` | plugin declaring no `allowed_users_env` → resolves, doesn't raise |

Note on the third: a platform absent from the registry *entirely* is unreachable here — `Platform("...")` rejects unknown names before this code runs — so the reachable edge case is a registered entry with an empty `allowed_users_env`.

Verified in production afterward on the affected install: resolved behavior became `ignore`, and a real text from an unauthorized number produced an `Unauthorized user` log line, no agent dispatch, and **zero outbound records** in the carrier's billing detail records for that window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2 (Python 3.11)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstring for rule 5 updated
- [x] N/A — no config keys added or changed (`unauthorized_dm_behavior` already exists; this only changes how the *default* is derived)
- [x] N/A — no architecture or workflow change
- [x] I've considered cross-platform impact — pure Python, no platform-specific behavior
- [x] N/A — no tool behavior changed

## Notes for reviewers

Two things worth a second opinion:

**This changes a default, so it is technically a behavior change** for anyone running a plugin platform with an allowlist configured who was relying on pairing codes still going out to strangers. I'd argue that combination is the bug, not a feature — the allowlist is the operator explicitly restricting access, which is precisely the #9337 reasoning — but it's a deliberate call and worth flagging rather than burying.

**A registry lookup was preferred over adding entries to the static map.** Adding `Platform.TELNYX_SMS` (or any other single platform) would fix one case and leave the next plugin to rediscover this the same way — the QQBOT test in this file is evidence the hardcoded map has already been missed once before.

Small, related cleanup I did **not** bundle here: CONTRIBUTING.md's duplicate-search snippet recommends `gh search prs --repo ... --state all`, but `--state` only accepts `open|closed`, so that command errors out. Happy to send it as a separate docs PR.
