### PR TITLE
fix(compression): size the summary deadline to the summary it asks for

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -8602,7 +8602,44 @@ _DEFAULT_AUX_TIMEOUT = 30.0
 # per-call ``timeout=``.  A floor is harmless for fast compression models
 # (they finish before the deadline) and is a minimum, so a higher config value
 # is kept unchanged.
+#
+# The flat floor covers connect + prompt ingestion + reasoning before the first
+# summary token, but NOT the summary itself: the compressor asks for up to
+# ``_SUMMARY_TOKENS_CEILING`` (10K) output tokens, and a slow reasoning
+# summariser cannot emit that inside a size-blind deadline.  A measured
+# gpt-5.6 class model on the ChatGPT/Codex route sustains ~18 tok/s, so a 10K
+# target needs ~9 minutes of generation and times out on EVERY attempt — the
+# session then never compacts, grows past its window, and each failure arms a
+# longer summary cooldown while the transcript keeps growing.  So the floor is
+# scaled by the output the caller says it will request; see
+# :func:`_compression_timeout_floor`.
 _COMPRESSION_TIMEOUT_FLOOR_SECONDS = 300.0
+# Slowest sustained summary output rate we still treat as "alive", in tokens
+# per second.  Anything slower is not merely slow — the host's own idle
+# watchdog (``compression.context_timeout_seconds``) aborts a stream that
+# stops producing tokens, so this only has to bound a *streaming* call.
+_COMPRESSION_MIN_SUMMARY_TOKENS_PER_SECOND = 15.0
+# Absolute cap so a pathological budget can't produce an unbounded deadline.
+_COMPRESSION_TIMEOUT_CEILING_SECONDS = 1800.0
+
+
+def _compression_timeout_floor(expected_output_tokens: Optional[int]) -> float:
+    """Return the compression deadline floor for a summary of that size.
+
+    ``expected_output_tokens`` is the summary budget the caller is about to
+    request (``None``/0 when unknown, which keeps the historical flat floor).
+    The result is base + generation time at the slowest rate we consider
+    healthy, capped by :data:`_COMPRESSION_TIMEOUT_CEILING_SECONDS`.
+    """
+    base = _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+    try:
+        budget = int(expected_output_tokens or 0)
+    except (TypeError, ValueError):
+        return base
+    if budget <= 0:
+        return base
+    generation = budget / _COMPRESSION_MIN_SUMMARY_TOKENS_PER_SECOND
+    return min(base + generation, _COMPRESSION_TIMEOUT_CEILING_SECONDS)
 
 
 def _get_auxiliary_task_config(task: str) -> Dict[str, Any]:
@@ -8783,7 +8820,11 @@ def _get_task_timeout(task: str, default: float = _DEFAULT_AUX_TIMEOUT) -> float
     return default
 
 
-def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
+def _effective_aux_timeout(
+    task: str,
+    timeout: Optional[float],
+    expected_output_tokens: Optional[int] = None,
+) -> float:
     """Resolve the effective timeout for an auxiliary LLM call.
 
     Uses the caller-provided ``timeout`` when given; otherwise reads
@@ -8793,10 +8834,16 @@ def _effective_aux_timeout(task: str, timeout: Optional[float]) -> float:
     (#54915).  The floor is intentionally skipped when the caller passes an
     explicit ``timeout=`` — explicit per-call deadlines are always honoured —
     and it is a minimum (``max``), so a config value already above it is kept.
+
+    ``expected_output_tokens`` lets the caller declare how large a response it
+    is about to ask for; the compression floor scales with it so a large
+    summary budget is not handed a deadline it provably cannot meet.
     """
     effective = timeout if timeout is not None else _get_task_timeout(task)
     if timeout is None and task == "compression":
-        effective = max(effective, _COMPRESSION_TIMEOUT_FLOOR_SECONDS)
+        effective = max(
+            effective, _compression_timeout_floor(expected_output_tokens)
+        )
     return effective
 
 
@@ -9933,6 +9980,7 @@ def call_llm(
     stream_options: dict = None,
     route_info: Optional[Dict[str, str]] = None,
     latency_info: Optional[Dict[str, int]] = None,
+    expected_output_tokens: Optional[int] = None,
 ) -> Any:
     """Run an auxiliary LLM request, applying the configured task limit."""
     queue_started_at = time.monotonic()
