### PR TITLE
fix(mcp): detect WAL and same-tick SQLite commits

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -33,6 +33,7 @@ import json
 import logging
 import os
 import re
+import sqlite3
 import sys
 import threading
 import time
@@ -352,6 +353,12 @@ class EventBridge:
         self._pending_approvals: Dict[str, dict] = {}
         # mtime cache — skip expensive work when state.db hasn't changed
         self._state_db_mtime: float = 0.0
+        # PRAGMA data_version watermark, sampled on the long-lived read-only
+        # connection below. Only comparable across samples from that ONE
+        # connection, so it is reset whenever the connection is reopened.
+        self._state_db_version: Optional[int] = None
+        self._state_watch_conn: Optional[sqlite3.Connection] = None
+        self._state_watch_identity: Optional[tuple[int, int]] = None
         self._cached_sessions_index: dict = {}
 
     def start(self):
@@ -376,6 +383,18 @@ class EventBridge:
         self._new_event.set()  # Wake any waiters
         if self._thread:
             self._thread.join(timeout=5)
+        # The polling thread is the only user of the watcher connection once it
+        # is running, so close it only when that thread has actually finished.
+        # A thread that outlived the join may still be inside _poll_once, and
+        # leaking a read-only descriptor until the process exits is cheaper
+        # than closing a connection out from under a live statement.
+        if self._thread is not None and self._thread.is_alive():
+            logger.warning(
+                "EventBridge: poll thread still running after stop(); "
+                "leaving the state.db watcher open"
+            )
+        else:
+            self._close_state_watch_conn()
         logger.debug("EventBridge stopped")
 
     def poll_events(
@@ -494,14 +513,11 @@ class EventBridge:
         except ImportError:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
         try:
-            self._state_db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
-        except OSError:
-            self._state_db_mtime = 0.0
-        try:
-            self._cached_sessions_index = _load_sessions_index()
+            entries = self._refresh_index_and_watermark(db_file)
         except Exception:
-            self._cached_sessions_index = {}
-        for session_key, entry in self._cached_sessions_index.items():
+            self._cached_sessions_index = entries = {}
+            self._state_db_mtime, self._state_db_version = self._sample_state_watermark(db_file)
+        for session_key, entry in entries.items():
             session_id = entry.get("session_id", "")
             if not session_id:
                 continue
@@ -514,6 +530,117 @@ class EventBridge:
                 latest = max(all_ts)
                 if latest > 0.0:
                     self._last_poll_timestamps[session_key] = latest
+
+    def _refresh_index_and_watermark(self, db_file: Path) -> dict:
+        """Refresh the routing index and record the watermark it has observed.
+
+        The stored watermark is sampled AFTER an index refresh, because that
+        refresh opens SessionDB, whose schema initialisation commits the first
+        time it runs against a database. A watermark taken before it would
+        record the bridge's own write as a peer's change and force a redundant
+        scan on the next tick.
+
+        Only one skew is dangerous: a watermark ahead of the index. A session
+        registered after the index query but before the sample would be absent
+        from the entries below AND already counted in the watermark, so every
+        later poll would take the confirmed-quiet skip and its first message
+        would wait for an unrelated commit — the dropped-new-conversation
+        shape (#8925) this poller exists to avoid. So when anything at all
+        committed while the index was being read, the index is read once more,
+        now that the watermark is fixed: that read sees everything committed
+        through it, and a commit landing afterwards moves the version again
+        and is picked up on the next poll. The opposite skew — index ahead of
+        the watermark — only ever costs one redundant scan.
+        """
+        before = self._sample_state_watermark(db_file)
+        entries = _load_sessions_index()
+        self._state_db_mtime, self._state_db_version = self._sample_state_watermark(db_file)
+        if (self._state_db_mtime, self._state_db_version) != before:
+            entries = _load_sessions_index()
+        self._cached_sessions_index = entries
+        return entries
+
+    def _close_state_watch_conn(self) -> None:
+        """Drop the watcher connection; the next sample reopens it."""
+        conn, self._state_watch_conn = self._state_watch_conn, None
+        self._state_watch_identity = None
+        if conn is None:
+            return
+        try:
+            conn.close()
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("EventBridge: closing state.db watcher failed: %s", exc)
+
+    def _sample_state_watermark(self, db_file: Path) -> tuple[float, Optional[int]]:
+        """Return the (mtime, data_version) pair state.db shows right now.
+
+        Both halves are taken at the same instant so the gate in _poll_once
+        compares like with like on the next tick; a missing file yields the
+        (0.0, None) "nothing to watch" pair.
+        """
+        try:
+            db_stat = db_file.stat()
+        except OSError:
+            self._close_state_watch_conn()
+            return 0.0, None
+        return db_stat.st_mtime, self._sample_state_db_version(db_file, db_stat)
+
+    def _sample_state_db_version(self, db_file: Path, db_stat) -> Optional[int]:
+        """Return state.db's PRAGMA data_version, or None when it can't be read.
+
+        data_version changes whenever ANOTHER connection commits, including WAL
+        commits that never touch the main file's mtime, so it answers the
+        question mtime cannot: has anything landed since the last sample?
+
+        The counter is per-connection, so samples are only comparable while the
+        same connection stays open. A replaced file (different st_dev/st_ino)
+        therefore closes the old connection and clears the watermark, which
+        makes the caller treat the database as changed.
+
+        None means "unknown" — the file is not a readable SQLite database, the
+        open failed, or the read raced a writer. Callers must scan on None
+        rather than assume the database is quiet.
+        """
+        identity = (db_stat.st_dev, db_stat.st_ino)
+        if self._state_watch_conn is not None and identity != self._state_watch_identity:
+            self._close_state_watch_conn()
+
+        if self._state_watch_conn is None:
+            try:
+                from hermes_cli.sqlite_safe_read import (
+                    UntrackableConnectionError,
+                    connect_tracked,
+                )
+            except ImportError as exc:
+                logger.debug("EventBridge: sqlite_safe_read unavailable: %s", exc)
+                return None
+            try:
+                # Tracked, so the byte-probe guard in sqlite_safe_read still
+                # holds; read-only and isolation_level=None, so watching takes
+                # no lock the gateway's writers could contend with.
+                conn = connect_tracked(
+                    f"file:{db_file}?mode=ro",
+                    tracking_path=db_file,
+                    uri=True,
+                    check_same_thread=False,
+                    isolation_level=None,
+                    timeout=1.0,
+                )
+            except (UntrackableConnectionError, sqlite3.Error, OSError) as exc:
+                logger.debug("EventBridge: state.db watcher open failed: %s", exc)
+                return None
+            self._state_watch_conn = conn
+            self._state_watch_identity = identity
+            self._state_db_version = None
+
+        try:
+            row = self._state_watch_conn.execute("PRAGMA data_version").fetchone()
+        except (sqlite3.Error, OSError) as exc:
+            logger.debug("EventBridge: state.db data_version unreadable: %s", exc)
+            self._close_state_watch_conn()
+            return None
+        return row[0] if row else None
+
     def _poll_loop(self):
         """Background loop: poll SessionDB for new messages."""
         db = _get_session_db()
@@ -537,13 +664,19 @@ class EventBridge:
     def _poll_once(self, db):
         """Check for new messages across all sessions.
 
-        Uses a single mtime check on state.db to skip work when nothing
-        has changed — makes 200ms polling essentially free.  Since #9006
-        the routing index itself lives in state.db (session rows carry
-        session_key/origin metadata), so a new conversation and its first
-        message land in the SAME file and one mtime check covers both —
-        eliminating the old dual-file (sessions.json + state.db) race that
-        could drop brand-new conversations (#8925).
+        A cheap mtime check on state.db carries the common case — it makes
+        200ms polling essentially free.  Since #9006 the routing index itself
+        lives in state.db (session rows carry session_key/origin metadata), so
+        a new conversation and its first message land in the SAME file and one
+        check covers both — eliminating the old dual-file (sessions.json +
+        state.db) race that could drop brand-new conversations (#8925).
+
+        An unchanged mtime is not proof of an unchanged database: filesystem
+        timestamps tick on the coarse clock, so a commit landing in the same
+        tick as the previous stat leaves the mtime identical, and under WAL a
+        commit does not touch the main file at all until checkpoint. So the
+        database itself is asked, via PRAGMA data_version, before any poll is
+        skipped.
         """
         try:
             from hermes_constants import get_hermes_home
@@ -552,19 +685,32 @@ class EventBridge:
             db_file = Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")) / "state.db"
 
         try:
-            db_mtime = db_file.stat().st_mtime if db_file.exists() else 0.0
+            db_stat = db_file.stat()
         except OSError:
-            db_mtime = 0.0
+            db_stat = None
 
-        if db_mtime == self._state_db_mtime:
-            return  # Nothing changed since last poll — skip entirely
+        db_mtime = db_stat.st_mtime if db_stat is not None else 0.0
 
-        self._state_db_mtime = db_mtime
+        if db_stat is None:
+            # Nothing to watch: drop the connection and the watermark so a
+            # recreated state.db is sampled from scratch.
+            self._close_state_watch_conn()
+            self._state_db_version = None
+            if db_mtime == self._state_db_mtime:
+                return  # Still absent since last poll — skip entirely
+        elif db_mtime == self._state_db_mtime:
+            version = self._sample_state_db_version(db_file, db_stat)
+            # An unreadable version (None) leaves quiescence unconfirmed, so
+            # the scan below runs rather than risk dropping events.
+            if version is not None and version == self._state_db_version:
+                return  # Confirmed quiet since last poll — skip entirely
+
         # Refresh the routing index from state.db on every change tick —
         # it's a single indexed query and it can never lag the messages
-        # table (both live in the same database file).
-        self._cached_sessions_index = _load_sessions_index()
-        entries = self._cached_sessions_index
+        # table (both live in the same database file). The watermark is taken
+        # with it, so the index can never trail what the skip gate treats as
+        # already seen; see _refresh_index_and_watermark.
+        entries = self._refresh_index_and_watermark(db_file)
 
         for session_key, entry in entries.items():
             session_id = entry.get("session_id", "")

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -9,6 +9,7 @@ Three layers of tests:
 """
 
 import asyncio
+import contextlib
 import inspect
 import json
 import os
@@ -1094,6 +1095,111 @@ class TestEdgeCases:
 # 7. EVENT BRIDGE POLL LOOP E2E — real SQLite DB, mtime optimization
 # ---------------------------------------------------------------------------
 
+_POLL_SESSION_KEY = "agent:main:telegram:dm:poll_regression"
+
+
+@contextlib.contextmanager
+def _baselined_bridge(tmp_path, monkeypatch, session_id):
+    """Yield (bridge, db, db_path) for a bridge baselined over a real state.db.
+
+    The database holds one message and the routing index names one session, so
+    the bridge has recorded that session's latest timestamp and state.db's
+    watermark: anything committed afterwards is a genuinely new event.
+
+    Baselining opens the bridge's read-only watcher connection, so the whole
+    test body runs inside this manager and stop() closes it however the test
+    ends.
+    """
+    import mcp_serve
+
+    sessions_dir = tmp_path / "sessions"
+    sessions_dir.mkdir()
+    monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+    (sessions_dir / "sessions.json").write_text(json.dumps({
+        _POLL_SESSION_KEY: {
+            "session_key": _POLL_SESSION_KEY,
+            "session_id": session_id,
+            "platform": "telegram",
+            "updated_at": "2026-03-29T15:00:01",
+            "origin": {"platform": "telegram", "chat_id": "poll_regression"},
+        }
+    }))
+
+    db_path = tmp_path / "state.db"
+    _create_test_db(db_path, session_id, [
+        {"role": "user", "content": "baselined", "timestamp": "2026-03-29T15:00:01"},
+    ])
+
+    class CountingDB:
+        def __init__(self):
+            self.call_count = 0
+
+        def get_messages(self, sid):
+            self.call_count += 1
+            conn = sqlite3.connect(str(db_path))
+            conn.row_factory = sqlite3.Row
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                (sid,),
+            ).fetchall()
+            conn.close()
+            return [dict(r) for r in rows]
+
+    db = CountingDB()
+    monkeypatch.setattr(mcp_serve, "_get_session_db", lambda: db)
+
+    bridge = mcp_serve.EventBridge()
+    bridge._establish_baseline()
+    try:
+        yield bridge, db, db_path
+    finally:
+        bridge.stop()
+
+
+def _commit_reply(db_path, session_id, content, conn=None):
+    """Commit one message through a connection other than the bridge's."""
+    writer = conn if conn is not None else sqlite3.connect(str(db_path))
+    try:
+        writer.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) VALUES (?, ?, ?, ?)",
+            (session_id, "assistant", content, "2026-03-29T15:00:09"),
+        )
+        writer.commit()
+    finally:
+        if conn is None:
+            writer.close()
+
+
+def _messages_in_main_db_file(db_path, tmp_path, session_id):
+    """Return the message contents readable from state.db's main file alone.
+
+    The file is copied WITHOUT its -wal sidecar, so a commit still parked in
+    the write-ahead log is invisible here while the live database still
+    serves it — which is what makes "not yet checkpointed" an assertion rather
+    than an assumption.
+    """
+    main_only = tmp_path / "state-main-file-only.db"
+    main_only.write_bytes(db_path.read_bytes())
+    conn = sqlite3.connect(str(main_only))
+    try:
+        return [row[0] for row in conn.execute(
+            "SELECT content FROM messages WHERE session_id = ? ORDER BY id",
+            (session_id,),
+        )]
+    finally:
+        conn.close()
+
+
+def _pin_mtime(db_path, stat_result):
+    """Restore db_path's timestamps to stat_result, to the nanosecond.
+
+    Reproduces what a coarse filesystem clock does on its own — leave the mtime
+    byte-identical across a commit — without depending on the granularity of
+    the clock the tests happen to run on.
+    """
+    os.utime(db_path, ns=(stat_result.st_atime_ns, stat_result.st_mtime_ns))
+
+
 class TestEventBridgePollE2E:
     """End-to-end tests for the EventBridge polling loop with real files."""
 
