### PR TITLE
feat(skills): add public-repo-hygiene optional security skill

### DIFF
--- a/optional-skills/security/public-repo-hygiene/SKILL.md
+++ b/optional-skills/security/public-repo-hygiene/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: public-repo-hygiene
+description: "Audit full git history for secrets/PII before going public."
+version: 1.0.0
+author: WolfurX
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [Security, Git, Secrets, Privacy, Audit, Pre-publish]
+    category: security
+    related_skills: [oss-forensics, 1password]
+---
+
+# Public Repo Hygiene
+
+Audits a repository's **entire git history** — every blob reachable from any
+ref, binaries included, plus commit and tag messages and author/committer
+identities — before it becomes public. The working tree is not the repo:
+deleted files, old branches, and force-push leftovers still hold blobs that
+`ls-files` will never show, and they all ship the moment the repo goes public.
+
+Pure Python stdlib + git. No scanner installs, no network.
+
+## When to Use
+
+- Before the first push of a repo that is or will become public.
+- Before `gh repo create --public` or flipping a private repo's visibility.
+- Before opening a PR from a fork (your commits ride along).
+- User asks for a credentials or PII audit of their repositories.
+
+## Prerequisites
+
+`python3` and `git` on PATH. Optional: `~/.hermes/personal-patterns.txt`
+with one regex per line for the user's own identity strings (see
+`references/personal-patterns.example.txt`). Offer to create it on first
+use — names, personal emails, usernames, phone prefixes — the scanner
+always checks the current username and home path even without it.
+
+## How to Run
+
+```bash
+# audit one repo (bare, mirror, or normal clone; cwd if no args)
+python3 scripts/history_scan.py /path/to/repo
+
+# audit a directory of mirror clones
+git clone --mirror git@github.com:user/project.git /tmp/audit/project.git
+python3 scripts/history_scan.py /tmp/audit
+
+# with an explicit personal-patterns file
+python3 scripts/history_scan.py --personal /path/to/patterns.txt /path/to/repo
+```
+
+Exit code is nonzero when anything hit, so it can gate a publish step — but
+hits still need judgment (step 3 below); the exit code is a flag, not a verdict.
+
+## Procedure
+
+**1. Identity first — before the first commit.** Check what identity will be
+baked into history:
+
+```bash
+git config user.email    # global AND any repo-local override
+```
+
+If the user wants their personal address out of public history, set the
+GitHub noreply address (`ID+username@users.noreply.github.com`) before
+committing, and point them at two GitHub settings that enforce it
+server-side: **"Keep my email addresses private"** and **"Block command line
+pushes that expose my email"**. Identity is baked into every commit at
+commit time; fixing it later means rewriting and force-pushing.
+
+**2. Scan the full history** with `scripts/history_scan.py` (see How to Run).
+For a repo that already has a remote, prefer scanning a `--mirror` clone: it
+holds exactly the refs a `git push` publishes.
+
+**3. Judge the hits.** Placeholders (`${ENV_VAR}`, `sk-YOUR_KEY_HERE`,
+documentation samples) are fine — say so and move on. For a real secret:
+
+- **Not yet pushed:** remove it, recommit, rescan.
+- **Already pushed anywhere public:** the secret is burned. **Rotate it at
+  the provider first**, then rewrite history (`git filter-repo`), then
+  force-push. Rewriting without rotating fixes nothing — assume it was
+  scraped the moment it was pushed.
+
+**4. Repo-level checks** before publishing:
+
+```bash
+git ls-files | grep -iE '\.env|creds|secret|key'   # committed config files
+```
+
+CI workflows must reference `${{ secrets.* }}`, never literals. Committed
+databases and binaries are covered by the scan (bytes-level regex).
+
+**5. Report** to the user: identities found in history, real hits vs
+placeholders, and what was rotated/rewritten. Never print a full secret into
+the conversation — the scanner already truncates fragments to 70 chars;
+refer to hits by file path and pattern name.
+
+## Pitfalls
+
+- **Platform views lie.** A hosting site's file browser or API shows the
+  default branch's tree, not history. Audit all refs (the scanner uses
+  `--all`), or leaked blobs survive in old branches.
+- **Forks inherit upstream noise.** In a fork, judge hits by whether *your*
+  commits introduced them: `git log --all --author=<you> -p`.
+- **Rewrite-then-rotate is backwards.** Rotate first; a rewritten secret is
+  still burned if it was ever public.
+- **The scanner is pattern-based.** High-entropy secrets with no known
+  prefix can slip through; the content-email report and identity list are
+  there to catch what patterns miss. Treat "0 hits" as necessary, not
+  sufficient, for high-stakes repos.
+
+## Verification
+
+- `RESULT: 0 pattern hit(s)` for every repo, or every hit judged and
+  reported as a placeholder.
+- `git log --all --format='%ae %ce' | sort -u` lists only intended
+  identities.
+- After any history rewrite: rescan, and confirm the rotated credential's
+  old value is dead at the provider.

