### PR TITLE
feat(gateway): honor adapter-declared session scope for plugin platforms

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -472,12 +472,12 @@ agent's system prompt. It tells the agent:
 ### Construction (`build_session_context`)
 
 ```python
-def build_session_context(source, config, session_entry=None) -> SessionContext
+def build_session_context(source, config, session_entry=None, session_store=None) -> SessionContext
 ```
 
 1. Collects connected platforms from config.
 2. Collects home channels for each platform.
-3. Determines `shared_multi_user_session` via `is_shared_multi_user_session()`.
+3. Determines `shared_multi_user_session` via `is_shared_multi_user_session()` — pass `session_store` so adapter-declared scope overrides are honored; omitting it falls back to the gateway-config defaults, which can disagree with the session key.
 4. Attaches session metadata (key, id, timestamps) if `session_entry` is provided.
 
 ### PII Redaction (`build_session_context_prompt`)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2080,7 +2080,8 @@ if not _configured_cwd or _configured_cwd in CWD_PLACEHOLDERS:
 from gateway.config import (
     ChannelOverride, Platform, GatewayConfig, PlatformConfig, _getenv, load_gateway_config)
 from gateway.session import (
-    AsyncSessionStore, SessionStore, SessionSource, SessionContext, build_session_key)
+    AsyncSessionStore, SessionStore, SessionSource, SessionContext, build_session_key,
+    config_session_scope)
 # Telegram topic routing (#22773, regression fixed #52060): a
 # ``telegram:<positive_chat_id>:<numeric_thread_id>`` cron target is ambiguous — a forum-style topic in a
 # private chat and a genuine Bot API channel Direct-Messages topic share the same shape and need OPPOSITE
@@ -3823,10 +3824,19 @@ class GatewayRunner(
                     _profile = get_active_profile_name() or "default"
                 except Exception:
                     _profile = None
+        group_per_user, thread_per_user = self._resolve_session_scope_for(source)
         return build_session_key(
-            source, group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+            source, group_sessions_per_user=group_per_user, thread_sessions_per_user=thread_per_user,
             profile=_profile)
+
+    def _resolve_session_scope_for(self, source: SessionSource) -> tuple[bool, bool]:
+        """(group_sessions_per_user, thread_sessions_per_user) for *source*: the real store honors
+        adapter-declared overrides; bare/legacy runners and test doubles keep the gateway-config
+        defaults. The one place runner-side code reads isolation flags."""
+        store = getattr(self, "session_store", None)
+        if isinstance(store, SessionStore):
+            return store.resolve_session_scope(source)
+        return config_session_scope(getattr(self, "config", None))
 
     # Telegram General topic in forum-enabled private chats: clients omit message_thread_id or send "1"; both = root.
     _TELEGRAM_GENERAL_TOPIC_IDS = frozenset({"", "1"})

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -23,7 +23,7 @@ from gateway.config import Platform, platform_binds_port as _platform_binds_port
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.restart import is_global_startup_conflict
 from gateway.run_shutdown import _log_suppressed
-from gateway.session import SessionSource
+from gateway.session import SessionSource, SessionStore, config_session_scope
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, Optional
 
@@ -1005,7 +1005,8 @@ class GatewayAdapterLifecycleMixin:
                 credential_claim, claimed, profile_name, platform, "credential"
             ) or self._refuse_duplicate_claim(listener_claim, claimed, profile_name, platform, "listener"):
                 continue
-            self._configure_profile_adapter(adapter, profile_name, platform)
+            self._configure_profile_adapter(
+                adapter, profile_name, platform, scope_defaults=config_session_scope(profile_cfg))
             try:
                 with _profile_runtime_scope(profile_home, hydrate_secrets=False):
                     success = await self._connect_initial_adapter_with_timeout(adapter, platform)
@@ -1029,16 +1030,40 @@ class GatewayAdapterLifecycleMixin:
             logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
         return connected
 
