### PR TITLE
fix(telegram): invalidate deleted status cache

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -236,6 +236,7 @@ from gateway.platforms.base import (
 )
 from plugins.platforms.telegram.telegram_ids import (
     normalize_telegram_chat_id,
+    telegram_chat_id_key,
 )
 from plugins.platforms.telegram.telegram_network import (
     SEED_FALLBACK_IPS,
@@ -5754,7 +5755,7 @@ class TelegramAdapter(BasePlatformAdapter):
         message in place. If the edit fails (message deleted, too old, etc.)
         we drop the cached id and send fresh.
         """
-        key = (str(chat_id), str(status_key))
+        key = (telegram_chat_id_key(chat_id), str(status_key))
         cached_id = self._status_message_ids.get(key)
         if cached_id is not None:
             result = await self.edit_message(
@@ -6208,6 +6209,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id=normalize_telegram_chat_id(chat_id),
                 message_id=int(message_id),
             )
+            # ``send_or_update_status`` caches the Telegram message id so later
+            # updates can edit the same bubble. Once cleanup deletes that
+            # bubble, retaining the id makes the next turn edit a message that
+            # no longer exists ("Message to edit not found"). Invalidate only
+            # entries that point at this exact chat/message pair.
+            chat_key = telegram_chat_id_key(chat_id)
+            message_key = str(message_id)
+            for status_cache_key, cached_id in list(self._status_message_ids.items()):
+                if (
+                    telegram_chat_id_key(status_cache_key[0]) == chat_key
+                    and str(cached_id) == message_key
+                ):
+                    self._status_message_ids.pop(status_cache_key, None)
             return True
         except Exception as e:
             logger.debug(

--- a/tests/gateway/test_telegram_status_update.py
+++ b/tests/gateway/test_telegram_status_update.py
@@ -106,3 +106,29 @@ async def test_distinct_status_keys_do_not_collide(adapter):
     assert adapter._status_message_ids[("chat-1", "model-switch")] == "200"
 
 
+@pytest.mark.asyncio
+async def test_deleting_status_message_invalidates_cached_id(adapter):
+    """A deleted status bubble must never be edited on the next update."""
+    adapter._bot.delete_message = AsyncMock(return_value=True)
+    adapter._status_message_ids[("-100123", "lifecycle")] = "100"
+    adapter._status_message_ids[("-100123", "other")] = "200"
+    adapter._status_message_ids[("chat-2", "lifecycle")] = "100"
+
+    deleted = await adapter.delete_message("  -100123  ", "100")
+
+    assert deleted is True
+    assert ("-100123", "lifecycle") not in adapter._status_message_ids
+    assert adapter._status_message_ids[("-100123", "other")] == "200"
+    assert adapter._status_message_ids[("chat-2", "lifecycle")] == "100"
+
+    adapter.send.return_value = SendResult(success=True, message_id="300")
+    result = await adapter.send_or_update_status(
+        -100123, "lifecycle", "새 상태 메시지",
+    )
+
+    assert result.success is True
+    adapter.send.assert_awaited_once()
+    adapter.edit_message.assert_not_awaited()
+    assert adapter._status_message_ids[("-100123", "lifecycle")] == "300"
+
+


### PR DESCRIPTION
## Summary
- canonicalize Telegram status-cache chat keys
- invalidate cached status message IDs after successful deletion
- prevent later updates from editing a bubble that no longer exists

## Regression coverage
- verifies equivalent chat-id forms invalidate the same cache entry
- verifies unrelated status and chat entries remain intact
- verifies the next update sends fresh instead of editing stale state

## Verification
- `71 passed` across Telegram status update, cleanup progress, and stream consumer tests
- independent Fable 5 review: PASS, no blocking issues