@@ -9987,6 +10035,7 @@ def call_llm(
                 stream=stream,
                 stream_options=stream_options,
                 route_info=route_info,
+                expected_output_tokens=expected_output_tokens,
             )
         if stream and semaphore is not None:
             stream_semaphore = semaphore
@@ -10037,6 +10086,7 @@ def _call_llm_impl(
     stream: bool = False,
     stream_options: dict = None,
     route_info: Optional[Dict[str, str]] = None,
+    expected_output_tokens: Optional[int] = None,
 ) -> Any:
     """Centralized synchronous LLM call.
 
@@ -10068,6 +10118,10 @@ def _call_llm_impl(
             output can stream to the user.
         stream_options: Passed through to the request when stream is True
             (e.g. {"include_usage": True}).
+        expected_output_tokens: How many output tokens this call will ask the
+            model to produce. Only used to size the compression deadline floor
+            (see :func:`_compression_timeout_floor`); it is never sent on the
+            wire and never caps the response.
 
     Returns:
         Response object with .choices[0].message.content, OR — when stream=True —
@@ -10168,7 +10222,9 @@ def _call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
+    effective_timeout = _effective_aux_timeout(
+        task, timeout, expected_output_tokens
+    )
     request_provider = effective_provider or resolved_provider
     compression_config = (
         _get_auxiliary_task_config("compression") if task == "compression" else {}
@@ -10887,6 +10943,7 @@ async def async_call_llm(
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    expected_output_tokens: Optional[int] = None,
 ) -> Any:
     """Run an asynchronous auxiliary LLM request under the configured limit."""
     semaphore = _acquire_async_aux_semaphore(task)
@@ -10908,6 +10965,7 @@ async def async_call_llm(
             extra_body=extra_body,
             reasoning_config=reasoning_config,
             route_info=route_info,
+            expected_output_tokens=expected_output_tokens,
         )
     finally:
         if semaphore is not None:
@@ -10930,6 +10988,7 @@ async def _async_call_llm_impl(
     extra_body: dict = None,
     reasoning_config: Optional[dict] = None,
     route_info: Optional[Dict[str, str]] = None,
+    expected_output_tokens: Optional[int] = None,
 ) -> Any:
     """Centralized asynchronous LLM call.
 
@@ -11019,7 +11078,9 @@ async def _async_call_llm_impl(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
                 f"Run: hermes setup")
 