+    def _register_adapter_session_scope(
+        self, adapter, profile: Optional[str] = None, scope_defaults: Optional[tuple] = None,
+    ) -> None:
+        """Register the adapter's ``config.extra`` isolation flags with the store, keyed (profile,
+        platform), so plugin/out-of-tree platforms with no config.platforms entry key sessions the way
+        the adapter asks. Runs at handler wiring — BEFORE ``connect()``, which is where Telegram polling
+        / webhooks go inbound-reachable. A missing or explicit ``None`` flag becomes the OWNING gateway
+        config's default (``scope_defaults``: a secondary profile's; the primary's otherwise) and is
+        written back, so the adapter's own key derivation reads the same concrete tuple. Bare/legacy
+        runners without a real store (test doubles) skip registration."""
+        extra = getattr(getattr(adapter, "config", None), "extra", None)
+        store = getattr(self, "session_store", None)
+        if not isinstance(extra, dict) or not isinstance(store, SessionStore):
+            return
+        defaults = scope_defaults or config_session_scope(getattr(self, "config", None))
+        for key, default in zip(("group_sessions_per_user", "thread_sessions_per_user"), defaults):
+            if extra.get(key) is None:
+                extra[key] = default
+        store.register_platform_session_scope(
+            adapter.platform.value, group_sessions_per_user=extra["group_sessions_per_user"],
+            thread_sessions_per_user=extra["thread_sessions_per_user"], profile=profile)
+
     def _wire_adapter_handlers(
         self, adapter: BasePlatformAdapter, *, message_handler=None, fatal_error_handler=None,
         busy_session_handler=None, authorization_check=None, platform_event_handler=None,
-        busy_text_mode: Optional[str] = None,
+        busy_text_mode: Optional[str] = None, profile: Optional[str] = None,
+        scope_defaults: Optional[tuple] = None,
     ) -> None:
         """Install the runner callbacks every adapter needs (defaults = primary handlers;
         secondary wiring passes profile-scoped variants). ``set_reaction_handler`` is optional."""
         adapter.set_message_handler(message_handler or self._primary_message_handler())
         adapter.set_fatal_error_handler(fatal_error_handler or self._handle_adapter_fatal_error)
         adapter.set_session_store(self.session_store)
+        self._register_adapter_session_scope(adapter, profile=profile, scope_defaults=scope_defaults)
         adapter.set_busy_session_handler(busy_session_handler or self._handle_active_session_busy_message)
         _set_reaction = getattr(adapter, "set_reaction_handler", None)
         if callable(_set_reaction):
@@ -1051,9 +1076,11 @@ class GatewayAdapterLifecycleMixin:
         adapter._busy_text_mode = (self._busy_text_mode if busy_text_mode is None else busy_text_mode)
 
     def _configure_profile_adapter(
-        self, adapter: BasePlatformAdapter, profile_name: str, platform: Platform
+        self, adapter: BasePlatformAdapter, profile_name: str, platform: Platform,
+        scope_defaults: Optional[tuple] = None,
     ) -> None:
-        """Install the profile-scoped handlers shared by startup and reconnect."""
+        """Install the profile-scoped handlers shared by startup and reconnect. ``scope_defaults`` is
+        the OWNING profile's gateway isolation defaults (its config, not the primary's)."""
         # Runtime status is process-scoped: key on profile:platform so health shows WHICH secondary failed.
         adapter._runtime_status_platform_key = f"{profile_name}:{platform.value}"
         # Declare ownership BEFORE any inbound event: adapter-level session keys are derived at ingress,
@@ -1071,6 +1098,7 @@ class GatewayAdapterLifecycleMixin:
             busy_session_handler=self._make_profile_busy_session_handler(profile_name),
             authorization_check=self._make_adapter_auth_check(platform, profile_name=profile_name),
             platform_event_handler=self._make_profile_platform_event_handler(profile_name),
+            profile=profile_name, scope_defaults=scope_defaults,
             busy_text_mode=(
                 text_modes.get(profile_name, self._busy_text_mode)
                 if isinstance(text_modes, dict)
@@ -1096,7 +1124,8 @@ class GatewayAdapterLifecycleMixin:
         # Hydrate external secret sources off-loop so they cannot starve heartbeats.
         await asyncio.to_thread(hydrate_profile_secret_sources, profile_home)
         with _profile_runtime_scope(profile_home, hydrate_secrets=False):
-            profile_config = load_gateway_config().platforms.get(platform)
+            profile_gateway_cfg = load_gateway_config()
+            profile_config = profile_gateway_cfg.platforms.get(platform)
             if profile_config is None or not profile_config.enabled:
                 return None, None
             # Startup credential gate mirror: a removed credential must not rebuild.
@@ -1116,7 +1145,9 @@ class GatewayAdapterLifecycleMixin:
                 )
                 return None, None
             try:
-                self._configure_profile_adapter(adapter, profile_name, platform)
+                self._configure_profile_adapter(
+                    adapter, profile_name, platform,
+                    scope_defaults=config_session_scope(profile_gateway_cfg))
                 success = await self._connect_adapter_with_timeout(adapter, platform, is_reconnect=True)
             except BaseException:
                 # Caller never sees this adapter; release its partial resources here.
