### PR TITLE
feat(gateway): add pre_gateway_send plugin hook for outbound message gating (#37271)

### DIFF
--- a/gateway/builtin_hooks/__init__.py
+++ b/gateway/builtin_hooks/__init__.py
@@ -1,1 +1,82 @@
 """Built-in gateway hooks that are always registered."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Patterns that indicate admin/internal messages that should not leak to groups.
+_ADMIN_PATTERNS = [
+    re.compile(p, re.IGNORECASE) for p in [
+        r"\badmin\b.*\b(panel|interface|dashboard)\b",
+        r"\b(internal|debug|diagnostic)\b.*\b(message|log|output)\b",
+        r"\brecovery\b.*\b(job|task|process)\b",
+        r"\bcold.?start\b.*\b(cursor|replay|restore)\b",
+        r"\bsystem\b.*\b(notification|alert|status)\b",
+    ]
+]
+
+
+def _is_admin_content(text: str) -> bool:
+    """Fast-path keyword check for admin/internal content."""
+    return any(p.search(text) for p in _ADMIN_PATTERNS)
+
+
+def outbound_gate(
+    content: str,
+    chat_type: str = "dm",
+    gateway: Any = None,
+    **kwargs: Any,
+) -> Optional[Dict[str, Any]]:
+    """Reference pre_gateway_send gate: block admin content from group chats.
+
+    Reads config from gateway.config.gateway.gate (if present):
+      enabled: bool (default False)
+      group_chat_types: list[str] (default ["group", "supergroup"])
+      redirect_target: str (default "" — no redirect, just block)
+
+    Returns None (allow) or an action dict (block/redirect).
+    """
+    # Only gate group/supergroup messages
+    gated_types = {"group", "supergroup"}
+    if chat_type not in gated_types:
+        return None
+
+    # Check gateway config for gate settings
+    gate_config = None
+    if gateway is not None:
+        try:
+            gw_config = getattr(gateway, "config", None)
+            if gw_config is not None:
+                gate_config = getattr(gw_config, "gate", None)
+        except Exception:
+            pass
+
+    # If no config or not enabled, allow everything
+    if gate_config is None:
+        return None
+    if not getattr(gate_config, "enabled", False):
+        return None
+
+    # Check gated chat types from config
+    config_gated_types = getattr(gate_config, "group_chat_types", None)
+    if config_gated_types and chat_type not in config_gated_types:
+        return None
+
+    # Fast-path: if content doesn't match admin patterns, allow
+    if not _is_admin_content(content):
+        return None
+
+    # Admin content detected in a group chat — block or redirect
+    redirect_target = getattr(gate_config, "redirect_target", "") or ""
+    if redirect_target:
+        return {"action": "redirect", "target": redirect_target}
+    return {"action": "block", "reason": "admin-content-gate"}
+
+
+def register_builtin_hooks(ctx: Any) -> None:
+    """Register all built-in hooks with the plugin context."""
+    ctx.register_hook("pre_gateway_send", outbound_gate)

--- a/gateway/builtin_hooks/__init__.py
+++ b/gateway/builtin_hooks/__init__.py
@@ -33,7 +33,7 @@ def outbound_gate(
 ) -> Optional[Dict[str, Any]]:
     """Reference pre_gateway_send gate: block admin content from group chats.
 
-    Reads config from gateway.config.gateway.gate (if present):
+    Reads config from gateway.config.gate (if present):
       enabled: bool (default False)
       group_chat_types: list[str] (default ["group", "supergroup"])
       redirect_target: str (default "" — no redirect, just block)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5909,7 +5909,7 @@ class TurnRunner:
                         hook_context={
                             "gateway": self._runner,
                             "source": ctx.source,
-                            "chat_type": ctx.source.chat_type,
+                            "chat_type": getattr(getattr(ctx, "source", None), "chat_type", None),
                             "session_store": getattr(self._runner, "session_store", None),
                         },
                     )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14227,6 +14227,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         self._running = True
         self._install_plugin_message_injector()
+        self._register_builtin_plugin_hooks()
         self._update_runtime_status("running")
 
         try:
@@ -20294,6 +20295,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self,
             self._schedule_plugin_message_injection,
         )
