### PR TITLE
fix(tui): resolve truncate target row ids against the un-repaired durable transcript

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -6663,6 +6663,189 @@ def test_prompt_submit_row_id_not_found(monkeypatch):
         server._sessions.pop("missing-row-sid", None)
 
 
+def _mk_merge_fake_db(verbatim, repaired, replaced):
+    """SessionDB stand-in answering exactly like the real store: the repaired
+    view (what `_load_durable_truncation_history` historically loaded) has the
+    user;user run merged away, the un-repaired view keeps every physical row.
+    """
+
+    class _FakeDB:
+        def get_messages_as_conversation(
+            self,
+            key,
+            include_ancestors=False,
+            repair_alternation=False,
+            include_row_ids=False,
+            **_kwargs,
+        ):
+            import copy as _copy
+
+            assert key == "session-key"
+            assert include_row_ids is True
+            return _copy.deepcopy(repaired if repair_alternation else verbatim)
+
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False, **_kwargs
+        ):
+            replaced.append((key, list(messages)))
+
+    return _FakeDB()
+
+
+def test_prompt_submit_resolves_row_id_swallowed_by_marker_merge(monkeypatch):
+    """#94486 (live-session shape): model-switch markers persist as role=user
+    (#48338), so the just-sent prompt forms a user;user run that
+    repair_message_sequence merges into the FIRST row — the target's _row_id
+    vanishes from the repaired view and truncate_before_row_id fails closed
+    (4018) even though the row is physically present. Identity resolution must
+    read the un-repaired durable transcript, the same discipline the rebind
+    path already applies ('repair can merge a physical user;user pair while
+    preserving only the first row id').
+    """
+    import contextlib
+    import copy
+
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    verbatim = [
+        {"_row_id": 201, "role": "user", "content": "first"},
+        {"_row_id": 202, "role": "assistant", "content": "reply 1"},
+        {
+            "_row_id": 203,
+            "role": "user",
+            "display_kind": "model_switch",
+            "content": "[System: The active model for this chat has changed to ds4.]",
+        },
+        {
+            "_row_id": 204,
+            "role": "user",
+            "display_kind": "model_switch",
+            "content": "[System: The active model for this chat has changed to kk3.]",
+        },
+        {"_row_id": 205, "role": "user", "content": "the interrupted prompt"},
+    ]
+    repaired = copy.deepcopy(verbatim)
+    assert repair_message_sequence(None, repaired) == 2  # 3-row run, two merges
+    # On current main the merge buries the plain row's id inside the marker.
+    assert len(repaired) == 3
+
+    replaced = []
+    fake_db = _mk_merge_fake_db(verbatim, repaired, replaced)
+
+    @contextlib.contextmanager
+    def _fake_session_db(_session):
+        yield fake_db
+
+    # Live history as a running session holds it after a turn rewrite: every
+    # physical row present, row-id stamps lost (provider-format rewrite), so
+    # resolution must go through the durable fallback.
+    live = [
+        {k: v for k, v in message.items() if k != "_row_id"} for message in verbatim
+    ]
+    server._sessions["marker-merge-sid"] = _session(history=list(live))
+    monkeypatch.setattr(server, "_session_db", _fake_session_db)
+    monkeypatch.setattr(server, "_get_db", lambda: fake_db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "marker-merge-sid",
+                    "text": "edited prompt",
+                    "truncate_before_row_id": 205,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert isinstance(resp, dict)
+        err = resp.get("error")
+        assert err is None, err
+        # The cut lands before row 205: the markers and everything earlier
+        # survive (durable rows healed their stamps onto the live list).
+        assert len(replaced) == 1
+        assert replaced[0][0] == "session-key"
+        assert [m["content"] for m in replaced[0][1]] == [
+            "first",
+            "reply 1",
+            verbatim[2]["content"],
+            verbatim[3]["content"],
+        ]
+        assert len(server._sessions["marker-merge-sid"]["history"]) == 4
+    finally:
+        server._sessions.pop("marker-merge-sid", None)
+
+
+def test_prompt_submit_resolves_row_id_swallowed_by_plain_user_merge(monkeypatch):
+    """Same swallowed-id class with NO display marker: an interrupted turn
+    persists no assistant row, the user's resend lands as a second consecutive
+    plain user row, and repair merges it into the earlier one — the resend's
+    row id is unresolvable on every later rewind/edit. Repair-side address
+    preservation keyed on display_kind cannot reach this shape; reading the
+    un-repaired transcript for identity can.
+    """
+    import contextlib
+    import copy
+
+    from agent.agent_runtime_helpers import repair_message_sequence
+
+    verbatim = [
+        {"_row_id": 301, "role": "user", "content": "first"},
+        {"_row_id": 302, "role": "assistant", "content": "reply 1"},
+        {"_row_id": 303, "role": "user", "content": "prompt whose turn was cut off"},
+        {"_row_id": 304, "role": "user", "content": "the resent prompt"},
+    ]
+    repaired = copy.deepcopy(verbatim)
+    assert repair_message_sequence(None, repaired) == 1
+    assert len(repaired) == 3
+    assert repaired[2]["_row_id"] == 303  # merge keeps only the FIRST row id
+
+    replaced = []
+    fake_db = _mk_merge_fake_db(verbatim, repaired, replaced)
+
+    @contextlib.contextmanager
+    def _fake_session_db(_session):
+        yield fake_db
+
+    live = [
+        {k: v for k, v in message.items() if k != "_row_id"} for message in verbatim
+    ]
+    server._sessions["plain-merge-sid"] = _session(history=list(live))
+    monkeypatch.setattr(server, "_session_db", _fake_session_db)
+    monkeypatch.setattr(server, "_get_db", lambda: fake_db)
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
+
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {
+                    "session_id": "plain-merge-sid",
+                    "text": "edited resend",
+                    "truncate_before_row_id": 304,
+                    "confirm_truncate": True,
+                },
+            }
+        )
+        assert isinstance(resp, dict)
+        err = resp.get("error")
+        assert err is None, err
+        assert len(replaced) == 1
+        assert [m["content"] for m in replaced[0][1]] == [
+            "first",
+            "reply 1",
+            "prompt whose turn was cut off",
+        ]
+        assert len(server._sessions["plain-merge-sid"]["history"]) == 3
+    finally:
+        server._sessions.pop("plain-merge-sid", None)
+
+
 def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
     """truncate_before_row_id must not match string platform IDs."""
     history = [

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -127,19 +127,26 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     if hit is not None:
         return hit
 
-    db_history = _load_durable_truncation_history(session)
+    # Identity lookups read the UN-REPAIRED transcript: repair merges any
+    # user;user run into its first row (a model-switch marker run, or an
+    # interrupted turn that persisted no assistant row followed by a resend),
+    # and the merged row keeps only the first row's _row_id — the absorbed
+    # rows' ids vanish from the repaired view, so resolving against it fails
+    # closed on rows that are physically present (#94486's live-session
+    # shape). The rebind path below already reads the un-repaired active-id
+    # set for exactly this reason; resolution must too.
+    db_history = _load_durable_truncation_history(session, repair_alternation=False)
     if db_history is None:
         return None
 
     # Heal missing in-memory stamps when the live list still lines up 1:1 with
     # the durable transcript (common after turn-completion rewrites). Equal
-    # length alone is NOT proof of alignment: the durable copy above is loaded
-    # with repair_alternation=True (which can merge/drop rows) while the live
-    # list is unrepaired, and memory can carry optimistic/marker rows — so the
-    # two can coincide in length while position-shifted. A positional stamp on
-    # a misaligned pair is sticky and re-aims every later rewind at the wrong
-    # durable row. Stamp only when EVERY pair agrees (all-or-nothing): roles
-    # must match on every pair, and addressable user turns must match content.
+    # length alone is NOT proof of alignment: memory can carry
+    # optimistic/marker rows — the two can coincide in length while
+    # position-shifted. A positional stamp on a misaligned pair is sticky and
+    # re-aims every later rewind at the wrong durable row. Stamp only when
+    # EVERY pair agrees (all-or-nothing): roles must match on every pair, and
+    # addressable user turns must match content.
     if len(db_history) == len(history) and all(
         _mem_db_pair_agrees(mem, db_msg)
         for mem, db_msg in zip(history, db_history)
@@ -160,9 +167,10 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     if db_ord < 0 or db_ord >= len(mem_user_indices):
         return None
     mem_idx = mem_user_indices[db_ord]
-    # Same-ordinal mapping across two lists that can diverge (the repaired
-    # durable copy may have merged a user;user pair, shifting every later
-    # user ordinal). Trust the mapping only when the mapped live turn shows
+    # Same-ordinal mapping across two lists that can still diverge (the live
+    # list itself may have been materialized from a repaired, merged view on
+    # resume, shifting every later user ordinal relative to the physical
+    # rows). Trust the mapping only when the mapped live turn shows
     # the same content as the durable target — otherwise refuse (the caller
     # returns fail-closed 4018) rather than cut the wrong turn (#82959).
     if not _mem_db_pair_agrees(history[mem_idx], db_history[db_idx]):


### PR DESCRIPTION
## What does this PR do?

`prompt.submit` with `truncate_before_row_id` (Desktop edit / restore-checkpoint / regenerate) can fail closed with **4018 "target user message is no longer in session history"** while the row is physically present and active in `state.db` — the submitted edit is silently dropped and every retry fails identically.

Verified against a live incident: four `prompt.submit` refusals over three minutes, all `target row_id <N> not found for session <sid> (in-memory + durable)`, while a direct SQL read showed row `<N>` present, `active=1`, in the correct session. Loading the same session through `SessionDB.get_messages_as_conversation` reproduces the disappearance deterministically: the row is present with `repair_alternation=False` and **absent** with `repair_alternation=True`.

Root cause chain:

1. `repair_message_sequence` Pass 3 merges any run of consecutive `role=user` rows **into the first row of the run**, keeping only that row's `_row_id`. Two durable shapes produce such a run:
   - model-switch markers persisted as `role=user` (#48338) immediately before the real prompt, when the turn is interrupted/errors before any assistant row persists;
   - an interrupted turn that persisted no assistant row, followed by a normal resend — a plain `user;user` pair with **no display marker at all**.
2. `_resolve_truncate_row_id`'s durable fallback loads the transcript via `_load_durable_truncation_history` with `repair_alternation=True` (the default), so the absorbed rows' ids do not exist in the view it searches.
3. The in-memory lookup can't save it either right after an interrupt (live turn rewrites lose `_row_id` stamps, and the length-mismatched repaired view blocks the heal), so resolution fails closed on every retry.

The fix extends the discipline the **rebind path already established** a hundred lines below (`repair can merge a physical user;user pair while preserving only the first row id — read the authoritative un-repaired active-id set`): identity resolution now loads the durable transcript with `repair_alternation=False`. Physical row ids are a property of stored rows; the lossy repair view exists for model replay, not for addressing. Fail-closed behavior is unchanged whenever the live list genuinely diverges — the all-pairs heal gate and the `#82959` content-agreement check still guard every mapping.

Relationship to #94500 (credit: that PR identified the marker-merge mechanism first): #94500 keeps marker-merged pairs addressable **in the repaired view**, which covers the post-resume shape where the live list itself is materialized merged. This PR covers the complementary live-session shape — an unmerged live history whose target id is absent from the repaired durable view — and every merge shape at once, including plain `user;user` runs with no display marker, which marker-keyed address preservation cannot reach. The two compose; neither alone covers both shapes.

## Related Issue

Refs #94486 (live-session shape of the same report), #84345 (regression reported after #87563)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/methods_prompt.py` — `_resolve_truncate_row_id` loads the durable transcript with `repair_alternation=False`; comments updated to match (the heal gate and ordinal-mapping guard now describe the actual divergence source).
- `tests/test_tui_gateway_server.py` — two regression tests through the real `prompt.submit` handler:
  - `test_prompt_submit_resolves_row_id_swallowed_by_marker_merge` — two `model_switch` markers + plain prompt (the incident shape);
  - `test_prompt_submit_resolves_row_id_swallowed_by_plain_user_merge` — interrupted turn + resend, no display marker (the shape repair-side preservation cannot reach).

## Testing

Discriminating matrix, all on the real handler with a `SessionDB` stand-in whose repaired/un-repaired views are produced by the real `repair_message_sequence`:

| Tree | both new tests |
|---|---|
| `main` (unfixed) | **FAIL** — 4018, log line byte-identical to the production incident |
| `main` + this PR | **PASS** |
| PR tree with `methods_prompt.py` reverted to `main` | **FAIL** (discriminating power) |

Regression sweep: all 41 `truncat/rewind/row_id/ordinal` tests in `tests/test_tui_gateway_server.py` and all 53 tests in `tests/run_agent/test_message_sequence_repair.py` pass.

Note: the new tests stay red on `main` **even with #94500's agent-side change applied** for the plain `user;user` shape (no `display_kind` to key on), and for the marker shape in the live-session variant (the `#82959` content guard refuses the merged-vs-plain mapping) — this is the differential evidence that the two PRs cover disjoint shapes.