@@ -1442,11 +1473,6 @@ class GatewayAdapterLifecycleMixin:
     def _instantiate_adapter(self, platform: Platform, config: Any) -> Optional[BasePlatformAdapter]:
         """Instantiate the adapter for a platform: plugin registry first, then built-ins."""
         from gateway.run import _instantiate_builtin_adapter
-        if hasattr(config, "extra") and isinstance(config.extra, dict):
-            config.extra.setdefault("group_sessions_per_user", self.config.group_sessions_per_user)
-            config.extra.setdefault(
-                "thread_sessions_per_user", getattr(self.config, "thread_sessions_per_user", False)
-            )
         with _log_suppressed(logging.DEBUG, "Platform registry lookup for '%s' failed: %s", platform.value):
             from gateway.platform_registry import platform_registry
             if platform_registry.is_registered(platform.value):

--- a/gateway/run_inbound.py
+++ b/gateway/run_inbound.py
@@ -1322,9 +1322,9 @@ class GatewayInboundMixin:
 
     def _prefix_inbound_sender_context(self, event: MessageEvent, source: SessionSource, message_text: str) -> str:
         """Attribute the sender in shared multi-user sessions and prepend history-backfill channel context."""
+        _group_per_user, _thread_per_user = self._resolve_session_scope_for(source)
         _is_shared_multi_user = is_shared_multi_user_session(
-            source, group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
+            source, group_sessions_per_user=_group_per_user, thread_sessions_per_user=_thread_per_user,
         )
         if _is_shared_multi_user and source.user_name:
             # Display names are attacker-influenceable: neutralize newlines/control chars or a

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -20,7 +20,7 @@ from gateway.config import Platform
 from gateway.delivery import looks_like_telegram_private_chat_id
 from gateway.platforms.base import BasePlatformAdapter
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.session import SessionSource, build_session_key
+from gateway.session import SessionSource
 from gateway.restart import (
     DEFAULT_GATEWAY_CRON_DRAIN_TIMEOUT, GATEWAY_FATAL_CONFIG_EXIT_CODE, is_global_startup_conflict
 )
@@ -1452,39 +1452,15 @@ class GatewayStartupMixin:
             handoff_config=handoff_config,
         )
 
-    def _handoff_session_key(self, dest, profile_name: Optional[str]) -> str:
-        """Destination session_key by the adapters' own rules. Thread keys omit user_id so the next
-        message shares it. Namespaced to the queuing profile (else a multiplexed gateway builds
-        ``agent:main:...`` while the profile's adapter routes on ``agent:<profile>:...``); the store
-        resolver is only the root fallback. The isinstance check is load-bearing: a Mock store returns
-        a truthy MagicMock."""
-        platform_cfg = dest.handoff_config.platforms.get(dest.platform)
-        extra = platform_cfg.extra if platform_cfg else {}
-        handoff_profile = profile_name if (profile_name and profile_name != "default") else None
-        if handoff_profile is None:
-            try:
-                store = getattr(self.async_session_store, "_store", self.async_session_store)
-                resolver = getattr(store, "_resolve_profile_for_key", None)
-                # Resolve the bound text channel's channel_prompt so voice input gets the same per-channel
-                # context as typed messages (#50149).
-                if callable(resolver):
-                    resolved = resolver(dest.source)
-                    if isinstance(resolved, str) and resolved.strip():
-                        handoff_profile = resolved
-            except Exception:
-                logger.debug("Handoff: could not resolve profile namespace", exc_info=True)
-        return build_session_key(
-            dest.source, group_sessions_per_user=extra.get("group_sessions_per_user", True),
-            thread_sessions_per_user=extra.get("thread_sessions_per_user", False), profile=handoff_profile,
-        )
-
     async def _process_handoff(self, row: Dict[str, Any], profile_name: Optional[str] = None) -> None:
         """Execute one handoff row; raises on failure (caller marks failed). ``profile_name`` (None =
         root) is the profile whose store queued it — load-bearing under multiplex: secondaries live in
         ``_profile_adapters`` and the key must be namespaced ``agent:<profile>:...`` or nobody reads it."""
         cli_session_id = row["id"]
         dest = await self._handoff_resolve_destination(row, profile_name)
