### PR TITLE
feat(api): propagate authenticated external turn correlation

### DIFF
--- a/.github/workflows/basshub-companion-image.yml
+++ b/.github/workflows/basshub-companion-image.yml
@@ -1,0 +1,45 @@
+name: BassHUB companion image
+
+# Builds the companion Hermes image (MCP approval-origin forwarding +
+# authenticated X-Hermes-Turn-Id) and publishes it to GHCR under an immutable
+# digest, as required by BassHUB v0.2.27+ inline-approval provisioning
+# (deploy/hermes/NOTES.md: stock nousresearch/hermes-agent is origin-blind and
+# scripts/hermes-user.sh refuses non-digest images).
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        id: push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/iammrbass/hermes-agent-basshub:companion-${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Print immutable reference
+        run: |
+          echo "IMMUTABLE IMAGE: ghcr.io/iammrbass/hermes-agent-basshub@${{ steps.push.outputs.digest }}"
+          echo "BUILT FROM: ${{ github.sha }}"

--- a/.github/workflows/basshub-companion-image.yml
+++ b/.github/workflows/basshub-companion-image.yml
@@ -7,6 +7,9 @@ name: BassHUB companion image
 # scripts/hermes-user.sh refuses non-digest images).
 on:
   workflow_dispatch:
+  push:
+    branches: [integration/basshub-v0.2.27-modern]
+    paths: ['.github/workflows/basshub-companion-image.yml']
 
 permissions:
   contents: read

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -5049,6 +5049,13 @@ class APIServerAdapter(BasePlatformAdapter):
         if limited is not None:
             return limited
 
+        external_turn_id = request.headers.get("X-Hermes-Turn-Id")
+        if external_turn_id is not None:
+            if not self._api_key:
+                return web.json_response(_openai_error("External turn correlation requires API key authentication"), status=403)
+            if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", external_turn_id):
+                return web.json_response(_openai_error("Invalid external turn ID"), status=400)
+
         # Parse request body
         try:
             body = await request.json()
@@ -5273,6 +5280,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 tool_complete_callback=_on_tool_complete,
                 agent_ref=agent_ref,
                 gateway_session_key=gateway_session_key,
+                external_turn_id=external_turn_id,
                 **agent_overrides,
                 route=route,
             ))
@@ -5294,6 +5302,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 ephemeral_system_prompt=system_prompt,
                 session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                external_turn_id=external_turn_id,
                 **agent_overrides,
                 route=route,
             )
@@ -7265,6 +7274,7 @@ class APIServerAdapter(BasePlatformAdapter):
         requested_runtime: Optional[Dict[str, Any]] = None,
         route_source: str = "global",
         confirmed_runtime_lock: bool = False,