-    effective_timeout = _effective_aux_timeout(task, timeout)
+    effective_timeout = _effective_aux_timeout(
+        task, timeout, expected_output_tokens
+    )
     request_provider = effective_provider or resolved_provider
     _set_relay_auxiliary_route(
         request_provider,

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5153,6 +5153,14 @@ Spend up to ~{_LEAN_SESSION_LOG_BUDGET_TOKENS} tokens here — this section is t
         else:
             _session_log_section = ""
 
+        # Total output this prompt asks for. Used both in the visible "Target
+        # ~N tokens" directive and to size the auxiliary deadline, so the two
+        # can never drift apart (a deadline smaller than the ask times out on
+        # every attempt).
+        _requested_summary_tokens = summary_budget + (
+            _LEAN_SESSION_LOG_BUDGET_TOKENS if _session_log_section else 0
+        )
+
         _template_sections = f"""{HISTORICAL_TASK_HEADING}
 {_historical_task_instructions}
 
@@ -5205,7 +5213,7 @@ repeat each one verbatim here — copy the exact text, do NOT paraphrase, summar
 or describe them. These markers tell the agent which skills must be reloaded before
 use. If none appear, omit this section entirely.]
 
-Target ~{summary_budget + (_LEAN_SESSION_LOG_BUDGET_TOKENS if _session_log_section else 0)} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
+Target ~{_requested_summary_tokens} tokens. Be CONCRETE — include file paths, command outputs, error messages, line numbers, and specific values. Avoid vague descriptions like "made some changes" — say exactly what changed.
 {_temporal_anchoring_rule}
 Write only the summary body. Do not include any preamble or prefix."""
 
@@ -5275,6 +5283,15 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # summaries and compaction loops. Omitting lets the adapter
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
+                #
+                # Declare how much output the prompt above asks for so the
+                # deadline can be sized to it. Without this the compression
+                # timeout floor is size-blind: a slow reasoning summariser
+                # asked for a 10K-token handoff exhausts a flat deadline on
+                # every attempt, so the session never compacts and grows past
+                # its own context window. Advisory only — never sent on the
+                # wire, never a cap (see the max_tokens note above).
+                "expected_output_tokens": _requested_summary_tokens,
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model

--- a/tests/agent/test_compression_summary_deadline_budget.py
+++ b/tests/agent/test_compression_summary_deadline_budget.py
@@ -1,0 +1,286 @@
+"""The compression deadline must cover the summary the compressor asks for.
+
+Symptom this guards: a session stops compacting forever. The compressor asks
+for a handoff of up to ``_SUMMARY_TOKENS_CEILING`` (10K) output tokens, but the
+auxiliary deadline was a flat 300 s regardless of that ask. A reasoning
+summariser sustaining ~18 tok/s needs ~9 minutes for a 10K-token summary, so
+every attempt exhausted the deadline, compression aborted, the transcript kept
+growing past the model's context window, and each failure armed a longer
+summary cooldown.
+
+The contract asserted here is a relation, not a snapshot: whatever output the
+compression prompt requests, the deadline handed to the provider must be able
+to produce it at the slowest rate we still consider healthy.
+"""
+
+import re
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+
+from agent.auxiliary_client import (
+    _COMPRESSION_MIN_SUMMARY_TOKENS_PER_SECOND,
+    _COMPRESSION_TIMEOUT_CEILING_SECONDS,
+    _COMPRESSION_TIMEOUT_FLOOR_SECONDS,
+    _compression_timeout_floor,
+    async_call_llm,
+    call_llm,
+)
+
+# A config-derived compression timeout well below any scaled floor, so the
+# floor is what reaches the provider.
+LOW_CONFIG_TIMEOUT = 120.0
+
+
+def _seconds_needed(output_tokens: int) -> float:
+    """Wall clock the slowest healthy summariser needs for that many tokens."""
+    return output_tokens / _COMPRESSION_MIN_SUMMARY_TOKENS_PER_SECOND
+
+
+def _client_sync():
+    client = MagicMock()
+    client.base_url = "https://api.openai.com/v1"
+    client.chat.completions.create.return_value = {"ok": True}
+    return client
+
+
+def _client_async():
+    client = MagicMock()
+    client.base_url = "https://api.openai.com/v1"
+    client.chat.completions.create = AsyncMock(return_value={"ok": True})
+    return client
+
+
+def _patches(client, *, task_timeout):
+    return (
+        patch("agent.auxiliary_client._resolve_task_provider_model",
+              return_value=("openai-codex", "gpt-5.6", None, None, None)),
+        patch("agent.auxiliary_client._get_cached_client",
+              return_value=(client, "gpt-5.6")),
+        patch("agent.auxiliary_client._validate_llm_response",
+              side_effect=lambda resp, _task, **_kw: resp),
+        patch("agent.auxiliary_client._get_task_timeout",
+              return_value=task_timeout),
+    )
+
+
+class TestCompressionTimeoutFloorScaling:
+    """The floor itself, as a pure function of the requested output size."""
+
+    def test_unknown_budget_keeps_the_flat_floor(self):
+        assert _compression_timeout_floor(None) == _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+        assert _compression_timeout_floor(0) == _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+
+    @pytest.mark.parametrize("budget", [2_000, 6_000, 10_000, 14_000])
+    def test_floor_covers_generating_the_requested_output(self, budget):
+        """The whole bug: a deadline smaller than the ask times out every time."""
+        floor = _compression_timeout_floor(budget)
+        assert floor >= _seconds_needed(budget), (
+            f"a {budget}-token summary needs >= {_seconds_needed(budget):.0f}s of "
+            f"generation but the deadline is {floor:.0f}s"
+        )
+
+    def test_floor_is_monotonic_in_the_requested_output(self):
+        floors = [_compression_timeout_floor(b) for b in (1_000, 5_000, 10_000)]
+        assert floors == sorted(floors)
+        assert floors[0] < floors[-1], "a bigger ask must not get an equal deadline"
+
+    def test_floor_never_drops_below_the_historical_flat_floor(self):
+        """Prompt ingestion and pre-token reasoning still need the base budget."""
+        assert _compression_timeout_floor(1) >= _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+
+    def test_pathological_budget_stays_bounded(self):
+        assert (
+            _compression_timeout_floor(10_000_000)
+            == _COMPRESSION_TIMEOUT_CEILING_SECONDS
+        )
+
+    def test_garbage_budget_degrades_to_the_flat_floor(self):
+        assert _compression_timeout_floor("lots") == _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+        assert _compression_timeout_floor(-5) == _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+
+
+class TestDeclaredBudgetReachesTheProvider:
+    """``expected_output_tokens`` must actually widen the deadline on the wire."""
+
+    def test_declared_budget_widens_the_deadline(self):
+        client = _client_sync()
+        budget = 10_000
+        p1, p2, p3, p4 = _patches(client, task_timeout=LOW_CONFIG_TIMEOUT)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "summarise this"}],
+                expected_output_tokens=budget,
+            )
+        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        assert timeout >= _seconds_needed(budget)
+        assert timeout > _COMPRESSION_TIMEOUT_FLOOR_SECONDS, (
+            "a 10K-token ask must not be capped at the size-blind flat floor"
+        )
+
+    def test_undeclared_budget_keeps_prior_behavior(self):
+        client = _client_sync()
+        p1, p2, p3, p4 = _patches(client, task_timeout=LOW_CONFIG_TIMEOUT)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+            )
+        timeout = client.chat.completions.create.call_args.kwargs["timeout"]
+        assert timeout == _COMPRESSION_TIMEOUT_FLOOR_SECONDS
+
+    def test_explicit_per_call_timeout_still_wins(self):
+        """An explicit deadline is a caller contract; scaling must not raise it."""
+        client = _client_sync()
+        p1, p2, p3, p4 = _patches(client, task_timeout=LOW_CONFIG_TIMEOUT)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+                timeout=45.0,
+                expected_output_tokens=10_000,
+            )
+        assert client.chat.completions.create.call_args.kwargs["timeout"] == 45.0
+
+    def test_config_timeout_above_the_scaled_floor_is_kept(self):
+        client = _client_sync()
+        generous = _compression_timeout_floor(10_000) + 600.0
+        p1, p2, p3, p4 = _patches(client, task_timeout=generous)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+                expected_output_tokens=10_000,
+            )
+        assert client.chat.completions.create.call_args.kwargs["timeout"] == generous
+
+    def test_other_tasks_are_not_scaled(self):
+        """Only compression owns this floor; a declared budget must not leak."""
+        client = _client_sync()
+        p1, p2, p3, p4 = _patches(client, task_timeout=30.0)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "x"}],
+                expected_output_tokens=10_000,
+            )
+        assert client.chat.completions.create.call_args.kwargs["timeout"] == 30.0
+
+    def test_declared_budget_is_never_sent_on_the_wire(self):
+        """It sizes the deadline only — it must not become a request field."""
+        client = _client_sync()
+        p1, p2, p3, p4 = _patches(client, task_timeout=LOW_CONFIG_TIMEOUT)
+        with p1, p2, p3, p4:
+            call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+                expected_output_tokens=10_000,
+            )
+        sent = client.chat.completions.create.call_args.kwargs
+        assert "expected_output_tokens" not in sent
+        assert sent.get("max_tokens") is None
+        assert sent.get("max_completion_tokens") is None
+
+    @pytest.mark.asyncio
+    async def test_async_path_scales_identically(self):
+        client = _client_async()
+        budget = 10_000
+        p1, p2, p3, p4 = _patches(client, task_timeout=LOW_CONFIG_TIMEOUT)
+        with p1, p2, p3, p4:
+            await async_call_llm(
+                task="compression",
+                messages=[{"role": "user", "content": "x"}],
+                expected_output_tokens=budget,
+            )
+        sent = client.chat.completions.create.call_args.kwargs
+        assert sent["timeout"] >= _seconds_needed(budget)
+        assert "expected_output_tokens" not in sent
+
+
+def _compressor(*, tail_mode="lean"):
+    """Minimal compressor state for driving ``_generate_summary``."""
+    c = ContextCompressor.__new__(ContextCompressor)
+    c.protect_first_n = 2
+    c.protect_last_n = 5
+    c.tail_token_budget = 20_000
+    c.tail_mode = tail_mode
+    c.context_length = 272_000
+    c.threshold_percent = 0.80
+    c.threshold_tokens = 204_000
+    c.summary_target_ratio = 0.20
+    c.max_summary_tokens = 10_000
+    c.quiet_mode = True
+    c.compression_count = 0
+    c.last_prompt_tokens = 0
+    c._previous_summary = None
+    c._ineffective_compression_count = 0
+    c._verify_compaction_cleared_threshold = False
+    c._summary_failure_cooldown_until = 0.0
+    c.summary_model = None
+    c.model = "test-model"
+    c.provider = "test"
+    c.base_url = "http://localhost"
+    c.api_key = "test-key"
+    c.api_mode = "chat_completions"
+    return c
+
+
+def _long_turns():
+    """Enough content that the scaled budget is well above the minimum."""
+    body = "deploy the strimzi runtime and record the outcome. " * 400
+    return [
+        {"role": "user", "content": f"turn {i}: {body}"}
+        if i % 2 == 0
+        else {"role": "assistant", "content": f"turn {i}: {body}"}
+        for i in range(40)
+    ]
+
+
+class TestCompressorDeclaresWhatItAsksFor:
+    """The prompt's ask and the declared deadline input must not drift apart."""
+
+    @pytest.mark.parametrize("tail_mode", ["lean", "full"])
+    def test_declared_budget_matches_the_prompt_target(self, tail_mode):
+        compressor = _compressor(tail_mode=tail_mode)
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "## Goal\nship it."
+            return resp
+
+        with patch("agent.context_compressor.call_llm", fake_call_llm):
+            assert compressor._generate_summary(_long_turns()) is not None
+
+        prompt = captured["messages"][0]["content"]
+        target = re.search(r"Target ~(\d+) tokens", prompt)
+        assert target, "summary prompt must state the output it asks for"
+        assert captured["expected_output_tokens"] == int(target.group(1)), (
+            "the deadline is sized from expected_output_tokens; if it does not "
+            "match the tokens the prompt actually requests, the summary can "
+            "outlive its own deadline on every attempt"
+        )
+
+    def test_declared_budget_buys_enough_time_to_produce_it(self):
+        """End of the chain: what the compressor asks for is what it can wait for."""
+        compressor = _compressor()
+        captured = {}
+
+        def fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "## Goal\nship it."
+            return resp
+
+        with patch("agent.context_compressor.call_llm", fake_call_llm):
+            compressor._generate_summary(_long_turns())
+
+        declared = captured["expected_output_tokens"]
+        assert declared > 0
+        assert _compression_timeout_floor(declared) >= _seconds_needed(declared)


