### PR TITLE
fix(guardrails): cap vision_analyze calls per turn

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -179,6 +179,13 @@ class ToolCallGuardrailConfig:
 # pathological, so the defaults are deliberately low.
 _DEFAULT_MAX_WEB_SEARCHES_PER_TURN = 50
 _DEFAULT_MAX_SUBAGENTS_PER_TURN = 50
+# vision_analyze's cost lives in the PAYLOAD, not the response: each call
+# embeds the image into primary-model context, where it rides in history and
+# is re-sent on every subsequent API call. The no-progress detector keys on
+# result identity and can never see that, so payload-cost tools get a plain
+# per-turn call-count ceiling instead. (Observed incident: 295 vision calls
+# in one session against 4 distinct images.)
+_DEFAULT_MAX_VISION_CALLS_PER_TURN = 50
 
 
 @dataclass(frozen=True)
@@ -201,6 +208,7 @@ class LoopCapConfig:
 
     max_web_searches: int = _DEFAULT_MAX_WEB_SEARCHES_PER_TURN
     max_subagents: int = _DEFAULT_MAX_SUBAGENTS_PER_TURN
+    max_vision_calls: int = _DEFAULT_MAX_VISION_CALLS_PER_TURN
 
     @classmethod
     def from_mapping(cls, data: Mapping[str, Any] | None) -> "LoopCapConfig":
@@ -214,6 +222,9 @@ class LoopCapConfig:
             ),
             max_subagents=_non_negative_int(
                 data.get("max_subagents"), defaults.max_subagents
+            ),
+            max_vision_calls=_non_negative_int(
+                data.get("max_vision_calls"), defaults.max_vision_calls
             ),
         )
 
@@ -367,6 +378,7 @@ class ToolCallGuardrailController:
         # single agent loop rather than accumulating across the session.
         self._turn_web_search_count = 0
         self._turn_subagent_count = 0
+        self._turn_vision_count = 0
 
     @property
     def halt_decision(self) -> ToolGuardrailDecision | None:
@@ -690,6 +702,28 @@ class ToolCallGuardrailController:
                 self._halt_decision = decision
                 return decision
             self._turn_web_search_count += 1
+            return None
+
+        if tool_name == "vision_analyze":
+            cap = caps.max_vision_calls
+            if cap and self._turn_vision_count >= cap:
+                decision = ToolGuardrailDecision(
+                    action="block",
+                    code="loop_vision_cap",
+                    message=(
+                        f"Blocked vision_analyze: this turn has already made {cap} "
+                        "vision calls, the per-turn limit. Every analyzed image is "
+                        "embedded in context and re-sent on each subsequent API "
+                        "call, so re-analysis loops compound cost. Answer from "
+                        "the images already loaded instead of loading more."
+                    ),
+                    tool_name=tool_name,
+                    count=self._turn_vision_count,
+                    signature=signature,
+                )
+                self._halt_decision = decision
+                return decision
+            self._turn_vision_count += 1
             return None
 
         if tool_name == "delegate_task":

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -793,6 +793,7 @@ DEFAULT_CONFIG = {
         "loop_caps": {
             "max_web_searches": 50,   # max web_search calls per turn (0 = unlimited)
             "max_subagents": 50,      # max subagents spawned per turn (0 = unlimited)
+            "max_vision_calls": 50,   # max vision_analyze calls per turn (0 = unlimited); vision payloads ride in history, so runaway re-analysis compounds cost
         },
     },
 

--- a/tests/agent/test_tool_guardrails.py
+++ b/tests/agent/test_tool_guardrails.py
@@ -169,6 +169,91 @@ def test_web_search_cap_blocks_after_limit_regardless_of_hard_stop():
     assert decision.should_halt is True
 
 