+
+    def _register_builtin_plugin_hooks(self) -> None:
+        """Register built-in plugin hooks that are always active.
+
+        Called once during gateway startup after the plugin manager is
+        available. Registers the reference outbound gate from
+        gateway.builtin_hooks so it participates in pre_gateway_send
+        dispatch without requiring a user-installed plugin.
+        """
+        try:
+            from gateway.builtin_hooks import outbound_gate
+            from hermes_cli.plugins import get_plugin_manager
+
+            mgr = get_plugin_manager()
+            if not mgr.has_hook("pre_gateway_send"):
+                mgr.register_hook("pre_gateway_send", outbound_gate)
+                logger.info("Registered built-in outbound_gate for pre_gateway_send")
+        except Exception as exc:
+            logger.debug("Could not register built-in outbound gate: %s", exc)
 
     def _clear_plugin_message_injector(self) -> None:
         """Remove this runner's scheduler without clobbering a newer owner."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5906,6 +5906,12 @@ class TurnRunner:
                         on_before_finalize=_pause_typing_before_finalize,
                         initial_reply_to_id=ctx.event_message_id,
                         run_still_current=ctx._run_still_current,
+                        hook_context={
+                            "gateway": self._runner,
+                            "source": ctx.source,
+                            "chat_type": ctx.source.chat_type,
+                            "session_store": getattr(self._runner, "session_store", None),
+                        },
                     )
                     if _want_stream_deltas:
                         def _stream_delta_cb(text: str) -> None:
@@ -29824,6 +29830,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         on_before_finalize=_pause_typing_before_finalize,
                         initial_reply_to_id=event_message_id,
                         run_still_current=_run_still_current,
+                        hook_context={
+                            "gateway": self,
+                            "source": source,
+                            "chat_type": getattr(source, "chat_type", None),
+                            "session_store": getattr(self, "session_store", None),
+                        },
                     )
             except Exception as _sc_err:
                 logger.debug("Proxy: could not set up stream consumer: %s", _sc_err)

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -243,6 +243,7 @@ class GatewayStreamConsumer:
         on_before_finalize: Optional[Callable[[], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None,
+        hook_context: Optional[dict] = None,
     ):
         self.adapter = adapter
         self.chat_id = chat_id
@@ -353,6 +354,12 @@ class GatewayStreamConsumer:
         # /stop), the run() loop will abandon the stream early instead of
         # continuing to edit and deliver stale deltas.
         self._run_still_current = run_still_current or (lambda: True)
+
+        # Optional hook context for pre_gateway_send plugin interception.
+        self._hook_gateway = (hook_context or {}).get("gateway") if hook_context else None
+        self._hook_source = (hook_context or {}).get("source") if hook_context else None
+        self._hook_chat_type = (hook_context or {}).get("chat_type") if hook_context else None
+        self._hook_session_store = (hook_context or {}).get("session_store") if hook_context else None
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
@@ -2054,6 +2061,64 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return reply_to_id
+
+        # Fire pre_gateway_send plugin hook (outbound gate).
+        if self._hook_gateway is not None:
+            try:
+                from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+                _hook_results = _invoke_hook(
+                    "pre_gateway_send",
+                    content=text,
+                    platform=getattr(self.adapter, '_platform', getattr(self.adapter, 'platform', None)),
+                    chat_id=self.chat_id,
+                    source=self._hook_source,
+                    chat_type=self._hook_chat_type,
+                    gateway=self._hook_gateway,
+                    session_store=self._hook_session_store,
+                )
+            except Exception as _hook_exc:
+                logger.warning("pre_gateway_send invocation failed: %s", _hook_exc)
+                _hook_results = []
+
+            for _result in _hook_results:
+                if not isinstance(_result, dict):
+                    continue
+                _action = _result.get("action")
+                if _action == "block":
+                    logger.info(
+                        "pre_gateway_send block: reason=%s chat=%s",
+                        _result.get("reason"), self.chat_id,
+                    )
+                    return reply_to_id  # silently drop
+                if _action == "redirect":
+                    _new_target = _result.get("target")
+                    if isinstance(_new_target, str) and _new_target:
+                        # Parse platform:chat_id format
+                        _parts = _new_target.split(":", 1)
+                        if len(_parts) == 2:
+                            _redirect_platform, _redirect_chat = _parts
+                            # Find adapter for redirect platform
+                            if self._hook_gateway is not None:
+                                try:
+                                    from gateway.config import Platform as _Platform
+                                    _rp = _Platform(str(_redirect_platform))
+                                    _redirect_adapter = self._hook_gateway.adapters.get(_rp)
+                                    if _redirect_adapter:
+                                        result = await _redirect_adapter.send(
+                                            chat_id=str(_redirect_chat),
+                                            content=text,
+                                            reply_to=None,
+                                            metadata=self._metadata_for_send(final=final, expect_edits=False),
+                                        )
+                                        if result.success:
+                                            logger.info("pre_gateway_send redirected to %s", _new_target)
+                                            return reply_to_id
+                                except Exception as _redir_err:
+                                    logger.warning("pre_gateway_send redirect failed: %s", _redir_err)
+                    # Fall through to normal send if redirect failed
+                if _action == "allow":
+                    break
+
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2048,6 +2048,135 @@ class GatewayStreamConsumer:
         """
         return _BasePlatformAdapter.strip_media_directives_for_display(text)
 