### PR DESCRIPTION
## Symptom

A session stops compacting **permanently** and grows past its own context window.

```
Preflight compression: ~580,840 tokens >= 204,000 threshold (model gpt-5.6-sol, ctx 272,000)
context compression started: messages=436 tokens=~580,840
Context compression still streaming after 120s (last progress 0.0s ago) — extending wait
Context compression still streaming after 240s (last progress 0.0s ago) — extending wait
Context compression made no progress for 120.0s (total wait 420.0s); continuing without compression
Failed to generate context summary: Codex auxiliary Responses stream exceeded 300.0s
  total timeout. Further summary attempts paused for 900 seconds.
```

Observed on one session across **12 consecutive failures over 14 hours** (last success
`17:19`, then every attempt failed), ending with real provider prompts of **449K tokens
against a 272K window** and per-call latencies of 86–105s. A sibling session on the same
route, same model, same host kept compacting fine — it was just small enough to land
under 300s.

## Root cause

`last progress 0.0s ago` is a **streamed token**. The call was not hung; it was killed
mid-summary by a deadline that never accounted for the output it asked for.

Two constants disagree:

| | value | where |
|---|---|---|
| summary the compressor **asks for** | up to `_SUMMARY_TOKENS_CEILING` = **10,000** tokens (`min(0.2·content, min(0.05·ctx, 10K))`, + 4K lean session log) | `context_compressor.py` |
| deadline it is **given** | flat **300s**, independent of that ask | `_COMPRESSION_TIMEOUT_FLOOR_SECONDS` |

