### PR TITLE
fix(cli): scope the shared SCM-host ambiguity guard to the gateway's direct parent

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1127,15 +1127,21 @@ def find_windows_gateway_services(
                         f"SCM service {service_name} has indeterminate status: "
                         f"{service_status}"
                     )
-            shared_service_pids = [
-                pid
-                for pid in ancestor_pids
-                if len(service_names_by_pid.get(pid, set())) > 1
-            ]
-            if shared_service_pids:
+            # A shared SCM host is a candidate owner only when it directly
+            # parents the gateway: its child could belong to any of the
+            # hosted services, so ownership stays ambiguous and the update
+            # must fail closed. A shared host merely sitting further up the
+            # ancestry — the Task Scheduler host above a Scheduled-Task
+            # gateway's cmd.exe/wscript.exe launcher — owns nothing there;
+            # attribution then finds no single-service ancestor and the
+            # generic PID pause path handles the gateway instead.
+            direct_parent_pid = ancestor_pids[0] if ancestor_pids else None
+            if direct_parent_pid is not None and len(
+                service_names_by_pid.get(direct_parent_pid, set())
+            ) > 1:
                 raise RuntimeError(
                     "Gateway ownership is ambiguous under shared SCM host PID(s): "
-                    + ", ".join(str(pid) for pid in shared_service_pids)
+                    f"{direct_parent_pid}"
                 )
             service_pid = next(
                 (

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -1231,6 +1231,123 @@ def test_find_windows_gateway_services_rejects_shared_service_host_pid(monkeypat
         )
 
 
+def test_find_windows_gateway_services_ignores_shared_host_above_task_launcher(
+    monkeypatch,
+):
+    """A Scheduled-Task gateway below the Task Scheduler host is not service-owned.
+
+    The Task Scheduler's svchost.exe always hosts several SCM services and the
+    task launcher (cmd.exe/wscript.exe) sits between it and the gateway, so
+    the shared host is a plain ancestor rather than a candidate owner: the
+    gateway must fall through to the generic non-service pause path (#99911).
+    """
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name, pid, status="running"):
+            self.name = name
+            self.pid = pid
+            self.status = status
+
+        def as_dict(self):
+            return {"name": self.name, "pid": self.pid, "status": self.status}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(200), FakeProcess(100)]
+
+        def children(self, recursive=False):
+            raise AssertionError(
+                "a non-service gateway must not be attributed to any service"
+            )
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [
+            FakeService("ServiceA", 100),
+            FakeService("ServiceB", 100),
+        ],
+        Process=FakeProcess,
+    )
+
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+
+    assert result == []
+
+
+def test_find_windows_gateway_services_maps_service_below_shared_ancestor(
+    monkeypatch,
+):
+    """A shared SCM host higher in the ancestry must not shadow a verified owner.
+
+    Real service wrappers (WinSW/NSSM/sc.exe create) are single-service
+    processes; a shared host above them is unrelated to ownership and the
+    verified single-service ancestor still wins the attribution.
+    """
+    monkeypatch.setattr(gateway.sys, "platform", "win32")
+    profile = SimpleNamespace(profile="default", pid=300, create_time=300.0)
+
+    class FakeService:
+        def __init__(self, name, pid, status="running"):
+            self.name = name
+            self.pid = pid
+            self.status = status
+
+        def as_dict(self):
+            return {"name": self.name, "pid": self.pid, "status": self.status}
+
+    class FakeProcess:
+        def __init__(self, pid):
+            self.pid = pid
+
+        def parents(self):
+            return [FakeProcess(200), FakeProcess(100)]
+
+        def children(self, recursive=False):
+            assert self.pid == 200
+            assert recursive is True
+            return [FakeProcess(300)]
+
+        def create_time(self):
+            return float(self.pid)
+
+    fake_psutil = SimpleNamespace(
+        win_service_iter=lambda: [
+            FakeService("HermesGateway", 200),
+            FakeService("ServiceA", 100),
+            FakeService("ServiceB", 100),
+        ],
+        Process=FakeProcess,
+    )
+
+    result = gateway.find_windows_gateway_services(
+        psutil_module=fake_psutil,
+        profile_processes=[profile],
+    )
+
+    assert result == [
+        gateway.WindowsGatewayService(
+            name="HermesGateway",
+            profile="default",
+            service_pid=200,
+            gateway_pid=300,
+            descendant_pids=frozenset({300}),
+            descendant_identities=((300, 300.0),),
+            service_create_time=200.0,
+            gateway_create_time=300.0,
+        )
+    ]
+
+
 def test_find_windows_gateway_services_fails_closed_on_service_access_error(
     monkeypatch,
 ):


