### PR TITLE
fix(dashboard): report symlinked directories as directories in /api/fs/list

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3050,7 +3050,11 @@ async def fs_list(path: str):
                 entries.append({
                     "name": entry.name,
                     "path": str(target / entry.name),
-                    "isDirectory": entry.is_dir(follow_symlinks=False),
+                    # The read/write endpoints resolve symlinks before
+                    # classifying the target.  Follow them here as well so a
+                    # directory link is navigable instead of being exposed as
+                    # a file that immediately fails /api/fs/read-text.
+                    "isDirectory": entry.is_dir(follow_symlinks=True),
                 })
         entries.sort(key=lambda item: (not item["isDirectory"], item["name"].lower(), item["name"]))
         return {"entries": entries}

--- a/tests/hermes_cli/test_web_server_fs.py
+++ b/tests/hermes_cli/test_web_server_fs.py
@@ -45,6 +45,25 @@ def test_fs_list_sorts_and_hides_noise(client, tmp_path):
     assert all(entry["name"] not in {".git", "node_modules"} for entry in entries)
 
 
+def test_fs_list_reports_symlinked_directory_as_directory(client, tmp_path):
+    root = tmp_path / "project"
+    root.mkdir()
+    target = tmp_path / "shared"
+    target.mkdir()
+    link = root / "linked-dir"
+    try:
+        link.symlink_to(target, target_is_directory=True)
+    except OSError as exc:
+        pytest.skip(f"directory symlinks unavailable on this host: {exc}")
+
+    response = client.get("/api/fs/list", params={"path": str(root)})
+
+    assert response.status_code == 200
+    assert response.json()["entries"] == [
+        {"name": "linked-dir", "path": str(link), "isDirectory": True}
+    ]
+
+
 def test_fs_read_data_url_rejects_over_cap(client, tmp_path, monkeypatch):
     monkeypatch.setattr(web_server, "_FS_DATA_URL_MAX_BYTES", 3)
     target = tmp_path / "image.png"


### PR DESCRIPTION
Fixes #98163

## Problem
\GET /api/fs/list\ classified entries with \DirEntry.is_dir(follow_symlinks=False)\. A symlink pointing at a directory was therefore serialized as \isDirectory: false\, so the remote Desktop file panel treated it as a file. Its next request to \/api/fs/read-text\ followed the same symlink during \stat()\ and correctly rejected it with \400 Path points to a directory\. The list and read/navigation endpoints disagreed, making symlinked project folders impossible to browse.

## Fix
Follow symlinks when classifying list entries (\entry.is_dir(follow_symlinks=True)\). This matches the endpoint behavior that follows the target when navigating/reading paths and preserves the existing authenticated arbitrary-path policy. Broken symlinks still classify as non-directories.

## Verification
Added a behavioral endpoint test that creates a directory symlink and asserts \/api/fs/list\ returns \isDirectory: true\. \	ests/hermes_cli/test_web_server_fs.py\: 5 passed, 1 skipped on this Windows host because unprivileged directory symlink creation is unavailable.