+def test_vision_cap_blocks_after_limit_with_distinct_args():
+    # The incident contract: vision_analyze's cost lives in the PAYLOAD (each
+    # call embeds an image that then rides in history), so DISTINCT arguments
+    # must still consume the cap. The result-identity no-progress detector can
+    # never see this — a runaway re-analysis loop varies the question and/or
+    # cycles a handful of images, so every call looks novel to it.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            hard_stop_enabled=False,
+            loop_caps=LoopCapConfig(max_vision_calls=3),
+        )
+    )
+    for i in range(3):
+        decision = controller.before_call(
+            "vision_analyze", {"image_url": f"/tmp/sheet{i}.jpg", "question": f"q{i}"}
+        )
+        assert decision.action == "allow"
+    decision = controller.before_call(
+        "vision_analyze", {"image_url": "/tmp/sheet3.jpg", "question": "q3"}
+    )
+    assert decision.action == "block"
+    assert decision.code == "loop_vision_cap"
+    assert decision.should_halt is True
+
+
+def test_vision_cap_zero_disables():
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_vision_calls=0))
+    )
+    for i in range(100):
+        assert (
+            controller.before_call("vision_analyze", {"image_url": f"/tmp/{i}.jpg"}).action
+            == "allow"
+        )
+
+
+def test_vision_cap_resets_between_turns():
+    # Caps bound a single agent loop, not the whole session: reset_for_turn()
+    # must clear the counter or a long conversation would exhaust the budget.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(loop_caps=LoopCapConfig(max_vision_calls=2))
+    )
+    for i in range(2):
+        assert controller.before_call("vision_analyze", {"image_url": f"/tmp/{i}.jpg"}).action == "allow"
+    assert controller.before_call("vision_analyze", {"image_url": "/tmp/x.jpg"}).action == "block"
+
+    controller.reset_for_turn()
+    assert controller.before_call("vision_analyze", {"image_url": "/tmp/y.jpg"}).action == "allow"
+
+
+def test_vision_cap_from_mapping_round_trips_and_falls_back():
+    # Relational, not a frozen literal: an explicit value survives, an absent
+    # key yields the dataclass default, and junk/negative falls back to it.
+    assert LoopCapConfig.from_mapping({"max_vision_calls": 7}).max_vision_calls == 7
+    assert LoopCapConfig.from_mapping({"max_vision_calls": 0}).max_vision_calls == 0
+    default = LoopCapConfig().max_vision_calls
+    assert LoopCapConfig.from_mapping({}).max_vision_calls == default
+    assert LoopCapConfig.from_mapping({"max_vision_calls": -5}).max_vision_calls == default
+    assert LoopCapConfig.from_mapping({"max_vision_calls": "nope"}).max_vision_calls == default
+
+
+def test_vision_cap_does_not_consume_sibling_cap_budgets():
+    # Each capped tool keeps an independent per-turn counter.
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(
+            loop_caps=LoopCapConfig(max_vision_calls=2, max_web_searches=2),
+        )
+    )
+    for i in range(2):
+        assert controller.before_call("vision_analyze", {"image_url": f"/tmp/{i}.jpg"}).action == "allow"
+    assert controller.before_call("vision_analyze", {"image_url": "/tmp/x.jpg"}).action == "block"
+    # web_search budget is untouched by the exhausted vision budget.
+    assert controller.before_call("web_search", {"query": "q"}).action == "allow"
+
+
+def test_default_config_enables_a_vision_cap():
+    # Config -> dataclass propagation, asserted as an invariant rather than a
+    # frozen literal: the shipped default must be a positive (enabled) cap.
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+    shipped = DEFAULT_CONFIG["tool_loop_guardrails"]["loop_caps"]["max_vision_calls"]
+    assert shipped > 0
+    assert LoopCapConfig.from_mapping({"max_vision_calls": shipped}).max_vision_calls == shipped
+
+
 
 
 


### PR DESCRIPTION
## Symptom

A single Telegram session made **295 `vision_analyze` calls in ~60 minutes against 4 distinct images** — contact sheets, re-analyzed ~74 times each. It ran until `agent.max_turns` ended the turn. No guardrail fired.

Measured from `state.db` `messages.tool_calls`:

| | |
|---|---|
| `vision_analyze` calls | 295 |
| distinct image paths | 4 |
| calls per image | ~74x |
| calls using a `region` crop | 0 / 295 |
| terminated by | `agent.max_turns` |