+    # Sentinel returned by _apply_outbound_gate when the message was
+    # intercepted (blocked or redirected). Callers MUST NOT deliver when
+    # they receive this value. Using a sentinel instead of None avoids
+    # ambiguity with reply_to_id=None (which _send_or_edit passes).
+    _GATE_BLOCKED: str = "__gate_blocked__"
+
+    async def _apply_outbound_gate(
+        self,
+        text: str,
+        *,
+        final: bool = False,
+        reply_to_id: Optional[str] = None,
+    ) -> Optional[str]:
+        """Apply the pre_gateway_send plugin hook gate.
+
+        Returns None to allow normal delivery, or ``_GATE_BLOCKED`` to
+        indicate the message was intercepted (blocked or redirected). When
+        ``_GATE_BLOCKED`` is returned, the caller MUST NOT proceed with
+        its own delivery.
+
+        Composition: all registered hooks fire; the first non-allow action
+        wins. ``allow`` / ``None`` results are skipped — they never terminate
+        evaluation. This ensures a safety plugin registered after a permissive
+        plugin still takes effect.
+        """
+        if self._hook_gateway is None:
+            return None
+
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _hook_results = _invoke_hook(
+                "pre_gateway_send",
+                content=text,
+                platform=getattr(self.adapter, '_platform', getattr(self.adapter, 'platform', None)),
+                chat_id=self.chat_id,
+                source=self._hook_source,
+                chat_type=self._hook_chat_type,
+                gateway=self._hook_gateway,
+                session_store=self._hook_session_store,
+            )
+        except Exception as _hook_exc:
+            logger.warning("pre_gateway_send invocation failed: %s", _hook_exc)
+            return None  # fail-open on hook infrastructure error
+
+        for _result in _hook_results:
+            if not isinstance(_result, dict):
+                continue
+            _action = _result.get("action")
+            if _action == "allow" or _action is None:
+                continue  # permissive — keep evaluating
+            if _action == "block":
+                logger.info(
+                    "pre_gateway_send block: reason=%s chat=%s",
+                    _result.get("reason"), self.chat_id,
+                )
+                return self._GATE_BLOCKED
+            if _action == "redirect":
+                _new_target = _result.get("target")
+                if isinstance(_new_target, str) and _new_target:
+                    _parts = _new_target.split(":", 1)
+                    if len(_parts) == 2:
+                        _redirect_platform, _redirect_chat = _parts
+                        if self._hook_gateway is not None:
+                            try:
+                                from gateway.config import Platform as _Platform
+                                _rp = _Platform(_redirect_platform.strip().lower())
+                                _redirect_adapter = self._hook_gateway.adapters.get(_rp)
+                                if _redirect_adapter:
+                                    result = await _redirect_adapter.send(
+                                        chat_id=str(_redirect_chat),
+                                        content=text,
+                                        reply_to=None,
+                                        metadata=self._metadata_for_send(final=final, expect_edits=False),
+                                    )
+                                    if result.success:
+                                        logger.info("pre_gateway_send redirected to %s", _new_target)
+                                        return self._GATE_BLOCKED
+                            except Exception as _redir_err:
+                                logger.warning("pre_gateway_send redirect failed: %s", _redir_err)
+                # Fail-closed: do NOT leak to original group chat if redirect fails
+                logger.warning(
+                    "pre_gateway_send redirect failed for target %s; dropping message to prevent leakage",
+                    _new_target,
+                )
+                return self._GATE_BLOCKED
+            # Unknown action — treat as allow, keep evaluating
+
+        # No actionable result found — all results were permissive (allow/None)
+        # or empty. Default to allow (normal delivery).
+        return None
+
+    async def _gate_and_send(
+        self,
+        text: str,
+        reply_to_id: Optional[str],
+        *,
+        final: bool = False,
+    ) -> Optional[str]:
+        """Apply outbound gate, then send if allowed.
+
+        Convenience wrapper used by egress points that call
+        ``adapter.send()`` directly. Returns the message_id on success,
+        or ``reply_to_id`` if the gate blocked/redirected.
+        """
+        gate_result = await self._apply_outbound_gate(
+            text, final=final, reply_to_id=reply_to_id,
+        )
+        if gate_result is not None:
+            return reply_to_id  # blocked or redirected
+        result = await self.adapter.send(
+            chat_id=self.chat_id,
+            content=text,
+            reply_to=reply_to_id,
+            metadata=self._metadata_for_send(
+                final=final,
+                expect_edits=not final,
+            ),
+        )
+        if result.success and result.message_id:
+            self._message_id = str(result.message_id)
+            self._track_preview_ids_from_result(result)
+            self._already_sent = True
+            self._last_sent_text = text
+            self._notify_new_message()
+            return str(result.message_id)
+        else:
+            self._edit_supported = False
+            return reply_to_id
+
     async def _send_new_chunk(
         self,
         text: str,
@@ -2063,93 +2192,7 @@ class GatewayStreamConsumer:
         if not text.strip():
             return reply_to_id
 
-        # Fire pre_gateway_send plugin hook (outbound gate).
-        if self._hook_gateway is not None:
-            try:
-                from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
-                    "pre_gateway_send",
-                    content=text,
-                    platform=getattr(self.adapter, '_platform', getattr(self.adapter, 'platform', None)),
-                    chat_id=self.chat_id,
-                    source=self._hook_source,
-                    chat_type=self._hook_chat_type,
-                    gateway=self._hook_gateway,
-                    session_store=self._hook_session_store,
-                )
-            except Exception as _hook_exc:
-                logger.warning("pre_gateway_send invocation failed: %s", _hook_exc)
-                _hook_results = []
-
-            for _result in _hook_results:
-                if not isinstance(_result, dict):
-                    continue
-                _action = _result.get("action")
-                if _action == "block":
-                    logger.info(
-                        "pre_gateway_send block: reason=%s chat=%s",
-                        _result.get("reason"), self.chat_id,
-                    )
-                    return reply_to_id  # silently drop
-                if _action == "redirect":
-                    _new_target = _result.get("target")
-                    if isinstance(_new_target, str) and _new_target:
-                        # Parse platform:chat_id format
-                        _parts = _new_target.split(":", 1)
-                        if len(_parts) == 2:
-                            _redirect_platform, _redirect_chat = _parts
-                            # Find adapter for redirect platform
-                            if self._hook_gateway is not None:
-                                try:
-                                    from gateway.config import Platform as _Platform
-                                    _rp = _Platform(_redirect_platform.strip().lower())
-                                    _redirect_adapter = self._hook_gateway.adapters.get(_rp)
-                                    if _redirect_adapter:
-                                        result = await _redirect_adapter.send(
-                                            chat_id=str(_redirect_chat),
-                                            content=text,
-                                            reply_to=None,
-                                            metadata=self._metadata_for_send(final=final, expect_edits=False),
-                                        )
-                                        if result.success:
-                                            logger.info("pre_gateway_send redirected to %s", _new_target)
-                                            return reply_to_id
-                                except Exception as _redir_err:
-                                    logger.warning("pre_gateway_send redirect failed: %s", _redir_err)
-                    # Fail-closed: do NOT leak to original group chat if redirect fails
-                    logger.warning(
-                        "pre_gateway_send redirect failed for target %s; dropping message to prevent leakage",
-                        _new_target,
-                    )
-                    return reply_to_id
-                if _action == "allow":
-                    break
-
-        try:
-            result = await self.adapter.send(
-                chat_id=self.chat_id,
-                content=text,
-                reply_to=reply_to_id,
-                metadata=self._metadata_for_send(
-                    final=final,
-                    expect_edits=not final,
-                ),
-            )
-            if result.success and result.message_id:
-                self._message_id = str(result.message_id)
-                self._track_preview_ids_from_result(result)
-                self._already_sent = True
-                self._last_sent_text = text
-                # Fresh content bubble — close off any stale tool bubble
-                # above so the next tool starts a new bubble below.
-                self._notify_new_message()
-                return str(result.message_id)
-            else:
-                self._edit_supported = False
-                return reply_to_id
-        except Exception as e:
-            logger.error("Stream send chunk error: %s", e)
-            return reply_to_id
+        return await self._gate_and_send(text, reply_to_id, final=final)
 
     def _visible_prefix(self) -> str:
         """Return the visible text already shown in the streamed message."""
