### PR TITLE
fix: consume ephemeral output cap after successful request, not before

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1837,8 +1837,6 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
         ctx_len = getattr(agent, "context_compressor", None)
         ctx_len = ctx_len.context_length if ctx_len else None
         ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-        if ephemeral_out is not None:
-            agent._ephemeral_max_output_tokens = None  # consume immediately
         anthropic_kwargs = _transport.build_kwargs(
             model=agent.model,
             messages=anthropic_messages,
@@ -2028,8 +2026,6 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
 
     if _profile:
         _ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-        if _ephemeral_out is not None:
-            agent._ephemeral_max_output_tokens = None
 
         # Strip image parts for non-vision models that have provider profiles
         # (e.g. DeepSeek, Kimi). The legacy path below already does this, but
@@ -2063,8 +2059,6 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     # Reached only when get_provider_profile() returns None — i.e. a
     # completely unknown provider not in providers/ registry.
     _ephemeral_out = getattr(agent, "_ephemeral_max_output_tokens", None)
-    if _ephemeral_out is not None:
-        agent._ephemeral_max_output_tokens = None
 
     # Strip image parts for non-vision models (no-op when vision-capable).
     _msgs_for_chat = agent._prepare_messages_for_non_vision_model(api_messages)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6816,6 +6816,8 @@ def run_conversation(
             if agent.api_mode == "anthropic_messages":
                 _normalize_kwargs["strip_tool_prefix"] = agent._is_anthropic_oauth
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
+            # Success: consume ephemeral output cap now that request succeeded
+            agent._ephemeral_max_output_tokens = None
             assistant_message = normalized
             finish_reason = normalized.finish_reason
             

--- a/tests/test_ctx_halving_fix.py
+++ b/tests/test_ctx_halving_fix.py
@@ -197,13 +197,14 @@ class TestEphemeralMaxOutputTokens:
         kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
         assert kwargs["max_tokens"] == 5_000
 
-    def test_ephemeral_override_is_consumed_after_one_call(self):
-        """After one call the ephemeral override is cleared to None."""
+    def test_ephemeral_override_persists_through_build_api_kwargs(self):
+        """Ephemeral override survives _build_api_kwargs so retry sees it."""
         agent = self._make_agent()
         agent._ephemeral_max_output_tokens = 5_000
 
         agent._build_api_kwargs([{"role": "user", "content": "hi"}])
-        assert agent._ephemeral_max_output_tokens is None
+        # Not consumed yet — caller must clear after successful response
+        assert agent._ephemeral_max_output_tokens == 5_000
 
 
 


### PR DESCRIPTION
Fixes #99897

When an output-cap error triggers `agent._ephemeral_max_output_tokens`, the value was consumed immediately in `build_api_kwargs` — before the actual API call. If that call failed (and was retried via `restart_with_compressed_messages`), the ephemeral clamp was already cleared, so the retried request reverted to `max_tokens=None`.

**Changes:**
- Remove immediate consumption of `_ephemeral_max_output_tokens` in `chat_completion_helpers.py` (3 locations).
- Add consumption AFTER `normalize_response` in `conversation_loop.py` so the retry loop sees the computed clamp.

**Impact:**
Output-cap errors now correctly clamp `max_tokens` on retry. Before: retry spun endlessly because the clamp was lost after the first failed call.