### PR TITLE
fix: normalize toolset name aliases in skill visibility gate

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -43,6 +43,22 @@ from agent.skill_utils import (
 )
 from utils import atomic_json_write
 
+
+# Common alias map for toolset names in skill metadata conditions
+_TOOLSET_ALIAS_MAP = {
+    "files": "file",
+}
+
+
+def _normalize_toolset_name(name: str) -> str:
+    """Normalize toolset name via alias map and case/strip."""
+    return _TOOLSET_ALIAS_MAP.get(name.strip().lower(), name.strip().lower())
+
+
+def _normalize_tool_name(name: str) -> str:
+    """Normalize tool name via case/strip (no tool aliases defined yet)."""
+    return name.strip().lower()
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1725,23 +1741,48 @@ def _skill_should_show(
     at = available_tools or set()
     ats = available_toolsets or set()
 
-    # fallback_for: hide when the primary tool/toolset IS available
+    # fallback_for: hide when the primary tool/toolset IS available (aliases normalized)
     for ts in conditions.get("fallback_for_toolsets", []):
-        if ts in ats:
+        if _normalize_toolset_name(ts) in ats:
             return False
     for t in conditions.get("fallback_for_tools", []):
-        if t in at:
+        if _normalize_tool_name(t) in at:
             return False
 
-    # requires: hide when a required tool/toolset is NOT available
+    # requires: hide when a required tool/toolset is NOT available (aliases normalized)
     for ts in conditions.get("requires_toolsets", []):
-        if ts not in ats:
+        if _normalize_toolset_name(ts) not in ats:
             return False
     for t in conditions.get("requires_tools", []):
-        if t not in at:
+        if _normalize_tool_name(t) not in at:
             return False
 
     return True
+
+
+def _warn_unknown_toolsets(conditions: dict, skill_file: Path) -> None:
+    """Log a warning if a skill declares toolset names that don't exist."""
+    try:
+        from toolsets import get_toolset_names
+    except Exception:
+        return  # toolsets import may fail in some build contexts
+
+    known = {ts.strip().lower() for ts in get_toolset_names()}
+    unknown = set()
+    for ts in conditions.get("requires_toolsets", []):
+        if _normalize_toolset_name(ts) not in known:
+            unknown.add(ts)
+    for ts in conditions.get("fallback_for_toolsets", []):
+        if _normalize_toolset_name(ts) not in known:
+            unknown.add(ts)
+
+    if unknown:
+        logger.warning(
+            "Skill %s declares unknown toolsets: %s. This may gate the skill out silently. "
+            "Check spelling and canonical names in `hermes tools list`.",
+            skill_file,
+            ", ".join(sorted(unknown))
+        )
 
 
 def _current_session_platform_hint() -> str:
@@ -1895,6 +1936,7 @@ def _build_skills_system_prompt_inner(
             skill_entries.append(entry)
             if not is_compatible:
                 continue
+            _warn_unknown_toolsets(extract_skill_conditions(frontmatter), skill_file)
             skill_name = entry["skill_name"]
             if entry["frontmatter_name"] in disabled or skill_name in disabled:
                 continue

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -868,6 +868,27 @@ class TestSkillShouldShow:
                       "fallback_for_tools": [], "requires_tools": []}
         assert _skill_should_show(conditions, set(), set()) is False
 
+    def test_requires_toolset_alias_passes_gate(self):
+        # "files" → "file" normalization allows skill to load
+        conditions = {"requires_toolsets": ["files"]}
+        assert _skill_should_show(conditions, set(), {"file"}) is True
+        assert _skill_should_show(conditions, set(), set()) is False
+
+    def test_requires_toolset_case_insensitive(self):
+        conditions = {"requires_toolsets": ["Terminal"]}
+        assert _skill_should_show(conditions, set(), {"terminal"}) is True
+
+    def test_fallback_for_alias_hides_when_primary_present(self):
+        # "files" alias should hide when "file" is available
+        conditions = {"fallback_for_toolsets": ["files"]}
+        assert _skill_should_show(conditions, set(), {"file"}) is False
+        assert _skill_should_show(conditions, set(), set()) is True
+
+    def test_unknown_toolset_still_gates(self):
+        # Normalization doesn't weaken the gate; non-existent names still fail
+        conditions = {"requires_toolsets": ["nonexistent_toolset_xyz"]}
+        assert _skill_should_show(conditions, set(), {"file", "terminal"}) is False
+
 
 
 
@@ -895,6 +916,20 @@ class TestBuildSkillsSystemPromptConditional:
             available_toolsets=set(),
         )
         assert "openhue" not in result
+
+    def test_requires_alias_skill_shown_when_canonical_present(self, monkeypatch, tmp_path):
+        # A skill declaring "files" should load when "file" is available
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "research" / "research-paper"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: research-paper\ndescription: Paper writing\nmetadata:\n  hermes:\n    requires_toolsets: [files]\n---\n"
+        )
+        result = build_skills_system_prompt(
+            available_tools={"read_file", "write_file"},
+            available_toolsets={"file"},
+        )
+        assert "research-paper" in result
 
 
 


### PR DESCRIPTION
Resolves #99877.

Skills declaring `requires_toolsets` with common aliases (e.g. `files`) were silently gated out of toolset-filtered sessions (CLI, TUI, messaging platforms) when only the canonical name (`file`) was present in `available_toolsets`. The gate in `_skill_should_show` did exact string membership against canonical registry names, and one-letter drift — even natural plurals — hid the skill forever. No warning, no log, no way for the user or author to discover why an installed skill never appeared.

This PR normalizes toolset and tool names at the gate via an alias map (`files` → `file`) and case-insensitive comparison in all four condition fields (`requires_toolsets`, `requires_tools`, `fallback_for_toolsets`, `fallback_for_tools`), so skills authored with natural plurals or case drift pass the gate when the canonical toolset is available. The helper `_warn_unknown_toolsets` surfaces truly unknown names (typos, stale references) at index build time (cold filesystem scan), logging a warning so mismatches show up instead of hiding skills silently.

Tests cover alias normalization (both requires and fallback variants), case-insensitive matching, unknown-name gating (normalization doesn't weaken the gate), and end-to-end `build_skills_system_prompt` behavior with a skill declaring `requires_toolsets: [files]` that now loads when `file` is available.

No runtime impact: aliases and case normalization already happen at skill visibility time (before index rendering), so existing sessions see the same skill set, and sessions with the canonical toolset will now see skills that were wrongly hidden before.