### PR TITLE
fix(skills): reconcile singular/plural toolset names in the visibilit…

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1710,7 +1710,14 @@ def _canonical_toolset_name(name: str) -> str:
     Reconcile a one-letter singular/plural drift against the known toolset
     registry. Unknown names are returned unchanged, so a genuine typo still
     (correctly) gates the skill out rather than being force-matched.
+
+    A non-string / empty element (an empty ``requires_toolsets:`` value parses
+    to ``None``) is returned unchanged so the caller's membership check fails
+    closed exactly as the pre-canonicalization exact-match did — never raising
+    and crashing the whole snapshot's index build over one malformed skill.
     """
+    if not isinstance(name, str) or not name:
+        return name
     try:
         from toolsets import TOOLSETS
     except Exception:

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1698,6 +1698,32 @@ def _parse_skill_file(skill_file: Path) -> tuple[bool, dict, str]:
         return True, {}, ""
 
 
+def _canonical_toolset_name(name: str) -> str:
+    """Resolve a skill-authored toolset name to its canonical id.
+
+    Skill frontmatter is hand-authored, so the natural plural ``files`` drifts
+    from the canonical toolset id ``file`` (per ``hermes tools list`` /
+    ``toolsets.py``). Without reconciliation such a skill fails the
+    ``requires_toolsets`` gate in every toolset-filtered session and is silently
+    dropped from the index — no warning, no way to discover why (#99877).
+
+    Reconcile a one-letter singular/plural drift against the known toolset
+    registry. Unknown names are returned unchanged, so a genuine typo still
+    (correctly) gates the skill out rather than being force-matched.
+    """
+    try:
+        from toolsets import TOOLSETS
+    except Exception:
+        return name
+    if name in TOOLSETS:
+        return name
+    if name.endswith("s") and name[:-1] in TOOLSETS:
+        return name[:-1]
+    if (name + "s") in TOOLSETS:
+        return name + "s"
+    return name
+
+
 def _skill_should_show(
     conditions: dict,
     available_tools: "set[str] | None",
@@ -1724,10 +1750,15 @@ def _skill_should_show(
 
     at = available_tools or set()
     ats = available_toolsets or set()
+    # Reconcile the singular/plural toolset-name drift between hand-authored
+    # skill frontmatter and the canonical toolset ids (#99877). Tool names are
+    # exact identifiers with no singular/plural form, so only toolsets are
+    # canonicalized.
+    ats_canon = {_canonical_toolset_name(t) for t in ats}
 
     # fallback_for: hide when the primary tool/toolset IS available
     for ts in conditions.get("fallback_for_toolsets", []):
-        if ts in ats:
+        if _canonical_toolset_name(ts) in ats_canon:
             return False
     for t in conditions.get("fallback_for_tools", []):
         if t in at:
@@ -1735,7 +1766,7 @@ def _skill_should_show(
 
     # requires: hide when a required tool/toolset is NOT available
     for ts in conditions.get("requires_toolsets", []):
-        if ts not in ats:
+        if _canonical_toolset_name(ts) not in ats_canon:
             return False
     for t in conditions.get("requires_tools", []):
         if t not in at:

--- a/tests/agent/test_skill_toolset_alias_gate.py
+++ b/tests/agent/test_skill_toolset_alias_gate.py
@@ -47,6 +47,18 @@ def test_fallback_for_toolset_plural_hides_when_canonical_present():
     assert _skill_should_show(conds, set(), set()) is True        # absent -> show
 
 
+def test_non_string_requires_toolsets_element_gates_out():
+    # An empty `requires_toolsets:` value parses to None; malformed frontmatter
+    # may also carry non-string elements. These must gate the skill out (fail
+    # closed), never raise — a crash here aborts the whole index build, which is
+    # a worse failure mode than silently hiding one skill.
+    assert _skill_should_show({"requires_toolsets": [None]}, set(), {"file"}) is False
+    assert _skill_should_show({"requires_toolsets": [123]}, set(), {"file"}) is False
+    assert _skill_should_show({"requires_toolsets": ["files", None]}, set(), {"file"}) is False
+    # fallback_for with a bad element likewise must not raise.
+    assert _skill_should_show({"fallback_for_toolsets": [None]}, set(), {"file"}) is True
+
+
 def test_requires_tools_exact_match_unchanged():
     # Tool names are exact identifiers (no singular/plural form) — behaviour
     # must be untouched by the toolset canonicalization.

--- a/tests/agent/test_skill_toolset_alias_gate.py
+++ b/tests/agent/test_skill_toolset_alias_gate.py
@@ -1,0 +1,54 @@
+"""requires_toolsets gate reconciles the singular/plural toolset drift (#99877).
+
+Skill frontmatter is hand-authored, so the natural plural ``files`` diverges
+from the canonical toolset id ``file``. The visibility gate used exact string
+membership, so a skill declaring ``requires_toolsets: [files]`` failed the gate
+in every toolset-filtered session and was silently dropped. These tests pin
+that the canonical form is matched, that genuine typos are still gated out, and
+that exact-name behaviour (and ``requires_tools``) is unchanged.
+"""
+from agent.prompt_builder import _skill_should_show
+
+
+def test_plural_toolset_name_matches_canonical_singular():
+    # The regression: 'files' must satisfy a session that offers 'file'.
+    assert _skill_should_show({"requires_toolsets": ["files"]}, set(), {"file"}) is True
+
+
+def test_canonical_singular_still_matches():
+    assert _skill_should_show({"requires_toolsets": ["file"]}, set(), {"file"}) is True
+
+
+def test_required_toolset_absent_still_gates_out():
+    # Whichever spelling, if the session genuinely lacks it, hide the skill.
+    assert _skill_should_show({"requires_toolsets": ["file"]}, set(), set()) is False
+    assert _skill_should_show({"requires_toolsets": ["files"]}, set(), set()) is False
+
+
+def test_unknown_toolset_name_is_not_force_matched():
+    # A real typo (no singular/plural twin in the registry) must NOT be
+    # normalized into a match — the skill stays correctly gated.
+    assert _skill_should_show({"requires_toolsets": ["filez"]}, set(), {"file"}) is False
+
+
+def test_terminal_and_files_combo_loads_with_canonical_session():
+    # research-paper-writing shape: requires_toolsets: [terminal, files].
+    conds = {"requires_toolsets": ["terminal", "files"]}
+    assert _skill_should_show(conds, set(), {"terminal", "file"}) is True
+    # Missing one of them still gates out.
+    assert _skill_should_show(conds, set(), {"terminal"}) is False
+
+
+def test_fallback_for_toolset_plural_hides_when_canonical_present():
+    # fallback_for hides the skill when the primary IS available; the plural
+    # drift previously left it wrongly shown.
+    conds = {"fallback_for_toolsets": ["files"]}
+    assert _skill_should_show(conds, set(), {"file"}) is False   # file present -> hide
+    assert _skill_should_show(conds, set(), set()) is True        # absent -> show
+
+
+def test_requires_tools_exact_match_unchanged():
+    # Tool names are exact identifiers (no singular/plural form) — behaviour
+    # must be untouched by the toolset canonicalization.
+    assert _skill_should_show({"requires_tools": ["read_file"]}, {"read_file"}, set()) is True
+    assert _skill_should_show({"requires_tools": ["read_file"]}, set(), set()) is False


### PR DESCRIPTION
## What does this PR do?

The skill visibility gate (`_skill_should_show` in `agent/prompt_builder.py`)
checked `requires_toolsets` / `fallback_for_toolsets` with exact string
membership. The canonical toolset id is `file` (singular, per
`hermes tools list` / `toolsets.py`), so a skill authored with the natural
plural `files` — e.g. `research-paper-writing` (`requires_toolsets:
[terminal, files]`) — failed the gate in every toolset-filtered session and was
silently dropped from the index, with no warning or way to discover why
(#99877).

Canonicalize a one-letter singular/plural drift against the known toolset
registry (`toolsets.TOOLSETS`) before the membership check. Unknown names are
returned unchanged, so a genuine typo still (correctly) gates the skill out
rather than being force-matched. Tool names are exact identifiers with no
plural form, so only toolsets are canonicalized; `requires_tools` is unchanged.

## Related Issue

Fixes #99877

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` — `_canonical_toolset_name` helper; gate matches on
  the canonical form for `requires_toolsets` / `fallback_for_toolsets`.
- `tests/agent/test_skill_toolset_alias_gate.py` — plural match, canonical
  still matches, absent still gates out, typo not force-matched, fallback_for,
  and requires_tools unchanged.

## How to Test

    pytest tests/agent/test_skill_toolset_alias_gate.py -q

7 pass.