### PR TITLE
feat(discord): stream voice-turn TTS through mixer

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -15,7 +15,6 @@ import re
 import socket as _socket
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import uuid
@@ -252,13 +251,7 @@ def build_auto_tts_output_path(platform) -> str:
     from tools.tts_tool import OPUS_VOICE_PLATFORMS
 
     ext = "ogg" if _platform_name(platform) in OPUS_VOICE_PLATFORMS else "mp3"
-    audio_path = os.path.join(
-        tempfile.gettempdir(),
-        "hermes_voice",
-        f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}",
-    )
-    os.makedirs(os.path.dirname(audio_path), exist_ok=True)
-    return audio_path
+    return str(get_audio_cache_dir() / f"tts_reply_{uuid.uuid4().hex[:12]}.{ext}")
 
 
 def utf16_len(s: str) -> int:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -4832,8 +4832,12 @@ class BasePlatformAdapter(ABC):
         """
         return None
 
-    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
-        """Write one PCM chunk to the adapter's outbound audio track."""
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> Optional[bool]:
+        """Write one PCM chunk and optionally report whether audio was accepted.
+
+        Return ``False`` only when no PCM was accepted. ``None`` preserves
+        the legacy success contract, while truthy returns also mean accepted.
+        """
         pass
 
     async def finish_streaming_tts(self, handle: StreamingTTSHandle, *, interrupted: bool = False) -> None:

--- a/gateway/streaming_tts_consumer.py
+++ b/gateway/streaming_tts_consumer.py
@@ -332,8 +332,8 @@ class StreamingTTSConsumer:
             if not chunk:
                 continue
             was_audible = self._handle.audible
-            await self._adapter.write_streaming_tts(self._handle, chunk)
-            if not was_audible:
+            accepted = await self._adapter.write_streaming_tts(self._handle, chunk)
+            if not was_audible and accepted is not False:
                 self._handle.audible = True
                 self._suppress_whole_file = True
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -26,6 +26,7 @@ import time
 import traceback
 from collections import defaultdict
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Any, Tuple
 from urllib.parse import quote, urljoin
 
