### PR TITLE
fix(agent): gate Ollama num_ctx compressor clamp on local endpoints (#99943)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -3080,8 +3080,16 @@ def init_agent(
     # serves. (Overlaps #60103's silent-clamp dead zone; this is the
     # init-order half.)
     _cc_window = getattr(agent.context_compressor, "context_length", 0) or 0
+    # model.ollama_num_ctx is an Ollama knob (VRAM cap for a local server);
+    # a stale value left in config from local-only setups must not clamp a
+    # cloud session to that token count. The auto-detection branch above
+    # already gates on is_local_endpoint — the explicit-override path and
+    # this clamp follow the same rule: Ollama settings only steer Ollama
+    # endpoints.
+    _num_ctx_is_local = bool(agent.base_url) and is_local_endpoint(agent.base_url)
     if (
-        agent._ollama_num_ctx
+        _num_ctx_is_local
+        and agent._ollama_num_ctx
         and agent._ollama_num_ctx > 0
         and _cc_window
         and agent._ollama_num_ctx < _cc_window

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -187,3 +187,44 @@ class TestCompressorClampsToNumCtx:
         # num_ctx above the resolved window must not RAISE the compressor
         # window: the clamp is one-directional.
         assert agent.context_compressor.context_length == 65536
+
+    def _build_cloud_agent(self, cfg, probed_ctx):
+        import agent.context_compressor as cc_mod
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+            patch("hermes_cli.config.load_config", return_value=cfg),
+            patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+            patch(
+                "agent.model_metadata.get_model_context_length",
+                return_value=probed_ctx,
+            ),
+            patch.object(
+                cc_mod, "get_model_context_length", return_value=probed_ctx,
+            ),
+        ):
+            from run_agent import AIAgent
+            return AIAgent(
+                model="glm-5.3-flash",
+                api_key="sk-test",
+                base_url="https://api.z.ai/api/paas/v4",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+            )
+
+    def test_cloud_endpoint_ignores_ollama_num_ctx_override(self):
+        """A stale model.ollama_num_ctx (set to cap VRAM on a local Ollama
+        box) must not clamp a cloud session's compressor to that value —
+        ollama_num_ctx only steers local endpoints, matching the
+        auto-detection branch."""
+        agent = self._build_cloud_agent(
+            {"agent": {}, "model": {"ollama_num_ctx": 65536}},
+            probed_ctx=1000000,
+        )
+        # The override is still recorded (it applies when the user points
+        # the session back at the local server)…
+        assert agent._ollama_num_ctx == 65536
+        # …but the compressor keeps the provider-resolved 1M window.
+        assert agent.context_compressor.context_length == 1000000


### PR DESCRIPTION
## Problem

`model.ollama_num_ctx` is an Ollama knob — a VRAM cap for a local server. Since `cb71d5f1b1` ("clamp compressor window to Ollama num_ctx resolved after construction") the init-time clamp in `agent/agent_init.py` fires whenever `agent._ollama_num_ctx` is set and smaller than the resolved window — with no endpoint check. A stale `model.ollama_num_ctx: 65536` left in config from a local-only setup silently clamps cloud sessions to 65,536 tokens: the status bar shows a wrong context limit and auto-compression triggers at ~49K on models whose real window is 1M.

Reported in #99943 (observed with `glm-5.3-flash` @ z.ai resolving 1M, clamped to 65536).

## Fix

Gate the clamp on `is_local_endpoint(agent.base_url)` — the same guard the auto-detection branch a few lines above already uses (`if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url)`). Ollama settings only steer local endpoints; cloud sessions keep the provider-resolved window. Users who want to cap a cloud model's window can use `model.context_length`, which is endpoint-agnostic by design.

`agent._ollama_num_ctx` itself is still recorded from the explicit override (it applies when the session points back at the local server), and the `extra_body.options.num_ctx` injection in the custom/Ollama provider profile remains untouched.

## Testing

- New `test_cloud_endpoint_ignores_ollama_num_ctx_override`: config `ollama_num_ctx: 65536` + z.ai base URL + 1M resolved window → compressor keeps 1,000,000. RED without the gate (logs the exact `clamped 1000000 -> 65536` line from the issue), GREEN with it.
- Existing `TestCompressorClampsToNumCtx` local-endpoint tests (clamp to num_ctx when smaller; one-directional) still pass — local behavior unchanged.
- `tests/test_ollama_num_ctx.py` 10/10, `tests/plugins/model_providers/test_custom_profile.py` + `tests/agent/test_model_metadata*.py` 172/172 green.
- `ruff check` clean on both touched files.

Fixes #99943