@@ -2648,6 +2691,10 @@ class GatewayStreamConsumer:
             # set in tandem with _draft_id in run().  Disable to be safe.
             self._use_draft_streaming = False
             return False
+        # Outbound gate: fire pre_gateway_send hook before draft frame.
+        gate_result = await self._apply_outbound_gate(text)
+        if gate_result is not None:
+            return False  # blocked or redirected
         # Carry the per-turn identity on EVERY frame (review B2): the
         # turn-final send goes out via _metadata_for_send, which stamps
         # reply_to_message_id — the relay adapter keys draft/seal state on
@@ -2955,6 +3002,10 @@ class GatewayStreamConsumer:
         # and take the normal edit path instead.
         if self._turn_split_delivery:
             return False
+        # Outbound gate: fire pre_gateway_send hook before fresh-final send.
+        gate_result = await self._apply_outbound_gate(text, final=True)
+        if gate_result is not None:
+            return False  # blocked or redirected
         stale_ids = set(self._preview_message_ids)
         if self._message_id and self._message_id != "__no_edit__":
             stale_ids.add(self._message_id)
@@ -3148,6 +3199,15 @@ class GatewayStreamConsumer:
                 and self.cfg.cursor in text
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
+
+        # Outbound gate: fire pre_gateway_send hook before any delivery.
+        # This intercepts ALL transport paths (native streaming, drafts,
+        # edits, fresh-final, fallback sends) from a single point.
+        gate_result = await self._apply_outbound_gate(
+            text, final=finalize, reply_to_id=None,
+        )
+        if gate_result is not None:
+            return False  # blocked or redirected — no delivery occurred
 
         # Native streaming transport (e.g. WeCom): every frame — first send,
         # mid-stream updates, and the final answer — flows through

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -243,6 +243,7 @@ class GatewayStreamConsumer:
         on_before_finalize: Optional[Callable[[], Any]] = None,
         initial_reply_to_id: Optional[str] = None,
         run_still_current: Optional[Callable[[], bool]] = None,
+        *,
         hook_context: Optional[dict] = None,
     ):
         self.adapter = adapter
@@ -2101,7 +2102,7 @@ class GatewayStreamConsumer:
                             if self._hook_gateway is not None:
                                 try:
                                     from gateway.config import Platform as _Platform