A reasoning summariser sustaining ~18 tok/s needs ~9 minutes for a 10K-token handoff,
so the deadline is exhausted on every attempt. Compression then aborts on a
summary-generation failure — correctly, a placeholder handoff is worse than none — so
the transcript is preserved, keeps growing, the next attempt asks for the same budget
and fails identically, and the cooldown ladder (60s → 300s → 900s) stretches while the
session climbs further past its window. It never recovers on its own.

### Reproduction

Rebuilt the exact failing payload from `state.db` (`_serialize_for_summary` +
`_bound_summary_input`, 40.5K prompt tokens) and fired the real aux path:

| prompt | model | result |
|---|---|---|
| simplified 4-section template, no target directive | `gpt-5.6-sol` | **47.9s** ✅ |
| real full template + `Target ~10000 tokens` | `gpt-5.6-sol` | **265.8s** — under 300s only because the offline repro omits the previous-summary block the live path carries |
| real full template + `Target ~10000 tokens` | `gpt-5.3-codex-spark` | **7.0s** ✅ |

Same route, same content, same account: the deadline tracks the size of the *ask*, and
nothing in the code sized it that way.

## Fix

Let a caller declare the output it is about to request, and scale the compression floor
by it:

```
_compression_timeout_floor(n) = min(300s + n / 15 tok/s, 1800s)
```