--- a/optional-skills/security/public-repo-hygiene/references/personal-patterns.example.txt
+++ b/optional-skills/security/public-repo-hygiene/references/personal-patterns.example.txt
@@ -1,0 +1,10 @@
+# Personal identity patterns for history_scan.py — one Python regex per line.
+# Copy to ~/.hermes/personal-patterns.txt (or pass --personal FILE).
+# These catch YOUR identity leaking into a repo that is about to go public:
+# real names, personal emails, usernames, phone prefixes, employer names.
+# Patterns are matched case-sensitively unless you add (?i).
+#
+# (?i)(jane|janedoe|j\.doe)
+# (?i)jane\.doe@gmail\.com
+# \+44[0-9]{7,}
+# (?i)acme-internal

--- a/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
+++ b/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Full-git-history secret and identity scan. Stdlib only, no dependencies.
+
+Usage:
+    history_scan.py [--personal FILE] [PATH ...]
+
+Each PATH is a git repo (bare/mirror or normal) or a directory containing
+<name>.git mirror clones. With no PATH: scans the cwd if it is a repo,
+otherwise every *.git directory inside it.
+
+Scans every blob reachable from ANY ref (git rev-list --objects --all),
+binaries included, plus commit messages and annotated tag messages, and
+reports every author/committer identity in history.
+
+Personal patterns: one regex per line (blank lines and # comments ignored)
+from --personal FILE, or ~/.hermes/personal-patterns.txt if it exists.
+The current user's username and home directory path are always checked.
+"""
+import subprocess, re, sys, os, collections
+
+SECRET_PATTERNS = [
+    ("stripe-style sk_", rb"sk_[A-Za-z0-9]{16,}"),
+    ("google-api-key", rb"AIza[0-9A-Za-z_\-]{35}"),
+    ("google-oauth-secret", rb"GOCSPX-[A-Za-z0-9_\-]{20,}"),
+    ("github-token", rb"(?:gh[pousr]_[A-Za-z0-9]{20,}|github_pat_[A-Za-z0-9_]{20,})"),
+    ("aws-key", rb"AKIA[0-9A-Z]{16}"),
+    ("openai-style sk-", rb"sk-[A-Za-z0-9_\-]{20,}"),
+    ("xai-key", rb"xai-[A-Za-z0-9]{20,}"),
+    ("huggingface-token", rb"hf_[A-Za-z0-9]{30,}"),
+    ("npm-token", rb"npm_[A-Za-z0-9]{36}"),
+    ("agentmail-key", rb"\bam_[A-Za-z0-9]{20,}"),
+    ("telegram-bot-token", rb"\b[0-9]{8,10}:AA[A-Za-z0-9_\-]{33}\b"),
+    ("slack-token", rb"xox[baprs]-[A-Za-z0-9\-]{10,}"),
+    ("slack-webhook", rb"hooks\.slack\.com/services/T[A-Za-z0-9/]+"),
+    ("sendgrid-key", rb"SG\.[A-Za-z0-9_\-]{20,}\.[A-Za-z0-9_\-]{20,}"),
+    ("private-key-block", rb"-----BEGIN [A-Z ]*PRIVATE KEY"),
+    ("jwt", rb"eyJ[A-Za-z0-9_\-]{15,}\.eyJ[A-Za-z0-9_\-]{15,}"),
+    ("bearer-literal", rb"[Bb]earer\s+[A-Za-z0-9_\-\.=]{20,}"),
+    ("generic-assignment", rb"(?i)(api[_\-]?key|apikey|api_secret|client_secret|access_token|auth_token|passwd|password)[\"']?\s*[:=]\s*[\"'][^\"'\s]{8,}[\"']"),
+    # bare .env-style lines: API_KEY=value with no quotes
+    ("env-assignment", rb"(?m)^(?:export[ \t]+)?[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?)[A-Z0-9_]*[ \t]*=[ \t]*[^\s\"'#$][^\s\"']{7,}"),
+    ("solana-keypair-json", rb"\[(?:\s*\d{1,3}\s*,){63}\s*\d{1,3}\s*\]"),
+]
+EMAIL = re.compile(rb"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
+EMAIL_NOISE = re.compile(rb"(?i)(example\.com|users\.noreply\.github\.com|@2x|sentry|schema|\.png|\.jpg|@[0-9]+\.[0-9]+|node_modules|@babel|@types|@keyframes|@media)")
+
+def load_personal_patterns(argv):
+    """Return ([(label, compiled_bytes_pattern)], remaining_argv)."""
+    path = None
+    if "--personal" in argv:
+        i = argv.index("--personal")
+        try:
+            path = argv[i + 1]
+        except IndexError:
+            sys.exit("--personal needs a file argument")
+        argv = argv[:i] + argv[i + 2:]
+    else:
+        default = os.path.join(
+            os.environ.get("HERMES_HOME", os.path.expanduser("~/.hermes")),
+            "personal-patterns.txt")
+        if os.path.isfile(default):
+            path = default
+
+    pats = []
+    home = os.path.expanduser("~")
+    if home and home not in ("/", "\\"):
+        pats.append(("home-path", re.compile(re.escape(home.encode()))))
+        user = os.path.basename(home.rstrip("/\\"))
+        if len(user) >= 3:
+            pats.append(("username", re.compile(rb"(?i)\b" + re.escape(user.encode()) + rb"\b")))
+    if path:
+        with open(path, "rb") as f:
+            for n, line in enumerate(f, 1):
+                line = line.strip()
+                if not line or line.startswith(b"#"):
+                    continue
+                try:
+                    pats.append((f"personal:{n}", re.compile(line)))
+                except re.error as e:
+                    print(f"!! bad personal pattern line {n}: {e}", file=sys.stderr)
+    return pats, argv
+
+def resolve_repos(paths):
+    paths = paths or ["."]
+    repos = []
+    for p in paths:
+        p = os.path.abspath(p)
+        if subprocess.run(["git", "-C", p, "rev-parse", "--git-dir"],
+                          capture_output=True).returncode == 0:
+            repos.append(p)
+        elif os.path.isdir(p):
+            sub = [os.path.join(p, d) for d in sorted(os.listdir(p)) if d.endswith(".git")]
+            if not sub:
+                print(f"!! {p}: not a repo and holds no *.git dirs", file=sys.stderr)
+            repos.extend(sub)
+        else:
+            print(f"!! {p}: no such directory", file=sys.stderr)
+    return repos
+
+def git(repo, *args, binary=False):
+    r = subprocess.run(["git", "-C", repo] + list(args), capture_output=True)
+    return r.stdout if binary else r.stdout.decode(errors="replace")
+
+def main():
+    personal, argv = load_personal_patterns(sys.argv[1:])
+    all_patterns = SECRET_PATTERNS + [(n, p.pattern) for n, p in personal]
+
+    def scan_bytes(data, hits, where):
+        for name, pat in all_patterns:
+            for m in re.finditer(pat, data):
+                frag = m.group(0)[:70]
+                hits[(name, where)].add(frag.decode(errors="replace"))
+
+    exit_hits = 0
+    for repo in resolve_repos(argv):
+        print("#" * 70)
+        print("## REPO:", repo)
+        ids = git(repo, "log", "--all", "--format=%an <%ae> | %cn <%ce>")
+        counts = collections.Counter(ids.strip().splitlines())
+        print("-- commit identities:")
+        for k, v in counts.most_common():
+            print(f"   {v:4d}x {k}")
+
+        hits = collections.defaultdict(set)
+        email_hits = collections.defaultdict(set)
+
+        msgs = git(repo, "log", "--all", "--format=%H%x00%B%x00", binary=True)
+        for chunk in msgs.split(b"\x00\x00"):
+            parts = chunk.strip(b"\n\x00").split(b"\x00", 1)
+            if len(parts) == 2:
+                scan_bytes(parts[1], hits, f"commit-msg {parts[0][:10].decode()}")
+        tags = git(repo, "tag", "-l", "--format=%(objectname) %(contents)", binary=True)
+        if tags.strip():
+            scan_bytes(tags, hits, "tag-messages")
+
+        out = git(repo, "rev-list", "--objects", "--all")
+        blobs = {}
+        for line in out.splitlines():
+            parts = line.split(" ", 1)
+            if len(parts) == 2 and parts[1]:
+                blobs.setdefault(parts[0], parts[1])
+        types = {}
+        p = subprocess.run(["git", "-C", repo, "cat-file", "--batch-check"],
+                           input="\n".join(blobs.keys()).encode(), capture_output=True)
+        for line in p.stdout.decode().splitlines():
+            parts = line.split()
+            if len(parts) >= 3 and parts[1] == "blob":
+                types[parts[0]] = int(parts[2])
+
+        nbin = 0
+        for sha, path in blobs.items():
+            if sha not in types:
+                continue
+            if types[sha] > 20_000_000:
+                print(f"   !! skipped huge blob {path} ({types[sha]}b)")
+                continue
+            data = git(repo, "cat-file", "blob", sha, binary=True)
+            is_bin = b"\x00" in data[:8192]
+            if is_bin:
+                nbin += 1
+            scan_bytes(data, hits, path)
+            if not is_bin:
+                for m in EMAIL.finditer(data):
+                    e = m.group(0)
+                    if not EMAIL_NOISE.search(e):
+                        email_hits[e.decode(errors="replace")].add(path)
+
+        print(f"-- scanned {len(types)} blobs ({nbin} binary) + commit/tag messages")
+        if hits:
+            print("-- pattern hits:")
+            for (name, where), frags in sorted(hits.items()):
+                for f in sorted(frags)[:6]:
+                    print(f"   [{name}] {where}: {f}")
+        else:
+            print("-- pattern hits: none")
+        if email_hits:
+            print("-- emails found in content:")
+            for e, paths in sorted(email_hits.items()):
+                print(f"   {e}  ({', '.join(sorted(paths)[:4])})")
+        n = sum(len(v) for v in hits.values())
+        exit_hits += n
+        print(f"RESULT: {n} pattern hit(s), {len(email_hits)} distinct content email(s)")
+        print()
+    # Nonzero exit when anything hit, so callers can gate on it. Hits still
+    # need human judgment (placeholders are fine) — this is a flag, not a verdict.
+    sys.exit(1 if exit_hits else 0)
+
+if __name__ == "__main__":
+    main()

--- a/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
+++ b/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
@@ -16,7 +16,7 @@ Personal patterns: one regex per line (blank lines and # comments ignored)
 from --personal FILE, or ~/.hermes/personal-patterns.txt if it exists.
 The current user's username and home directory path are always checked.
 """
-import subprocess, re, sys, os, collections
+import subprocess, re, sys, os, collections, threading
 
 SECRET_PATTERNS = [
     ("stripe-style sk_", rb"sk_[A-Za-z0-9]{16,}"),
@@ -37,8 +37,10 @@ SECRET_PATTERNS = [
     ("jwt", rb"eyJ[A-Za-z0-9_\-]{15,}\.eyJ[A-Za-z0-9_\-]{15,}"),
     ("bearer-literal", rb"[Bb]earer\s+[A-Za-z0-9_\-\.=]{20,}"),
     ("generic-assignment", rb"(?i)(api[_\-]?key|apikey|api_secret|client_secret|access_token|auth_token|passwd|password)[\"']?\s*[:=]\s*[\"'][^\"'\s]{8,}[\"']"),
-    # bare .env-style lines: API_KEY=value with no quotes
-    ("env-assignment", rb"(?m)^(?:export[ \t]+)?[A-Z][A-Z0-9_]*(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?)[A-Z0-9_]*[ \t]*=[ \t]*[^\s\"'#$][^\s\"']{7,}"),
+    # bare .env-style lines, any case: API_KEY=value, db_password=value, TOKEN=value.
+    # The key word must stand alone or be joined by underscores (so keyUsage and
+    # MAX_TOKENS don't match); the value must not look like a call.
+    ("env-assignment", rb"(?im)^(?:export[ \t]+)?(?:[A-Z0-9_]*_)?(?:KEY|TOKEN|SECRET|PASSWORD|PASSWD|CREDENTIALS?)(?:_[A-Z0-9_]*)?[ \t]*=[ \t]*[^\s\"'#$(][^\s\"'()]{7,}(?=[\s\"']|$)"),
     ("solana-keypair-json", rb"\[(?:\s*\d{1,3}\s*,){63}\s*\d{1,3}\s*\]"),
 ]
 EMAIL = re.compile(rb"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}")
@@ -101,15 +103,54 @@ def git(repo, *args, binary=False):
     r = subprocess.run(["git", "-C", repo] + list(args), capture_output=True)
     return r.stdout if binary else r.stdout.decode(errors="replace")
 
+def cat_blobs(repo, shas):
+    """Yield (sha, data) for each blob from one `cat-file --batch` process."""
+    p = subprocess.Popen(["git", "-C", repo, "cat-file", "--batch"],
+                         stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+    def feed():
+        for sha in shas:
+            p.stdin.write(sha.encode() + b"\n")
+        p.stdin.close()
+    threading.Thread(target=feed, daemon=True).start()
+    while True:
+        header = p.stdout.readline()
+        if not header:
+            break
+        parts = header.split()
+        if len(parts) < 3:  # "<sha> missing"
+            continue
+        data = p.stdout.read(int(parts[2]))
+        p.stdout.read(1)  # newline after the object body
+        yield parts[0].decode(), data
+    p.wait()
+
+def blob_paths(repo, shas):
+    """{sha: every path that ever held it} for the given blobs, from one pass
+    over the history's raw diffs (rev-list --objects names each blob once)."""
+    out = git(repo, "log", "--all", "--raw", "--no-renames", "--no-abbrev",
+              "--format=", "-z", binary=True)
+    paths = collections.defaultdict(set)
+    fields = out.split(b"\x00")  # ":<mode> <mode> <old> <new> <status>", "<path>", ...
+    for meta, path in zip(fields[::2], fields[1::2]):
+        parts = meta.split()
+        if len(parts) == 5 and parts[4] != b"D":
+            sha = parts[3].decode()
+            if sha in shas:
+                paths[sha].add(path.decode(errors="replace"))
+    return paths
+
 def main():
     personal, argv = load_personal_patterns(sys.argv[1:])
     all_patterns = SECRET_PATTERNS + [(n, p.pattern) for n, p in personal]
 
     def scan_bytes(data, hits, where):
+        found = False
         for name, pat in all_patterns:
             for m in re.finditer(pat, data):
                 frag = m.group(0)[:70]
                 hits[(name, where)].add(frag.decode(errors="replace"))
+                found = True
+        return found
 
     exit_hits = 0
     for repo in resolve_repos(argv):
@@ -148,30 +189,48 @@ def main():
             if len(parts) >= 3 and parts[1] == "blob":
                 types[parts[0]] = int(parts[2])
 
-        nbin = 0
+        wanted = []
         for sha, path in blobs.items():
             if sha not in types:
                 continue
             if types[sha] > 20_000_000:
                 print(f"   !! skipped huge blob {path} ({types[sha]}b)")
                 continue
-            data = git(repo, "cat-file", "blob", sha, binary=True)
+            wanted.append(sha)
+
+        nbin = 0
+        hit_blobs = collections.defaultdict(set)
+        for sha, data in cat_blobs(repo, wanted):
+            path = blobs[sha]
             is_bin = b"\x00" in data[:8192]
             if is_bin:
                 nbin += 1
-            scan_bytes(data, hits, path)
+            if scan_bytes(data, hits, path):
+                hit_blobs[path].add(sha)
             if not is_bin:
                 for m in EMAIL.finditer(data):
                     e = m.group(0)
                     if not EMAIL_NOISE.search(e):
                         email_hits[e.decode(errors="replace")].add(path)
 
+        # The same content may live at other paths too; resolve those for hits only.
+        also = {}
+        if hit_blobs:
+            found = blob_paths(repo, set().union(*hit_blobs.values()))
+            for path, shas in hit_blobs.items():
+                more = set().union(*(found.get(sha, set()) for sha in shas)) - {path}
+                if more:
+                    also[path] = sorted(more)
+
         print(f"-- scanned {len(types)} blobs ({nbin} binary) + commit/tag messages")
         if hits:
             print("-- pattern hits:")
             for (name, where), frags in sorted(hits.items()):
+                loc = where
+                if where in also:
+                    loc += f" (also at {', '.join(also[where][:4])})"
                 for f in sorted(frags)[:6]:
-                    print(f"   [{name}] {where}: {f}")
+                    print(f"   [{name}] {loc}: {f}")
         else:
             print("-- pattern hits: none")
         if email_hits:

--- a/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
+++ b/optional-skills/security/public-repo-hygiene/scripts/history_scan.py
@@ -124,11 +124,12 @@ def main():
         hits = collections.defaultdict(set)
         email_hits = collections.defaultdict(set)
 
-        msgs = git(repo, "log", "--all", "--format=%H%x00%B%x00", binary=True)
-        for chunk in msgs.split(b"\x00\x00"):
-            parts = chunk.strip(b"\n\x00").split(b"\x00", 1)
-            if len(parts) == 2:
-                scan_bytes(parts[1], hits, f"commit-msg {parts[0][:10].decode()}")
+        # -z separates commits with NUL; each record is "<hash>\n<body>".
+        msgs = git(repo, "log", "--all", "-z", "--format=%H%n%B", binary=True)
+        for rec in msgs.split(b"\x00"):
+            sha, _, body = rec.partition(b"\n")
+            if sha and body.strip():
+                scan_bytes(body, hits, f"commit-msg {sha[:10].decode()}")
         tags = git(repo, "tag", "-l", "--format=%(objectname) %(contents)", binary=True)
         if tags.strip():
             scan_bytes(tags, hits, "tag-messages")


### PR DESCRIPTION
## What does this PR do?

Adds an optional security skill that audits a repository's **entire git history** before it goes public: every blob reachable from any ref (binaries included), commit and tag messages, and all author/committer identities. The working tree is not the repo — deleted files, old branches, and force-push leftovers all ship the moment visibility flips.

Pure Python stdlib + git; no scanner installs, no network.

What it covers that existing options here don't:

- Bare `.env`-style assignments (`API_KEY=value`, no quotes) that quoted-value patterns miss — dotenv files are where secrets actually live.
- Secrets and PII in **commit messages** and annotated tag messages.
- Identity leakage: personal emails in commit metadata, plus user-supplied personal patterns (`~/.hermes/personal-patterns.txt`) for names/usernames/phones; the current username and home path are always checked.
- Token formats: GitHub, AWS, Google API/OAuth, OpenAI-style, xAI, HuggingFace, npm, AgentMail, Telegram bots, Slack tokens/webhooks, SendGrid, JWTs, private-key blocks, Solana keypair JSON, generic key/value assignments.

The SKILL.md also encodes the judgment steps: placeholders vs real hits, rotate-at-provider-first before `git filter-repo`, fork-noise attribution, and GitHub's server-side email-privacy settings.

Duplicate check: closest is #86575 (open), a working-tree scan wrapping detect-secrets/trufflehog. This is complementary, not competing: history-wide pre-publish audit, zero dependencies, commit-message and identity coverage. #82185 / #98363 / #36740 concern this repo's own CI, not a user-facing skill.

## Related Issue

No existing issue; searched open and closed issues for secret scanning / credential leak / repo hygiene first.

## Type of Change

- [x] 🎯 New skill (bundled or hub)

## Changes Made

- `optional-skills/security/public-repo-hygiene/SKILL.md`
- `optional-skills/security/public-repo-hygiene/scripts/history_scan.py`
- `optional-skills/security/public-repo-hygiene/references/personal-patterns.example.txt`

Docs catalog pages are generated (`website/scripts/generate-skill-docs.py`), so none are included; happy to run the generator in-PR if preferred.

## How to Test

1. Build a planted-secrets repo: a fake `ghp_...` token in a tracked file, a bare `API_KEY=...` line in `.env`, a fake `xai-...` key in a commit message, an `AKIA...` string inside a binary blob; then `git rm --cached .env`, commit, and keep the old state only on a side branch.
2. `python3 optional-skills/security/public-repo-hygiene/scripts/history_scan.py /path/to/that/repo` → all planted items reported (including the `.env` reachable only via the side branch and the commit-message hit), exit code 1.
3. Run it on a clean repo → `RESULT: 0 pattern hit(s)`, exit code 0. `${ENV_VAR}`-style placeholders are not flagged.
4. Personal patterns: `--personal file` with `(?i)janedoe` flags a commit message containing that name.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate (closest: #86575, see above)
- [x] My PR contains **only** changes related to this fix/feature (one commit, three files)
- [ ] I've run `pytest tests/ -q` — not run: no runtime code touched, skill-only addition under `optional-skills/`
- [ ] I've added tests for my changes — scanner verified against the planted-secrets procedure above; no `tests/` coverage since the suite doesn't exercise optional skills
- [x] I've tested on my platform: Arch Linux (script-level, Python 3 + git)

### Documentation & Housekeeping

- [x] Relevant documentation — catalog pages are generated; nothing manual to update
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact considered — stdlib + git only; path handling via `os.path`; `platforms: [linux, macos, windows]`
- [x] Tool descriptions/schemas — N/A

## For New Skills

- [x] Broadly useful — anyone publishing a repo; placed in `optional-skills/` per the guide
- [x] SKILL.md follows the standard format (frontmatter, When to Use, How to Run, Procedure, Pitfalls, Verification)
- [x] No external dependencies (Python stdlib + git)
- [ ] Tested end-to-end via `hermes --toolsets skills -q ...` — not run (no Hermes install on this machine); the script and SKILL.md procedure were tested directly as described above
