### PR TITLE
fix(plugins): unload the doctor's temp plugin before removing its home

### DIFF
--- a/hermes_cli/plugin_dev.py
+++ b/hermes_cli/plugin_dev.py
@@ -116,6 +116,18 @@ def _doctor_runtime(plugin_path: Path):
             registered_hooks=tuple(loaded.hooks_registered),
         )
     finally:
+        # Dispose the plugin's own registrations FIRST, while the temporary
+        # HERMES_HOME still exists. This runs the host-owned ctx.on_unload(...)
+        # callbacks — e.g. closing a SQLite handle a context-engine plugin
+        # opened under that home. Without it the DB stays open and stack.close()
+        # below (TemporaryDirectory removal) fails with WinError 32 on Windows
+        # (#99918). Best-effort: the snapshot restore below remains the
+        # authoritative registry cleanup, so an unload hiccup never masks it or
+        # the original exception.
+        try:
+            manager.unload()
+        except Exception:
+            pass
         entries_after = {entry.name: entry for entry in registry._snapshot_entries()}
         changed_names = {
             name

--- a/tests/hermes_cli/test_plugin_doctor_unload.py
+++ b/tests/hermes_cli/test_plugin_doctor_unload.py
@@ -1,0 +1,77 @@
+"""`plugins doctor` must unload the plugin before removing the temp home (#99918).
+
+Doctor loads a plugin under a temporary ``HERMES_HOME`` through a throwaway
+``PluginManager``. It restored the global registries and closed the temp dir but
+never called ``manager.unload()``, so host-owned ``ctx.on_unload(...)`` callbacks
+never ran. A context-engine plugin that opened SQLite under the temp home thus
+left the DB open, and ``TemporaryDirectory`` removal failed with ``WinError 32``
+on Windows.
+
+The platform-independent contract these tests pin is the root cause itself: the
+``on_unload`` callback must fire during doctor teardown (which is what closes the
+DB handle and makes the Windows removal succeed). We assert the callback ran via
+a sentinel written outside the temp home, so the test catches the regression on
+every platform — not only where the filesystem locks open files.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+
+def _write_plugin(root: Path, marker: Path) -> Path:
+    plugin = root / "lifecycle-plugin"
+    plugin.mkdir()
+    (plugin / "plugin.yaml").write_text("name: lifecycle-plugin\n", encoding="utf-8")
+    # register() stashes a durable resource and registers on_unload to release
+    # it — the exact shape of a context-engine plugin holding a SQLite handle.
+    (plugin / "__init__.py").write_text(
+        "import os\n"
+        "from pathlib import Path\n\n"
+        "def register(ctx):\n"
+        "    marker = os.environ['DOCTOR_UNLOAD_MARKER']\n"
+        "    ctx.on_unload(lambda: Path(marker).write_text('unloaded'))\n",
+        encoding="utf-8",
+    )
+    return plugin
+
+
+def test_doctor_runs_on_unload_during_teardown(tmp_path: Path) -> None:
+    from hermes_cli.plugin_dev import doctor_plugin
+
+    marker = tmp_path / "unloaded.marker"  # outside the temp HERMES_HOME
+    plugin = _write_plugin(tmp_path, marker)
+
+    with patch.dict(os.environ, {"DOCTOR_UNLOAD_MARKER": str(marker)}, clear=False):
+        report = doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
+    assert marker.exists(), "ctx.on_unload must run before the temp home is removed"
+    assert marker.read_text() == "unloaded"
+
+
+def test_doctor_still_reports_and_cleans_up_for_unload_plugin(tmp_path: Path) -> None:
+    # The added unload must not disturb the existing teardown contract: registry
+    # entries restored, no hermes_plugins.* module leak.
+    import sys
+
+    from hermes_cli.plugin_dev import doctor_plugin
+    from tools.registry import registry
+
+    marker = tmp_path / "unloaded2.marker"
+    plugin = _write_plugin(tmp_path, marker)
+    before_modules = {
+        name for name in sys.modules
+        if name == "hermes_plugins" or name.startswith("hermes_plugins.")
+    }
+
+    with patch.dict(os.environ, {"DOCTOR_UNLOAD_MARKER": str(marker)}, clear=False):
+        report = doctor_plugin(plugin)
+
+    assert report.ok, report.format_text()
+    after_modules = {
+        name for name in sys.modules
+        if name == "hermes_plugins" or name.startswith("hermes_plugins.")
+    }
+    assert after_modules == before_modules


### PR DESCRIPTION
## What does this PR do?

`plugins doctor <plugin>` loads a plugin under a temporary `HERMES_HOME` via a
throwaway `PluginManager`, restores the global registries in `finally`, and
closes the `ExitStack` (removing the temp dir) — but never calls
`manager.unload()`. So host-owned `ctx.on_unload(...)` callbacks and
registration disposal never run. A context-engine plugin that opened SQLite
under the temp home left the DB handle open, and the `TemporaryDirectory`
removal failed with `WinError 32` on Windows (#99918).

Call `manager.unload()` at the top of the teardown `finally`, while the
temporary home still exists, so registration disposal + `on_unload` callbacks
(e.g. closing the SQLite handle) run before the directory is removed.
Best-effort: the existing snapshot restore stays the authoritative registry
cleanup, so an unload hiccup never masks it or the original exception.

## Related Issue

Fixes #99918
## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugin_dev.py` — `_doctor_runtime` unloads the temp manager before
  the temp home is removed.
- `tests/hermes_cli/test_plugin_doctor_unload.py` — assert `ctx.on_unload` fires
  during doctor teardown (platform-independent), and that registry/module
  cleanup is unchanged.

## How to Test

    pytest tests/hermes_cli/test_plugin_doctor_unload.py -q

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A