-        session_key = self._handoff_session_key(dest, profile_name)
+        # dest.source carries the queuing profile, so the store namespaces the key ``agent:<profile>:...``
+        # under multiplex (else nobody reads it) and honors adapter-declared scope like every other site.
+        session_key = self._session_key_for_source(dest.source)
         # Ensure a session_store entry exists for this key; switch_session then re-points it.
         await self.async_session_store.get_or_create_session(dest.source)
         # switch_session ends the prior session and reopens the CLI session under the new key.

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1830,7 +1830,7 @@ class GatewayTurnMixin:
         running (history unreadable); ``None`` drops the turn (inbound text rejected)."""
         from gateway.run import _load_gateway_config
         _was_auto_reset, _is_new_session = await self._hmwa_open_session(session_entry, session_key, source)
-        context = build_session_context(source, self.config, session_entry)
+        context = build_session_context(source, self.config, session_entry, session_store=self.session_store)
         # Session context variables for tools (task-local, concurrency-safe)
         _session_env_tokens = self._set_session_env(context)
         # Self-injected turns (MessageEvent(internal=True)) persist with a DB-only display_kind so

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -1168,14 +1168,26 @@ class SessionStore(
             return entry.session_id if entry else None
 
 
+def config_session_scope(config: Any) -> tuple[bool, bool]:
+    """(group_sessions_per_user, thread_sessions_per_user) from the gateway config — the default
+    every scope resolver falls back to when no adapter registered an override."""
+    return (getattr(config, "group_sessions_per_user", True),
+            getattr(config, "thread_sessions_per_user", False))
+
+
 def build_session_context(
-    source: SessionSource, config: GatewayConfig, session_entry: Optional[SessionEntry] = None
+    source: SessionSource, config: GatewayConfig, session_entry: Optional[SessionEntry] = None,
+    session_store: Optional["SessionStore"] = None,
 ) -> SessionContext:
-    """Build a full session context (for system prompt injection)."""
+    """Build a full session context (for system prompt injection). Pass ``session_store`` so the
+    shared-session flag honors adapter-declared scope and stays in lock-step with the session key;
+    without it the gateway-config defaults apply."""
     connected = config.get_connected_platforms()
+    group_per_user, thread_per_user = (
+        session_store.resolve_session_scope(source) if isinstance(session_store, SessionStore)
+        else config_session_scope(config))
     shared = is_shared_multi_user_session(
-        source, group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
-        thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
+        source, group_sessions_per_user=group_per_user, thread_sessions_per_user=thread_per_user,
     )
     context = SessionContext(
         source=source, connected_platforms=connected, shared_multi_user_session=shared,

--- a/gateway/session_recovery.py
+++ b/gateway/session_recovery.py
@@ -87,14 +87,46 @@ class SessionRecoveryMixin:
             return requested_profile is None or recovered_profile == requested_profile
         return recovered_profile == self._active_profile_name()
 
+    def register_platform_session_scope(
+        self, platform: str, *, group_sessions_per_user: bool, thread_sessions_per_user: bool,
+        profile: Optional[str] = None,
+    ) -> None:
+        """Record an accepted adapter's resolved isolation flags so the store — the owner of routing
+        keys — keys that platform's sources the way the adapter does, even when the platform has no
+        entry in the gateway's config.platforms map (plugin/out-of-tree adapters). Keyed per
+        (profile, platform) so one multiplexed profile's override cannot leak into another's;
+        ``profile=None`` is the default for any profile without its own registration."""
+        # (profile, platform value) -> (group_per_user, thread_per_user); consulted before the
+        # gateway-config defaults by resolve_session_scope().
+        self._lazy("_platform_session_scope", dict)[(profile, platform)] = (
+            bool(group_sessions_per_user), bool(thread_sessions_per_user))
+
+    def resolve_session_scope(
+        self, source: SessionSource, profile: Optional[str] = None
+    ) -> tuple[bool, bool]:
+        """(group_sessions_per_user, thread_sessions_per_user) for *source*: the scope its adapter
+        registered for (profile, platform), else the gateway-config defaults. Every key derivation
+        and every guard that must agree with key shape resolves through here."""
+        platform_value = getattr(source.platform, "value", str(source.platform))
+        if profile is None:
+            profile = self._resolve_profile_for_key(source)
+        registry = self._lazy("_platform_session_scope", dict)
+        for profile_key in (profile, None):
+            scope = registry.get((profile_key, platform_value))
+            if scope is not None:
+                return scope
+        from gateway.session import config_session_scope
+        return config_session_scope(self.config)
+
     def _generate_session_key(self, source: SessionSource, key_source: Optional[SessionSource] = None) -> str:
         """Session key for *source* (profile from *source*; key from *key_source* if given)."""
         from gateway.session import build_session_key
+        profile = self._resolve_profile_for_key(source)
+        group_per_user, thread_per_user = self.resolve_session_scope(source, profile=profile)
         return build_session_key(
             key_source if key_source is not None else source,
-            group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
-            profile=self._resolve_profile_for_key(source))
+            group_sessions_per_user=group_per_user, thread_sessions_per_user=thread_per_user,
+            profile=profile)
 
     def _legacy_slack_session_key(self, source: SessionSource) -> Optional[str]:
         """Pre-workspace Slack key for an explicitly scoped source. Deliberately Slack-only: an