The questions varied only cosmetically between passes ("各写真(#1-#8)の状態", then #9-#16, then #17-#24, cycling), which matters for the fix — see below.

## Why nothing caught it

`vision_analyze`'s cost lives in the **payload**, not the response. Each call embeds the image into primary-model context, where it rides in history and is re-sent on every subsequent API call (`tools/vision_tools.py:1337-1343`, ref #92699). The existing no-progress detector cannot see this class of runaway, for two independent reasons:

1. **`vision_analyze` is in neither `IDEMPOTENT_TOOL_NAMES` nor `MUTATING_TOOL_NAMES`** (`agent/tool_guardrails.py:20-60`). `_is_idempotent()` (`:522-525`) returns `False`, so `after_call()` early-returns at `:495-497` before any tracking. Vision repeats are never counted.
2. **Even if it were listed, the detector keys on `_result_hash(result)`** — but `vision_analyze` returns a multimodal **dict** envelope (`vision_tools.py:1160-1176`), not a string. `observe_call()` (`:575-590`) only forms streaks for plain-`str` results; non-string results reset the count. A loop that varies the question per pass looks novel on every call regardless.

**The obvious fix is a trap:** adding `vision_analyze` to `IDEMPOTENT_TOOL_NAMES` would pass that dict into `_result_hash()` (`:499`), which assumes `str | None` (`safe_json_loads(result or "")`, `.encode` at `:854`). `run_agent.py:8395` guards str-ness for `observe_call`, but `after_call` at `:8376` receives the raw result. That route is a type error, not a fix.

## The fix

Cap the call **count** via the existing `loop_caps` mechanism, which already runs in `before_call` at `:384-386` — *ahead* of the `hard_stop_enabled` gate at `:388` — and blocks regardless of it (docstring `:194-201`). No new machinery, no default-posture change required.

Default `50`/turn, `0` disables, matching the `web_search` and `delegate_task` caps. Not strictly behavior-neutral — a turn's 51st vision call is blocked — but such a turn is pathological by construction, and this is the same deliberate-safety semantics the two existing caps already ship with.

**Replaying the incident against the shipped default: 295 attempted → 50 allowed, 245 blocked.**

### Why a count cap, not a generic mechanism

A generic "expensive tool" registry would be speculative infrastructure — the class has exactly one known member today. `_check_loop_cap` is already a named-tool ladder (`web_search`, `delegate_task`); a third named branch is the established pattern. When a second payload-cost tool appears, that is the moment to table-drive it.

## Tests

Added to `tests/agent/test_tool_guardrails.py`, alongside the existing loop-cap coverage. Behavior contracts, no source-text assertions, no frozen literals:

- `test_vision_cap_blocks_after_limit_with_distinct_args` — the incident contract: **distinct** args each consume the cap (precisely what the signature-keyed detector cannot do)
- `test_vision_cap_zero_disables`
- `test_vision_cap_resets_between_turns`
- `test_vision_cap_from_mapping_round_trips_and_falls_back` — explicit / absent / negative / junk, asserted against `LoopCapConfig()`'s default rather than the literal
- `test_vision_cap_does_not_consume_sibling_cap_budgets`
- `test_default_config_enables_a_vision_cap` — config→dataclass propagation asserted as `> 0`, not `== 50`

```
$ scripts/run_tests.sh tests/agent/test_tool_guardrails.py -q
=== Summary: 1 files, 13 tests passed, 0 failed (100% complete) ===
```

Sibling suites green: `tests/tools/test_delegate_control_actions.py`, `tests/agent/test_stall_guards.py`, `tests/run_agent/test_tool_call_guardrail_runtime.py`, `tests/hermes_cli/test_config.py` (120 passed, 0 failed).

## Caching / compression

- **Cache-safe.** The block fires in `before_call`; the refusal enters as a synthetic tool result (`run_agent._guardrail_block_result:8424`) — append-only, no mutation of already-sent context. Same mechanism the two existing caps use.
- **No interaction with result-stub dedupe.** Stubbing applies only to plain-string results (`run_agent.py:8410`), so multimodal envelopes pass through untouched; the cap cannot cause a fresh image to be stripped.
- **Scope limit, stated plainly:** this bounds *growth*. It does not evict images already resident in history — that would be a compression-path change with real cache-invalidation tradeoffs, and is deliberately not bundled here.

## Known limitation

The cap is per-**turn**; the incident was 295 calls across a session. It catches this case because the calls clustered within turns (295 before turn 150 ended it). A pathological loop spread thinly across many turns would still evade it.