### PR TITLE
chore(contributors): drop case-colliding agent@agents-Mac-mini.local entry

### DIFF
--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,0 @@
-momomojo


### PR DESCRIPTION
## Problem
The repo carries two entries for the same contributor email differing only by case:
- contributors/emails/agent@Agents-Mac-mini.local -> skip-agent (added in 55db6187e5)
- contributors/emails/agent@agents-Mac-mini.local -> momomojo (re-added by bb06a8d414)

On case-insensitive filesystems (Windows/NTFS), the working tree can never match both blobs at the same time, so git status permanently reports a modified file. Every hermes update run detects this as a local change and autostashes it — Windows users accumulate one autostash per upgrade (this machine has 21 since Aug 16).

## Fix
Drop the lowercase duplicate and keep the canonical skip-agent mapping. This mirrors the intent of 693c0e1c62, which removed both entries but was partially reverted by bb06a8d414.

## Test plan
After this change, git status on a case-insensitive filesystem is clean (verified locally with the file content set to skip-agent).