### PR TITLE
Prevent duplicate replies from process notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2958,32 +2958,19 @@ def _format_concise_process_notification(
 
 
 def _format_gateway_process_notification(evt: dict) -> "str | None":
-    """Format a watch pattern event from completion_queue into a [IMPORTANT:] message."""
+    """Render model-facing watch telemetry with the shared silence contract."""
+    from tools.process_registry_notifications import format_process_notification
+
     evt_type = evt.get("type", "completion")
-    _sid = evt.get("session_id", "unknown")
-    _cmd = evt.get("command", "unknown")
-
-    # watch_disabled / overflow events carry their summary in `message` (process_registry formatter).
-    if evt_type in ("watch_disabled", "watch_overflow_tripped", "watch_overflow_released"):
-        return f"[IMPORTANT: {evt.get('message', '')}]"
-
-    if evt_type == "watch_match":
-        _pat = evt.get("pattern", "?")
-        _out = evt.get("output", "")
-        _sup = evt.get("suppressed", 0)
-        text = (
-            f"[IMPORTANT: Background process {_sid} matched "
-            f"watch pattern \"{_pat}\".\n"
-            f"Command: {_cmd}\nMatched output:\n{_out}")
-        if _sup:
-            text += f"\n({_sup} earlier matches were suppressed by rate limit)"
-        text += "]"
-        return text
-
-    if evt_type == "async_delegation":
-        from tools.process_registry_notifications import format_process_notification
-        return format_process_notification(evt)
-
+    if evt_type in {
+        "watch_match", "watch_disabled", "watch_overflow_tripped",
+        "watch_overflow_released", "async_delegation",
+    }:
+        return format_process_notification(
+            evt,
+            include_no_reply_contract=True,
+            include_attribution=evt_type != "watch_match",
+        )
     return None
 
 

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -1293,7 +1293,9 @@ class GatewayNotificationsMixin:
                 f"\n- … and {omitted} more completion(s); inspect them with "
                 "the process tool if they affect the conclusion."
             )
-        lines.append("If a result does not change the current conclusion, absorb it silently.]")
+        from tools.process_registry_notifications import PROCESS_NOTIFICATION_NO_REPLY_CONTRACT
+
+        lines.append(PROCESS_NOTIFICATION_NO_REPLY_CONTRACT + "]")
         return "\n".join(lines)
 
     def _record_coalesced_completion_siblings(self, events: list[dict]) -> None:

--- a/tools/process_registry_notifications.py
+++ b/tools/process_registry_notifications.py
@@ -339,24 +339,38 @@ def _completion_status(evt: dict) -> str:
     return _REASON_STATUS.get(reason) or ("completed normally" if evt.get("exit_code", "?") == 0 else "exited")
 
 
-def format_process_notification(evt: dict) -> "str | None":
+PROCESS_NOTIFICATION_NO_REPLY_CONTRACT = (
+    "If this process event does not materially change or correct an answer "
+    "you have already delivered, respond exactly NO_REPLY so no redundant "
+    "follow-up is sent. Do not send a message merely to acknowledge receipt."
+)
+
+
+def format_process_notification(
+    evt: dict, *, include_no_reply_contract: bool = False, include_attribution: bool = True,
+) -> "str | None":
     """Format a completion_queue event into an ``[IMPORTANT: ...]`` message."""
+    def finalize(text: str) -> str:
+        if include_no_reply_contract:
+            return f"{text[:-1]}\n\n{PROCESS_NOTIFICATION_NO_REPLY_CONTRACT}]"
+        return text
+
     evt_type = evt.get("type", "completion")
     # watch_disabled and overflow events carry their own human-readable `message`;
     # otherwise overflow events would fall through to the completion formatter as a
     # phantom "process exited (exit code ?)".
     if evt_type in ("watch_disabled", "watch_overflow_tripped", "watch_overflow_released"):
-        return f"[IMPORTANT: {evt.get('message', '')}]"
+        return finalize(f"[IMPORTANT: {evt.get('message', '')}]")
     if evt_type == "async_delegation":
         return _format_async_delegation(evt)
     _sid, _cmd = evt.get("session_id", "unknown"), evt.get("command", "unknown")
-    _attribution = _delegation_attribution_line(evt)
-    if evt.get("handoff_note"):
+    _attribution = _delegation_attribution_line(evt) if include_attribution else None
+    if include_attribution and evt.get("handoff_note"):
         _attribution = f"Handed off to you by a subagent before it finished. Purpose: {evt['handoff_note']}"
     attribution = f"{_attribution}\n" if _attribution else ""
     if evt_type == "watch_match":
         _sup = evt.get("suppressed", 0)
-        return (
+        return finalize(
             f"[IMPORTANT: Background process {_sid} matched watch pattern \"{evt.get('pattern', '?')}\".\n"
             f"{attribution}Command: {_cmd}\nMatched output:\n{evt.get('output', '')}"
             + (f"\n({_sup} earlier matches were suppressed by rate limit)" if _sup else "") + "]")
@@ -370,6 +384,6 @@ def format_process_notification(evt: dict) -> "str | None":
             "...(output trimmed — subagent-owned process; see the "
             "delegation's live transcript for full output)\n"
             + _out[-600:])
-    return (
+    return finalize(
         f"[IMPORTANT: Background process {_sid} {_completion_status(evt)} (exit code {_exit}{_signal}).\n"
         f"{attribution}Command: {_cmd}\nOutput:\n{_out}]")


### PR DESCRIPTION
## Summary

- Allow process completion and watch notifications to reconcile silently with `NO_REPLY` when they do not change an already delivered answer.
- Route gateway watch notifications through the shared process formatter so the contract cannot drift.
- Cover watch, single and batched completion, disabled-watch, and overflow events with regression tests.

## Motivation

A queued background-process readiness event can be injected after the originating turn has already sent its final response. Because the event is a full internal conversation turn, the model can acknowledge it or repeat the completed answer, producing a duplicate public message.

This keeps process telemetry actionable while making the no-news outcome explicit. Existing gateway silence filtering suppresses the exact `NO_REPLY` token, while substantive updates continue to be delivered normally.

Refs #52694

## Verification

- `scripts/run_tests.sh tests/tools/test_process_registry.py tests/gateway/test_background_process_notifications.py tests/gateway/test_completion_delivery.py tests/gateway/test_gateway_silence_tokens.py -q` (156 passed, 5 skipped)
- `uvx ruff check tools/process_registry.py gateway/run.py tests/tools/test_process_registry.py tests/gateway/test_background_process_notifications.py tests/gateway/test_completion_delivery.py`
- Regression test failed on pre-fix `main` because process notifications did not contain the no-news contract.

## Test boundary

Covers model-facing process notification formatting, gateway/shared formatter parity, and the existing exact-token silence filter. It does not invoke a live model in CI, so model compliance is verified during the post-promotion canary.

## Risk and exclusions

The contract is opt-in only for model-facing gateway process events. CLI, TUI, and Desktop displays keep their existing text. Async-delegation summaries are unchanged because #66507 owns that separate behavior.