### PR TITLE
fix(gateway): keep voice-session segment sends interim

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -486,6 +486,7 @@ class GatewayStreamConsumer:
         self,
         *,
         final: bool = False,
+        is_turn_final: bool = True,
         expect_edits: bool = False,
     ) -> dict | None:
         """Return per-send metadata for stream-created messages.
@@ -506,6 +507,12 @@ class GatewayStreamConsumer:
             meta["expect_edits"] = True
         if final:
             meta["notify"] = True
+            if not is_turn_final:
+                # A segment boundary closes only the current preview. Some
+                # adapters (including voice-session) interpret notify=True
+                # as the protocol's terminal text frame, so preserve the
+                # distinction explicitly until the actual turn completion.
+                meta["_interim_send"] = True
         return meta or None
 
     @property
@@ -2891,7 +2898,10 @@ class GatewayStreamConsumer:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
-                metadata=self._metadata_for_send(final=True),
+                metadata=self._metadata_for_send(
+                    final=True,
+                    is_turn_final=is_turn_final,
+                ),
             )
         except Exception as e:
             logger.debug("Fresh-final send failed, falling back to edit: %s", e)
@@ -3513,6 +3523,7 @@ class GatewayStreamConsumer:
                     reply_to=self._initial_reply_to_id,
                     metadata=self._metadata_for_send(
                         final=finalize,
+                        is_turn_final=is_turn_final,
                         expect_edits=not finalize,
                     ),
                 )

--- a/tests/gateway/test_stream_final_contract.py
+++ b/tests/gateway/test_stream_final_contract.py
@@ -107,6 +107,27 @@ class TestConsumerDeclaredFinal:
 
 class TestInterimSendContract:
     @pytest.mark.asyncio
+    async def test_nonfinal_segment_finalize_is_marked_interim(self):
+        """A tool boundary must not close a voice-session turn."""
+        adapter = _make_draft_adapter()
+        adapter.draft_stream_is_message = False
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=1, cursor="",
+        )
+        sc = GatewayStreamConsumer(adapter, "D1", cfg)
+        sc._use_draft_streaming = True
+
+        assert await sc._send_or_edit(
+            "preamble", finalize=True, is_turn_final=False
+        ) is True
+
+        assert adapter.send_calls[-1]["metadata"] == {
+            "notify": True,
+            "_interim_send": True,
+        }
+
+    @pytest.mark.asyncio
     async def test_commentary_is_marked_interim(self):
         adapter = _make_draft_adapter()
         cfg = StreamConsumerConfig(


### PR DESCRIPTION
## Summary

A streamed tool/segment boundary calls `GatewayStreamConsumer._send_or_edit(..., finalize=True, is_turn_final=False)`. The consumer was setting `notify=True` without preserving that this was only an interim segment close.

The voice-session adapter interprets `notify=True` without `_interim_send` as terminal `text_final`, then emits `turn_end`. The client stops consuming the WebSocket at that point, so the remainder of the model response is cut off.

This change:

- carries `is_turn_final` through the consumer's send metadata builder;
- marks non-turn-final finalizations with the existing internal `_interim_send` marker;
- propagates the distinction through both the first-send and fresh-final lanes;
- adds a regression proving a tool-boundary finalize stays interim.

No wire-format change is introduced; the marker is already handled internally by the streaming adapters.

## Validation

- `scripts/run_tests.sh tests/gateway/test_stream_consumer.py tests/gateway/test_stream_final_contract.py -q`: **74 passed, 1 skipped**
- `scripts/run_tests.sh tests/gateway -q`: **7317 passed, 48 skipped, 9 failed**

The full-suite failures are unrelated platform/environment cases on macOS: Darwin path-length limits in existing long-path and UNIX-socket tests, unavailable abstract UNIX sockets, the local shutdown diagnostic subprocess, a readiness expectation, missing optional WeCom XML support, and one timing-sensitive turn-lease test. The affected stream suites passed.