### PR DESCRIPTION
## What does this PR do?

On Windows, `hermes update` crashes with `Gateway ownership is ambiguous under shared SCM host PID(s)` whenever the gateway autostarts through the official **Hermes_Gateway Scheduled Task**. The Task Scheduler runs the task under a shared `svchost.exe` that hosts many SCM services, and `find_windows_gateway_services()` raised whenever **any** ancestor PID hosted more than one service — so the standard autostart mechanism could never pass the guard, and the update aborted before the pull on every run.

The guard's fail-closed intent (from #790e1eb) is to prevent attributing a gateway to a service when its ownership cannot be proven. But a shared host that only sits **further up the ancestry** — above the task's `gateway.cmd`/`wscript.exe` launcher — is an ancestor, not a candidate owner: attribution looks for a single-service ancestor, finds none, and the correct outcome is "not service-owned", after which the existing generic PID pause path (`find_gateway_pids`/`terminate_pid`) handles the gateway. This PR scopes the ambiguity raise to the one case where a shared host genuinely blocks attribution: when it is the gateway's **direct parent**.

Real service wrappers (WinSW, NSSM, `sc.exe create`) are single-service processes and remain attributed exactly as before; ambiguity still fails closed when a shared svchost directly parents the gateway.

## Related Issue

Fixes #99911

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py` — in `find_windows_gateway_services()`, the shared-SCM-host ambiguity check now only fails closed when the shared host is the gateway's direct parent (`ancestor_pids[0]`), instead of raising on any shared host anywhere in the ancestry. The single-service attribution logic is unchanged.
- `tests/hermes_cli/test_gateway.py` — added two regression tests:
  - `test_find_windows_gateway_services_ignores_shared_host_above_task_launcher`: gateway → cmd.exe → shared svchost (Task Scheduler shape) returns `[]` instead of raising, and never touches service attribution.
  - `test_find_windows_gateway_services_maps_service_below_shared_ancestor`: a verified single-service owner below a shared ancestor is still attributed, proving the guard no longer over-blocks real service installs.

## How to Test

On macOS host (no Windows required — the function is pure logic over injected psutil fakes):

1. `python -m pytest tests/hermes_cli/test_gateway.py -q` → Observed result: **39 passed, 3 skipped** (includes the 2 new regression tests; the pre-existing `rejects_shared_service_host_pid` fail-closed test still passes unchanged).
2. `python -m pytest tests/hermes_cli/test_windows_update_restart_reconciliation.py tests/hermes_cli/test_update_concurrent_quarantine.py tests/hermes_cli/test_windows_gateway_cold_start_desktop_lifecycle.py tests/hermes_cli/test_update_fleet_check_fail_closed.py tests/hermes_cli/test_update_orphan_backend_reap.py tests/hermes_cli/test_lazy_refresh_venv_repair.py tests/hermes_cli/test_update_head_moved_gate.py tests/hermes_cli/test_scan_venv_blockers.py tests/hermes_cli/test_desktop_lifecycle_windows_live.py tests/hermes_cli/test_update_parked_branch_guard.py tests/hermes_cli/test_update_fleet_restart_pending.py tests/hermes_cli/test_update_venv_health.py -q` → Observed result: **156 passed, 3 failed**; the 3 failures (`test_update_success_when_head_moves`, `test_redact_sensitive_text_failure_returns_fully_redacted`, `test_marker_written_after_pull_cleared_after_successful_restart`) reproduce identically on a clean `upstream/main` checkout, so they are pre-existing environment failures unrelated to this change.

On Windows, the reporter's repro (gateway running via the Hermes_Gateway Scheduled Task, then `hermes update`) should proceed past ownership discovery and pause the gateway through the generic PID path instead of aborting.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites for the touched code paths pass; the 3 unrelated failures noted above are baseline-identical on clean `upstream/main`
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (logic-level tests via injected psutil fakes; Windows behavior covered by the regression tests' process-tree shapes)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline comment documents the scoping rule)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the changed function is Windows-only (`sys.platform != "win32"` early-return)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

```
$ python -m pytest tests/hermes_cli/test_gateway.py -q
39 passed, 3 skipped in 0.96s
```
