### PR TITLE
feat(agent): add config toggles for hardcoded system prompt blocks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2071,6 +2071,15 @@ def init_agent(
     # set this so the gate doesn't depend on write ordering.
     agent._session_title_hint = None
 
+    # System-prompt injection toggles — opt-out for blocks that are
+    # unconditionally injected today.  All default True (zero behavior
+    # change).  Set False to suppress the corresponding block and save
+    # tokens in the cached system prompt.
+    agent._help_guidance = bool(_agent_section.get("help_guidance", True))
+    agent._profile_hint = bool(_agent_section.get("profile_hint", True))
+    agent._timestamp_line = bool(_agent_section.get("timestamp_line", True))
+    agent._environment_hints = bool(_agent_section.get("environment_hints", True))
+
     # Per-platform prompt-hint overrides (config.yaml → platform_hints).
     # Lets an enterprise admin append to or replace Hermes' built-in
     # platform hint for a single messaging platform (e.g. WhatsApp) without

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -495,7 +495,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # per-session, so cache-safe either way.
     _has_skill_view = "skill_view" in (agent.valid_tool_names or set())
     _help_guidance_slot = len(stable_parts)
-    stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
+    if getattr(agent, "_help_guidance", True):
+        stable_parts.append(HERMES_AGENT_HELP_GUIDANCE_NO_SKILLS)
+    else:
+        stable_parts.append("")  # preserve slot index for downstream code
 
     # Universal task-completion / no-fabrication guidance.  Applied to ALL
     # models regardless of tool_use_enforcement gating — the failure modes
@@ -653,7 +656,8 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # rendered index line keeps this a pure string check — no second
     # filesystem scan, and it inherits the index cache's stability).
     if _has_skill_view and "- hermes-agent:" in skills_prompt:
-        stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
+        if getattr(agent, "_help_guidance", True):
+            stable_parts[_help_guidance_slot] = HERMES_AGENT_HELP_GUIDANCE
 
     # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
     # of the requested model. Inject explicit model identity into the system prompt
@@ -672,9 +676,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # Environment hints (WSL, Termux, etc.) — tell the agent about the
     # execution environment so it can translate paths and adapt behavior.
     # Stable for the lifetime of the process.
-    _env_hints = _r.build_environment_hints()
-    if _env_hints:
-        stable_parts.append(_env_hints)
+    # Gated by config.yaml ``agent.environment_hints`` (default True).
+    if getattr(agent, "_environment_hints", True):
+        _env_hints = _r.build_environment_hints()
+        if _env_hints:
+            stable_parts.append(_env_hints)
 
     # Coding posture (base Hermes, any interactive coding surface in a code
     # workspace — see agent/coding_context.py). Keep the operating brief in
@@ -796,14 +802,15 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     else:
         _home_str = _root_str = str(get_hermes_home())
     if active_profile == "default":
-        post_workspace_parts.append(
-            "Active Hermes profile: default. Other profiles (if any) live "
-            "under " + _root_str + "/profiles/<name>/. Each profile has its own "
-            "skills/, plugins/, cron/, and memories/ that affect a different "
-            "session than this one. Do not modify another profile's "
-            "skills/plugins/cron/memories unless the user explicitly directs "
-            "you to."
-        )
+        if getattr(agent, "_profile_hint", True):
+            post_workspace_parts.append(
+                "Active Hermes profile: default. Other profiles (if any) live "
+                "under " + _root_str + "/profiles/<name>/. Each profile has its own "
+                "skills/, plugins/, cron/, and memories/ that affect a different "
+                "session than this one. Do not modify another profile's "
+                "skills/plugins/cron/memories unless the user explicitly directs "
+                "you to."
+            )
     else:
         # A non-default name is only ever returned when the resolved home is
         # ALREADY <root>/profiles/<name> — that is exactly how both
@@ -812,17 +819,18 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         # /profiles/<name> again doubled it (#72894). The default profile's
         # data sits at the ROOT (get_default_hermes_root()), which in ambient
         # profile mode is NOT get_hermes_home().
-        profile_home = _home_str
-        default_root = get_default_hermes_root()
-        post_workspace_parts.append(
-            f"Active Hermes profile: {active_profile}. This session reads "
-            f"and writes {profile_home}/. The default "
-            f"profile's data lives at {default_root}/skills/, {default_root}/plugins/, "
-            f"{default_root}/cron/, {default_root}/memories/ — those belong to a "
-            f"different session run from a different shell. Do NOT modify "
-            f"another profile's skills/plugins/cron/memories unless the user "
-            f"explicitly directs you to."
-        )
+        if getattr(agent, "_profile_hint", True):
+            profile_home = _home_str
+            default_root = get_default_hermes_root()
+            post_workspace_parts.append(
+                f"Active Hermes profile: {active_profile}. This session reads "
+                f"and writes {profile_home}/. The default "
+                f"profile's data lives at {default_root}/skills/, {default_root}/plugins/, "
+                f"{default_root}/cron/, {default_root}/memories/ — those belong to a "
+                f"different session run from a different shell. Do NOT modify "
+                f"another profile's skills/plugins/cron/memories unless the user "
+                f"explicitly directs you to."
+            )
 
     platform_key = (agent.platform or "").lower().strip()
     # Resolve the built-in/plugin default hint for this platform, then apply
@@ -978,53 +986,55 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # ``get_timezone()`` returns None when no timezone is configured, in which
     # case we fall back to the abbreviation of the server-local (still tz-aware)
     # time.
-    _tz = _hermes_tz()
-    _zone_bits = []
-    _iana = getattr(_tz, "key", None)
-    if _iana:
-        _zone_bits.append(_iana)
-    _abbrev = now.strftime("%Z")
-    if _abbrev and _abbrev != _iana:
-        _zone_bits.append(_abbrev)
-    _offset = now.strftime("%z")
-    if _offset:  # '-0400' -> 'UTC-04:00'
-        _zone_bits.append(f"UTC{_offset[:3]}:{_offset[3:]}")
-    _zone_suffix = f" ({', '.join(_zone_bits)})" if _zone_bits else ""
-    _start = _session_start_like(agent, now)
-    timestamp_line = (
-        f"Conversation started: {_start.strftime('%A, %B %d, %Y')}{_zone_suffix}"
-    )
-    # Second line (maintainer design, salvaging #96224's anchor): long-lived
-    # sessions — Bot Mode forever-chats, messenger channels people never
-    # close — span many days and many compactions. A lone birth date leads
-    # the model to believe it is still living in that old day. The prompt is
-    # rebuilt at every compaction boundary, so stamp the rebuild day too:
-    # 'started' stays anchored and byte-stable, 'as of' refreshes exactly
-    # when the cache prefix is already being invalidated (compaction), so
-    # the added line costs no extra cache churn. Same-day sessions skip the
-    # second line entirely — nothing to correct, and the single-line shape
-    # stays byte-identical for the day (prefix-cache safe).
-    if now.strftime("%Y%m%d") != _start.strftime("%Y%m%d"):
-        timestamp_line += (
-            f"\nToday's date (as of the last context rebuild): "
-            f"{now.strftime('%A, %B %d, %Y')} — trust this over the start "
-            f"date for what day it is now; query tools for exact time."
+    # Gated by config.yaml ``agent.timestamp_line`` (default True).
+    if getattr(agent, "_timestamp_line", True):
+        _tz = _hermes_tz()
+        _zone_bits = []
+        _iana = getattr(_tz, "key", None)
+        if _iana:
+            _zone_bits.append(_iana)
+        _abbrev = now.strftime("%Z")
+        if _abbrev and _abbrev != _iana:
+            _zone_bits.append(_abbrev)
+        _offset = now.strftime("%z")
+        if _offset:  # '-0400' -> 'UTC-04:00'
+            _zone_bits.append(f"UTC{_offset[:3]}:{_offset[3:]}")
+        _zone_suffix = f" ({', '.join(_zone_bits)})" if _zone_bits else ""
+        _start = _session_start_like(agent, now)
+        timestamp_line = (
+            f"Conversation started: {_start.strftime('%A, %B %d, %Y')}{_zone_suffix}"
         )
-    # Bot Chat sessions are effectively eternal — a birth date frozen in the
-    # prompt becomes confidently-wrong misinformation within days. Timeless
-    # prompts keep the identity lines but drop the date (the timezone still
-    # rides workspace context; live time comes from the terminal tool).
-    if getattr(agent, "_bot_chat_timeless_prompt", False):
-        timestamp_line = f"Timezone: {', '.join(_zone_bits)}" if _zone_bits else ""
-    if agent.pass_session_id and agent.session_id:
-        timestamp_line += f"\nSession ID: {agent.session_id}"
-    if agent.model:
-        timestamp_line += f"\nModel: {agent.model}"
-    if agent.provider:
-        timestamp_line += f"\nProvider: {agent.provider}"
-    if agent.platform:
-        timestamp_line += f"\nPlatform: {agent.platform}"
-    volatile_parts.append(timestamp_line)
+        # Second line (maintainer design, salvaging #96224's anchor): long-lived
+        # sessions — Bot Mode forever-chats, messenger channels people never
+        # close — span many days and many compactions. A lone birth date leads
+        # the model to believe it is still living in that old day. The prompt is
+        # rebuilt at every compaction boundary, so stamp the rebuild day too:
+        # 'started' stays anchored and byte-stable, 'as of' refreshes exactly
+        # when the cache prefix is already being invalidated (compaction), so
+        # the added line costs no extra cache churn. Same-day sessions skip the
+        # second line entirely — nothing to correct, and the single-line shape
+        # stays byte-identical for the day (prefix-cache safe).
+        if now.strftime("%Y%m%d") != _start.strftime("%Y%m%d"):
+            timestamp_line += (
+                f"\nToday's date (as of the last context rebuild): "
+                f"{now.strftime('%A, %B %d, %Y')} — trust this over the start "
+                f"date for what day it is now; query tools for exact time."
+            )
+        # Bot Chat sessions are effectively eternal — a birth date frozen in the
+        # prompt becomes confidently-wrong misinformation within days. Timeless
+        # prompts keep the identity lines but drop the date (the timezone still
+        # rides workspace context; live time comes from the terminal tool).
+        if getattr(agent, "_bot_chat_timeless_prompt", False):
+            timestamp_line = f"Timezone: {', '.join(_zone_bits)}" if _zone_bits else ""
+        if agent.pass_session_id and agent.session_id:
+            timestamp_line += f"\nSession ID: {agent.session_id}"
+        if agent.model:
+            timestamp_line += f"\nModel: {agent.model}"
+        if agent.provider:
+            timestamp_line += f"\nProvider: {agent.provider}"
+        if agent.platform:
+            timestamp_line += f"\nPlatform: {agent.platform}"
+        volatile_parts.append(timestamp_line)
 
     return {
         "stable":   "\n\n".join(p.strip() for p in stable_parts   if p and p.strip()),

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -212,6 +212,27 @@ DEFAULT_CONFIG = {
         # Bot Mode teammate-messaging protocol section (silent unless a
         # profile is managed by the desktop's Bot Mode).
         "bot_mode_protocol": True,
+        # Hermes self-help guidance — injects a pointer to the Hermes docs
+        # and the hermes-agent skill so the model can answer questions about
+        # its own configuration, features, and capabilities.  Set False to
+        # suppress (saves ~60 tokens in the cached system prompt).
+        "help_guidance": True,
+        # Active-profile hint — names the Hermes profile the agent is
+        # running under and warns against cross-profile writes.  Set False
+        # to suppress (saves ~40 tokens).  Useful for single-profile
+        # installs or fully custom system prompts.
+        "profile_hint": True,
+        # Timestamp / session / model / provider line in the volatile tier.
+        # Includes conversation start date, timezone, and (when
+        # pass_session_id is set) the session ID.  Set False to suppress
+        # the entire block (saves ~30 tokens).  The model can still query
+        # time and identity via tools.
+        "timestamp_line": True,
+        # Environment hints — host OS, user home, cwd (local backends) or
+        # backend probe description (remote backends).  Set False to
+        # suppress the entire block (saves ~30 tokens).  The model can
+        # still discover environment facts via terminal tools.
+        "environment_hints": True,
         # Embedder-supplied environment description appended to the system
         # prompt's environment-hints block. Lets a host that wraps Hermes
         # (sandbox runner, managed platform) explain the runtime environment

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -763,3 +763,89 @@ class TestConversationStartedTwoLine:
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
 
+
+class TestInjectionToggles:
+    """Verify that the four new ``agent.*`` config toggles suppress their
+    corresponding system-prompt blocks when set to False."""
+
+    def _build(self, **overrides):
+        base = dict(
+            load_soul_identity=False,
+            skip_context_files=False,
+            valid_tool_names=[],
+            _task_completion_guidance=False,
+            _tool_use_enforcement=False,
+            _environment_probe=False,
+            _kanban_worker_guidance="",
+            _memory_store=None,
+            _memory_manager=None,
+            model="test-model",
+            provider="test-provider",
+            platform="cli",
+            pass_session_id=True,
+            session_id="20260101_120000_test",
+            _emit_status=lambda *_a, **_kw: None,
+            _help_guidance=True,
+            _profile_hint=True,
+            _timestamp_line=True,
+            _environment_hints=True,
+            _bot_mode_protocol=False,
+            _parallel_tool_call_guidance=False,
+        )
+        base.update(overrides)
+        return SimpleNamespace(**base)
+
+    def _parts(self, agent):
+        import agent.system_prompt as sp
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_environment_hints", return_value="HOST_HINT"),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+            patch("run_agent.build_skills_system_prompt", return_value=""),
+        ):
+            return sp.build_system_prompt_parts(agent)
+
+    # --- help_guidance ---
+
+    def test_help_guidance_enabled_by_default(self):
+        parts = self._parts(self._build())
+        assert "hermes-agent.nousresearch.com/docs" in parts["stable"]
+
+    def test_help_guidance_disabled(self):
+        parts = self._parts(self._build(_help_guidance=False))
+        assert "hermes-agent.nousresearch.com/docs" not in parts["stable"]
+
+    # --- profile_hint ---
+
+    def test_profile_hint_enabled_by_default(self):
+        parts = self._parts(self._build())
+        full = "\n\n".join(parts[k] for k in ("stable", "context", "volatile"))
+        assert "Active Hermes profile:" in full
+
+    def test_profile_hint_disabled(self):
+        parts = self._parts(self._build(_profile_hint=False))
+        full = "\n\n".join(parts[k] for k in ("stable", "context", "volatile"))
+        assert "Active Hermes profile:" not in full
+
+    # --- timestamp_line ---
+
+    def test_timestamp_line_enabled_by_default(self):
+        parts = self._parts(self._build())
+        assert "Conversation started:" in parts["volatile"]
+
+    def test_timestamp_line_disabled(self):
+        parts = self._parts(self._build(_timestamp_line=False))
+        assert "Conversation started:" not in parts["volatile"]
+        assert "Model:" not in parts["volatile"]
+        assert "Provider:" not in parts["volatile"]
+
+    # --- environment_hints ---
+
+    def test_environment_hints_enabled_by_default(self):
+        parts = self._parts(self._build())
+        assert "HOST_HINT" in parts["stable"]
+
+    def test_environment_hints_disabled(self):
+        parts = self._parts(self._build(_environment_hints=False))
+        assert "HOST_HINT" not in parts["stable"]
+


### PR DESCRIPTION
Closes #37253.

## What

Add four new `config.yaml` keys under `agent:` to opt out of system prompt blocks that were previously injected unconditionally:

```yaml
agent:
  help_guidance: false      # suppress HERMES_AGENT_HELP_GUIDANCE (~60 tokens)
  profile_hint: false       # suppress active-profile hint (~40 tokens)
  timestamp_line: false     # suppress date/session/model/provider line (~30 tokens)
  environment_hints: false  # suppress build_environment_hints() (~30 tokens)
```

All default `True` — zero behavior change for existing users.

## Why

Users running Hermes with custom SOUL.md identities or in environments where the hardcoded guidance is unnecessary token overhead currently have no way to opt out. This gives full control over system prompt content.

## How

Each toggle gates its corresponding block in `build_system_prompt_parts()` via `getattr(agent, "_X", True)` — fail-open for code paths that bypass `agent_init` (test stubs, external consumers).

## Files

| File | Change |
|---|---|
| `hermes_cli/config_defaults.py` | 4 new keys with docstrings |
| `agent/agent_init.py` | Wire keys → `agent._help_guidance`, `._profile_hint`, `._timestamp_line`, `._environment_hints` |
| `agent/system_prompt.py` | Gate each block behind its toggle |
| `tests/agent/test_system_prompt.py` | 8 new tests (enabled + disabled per toggle) |

## Note on issue item #5

The issue's fifth block (`build_nous_subscription_prompt()`) does not exist in the current codebase — it was likely removed before this change.

## Verification

- 57/57 tests pass in `test_system_prompt.py` (including 8 new)
- 156/156 pass across the broader prompt-related test suite
- Cross-vendor review: Gemini 3.7 Flash (High) + GPT-OSS 120B (Medium) — both ACCEPTABLE, no BLOCKERs or SHOULD-FIXs

## Open question

PR #72423 (remote backend probe toggle) adds `agent.remote_backend_probe` to the same `config_defaults.py` section. The two PRs are complementary (probe toggle disables the live SSH/docker probe; `environment_hints` suppresses the entire block) but will need a trivial merge resolution.
