### PR TITLE
fix(agent): honor server-classified coded errors from the Nous API

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5650,6 +5650,12 @@ def run_conversation(
                     FailoverReason.rate_limit,
                     FailoverReason.billing,
                     FailoverReason.upstream_rate_limit,
+                    # Coded per-user 429: shares the rate-limit retry plumbing
+                    # (Retry-After / adaptive backoff / status line) but must
+                    # NOT rotate credentials or fall back — the limit is on
+                    # the user, so both are useless. Excluded from the eager-
+                    # fallback predicate below.
+                    FailoverReason.user_rate_limit,
                 }
                 # Relay-wrapped output-cap errors: some gateways wrap an
                 # upstream "[400]: max_tokens (...) exceeds model's maximum
@@ -5683,7 +5689,14 @@ def run_conversation(
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
                 _should_fallback = (
-                    (is_rate_limited and _wrapped_output_cap_budget is None)
+                    (
+                        is_rate_limited
+                        # A coded per-user 429 never benefits from switching
+                        # providers — the limit follows the user's account, so
+                        # the wait is the only recovery.
+                        and classified.reason != FailoverReason.user_rate_limit
+                        and _wrapped_output_cap_budget is None
+                    )
                     or (_is_transport_failure and retry_count >= 2)
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
@@ -6414,6 +6427,16 @@ def run_conversation(
                     )
                 ) and not is_context_length_error
 
+                # Server-classified coded errors carry the server's own
+                # verdict: the 403 decision and the 429 per-user limit follow
+                # the user's account, so switching providers (like refreshing
+                # or rotating credentials) cannot change the outcome. Honor
+                # that verdict at every fallback gate below.
+                _no_fallback_verdict = classified.reason in {
+                    FailoverReason.entitlement_blocked,
+                    FailoverReason.user_rate_limit,
+                }
+
                 if is_client_error:
                     # Copilot self-heal BEFORE fallback: a stale/degraded
                     # credential surfaces as a 400
@@ -6447,14 +6470,18 @@ def run_conversation(
                     # exists; otherwise "trying fallback..." is a lie and the
                     # session looks like it's recovering when it's about to
                     # abort silently (#35314, #17446).
-                    if agent._has_pending_fallback():
+                    if _no_fallback_verdict:
+                        # Server said switching providers cannot help — skip
+                        # the attempt entirely (and the lying announcement).
+                        pass
+                    elif agent._has_pending_fallback():
                         if classified.reason == FailoverReason.content_policy_blocked:
                             agent._buffer_status("⚠️ Provider safety filter blocked this request — trying fallback...")
                         elif classified.reason == FailoverReason.ssl_cert_verification:
                             agent._buffer_status("⚠️ TLS certificate verification failed — trying fallback...")
                         else:
                             agent._buffer_status(f"⚠️ Non-retryable error (HTTP {status_code}) — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if not _no_fallback_verdict and agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0
@@ -6476,7 +6503,18 @@ def run_conversation(
                     # it verbatim (e.g. a cron failure notification dumped a
                     # ~60KB Cloudflare challenge page as 31 Discord messages).
                     _nonretryable_summary = agent._summarize_api_error(api_error)
-                    if classified.reason == FailoverReason.content_policy_blocked:
+                    if classified.reason == FailoverReason.entitlement_blocked:
+                        # Server-classified coded 403: the server's own
+                        # message is authoritative and user-actionable —
+                        # use it as the turn's error verbatim instead of the
+                        # generic "Non-retryable error (HTTP 403)" auth
+                        # phrasing that misdirects toward key/credential
+                        # fixes. Falls back to the summary when the body
+                        # carried no message.
+                        _verbatim = (classified.message or _nonretryable_summary).strip()
+                        _nonretryable_summary = _verbatim
+                        agent._emit_status(f"❌ {_verbatim}")
+                    elif classified.reason == FailoverReason.content_policy_blocked:
                         agent._emit_status(
                             f"❌ Provider safety filter blocked this request: "
                             f"{_nonretryable_summary}"
@@ -6645,6 +6683,11 @@ def run_conversation(
                         "completed": False,
                         "failed": True,
                         "error": _nonretryable_summary,
+                        # Surface the classified reason so UI consumers can
+                        # render the right recovery signal instead of
+                        # re-deriving it from the error text.
+                        "failure_reason": classified.reason.value,
+                        "failure_retryable": bool(classified.retryable),
                     }
 
                 if retry_count >= max_retries:
@@ -6666,9 +6709,14 @@ def run_conversation(
                         agent._fallback_activated = False
                         continue
                     # Try fallback before giving up entirely
-                    if agent._has_pending_fallback():
+                    if _no_fallback_verdict:
+                        # Server said switching providers cannot help (coded
+                        # per-user limit / terminal coded 403) — skip the
+                        # attempt and its announcement.
+                        pass
+                    elif agent._has_pending_fallback():
                         agent._buffer_status(f"⚠️ Max retries ({max_retries}) exhausted — trying fallback...")
-                    if agent._try_activate_fallback():
+                    if not _no_fallback_verdict and agent._try_activate_fallback():
                         active_system_prompt = _sync_failover_system_message(
                             agent, api_messages, active_system_prompt)
                         retry_count = 0

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -69,6 +69,14 @@ class FailoverReason(enum.Enum):
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
 
+    # Server-classified errors carrying a structured ``code`` the classifier
+    # does not recognize. The server explicitly labelled the failure, so its
+    # verdict on retry semantics is authoritative: 403 is terminal for the
+    # request (no refresh/rotation/fallback can help), 429 is a per-user
+    # limit that resets on its own schedule (wait, don't rotate).
+    entitlement_blocked = "entitlement_blocked"  # Coded 403 — server rejected this request; recovery is on the user's side
+    user_rate_limit = "user_rate_limit"          # Coded 429 — per-user limit; honor Retry-After, never rotate/fallback
+
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
     long_context_tier = "long_context_tier"    # Anthropic "extra usage" tier gate
@@ -164,6 +172,48 @@ def _billing_ambiguity_context(error_msg: str) -> Dict[str, Any]:
 # provider-scoped: other providers' generic billing codes historically remain
 # auth failures when they arrive as 403.
 _XAI_SPENDING_LIMIT_ERROR_CODE = "personal-team-blocked:spending-limit"
+
+# Provider name spellings that identify the Nous Inference API. Mirrors the
+# alias set used elsewhere in the codebase (see tools/delegate_tool.py).
+_NOUS_PROVIDER_ALIASES = frozenset({"nous", "nous-portal", "nousresearch"})
+
+# Structured error codes with established classification behavior — a coded
+# error carrying one of these keeps its existing rule and never falls through
+# to the generic unrecognized-code handling below.
+#
+# Contract: every code ``_classify_by_error_code`` claims, plus the codes the
+# status-based paths themselves key on. Derived by exercising the classifier's
+# own claim logic (see ``_known_structured_error_codes``) rather than
+# hand-maintained, so adding a known code cannot drift out of sync with this
+# set.
+_KNOWN_CODE_CLAIM_CHECKS = (
+    # _classify_by_error_code's claimed sets
+    frozenset({"resource_exhausted", "throttled", "rate_limit_exceeded"}),
+    lambda: _BILLING_ERROR_CODES,
+    frozenset({"model_not_found", "model_not_available", "invalid_model"}),
+    frozenset({"context_length_exceeded", "max_tokens_exceeded"}),
+    frozenset({"invalid_encrypted_content"}),
+    # Status-path codes with their own behavior regardless of body shape
+    frozenset({"usage_limit_reached", "invalid_request_error",
+               "unknown_parameter", "unsupported_parameter"}),
+)
+
+
+def _known_structured_error_codes() -> frozenset:
+    """Codes with established classification behavior (see above contract)."""
+    codes: set = set()
+    for entry in _KNOWN_CODE_CLAIM_CHECKS:
+        if callable(entry):
+            codes.update(entry())
+        else:
+            codes.update(entry)
+    return frozenset(codes)
+
+
+def _is_unrecognized_structured_code(error_code: str) -> bool:
+    """True when ``error_code`` carries no established classification rule."""
+    return (error_code or "").strip().lower() not in _known_structured_error_codes()
+
 
 # Structured provider codes that mean the account cannot serve paid traffic
 # until credits/subscription capacity is restored. xAI returns its explicit
@@ -1287,6 +1337,24 @@ def _classify_by_status(
                 should_rotate_credential=True,
                 should_fallback=True,
             )
+        # Server-classified 403: the body carries a structured ``code`` this
+        # classifier does not recognize. The server labelled the failure
+        # itself, so its verdict is authoritative — the request is terminal
+        # (retrying, refreshing, or rotating credentials cannot change the
+        # server's decision) and the body ``message`` is user-actionable.
+        # Surface it verbatim instead of the misleading generic auth path,
+        # and burn no credential refresh on the way out.
+        if (
+            error_code
+            and provider in _NOUS_PROVIDER_ALIASES
+            and _is_unrecognized_structured_code(error_code)
+        ):
+            return result_fn(
+                FailoverReason.entitlement_blocked,
+                retryable=False,
+                should_rotate_credential=False,
+                should_fallback=False,
+            )
         return result_fn(
             FailoverReason.auth,
             retryable=False,
@@ -1427,6 +1495,24 @@ def _classify_by_status(
                 retryable=False,
                 should_rotate_credential=True,
                 should_fallback=True,
+            )
+        # Server-classified 429: a structured ``code`` this classifier does
+        # not recognize marks a per-user limit that resets on its own
+        # schedule. The wait is the recovery — honor Retry-After (the retry
+        # loop reads it) — but neither credential rotation (the limit is on
+        # the user, not the key) nor provider fallback (the limit follows the
+        # user to any credential on the same account) can help. The body
+        # ``message`` is authoritative and user-actionable.
+        if (
+            error_code
+            and provider in _NOUS_PROVIDER_ALIASES
+            and _is_unrecognized_structured_code(error_code)
+        ):
+            return result_fn(
+                FailoverReason.user_rate_limit,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=False,
             )
         return result_fn(
             FailoverReason.rate_limit,

--- a/agent/error_surface.py
+++ b/agent/error_surface.py
@@ -51,6 +51,10 @@ _REASON_TO_LAYER = {
     "auth_permanent": LAYER_AUTH,
     "billing": LAYER_BILLING,
     "billing_unverified": LAYER_BILLING,
+    # Server-classified authorization rejection (coded 403): the provider's
+    # verdict, not a transport or format problem — the auth layer's
+    # "authentication/authorization failed" framing fits.
+    "entitlement_blocked": LAYER_AUTH,
 }
 
 # Transport-ish reasons: the failure is between us and the base_url, not a
@@ -76,6 +80,8 @@ _NON_RETRYABLE_REASONS = {
     "model_not_found",
     "format_error",
     "ssl_cert_verification",
+    # Server-classified coded 403 — terminal for the request.
+    "entitlement_blocked",
 }
 
 # Providers whose base_url is user-supplied rather than a known vendor —

--- a/cli.py
+++ b/cli.py
@@ -22231,7 +22231,7 @@ def main(
                             _exit_code = 1
                             if os.environ.get("HERMES_KANBAN_TASK") and result.get(
                                 "failure_reason"
-                            ) in ("rate_limit", "billing"):
+                            ) in ("rate_limit", "billing", "user_rate_limit"):
                                 try:
                                     from hermes_cli.kanban_db import (
                                         KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -67,6 +67,7 @@ class TestFailoverReason:
             "multimodal_tool_content_unsupported",
             "provider_policy_blocked",
             "content_policy_blocked",
+            "entitlement_blocked", "user_rate_limit",
             "thinking_signature", "long_context_tier",
             "oauth_long_context_beta_forbidden",
             "llama_cpp_grammar_pattern",

--- a/tests/agent/test_server_coded_errors.py
+++ b/tests/agent/test_server_coded_errors.py
@@ -1,0 +1,435 @@
+"""Server-classified coded errors from the Nous Inference API.
+
+The gateway attaches a machine-readable ``code`` to some error bodies
+alongside the structured extras (``reason``, ``retry_after``, ...). For
+those errors the server's ``message`` is authoritative and user-actionable,
+and the HTTP status carries the retry semantics:
+
+* a 403 with a code is terminal for that request — retrying, refreshing,
+  or rotating credentials cannot change the server's decision;
+* a 429 with a code is a per-user limit that resets on its own schedule
+  (Retry-After is set) — credential rotation and provider fallback both
+  follow the user's account, so neither helps.
+
+The classifier expresses these as ``entitlement_blocked`` (terminal,
+non-rotating, non-falling-back) and ``user_rate_limit`` (retryable with
+Retry-After, non-rotating, non-falling-back) — but ONLY when the code is
+not one the classifier already recognizes (billing codes,
+``resource_exhausted``, ``model_not_found``, ...). Errors with no ``code``
+field are untouched.
+
+All error codes in fixtures are synthetic — they stand in for whatever
+codes the server ships, deliberately resembling none of them.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from agent.error_classifier import (
+    FailoverReason,
+    _known_structured_error_codes,
+    classify_api_error,
+)
+
+
+class MockAPIError(Exception):
+    """Simulates an OpenAI SDK APIStatusError with a structured body."""
+
+    def __init__(self, message, status_code=None, body=None, headers=None):
+        super().__init__(message)
+        self.status_code = status_code
+        self.body = body or {}
+        self.response = SimpleNamespace(headers=headers or {})
+
+
+def _coded_error(status, code, message):
+    """A Nous-shaped coded error body: {status, message, code?}."""
+    return MockAPIError(
+        message,
+        status_code=status,
+        body={"status": status, "message": message, "code": code},
+    )
+
+
+# ── Classifier: unrecognized-code 403 ─────────────────────────────────
+
+class TestCoded403EntitlementBlocked:
+    def test_unknown_code_403_is_entitlement_blocked(self):
+        e = _coded_error(
+            403,
+            "example_terminal_entitlement",
+            "This account may not use that capability. Manage it in the portal.",
+        )
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.entitlement_blocked
+        assert result.retryable is False
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is False
+
+    def test_server_message_preserved_verbatim(self):
+        message = "This account may not use that capability. Manage it in the portal."
+        e = _coded_error(403, "example_terminal_entitlement", message)
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.message == message
+
+    def test_not_auth_reason(self):
+        """is_auth drives the credential-refresh machinery — must stay off."""
+        e = _coded_error(403, "example_terminal_entitlement", "denied")
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.is_auth is False
+
+    def test_provider_aliases_accepted(self):
+        for provider in ("nous", "Nous", "nous-portal", "nousresearch"):
+            e = _coded_error(403, "example_terminal_entitlement", "denied")
+            result = classify_api_error(e, provider=provider, model="m")
+            assert result.reason == FailoverReason.entitlement_blocked, provider
+
+    def test_other_providers_untouched(self):
+        """The rule is Nous-scoped: a coded 403 elsewhere stays generic auth."""
+        e = _coded_error(403, "example_terminal_entitlement", "denied")
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.auth
+        assert result.should_fallback is True
+
+
+# ── Classifier: unrecognized-code 429 ─────────────────────────────────
+
+class TestCoded429UserRateLimit:
+    def test_unknown_code_429_is_user_rate_limit(self):
+        e = _coded_error(
+            429,
+            "example_user_limit",
+            "You have used up your request budget. It resets automatically.",
+        )
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.user_rate_limit
+        assert result.retryable is True
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is False
+
+    def test_server_message_preserved(self):
+        message = "You have used up your request budget. It resets automatically."
+        e = _coded_error(429, "example_user_limit", message)
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.message == message
+
+    def test_retry_after_body_extra_accepted(self):
+        """The structured retry_after extra is valid on a coded body."""
+        e = MockAPIError(
+            "limited",
+            status_code=429,
+            body={
+                "status": 429,
+                "message": "You have used up your request budget.",
+                "code": "example_user_limit",
+                "retry_after": 120,
+            },
+        )
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.user_rate_limit
+
+    def test_other_providers_untouched(self):
+        e = _coded_error(429, "example_user_limit", "too many requests")
+        result = classify_api_error(e, provider="openrouter", model="x")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+
+# ── Classifier: recognized codes and bare errors keep behavior ────────
+
+class TestKnownCodesAndBareErrorsUntouched:
+    def test_known_billing_code_403_stays_billing(self):
+        e = _coded_error(403, "insufficient_credits", "insufficient credits")
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.billing
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_known_resource_exhausted_429_stays_rate_limit(self):
+        e = _coded_error(429, "resource_exhausted", "resource exhausted")
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.rate_limit
+
+    def test_known_model_not_found_404_untouched(self):
+        e = _coded_error(404, "model_not_found", "model not found")
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.model_not_found
+
+    def test_bare_403_without_code_stays_auth(self):
+        e = MockAPIError("Forbidden", status_code=403)
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.auth
+        assert result.should_fallback is True
+
+    def test_bare_429_without_code_stays_rate_limit(self):
+        e = MockAPIError("Too Many Requests", status_code=429)
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+        assert result.should_fallback is True
+
+    def test_billing_message_shape_wins_over_unknown_code(self):
+        """A coded 403 whose message matches billing patterns keeps billing."""
+        e = _coded_error(
+            403,
+            "example_terminal_entitlement",
+            "This request requires available credits. Your account balance is too low.",
+        )
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.billing
+
+    def test_usage_limit_reached_429_keeps_existing_disambiguation(self):
+        """``usage_limit_reached`` has its own status-path behavior."""
+        e = _coded_error(
+            429, "usage_limit_reached", "Your account has reached its usage limit."
+        )
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
+
+    def test_overload_message_429_stays_overloaded(self):
+        e = _coded_error(429, "example_user_limit", "The service is overloaded.")
+        result = classify_api_error(e, provider="nous", model="hermes-4")
+        assert result.reason == FailoverReason.overloaded
+
+    def test_known_code_registry_covers_classifier_claims(self):
+        """The known-code registry is a contract with ``_classify_by_error_code``:
+        every code that function claims must be in the registry, so the
+        unrecognized-code rule can never steal an established classification."""
+        from agent.error_classifier import _classify_by_error_code
+
+        def _claim_probe(code):
+            return _classify_by_error_code(
+                code, "", lambda reason, **kw: SimpleNamespace(reason=reason)
+            )
+
+        claimed = {
+            "resource_exhausted", "throttled", "rate_limit_exceeded",
+            "model_not_found", "model_not_available", "invalid_model",
+            "context_length_exceeded", "max_tokens_exceeded",
+            "invalid_encrypted_content",
+        }
+        for code in claimed:
+            assert _claim_probe(code) is not None, code
+            assert code in _known_structured_error_codes(), code
+
+
+# ── Agent loop: coded 403 aborts with the server message, no recovery ──
+
+def _make_nous_agent():
+    """A minimal AIAgent on the Nous provider that never touches the network."""
+    from run_agent import AIAgent
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://inference-api.nousresearch.com/v1",
+            provider="nous",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    agent.valid_tool_names = set()
+    agent.client = MagicMock()
+    agent._persist_session = lambda *a, **k: None
+    agent._save_trajectory = lambda *a, **k: None
+    agent._cleanup_task_resources = lambda *a, **k: None
+    return agent
+
+
+_SERVER_403_MESSAGE = (
+    "This account may not use that capability. Manage it in the portal."
+)
+
+
+class _Coded403(Exception):
+    status_code = 403
+    body = {
+        "status": 403,
+        "message": _SERVER_403_MESSAGE,
+        "code": "example_terminal_entitlement",
+    }
+
+    def __str__(self):
+        return "Error code: 403 — request rejected"
+
+
+class TestCoded403AbortPath:
+    def test_aborts_with_server_message_no_refresh_no_fallback(self):
+        agent = _make_nous_agent()
+
+        def _fail(api_kwargs):
+            raise _Coded403()
+
+        agent._interruptible_api_call = _fail
+
+        fallback = MagicMock(return_value=True)
+        with (
+            patch.object(agent, "_try_activate_fallback", fallback),
+            patch.object(
+                agent,
+                "_try_refresh_nous_client_credentials",
+                MagicMock(
+                    side_effect=AssertionError(
+                        "Nous credential refresh must not run for a coded 403"
+                    )
+                ),
+            ),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["failed"] is True
+        assert result["failure_reason"] == "entitlement_blocked"
+        assert result["failure_retryable"] is False
+        assert _SERVER_403_MESSAGE in result["error"], (
+            "the server's own message must surface verbatim in the abort notice"
+        )
+        assert "Non-retryable error (HTTP 403)" not in result["error"]
+        fallback.assert_not_called()
+
+    def test_pool_recovery_never_rotates_or_refreshes(self):
+        """The real pool-recovery helper must not touch the pool for this
+        reason — no rotation, no refresh, no exhaustion marking."""
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        agent = _make_nous_agent()
+        pool = MagicMock()
+        pool.provider = ""  # unscoped pool: the provider guard is skipped
+        agent._credential_pool = pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent,
+            status_code=403,
+            has_retried_429=False,
+            classified_reason=FailoverReason.entitlement_blocked,
+        )
+        assert recovered is False
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        pool.try_refresh_matching.assert_not_called()
+
+
+# ── Agent loop: coded 429 waits per Retry-After, rotates/falls back nothing ──
+
+class _Coded429(Exception):
+    status_code = 429
+    body = {
+        "status": 429,
+        "message": "You have used up your request budget. It resets automatically.",
+        "code": "example_user_limit",
+    }
+
+    def __init__(self, retry_after):
+        self.response = SimpleNamespace(headers={"retry-after": str(retry_after)})
+
+    def __str__(self):
+        return "Error code: 429 — limited"
+
+
+class TestCoded429RetryPath:
+    def _run_against_persistent_429(self, agent, retry_after, captured=None):
+        err = _Coded429(retry_after)
+
+        def _fail(api_kwargs):
+            raise err
+
+        agent._interruptible_api_call = _fail
+        if captured is not None:
+            original_buffer = agent._buffer_status
+
+            def _capture(msg, *args, **kwargs):
+                captured.append(msg)
+                return original_buffer(msg, *args, **kwargs)
+
+            agent._buffer_status = _capture
+        return agent.run_conversation("hello")
+
+    def test_retry_after_honored_verbatim(self):
+        """The wait status echoes the server's Retry-After value, not backoff."""
+        agent = _make_nous_agent()
+        agent._credential_pool = None
+        captured = []
+        original_buffer = agent._buffer_status
+
+        def _capture(msg, *args, **kwargs):
+            captured.append(msg)
+            # Interrupt during the wait so the test doesn't sleep 37 real
+            # seconds; the status line was already emitted before the sleep.
+            if "Waiting" in msg:
+                agent._interrupt_requested = True
+            return original_buffer(msg, *args, **kwargs)
+
+        agent._buffer_status = _capture
+        fallback = MagicMock(return_value=True)
+        with patch.object(agent, "_try_activate_fallback", fallback):
+            self._run_against_persistent_429(agent, 37, captured)
+
+        waits = [m for m in captured if "Waiting" in m]
+        assert waits, "expected a rate-limit wait status"
+        assert "Waiting 37.0s" in waits[0], waits[0]
+        fallback.assert_not_called()
+
+    def test_terminal_after_retries_without_fallback_or_rotation(self):
+        """Retries exhaust (tiny Retry-After keeps it fast), then the terminal
+        result names the reason — and no fallback/pool rotation ever ran."""
+        agent = _make_nous_agent()
+        agent._credential_pool = None
+        captured = []
+        fallback = MagicMock(return_value=True)
+        rotate = MagicMock(return_value=None)
+        with (
+            patch.object(agent, "_try_activate_fallback", fallback),
+            patch.object(agent, "_swap_credential", rotate),
+        ):
+            result = self._run_against_persistent_429(agent, 0.1, captured)
+
+        assert result["failed"] is True
+        assert result["failure_reason"] == "user_rate_limit"
+        assert result["failure_retryable"] is True
+        server_message = _Coded429.body["message"]
+        assert server_message in result["error"], (
+            "the server's own message must surface in the terminal notice"
+        )
+        fallback.assert_not_called()
+        rotate.assert_not_called()
+
+    def test_never_writes_shared_rate_limit_state(self):
+        """A coded per-user 429 must not feed the cross-session Nous breaker
+        (agent/nous_rate_guard.py) — tripwire for anyone widening that gate
+        to include the new reason."""
+        import agent.nous_rate_guard as guard
+
+        agent = _make_nous_agent()
+        agent._credential_pool = None
+        with (
+            patch.object(guard, "record_nous_rate_limit") as record,
+            patch.object(guard, "is_genuine_nous_rate_limit", return_value=True),
+        ):
+            self._run_against_persistent_429(agent, 0.1)
+
+        record.assert_not_called()
+
+    def test_pool_recovery_never_rotates_or_refreshes(self):
+        from agent.agent_runtime_helpers import recover_with_credential_pool
+
+        agent = _make_nous_agent()
+        pool = MagicMock()
+        pool.provider = ""  # unscoped pool: the provider guard is skipped
+        agent._credential_pool = pool
+
+        recovered, has_retried = recover_with_credential_pool(
+            agent,
+            status_code=429,
+            has_retried_429=True,
+            classified_reason=FailoverReason.user_rate_limit,
+        )
+        assert recovered is False
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        pool.try_refresh_matching.assert_not_called()


### PR DESCRIPTION
## Aim

When the Nous Inference API attaches a machine-readable `code` to an error body (alongside the structured extras like `reason` / `retry_after`), the server's `message` is authoritative and the HTTP status carries the retry semantics. The classifier currently treats these as generic failures:

- a coded **403** lands as `Non-retryable error (HTTP 403)` via the auth classification — misleading (it points at credential fixes), and it can burn a Nous credential refresh before aborting, which cannot help;
- a coded **429** triggers credential rotation and provider fallback, and feeds the cross-session Nous rate-limit breaker — none of which helps a per-user limit that resets on its own schedule.

## Implementation

Generic rule for Nous-provider errors carrying a `code` the classifier does not already recognize:

- **403 + code → new `FailoverReason.entitlement_blocked`**: terminal for the request — no retry, no credential refresh, no pool rotation, no fallback. The server's `message` surfaces verbatim in the abort notice instead of the generic auth phrasing.
- **429 + code → new `FailoverReason.user_rate_limit`**: retryable and honors Retry-After through the existing rate-limit plumbing, but never rotates credentials, never falls back, and never writes shared rate-limit state.

Codes the classifier already knows (billing codes, `resource_exhausted`, `model_not_found`, `usage_limit_reached`, …) keep their existing behavior via a known-code registry derived from the classifier's own claim sets — errors with no `code` field are completely untouched.

Consumer wiring:

- `agent/conversation_loop.py`: `user_rate_limit` joins the rate-limit retry plumbing (Retry-After / backoff / status lines) but is excluded from the eager-fallback predicate; a `_no_fallback_verdict` guard skips fallback at the client-error abort gate and the max-retries gate; the `entitlement_blocked` abort emits the server message verbatim and stamps it as the turn error; the non-retryable return now carries `failure_reason`/`failure_retryable` like the other terminal paths.
- `agent/error_surface.py`: `entitlement_blocked` maps to the auth layer and the non-retryable set.
- `cli.py`: the kanban worker exit-code classifier treats `user_rate_limit` as a quota wall (EX_TEMPFAIL, no failure count) like `rate_limit`/`billing`.
- The cross-session `agent/nous_rate_guard.py` writer stays uninvolved: its loop call site is gated on `reason == rate_limit`, and a regression test pins that a coded 429 never trips it.

## Tests

`tests/agent/test_server_coded_errors.py` (24 tests, synthetic codes only): classifier rules, known-code/bare-error invariants, a registry-covers-claims contract test, real `run_conversation` abort/retry behavior against a mocked Nous client (verbatim message, no refresh, no rotation, no fallback, Retry-After honored, rate-guard never written). Existing classifier/error-surface/pool suites pass unchanged.