### PR TITLE
fix(update): let Scheduled Task gateways update on Windows

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1131,6 +1131,10 @@ def find_windows_gateway_services(
                 pid
                 for pid in ancestor_pids
                 if len(service_names_by_pid.get(pid, set())) > 1
+                # The standard Hermes Scheduled Task descends from the
+                # Task Scheduler service's shared svchost. That host is a
+                # launcher, not an SCM owner of the gateway process.
+                and "Schedule" not in service_names_by_pid[pid]
             ]
             if shared_service_pids:
                 raise RuntimeError(

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1211,7 +1211,7 @@ def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypat
             self.pid = pid
 
         def parents(self):
-            return [FakeProcess(100)]
+            return [FakeProcess(200), FakeProcess(100)]
 
         def children(self, recursive=False):
             return [FakeProcess(300)]
@@ -1229,6 +1229,39 @@ def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypat
             psutil_module=fake_psutil,
             profile_processes=[profile],
         )
+
+
+def test_find_windows_gateway_services_ignores_task_scheduler_host(monkeypatch):
+    """Task Scheduler's shared host is an ancestor, not the gateway's owner."""
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name):
+            self.name = name
+
+        def as_dict(self):
+            return {"name": self.name, "pid": 100, "status": "running"}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(200), FakeProcess(100)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [FakeService("Schedule"), FakeService("RpcSs")],
+        Process=FakeProcess,
+    )
+
+    assert gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    ) == []
 
 
 def test_find_windows_gateway_services_fails_closed_on_service_access_error(


### PR DESCRIPTION
## What does this PR do?

This lets `hermes update` pause a standard Windows Scheduled Task gateway instead of aborting before the pull with an ambiguous SCM ownership error. It excludes the Task Scheduler service's shared host from SCM ownership attribution while retaining the fail-closed guard for every other shared service host.

### Symptom

With the standard `Hermes_Gateway` Scheduled Task running on Windows, `hermes update` aborts with `Gateway ownership is ambiguous under shared SCM host PID(s)`.

### Impact

Affected Windows users must stop the Scheduled Task and gateway processes manually before every update, then restart them afterward.

### Bug Cause

**Trigger:** `hermes_cli/gateway.py:1130` / `find_windows_gateway_services()` / a validated gateway has the Task Scheduler service's shared `svchost.exe` in its ancestry.

**Causal chain:**
1. The standard Scheduled Task launches the gateway below the Task Scheduler service host.
2. SCM enumeration reports multiple running services for that shared host PID, including the canonical `Schedule` service.
3. Service ownership discovery treats that launcher ancestor as an ambiguous gateway owner, so the update aborts before its existing non-service pause path can stop the gateway.

**Why it is wrong:** Task Scheduler launches the gateway but does not own it as a stoppable SCM service. Its shared host must not enter SCM ownership attribution.

**Working sibling / contrast:** Gateways owned by a uniquely identified SCM service are still mapped and stopped through SCM. Shared hosts that do not contain the Task Scheduler service still fail closed.

**Ruled out:** This is not a general failure to enumerate Windows services. The regression test supplies valid service and process identities and isolates the incorrect shared-host classification.

### Fix

Exclude a shared service host containing the canonical Windows Task Scheduler service name, `Schedule`, from the ambiguity candidates. Add paired regression coverage proving Scheduled Task ancestry returns no SCM owner while an arbitrary shared SCM host at the same ancestry depth still raises.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` - do not treat Task Scheduler's shared service host as an SCM gateway owner.
- `tests/hermes_cli/test_gateway.py` - cover Scheduled Task ancestry and preserve the arbitrary shared-host fail-closed contract.

## How to Test

1. Run the gateway ownership tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway.py -q
```

2. Run the Windows update pause and restart regression suites:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_concurrent_quarantine.py -q
scripts/run_tests.sh tests/hermes_cli/test_windows_update_restart_reconciliation.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated regression coverage exercises the ownership decision and related update pause/restart paths.