@@ -156,11 +157,13 @@ from gateway.platforms.helpers import (
 )
 from utils import atomic_json_write, env_float, env_int
 from gateway.platforms.base import (
+    AudioFormat,
     BasePlatformAdapter,
     MessageEvent,
     MessageType,
     ProcessingOutcome,
     SendResult,
+    StreamingTTSHandle,
     cache_image_from_url,
     cache_image_from_bytes,
     cache_audio_from_url,
@@ -1029,6 +1032,18 @@ def _read_discord_prompt_timeout() -> int:
     if seconds > _DISCORD_PROMPT_TIMEOUT_MAX:
         return _DISCORD_PROMPT_TIMEOUT_MAX
     return seconds
+
+
+@dataclass
+class _DiscordStreamingTTSHandle(StreamingTTSHandle):
+    """Discord-specific state for one bounded mixer speech child."""
+
+    guild_id: int = 0
+    mixer: Any = None
+    child: Any = None
+    carry: bytes = b""
+    drain_task: Optional[asyncio.Task] = None
+    timeout_rearmed: bool = False
 
 
 class DiscordAdapter(BasePlatformAdapter):
@@ -4180,6 +4195,165 @@ class DiscordAdapter(BasePlatformAdapter):
                 success = await self.play_in_voice_channel(gid, audio_path)
                 return SendResult(success=success)
         return await self.send_voice(chat_id=chat_id, audio_path=audio_path, **kwargs)
+
+    def _resolve_streaming_voice_mixer(self, chat_id: str) -> Optional[Tuple[int, Any]]:
+        """Return the connected, currently-installed mixer bound to *chat_id*."""
+        for guild_id, text_channel_id in getattr(self, "_voice_text_channels", {}).items():
+            if str(text_channel_id) != str(chat_id):
+                continue
+            voice_client = getattr(self, "_voice_clients", {}).get(guild_id)
+            mixer = getattr(self, "_voice_mixers", {}).get(guild_id)
+            try:
+                connected = voice_client is not None and voice_client.is_connected()
+            except Exception:
+                connected = False
+            if connected and mixer is not None and hasattr(mixer, "begin_streaming_speech"):
+                return guild_id, mixer
+        return None
+
+    @staticmethod
+    def _supports_discord_streaming_format(audio_format: AudioFormat) -> bool:
+        return (audio_format.sample_width == 2 and (
+            (audio_format.sample_rate == 24000 and audio_format.channels == 1)
+            or (audio_format.sample_rate == 48000 and audio_format.channels == 2)
+        ))
+
+    @staticmethod
+    def _discord_streaming_numpy_available() -> bool:
+        try:
+            import numpy  # noqa: F401, PLC0415 - optional voice dependency
+        except ImportError:
+            return False
+        return True
+
+    def supports_streaming_tts(self, chat_id: str, audio_format: AudioFormat) -> bool:
+        return (
+            self._resolve_streaming_voice_mixer(chat_id) is not None
+            and self._discord_streaming_numpy_available()
+            and self._supports_discord_streaming_format(audio_format)
+        )
+
+    async def begin_streaming_tts(
+        self,
+        chat_id: str,
+        audio_format: AudioFormat,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> Optional[StreamingTTSHandle]:
+        del metadata
+        resolved = self._resolve_streaming_voice_mixer(chat_id)
+        if (
+            resolved is None
+            or not self._discord_streaming_numpy_available()
+            or not self._supports_discord_streaming_format(audio_format)
+        ):
+            return None
+        guild_id, mixer = resolved
+        try:
+            child = mixer.begin_streaming_speech()
+        except Exception:
+            logger.debug("Failed to begin Discord streaming speech", exc_info=True)
+            return None
+        if child is None:
+            return None
+        current = self._resolve_streaming_voice_mixer(chat_id)
+        if current is None or current[0] != guild_id or current[1] is not mixer:
+            child.abort()
+            return None
+        self._cancel_voice_timeout(guild_id)
+        return _DiscordStreamingTTSHandle(
+            chat_id=str(chat_id), audio_format=audio_format, guild_id=guild_id,
+            mixer=mixer, child=child,
+        )
+
+    @staticmethod
+    def _discord_streaming_pcm(handle: _DiscordStreamingTTSHandle, chunk: bytes) -> bytes:
+        data = handle.carry + chunk
+        handle.carry = data[-1:] if len(data) % 2 else b""
+        data = data[:len(data) - len(handle.carry)]
+        if not data:
+            return b""
+        if handle.audio_format.sample_rate == 48000:
+            return data
+        import numpy as np  # noqa: PLC0415 - optional voice dependency
+        samples = np.frombuffer(data, dtype="<i2")
+        return np.repeat(samples, 4).astype("<i2", copy=False).tobytes()
+
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
+        if not isinstance(handle, _DiscordStreamingTTSHandle) or handle.aborted or not chunk:
+            return
+        current = self._resolve_streaming_voice_mixer(handle.chat_id)
+        if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
+            return
+        pcm = self._discord_streaming_pcm(handle, chunk)
+        if not pcm:
+            return
+        await asyncio.to_thread(handle.child.write, pcm)
+        if not handle.aborted:
+            handle.audible = True
+
+    async def finish_streaming_tts(
+        self, handle: StreamingTTSHandle, *, interrupted: bool = False,
+    ) -> None:
+        if not isinstance(handle, _DiscordStreamingTTSHandle) or handle.aborted:
+            return
+        if interrupted:
+            await self.abort_streaming_tts(handle)
+            return
+        handle.child.finish()
+        if handle.drain_task is None or handle.drain_task.done():
+            handle.drain_task = asyncio.create_task(
+                self._rearm_voice_timeout_after_stream(handle)
+            )
+
+    async def _rearm_voice_timeout_after_stream(
+        self, handle: _DiscordStreamingTTSHandle,
+    ) -> None:
+        """Re-arm only once this child has drained without a mixer replacement."""
+        deadline = asyncio.get_running_loop().time() + 30.0
+        try:
+            while asyncio.get_running_loop().time() < deadline:
+                if handle.aborted:
+                    return
+                current = self._resolve_streaming_voice_mixer(handle.chat_id)
+                if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
+                    return
+                if handle.child.drained and not handle.mixer.speech_active:
+                    # Resolve again immediately before resetting the timer so a
+                    # concurrent leave/rejoin cannot reset a new mixer.
+                    current = self._resolve_streaming_voice_mixer(handle.chat_id)
+                    if (
+                        current is not None
+                        and current[0] == handle.guild_id
+                        and current[1] is handle.mixer
+                        and not handle.mixer.speech_active
+                    ):
+                        self._reset_voice_timeout(handle.guild_id)
+                        handle.timeout_rearmed = True
+                    return
+                await asyncio.sleep(0.02)
+        except asyncio.CancelledError:
+            return
+
+    async def abort_streaming_tts(
+        self, handle: StreamingTTSHandle, error: Optional[str] = None,
+    ) -> None:
+        del error
+        if not isinstance(handle, _DiscordStreamingTTSHandle) or handle.aborted:
+            return
+        handle.aborted = True
+        if handle.drain_task is not None:
+            handle.drain_task.cancel()
+        handle.child.abort()
+        current = self._resolve_streaming_voice_mixer(handle.chat_id)
+        if (
+            not handle.timeout_rearmed
+            and current is not None
+            and current[0] == handle.guild_id
+            and current[1] is handle.mixer
+            and not handle.mixer.speech_active
+        ):
+            self._reset_voice_timeout(handle.guild_id)
+            handle.timeout_rearmed = True
 
     async def send_voice(
         self,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4290,19 +4290,19 @@ class DiscordAdapter(BasePlatformAdapter):
         samples = np.frombuffer(data, dtype="<i2")
         return np.repeat(samples, 4).astype("<i2", copy=False).tobytes()
 
-    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> None:
+    async def write_streaming_tts(self, handle: StreamingTTSHandle, chunk: bytes) -> bool:
         if not isinstance(handle, _DiscordStreamingTTSHandle) or handle.aborted or not chunk:
-            return
+            return False
         current = self._resolve_streaming_voice_mixer(handle.chat_id)
         if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
             await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")
             raise RuntimeError("Discord voice mixer is no longer active")
         pcm = self._discord_streaming_pcm(handle, chunk)
         if not pcm:
-            return
+            return False
         accepted = await asyncio.to_thread(handle.child.write, pcm)
         if not accepted:
-            raise RuntimeError("Discord streaming TTS write accepted no PCM")
+            return False
         # A successful child write may already have been consumed by Discord;
         # suppress whole-file fallback before detecting any later abort/staleness.
         handle.audible = True
@@ -4312,6 +4312,7 @@ class DiscordAdapter(BasePlatformAdapter):
         if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
             await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")
             raise RuntimeError("Discord voice mixer is no longer active")
+        return True
 
     async def finish_streaming_tts(
         self, handle: StreamingTTSHandle, *, interrupted: bool = False,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4301,6 +4301,10 @@ class DiscordAdapter(BasePlatformAdapter):
         if not pcm:
             return
         await asyncio.to_thread(handle.child.write, pcm)
+        current = self._resolve_streaming_voice_mixer(handle.chat_id)
+        if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
+            await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")
+            raise RuntimeError("Discord voice mixer is no longer active")
         if not handle.aborted:
             handle.audible = True
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4295,7 +4295,8 @@ class DiscordAdapter(BasePlatformAdapter):
             return
         current = self._resolve_streaming_voice_mixer(handle.chat_id)
         if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
-            return
+            await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")
+            raise RuntimeError("Discord voice mixer is no longer active")
         pcm = self._discord_streaming_pcm(handle, chunk)
         if not pcm:
             return

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4198,16 +4198,28 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def _resolve_streaming_voice_mixer(self, chat_id: str) -> Optional[Tuple[int, Any]]:
         """Return the connected, currently-installed mixer bound to *chat_id*."""
+        try:
+            from voice_mixer import VoiceMixer
+        except ImportError:
+            from .voice_mixer import VoiceMixer
+
         for guild_id, text_channel_id in getattr(self, "_voice_text_channels", {}).items():
             if str(text_channel_id) != str(chat_id):
                 continue
             voice_client = getattr(self, "_voice_clients", {}).get(guild_id)
             mixer = getattr(self, "_voice_mixers", {}).get(guild_id)
+            if voice_client is None:
+                continue
             try:
-                connected = voice_client is not None and voice_client.is_connected()
+                connected = voice_client.is_connected()
+                active_mixer_output = (
+                    connected
+                    and voice_client.is_playing()
+                    and getattr(voice_client, "source", mixer) is mixer
+                )
             except Exception:
-                connected = False
-            if connected and mixer is not None and hasattr(mixer, "begin_streaming_speech"):
+                active_mixer_output = False
+            if active_mixer_output and isinstance(mixer, VoiceMixer):
                 return guild_id, mixer
         return None
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4301,6 +4301,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if not pcm:
             return
         await asyncio.to_thread(handle.child.write, pcm)
+        if handle.aborted:
+            raise RuntimeError("Discord streaming TTS write was aborted")
         # A successful child write may already have been consumed by Discord;
         # suppress whole-file fallback before detecting any later staleness.
         handle.audible = True

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4301,12 +4301,13 @@ class DiscordAdapter(BasePlatformAdapter):
         if not pcm:
             return
         await asyncio.to_thread(handle.child.write, pcm)
+        # A successful child write may already have been consumed by Discord;
+        # suppress whole-file fallback before detecting any later staleness.
+        handle.audible = True
         current = self._resolve_streaming_voice_mixer(handle.chat_id)
         if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
             await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")
             raise RuntimeError("Discord voice mixer is no longer active")
-        if not handle.aborted:
-            handle.audible = True
 
     async def finish_streaming_tts(
         self, handle: StreamingTTSHandle, *, interrupted: bool = False,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -4300,12 +4300,14 @@ class DiscordAdapter(BasePlatformAdapter):
         pcm = self._discord_streaming_pcm(handle, chunk)
         if not pcm:
             return
-        await asyncio.to_thread(handle.child.write, pcm)
+        accepted = await asyncio.to_thread(handle.child.write, pcm)
+        if not accepted:
+            raise RuntimeError("Discord streaming TTS write accepted no PCM")
+        # A successful child write may already have been consumed by Discord;
+        # suppress whole-file fallback before detecting any later abort/staleness.
+        handle.audible = True
         if handle.aborted:
             raise RuntimeError("Discord streaming TTS write was aborted")
-        # A successful child write may already have been consumed by Discord;
-        # suppress whole-file fallback before detecting any later staleness.
-        handle.audible = True
         current = self._resolve_streaming_voice_mixer(handle.chat_id)
         if current is None or current[0] != handle.guild_id or current[1] is not handle.mixer:
             await self.abort_streaming_tts(handle, error="Discord voice mixer is no longer active")

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -413,6 +413,10 @@ class VoiceMixer(discord.AudioSource):
             if self._closed:
                 return SILENCE_FRAME
 
+            self._streaming_speech = [
+                child for child in self._streaming_speech if not child.finished
+            ]
+
             np = _require_numpy()
             acc: "Optional[np.ndarray]" = None
 
@@ -428,7 +432,11 @@ class VoiceMixer(discord.AudioSource):
                             self._discard_finished_streaming_child_locked(child)
                         continue
                     acc = frame if acc is None else acc + frame
-                    still_live.append(child)
+                    if child.finished:
+                        if isinstance(child, StreamingMixerChild):
+                            self._discard_finished_streaming_child_locked(child)
+                    else:
+                        still_live.append(child)
                 self._speech = still_live
                 if not self._speech and self._speech_active:
                     self._begin_duck_release_locked()

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -197,33 +197,41 @@ class StreamingMixerChild:
     def drained(self) -> bool:
         return self.finished
 
-    def write(self, pcm: bytes) -> None:
-        """Append PCM, blocking while the fixed frame buffer is full."""
+    def write(self, pcm: bytes) -> bool:
+        """Append PCM and report whether any input was accepted.
+
+        Writers block while the fixed frame buffer is full.  A later abort may
+        discard already accepted PCM, but does not change this result: callers
+        use it to distinguish a pre-audio cancellation from a possible replay.
+        """
         if not pcm:
-            return
+            return False
 
         pcm_view = memoryview(pcm)
         offset = 0
+        accepted = False
         capacity = STREAMING_BUFFER_FRAME_CAPACITY * FRAME_SIZE
         while offset < len(pcm_view):
             activate = False
             with self._condition:
                 while len(self._buffer) >= capacity:
                     if self._input_finished or self._aborted:
-                        return
+                        return accepted
                     self._condition.wait()
                 if self._input_finished or self._aborted:
-                    return
+                    return accepted
 
                 size = min(capacity - len(self._buffer), len(pcm_view) - offset)
                 self._buffer.extend(pcm_view[offset:offset + size])
                 offset += size
+                accepted = True
                 if not self._activated:
                     self._activated = True
                     activate = True
 
             if activate and self._on_first_write is not None:
                 self._on_first_write(self)
+        return accepted
 
     def finish(self) -> None:
         """Mark input complete so a final partial frame may be zero-padded."""

--- a/plugins/platforms/discord/voice_mixer.py
+++ b/plugins/platforms/discord/voice_mixer.py
@@ -44,7 +44,7 @@ the mixer's output cannot echo back into transcription.
 
 import logging
 import threading
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Callable, List, Optional
 
 import discord
 
@@ -80,6 +80,7 @@ SAMPLES_PER_FRAME = SAMPLE_RATE * FRAME_LENGTH_MS // 1000   # 960
 FRAME_SIZE = SAMPLES_PER_FRAME * CHANNELS * SAMPLE_WIDTH    # 3840 bytes
 BYTES_PER_MS = SAMPLE_RATE * CHANNELS * SAMPLE_WIDTH // 1000  # 192
 SILENCE_FRAME = b"\x00" * FRAME_SIZE
+STREAMING_BUFFER_FRAME_CAPACITY = 50
 
 
 class MixerChild:
@@ -153,6 +154,117 @@ class MixerChild:
         return samples
 
 
+class StreamingMixerChild:
+    """A bounded, appendable 48 kHz stereo s16le speech source.
+
+    Writers may run on a worker thread while Discord drains frames from its
+    audio sender thread.  The bounded byte buffer applies backpressure without
+    requiring an asyncio primitive, and only a completed stream pads its final
+    partial frame.
+    """
+
+    __slots__ = (
+        "name", "gain", "is_speech", "fade_frames", "_fade_done", "_buffer",
+        "_condition", "_input_finished", "_aborted", "_activated",
+        "_on_first_write",
+    )
+
+    def __init__(
+        self,
+        *,
+        gain: float = 1.0,
+        fade_in_ms: int = 0,
+        on_first_write: Optional[Callable[["StreamingMixerChild"], None]] = None,
+    ):
+        self.name = "streaming-speech"
+        self.gain = float(gain)
+        self.is_speech = True
+        self.fade_frames = max(0, fade_in_ms // FRAME_LENGTH_MS)
+        self._fade_done = 0
+        self._buffer = bytearray()
+        self._condition = threading.Condition()
+        self._input_finished = False
+        self._aborted = False
+        self._activated = False
+        self._on_first_write = on_first_write
+
+    @property
+    def finished(self) -> bool:
+        with self._condition:
+            return (self._input_finished or self._aborted) and not self._buffer
+
+    @property
+    def drained(self) -> bool:
+        return self.finished
+
+    def write(self, pcm: bytes) -> None:
+        """Append PCM, blocking while the fixed frame buffer is full."""
+        if not pcm:
+            return
+
+        pcm_view = memoryview(pcm)
+        offset = 0
+        capacity = STREAMING_BUFFER_FRAME_CAPACITY * FRAME_SIZE
+        while offset < len(pcm_view):
+            activate = False
+            with self._condition:
+                while len(self._buffer) >= capacity:
+                    if self._input_finished or self._aborted:
+                        return
+                    self._condition.wait()
+                if self._input_finished or self._aborted:
+                    return
+
+                size = min(capacity - len(self._buffer), len(pcm_view) - offset)
+                self._buffer.extend(pcm_view[offset:offset + size])
+                offset += size
+                if not self._activated:
+                    self._activated = True
+                    activate = True
+
+            if activate and self._on_first_write is not None:
+                self._on_first_write(self)
+
+    def finish(self) -> None:
+        """Mark input complete so a final partial frame may be zero-padded."""
+        with self._condition:
+            self._input_finished = True
+            self._condition.notify_all()
+
+    def abort(self) -> None:
+        """Drop queued audio and wake all blocked writers."""
+        with self._condition:
+            self._aborted = True
+            self._buffer.clear()
+            self._condition.notify_all()
+
+    def read_frame(self) -> "Optional[np.ndarray]":
+        """Return the next complete frame, or None while awaiting more input."""
+        with self._condition:
+            if self._aborted:
+                return None
+            if len(self._buffer) >= FRAME_SIZE:
+                chunk = bytes(self._buffer[:FRAME_SIZE])
+                del self._buffer[:FRAME_SIZE]
+            elif self._input_finished and self._buffer:
+                chunk = bytes(self._buffer)
+                self._buffer.clear()
+                chunk += b"\x00" * (FRAME_SIZE - len(chunk))
+            else:
+                return None
+            self._condition.notify_all()
+
+        np = _require_numpy()
+        samples = np.frombuffer(chunk, dtype=np.int16).astype(np.float32)
+        gain = self.gain
+        if self.fade_frames and self._fade_done < self.fade_frames:
+            self._fade_done += 1
+            gain *= self._fade_done / self.fade_frames
+        if gain != 1.0:
+            samples = samples * gain
+        return samples
+
+
 class VoiceMixer(discord.AudioSource):
     """A continuous ``discord.AudioSource`` that mixes N child streams.
 
@@ -176,7 +288,8 @@ class VoiceMixer(discord.AudioSource):
     ):
         self._lock = threading.Lock()
         self._ambient: Optional[MixerChild] = None
-        self._speech: List[MixerChild] = []
+        self._speech: List[MixerChild | StreamingMixerChild] = []
+        self._streaming_speech: List[StreamingMixerChild] = []
         self._ambient_gain = float(ambient_gain)
         self._duck_gain = float(duck_gain)
         self._speech_gain = float(speech_gain)
@@ -230,6 +343,35 @@ class VoiceMixer(discord.AudioSource):
             if self._ambient is not None:
                 self._ambient.gain = self._duck_gain
 
+    def begin_streaming_speech(
+        self, *, gain: Optional[float] = None, fade_in_ms: int = 40
+    ) -> StreamingMixerChild:
+        """Create an appendable speech child that activates on its first write."""
+        child = StreamingMixerChild(
+            gain=self._speech_gain if gain is None else float(gain),
+            fade_in_ms=fade_in_ms,
+            on_first_write=self._start_streaming_speech,
+        )
+        with self._lock:
+            if self._closed:
+                child.abort()
+            else:
+                self._streaming_speech.append(child)
+        return child
+
+    def _start_streaming_speech(self, child: StreamingMixerChild) -> None:
+        with self._lock:
+            if self._closed:
+                child.abort()
+                return
+            if child.finished:
+                return
+            self._speech.append(child)
+            self._speech_active = True
+            self._duck_release_left = 0
+            if self._ambient is not None:
+                self._ambient.gain = self._duck_gain
+
     @property
     def speech_active(self) -> bool:
         with self._lock:
@@ -238,8 +380,19 @@ class VoiceMixer(discord.AudioSource):
     def stop_speech(self) -> None:
         """Drop any in-flight speech immediately and release the duck."""
         with self._lock:
+            for child in self._streaming_speech:
+                child.abort()
+            self._streaming_speech.clear()
             self._speech.clear()
             self._begin_duck_release_locked()
+
+    def _discard_finished_streaming_child_locked(
+        self, child: StreamingMixerChild
+    ) -> None:
+        try:
+            self._streaming_speech.remove(child)
+        except ValueError:
+            pass
 
     def _begin_duck_release_locked(self) -> None:
         self._speech_active = False
@@ -265,10 +418,14 @@ class VoiceMixer(discord.AudioSource):
 
             # Speech children (drop exhausted ones; release duck when last ends)
             if self._speech:
-                still_live: List[MixerChild] = []
+                still_live: List[MixerChild | StreamingMixerChild] = []
                 for child in self._speech:
                     frame = child.read_frame()
                     if frame is None:
+                        if not child.finished:
+                            still_live.append(child)
+                        elif isinstance(child, StreamingMixerChild):
+                            self._discard_finished_streaming_child_locked(child)
                         continue
                     acc = frame if acc is None else acc + frame
                     still_live.append(child)
@@ -301,6 +458,9 @@ class VoiceMixer(discord.AudioSource):
         with self._lock:
             self._closed = True
             self._ambient = None
+            for child in self._streaming_speech:
+                child.abort()
+            self._streaming_speech.clear()
             self._speech.clear()
 
 

--- a/tests/gateway/test_base_auto_tts_output_format.py
+++ b/tests/gateway/test_base_auto_tts_output_format.py
@@ -12,6 +12,7 @@ voice bubble). The fix passes an explicit output path from
 
 import asyncio
 import json
+from pathlib import Path
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -23,6 +24,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
     build_auto_tts_output_path,
+    get_audio_cache_dir,
 )
 from gateway.session import SessionSource, build_session_key
 from tools.tts_tool import OPUS_VOICE_PLATFORMS
@@ -84,6 +86,24 @@ def _hold_typing():
 def test_output_path_is_mp3_for_non_opus_platforms(platform):
     path = build_auto_tts_output_path(platform)
     assert path.endswith(".mp3"), path
+
+
+@pytest.mark.parametrize(
+    ("platform", "extension"),
+    [(Platform.TELEGRAM, ".ogg"), (Platform.DISCORD, ".mp3")],
+)
+def test_output_path_uses_audio_cache_with_platform_extension(
+    tmp_path, monkeypatch, platform, extension
+):
+    """Auto-TTS output is safe for the TTS tool and native to its platform."""
+    monkeypatch.setattr(
+        "gateway.platforms.base.AUDIO_CACHE_DIR", tmp_path / "audio_cache"
+    )
+
+    output_path = Path(build_auto_tts_output_path(platform))
+
+    assert output_path.parent == get_audio_cache_dir()
+    assert output_path.suffix == extension
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -7,7 +7,9 @@ integration (install on join, play routing, ack) is tested with the standard
 ``object.__new__(DiscordAdapter)`` helper used elsewhere in the voice suite.
 """
 
+import asyncio
 import os
+import struct
 import sys
 import threading
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -175,6 +177,139 @@ def _make_adapter(fx_cfg=None):
         "ack_enabled": True, "ack_phrases": ["One moment."],
     }
     return adapter
+
+
+class TestDiscordStreamingTTS:
+    @pytest.mark.asyncio
+    async def test_connected_bound_mixer_supports_and_begins_stream(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        mixer = vm.VoiceMixer()
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+
+        audio_format = AudioFormat(24000, 1, 2)
+        assert adapter.supports_streaming_tts("222", audio_format) is True
+
+        handle = await adapter.begin_streaming_tts("222", audio_format)
+
+        assert handle is not None
+        assert handle.guild_id == 111
+        assert handle.mixer is mixer
+        assert handle.child in mixer._streaming_speech
+        adapter._cancel_voice_timeout.assert_called_once_with(111)
+
+    @pytest.mark.asyncio
+    async def test_split_24k_mono_pcm_writes_as_fifo_discord_pcm(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        mixer = vm.VoiceMixer()
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+
+        handle = await adapter.begin_streaming_tts("222", AudioFormat(24000, 1, 2))
+        source = b"\x01\x00\xfe\xff\x03\x00"
+        for chunk in (source[:1], source[1:3], source[3:]):
+            await adapter.write_streaming_tts(handle, chunk)
+        await adapter.finish_streaming_tts(handle)
+
+        handle.child.fade_frames = 0
+        frame = handle.child.read_frame()
+        expected = b"".join(struct.pack("<hhhh", sample, sample, sample, sample)
+                            for sample in (1, -2, 3))
+        assert frame is not None
+        np.testing.assert_array_equal(
+            frame[:12], np.frombuffer(expected, dtype=np.int16).astype(np.float32),
+        )
+
+    @pytest.mark.asyncio
+    async def test_unavailable_or_stale_voice_state_declines_streaming(self):
+        from gateway.platforms.base import AudioFormat
+
+        audio_format = AudioFormat(24000, 1, 2)
+        adapter = _make_adapter()
+        assert adapter.supports_streaming_tts("222", audio_format) is False
+        assert await adapter.begin_streaming_tts("222", audio_format) is None
+
+        vc = MagicMock()
+        vc.is_connected.return_value = False
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        assert adapter.supports_streaming_tts("222", audio_format) is False
+        assert await adapter.begin_streaming_tts("222", audio_format) is None
+
+        vc.is_connected.return_value = True
+        with patch.object(adapter, "_discord_streaming_numpy_available", return_value=False):
+            assert adapter.supports_streaming_tts("222", audio_format) is False
+            assert await adapter.begin_streaming_tts("222", audio_format) is None
+
+        child = MagicMock()
+
+        class StaleMixer:
+            def begin_streaming_speech(self):
+                adapter._voice_mixers.pop(111)
+                return child
+
+        adapter._voice_mixers[111] = StaleMixer()
+        assert await adapter.begin_streaming_tts("222", audio_format) is None
+        child.abort.assert_called_once_with()
+
+    @pytest.mark.asyncio
+    async def test_finish_waits_for_drain_and_abort_drops_late_writes(self):
+        from gateway.platforms.base import AudioFormat
+
+        class Child:
+            def __init__(self):
+                self.drained = False
+                self.finish = MagicMock()
+                self.abort = MagicMock()
+                self.write = MagicMock()
+
+        class Mixer:
+            def __init__(self):
+                self.child = Child()
+                self.speech_active = True
+
+            def begin_streaming_speech(self):
+                return self.child
+
+        adapter = _make_adapter()
+        vc = MagicMock()
+        vc.is_connected.return_value = True
+        mixer = Mixer()
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+        adapter._reset_voice_timeout = MagicMock()
+        handle = await adapter.begin_streaming_tts("222", AudioFormat(24000, 1, 2))
+
+        await adapter.finish_streaming_tts(handle)
+
+        mixer.child.finish.assert_called_once_with()
+        assert adapter._reset_voice_timeout.call_count == 0
+        assert handle.drain_task is not None
+
+        mixer.child.drained = True
+        mixer.speech_active = False
+        await asyncio.wait_for(handle.drain_task, timeout=0.5)
+        adapter._reset_voice_timeout.assert_called_once_with(111)
+
+        await adapter.abort_streaming_tts(handle)
+        await adapter.abort_streaming_tts(handle)
+        await adapter.write_streaming_tts(handle, b"\x01\x00")
+        mixer.child.abort.assert_called_once_with()
+        mixer.child.write.assert_not_called()
 
 
 class TestVoiceMixerActive:

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -314,6 +314,115 @@ class TestDiscordStreamingTTS:
         )
 
     @pytest.mark.asyncio
+    async def test_carry_only_pcm_keeps_consumer_fallback_eligible(self):
+        """A split int16 prefix is not accepted audio until its second byte arrives."""
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class CarryOnlyStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def stream(self, text):
+                del text
+                yield b"\x01"
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=CarryOnlyStreamer()):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+
+            consumer.on_delta("A complete answer that reaches the streaming provider.")
+            consumer.finish()
+            completed = await consumer.wait_complete(timeout=1.0)
+
+        assert completed is False
+        assert consumer.completed is False
+        assert consumer.audible is False
+        assert consumer.suppress_whole_file is False
+        assert consumer._handle.carry == b"\x01"
+        assert child._activated is False
+        assert mixer.speech_active is False
+
+    @pytest.mark.asyncio
+    async def test_split_sample_activates_child_only_after_second_byte(self):
+        """The completed int16 sample is accepted after a carry-only prefix."""
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class SplitSampleStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def __init__(self):
+                self.first_yielded = threading.Event()
+                self.release_second = threading.Event()
+
+            def stream(self, text):
+                del text
+                self.first_yielded.set()
+                yield b"\x01"
+                assert self.release_second.wait(timeout=1.0)
+                yield b"\x00"
+
+        streamer = SplitSampleStreamer()
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=streamer):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+
+            consumer.on_delta("A complete answer that reaches the streaming provider.")
+            consumer.finish()
+            assert await asyncio.to_thread(streamer.first_yielded.wait, 1.0)
+            for _ in range(100):
+                if consumer._handle.carry:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer._handle.carry == b"\x01"
+            assert consumer.audible is False
+            assert consumer.suppress_whole_file is False
+            assert child._activated is False
+
+            streamer.release_second.set()
+            completed = await consumer.wait_complete(timeout=1.0)
+
+        assert completed is True
+        assert consumer.completed is True
+        assert consumer.audible is True
+        assert consumer.suppress_whole_file is True
+        assert child._activated is True
+
+    @pytest.mark.asyncio
     async def test_stale_after_begin_fails_consumer_before_audio_for_fallback(self):
         from gateway.streaming_tts_consumer import StreamingTTSConsumer
         from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -358,6 +358,67 @@ class TestDiscordStreamingTTS:
         assert mixer.speech_active is False
 
     @pytest.mark.asyncio
+    async def test_aborted_worker_write_before_child_lock_keeps_whole_file_fallback(self):
+        """An aborted child that accepts no PCM must fail before audio."""
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class SingleChunkStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def stream(self, text):
+                del text
+                yield b"\xe8\x03" * (vm.FRAME_SIZE // 8)
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+        write_entered = threading.Event()
+        release_write = threading.Event()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+            original_write = vm.StreamingMixerChild.write
+
+            def write_after_abort_window(self, pcm):
+                if self is child:
+                    write_entered.set()
+                    assert release_write.wait(timeout=1)
+                return original_write(self, pcm)
+
+            with patch.object(vm.StreamingMixerChild, "write", write_after_abort_window):
+                consumer.on_delta("A complete answer.")
+                consumer.finish()
+                assert await asyncio.to_thread(write_entered.wait, 1)
+                await adapter.abort_streaming_tts(consumer._handle)
+                release_write.set()
+                completed = await consumer.wait_complete(timeout=1.0)
+
+        assert completed is False
+        assert consumer.completed is False
+        assert consumer.audible is False
+        assert consumer.suppress_whole_file is False
+        assert child.drained is True
+        assert child._aborted is True
+        assert child._activated is False
+        assert child._buffer == bytearray()
+        assert mixer.speech_active is False
+
+    @pytest.mark.asyncio
     async def test_mixer_replaced_after_worker_write_suppresses_whole_file_replay(self):
         """PCM consumed before post-write staleness still suppresses file replay."""
         from gateway.streaming_tts_consumer import StreamingTTSConsumer

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -77,6 +77,37 @@ class TestVoiceMixerCore:
         assert child.drained is True
         assert child.read_frame() is None
 
+    def test_final_padded_streaming_frame_removes_active_child_on_same_read(self):
+        mixer = vm.VoiceMixer()
+        child = mixer.begin_streaming_speech(fade_in_ms=0)
+        partial = b"\x03\x00" * 10
+        child.write(partial)
+        child.finish()
+
+        frame = mixer.read()
+
+        np.testing.assert_array_equal(
+            np.frombuffer(frame, dtype=np.int16),
+            np.frombuffer(
+                partial + b"\x00" * (vm.FRAME_SIZE - len(partial)), dtype=np.int16
+            ),
+        )
+        assert mixer.speech_active is False
+        assert child not in mixer._speech
+        assert child not in mixer._streaming_speech
+
+    def test_read_discards_finished_never_activated_stream_only(self):
+        mixer = vm.VoiceMixer()
+        unfinished = mixer.begin_streaming_speech(fade_in_ms=0)
+        finished = mixer.begin_streaming_speech(fade_in_ms=0)
+        finished.finish()
+
+        mixer.read()
+
+        assert finished not in mixer._streaming_speech
+        assert unfinished in mixer._streaming_speech
+        assert mixer.speech_active is False
+
     def test_streaming_child_abort_wakes_writer_blocked_at_capacity(self):
         mixer = vm.VoiceMixer()
         child = mixer.begin_streaming_speech(fade_in_ms=0)

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -9,6 +9,7 @@ integration (install on join, play routing, ack) is tested with the standard
 
 import os
 import sys
+import threading
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -50,6 +51,58 @@ class TestVoiceMixerCore:
     def test_is_opus_false(self):
         # discord.py sends raw PCM when is_opus() is False.
         assert vm.VoiceMixer().is_opus() is False
+
+    def test_streaming_child_reads_fifo_and_drains_after_final_padding(self):
+        mixer = vm.VoiceMixer()
+        child = mixer.begin_streaming_speech(fade_in_ms=0)
+        first = b"\x01\x00" * (vm.FRAME_SIZE // 2)
+        second = b"\x02\x00" * (vm.FRAME_SIZE // 2)
+        partial = b"\x03\x00" * 10
+
+        child.write(first + second + partial)
+        child.finish()
+
+        np.testing.assert_array_equal(
+            child.read_frame(), np.frombuffer(first, dtype=np.int16).astype(np.float32)
+        )
+        np.testing.assert_array_equal(
+            child.read_frame(), np.frombuffer(second, dtype=np.int16).astype(np.float32)
+        )
+        np.testing.assert_array_equal(
+            child.read_frame(),
+            np.frombuffer(
+                partial + b"\x00" * (vm.FRAME_SIZE - len(partial)), dtype=np.int16
+            ).astype(np.float32),
+        )
+        assert child.drained is True
+        assert child.read_frame() is None
+
+    def test_streaming_child_abort_wakes_writer_blocked_at_capacity(self):
+        mixer = vm.VoiceMixer()
+        child = mixer.begin_streaming_speech(fade_in_ms=0)
+        child.write(b"\x01\x00" * (
+            vm.STREAMING_BUFFER_FRAME_CAPACITY * vm.FRAME_SIZE // 2
+        ))
+        started = threading.Event()
+        completed = threading.Event()
+
+        def write_one_more_frame():
+            started.set()
+            child.write(b"\x02\x00" * (vm.FRAME_SIZE // 2))
+            completed.set()
+
+        writer = threading.Thread(target=write_one_more_frame)
+        writer.start()
+        assert started.wait(timeout=1)
+        assert not completed.wait(timeout=0.1)
+
+        child.abort()
+
+        writer.join(timeout=1)
+        assert not writer.is_alive()
+        assert completed.is_set()
+        assert child.read_frame() is None
+        assert child.drained is True
 
     def test_ambient_loops_and_is_quiet(self):
         mx = vm.VoiceMixer(ambient_gain=0.2)

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -280,6 +280,84 @@ class TestDiscordStreamingTTS:
         )
 
     @pytest.mark.asyncio
+    async def test_native_48k_stereo_pcm_reaches_mixer_in_fifo_order(self):
+        from gateway.platforms.base import AudioFormat
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+        source = bytes(range(256)) * 15  # exactly one 48kHz stereo 20ms frame
+
+        handle = await adapter.begin_streaming_tts("222", AudioFormat(48000, 2, 2))
+        assert isinstance(handle, _DiscordStreamingTTSHandle)
+        for chunk in (source[:1], source[1:138], source[138:]):
+            await adapter.write_streaming_tts(handle, chunk)
+        await adapter.finish_streaming_tts(handle)
+
+        handle.child.fade_frames = 0
+        frame = mixer.read()
+        assert len(frame) == len(source)
+        np.testing.assert_array_equal(
+            np.frombuffer(frame, dtype=np.int16), np.frombuffer(source, dtype=np.int16)
+        )
+
+    @pytest.mark.asyncio
+    async def test_stale_after_begin_fails_consumer_before_audio_for_fallback(self):
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class SingleChunkStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def stream(self, text):
+                del text
+                yield b"\x01\x00" * 32
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+
+            # The existing voice connection replaces/unlinks the mixer between
+            # begin and the first PCM write.
+            adapter._voice_mixers.pop(111)
+            consumer.on_delta("A complete answer.")
+            consumer.finish()
+            completed = await consumer.wait_complete(timeout=1.0)
+
+        # The consumer's pre-audio failure state keeps whole-file fallback
+        # eligible; the obsolete child receives neither PCM nor activation.
+        assert completed is False
+        assert consumer.completed is False
+        assert consumer.audible is False
+        assert consumer.suppress_whole_file is False
+        assert child.drained is True
+        assert child._aborted is True
+        assert child._activated is False
+        assert mixer.speech_active is False
+
+    @pytest.mark.asyncio
     async def test_unavailable_or_stale_voice_state_declines_streaming(self):
         from gateway.platforms.base import AudioFormat
 

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -358,6 +358,69 @@ class TestDiscordStreamingTTS:
         assert mixer.speech_active is False
 
     @pytest.mark.asyncio
+    async def test_mixer_replaced_during_worker_write_fails_before_audio_for_fallback(self):
+        """A stale child write must fail before the consumer marks it audible."""
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class SingleChunkStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def stream(self, text):
+                del text
+                yield b"\x01\x00" * 32
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+        write_started = threading.Event()
+        release_write = threading.Event()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+            original_write = vm.StreamingMixerChild.write
+
+            def blocking_write(self, pcm):
+                if self is child:
+                    write_started.set()
+                    if not release_write.wait(timeout=1.0):
+                        raise TimeoutError("test worker write was not released")
+                return original_write(self, pcm)
+
+            with patch.object(vm.StreamingMixerChild, "write", blocking_write):
+                consumer.on_delta("A complete answer.")
+                consumer.finish()
+                assert await asyncio.to_thread(write_started.wait, 1.0)
+
+                replacement = vm.VoiceMixer()
+                adapter._voice_mixers[111] = replacement
+                vc.source = replacement
+                release_write.set()
+                completed = await consumer.wait_complete(timeout=1.0)
+
+        assert completed is False
+        assert consumer.completed is False
+        assert consumer.audible is False
+        assert consumer.suppress_whole_file is False
+        assert child.drained is True
+        assert child._aborted is True
+        assert child._activated is True
+
+    @pytest.mark.asyncio
     async def test_unavailable_or_stale_voice_state_declines_streaming(self):
         from gateway.platforms.base import AudioFormat
 

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -179,15 +179,29 @@ def _make_adapter(fx_cfg=None):
     return adapter
 
 
+class _VoiceClientState:
+    """Concrete voice-client state double for resolver lifecycle tests."""
+
+    def __init__(self, source: object | None, *, connected=True, playing=True):
+        self.source = source
+        self.connected = connected
+        self.playing = playing
+
+    def is_connected(self):
+        return self.connected
+
+    def is_playing(self):
+        return self.playing
+
+
 class TestDiscordStreamingTTS:
     @pytest.mark.asyncio
     async def test_connected_bound_mixer_supports_and_begins_stream(self):
         from gateway.platforms.base import AudioFormat
 
         adapter = _make_adapter()
-        vc = MagicMock()
-        vc.is_connected.return_value = True
         mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 222
         adapter._voice_mixers[111] = mixer
@@ -205,13 +219,46 @@ class TestDiscordStreamingTTS:
         adapter._cancel_voice_timeout.assert_called_once_with(111)
 
     @pytest.mark.asyncio
+    async def test_duck_typed_non_voice_mixer_declines_streaming(self):
+        from gateway.platforms.base import AudioFormat
+
+        class DuckTypedMixer:
+            begin_streaming_speech = MagicMock()
+
+        adapter = _make_adapter()
+        duck_typed_mixer = DuckTypedMixer()
+        vc = _VoiceClientState(duck_typed_mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = duck_typed_mixer
+
+        audio_format = AudioFormat(24000, 1, 2)
+        assert adapter.supports_streaming_tts("222", audio_format) is False
+        assert await adapter.begin_streaming_tts("222", audio_format) is None
+        duck_typed_mixer.begin_streaming_speech.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_connected_nonplaying_mixer_declines_streaming(self):
+        from gateway.platforms.base import AudioFormat
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer, playing=False)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+
+        audio_format = AudioFormat(24000, 1, 2)
+        assert adapter.supports_streaming_tts("222", audio_format) is False
+        assert await adapter.begin_streaming_tts("222", audio_format) is None
+
+    @pytest.mark.asyncio
     async def test_split_24k_mono_pcm_writes_as_fifo_discord_pcm(self):
         from gateway.platforms.base import AudioFormat
 
         adapter = _make_adapter()
-        vc = MagicMock()
-        vc.is_connected.return_value = True
         mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 222
         adapter._voice_mixers[111] = mixer
@@ -241,75 +288,64 @@ class TestDiscordStreamingTTS:
         assert adapter.supports_streaming_tts("222", audio_format) is False
         assert await adapter.begin_streaming_tts("222", audio_format) is None
 
-        vc = MagicMock()
-        vc.is_connected.return_value = False
+        vc = _VoiceClientState(None, connected=False)
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 222
         assert adapter.supports_streaming_tts("222", audio_format) is False
         assert await adapter.begin_streaming_tts("222", audio_format) is None
 
-        vc.is_connected.return_value = True
+        vc.connected = True
         with patch.object(adapter, "_discord_streaming_numpy_available", return_value=False):
             assert adapter.supports_streaming_tts("222", audio_format) is False
             assert await adapter.begin_streaming_tts("222", audio_format) is None
 
-        child = MagicMock()
-
-        class StaleMixer:
+        class RemovingVoiceMixer(vm.VoiceMixer):
             def begin_streaming_speech(self):
+                child = super().begin_streaming_speech()
                 adapter._voice_mixers.pop(111)
                 return child
 
-        adapter._voice_mixers[111] = StaleMixer()
+        mixer = RemovingVoiceMixer()
+        vc.source = mixer
+        adapter._voice_mixers[111] = mixer
         assert await adapter.begin_streaming_tts("222", audio_format) is None
-        child.abort.assert_called_once_with()
+        assert mixer._streaming_speech[0].drained is True
 
     @pytest.mark.asyncio
     async def test_finish_waits_for_drain_and_abort_drops_late_writes(self):
         from gateway.platforms.base import AudioFormat
-
-        class Child:
-            def __init__(self):
-                self.drained = False
-                self.finish = MagicMock()
-                self.abort = MagicMock()
-                self.write = MagicMock()
-
-        class Mixer:
-            def __init__(self):
-                self.child = Child()
-                self.speech_active = True
-
-            def begin_streaming_speech(self):
-                return self.child
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
 
         adapter = _make_adapter()
-        vc = MagicMock()
-        vc.is_connected.return_value = True
-        mixer = Mixer()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
         adapter._voice_clients[111] = vc
         adapter._voice_text_channels[111] = 222
         adapter._voice_mixers[111] = mixer
         adapter._cancel_voice_timeout = MagicMock()
         adapter._reset_voice_timeout = MagicMock()
         handle = await adapter.begin_streaming_tts("222", AudioFormat(24000, 1, 2))
+        assert isinstance(handle, _DiscordStreamingTTSHandle)
 
+        await adapter.write_streaming_tts(handle, b"\x01\x00" * (vm.FRAME_SIZE // 2))
         await adapter.finish_streaming_tts(handle)
 
-        mixer.child.finish.assert_called_once_with()
         assert adapter._reset_voice_timeout.call_count == 0
         assert handle.drain_task is not None
 
-        mixer.child.drained = True
-        mixer.speech_active = False
+        for _ in range(4):
+            mixer.read()
+        assert handle.child.drained is True
+        assert mixer.speech_active is False
+        assert adapter._resolve_streaming_voice_mixer("222") == (111, mixer)
         await asyncio.wait_for(handle.drain_task, timeout=0.5)
         adapter._reset_voice_timeout.assert_called_once_with(111)
 
         await adapter.abort_streaming_tts(handle)
         await adapter.abort_streaming_tts(handle)
         await adapter.write_streaming_tts(handle, b"\x01\x00")
-        mixer.child.abort.assert_called_once_with()
-        mixer.child.write.assert_not_called()
+        assert handle.aborted is True
+        assert handle.child.drained is True
 
 
 class TestVoiceMixerActive:

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -110,6 +110,13 @@ class TestVoiceMixerCore:
         assert unfinished in mixer._streaming_speech
         assert mixer.speech_active is False
 
+    def test_streaming_child_write_reports_false_when_aborted_before_acceptance(self):
+        child = vm.VoiceMixer().begin_streaming_speech(fade_in_ms=0)
+        child.abort()
+
+        assert child.write(b"\x01\x00" * (vm.FRAME_SIZE // 2)) is False
+        assert child._activated is False
+
     def test_streaming_child_abort_wakes_writer_blocked_at_capacity(self):
         mixer = vm.VoiceMixer()
         child = mixer.begin_streaming_speech(fade_in_ms=0)
@@ -358,6 +365,65 @@ class TestDiscordStreamingTTS:
         assert mixer.speech_active is False
 
     @pytest.mark.asyncio
+    async def test_accepted_then_abort_before_worker_resume_suppresses_whole_file_replay(self):
+        """Accepted PCM may be consumed even when abort wins the resume race."""
+        from gateway.streaming_tts_consumer import StreamingTTSConsumer
+        from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
+
+        class SingleChunkStreamer:
+            sample_rate = 24000
+            channels = 1
+            sample_width = 2
+
+            def stream(self, text):
+                del text
+                # 480 mono samples upsample to one complete Discord frame.
+                yield b"\xe8\x03" * (vm.FRAME_SIZE // 8)
+
+        adapter = _make_adapter()
+        mixer = vm.VoiceMixer()
+        vc = _VoiceClientState(mixer)
+        adapter._voice_clients[111] = vc
+        adapter._voice_text_channels[111] = 222
+        adapter._voice_mixers[111] = mixer
+        adapter._cancel_voice_timeout = MagicMock()
+        pcm_consumed = threading.Event()
+
+        with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
+            consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
+            consumer.start()
+            for _ in range(100):
+                if consumer.started:
+                    break
+                await asyncio.sleep(0.01)
+            assert consumer.started is True
+            assert isinstance(consumer._handle, _DiscordStreamingTTSHandle)
+            child = consumer._handle.child
+            real_to_thread = asyncio.to_thread
+
+            async def consume_then_abort_before_worker_resume(func, /, *args, **kwargs):
+                result = await real_to_thread(func, *args, **kwargs)
+                if getattr(func, "__self__", None) is child and func.__name__ == "write":
+                    assert mixer.read() != vm.SILENCE_FRAME
+                    pcm_consumed.set()
+                    await adapter.abort_streaming_tts(consumer._handle)
+                return result
+
+            with patch("asyncio.to_thread", consume_then_abort_before_worker_resume):
+                consumer.on_delta("A complete answer.")
+                consumer.finish()
+                completed = await consumer.wait_complete(timeout=1.0)
+
+        assert pcm_consumed.is_set()
+        assert completed is False
+        assert consumer.completed is False
+        assert consumer.audible is True
+        assert consumer.suppress_whole_file is True
+        assert child.drained is True
+        assert child._aborted is True
+        assert child._activated is True
+
+    @pytest.mark.asyncio
     async def test_aborted_worker_write_before_child_lock_keeps_whole_file_fallback(self):
         """An aborted child that accepts no PCM must fail before audio."""
         from gateway.streaming_tts_consumer import StreamingTTSConsumer
@@ -381,6 +447,7 @@ class TestDiscordStreamingTTS:
         adapter._cancel_voice_timeout = MagicMock()
         write_entered = threading.Event()
         release_write = threading.Event()
+        write_results = []
 
         with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
             consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
@@ -398,7 +465,10 @@ class TestDiscordStreamingTTS:
                 if self is child:
                     write_entered.set()
                     assert release_write.wait(timeout=1)
-                return original_write(self, pcm)
+                result = original_write(self, pcm)
+                if self is child:
+                    write_results.append(result)
+                return result
 
             with patch.object(vm.StreamingMixerChild, "write", write_after_abort_window):
                 consumer.on_delta("A complete answer.")
@@ -409,6 +479,7 @@ class TestDiscordStreamingTTS:
                 completed = await consumer.wait_complete(timeout=1.0)
 
         assert completed is False
+        assert write_results == [False]
         assert consumer.completed is False
         assert consumer.audible is False
         assert consumer.suppress_whole_file is False

--- a/tests/gateway/test_discord_voice_mixer.py
+++ b/tests/gateway/test_discord_voice_mixer.py
@@ -358,8 +358,8 @@ class TestDiscordStreamingTTS:
         assert mixer.speech_active is False
 
     @pytest.mark.asyncio
-    async def test_mixer_replaced_during_worker_write_fails_before_audio_for_fallback(self):
-        """A stale child write must fail before the consumer marks it audible."""
+    async def test_mixer_replaced_after_worker_write_suppresses_whole_file_replay(self):
+        """PCM consumed before post-write staleness still suppresses file replay."""
         from gateway.streaming_tts_consumer import StreamingTTSConsumer
         from plugins.platforms.discord.adapter import _DiscordStreamingTTSHandle
 
@@ -370,7 +370,8 @@ class TestDiscordStreamingTTS:
 
             def stream(self, text):
                 del text
-                yield b"\x01\x00" * 32
+                # 480 mono samples upsample to one complete Discord frame.
+                yield b"\xe8\x03" * (vm.FRAME_SIZE // 8)
 
         adapter = _make_adapter()
         mixer = vm.VoiceMixer()
@@ -379,8 +380,7 @@ class TestDiscordStreamingTTS:
         adapter._voice_text_channels[111] = 222
         adapter._voice_mixers[111] = mixer
         adapter._cancel_voice_timeout = MagicMock()
-        write_started = threading.Event()
-        release_write = threading.Event()
+        pcm_consumed = threading.Event()
 
         with patch("tools.tts_streaming.resolve_streaming_provider", return_value=SingleChunkStreamer()):
             consumer = StreamingTTSConsumer(adapter, "222", {}, asyncio.get_running_loop())
@@ -394,28 +394,28 @@ class TestDiscordStreamingTTS:
             child = consumer._handle.child
             original_write = vm.StreamingMixerChild.write
 
-            def blocking_write(self, pcm):
+            def write_consume_then_replace(self, pcm):
+                result = original_write(self, pcm)
                 if self is child:
-                    write_started.set()
-                    if not release_write.wait(timeout=1.0):
-                        raise TimeoutError("test worker write was not released")
-                return original_write(self, pcm)
+                    # The actual child write has queued a full frame and the
+                    # mixer consumes it before the adapter's stale recheck.
+                    assert mixer.read() != vm.SILENCE_FRAME
+                    pcm_consumed.set()
+                    replacement = vm.VoiceMixer()
+                    adapter._voice_mixers[111] = replacement
+                    vc.source = replacement
+                return result
 
-            with patch.object(vm.StreamingMixerChild, "write", blocking_write):
+            with patch.object(vm.StreamingMixerChild, "write", write_consume_then_replace):
                 consumer.on_delta("A complete answer.")
                 consumer.finish()
-                assert await asyncio.to_thread(write_started.wait, 1.0)
-
-                replacement = vm.VoiceMixer()
-                adapter._voice_mixers[111] = replacement
-                vc.source = replacement
-                release_write.set()
                 completed = await consumer.wait_complete(timeout=1.0)
 
+        assert pcm_consumed.is_set()
         assert completed is False
         assert consumer.completed is False
-        assert consumer.audible is False
-        assert consumer.suppress_whole_file is False
+        assert consumer.audible is True
+        assert consumer.suppress_whole_file is True
         assert child.drained is True
         assert child._aborted is True
         assert child._activated is True

--- a/tests/gateway/test_streaming_tts_consumer.py
+++ b/tests/gateway/test_streaming_tts_consumer.py
@@ -406,6 +406,49 @@ class TestAbortAndCancellation:
 class TestFallbackSafety:
     """Pre-audio failure falls back; post-audio failure does not replay."""
 
+    def test_explicit_false_write_result_keeps_whole_file_fallback_eligible(self):
+        class NoAcceptanceAdapter(FakeVoiceAdapter):
+            async def write_streaming_tts(self, handle, chunk):
+                self.written_chunks.append(chunk)
+                return False
+
+        async def run(loop):
+            adapter = NoAcceptanceAdapter()
+            streamer = FakeStreamer(chunks_per_clause=1)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("A sentence whose PCM is not accepted. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is False
+            assert consumer.audible is False
+            assert consumer.suppress_whole_file is False
+
+        _run_test(run)
+
+    def test_none_write_result_preserves_legacy_acceptance(self):
+        class LegacyNoneAdapter(FakeVoiceAdapter):
+            async def write_streaming_tts(self, handle, chunk):
+                self.written_chunks.append(chunk)
+
+        async def run(loop):
+            adapter = LegacyNoneAdapter()
+            streamer = FakeStreamer(chunks_per_clause=1)
+            consumer = _make_consumer(adapter, "chat1", loop, streamer)
+
+            consumer.start()
+            consumer.on_delta("A sentence whose adapter uses the legacy result. ")
+            consumer.finish()
+
+            completed = await consumer.wait_complete(timeout=5.0)
+            assert completed is True
+            assert consumer.audible is True
+            assert consumer.suppress_whole_file is True
+
+        _run_test(run)
+
     def test_pre_audio_failure_falls_back(self):
         async def run(loop):
             adapter = FakeVoiceAdapter()


### PR DESCRIPTION
## Summary
- route automatic TTS artifacts through the approved audio cache
- add bounded Discord-native streaming PCM mixer support
- stream Discord voice-turn TTS through the existing consumer with safe fallback/no-replay behavior
- cover mixer replacement, abort timing, accepted-write, and split-PCM carry races

## Verification
- `uv run --extra dev --extra voice pytest -o 'addopts=' tests/gateway/test_base_auto_tts_output_format.py tests/gateway/test_discord_voice_mixer.py tests/gateway/test_streaming_tts_consumer.py tests/gateway/test_voice_command.py::TestVoiceTTSPlayback -q` — 56 passed\n- Ruff passed for all changed files\n- `git diff --check` passed\n\n## Scope\nNo streaming STT, endpointing, receiver, barge-in, configuration, or environment-variable changes.