--- a/gateway/slash_commands_session.py
+++ b/gateway/slash_commands_session.py
@@ -19,7 +19,7 @@ from agent.turn_context import extract_api_content_sidecar
 from gateway.config import Platform
 from gateway.platforms.base import EphemeralReply
 from gateway.platforms.event import MessageEvent, MessageType
-from gateway.session import SessionSource, build_session_key, is_shared_multi_user_session
+from gateway.session import SessionSource, is_shared_multi_user_session
 from gateway.session_transcript import TranscriptReadError
 from gateway.slash_commands_status import HISTORY_UNREADABLE
 
@@ -293,9 +293,9 @@ class GatewaySessionCommandsMixin:
     def _is_shared_session_source(self, source: SessionSource) -> bool:
         """Whether *source*'s session key is shared by every participant (not per-user); mirrors
         build_session_key's isolation rules so the guards stay in lock-step with the key."""
+        group_per_user, thread_per_user = self._resolve_session_scope_for(source)
         return is_shared_multi_user_session(
-            source, group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
-            thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False))
+            source, group_sessions_per_user=group_per_user, thread_sessions_per_user=thread_per_user)
 
     def _resume_caller_is_admin(self, source: SessionSource) -> bool:
         """Whether *source* is an EXPLICITLY-configured admin (cross-origin /resume, /sessions).
@@ -443,7 +443,7 @@ class GatewaySessionCommandsMixin:
             return t("gateway.undo.nothing")
         session_entry.last_prompt_tokens = 0  # transcript was truncated
         try:
-            self._evict_cached_agent(build_session_key(source))
+            self._evict_cached_agent(self._session_key_for_source(source))
         except Exception as e:
             logger.debug("undo: cached-agent eviction skipped: %s", e)
         target_text = result["target_text"]

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -5734,19 +5734,29 @@ class SlackAdapter(BasePlatformAdapter):
         """Thread session key via ``build_session_key()`` (honours per-user isolation).
         ``chat_type`` must come from the event's ``channel_type``, not the ID prefix (MPIM ids
         start with ``G``)."""
-        session_store = getattr(self, "_session_store", None)
-        if not session_store:
+        if not getattr(self, "_session_store", None):
             return None
         try:
             from gateway.session import build_session_key
             source = self._thread_session_source(channel_id, thread_ts, user_id, team_id, chat_type)
-            store_cfg = getattr(session_store, "config", None)
+            group_per_user, thread_per_user = self._thread_scope(source)
             return build_session_key(
-                source, group_sessions_per_user=getattr(store_cfg, "group_sessions_per_user", True),
-                thread_sessions_per_user=getattr(store_cfg, "thread_sessions_per_user", False),
+                source, group_sessions_per_user=group_per_user, thread_sessions_per_user=thread_per_user,
                 profile=self._session_key_profile(source))
         except Exception:
             return None
+
+    def _thread_scope(self, source: Any) -> tuple:
+        """(group_sessions_per_user, thread_sessions_per_user) for a thread source: the store's
+        registry-aware resolver (adapter-declared scope) when it is a real store, else its config.
+        Resolved under the ADAPTER's owning profile — the same namespace ``build_session_key`` gets
+        two lines later — not the store's active-profile guess (a secondary Slack bot would miss its
+        own registration otherwise)."""
+        from gateway.session import SessionStore, config_session_scope
+        store = getattr(self, "_session_store", None)
+        if isinstance(store, SessionStore):
+            return store.resolve_session_scope(source, profile=self._session_key_profile(source))
+        return config_session_scope(getattr(store, "config", None))
 
     @staticmethod
     def _thread_session_source(
@@ -5761,8 +5771,9 @@ class SlackAdapter(BasePlatformAdapter):
         """Per-process key for the once-per-thread rehydration check; per-user when
         ``thread_sessions_per_user`` is on, like the session key."""
         key = f"{team_id}:{channel_id}:{thread_ts}"
-        store_cfg = getattr(getattr(self, "_session_store", None), "config", None)
-        return f"{key}:{user_id}" if getattr(store_cfg, "thread_sessions_per_user", False) else key
+        _, thread_per_user = self._thread_scope(
+            self._thread_session_source(channel_id, thread_ts, user_id, team_id, "group"))
+        return f"{key}:{user_id}" if thread_per_user else key
 
     def _mark_thread_rehydration_checked(
         self, channel_id: str, thread_ts: str, user_id: str, team_id: str = "") -> None:

--- a/tests/gateway/test_resume_command.py
+++ b/tests/gateway/test_resume_command.py
@@ -876,6 +876,34 @@ class TestSameOriginChatGroupScoping:
                              user_id_alt=user_id_alt, thread_id=thread_id)
 
 
+    def test_same_origin_honors_adapter_registered_override(self, tmp_path):
+        """An adapter-registered shared scope must flip the IDOR guard the
+        same way it flips the session key: with group_sessions_per_user=False
+        registered for the platform, co-members share the session (guard
+        allows); without the registration the config default (per-user)
+        blocks. Exercises the real SessionStore resolution, not the mock."""
+        from gateway.session import SessionStore
+
+        runner = _make_runner()
+        runner.config.group_sessions_per_user = True
+        runner.session_store = SessionStore(
+            sessions_dir=tmp_path, config=runner.config
+        )
+        alice, bob = self._src("alice"), self._src("bob")
+        assert runner._same_origin_chat(alice, bob) is False
+
+        runner.session_store.register_platform_session_scope(
+            "discord",
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+        )
+        assert runner._same_origin_chat(alice, bob) is True
+        # The runner-side key every slash/control consumer uses must be byte-identical
+        # to the store's routing key, else control plane and persistence split.
+        store_key = runner.session_store.get_or_create_session(alice).session_key
+        assert store_key == "agent:main:discord:group:guild-123"
+        assert runner._session_key_for_source(alice) == store_key
+
     def test_dm_cross_user_blocked_without_chat_id(self):
         # No-chat_id DM: build_session_key falls back to the participant id
         # (user_id_alt or user_id), so two different participants are different

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -19,6 +19,12 @@ from gateway.session import (
     neutralize_untrusted_inline_text,
 )
 
+
+def discord_group_source(**overrides) -> SessionSource:
+    """A Discord group-chat source (the registered-scope tests' shared shape)."""
+    values = {"platform": Platform.DISCORD, "chat_id": "guild-123", "chat_type": "group", "user_id": "alice"}
+    return SessionSource(**(values | overrides))
+
 # Legacy name preserved for these tests; product renamed the function to
 # canonical_whatsapp_identifier.  Keep the tests referencing the old name
 # working without duplicating the suite.
@@ -700,6 +706,127 @@ class TestWhatsAppSessionKeyConsistency:
         assert first_entry.session_key == "agent:main:discord:group:guild-123"
         assert second_entry.session_key == "agent:main:discord:group:guild-123"
         assert first_entry.session_id == second_entry.session_id
+
+    @pytest.mark.parametrize(
+        ("registered", "expected_shared"),
+        [
+            pytest.param(True, True, id="adapter-override-shares"),
+            pytest.param(False, False, id="unregistered-follows-global"),
+        ],
+    )
+    def test_adapter_declared_scope_beats_global_default(
+        self, store, registered, expected_shared
+    ):
+        """A platform absent from config.platforms (plugin/out-of-tree
+        adapter) keys sessions by its adapter-registered scope; without a
+        registration the global default still governs.
+
+        Regression: plugin adapters set extra.group_sessions_per_user on
+        their own PlatformConfig, but the store derived keys from the global
+        gateway config only, so a plugin group chat silently split into
+        per-user sessions and cross-contaminated multi-user context."""
+        store.config.group_sessions_per_user = True  # global default: isolated
+        if registered:
+            store.register_platform_session_scope(
+                "discord",
+                group_sessions_per_user=False,
+                thread_sessions_per_user=False,
+            )
+
+        alice = discord_group_source(user_name="Alice")
+        bob = discord_group_source(user_id="bob", user_name="Bob")
+
+        alice_entry = store.get_or_create_session(alice)
+        bob_entry = store.get_or_create_session(bob)
+
+        if expected_shared:
+            assert alice_entry.session_key == "agent:main:discord:group:guild-123"
+            assert alice_entry.session_key == bob_entry.session_key
+            assert alice_entry.session_id == bob_entry.session_id
+        else:
+            assert alice_entry.session_key != bob_entry.session_key
+            assert alice_entry.session_id != bob_entry.session_id
+
+    def test_adapter_declared_scope_is_profile_keyed(self, store):
+        """One profile's override must not leak into another profile's key
+        shape: a registration for a named profile is invisible to the active
+        (default) profile, while a profile=None registration is the
+        every-profile default."""
+        store.config.group_sessions_per_user = True
+        store.register_platform_session_scope(
+            "discord",
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+            profile="eva",
+        )
+
+        source = discord_group_source()
+        # Active profile has no registration — global default (isolated) wins.
+        assert store.resolve_session_scope(source) == (True, False)
+
+        store.register_platform_session_scope(
+            "discord",
+            group_sessions_per_user=False,
+            thread_sessions_per_user=True,
+        )
+        assert store.resolve_session_scope(source) == (False, True)
+
+        # Multiplexed: a source on "eva" gets eva's registration; a profile with
+        # no registration of its own falls through to the profile=None default.
+        store.config.multiplex_profiles = True
+        eva = replace(source, profile="eva")
+        other = replace(source, profile="other")
+        assert store.resolve_session_scope(eva) == (False, False)
+        assert store.resolve_session_scope(other) == (False, True)
+
+    def test_session_context_shared_flag_follows_adapter_scope(self, store):
+        """The agent-facing shared_multi_user_session flag must agree with
+        the session key: an adapter-declared shared group is announced as
+        multi-user even when the global default would isolate it."""
+        from gateway.session import build_session_context
+
+        store.config.group_sessions_per_user = True
+        store.register_platform_session_scope(
+            "discord",
+            group_sessions_per_user=False,
+            thread_sessions_per_user=False,
+        )
+        source = discord_group_source()
+
+        with_store = build_session_context(
+            source, store.config, session_store=store
+        )
+        without_store = build_session_context(source, store.config)
+
+        assert with_store.shared_multi_user_session is True
+        assert without_store.shared_multi_user_session is False
+
+    def test_secondary_adapter_scope_seeds_from_owning_profile_defaults(self, tmp_path):
+        """Registration seeds a missing/None isolation flag from the OWNING gateway config (a
+        secondary profile's, not the primary's), writes it into config.extra, and resolves that
+        tuple under the adapter's profile. Primary group_sessions_per_user=False must not leak
+        into a secondary that isolates."""
+        from types import SimpleNamespace
+
+        from gateway.run import GatewayRunner
+
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner.config = GatewayConfig(
+            group_sessions_per_user=False, thread_sessions_per_user=False, multiplex_profiles=True,
+        )
+        runner.session_store = SessionStore(sessions_dir=tmp_path, config=runner.config)
+        extra = {"group_sessions_per_user": None, "thread_sessions_per_user": False}
+        adapter = SimpleNamespace(platform=Platform.DISCORD, config=SimpleNamespace(extra=extra))
+
+        runner._register_adapter_session_scope(adapter, profile="eva", scope_defaults=(True, True))
+
+        # None seeded from the secondary's default (True), explicit False kept and written back.
+        assert extra == {"group_sessions_per_user": True, "thread_sessions_per_user": False}
+        assert runner.session_store.resolve_session_scope(discord_group_source(profile="eva")) == (True, False)
+        # A primary adapter (no owning defaults passed) seeds from the primary config.
+        primary = SimpleNamespace(platform=Platform.DISCORD, config=SimpleNamespace(extra={}))
+        runner._register_adapter_session_scope(primary)
+        assert primary.config.extra == {"group_sessions_per_user": False, "thread_sessions_per_user": False}
 
     def test_telegram_dm_includes_chat_id(self):
         """Non-WhatsApp DMs should also include chat_id to separate users."""

--- a/tests/gateway/test_slack_channel_session_scope.py
+++ b/tests/gateway/test_slack_channel_session_scope.py
@@ -162,3 +162,28 @@ class TestThreadReplyAlwaysScopesByThread:
             f"thread reply dropped with reply_in_thread={reply_in_thread}"
         )
         assert captured[0].source.thread_id == "1700000000.000009"