@@ -1419,6 +1525,94 @@ class TestEventBridgePollE2E:
         assert len(events) == 1
         assert events[0]["session_key"] == "agent:main:telegram:dm:fresh"
         assert events[0]["content"] == "hello after baseline"
+
+    def test_poll_delivers_commit_landing_within_one_mtime_tick(self, tmp_path, monkeypatch):
+        """A commit whose mtime is indistinguishable from the previous poll's
+        must still be delivered.
+
+        File timestamps tick on the coarse clock, so a commit landing in the
+        same tick as the last stat leaves state.db's mtime byte-identical. The
+        mtime is restored to the baselined value so that condition holds on any
+        clock granularity instead of by timing luck.
+        """
+        session_id = "20260329_150000_same_tick"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+            assert bridge._state_db_mtime == baseline_stat.st_mtime
+
+            _commit_reply(db_path, session_id, "same-tick reply")
+            _pin_mtime(db_path, baseline_stat)
+            assert db_path.stat().st_mtime == bridge._state_db_mtime
+
+            bridge._poll_once(db)
+            events = bridge.poll_events(after_cursor=0)["events"]
+
+        assert [e["content"] for e in events] == ["same-tick reply"]
+
+    def test_poll_delivers_wal_commit_parked_before_checkpoint(self, tmp_path, monkeypatch):
+        """A WAL commit must be delivered before anything checkpoints it.
+
+        In WAL mode the commit lands in state.db-wal and the main file is left
+        alone until checkpoint, so its mtime cannot report the write.
+        Autocheckpointing is off and the writer connection stays open across
+        the poll, and the test proves the commit is still parked rather than
+        assuming it: the row is readable from the live database and absent from
+        the main file on its own.
+        """
+        session_id = "20260329_150000_wal_commit"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+
+            writer = sqlite3.connect(str(db_path))
+            try:
+                # Switching journal mode rewrites the main file's header; the
+                # pin below puts its mtime back to the value the bridge
+                # baselined, so only the WAL commit is left for the poll to
+                # notice.
+                assert writer.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+                writer.execute("PRAGMA wal_autocheckpoint=0")
+                _commit_reply(db_path, session_id, "wal reply", conn=writer)
+
+                assert "wal reply" in [m["content"] for m in db.get_messages(session_id)]
+                assert "wal reply" not in _messages_in_main_db_file(
+                    db_path, tmp_path, session_id)
+
+                _pin_mtime(db_path, baseline_stat)
+                assert db_path.stat().st_mtime == bridge._state_db_mtime
+
+                bridge._poll_once(db)
+                events = bridge.poll_events(after_cursor=0)["events"]
+            finally:
+                writer.close()
+
+        assert [e["content"] for e in events] == ["wal reply"]
+
+    def test_poll_after_delivery_skips_when_nothing_committed(self, tmp_path, monkeypatch):
+        """Confirming quiescence must stay as cheap as the old mtime check.
+
+        Both polls see the same pinned mtime, so the skip can only come from
+        the database itself reporting no commit — not from a timestamp that
+        happened to move.
+        """
+        session_id = "20260329_150000_quiet_after"
+        with _baselined_bridge(tmp_path, monkeypatch, session_id) as (bridge, db, db_path):
+            baseline_stat = db_path.stat()
+
+            _commit_reply(db_path, session_id, "delivered reply")
+            _pin_mtime(db_path, baseline_stat)
+
+            bridge._poll_once(db)
+            assert bridge.poll_events(after_cursor=0)["events"]
+            delivered_calls = db.call_count
+            assert delivered_calls >= 1
+
+            # Nothing commits between the two polls.
+            _pin_mtime(db_path, baseline_stat)
+            assert db_path.stat().st_mtime == bridge._state_db_mtime
+            bridge._poll_once(db)
+
+        assert db.call_count == delivered_calls, \
+            "A poll over a confirmed-quiet state.db must not read messages"
 
     def test_poll_interval_is_200ms(self):
         """Verify the poll interval constant."""


