### PR TITLE
fix(cli): show all configured platforms in TUI gateway status

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12459,16 +12459,32 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 Platform.DISCORD: ("Discord", "DISCORD_BOT_TOKEN"),
                 Platform.SLACK: ("Slack", "SLACK_BOT_TOKEN"),
                 Platform.WHATSAPP: ("WhatsApp", "WHATSAPP_ENABLED"),
+                Platform.SIGNAL: ("Signal", "SIGNAL_SIGNALING_KEY"),
             }
-            
-            for platform, (name, env_var) in platform_status.items():
-                pconfig = config.platforms.get(platform)
+
+            # Show all configured platforms first (including Signal, A2A, and
+            # any plugin adapter), then fall back to listing the well-known
+            # four for users who have nothing configured yet.
+            seen = set()
+            for platform, pconfig in config.platforms.items():
+                entry = platform_status.get(platform)
+                if entry:
+                    pname = entry[0]
+                else:
+                    pname = platform.value.upper() if len(platform.value) <= 6 else platform.value.title()
                 if pconfig and pconfig.enabled:
                     home = config.get_home_channel(platform)
                     home_str = f" → {home.name}" if home else ""
-                    print(f"    ✓ {name:<12} Enabled{home_str}")
+                    print(f"    ✓ {pname:<12} Enabled{home_str}")
                 else:
-                    print(f"    ○ {name:<12} Not configured ({env_var})")
+                    label = f" ({entry[1]})" if entry else ""
+                    print(f"    ○ {pname:<12} Not configured{label}")
+                seen.add(platform)
+
+            # Show well-known platforms not in config.platforms
+            for platform, (pname, env_var) in platform_status.items():
+                if platform not in seen:
+                    print(f"    ○ {pname:<12} Not configured ({env_var})")
             
             print()
             print("  Session Reset Policy:")

--- a/cli.py
+++ b/cli.py
@@ -12454,37 +12454,47 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             print("  Messaging Platform Configuration:")
             print("  " + "-" * 55)
             
-            platform_status = {
-                Platform.TELEGRAM: ("Telegram", "TELEGRAM_BOT_TOKEN"),
-                Platform.DISCORD: ("Discord", "DISCORD_BOT_TOKEN"),
-                Platform.SLACK: ("Slack", "SLACK_BOT_TOKEN"),
-                Platform.WHATSAPP: ("WhatsApp", "WHATSAPP_ENABLED"),
-                Platform.SIGNAL: ("Signal", "SIGNAL_SIGNALING_KEY"),
+            from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+
+            _DISPLAY_OVERRIDES = {
+                Platform.WHATSAPP: "WhatsApp",
+                Platform.WHATSAPP_CLOUD: "WhatsApp Cloud",
+                Platform.SIGNAL: "Signal",
+                Platform.HOMEASSISTANT: "Home Assistant",
+                Platform.API_SERVER: "API Server",
+                Platform.MSGRAPH_WEBHOOK: "MSGraph Webhook",
+                Platform.WECOM_CALLBACK: "WeCom Callback",
             }
 
-            # Show all configured platforms first (including Signal, A2A, and
-            # any plugin adapter), then fall back to listing the well-known
-            # four for users who have nothing configured yet.
-            seen = set()
-            for platform, pconfig in config.platforms.items():
-                entry = platform_status.get(platform)
-                if entry:
-                    pname = entry[0]
-                else:
-                    pname = platform.value.upper() if len(platform.value) <= 6 else platform.value.title()
+            def _platform_display_name(platform: Platform) -> str:
+                if platform in _DISPLAY_OVERRIDES:
+                    return _DISPLAY_OVERRIDES[platform]
+                return platform.value.replace("_", " ").title()
+
+            def _platform_env_var(platform: Platform) -> str:
+                return PLATFORM_TOKEN_ENV_NAMES.get(platform, "")
+
+            # All platforms the gateway knows about: static members plus any
+            # plugin platforms actually configured (dynamic members via
+            # Platform._missing_).  Signal/A2A appear here; the panel is
+            # driven from the platform registry, not a hardcoded subset.
+            known_platforms = list(config.platforms.keys())
+            for p in Platform:
+                if p.value != "local" and p not in known_platforms:
+                    known_platforms.append(p)
+            known_platforms.sort(key=lambda p: p.value)
+
+            for platform in known_platforms:
+                pconfig = config.platforms.get(platform)
+                pname = _platform_display_name(platform)
+                env_var = _platform_env_var(platform)
                 if pconfig and pconfig.enabled:
                     home = config.get_home_channel(platform)
                     home_str = f" → {home.name}" if home else ""
                     print(f"    ✓ {pname:<12} Enabled{home_str}")
                 else:
-                    label = f" ({entry[1]})" if entry else ""
+                    label = f" ({env_var})" if env_var else ""
                     print(f"    ○ {pname:<12} Not configured{label}")
-                seen.add(platform)
-
-            # Show well-known platforms not in config.platforms
-            for platform, (pname, env_var) in platform_status.items():
-                if platform not in seen:
-                    print(f"    ○ {pname:<12} Not configured ({env_var})")
             
             print()
             print("  Session Reset Policy:")


### PR DESCRIPTION
Fixes #99788 — the TUI gateway status panel never shows Signal/A2A.

## Problem

`_show_gateway_status` (the `/platforms` command) built its panel from a hardcoded four-entry dict (`TELEGRAM`/`DISCORD`/`SLACK`/`WHATSAPP`), so Signal and plugin platforms like A2A never rendered even when the gateway reported them connected. A user running only Signal + A2A saw every platform as "Not configured".

## Approach

The panel is now driven from the **platform registry** instead of a hardcoded subset:

- Lists every static `Platform` member plus any configured plugin platform (dynamic members via `Platform._missing_`), rendering each as `✓ Enabled` or `○ Not configured`.
- Display names use a small override table for special cases (`whatsapp_cloud`, `msgraph_webhook`, …); everything else derives from the platform value.
- Env-var hints reuse the existing `PLATFORM_TOKEN_ENV_NAMES` map (`gateway/config.py`) so the panel stays consistent with the rest of the config surface — no second source of truth.

## Test Plan

Verified with a mocked config containing Signal + A2A (enabled) and Telegram (disabled): the panel shows both new platforms as Enabled, lists every static member (Slack/Weixin/WhatsApp … with their token env vars), and `python -m py_compile` is clean.

## Risk & Exclusions

- Display-only change; no gateway behavior touched.
- This is the config view (like the rest of `/platforms`); live connected/disconnected state remains the desktop app's job.