+
+
+def test_thread_keys_follow_adapter_registered_scope_under_owning_profile(adapter, tmp_path):
+    """A secondary (multiplexed) Slack bot's thread session key and rehydration key must follow the
+    scope its adapter registered under ITS profile — not the gateway default, and not a lookup
+    under the store's active-profile guess."""
+    from gateway.config import GatewayConfig
+    from gateway.session import SessionStore
+
+    cfg = GatewayConfig(group_sessions_per_user=True, thread_sessions_per_user=False,
+                        multiplex_profiles=True)
+    adapter._session_store = SessionStore(sessions_dir=tmp_path, config=cfg)
+    adapter._owner_profile = "eva"
+    # Another profile's per-user-thread registration is invisible to eva: shared thread key.
+    adapter._session_store.register_platform_session_scope(
+        "slack", group_sessions_per_user=True, thread_sessions_per_user=True, profile="other")
+    assert adapter._build_thread_session_key("C1", "111.222", "U1", "T1") == (
+        "agent:eva:slack:group:T1:C1:111.222")
+    assert adapter._thread_rehydration_key("C1", "111.222", "U1", "T1") == "T1:C1:111.222"
+
+    adapter._session_store.register_platform_session_scope(
+        "slack", group_sessions_per_user=True, thread_sessions_per_user=True, profile="eva")
+    assert adapter._build_thread_session_key("C1", "111.222", "U1", "T1") == (
+        "agent:eva:slack:group:T1:C1:111.222:U1")
+    assert adapter._thread_rehydration_key("C1", "111.222", "U1", "T1") == "T1:C1:111.222:U1"