-                                    _rp = _Platform(str(_redirect_platform))
+                                    _rp = _Platform(_redirect_platform.strip().lower())
                                     _redirect_adapter = self._hook_gateway.adapters.get(_rp)
                                     if _redirect_adapter:
                                         result = await _redirect_adapter.send(
@@ -2115,7 +2116,12 @@ class GatewayStreamConsumer:
                                             return reply_to_id
                                 except Exception as _redir_err:
                                     logger.warning("pre_gateway_send redirect failed: %s", _redir_err)
-                    # Fall through to normal send if redirect failed
+                    # Fail-closed: do NOT leak to original group chat if redirect fails
+                    logger.warning(
+                        "pre_gateway_send redirect failed for target %s; dropping message to prevent leakage",
+                        _new_target,
+                    )
+                    return reply_to_id
                 if _action == "allow":
                     break
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -233,6 +233,16 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Gateway pre-send hook. Fired once per outbound message chunk in
+    # GatewayStreamConsumer._send_new_chunk() BEFORE adapter.send().
+    # Plugins may return a dict to influence delivery:
+    #   {"action": "allow"}  /  None             -> normal delivery
+    #   {"action": "redirect", "target": "..."}  -> send to different target
+    #   {"action": "block", "reason": "..."}     -> silently drop
+    # Kwargs: content: str, platform: Platform, chat_id: str,
+    #         source: SessionSource, chat_type: str,
+    #         gateway: GatewayRunner, session_store.
+    "pre_gateway_send",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/tests/gateway/test_pre_gateway_send.py
+++ b/tests/gateway/test_pre_gateway_send.py
@@ -353,3 +353,156 @@ class TestBuiltinOutboundGate:
         assert _is_admin_content("system notification alert") is True
         assert _is_admin_content("Hello, how are you?") is False
         assert _is_admin_content("The weather is nice today") is False
+
+
+# --- Composition semantics tests ---
+
+
+@pytest.mark.asyncio
+async def test_composition_allow_then_block_blocks(monkeypatch):
+    """[allow, block] → block. Safety plugin registered after permissive one still wins."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "allow"}, {"action": "block", "reason": "safety"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"
+
+
+@pytest.mark.asyncio
+async def test_composition_none_then_redirect_redirects(monkeypatch):
+    """[None, redirect] → redirect. First actionable result wins."""
+    redirect_adapter = AsyncMock()
+    redirect_adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="redir_msg"))
+
+    gateway = SimpleNamespace(
+        config=SimpleNamespace(gate=None),
+        adapters={Platform.TELEGRAM: redirect_adapter},
+        session_store=MagicMock(),
+    )
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [None, {"action": "redirect", "target": "telegram:99999"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context(gateway=gateway)
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    redirect_adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_composition_multiple_allows_delivers(monkeypatch):
+    """[allow, allow, allow] → allow (no actionable result, default allow)."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "allow"}, {"action": "allow"}, {"action": "allow"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_awaited_once()
+    assert result == "msg_1"
+
+
+@pytest.mark.asyncio
+async def test_composition_block_then_allow_blocks(monkeypatch):
+    """[block, allow] → block. First actionable result wins."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "block", "reason": "first"}, {"action": "allow"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"
+
+
+@pytest.mark.asyncio
+async def test_composition_conflicting_non_allow_first_wins(monkeypatch):
+    """[block, redirect] → block. First actionable result wins."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [
+                {"action": "block", "reason": "first"},
+                {"action": "redirect", "target": "telegram:99999"},
+            ]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"
+
+
+# --- Real dispatch path tests ---
+
+
+@pytest.mark.asyncio
+async def test_gate_fires_on_send_or_edit_path(monkeypatch):
+    """The gate fires through _send_or_edit (the main streaming delivery path)."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "block", "reason": "gate-on-edit-path"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_or_edit("Hello world", finalize=False)
+
+    # _send_or_edit returns False when blocked
+    assert result is False
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_gate_fires_on_try_fresh_final_path(monkeypatch):
+    """The gate fires through _try_fresh_final."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "block", "reason": "gate-on-fresh-final"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._try_fresh_final("Hello world")
+
+    # _try_fresh_final returns False when blocked
+    assert result is False
+    adapter.send.assert_not_awaited()