### PR DESCRIPTION
## What does this PR do?

Makes the MCP EventBridge detect committed SQLite changes even when `state.db` keeps the same mtime or the commit remains only in `state.db-wal`.

The bridge keeps its cheap mtime fast path, but confirms an apparently quiet database with `PRAGMA data_version` on a long-lived, tracked, read-only connection. An unreadable version fails open to a scan. Database replacement is detected by device/inode identity, and the watcher is closed safely with the polling thread.

This is a conflict-resolved rebase of #82435 onto current `main` (`f98f5e74e`), preserving Vadim Comanescu as the author of both commits. It is not an independent reimplementation. #82412 is the smaller filesystem-signature alternative; `data_version` covers WAL frame reuse and same-tick commits without relying on WAL mtime or size changes.

## Related Issue

Fixes #82377
Fixes #82433

Related: #82412, #82435

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `mcp_serve.py`: add SQLite-native change tracking to `EventBridge`, including replacement, race, error, and shutdown handling.
- `tests/test_mcp_serve.py`: add deterministic real-SQLite coverage for same-mtime commits, uncheckpointed WAL commits, and the confirmed-quiet fast path.

## How to Test

1. Baseline an EventBridge over a real temporary `state.db`.
2. Commit through a second SQLite connection, pin the main DB mtime to its baseline value, and verify the message is delivered.
3. Repeat in WAL mode with autocheckpoint disabled and verify delivery while the row is absent from a copy of the main DB file alone.

Validation on macOS 26 / Python 3.12.8:

- `scripts/run_tests.sh tests/test_mcp_serve.py` — 92 passed.
- `scripts/run_tests.sh tests/test_mcp_serve.py tests/test_sqlite_lock_safe_inspection.py tests/test_state_db_notadb_fail_closed.py` — 103 passed.
- `ruff check mcp_serve.py tests/test_mcp_serve.py` — passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs; this rebases the conflicted #82435 and preserves its authorship.
- [x] My PR contains only changes related to this fix.
- [ ] I've run the entire test suite; targeted and adjacent suites are green as listed above.
- [x] I've added tests for my changes.
- [x] I've tested on macOS 26 with Python 3.12.8.

### Documentation & Housekeeping

- [x] Documentation update: N/A; behavior and rationale are documented in code.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow changed.
- [x] Cross-platform impact considered: implementation uses stdlib SQLite/stat APIs and real filesystem tests.
- [x] Tool descriptions/schemas: N/A; no MCP surface changed.
