### PR TITLE
fix(desktop): dock the sidebar rails down to 640px

### DIFF
--- a/apps/desktop/src/app/layout-constants.ts
+++ b/apps/desktop/src/app/layout-constants.ts
@@ -18,8 +18,15 @@ export const PAGE_INSET_NEG_X = '-mx-[clamp(1.25rem,4vw,4rem)]'
 // for Tailwind's scanner (see PAGE_INSET_X note).
 export const PAGE_MAX_W = 'max-w-[75rem]'
 
-// Below this viewport width a docked sidebar leaves no room for content, so both
-// rails auto-collapse into the hover-reveal overlay. Single source of truth for
+// Narrowest window that still docks a rail in the grid; under it both rails
+// leave the grid and become the hover-reveal overlay. Single source of truth for
 // the responsive collapse point.
-export const SIDEBAR_COLLAPSE_BREAKPOINT_PX = 768
-export const SIDEBAR_COLLAPSE_MEDIA_QUERY = `(max-width: ${SIDEBAR_COLLAPSE_BREAKPOINT_PX}px)`
+//
+// A rail costs 237px (SIDEBAR_DEFAULT_WIDTH) and the chat beside it wants roughly
+// what a popped-out session window enforces on itself (420px), so docking stops
+// paying for itself around here — while still leaving an overlay band down to the
+// window's own 400px minimum. Expressed as a dock floor rather than a collapse
+// ceiling so half-screen splits stay docked on common laptop widths (1280 → 640).
+export const SIDEBAR_DOCK_MIN_WIDTH_PX = 640
+// `max-width` is inclusive: shave a hair so an exactly-640px window docks.
+export const SIDEBAR_COLLAPSE_MEDIA_QUERY = `(max-width: ${SIDEBAR_DOCK_MIN_WIDTH_PX - 0.02}px)`


### PR DESCRIPTION
## What does this PR do?

The sidebar rails left the grid for the hover-reveal overlay at 768px. That is a normal Desktop window size, not a phone: a half-screen split on a 1512px laptop is 756px and on a 1440px one is 720px, so putting Hermes beside an editor cost the docked sessions rail.

`SIDEBAR_COLLAPSE_MEDIA_QUERY` in `apps/desktop/src/app/layout-constants.ts` is the single source of truth here — it feeds `$narrowViewport` (pane tree), `revealNarrowPane` (⌘B / ⌘G routing), and `toggleReview` — so this is one constant, not a sweep.

The new value is derived from the layout rather than borrowed from Tailwind's `md`. A docked rail costs 237px (`SIDEBAR_DEFAULT_WIDTH`), and the chat beside it wants roughly the 420px a popped-out session window already enforces on itself (`SESSION_WINDOW_MIN_WIDTH`). That puts the honest floor near 657px, so 640 is where docking stops paying for itself, and it still leaves a real overlay band down to the window's own 400px minimum.

The constant is also restated as a dock floor (`SIDEBAR_DOCK_MIN_WIDTH_PX`) instead of a collapse ceiling, with the query shaved by a hundredth of a pixel. `max-width` is inclusive, so an exactly-640px window — half of a 1280px display — would otherwise have landed on the overlay side of the boundary it defines.

The other 768 in the renderer (`useIsMobile`) is untouched and unrelated: the chat sidebar renders with `collapsible="none"`, so shadcn's mobile Sheet branch never runs and there is no second overlay path competing with this one.

### What this PR does

- Collapse the rails below 640px instead of 768px, derived from `SIDEBAR_DEFAULT_WIDTH` + the popped-out session window's own floor
- Rename `SIDEBAR_COLLAPSE_BREAKPOINT_PX` to `SIDEBAR_DOCK_MIN_WIDTH_PX` so the constant reads as the narrowest width that still docks
- Subtract 0.02px in the query so an exactly-640px window docks rather than overlays

## Related Issue

N/A — reported directly.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## How to Test

- [x] `npx vitest run src/components/pane-shell/tree/renderer/narrow-overlays.test.tsx src/store/review.test.ts` — 42 passed. Both suites drive `$narrowViewport` directly, so they cover the overlay behavior without pinning the literal.
- [x] `npm run typecheck` — clean across the renderer, electron, and e2e projects.
- [x] Boundary probed live in a dev build over CDP: at 641 and 640 CSS px the rail is docked; at 639 it collapses to the overlay.
- Resize the window through 640px. Above it the sessions rail stays in the grid; below it the rail leaves the grid, the edge hover strip reveals it, and ⌘B pins it.
- At 666px (the tightest docked state) the chat pane is ~417px: the transcript still wraps and the composer is intact.

## Checklist

### Code

- [x] Conventional Commits
- [x] Only the collapse breakpoint
- [x] Existing narrow-overlay suites cover the behavior; no change-detector test added for the literal
- [x] Tested on macOS 15

### Documentation & Housekeeping

- [x] N/A for docs / config / AGENTS.md / tool schemas
- [x] No cross-platform impact — viewport media query, no host behavior