### PR DESCRIPTION
## What

`SessionStore` derives `group_sessions_per_user` / `thread_sessions_per_user` from the **global gateway config only**, so a platform adapter that declares its own isolation in `config.extra` is silently ignored on the main dispatch path. #81207 / #84925 fix this for platforms present in the gateway's `config.platforms` map — but a **plugin / out-of-tree platform adapter has no entry there**, so it falls through those fixes too.

This PR adds the missing seam: adapters register their resolved scope with the session store when their handlers are wired (before `connect()`), and every key derivation and every guard that must agree with key shape resolves through that registry before falling back to the gateway defaults.

- `SessionStore.register_platform_session_scope(platform, *, group_sessions_per_user, thread_sessions_per_user, profile=None)` / `resolve_session_scope(source, profile=None)` — keyed per `(profile, platform)` so multiplexed profiles can't leak overrides into each other; `profile=None` is the any-profile default. `_generate_session_key` resolves through it.
- `GatewayAdapterLifecycleMixin._register_adapter_session_scope` — runs from `_wire_adapter_handlers` (primary and secondary, via `_configure_profile_adapter`), i.e. **before `connect()`**, where Telegram polling / webhooks become inbound-reachable. A missing or explicit-`None` flag is seeded from the **owning** gateway config (a secondary profile's, not the primary's) and written back to `config.extra`, so adapter-side key derivation reads the same concrete tuple. The instantiate-time primary-config seed is deleted.
- `GatewayRunner._resolve_session_scope_for` — the one runner-side read of isolation flags: `_session_key_for_source`'s no-store fallback, the inbound sender-attribution gate, and the `/resume` IDOR guards (`_is_shared_session_source`) use it; `build_session_context` takes `session_store` so the agent-facing `shared_multi_user_session` flag agrees with the key.
- **One key owner everywhere:** `/undo` evicts under `_session_key_for_source`; the voice-handoff destination uses it too (`_handoff_session_key` deleted — `dest.source` already carries the queuing profile); Slack's thread / rehydration keys resolve through the store under the adapter's owning profile.
- `config_session_scope(config)` owns the config-default pair.