- **15 tok/s** is the slowest sustained rate we still treat as alive.
- A genuinely **hung** stream is still killed by the host's idle watchdog
  (`compression.context_timeout_seconds`, unchanged), so this only extends deadlines for
  calls that are actively producing tokens. Hang detection is not weakened.
- The 300s base still covers connect + prompt ingestion + pre-token reasoning.
- Explicit per-call `timeout=` still wins; a larger configured
  `auxiliary.compression.timeout` is still kept; other auxiliary tasks untouched.
- `expected_output_tokens` is **advisory only** — never sent on the wire, never a cap.
  The "NO `max_tokens` on the summary call" invariant is preserved and asserted.

The compressor now derives the prompt's `Target ~N tokens` directive **and** the declared
budget from one value, so the ask and the deadline cannot drift apart again.

## Tests

`tests/agent/test_compression_summary_deadline_budget.py` (19 tests). These assert a
**relation**, not a snapshot: whatever the prompt requests, the deadline must be able to
produce it at the slowest healthy rate.

- floor covers generation for 2K/6K/10K/14K budgets; monotonic in budget; never below the
  historical 300s; bounded at 1800s; garbage/negative degrades to the flat floor
- declared budget widens the deadline through real `call_llm` / `async_call_llm`
- undeclared budget keeps prior behaviour exactly (300s)
- explicit `timeout=` wins; higher config timeout kept; non-compression tasks unscaled
- declared budget never reaches the wire (sync + async), `max_tokens` still absent
- compressor invariant: `expected_output_tokens` == the `Target ~N tokens` the prompt
  actually asks for, in both `lean` and `full` tail modes

Reverting only the scaling arithmetic makes **8 of them fail** with a direct diagnostic:

```
AssertionError: a 10000-token summary needs >= 667s of generation but the deadline is 300s
```

```
scripts/run_tests.sh tests/agent/test_*compress*.py   → 54 files, 588 passed, 0 failed
scripts/run_tests.sh tests/agent/                     → 465 files, 5934 passed, 8 failed
```

Those 8 failures are pre-existing on clean `origin/main` in this environment (Anthropic
wire / vision routing client-shape tests) — verified by stashing the patch and re-running
them unchanged.
