### PR TITLE
fix(plugins): declare langfuse SDK in the manifest so a venv rebuild is visible

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2315,17 +2315,24 @@ def _run_post_setup(post_setup_key: str):
             _print_info("    Run manually: hermes auth spotify")
 
     elif post_setup_key == "langfuse":
-        # Install the langfuse SDK.
+        # Install the langfuse SDK. Keep this requirement in sync with
+        # plugins/observability/langfuse/plugin.yaml's python_dependencies —
+        # the plugin imports `propagate_attributes`, added in langfuse 3.9.0.
+        langfuse_req = "langfuse>=3.9.0,<5"
         try:
-            __import__("langfuse")
+            # Probe the symbol the plugin actually needs, not just the package:
+            # an older SDK (<3.9.0) imports fine but fails at plugin load.
+            mod = __import__("langfuse")
+            if not hasattr(mod, "propagate_attributes"):
+                raise ImportError("langfuse too old (needs >=3.9.0)")
             _print_success("    langfuse SDK already installed")
         except ImportError:
             _print_info("    Installing langfuse SDK...")
-            result = _pip_install(["langfuse", "--quiet"], timeout=120)
+            result = _pip_install([langfuse_req, "--quiet"], timeout=120)
             if result.returncode == 0:
                 _print_success("    langfuse SDK installed")
             else:
-                _print_warning("    langfuse SDK install failed — run manually: uv pip install langfuse")
+                _print_warning(f"    langfuse SDK install failed — run manually: uv pip install '{langfuse_req}'")
         # Opt the bundled observability/langfuse plugin into plugins.enabled.
         # The plugin ships in the repo but doesn't load until the user enables
         # it (standalone plugins are opt-in).

--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -12,7 +12,7 @@ Pick one:
 hermes tools  # → Langfuse Observability
 
 # Manual
-pip install langfuse
+pip install 'langfuse>=3.9.0,<5'
 hermes plugins enable observability/langfuse
 ```
 

--- a/plugins/observability/langfuse/plugin.yaml
+++ b/plugins/observability/langfuse/plugin.yaml
@@ -5,6 +5,10 @@ author: NousResearch
 requires_env:
   - HERMES_LANGFUSE_PUBLIC_KEY
   - HERMES_LANGFUSE_SECRET_KEY
+python_dependencies:
+  # propagate_attributes is imported unconditionally at module import and was
+  # added in 3.9.0 (absent in 3.8.1). Upper bound per the dependency policy.
+  - "langfuse>=3.9.0,<5"
 hooks:
   - pre_api_request
   - post_api_request


### PR DESCRIPTION
fix(plugins): declare langfuse SDK in the manifest so a venv rebuild is visible

## Symptom

Enable `observability/langfuse` via `hermes tools`, use it for a while,
rebuild the venv (or reinstall Hermes, or upgrade Python) — and tracing
silently stops. `config.yaml` still lists the plugin as enabled, the
dashboard just stays empty, and nothing surfaces an error.

The plugin's SDK is installed by the `hermes tools` post-setup hook
(`tools_config.py`, `post_setup_key == "langfuse"`), NOT by
`pyproject.toml`. So the venv rebuild drops `langfuse` while the plugin
stays enabled. At load, `_get_langfuse()` hits `Langfuse is None`, logs a
warning to a logger nobody is tailing, sets `_INIT_FAILED`, and returns —
fail-open by design.

Fail-open is right for an optional dependency. The problem is that the
user has no signal, so an observability layer they believe is recording
is not. That is worse than one they know is off.

## Fix

Hermes already has the seam for this: manifest v2 `python_dependencies`
(#64165), validated by `_parse_manifest_v2_fields` and checked at load by
`PluginManager._warn_python_dependencies`, which prints a named,
actionable warning when a declared dep is missing. The langfuse manifest
just never declared anything — it declares `requires_env` only. Of the
101 bundled plugins, zero use `python_dependencies`; this makes the
observability plugin the first, using machinery that already exists
rather than adding any.

- `plugin.yaml`: declare `langfuse>=3.9.0,<5`.
- `tools_config.py`: install that same pinned requirement instead of a
  bare `langfuse`, and probe for the symbol the plugin actually imports
  rather than just the package (see below).
- `README.md`: manual-install hint matches the pin.

## Why >=3.9.0 specifically, and why the probe changed

`plugins/observability/langfuse/__init__.py` line 41 does:

    from langfuse import Langfuse, propagate_attributes

`propagate_attributes` is not exported by every 3.x. Verified against
real wheels from PyPI:

    3.5.0  no        3.8.0  no
    3.6.0  no        3.8.1  no
    3.7.0  no        3.9.0  YES  <- floor

So a naive `>=3,<5` would have been wrong. The upper bound follows the
dependency policy `plugin_dev lint` enforces (it warns on entries with
no upper bound).

The same gap existed in the installer's idempotency check, which did:

    __import__("langfuse")   # passes on 3.8.1, which then fails at load

It now checks `hasattr(mod, "propagate_attributes")`, so an older SDK is
treated as needing an upgrade instead of being reported as "already
installed".

## Verification

Manifest parses; `_parse_manifest_v2_fields` returns the declaration.

`hermes plugins doctor observability/langfuse`:

    OK: runtime discovery, manifest parsing, import, and registration passed
    registrations: 0 tool(s), 11 hook(s)

No dependency warning with 4.14.4 installed (satisfied case stays quiet).

Simulating the post-rebuild state — declared, not installed — now
produces the signal that was missing:

    Plugin observability/langfuse declares Python dependencies that are
    not installed: langfuse>=3.9.0,<5. Hermes does not install plugin
    dependencies automatically; install them yourself, e.g.:
    pip install 'langfuse>=3.9.0,<5'

Behaviour is unchanged when the dep is present. No auto-install is added:
`python_dependencies` stays a declaration seam per the #64165 round-2
review, consistent with "Hermes never auto-installs plugin dependencies".

## Scope

Deliberately limited to the plugin that demonstrates the bug. A scan
found other bundled plugins with undeclared third-party imports
(`web/ddgs`, `web/exa`, `platforms/slack`, `platforms/feishu`,
`memory/mem0`, and others). Those are the same class and worth a
follow-up, but they belong in their own change with their own version
floors verified the same way — guessing bounds is how you ship a
`>=3,<5` that is quietly wrong.
