### PR TITLE
feat(email): add read-only / no-auto-reply mode

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -564,6 +564,23 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         self._skip_attachments = extra.get("skip_attachments", False)
 
+        # Read-only / no-auto-reply mode — configured via config.yaml:
+        #   platforms:
+        #     email:
+        #       read_only: true
+        # or the EMAIL_READ_ONLY=true env mirror (parity with the other EMAIL_*
+        # vars). When enabled the adapter still polls IMAP and dispatches
+        # incoming mail normally, but every outgoing send is suppressed (no SMTP)
+        # so a mailbox can be used purely as a read feed without ever replying to
+        # the sender (#99876). Suppressed sends return success so the gateway's
+        # delivery ledger treats them as delivered rather than retrying — the
+        # failure loop that disabling the SMTP credential would cause. Default
+        # OFF (behaviour unchanged unless explicitly enabled).
+        if "read_only" in extra:
+            self._read_only = bool(extra["read_only"])
+        else:
+            self._read_only = _esecret_bool("EMAIL_READ_ONLY", False)
+
         # Require the sender's From: domain to be authenticated (SPF/DKIM/DMARC)
         # before trusting it for authorization. The From: header is
         # attacker-controlled and unauthenticated by IMAP, so an allowlist keyed
@@ -1129,6 +1146,20 @@ class EmailAdapter(BasePlatformAdapter):
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
 
+    def _read_only_suppress(self, target: str, kind: str = "message") -> SendResult:
+        """Suppress an outgoing send in read-only mode (#99876).
+
+        Logs the drop and returns success so the gateway's delivery ledger
+        treats the reply as delivered rather than retrying it (the failure
+        loop a disabled SMTP credential would cause). Incoming IMAP delivery
+        is unaffected.
+        """
+        logger.info(
+            "[Email] read-only mode: suppressed outgoing %s to %s (no SMTP send)",
+            kind, target,
+        )
+        return SendResult(success=True, message_id="read-only-suppressed")
+
     async def send(
         self,
         chat_id: str,
@@ -1137,6 +1168,8 @@ class EmailAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send an email reply to the given address."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id)
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
@@ -1234,6 +1267,9 @@ class EmailAdapter(BasePlatformAdapter):
         images). No hard cap — email clients handle dozens of
         attachments fine, subject to SMTP message size limits.
         """
+        if getattr(self, "_read_only", False):
+            self._read_only_suppress(chat_id, "image batch")
+            return
         if not images:
             return
 
@@ -1336,6 +1372,8 @@ class EmailAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a file as an email attachment."""
+        if getattr(self, "_read_only", False):
+            return self._read_only_suppress(chat_id, "document")
         try:
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(

--- a/tests/gateway/test_email_read_only.py
+++ b/tests/gateway/test_email_read_only.py
@@ -1,0 +1,82 @@
+"""Email read-only / no-auto-reply mode (#99876).
+
+``platforms.email.extra.read_only: true`` (or ``EMAIL_READ_ONLY=1``) lets a
+mailbox be used purely as an inbound feed: IMAP polling / dispatch is
+unchanged, but every outgoing send is suppressed before it reaches SMTP. A
+suppressed send returns ``success=True`` so the gateway's delivery ledger
+marks it delivered rather than retrying — the failure loop that disabling the
+SMTP credential would cause. These tests pin that no SMTP helper is invoked in
+read-only mode, that the default (unset) still sends, and that all three
+adapter send entry points are covered.
+"""
+import asyncio
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+
+def _make_adapter(*, extra=None, env=None):
+    from gateway.config import PlatformConfig
+    from plugins.platforms.email.adapter import EmailAdapter
+
+    with patch.dict(os.environ, env or {}, clear=False):
+        return EmailAdapter(PlatformConfig(enabled=True, extra=extra or {}))
+
+
+class TestEmailReadOnly(unittest.TestCase):
+    def test_read_only_via_extra_suppresses_send(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "read-only-suppressed")
+        adapter._send_email.assert_not_called()
+
+    def test_read_only_via_env_suppresses_send(self):
+        adapter = _make_adapter(env={"EMAIL_READ_ONLY": "true"})
+        adapter._send_email = MagicMock(name="_send_email")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        adapter._send_email.assert_not_called()
+
+    def test_default_is_not_read_only_and_sends(self):
+        adapter = _make_adapter()  # no extra, no env -> read_only stays False
+        self.assertFalse(adapter._read_only)
+        adapter._send_email = MagicMock(return_value="<mid@localhost>")
+
+        result = asyncio.run(adapter.send("user@example.com", "hi"))
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "<mid@localhost>")
+        adapter._send_email.assert_called_once()
+
+    def test_extra_overrides_env(self):
+        # Explicit config.yaml value wins over the env mirror.
+        adapter = _make_adapter(extra={"read_only": False}, env={"EMAIL_READ_ONLY": "true"})
+        self.assertFalse(adapter._read_only)
+
+    def test_read_only_suppresses_document_and_image_batch(self):
+        adapter = _make_adapter(extra={"read_only": True})
+        adapter._send_email_with_attachment = MagicMock(name="doc")
+        adapter._send_email_with_attachments = MagicMock(name="imgs")
+
+        doc = asyncio.run(adapter.send_document("user@example.com", "/tmp/x.pdf"))
+        self.assertTrue(doc.success)
+        self.assertEqual(doc.message_id, "read-only-suppressed")
+        adapter._send_email_with_attachment.assert_not_called()
+
+        # send_multiple_images returns None; the point is no SMTP is attempted.
+        asyncio.run(
+            adapter.send_multiple_images(
+                "user@example.com", [("file:///tmp/a.png", "")],
+            )
+        )
+        adapter._send_email_with_attachments.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What does this PR do?

Add `platforms.email.extra.read_only: true` (or the `EMAIL_READ_ONLY` env
mirror) so an email mailbox can be used purely as an inbound feed: IMAP
polling and dispatch are unchanged, but every outgoing send is suppressed
before it reaches SMTP (#99876).

A suppressed send returns `success=True`, so the gateway's delivery ledger
marks it delivered rather than retrying — the failure/retry loop that
disabling the SMTP credential (the reporter's attempted workaround) would
cause. All three adapter entry points that reach SMTP are gated: `send()`,
`send_document()`, and `send_multiple_images()`; `send_image()` and the
base-class media methods already route through `send()`. Follows the existing
`skip_attachments` config precedent; default OFF, behaviour unchanged unless
enabled.

## Related Issue

Fixes #99876

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/email/adapter.py` — `read_only` config (extra + env);
  suppress `send` / `send_document` / `send_multiple_images` in read-only mode.
- `tests/gateway/test_email_read_only.py` — extra/env config, default-still-sends,
  extra-overrides-env, and document/image-batch suppression.

## How to Test

    pytest tests/gateway/test_email_read_only.py -q

5 pass.