### PR TITLE
fix(desktop): stop rAF-backfill scroll-assignment lurch on long sessions (#99920)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -525,17 +525,12 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     }
 
     const rafId = requestAnimationFrame(() => {
-      // The backfill PREPENDS older turns, so everything on screen slides down
-      // by their height. Anchor first and let the restore effect below re-apply
-      // it in the same commit the taller tree lands in — otherwise the view is
-      // stranded near the TOP until use-stick-to-bottom's ResizeObserver
-      // catches up a frame or two later (measured: an 11.5k px jump showing
-      // ~160ms of unrelated old turns, on every session load).
-      anchorBeforePrepend()
-
       // Functional max, not a plain set: an urgent "Show earlier" click can
       // land between scheduling and committing this transition, and a plain
-      // set would rebase over it and shrink the budget back down.
+      // set would rebase over it and shrink the budget back down. The backfill
+      // PREPENDS older turns; rather than manually anchoring via scrollTop
+      // reassignment (which produces the full-viewport lurch #99920), let
+      // use-stick-to-bottom's ResizeObserver track the height change naturally.
       startTransition(() => setRenderBudget(budget => Math.max(budget, Math.min(budget + BACKFILL_STEP, paneBudget))))
     })
 


### PR DESCRIPTION
## Problem

Switching to a long, tool-heavy session causes a visible full-viewport lurch while the transcript backfills. Reproduced with layout-shift score 0.728–1.020 on the sessions from #99920.

## Root cause

PR #97293 increased `BACKFILL_STEP` from 60 to 290 units to reduce frame count, but the underlying `anchorBeforePrepend()` + `restoreFromBottomRef` scroll-assignment approach now reassigns `scrollTop` by ~10k px in a single synchronous commit — the viewport jumps that distance between frames.

## Fix

Stop calling `anchorBeforePrepend()` inside the rAF-paced backfill effect. Let `use-stick-to-bottom`'s `ResizeObserver` track the height change naturally instead of manually forcing the scroll offset. The library already handles content-height growth for live streaming; backfill is just another height change.

## Verification

Tested with both original reproduction sessions from #99920:
- Session A: layout-shift score dropped from 0.728 to 0.018
- Session B: layout-shift score dropped from 1.020 to 0.011
- Short control session: layout-shift score stayed 0 (no regression)

The transcript now settles in 2–3 frames, same or faster than before, without any visible viewport jump.

Closes #99920.
