### PR TITLE
fix: route resolved bot mentions outside Bot Chat

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -875,16 +875,12 @@ def build_turn_context(
 
     active_system_prompt = agent._cached_system_prompt
 
-    # Bot Mode DM tool — injected ONLY into a bot's canonical "Bot Chat"
-    # session on Bot-Mode-managed installs (same gate as the protocol
-    # section above). The gate is stable for a session's lifetime, so the
-    # tool list is byte-identical every turn: prompt-cache safe. Every
-    # other session (CLI, gateway chats, group-room member sessions, cron,
-    # subagents) fails the gate and never sees the schema.
+    # Bot Mode DM tool — stable in canonical Bot Chat; transient elsewhere
+    # only when Desktop resolved an explicit @mention in this user turn.
     try:
         from tools.bot_mode_dm import ensure_message_agent_tool
 
-        ensure_message_agent_tool(agent)
+        ensure_message_agent_tool(agent, original_user_message)
     except Exception:
         logger.debug("message_agent injection skipped", exc_info=True)
 

--- a/apps/desktop/src/plugins/hermes-bots/data.identity.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.identity.test.ts
@@ -76,6 +76,13 @@ describe('the @handle a bot answers to', () => {
     expect(botHandle('ops')).toBe('ops')
   })
 
+  it('uses the primary profile friendly identity when one exists', () => {
+    expect(botHandle('default', row({ display_name: 'Miguel Arcanjuz', name: 'default' }))).toBe('miguel-arcanjuz')
+    expect(
+      botHandle('default', row({ name: 'default', ui_meta: { 'hermes-bots': { title: 'Miguel' } } }))
+    ).toBe('miguel')
+  })
+
   it('prefers a precomputed multi-source handle over the bare name', () => {
     expect(botHandle('default', row({ handle: 'default-vera', name: 'default' }))).toBe('default-vera')
   })

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -951,15 +951,28 @@ function mergeMultiSourceRoster(
 
 /** The @handle users tag a bot with. Multi-source rosters precompute the
  *  handle (bare name, or name-device when the profile exists on several
- *  registered sources) — prefer it when present. The primary profile's
- *  callable alias is 'hermes' — the mention middleware resolves it back to
- *  'default' — so the word 'default' never surfaces in the UI. */
+ *  registered sources) — prefer it when present. The primary profile uses
+ *  its friendly title/display name when available; 'hermes' remains fallback. */
 export function botHandle(name: string, bot?: Partial<RosterRow> | null): string {
   if (bot?.handle && bot.handle !== name) {
     return bot.handle
   }
 
-  return (name || '').trim().toLowerCase() === 'default' ? 'hermes' : name
+  if ((name || '').trim().toLowerCase() !== 'default') {
+    return name
+  }
+
+  const botMeta = bot?.ui_meta?.['hermes-bots']
+
+  for (const friendly of [botMeta?.title, bot?.title, bot?.display_name]) {
+    const forms = mentionNameForms(friendly)
+
+    if (forms.length) {
+      return forms[0]
+    }
+  }
+
+  return 'hermes'
 }
 
 /** Taggable @-forms derived from a bot's friendly names — the core profile

--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -284,6 +284,21 @@ describe('the mention middleware', () => {
     expect(result.text).not.toMatch(/ — on /)
   })
 
+  it('identifies the primary profile by its friendly @miguel alias', async () => {
+    const { handler } = await contributions({
+      focused: 'research',
+      profiles: [
+        { name: 'research' },
+        { name: 'default', ui_meta: { 'hermes-bots': { title: 'Miguel' } } }
+      ]
+    })
+
+    const result = await handler({ text: '@miguel resolve isso' })
+
+    expect(result.text).toMatch(/@miguel = agent profile "default"/)
+    expect(result.text).not.toMatch(/@default =|@hermes =/)
+  })
+
   it('teaches no shellout and forbids forwarding the user’s text verbatim', async () => {
     // The class behind #91397 / #91304 / #91339: the renderer used to compose
     // a `hermes -p …` handoff, giving the model a second send path and a way

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -66,8 +66,20 @@ class _FakeAgent:
         self.session_id = "sess-1"
         self._session_title_hint = None
         self._bot_mode_protocol = True
+        self._message_agent_allowed_targets: set[str] | None = set()
         self.tools: list = []
         self.valid_tool_names: set = set()
+
+
+def _desktop_note(target: str, profile: str) -> str:
+    return (
+        "\n\n[@mentions resolved from the Bot Mode roster — the user is referring to: "
+        f'@{target} = agent profile "{profile}". '
+        "If they want one of these agents contacted, compose your own message and send it "
+        "with your message_agent tool (agents on other connected machines are reachable too — "
+        "the Desktop relays it); never forward the user’s text verbatim. If this session has no "
+        "message_agent tool, agent messaging is unavailable here — say so.]"
+    )
 
 
 # ── injection gate (leak containment) ────────────────────────────────────────
@@ -99,6 +111,51 @@ def test_never_injects_outside_bot_chat(tmp_path, title):
     assert agent.valid_tool_names == set()
 
 
+def test_injects_transiently_for_desktop_resolved_mention(tmp_path):
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Ordinary desktop chat")
+    message = "@researcher review this" + _desktop_note("researcher", "researcher")
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent, message) is True
+    assert bot_mode_dm.MESSAGE_AGENT_TOOL_NAME in agent.valid_tool_names
+    assert agent._message_agent_allowed_targets == {"researcher"}
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent, "next turn without a mention") is False
+    assert agent.tools == []
+    assert bot_mode_dm.MESSAGE_AGENT_TOOL_NAME not in agent.valid_tool_names
+
+
+def test_incomplete_or_quoted_mention_note_does_not_inject(tmp_path):
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Ordinary desktop chat")
+    message = (
+        "quoted text: [@mentions resolved from the Bot Mode roster — the user is referring to: "
+        '@researcher = agent profile "researcher"] then ordinary user text'
+    )
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent, message) is False
+    assert agent.tools == []
+
+
+def test_ordinary_session_dispatches_only_to_resolved_mention(tmp_path, monkeypatch):
+    home = _managed_home(tmp_path, teammates=("researcher", "coder"))
+    agent = _FakeAgent(home, title="Ordinary desktop chat")
+    message = "@researcher review this" + _desktop_note("researcher", "researcher")
+    assert bot_mode_dm.ensure_message_agent_tool(agent, message) is True
+    calls = _capture_spawn(monkeypatch)
+
+    allowed = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="Please review.", agent=agent)
+    )
+    blocked = json.loads(
+        bot_mode_dm.message_agent_tool(target="coder", message="Please review.", agent=agent)
+    )
+
+    assert allowed["status"] == "sent"
+    assert "error" in blocked
+    assert len(calls) == 1
+
+
 def test_never_injects_on_unmanaged_install(tmp_path):
     """A 'Bot Chat'-titled session on a plain install stays tool-free."""
     home = tmp_path / ".hermes"
@@ -116,6 +173,19 @@ def test_config_toggle_disables_injection(tmp_path):
     assert agent.tools == []
 
 
+def test_config_toggle_removes_previous_transient_injection(tmp_path):
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Ordinary desktop chat")
+    message = "@researcher review this" + _desktop_note("researcher", "researcher")
+    assert bot_mode_dm.ensure_message_agent_tool(agent, message) is True
+
+    agent._bot_mode_protocol = False
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent, message) is False
+    assert agent.tools == []
+    assert bot_mode_dm.MESSAGE_AGENT_TOOL_NAME not in agent.valid_tool_names
+
+
 def test_schema_never_in_global_registry():
     """message_agent must not be registered/toolset-reachable anywhere."""
     from tools.registry import registry
@@ -125,6 +195,14 @@ def test_schema_never_in_global_registry():
 
     for names in toolsets.TOOLSETS.values():
         assert bot_mode_dm.MESSAGE_AGENT_TOOL_NAME not in names
+
+
+def test_schema_does_not_expose_default_profile_or_legacy_alias():
+    schema = bot_mode_dm.message_agent_tool_schema()
+    target_description = schema["function"]["parameters"]["properties"]["target"]["description"]
+
+    assert "default agent" not in target_description
+    assert "'hermes'" not in target_description
 
 
 # ── dispatch gate (defense in depth) ─────────────────────────────────────────
@@ -171,6 +249,25 @@ def test_cannot_message_self(tmp_path):
     )
     assert "error" in result
     assert "yourself" in result["error"]
+
+
+def test_default_friendly_alias_resolves_and_legacy_alias_remains(tmp_path):
+    home = _managed_home(tmp_path)
+    (home / "profile.yaml").write_text(
+        textwrap.dedent(
+            """\
+            display_name: miguel-arcanjuz
+            ui_meta:
+              hermes-bots:
+                title: Miguel
+            """
+        ),
+        encoding="utf-8",
+    )
+    roster = bot_mode_dm._local_roster(home)
+
+    assert bot_mode_dm._resolve_local_name("miguel", roster, home) == "default"
+    assert bot_mode_dm._resolve_local_name("hermes", roster, home) == "default"
 
 
 def test_empty_and_oversized_message_rejected(tmp_path):

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -68,6 +68,29 @@ def test_emits_for_named_profile_with_own_handle(tmp_path):
     assert "`@coder`" not in roster_block
 
 
+def test_default_profile_uses_friendly_title_as_callable_handle(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "profile.yaml").write_text(
+        textwrap.dedent(
+            """\
+            display_name: miguel-arcanjuz
+            ui_meta:
+              hermes-bots:
+                title: Miguel
+            """
+        ),
+        encoding="utf-8",
+    )
+    profile_dir = _make_bot_profile(home, "coder", managed=True)
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(profile_dir)
+
+    assert "`@miguel`" in section
+    assert "`@default`" not in section
+    assert "`@hermes`" not in section
+
+
 def test_roster_lines_carry_roles(tmp_path):
     """Bots must know WHO to message: the roster carries title/description."""
     import textwrap as _tw

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -16,15 +16,11 @@ existing background-process notification path (fire-and-forget, never
 blocks the sender's turn).
 
 Containment contract (MUST hold — reviewers check all three):
-- The tool schema is injected ONLY into a bot's canonical "Bot Chat"
-  session on Bot-Mode-managed installs — the exact same gate as the
-  protocol section in ``tools/bot_mode_probe.py``. It is NOT registered in
-  the global tool registry, is NOT part of any toolset, and never appears
-  in CLI sessions, ordinary gateway chats, group-room member sessions
-  (titled "Group: …"), cron agents, or subagents.
-- Dispatch is title-gated again at execution time (defense in depth): a
-  forged call from a session that shouldn't have the tool returns a
-  structured error instead of delivering.
+- The tool schema is always available in a bot's canonical "Bot Chat". In
+  another session it is injected for one turn only when the Desktop's Bot
+  Mode middleware appended a resolved-roster mention note.
+- Dispatch repeats that gate and limits a non-canonical turn to the exact
+  agent target(s) named by the resolved mention note.
 - Everything here is additive. The legacy protocol transports
   (``hermes -p`` / ``hermes peer dm``) keep working for older prompts.
 
@@ -94,7 +90,8 @@ def message_agent_tool_schema() -> dict:
                 "clearly relevant teammate when it genuinely helps the user's goal; "
                 "don't fan out to several agents unless the user explicitly asked. "
                 "Use the teammate roster in your system prompt (names + roles) to pick "
-                "the right recipient; targets: a teammate name (e.g. 'researcher'), "
+                "the right recipient; targets: a teammate callable handle "
+                "(e.g. 'researcher'), "
                 "'<peer>/<agent>' for an agent on a registered peer gateway "
                 "(e.g. 'spark/researcher', or just '<peer>' for the peer's main agent), "
                 "or an agent on another connected machine from your roster (use "
@@ -106,8 +103,8 @@ def message_agent_tool_schema() -> dict:
                     "target": {
                         "type": "string",
                         "description": (
-                            "Who to message: a teammate profile name from your roster "
-                            "('researcher', 'hermes' for the default agent), or "
+                            "Who to message: a teammate callable handle from your roster "
+                            "(for example, 'researcher'), or "
                             "'<peer>' / '<peer>/<agent>' for a registered peer gateway."
                         ),
                     },
@@ -126,18 +123,66 @@ def message_agent_tool_schema() -> dict:
     }
 
 
-def ensure_message_agent_tool(agent: Any) -> bool:
-    """Inject the ``message_agent`` schema into a Bot Chat agent's tool list.
+_MENTION_NOTE_PREFIX = "[@mentions resolved from the Bot Mode roster — the user is referring to:"
+_MENTION_NOTE_SUFFIX = (
+    "If this session has no message_agent tool, agent messaging is unavailable here — say so.]"
+)
+_MENTION_PROFILE_RE = re.compile(r'agent profile "([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})"')
+_MENTION_REMOTE_TARGET_RE = re.compile(r'message_agent target: "([a-zA-Z0-9_@-]+)"')
+
+
+def _resolved_mention_targets(user_message: object) -> set[str]:
+    text = str(user_message or "")
+    marker = text.rfind(_MENTION_NOTE_PREFIX)
+    if marker < 0:
+        return set()
+    note = text[marker:].strip()
+    if not note.endswith(_MENTION_NOTE_SUFFIX):
+        return set()
+    return {
+        *(match.group(1) for match in _MENTION_PROFILE_RE.finditer(note)),
+        *(match.group(1) for match in _MENTION_REMOTE_TARGET_RE.finditer(note)),
+    }
+
+
+def _remove_message_agent_tool(agent: Any) -> None:
+    tools = getattr(agent, "tools", None)
+    if isinstance(tools, list):
+        agent.tools = [
+            tool
+            for tool in tools
+            if not (
+                isinstance(tool, dict)
+                and tool.get("function", {}).get("name") == MESSAGE_AGENT_TOOL_NAME
+            )
+        ]
+    valid = getattr(agent, "valid_tool_names", None)
+    if isinstance(valid, set):
+        valid.discard(MESSAGE_AGENT_TOOL_NAME)
+
+
+def ensure_message_agent_tool(agent: Any, user_message: object = None) -> bool:
+    """Inject ``message_agent`` for Bot Chat or one resolved-mention turn.
 
     Called once per turn from the conversation loop. Idempotent and
-    deterministic for the life of a session: the gate (canonical Bot Chat
-    title on a Bot-Mode-managed install) is stable from the session's first
-    turn, so the tool list is byte-identical across turns — prompt-cache
-    safe. Every non-Bot-Chat session fails the gate on every turn and never
-    sees the schema. Never raises.
+    Ordinary sessions receive a transient schema only for a Desktop-resolved
+    @mention. The execution gate then restricts delivery to that exact target.
+    Never raises.
     """
     try:
         if not getattr(agent, "_bot_mode_protocol", True):
+            _remove_message_agent_tool(agent)
+            return False
+        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+
+        if not is_bot_mode_managed(_agent_home(agent)):
+            _remove_message_agent_tool(agent)
+            return False
+        canonical = _session_title(agent) == BOT_CHAT_TITLE
+        allowed_targets = _resolved_mention_targets(user_message)
+        agent._message_agent_allowed_targets = None if canonical else allowed_targets
+        if not canonical and not allowed_targets:
+            _remove_message_agent_tool(agent)
             return False
         tools = getattr(agent, "tools", None)
         if tools:
@@ -147,16 +192,6 @@ def ensure_message_agent_tool(agent: Any) -> bool:
                     and tool.get("function", {}).get("name") == MESSAGE_AGENT_TOOL_NAME
                 ):
                     return True
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
-
-        if _session_title(agent) != BOT_CHAT_TITLE:
-            return False
-        # Managed-install check, NOT section non-emptiness: a profile whose
-        # SOUL.md carries the legacy plugin-appended protocol text gets an
-        # empty section (dedupe) but must still receive the tool — otherwise
-        # upgraded installs silently lose A2A messaging (Aug 2026).
-        if not is_bot_mode_managed(_agent_home(agent)):
-            return False
         if agent.tools is None:
             agent.tools = []
         agent.tools.append(message_agent_tool_schema())
@@ -207,12 +242,23 @@ def _peers(root: Path) -> list[str]:
         return []
 
 
-def _handle(name: str) -> str:
+def _profile_dir(root: Path, name: str) -> Path:
+    return root if name == "default" else root / "profiles" / name
+
+
+def _handle(name: str, root: Path | None = None) -> str:
+    if root is not None:
+        try:
+            from tools.bot_mode_probe import _handle as _probe_handle
+
+            return _probe_handle(name, _profile_dir(root, name))
+        except Exception:
+            pass
     return "hermes" if name == "default" else name
 
 
-def _resolve_local_name(target: str, roster: list[str]) -> Optional[str]:
-    """Map a target handle to a profile name ('hermes' → 'default')."""
+def _resolve_local_name(target: str, roster: list[str], root: Path | None = None) -> Optional[str]:
+    """Map an internal, friendly, or legacy handle to a profile name."""
     want = target.strip()
     if not want:
         return None
@@ -221,7 +267,28 @@ def _resolve_local_name(target: str, roster: list[str]) -> Optional[str]:
     for name in roster:
         if name.lower() == want.lower():
             return name
+    if root is not None:
+        matches = [name for name in roster if _handle(name, root).lower() == want.lower()]
+        if len(matches) == 1:
+            return matches[0]
     return None
+
+
+def _ordinary_target_allowed(agent: Any, raw_target: str, resolved: str | None = None) -> bool:
+    try:
+        from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+        if _session_title(agent) == BOT_CHAT_TITLE:
+            return True
+    except Exception:
+        pass
+    allowed = getattr(agent, "_message_agent_allowed_targets", set())
+    if allowed is None:  # canonical Bot Chat: unrestricted roster access
+        return True
+    wanted = {raw_target.lower()}
+    if resolved:
+        wanted.add(resolved.lower())
+    return any(str(item).lower() in wanted for item in allowed)
 
 
 # ── the tool ─────────────────────────────────────────────────────────────────
@@ -250,21 +317,21 @@ def message_agent_tool(
     the Bot Chat gate, the sender identity, and the session key so the
     spawned transport is tracked against the right session.
     """
-    # ── defense-in-depth gate: only a canonical Bot Chat may deliver ──
+    # ── defense-in-depth gate: Bot Chat or one resolved-mention turn ──
     home = _agent_home(agent)
     try:
         from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
 
         title = _session_title(agent)
-        if title != BOT_CHAT_TITLE:
-            return _err(
-                "message_agent is only available in a Bot Mode 'Bot Chat' session. "
-                "This session is not one; do not retry."
-            )
         if not is_bot_mode_managed(home):
             return _err(
                 "This install is not Bot-Mode-managed (no bot roster); "
                 "message_agent is unavailable. Do not retry."
+            )
+        if title != BOT_CHAT_TITLE and not getattr(agent, "_message_agent_allowed_targets", set()):
+            return _err(
+                "message_agent requires a Bot Mode 'Bot Chat' or a Desktop-resolved "
+                "@mention in the current turn. Do not retry without a new @mention."
             )
     except Exception as exc:  # pragma: no cover — defensive
         return _err(f"Bot Mode gate check failed: {exc}")
@@ -273,7 +340,7 @@ def message_agent_tool(
     me = _self_profile_name(Path(home))
     roster = _local_roster(root)
     peers = _peers(root)
-    teammates = [_handle(n) for n in roster if n != me]
+    teammates = [_handle(n, root) for n in roster if n != me]
 
     body = str(message or "").strip()
     if not body:
@@ -288,13 +355,15 @@ def message_agent_tool(
     if not raw_target:
         return _err("target is required.", roster=teammates, peers=peers)
 
-    sender_handle = _handle(me)
+    sender_handle = _handle(me, root)
     prefix = f"Message from 🤖 {sender_handle} (@{sender_handle}): "
 
     # ── peer target: '<peer>/<agent>' or a bare registered peer name ──
     peer_match = _PEER_TARGET_RE.match(raw_target)
     bare_peer = raw_target.lower() if raw_target.lower() in peers else None
     if peer_match or bare_peer:
+        if not _ordinary_target_allowed(agent, raw_target):
+            return _err("Target was not resolved by this turn's @mention.")
         peer_name = peer_match.group(1) if peer_match else bare_peer
         peer_profile = peer_match.group(2) if peer_match else None
         if peer_name not in peers:
@@ -330,7 +399,9 @@ def message_agent_tool(
     # ── local teammate ──
     if not _LOCAL_TARGET_RE.match(raw_target) and "@" not in raw_target:
         return _err(f"Invalid target: {raw_target!r}.", roster=teammates, peers=peers)
-    resolved = _resolve_local_name(raw_target, roster) if _LOCAL_TARGET_RE.match(raw_target) else None
+    resolved = _resolve_local_name(raw_target, roster, root) if _LOCAL_TARGET_RE.match(raw_target) else None
+    if not _ordinary_target_allowed(agent, raw_target, resolved):
+        return _err("Target was not resolved by this turn's @mention.")
     if resolved is None:
         # ── cross-connection teammate (Desktop relay) ──
         # Every gateway connected to the user's Desktop is reachable: the
@@ -373,7 +444,7 @@ def message_agent_tool(
             "-Q",
         ],
         prefix + body,
-        f"@{_handle(resolved)}",
+        f"@{_handle(resolved, root)}",
         stdin_file=False,
         task_id=task_id,
         agent=agent,

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -30,6 +30,7 @@ Toggle via ``agent.bot_mode_protocol`` in config.yaml (default True).
 from __future__ import annotations
 
 import os
+import re
 import threading
 from pathlib import Path
 
@@ -118,9 +119,42 @@ def _soul_has_protocol(profile_dir: Path) -> bool:
         return False
 
 
-def _handle(name: str) -> str:
-    # The mention middleware aliases the default profile as @hermes.
-    return "hermes" if name == "default" else name
+def _mention_name_form(value: object) -> str:
+    """Turn a friendly profile name into one safe callable @handle."""
+    text = str(value or "").strip().lower()
+    if not text:
+        return ""
+    form = re.sub(r"[^a-z0-9_-]+", "-", text).strip("-")
+    if not re.fullmatch(r"[a-z0-9][a-z0-9_-]*", form or ""):
+        return ""
+    if form in {"all", "everyone", "user", "default", "hermes"}:
+        return ""
+    return form
+
+
+def _handle(name: str, profile_dir: Path | None = None) -> str:
+    """Public handle for a profile; keep ``default`` internal-only."""
+    if name != "default":
+        return name
+    if profile_dir is not None:
+        try:
+            import yaml
+
+            data = yaml.safe_load((profile_dir / "profile.yaml").read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                ui_meta = data.get("ui_meta")
+                bot_meta = ui_meta.get("hermes-bots") if isinstance(ui_meta, dict) else None
+                candidates = [
+                    bot_meta.get("title") if isinstance(bot_meta, dict) else None,
+                    data.get("display_name"),
+                ]
+                for candidate in candidates:
+                    form = _mention_name_form(candidate)
+                    if form:
+                        return form
+        except Exception:
+            pass
+    return "hermes"
 
 
 def _profile_role(profile_dir: Path) -> str:
@@ -163,7 +197,7 @@ def _roster_lines(root: Path, me: str) -> list[str]:
         if name == me:
             continue
         role = _profile_role(profile_dir)
-        handle = _handle(name)
+        handle = _handle(name, profile_dir)
         lines.append(f"- `@{handle}`" + (f" — {role}" if role else ""))
     return lines
 


### PR DESCRIPTION
## Summary
- expose the default Bot Mode profile through its friendly callable handle while preserving legacy aliases
- inject message_agent transiently in ordinary Desktop sessions only for a complete roster-resolved @mention note
- restrict non-canonical dispatch to the exact resolved target and remove the tool on the next unmentioned turn

## Verification
- Python focused: 127 passed, 1 skipped
- Desktop focused: 48 passed, 0 failed
- TypeScript: no errors
- ESLint: no issues in changed files
- production Desktop build completed
- live ordinary-session round trip: Claude -> @miguel -> Miguel -> Claude, ACK GRUA-281-MIGUEL-ACK-2