--- a/tests/gateway/test_pre_gateway_send.py
+++ b/tests/gateway/test_pre_gateway_send.py
@@ -1,0 +1,196 @@
+"""Tests for the pre_gateway_send plugin hook.
+
+The hook allows plugins to intercept outbound messages before they reach
+the platform adapter. It runs in GatewayStreamConsumer._send_new_chunk()
+and acts on returned action dicts:
+  {"action": "allow"} / None  -> normal delivery
+  {"action": "block", "reason": "..."}  -> silently drop
+  {"action": "redirect", "target": "platform:chat_id"}  -> send elsewhere
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+def _make_consumer(hook_context=None, platform=Platform.WHATSAPP):
+    """Build a GatewayStreamConsumer with a mock adapter."""
+    adapter = AsyncMock()
+    adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+    adapter._platform = platform
+    adapter.truncate_message = None
+    adapter.max_message_length = 4096
+    adapter.formatting_mode = "plain"
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_123",
+        config=StreamConsumerConfig(),
+        hook_context=hook_context,
+    )
+    return consumer, adapter
+
+
+def _make_hook_context(gateway=None, source=None, chat_type="group"):
+    """Build a hook_context dict."""
+    if gateway is None:
+        gateway = SimpleNamespace(
+            config=SimpleNamespace(gate=None),
+            adapters={},
+            session_store=MagicMock(),
+        )
+    if source is None:
+        source = SimpleNamespace(
+            platform=Platform.WHATSAPP,
+            user_id="user_1",
+            chat_id="chat_123",
+            user_name="tester",
+            chat_type=chat_type,
+        )
+    return {
+        "gateway": gateway,
+        "source": source,
+        "chat_type": chat_type,
+        "session_store": getattr(gateway, "session_store", None),
+    }
+
+
+@pytest.mark.asyncio
+async def test_block_action_drops_message(monkeypatch):
+    """Hook returning block prevents adapter.send from being called."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "block", "reason": "test-block"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"  # returns reply_to_id (drop)
+
+
+@pytest.mark.asyncio
+async def test_allow_action_delivers_normally(monkeypatch):
+    """Hook returning allow lets the message through."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "allow"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_awaited_once()
+    assert result == "msg_1"
+
+
+@pytest.mark.asyncio
+async def test_none_result_delivers_normally(monkeypatch):
+    """Hook returning None lets the message through."""
+    def _fake_hook(name, **kwargs):
+        return [None]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_redirect_action_sends_to_different_target(monkeypatch):
+    """Hook returning redirect sends to the redirect target instead."""
+    redirect_adapter = AsyncMock()
+    redirect_adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="redir_msg"))
+
+    gateway = SimpleNamespace(
+        config=SimpleNamespace(gate=None),
+        adapters={Platform.TELEGRAM: redirect_adapter},
+        session_store=MagicMock(),
+    )
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "redirect", "target": "telegram:99999"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context(gateway=gateway)
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    # Original adapter should NOT be called
+    adapter.send.assert_not_awaited()
+    # Redirect adapter should be called
+    redirect_adapter.send.assert_awaited_once()
+    call_kwargs = redirect_adapter.send.call_args
+    assert call_kwargs.kwargs["chat_id"] == "99999" or call_kwargs[1].get("chat_id") == "99999"
+
+
+@pytest.mark.asyncio
+async def test_hook_exception_falls_through(monkeypatch):
+    """Hook exception is caught and message delivers normally."""
+    def _failing_hook(name, **kwargs):
+        raise RuntimeError("plugin crash")
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _failing_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    # Should still deliver
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_no_hook_context_skips_hook(monkeypatch):
+    """Consumer without hook_context never invokes the hook."""
+    called = {"count": 0}
+    def _fake_hook(name, **kwargs):
+        called["count"] += 1
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    consumer, adapter = _make_consumer(hook_context=None)
+
+    await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    assert called["count"] == 0
+    adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_block_returns_reply_to_id(monkeypatch):
+    """When blocked, returns the original reply_to_id (not None)."""
+    def _fake_hook(name, **kwargs):
+        return [{"action": "block", "reason": "test"}]
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("text", "original_reply", final=True)
+    assert result == "original_reply"

--- a/tests/gateway/test_pre_gateway_send.py
+++ b/tests/gateway/test_pre_gateway_send.py
@@ -194,3 +194,162 @@ async def test_block_returns_reply_to_id(monkeypatch):
 
     result = await consumer._send_new_chunk("text", "original_reply", final=True)
     assert result == "original_reply"
+
+
+@pytest.mark.asyncio
+async def test_redirect_fail_closed_on_missing_adapter(monkeypatch):
+    """When redirect target platform has no adapter, message is dropped (fail-closed)."""
+    gateway = SimpleNamespace(
+        config=SimpleNamespace(gate=None),
+        adapters={},  # no adapters at all
+        session_store=MagicMock(),
+    )
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "redirect", "target": "telegram:99999"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context(gateway=gateway)
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    # Original adapter should NOT be called (fail-closed)
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"
+
+
+@pytest.mark.asyncio
+async def test_redirect_fail_closed_on_malformed_target(monkeypatch):
+    """When redirect target is malformed (no colon), message is dropped (fail-closed)."""
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "redirect", "target": "no-colon-here"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context()
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    assert result == "reply_1"
+
+
+@pytest.mark.asyncio
+async def test_redirect_normalizes_platform_case(monkeypatch):
+    """Redirect with lowercase platform string ('telegram') still works."""
+    redirect_adapter = AsyncMock()
+    redirect_adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="redir_msg"))
+
+    gateway = SimpleNamespace(
+        config=SimpleNamespace(gate=None),
+        adapters={Platform.TELEGRAM: redirect_adapter},
+        session_store=MagicMock(),
+    )
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_send":
+            return [{"action": "redirect", "target": "telegram:99999"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = _make_hook_context(gateway=gateway)
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    result = await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    adapter.send.assert_not_awaited()
+    redirect_adapter.send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_partial_hook_context_missing_gateway(monkeypatch):
+    """hook_context with gateway=None skips the hook entirely."""
+    called = {"count": 0}
+
+    def _fake_hook(name, **kwargs):
+        called["count"] += 1
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    ctx = {"gateway": None, "source": None, "chat_type": "group", "session_store": None}
+    consumer, adapter = _make_consumer(hook_context=ctx)
+
+    await consumer._send_new_chunk("Hello world", "reply_1", final=False)
+
+    assert called["count"] == 0
+    adapter.send.assert_awaited_once()
+
+
+# --- builtin_hooks reference gate tests ---
+
+
+class TestBuiltinOutboundGate:
+    """Tests for the reference pre_gateway_send gate in builtin_hooks."""
+
+    def test_dm_always_passes(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        assert outbound_gate("admin panel access", chat_type="dm") is None
+
+    def test_group_without_config_passes(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=None))
+        assert outbound_gate("admin panel access", chat_type="group", gateway=gateway) is None
+
+    def test_group_with_gate_disabled_passes(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gate_cfg = SimpleNamespace(enabled=False)
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=gate_cfg))
+        assert outbound_gate("admin panel access", chat_type="group", gateway=gateway) is None
+
+    def test_group_with_gate_enabled_blocks_admin_content(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gate_cfg = SimpleNamespace(enabled=True, group_chat_types=["group", "supergroup"], redirect_target="")
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=gate_cfg))
+        result = outbound_gate("admin panel access", chat_type="group", gateway=gateway)
+        assert result == {"action": "block", "reason": "admin-content-gate"}
+
+    def test_group_with_gate_enabled_passes_normal_content(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gate_cfg = SimpleNamespace(enabled=True, group_chat_types=["group", "supergroup"], redirect_target="")
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=gate_cfg))
+        assert outbound_gate("Hello, how are you?", chat_type="group", gateway=gateway) is None
+
+    def test_group_with_redirect_target(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gate_cfg = SimpleNamespace(enabled=True, group_chat_types=["group", "supergroup"], redirect_target="telegram:ADMIN_CHAT")
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=gate_cfg))
+        result = outbound_gate("admin panel access", chat_type="group", gateway=gateway)
+        assert result == {"action": "redirect", "target": "telegram:ADMIN_CHAT"}
+
+    def test_channel_type_passes(self):
+        from gateway.builtin_hooks import outbound_gate
+
+        gate_cfg = SimpleNamespace(enabled=True, group_chat_types=["group", "supergroup"], redirect_target="")
+        gateway = SimpleNamespace(config=SimpleNamespace(gate=gate_cfg))
+        assert outbound_gate("admin panel access", chat_type="channel", gateway=gateway) is None
+
+    def test_admin_patterns_match(self):
+        from gateway.builtin_hooks import _is_admin_content
+
+        assert _is_admin_content("admin panel access") is True
+        assert _is_admin_content("internal debug message") is True
+        assert _is_admin_content("recovery job started") is True
+        assert _is_admin_content("cold-start cursor restore") is True
+        assert _is_admin_content("system notification alert") is True
+        assert _is_admin_content("Hello, how are you?") is False
+        assert _is_admin_content("The weather is nice today") is False

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -462,8 +462,9 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
-| `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
-| `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
+|| `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
+|| `pre_gateway_send` | Directive/control | Outbound message chunk before adapter.send(); first valid `block`, `redirect`, or `allow` controls flow. | `content`, `platform`, `chat_id`, `source`, `chat_type`, `gateway`, `session_store` | Same privilege level as `pre_gateway_dispatch`. |
+|| `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
 | `pre_command` | Observer | Recognized slash command about to be dispatched, before the handler runs, on CLI and gateway cold-path dispatch; return ignored in v1 (directive-shaped dicts are logged at debug). Gateway running-agent intercept commands (`/stop`, `/approve` during an active run) are deliberately excluded — control-plane escape hatches must stay outside plugin reach. | `surface` (`"cli"` \| `"gateway"`), `command` (canonical name), `alias_used`, `args_raw`, `session_key`, `platform` | `args_raw` may contain user content or secrets typed after the command. |
 | `pre_approval_request` | Observer | Before prompted or smart approval; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id` | Command may contain secrets; smart observer preparation force-redacts, but surfaces do not all have identical redaction. |
 | `post_approval_response` | Observer | After a decision, timeout, or gateway notification failure; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id`, `choice`; smart path may add `decided_by` | Same command sensitivity plus decision metadata. |
@@ -1223,6 +1224,62 @@ def buffer_or_rewrite(event, **kwargs):
 
 def register(ctx):
     ctx.register_hook("pre_gateway_dispatch", buffer_or_rewrite)
+```
+
+### `pre_gateway_send`
+
+Fires **once per outbound message chunk** in the gateway, inside `GatewayStreamConsumer._send_new_chunk()`, **before** the content reaches the platform adapter. This is the outbound counterpart to `pre_gateway_dispatch` — while `pre_gateway_dispatch` intercepts incoming messages, `pre_gateway_send` intercepts outgoing ones. Use it to implement content gates, routing policies, or compliance checks that prevent certain messages from reaching group chats.
+
+**Callback signature:**
+
+```python
+def my_callback(content, platform, chat_id, source, chat_type, gateway, session_store, **kwargs):
+```
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `content` | `str` | The cleaned response text about to be sent. |
+| `platform` | `Platform` | Target platform enum (from the adapter). |
+| `chat_id` | `str` | Target chat ID. |
+| `source` | `SessionSource` | Original session source that triggered the response. |
+| `chat_type` | `str` | Chat type: `"dm"`, `"group"`, `"supergroup"`, or `"channel"`. |
+| `gateway` | `GatewayRunner` | The active gateway runner (for adapter access via `gateway.adapters`). |
+| `session_store` | `SessionStore` | The session store. |
+
+**Fires:** In `gateway/stream_consumer.py`, inside `GatewayStreamConsumer._send_new_chunk()`, after text cleaning but before `adapter.send()`. Only fires when the consumer was constructed with `hook_context` (the gateway always provides this for agent-generated responses).
+
+**Return value:** `None` or a dict. The first recognized action dict wins; remaining plugin results are ignored. Exceptions in plugin callbacks are caught and logged; the gateway always falls through to normal delivery on error.
+
+| Return | Effect |
+|--------|--------|
+| `{"action": "allow"}` / `None` | Normal delivery to the original target. |
+| `{"action": "redirect", "target": "platform:chat_id"}` | Send to a different platform/chat instead. If the redirect target is invalid or the adapter is unavailable, falls through to normal delivery. |
+| `{"action": "block", "reason": "..."}` | Silently drop the message — no delivery to any platform. |
+
+**Use cases:** Preventing admin/internal messages from leaking to public group chats; routing sensitive responses to DM channels; content compliance gates; per-chat-type delivery policies.
+
+**Example — block admin content from group chats:**
+
+```python
+def admin_gate(content, chat_type, **kwargs):
+    if chat_type in ("group", "supergroup") and "[ADMIN]" in content:
+        return {"action": "block", "reason": "admin-content-in-group"}
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_gateway_send", admin_gate)
+```
+
+**Example — redirect group responses to an admin DM:**
+
+```python
+def redirect_to_admin(content, chat_type, gateway, **kwargs):
+    if chat_type in ("group", "supergroup") and _is_sensitive(content):
+        return {"action": "redirect", "target": "telegram:ADMIN_CHAT_ID"}
+    return None
+
+def register(ctx):
+    ctx.register_hook("pre_gateway_send", redirect_to_admin)
 ```
 
 ---


### PR DESCRIPTION
## Summary

Adds a `pre_gateway_send` plugin hook — the outbound counterpart to the existing `pre_gateway_dispatch` hook. Plugins can classify, redirect, or block outgoing messages before they reach a platform adapter.

Closes #37271.

## Motivation

The current gateway has no post-generation classification check on outbound messages. When LLM classification fails (rare but real in production), admin/internal messages can leak to public group chats. This was observed in the 360Teams adapter where a CDP recovery job re-injected bot history including internal admin messages, and the LLM generated an admin-oriented response that was routed to a group chat instead of the admin DM channel.

## Architecture

```
Response generated by agent
         ↓
  GatewayStreamConsumer._send_new_chunk()
         ↓
  [invoke_hook("pre_gateway_send", ...)]
         ↓
  Plugin returns action dict → route accordingly
         ↓
  adapter.send()  ← only if allowed
```

## Hook contract

| Return | Behavior |
|--------|----------|
| `{"action": "allow"}` / `None` | Normal delivery to original target |
| `{"action": "redirect", "target": "platform:chat_id"}` | Send to different platform/target instead |
| `{"action": "block", "reason": "..."}` | Silently drop the message |

## Files changed

| File | Change |
|------|--------|
| `hermes_cli/plugins.py` | `pre_gateway_send` in `VALID_HOOKS` |
| `gateway/stream_consumer.py` | `hook_context` param + hook invocation in `_send_new_chunk()` |
| `gateway/run.py` | `hook_context` plumbed at both `GatewayStreamConsumer` construction sites |
| `gateway/builtin_hooks/__init__.py` | Reference gate (config-driven, opt-in, admin-pattern matching) |
| `tests/gateway/test_pre_gateway_send.py` | 19 tests (hook actions, fail-closed redirect, builtin gate) |
| `website/docs/user-guide/features/hooks.md` | Full hook docs + taxonomy table row |

## Design decisions

1. **Fires in `_send_new_chunk()`, not `_handle_message()`** — intercepts the actual delivery, not the agent processing. This is the "last mile" check.
2. **Fail-closed on redirect failure** — if the redirect target is invalid, missing, or the adapter fails, the message is dropped rather than falling through to the original group chat. This is the security-critical behavior.
3. **`hook_context` is keyword-only** — avoids breaking positional callers of `GatewayStreamConsumer.__init__`.
4. **Platform strings normalized** — `.strip().lower()` so lowercase inputs like `"telegram"` resolve correctly.
5. **Reference gate is opt-in** — `gateway.gate.enabled: false` by default. Real deployments implement their own plugin logic.

## Verification

- 19 new tests: all pass
- 69 existing tests: no regressions (stream consumer, pre_gateway_dispatch, plugin hooks)
- Cross-vendor review: Gemini 3.7 Flash (BLOCKER findings addressed) + GPT-OSS 120B (ACCEPTABLE)