**Composes with #84925**: registry → platform-config → defaults. Both now touch the `_configure_profile_adapter` / `_wire_adapter_handlers` seam; whichever lands second gets a small rebase.

## Why (production incident)

An iMessage-plugin deployment set `group_sessions_per_user: false` on the plugin's `PlatformConfig.extra` so a family group chat would share one context. The store never saw it: each family member got an isolated per-user session, and the agent answered one member's question with another member's unrelated task thread (a toll-bill payment status in reply to a calendar question). Since the platform came from a plugin, no amount of `config.platforms` fixing reaches it — the adapter itself is the only owner of that declaration.

## How to test

`scripts/run_tests.sh tests/gateway/` — new tests:

- `test_adapter_declared_scope_beats_global_default` (registered override shares the group session; unregistered platform still follows the global default),
- `test_adapter_declared_scope_is_profile_keyed` (named-profile registration is invisible to other profiles; under `multiplex_profiles` a source on that profile resolves it; `profile=None` is the every-profile default),
- `test_session_context_shared_flag_follows_adapter_scope` (agent-facing flag agrees with the key),
- `test_secondary_adapter_scope_seeds_from_owning_profile_defaults` (a secondary's missing flag seeds from its own profile's config, not the primary's, and is written back),
- `test_same_origin_honors_adapter_registered_override` (the IDOR guard flips with the registered scope through a real `SessionStore`, and the runner key is byte-identical to the store key),
- `test_thread_keys_follow_adapter_registered_scope_under_owning_profile` (a secondary Slack bot's thread + rehydration keys follow its own profile's registration).

Manual: run a gateway with any platform adapter whose `extra.group_sessions_per_user` differs from the global default; have two users message the same group; confirm one shared session key (`agent:main:<platform>:group:<chat_id>` with no per-user suffix).

Single commit, rebased onto current `main` (post `run.py` mixin split). +313/−66. Tested on macOS (full `tests/gateway/`; five pre-existing macOS-only failures fail identically on `main`).

Related: #81207, #84925, and the session-key half of #81860 (handoff destination-shape ownership stays adjacent, unchanged here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lqr7yMugdYt53YxrszjnSG