+        external_turn_id: Optional[str] = None,
     ) -> tuple:
         """
         Create an agent and run a conversation in a thread executor.
@@ -7355,11 +7365,14 @@ class APIServerAdapter(BasePlatformAdapter):
                     # ``agent_ref``, and only /v1/runs has a run_id, so neither
                     # is a usable hook for the rest.
                     self._shutdown_interruptible_agents[id(agent)] = agent
-                    result = agent.run_conversation(
+                    conversation_kwargs = dict(
                         user_message=user_message,
                         conversation_history=conversation_history,
                         task_id=effective_task_id,
                     )
+                    if external_turn_id is not None:
+                        conversation_kwargs["external_turn_id"] = external_turn_id
+                    result = agent.run_conversation(**conversation_kwargs)
                     usage = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,

--- a/model_tools.py
+++ b/model_tools.py
@@ -1550,12 +1550,22 @@ def handle_function_call(
                         enabled_tools=sandbox_enabled,
                     )
             else:
+                entry = registry.get_entry(function_name)
+                correlation = {}
+                if entry is not None and entry.toolset.startswith("mcp-"):
+                    correlation = {
+                        "session_id": session_id,
+                        "tool_call_id": tool_call_id,
+                        "turn_id": turn_id,
+                        "api_request_id": api_request_id,
+                    }
+
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,
-                        session_id=session_id,
                         user_task=user_task,
+                        **correlation,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/run_agent.py
+++ b/run_agent.py
@@ -8996,6 +8996,7 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        external_turn_id: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -9029,7 +9030,7 @@ class AIAgent:
             "task_id": effective_task_id,
             "platform": getattr(self, "platform", None) or "",
         }
-        relay_turn_id = (
+        relay_turn_id = external_turn_id or (
             f"{session_id or 'session'}:{effective_task_id}:{uuid.uuid4().hex[:8]}"
         )
         self._relay_pending_turn_id = relay_turn_id

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1818,6 +1818,118 @@ class TestEndpointAuth:
             assert resp.status == 401
 
 
+class TestExternalTurnIdContract:
+    """Authenticated callers may supply an exact, bounded correlation ID."""
+
+    _BODY = {
+        "model": "test",
+        "messages": [{"role": "user", "content": "hi"}],
+    }
+    _RESULT = (
+        {"final_response": "ok", "messages": [], "api_calls": 1},
+        {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+    )
+    _AUTH = {"Authorization": "Bearer sk-secret"}
+
+    @pytest.mark.asyncio
+    async def test_authenticated_non_streaming_passes_exact_value_unchanged(self, auth_adapter):
+        turn_id = "basshub.Turn_01:retry-2"
+        app = _create_app(auth_adapter)
+        with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = self._RESULT
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=self._BODY,
+                    headers={**self._AUTH, "X-Hermes-Turn-Id": turn_id},
+                )
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["external_turn_id"] == turn_id
+
+    @pytest.mark.asyncio
+    async def test_authenticated_streaming_passes_exact_value_unchanged(self, auth_adapter):
+        turn_id = "basshub:stream_01"
+
+        async def run_agent(**kwargs):
+            kwargs["stream_delta_callback"]("ok")
+            return self._RESULT
+
+        app = _create_app(auth_adapter)
+        with patch.object(auth_adapter, "_run_agent", side_effect=run_agent) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={**self._BODY, "stream": True},
+                    headers={**self._AUTH, "X-Hermes-Turn-Id": turn_id},
+                )
+                await resp.text()
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["external_turn_id"] == turn_id
+
+    @pytest.mark.asyncio
+    async def test_header_without_configured_api_key_is_forbidden_before_agent(self, adapter):
+        app = _create_app(adapter)
+        with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=self._BODY,
+                    headers={"X-Hermes-Turn-Id": "basshub-turn-1"},
+                )
+        assert resp.status == 403
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "turn_id",
+        ["trailing ", "has/slash", "", "x" * 129],
+        # aiohttp's client normalizes leading header whitespace before it reaches
+        # the server; trailing whitespace is preserved and exercises the exact
+        # (non-stripping) boundary contract over real HTTP.
+        ids=["trailing-space", "slash", "empty", "over-128"],
+    )
+    @pytest.mark.asyncio
+    async def test_malformed_value_is_rejected_before_agent(self, auth_adapter, turn_id):
+        app = _create_app(auth_adapter)
+        with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=self._BODY,
+                    headers={**self._AUTH, "X-Hermes-Turn-Id": turn_id},
+                )
+        assert resp.status == 400
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_leading_space_is_rejected_at_handler_boundary(self, auth_adapter):
+        # Real HTTP clients normalize leading OWS, so invoke the handler with
+        # the exact header mapping to pin the server-side contract explicitly.
+        request = MagicMock()
+        request.headers = {
+            **self._AUTH,
+            "X-Hermes-Turn-Id": " leading",
+        }
+        request.app = {"api_server_adapter": auth_adapter}
+        with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            resp = await auth_adapter._handle_chat_completions(request)
+        assert resp.status == 400
+        mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_absent_header_preserves_success_and_none_forwarding(self, auth_adapter):
+        app = _create_app(auth_adapter)
+        with patch.object(auth_adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+            mock_run.return_value = self._RESULT
+            async with TestClient(TestServer(app)) as cli:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json=self._BODY,
+                    headers=self._AUTH,
+                )
+        assert resp.status == 200
+        assert mock_run.call_args.kwargs["external_turn_id"] is None
+
+
 # ---------------------------------------------------------------------------
 # Config integration
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_delegate_session_context.py
+++ b/tests/tools/test_delegate_session_context.py
@@ -1,0 +1,108 @@
+"""Gateway session context propagation across delegation worker pools."""
+
+from __future__ import annotations
+
+import json
+import threading
+from concurrent.futures import ThreadPoolExecutor
+from types import SimpleNamespace
+
+
+def _gateway_identity() -> tuple[str, str, str]:
+    from gateway.session_context import get_session_env
+
+    return (
+        get_session_env("HERMES_SESSION_PLATFORM", ""),
+        get_session_env("HERMES_SESSION_CHAT_ID", ""),
+        get_session_env("HERMES_SESSION_ID", ""),
+    )
+
+
+def _parent_agent(**overrides):
+    values = {
+        "base_url": "https://example.test/v1",
+        "api_key": "test-key",
+        "provider": "test-provider",
+        "api_mode": "chat_completions",
+        "model": "test-model",
+        "platform": "api_server",
+        "_delegate_depth": 0,
+        "_interrupt_requested": False,
+        "_delegate_spinner": None,
+        "_memory_manager": None,
+        "_current_task_id": None,
+        "_current_turn_id": "turn-parent",
+        "_active_children": [],
+        "_active_children_lock": threading.Lock(),
+        "session_id": "parent-session",
+        "session_estimated_cost_usd": 0.0,
+        "session_cost_source": "none",
+        "session_cost_status": "unknown",
+        "tool_progress_callback": None,
+        "thinking_callback": None,
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class _ContextRecordingChild:
+    def __init__(self, captured: list[tuple[str, str, str]]):
+        self._captured = captured
+        self._credential_pool = None
+        self._subagent_id = None
+        self._delegate_role = "leaf"
+        self._delegate_saved_tool_names = []
+        self.tool_progress_callback = None
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_reasoning_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+
+    def run_conversation(self, user_message, task_id=None):
+        self._captured.append(_gateway_identity())
+        return {
+            "final_response": "done",
+            "completed": True,
+            "interrupted": False,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1, "max_iterations": 1}
+
+    def close(self):
+        return None
+
+
+def test_context_copies_are_isolated_between_concurrent_submissions(monkeypatch):
+    import tools.delegate_tool as delegate_tool
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    for name in ("HERMES_SESSION_PLATFORM", "HERMES_SESSION_CHAT_ID"):
+        monkeypatch.delenv(name, raising=False)
+
+    barrier = threading.Barrier(2)
+
+    def _read_after_both_start():
+        barrier.wait(timeout=5)
+        return _gateway_identity()[:2]
+
+    futures = []
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        for chat_id in ("c" * 32, "d" * 32):
+            tokens = set_session_vars(platform="api_server", chat_id=chat_id)
+            try:
+                futures.append(
+                    executor.submit(__import__("contextvars").copy_context().run, _read_after_both_start)
+                )
+            finally:
+                clear_session_vars(tokens)
+
+        observed = {future.result(timeout=5) for future in futures}
+
+    assert observed == {
+        ("api_server", "c" * 32),
+        ("api_server", "d" * 32),
+    }

--- a/tests/tools/test_mcp_tool_approval_origin.py
+++ b/tests/tools/test_mcp_tool_approval_origin.py
@@ -1,0 +1,469 @@
+"""Approval-origin metadata contracts for MCP tool calls."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import threading
+from types import SimpleNamespace
+
+import pytest
+
+
+_META_KEY = "dev.basshub/origin"
+
+
+class _NoopAsyncLock:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _RecordingSession:
+    def __init__(self, *, fail_first: bool = False):
+        self.calls: list[tuple[str, dict]] = []
+        self._calls_lock = threading.Lock()
+        self._fail_first = fail_first
+
+    async def call_tool(self, name: str, **kwargs):
+        with self._calls_lock:
+            self.calls.append((name, kwargs))
+            call_number = len(self.calls)
+        if self._fail_first and call_number == 1:
+            raise RuntimeError("force recovery")
+        return SimpleNamespace(
+            content=[SimpleNamespace(text="ok")],
+            isError=False,
+        )
+
+
+def _run_coro(coro_or_factory, timeout=30):
+    coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+    return asyncio.run(coro)
+
+
+@pytest.fixture
+def origin_server(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    session = _RecordingSession()
+    server = mcp_tool.MCPServerTask("origin-test")
+    server.session = session
+    server._rpc_lock = _NoopAsyncLock()
+    monkeypatch.setitem(mcp_tool._servers, "origin-test", server)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_coro)
+    yield mcp_tool, server, session
+    mcp_tool._servers.pop("origin-test", None)
+
+
+def _call_in_gateway_context(handler, *, platform: str, chat_id: str, **kwargs):
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    tokens = set_session_vars(platform=platform, chat_id=chat_id)
+    try:
+        return json.loads(handler({"value": 1}, **kwargs))
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_approval_origin_config_requires_explicit_per_server_opt_in():
+    from tools.mcp_tool import _approval_origin_metadata_enabled
+
+    assert _approval_origin_metadata_enabled("bass", {}) is False
+    assert _approval_origin_metadata_enabled(
+        "bass", {"request_metadata": {"approval_origin": False}}
+    ) is False
+    assert _approval_origin_metadata_enabled(
+        "bass", {"request_metadata": {"approval_origin": "true"}}
+    ) is True
+
+
+def test_opted_in_api_chat_sends_namespaced_origin_metadata(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    result = _call_in_gateway_context(
+        handler,
+        platform="api_server",
+        chat_id="a" * 32,
+        turn_id="turn-7",
+        tool_call_id="call-9",
+        api_request_id="api-request-fallback",
+    )
+
+    assert result == {"result": "ok"}
+    expected_request_id = "tool-" + hashlib.sha256(
+        b"turn-7\0call-9"
+    ).hexdigest()
+    assert session.calls == [
+        (
+            "dangerous_action",
+            {
+                "arguments": {"value": 1},
+                "meta": {
+                    _META_KEY: {
+                        "surface": "chat",
+                        "session_id": "a" * 32,
+                        "turn_id": "turn-7",
+                        "request_id": expected_request_id,
+                    }
+                },
+            },
+        )
+    ]
+
+
+def test_same_provider_tool_call_id_is_scoped_to_each_turn(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    for turn_id in ("turn-one", "turn-two"):
+        result = _call_in_gateway_context(
+            handler,
+            platform="api_server",
+            chat_id="d" * 32,
+            turn_id=turn_id,
+            tool_call_id="provider-reused-id",
+        )
+        assert result == {"result": "ok"}
+
+    origins = [call[1]["meta"][_META_KEY] for call in session.calls]
+    assert [origin["turn_id"] for origin in origins] == ["turn-one", "turn-two"]
+    assert origins[0]["request_id"] != origins[1]["request_id"]
+    assert all(origin["request_id"].startswith("tool-") for origin in origins)
+
+
+def test_missing_tool_call_ids_get_distinct_per_invocation_ids(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    # Both calls belong to one model response and therefore share the same
+    # turn/API request. Their generated request IDs must still be distinct.
+    for _ in range(2):
+        result = _call_in_gateway_context(
+            handler,
+            platform="api_server",
+            chat_id="e" * 32,
+            turn_id="turn-shared",
+            api_request_id="api-shared",
+        )
+        assert result == {"result": "ok"}
+
+    request_ids = [
+        call[1]["meta"][_META_KEY]["request_id"] for call in session.calls
+    ]
+    assert request_ids[0] != request_ids[1]
+    assert all(request_id.startswith("req-") for request_id in request_ids)
+
+
+def test_truthy_invalid_tool_call_id_uses_generated_fallback(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    _call_in_gateway_context(
+        handler,
+        platform="api_server",
+        chat_id="f" * 32,
+        turn_id="turn-valid",
+        tool_call_id="truthy\x01but-invalid",
+    )
+
+    origin = session.calls[0][1]["meta"][_META_KEY]
+    assert origin["request_id"].startswith("req-")
+
+
+def test_invalid_turn_id_falls_back_to_valid_api_request_id(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    _call_in_gateway_context(
+        handler,
+        platform="api_server",
+        chat_id="f" * 32,
+        turn_id="truthy\x01but-invalid",
+        api_request_id="api-valid-fallback",
+        tool_call_id="provider-call",
+    )
+
+    origin = session.calls[0][1]["meta"][_META_KEY]
+    assert origin["turn_id"] == "api-valid-fallback"
+    assert origin["request_id"].startswith("tool-")
+
+
+def test_unconfigured_server_never_receives_origin_metadata(origin_server):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "read_only",
+        10,
+        # The default is intentionally false.
+    )
+
+    _call_in_gateway_context(
+        handler,
+        platform="api_server",
+        chat_id="b" * 32,
+        turn_id="turn-private",
+        tool_call_id="call-private",
+    )
+
+    assert session.calls[0][1] == {"arguments": {"value": 1}}
+
+
+@pytest.mark.parametrize("platform", ["telegram", "discord", "cli", ""])
+def test_opt_in_does_not_forward_non_dashboard_chat_ids(origin_server, platform):
+    mcp_tool, _server, session = origin_server
+    handler = mcp_tool._make_tool_handler(
+        "origin-test",
+        "read_only",
+        10,
+        forward_approval_origin=True,
+    )
+
+    _call_in_gateway_context(
+        handler,
+        platform=platform,
+        chat_id="not-a-basshub-chat",
+        turn_id="turn-private",
+        tool_call_id="call-private",
+    )
+
+    assert session.calls[0][1] == {"arguments": {"value": 1}}
+
+
+def test_concurrent_handlers_keep_dashboard_origins_isolated(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+    from gateway.session_context import clear_session_vars, set_session_vars
+
+    session = _RecordingSession()
+    server = mcp_tool.MCPServerTask("concurrent-origin")
+    server.session = session
+    server._rpc_lock = _NoopAsyncLock()
+    monkeypatch.setitem(mcp_tool._servers, "concurrent-origin", server)
+
+    scheduled = threading.Barrier(2)
+
+    def _deferred_run(coro_or_factory, timeout=30):
+        coro = coro_or_factory() if callable(coro_or_factory) else coro_or_factory
+        scheduled.wait(timeout=5)
+        return asyncio.run(coro)
+
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _deferred_run)
+    handler = mcp_tool._make_tool_handler(
+        "concurrent-origin",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+    errors: list[BaseException] = []
+
+    def _worker(session_id: str, turn_id: str, request_id: str):
+        tokens = set_session_vars(platform="api_server", chat_id=session_id)
+        try:
+            result = json.loads(
+                handler({}, turn_id=turn_id, tool_call_id=request_id)
+            )
+            assert result == {"result": "ok"}
+        except BaseException as exc:  # surfaced on the main test thread below
+            errors.append(exc)
+        finally:
+            clear_session_vars(tokens)
+
+    threads = [
+        threading.Thread(target=_worker, args=("a" * 32, "turn-a", "call-a")),
+        threading.Thread(target=_worker, args=("b" * 32, "turn-b", "call-b")),
+    ]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert not any(thread.is_alive() for thread in threads)
+    assert errors == []
+    origins = {
+        call_kwargs["meta"][_META_KEY]["session_id"]:
+        call_kwargs["meta"][_META_KEY]
+        for _name, call_kwargs in session.calls
+    }
+    assert origins["a" * 32]["surface"] == "chat"
+    assert origins["a" * 32]["turn_id"] == "turn-a"
+    assert origins["b" * 32]["surface"] == "chat"
+    assert origins["b" * 32]["turn_id"] == "turn-b"
+    assert origins["a" * 32]["request_id"].startswith("tool-")
+    assert origins["b" * 32]["request_id"].startswith("tool-")
+    assert origins["a" * 32]["request_id"] != origins["b" * 32]["request_id"]
+
+
+def test_recovery_retry_reuses_the_same_origin_snapshot(monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    session = _RecordingSession(fail_first=True)
+    server = mcp_tool.MCPServerTask("retry-origin")
+    server.session = session
+    server._rpc_lock = _NoopAsyncLock()
+    monkeypatch.setitem(mcp_tool._servers, "retry-origin", server)
+    monkeypatch.setattr(mcp_tool, "_run_on_mcp_loop", _run_coro)
+
+    def _recover(_server_name, _exc, retry_call, _description):
+        return retry_call()
+
+    monkeypatch.setattr(mcp_tool, "_handle_auth_error_and_retry", _recover)
+    handler = mcp_tool._make_tool_handler(
+        "retry-origin",
+        "dangerous_action",
+        10,
+        forward_approval_origin=True,
+    )
+
+    result = _call_in_gateway_context(
+        handler,
+        platform="api_server",
+        chat_id="c" * 32,
+    )
+
+    assert result == {"result": "ok"}
+    assert len(session.calls) == 2
+    first_meta = session.calls[0][1]["meta"]
+    second_meta = session.calls[1][1]["meta"]
+    assert first_meta == second_meta
+    assert first_meta is second_meta
+    assert first_meta[_META_KEY]["turn_id"].startswith("turn-")
+    assert first_meta[_META_KEY]["request_id"].startswith("req-")
+
+
+def test_pinned_mcp_sdk_serializes_meta_as_protocol_params_meta(monkeypatch):
+    """Exercise the real optional MCP SDK's request serialization contract."""
+    pytest.importorskip("mcp")
+    from mcp import types
+    from mcp.client.session import ClientSession
+
+    captured = {}
+
+    async def _capture_send_request(self, request, result_type, **kwargs):
+        captured["request"] = request
+        # isError avoids output-schema validation, which is irrelevant here.
+        return types.CallToolResult(content=[], isError=True)
+
+    monkeypatch.setattr(ClientSession, "send_request", _capture_send_request)
+    session = object.__new__(ClientSession)
+    session._call_tool_adapter = types.CallToolResult
+    metadata = {
+        _META_KEY: {
+            "surface": "chat",
+            "session_id": "a" * 32,
+            "request_id": "req-sdk-contract",
+        }
+    }
+
+    asyncio.run(
+        session.call_tool(
+            "dangerous_action",
+            arguments={"value": 1},
+            meta=metadata,
+        )
+    )
+
+    payload = captured["request"].model_dump(
+        by_alias=True,
+        exclude_none=True,
+        mode="json",
+    )
+    assert payload["method"] == "tools/call"
+    assert payload["params"]["_meta"] == metadata
+
+
+def test_model_dispatch_passes_correlation_only_to_mcp_handlers(monkeypatch):
+    from model_tools import handle_function_call
+    from tools.registry import registry
+
+    captured: dict = {}
+    mcp_name = "mcp_origin_contract_test"
+    builtin_name = "origin_contract_builtin_test"
+    schema = {
+        "description": "Test handler context forwarding.",
+        "parameters": {"type": "object", "properties": {}},
+    }
+
+    def _mcp_handler(_args, **kwargs):
+        captured["mcp"] = kwargs
+        return json.dumps({"ok": True})
+
+    # This deliberately does not accept the new correlation keyword names.
+    # A non-MCP handler would raise if model_tools leaked them globally.
+    def _builtin_handler(_args, task_id=None, user_task=None):
+        captured["builtin"] = {"task_id": task_id, "user_task": user_task}
+        return json.dumps({"ok": True})
+
+    registry.register(
+        name=mcp_name,
+        toolset="mcp-origin-contract",
+        schema={**schema, "name": mcp_name},
+        handler=_mcp_handler,
+    )
+    registry.register(
+        name=builtin_name,
+        toolset="origin-contract",
+        schema={**schema, "name": builtin_name},
+        handler=_builtin_handler,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.middleware.run_tool_execution_middleware",
+        lambda _name, payload, call_next, **_kwargs: call_next(payload),
+    )
+    try:
+        common = dict(
+            task_id="task-1",
+            session_id="agent-session-1",
+            tool_call_id="call-1",
+            turn_id="turn-1",
+            api_request_id="api-1",
+            user_task="test",
+            skip_pre_tool_call_hook=True,
+            skip_tool_request_middleware=True,
+        )
+        assert json.loads(handle_function_call(mcp_name, {}, **common)) == {"ok": True}
+        assert json.loads(handle_function_call(builtin_name, {}, **common)) == {"ok": True}
+    finally:
+        registry.deregister(mcp_name)
+        registry.deregister(builtin_name)
+
+    assert captured["mcp"] == {
+        "task_id": "task-1",
+        "user_task": "test",
+        "session_id": "agent-session-1",
+        "tool_call_id": "call-1",
+        "turn_id": "turn-1",
+        "api_request_id": "api-1",
+    }
+    assert captured["builtin"] == {
+        "task_id": "task-1",
+        "user_task": "test",
+    }

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -97,6 +97,7 @@ Thread safety:
 import asyncio
 import contextvars
 import concurrent.futures
+import hashlib
 import errno
 import fnmatch
 import inspect
@@ -110,6 +111,7 @@ import shutil
 import sys
 import threading
 import time
+import uuid
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from typing import Callable
@@ -6067,7 +6069,54 @@ def _ensure_healthy_or_recycle(server: Any, server_name: str) -> None:
         _signal_reconnect(server)
 
 
-def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
+_BASSHUB_APPROVAL_ORIGIN_META_KEY = "dev.basshub/origin"
+_MAX_APPROVAL_ORIGIN_ID_CHARS = 256
+
+
+def _approval_origin_id(value: Any) -> str:
+    """Return a bounded printable correlation ID, or empty when invalid."""
+    if value is None:
+        return ""
+    text = str(value).strip()
+    if not text or len(text) > _MAX_APPROVAL_ORIGIN_ID_CHARS:
+        return ""
+    if any(ord(char) < 32 or ord(char) == 127 for char in text):
+        return ""
+    return text
+
+
+def _snapshot_approval_origin_metadata(kwargs: dict) -> Optional[Dict[str, Any]]:
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = str(get_session_env("HERMES_SESSION_PLATFORM", "") or "")
+        if platform.strip().lower() != "api_server":
+            return None
+        session_id = _approval_origin_id(get_session_env("HERMES_SESSION_CHAT_ID", ""))
+    except Exception:
+        return None
+    if not session_id:
+        return None
+    turn_id = (
+        _approval_origin_id(kwargs.get("turn_id"))
+        or _approval_origin_id(kwargs.get("api_request_id"))
+        or f"turn-{uuid.uuid4().hex}"
+    )
+    tool_id = _approval_origin_id(kwargs.get("tool_call_id"))
+    request_id = (
+        f"tool-{hashlib.sha256((turn_id + chr(0) + tool_id).encode()).hexdigest()}"
+        if tool_id
+        else f"req-{uuid.uuid4().hex}"
+    )
+    return {_BASSHUB_APPROVAL_ORIGIN_META_KEY: {
+        "surface": "chat",
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "request_id": request_id,
+    }}
+
+
+def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float, *, forward_approval_origin: bool = False):
     """Return a sync handler that calls an MCP tool via the background loop.
 
     The handler conforms to the registry's dispatch interface:
@@ -6142,6 +6191,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        request_meta = _snapshot_approval_origin_metadata(kwargs) if forward_approval_origin else None
+
         async def _call():
             _mark_server_call_started(server)
             async with server._rpc_lock, _track_inflight_rpc(
@@ -6182,7 +6233,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             f"exited; failing the call fast instead of "
                             f"waiting {float(tool_timeout):.0f}s"
                         )
-                    _call_coro = server.session.call_tool(tool_name, arguments=args)
+                    call_kwargs: Dict[str, Any] = {"arguments": args}
+                    if request_meta is not None:
+                        call_kwargs["meta"] = request_meta
+                    _call_coro = server.session.call_tool(tool_name, **call_kwargs)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
@@ -7017,6 +7071,19 @@ def _parse_boolish(value: Any, default: bool = True) -> bool:
     return default
 
 
+def _approval_origin_metadata_enabled(server_name: str, config: dict) -> bool:
+    request_metadata = config.get("request_metadata")
+    if request_metadata is None:
+        return False
+    if not isinstance(request_metadata, dict):
+        logger.warning(
+            "MCP config mcp_servers.%s.request_metadata must be a mapping; "
+            "approval origin metadata remains disabled",
+            server_name,
+        )
+        return False
+    return _parse_boolish(request_metadata.get("approval_origin"), default=False)
+
 def _get_lifecycle_seconds(config: dict, key: str) -> Optional[float]:
     """Return an optional positive lifecycle timeout from top-level/nested config."""
     raw = config.get(key)
@@ -7195,6 +7262,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
     exclude_set = _normalize_name_filter(
         tools_filter.get("exclude"), f"mcp_servers.{name}.tools.exclude"
     )
+    forward_approval_origin = _approval_origin_metadata_enabled(name, config)
 
     def _should_register(tool_name: str) -> bool:
         if include_active:
@@ -7229,7 +7297,8 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
                 "origin": f"tool {mcp_tool.name!r}",
                 "schema": schema,
                 "handler": _make_tool_handler(
-                    name, mcp_tool.name, server.tool_timeout
+                    name, mcp_tool.name, server.tool_timeout,
+                    forward_approval_origin=forward_approval_origin,
                 ),
                 "check_fn": check_fn,
             }


### PR DESCRIPTION
## Summary
- accepts validated authenticated X-Hermes-Turn-Id values for API chat completions
- propagates exact BassHUB run correlation into current turn context
- forwards fail-closed approval origin metadata through delegate and MCP paths

## Verification
- 119 API server tests passed
- 57 API run tests passed
- 15 approval-origin tests passed
- 9 focused external-turn contract tests passed
- git diff --check passed

Companion for iamMrBass/BassHUB v0.2.27 persistent concurrent chat.