### PR TITLE
fix(bot-mode): avoid false task rejection after a lost response

### DIFF
--- a/tests/tui_gateway/test_hosted_room_peer_http.py
+++ b/tests/tui_gateway/test_hosted_room_peer_http.py
@@ -309,6 +309,127 @@ def test_ambiguous_admission_replays_the_identical_idempotency_key(tmp_path):
     )["run_id"] == "run-recovered"
 
 
+def test_ambiguous_admission_cannot_be_downgraded_by_replay_refusal(tmp_path):
+    client = PeerRunsHTTPClient(
+        base_url="https://peer.example.test",
+        api_key="",
+        receipt_db_path=tmp_path / "state.db",
+    )
+    requests = []
+
+    def accepted_then_replay_refused(path, **kwargs):
+        requests.append((path, kwargs))
+        if len(requests) == 1:
+            raise PeerRunsHTTPError(
+                "peer response was lost",
+                retryable=True,
+                ambiguous=True,
+            )
+        raise PeerRunsHTTPError(
+            "peer endpoint refused the replay",
+            retryable=True,
+            not_admitted=True,
+        )
+
+    client._request = accepted_then_replay_refused
+    with pytest.raises(PeerRunsHTTPError) as caught:
+        client.dispatch(dispatch=_dispatch(), grant="signed.room.grant")
+
+    assert caught.value.retryable is True
+    assert caught.value.ambiguous is True
+    assert caught.value.not_admitted is False
+    assert len(requests) == 2
+    assert requests[0][1]["headers"] == requests[1][1]["headers"]
+    assert requests[0][1]["body"] == requests[1][1]["body"]
+
+
+def test_ambiguous_admission_malformed_replay_keeps_recovery_backoff(tmp_path):
+    now = [0.0]
+    client = PeerRunsHTTPClient(
+        base_url="https://peer.example.test",
+        api_key="",
+        receipt_db_path=tmp_path / "state.db",
+        clock=lambda: now[0],
+    )
+    requests = []
+
+    def response_lost_then_missing_run_id(path, **kwargs):
+        requests.append((path, kwargs))
+        if len(requests) == 1:
+            raise PeerRunsHTTPError(
+                "peer response was lost",
+                retryable=True,
+                ambiguous=True,
+            )
+        return {}
+
+    client._request = response_lost_then_missing_run_id
+    with pytest.raises(PeerRunsHTTPError) as caught:
+        client.recover_dispatch(dispatch=_dispatch(), grant="signed.room.grant")
+
+    assert caught.value.retryable is True
+    assert caught.value.ambiguous is True
+    assert caught.value.not_admitted is False
+    assert len(requests) == 2
+    with pytest.raises(PeerRunsHTTPError, match="backing off"):
+        client.recover_dispatch(dispatch=_dispatch(), grant="signed.room.grant")
+    assert len(requests) == 2
+
+
+def test_initial_missing_run_id_replays_once_then_backs_off(tmp_path):
+    now = [0.0]
+    client = PeerRunsHTTPClient(
+        base_url="https://peer.example.test",
+        api_key="",
+        receipt_db_path=tmp_path / "state.db",
+        clock=lambda: now[0],
+    )
+    requests = []
+
+    def missing_run_id(path, **kwargs):
+        requests.append((path, kwargs))
+        return {}
+
+    client._request = missing_run_id
+    with pytest.raises(PeerRunsHTTPError) as caught:
+        client.recover_dispatch(dispatch=_dispatch(), grant="signed.room.grant")
+
+    assert caught.value.retryable is True
+    assert caught.value.ambiguous is True
+    assert caught.value.not_admitted is False
+    assert len(requests) == 2
+    assert requests[0][1]["headers"] == requests[1][1]["headers"]
+    assert requests[0][1]["body"] == requests[1][1]["body"]
+
+    with pytest.raises(PeerRunsHTTPError, match="backing off"):
+        client.recover_dispatch(dispatch=_dispatch(), grant="signed.room.grant")
+    assert len(requests) == 2
+
+
+@pytest.mark.parametrize("body", [b"not-json", b"[]"])
+def test_malformed_post_success_is_ambiguous(monkeypatch, body):
+    monkeypatch.setattr(
+        "hermes_cli.urllib_security.open_credentialed_url",
+        lambda *_args, **_kwargs: io.BytesIO(body),
+    )
+    client = PeerRunsHTTPClient(
+        base_url="https://peer.example.test",
+        api_key="",
+    )
+
+    with pytest.raises(PeerRunsHTTPError) as caught:
+        client._request(
+            "/v1/runs",
+            method="POST",
+            body={},
+            room_grant="signed.room.grant",
+        )
+
+    assert caught.value.retryable is True
+    assert caught.value.ambiguous is True
+    assert caught.value.not_admitted is False
+
+
 def test_ambiguous_admission_recovery_is_bounded_and_backed_off(tmp_path):
     now = [0.0]
     client = PeerRunsHTTPClient(

--- a/tests/tui_gateway/test_hosted_room_peer_recovery.py
+++ b/tests/tui_gateway/test_hosted_room_peer_recovery.py
@@ -1,0 +1,105 @@
+"""Focused RoomLink peer-recovery regressions."""
+
+from pathlib import Path
+
+from gateway import hosted_room_driver as driver
+from gateway import hosted_rooms
+from gateway.hosted_room_peer import GatewayRoomCatalog, catalog_mapping
+from tui_gateway.hosted_room_peer_transport import PeerMemberRoute
+from tui_gateway.hosted_room_service import HostedRoomService
+
+from tests.tui_gateway.test_hosted_room_service import (
+    _FakePeerClient,
+    _server,
+)
+
+
+class _RecoveringPeerClient(_FakePeerClient):
+    def __init__(self) -> None:
+        super().__init__()
+        self.recoveries = []
+
+    def recover_dispatch(self, **kwargs):
+        dispatch = dict(kwargs["dispatch"])
+        self.recoveries.append({**kwargs, "dispatch": dispatch})
+        self.dispatches.append(dispatch)
+        return {
+            "status": "accepted",
+            "task_id": dispatch["task_id"],
+            "execution_generation": dispatch["execution_generation"],
+            "run_id": "run-recovered",
+        }
+
+
+def test_peer_recovery_replays_only_indeterminate_generation(tmp_path: Path):
+    db = tmp_path / "state.db"
+    catalog = GatewayRoomCatalog.from_mapping(
+        catalog_mapping(installation_id="install-peer", persistent_process=True)
+    )
+    route = PeerMemberRoute(
+        home_install_id=hosted_rooms.local_authority_gateway_id(),
+        member_id="member-peer",
+        target_install_id="install-peer",
+        target_profile="reviewer",
+        capability_digest=catalog.catalog_digest,
+        cancellation_scope_id="cancel-room-1",
+        trace_id="trace-room-1",
+        grant="signed.room.grant",
+    )
+    peer = _RecoveringPeerClient()
+    service = HostedRoomService(_server(), db_path=db)
+    service.register_peer_route(
+        room_id="room-1",
+        member_id="member-peer",
+        route=route,
+        client=peer,
+        target_url="https://peer.example.test",
+        catalog=catalog,
+    )
+    service.create_room(
+        room_id="room-1",
+        name="Peer room",
+        members=[
+            {"member_id": "default", "profile": "default", "handle": "hermes"},
+            {
+                "member_id": "member-peer",
+                "profile": "reviewer",
+                "handle": "reviewer",
+                "target": {
+                    "kind": "peer",
+                    "peer_id": "peer-review",
+                    "installation_id": "install-peer",
+                    "profile": "reviewer",
+                    "capability_digest": catalog.catalog_digest,
+                },
+            },
+        ],
+    )
+    identity = driver.TaskIdentity("room-1", "task-1", "thread-1", "turn-1")
+    task = {
+        "identity": identity,
+        "execution_generation": 1,
+        "payload": {
+            "target_member_id": "member-peer",
+            "target_profile": "reviewer",
+            "source_event_seq": 9,
+            "prompt": "Recover the accepted review.",
+        },
+    }
+
+    service._resolve_member_transport(
+        service.bindings()[0],
+        {**task, "status": "running"},
+    )
+    assert peer.recoveries == []
+
+    service._resolve_member_transport(
+        service.bindings()[0],
+        {**task, "status": "indeterminate"},
+    )
+
+    assert len(peer.recoveries) == 1
+    recovered = peer.recoveries[0]["dispatch"]
+    assert recovered["task_id"] == "task-1"
+    assert recovered["execution_generation"] == 1
+    assert recovered["prompt"] == "Recover the accepted review."

--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -247,23 +247,6 @@ class _ApprovalPeerClient(_FakePeerClient):
         return {"resolved": 1}
 
 
-class _RecoveringPeerClient(_FakePeerClient):
-    def __init__(self) -> None:
-        super().__init__()
-        self.recoveries = []
-
-    def recover_dispatch(self, **kwargs):
-        dispatch = dict(kwargs["dispatch"])
-        self.recoveries.append({**kwargs, "dispatch": dispatch})
-        self.dispatches.append(dispatch)
-        return {
-            "status": "accepted",
-            "task_id": dispatch["task_id"],
-            "execution_generation": dispatch["execution_generation"],
-            "run_id": "run-recovered",
-        }
-
-
 class _PromptRecordingRPC(_FakeRPC):
     def __init__(self) -> None:
         super().__init__()
@@ -2005,71 +1988,3 @@ def test_stale_local_approval_cannot_resolve_replacement_request(tmp_path: Path)
     assert service.status("room-1")["pending_actions"][0]["request_id"] == (
         "approval-B"
     )
-
-
-def test_peer_recovery_replays_the_same_execution_generation(tmp_path: Path):
-    db = tmp_path / "state.db"
-    catalog = GatewayRoomCatalog.from_mapping(
-        catalog_mapping(installation_id="install-peer", persistent_process=True)
-    )
-    route = PeerMemberRoute(
-        home_install_id=hosted_rooms.local_authority_gateway_id(),
-        member_id="member-peer",
-        target_install_id="install-peer",
-        target_profile="reviewer",
-        capability_digest=catalog.catalog_digest,
-        cancellation_scope_id="cancel-room-1",
-        trace_id="trace-room-1",
-        grant="signed.room.grant",
-    )
-    peer = _RecoveringPeerClient()
-    service = HostedRoomService(_server(), db_path=db)
-    service.register_peer_route(
-        room_id="room-1",
-        member_id="member-peer",
-        route=route,
-        client=peer,
-        target_url="https://peer.example.test",
-        catalog=catalog,
-    )
-    service.create_room(
-        room_id="room-1",
-        name="Peer room",
-        members=[
-            {"member_id": "default", "profile": "default", "handle": "hermes"},
-            {
-                "member_id": "member-peer",
-                "profile": "reviewer",
-                "handle": "reviewer",
-                "target": {
-                    "kind": "peer",
-                    "peer_id": "peer-review",
-                    "installation_id": "install-peer",
-                    "profile": "reviewer",
-                    "capability_digest": catalog.catalog_digest,
-                },
-            },
-        ],
-    )
-    identity = driver.TaskIdentity("room-1", "task-1", "thread-1", "turn-1")
-
-    service._resolve_member_transport(
-        service.bindings()[0],
-        {
-            "identity": identity,
-            "status": "indeterminate",
-            "execution_generation": 1,
-            "payload": {
-                "target_member_id": "member-peer",
-                "target_profile": "reviewer",
-                "source_event_seq": 9,
-                "prompt": "Recover the accepted review.",
-            },
-        },
-    )
-
-    assert len(peer.recoveries) == 1
-    recovered = peer.recoveries[0]["dispatch"]
-    assert recovered["task_id"] == "task-1"
-    assert recovered["execution_generation"] == 1
-    assert recovered["prompt"] == "Recover the accepted review."

--- a/tui_gateway/hosted_room_peer_http.py
+++ b/tui_gateway/hosted_room_peer_http.py
@@ -306,9 +306,17 @@ class PeerRunsHTTPClient:
         try:
             payload = json.loads(raw)
         except ValueError as exc:
-            raise PeerRunsHTTPError("peer returned non-JSON data") from exc
+            raise PeerRunsHTTPError(
+                "peer returned non-JSON data",
+                retryable=ambiguous,
+                ambiguous=ambiguous,
+            ) from exc
         if not isinstance(payload, dict):
-            raise PeerRunsHTTPError("peer returned a non-object response")
+            raise PeerRunsHTTPError(
+                "peer returned a non-object response",
+                retryable=ambiguous,
+                ambiguous=ambiguous,
+            )
         return payload
 
     @staticmethod
@@ -402,22 +410,38 @@ class PeerRunsHTTPClient:
         session_id = self._session_id(checked, grant=grant)
 
         def admit() -> dict[str, Any]:
-            return self._request(
+            result = self._request(
                 "/v1/runs", method="POST",
                 body={"input": checked.prompt, "hosted_room_dispatch": checked.as_mapping()},
                 headers={
                     "Idempotency-Key": f"room:{checked.task_id}:{checked.execution_generation}"},
                 room_grant=grant)
 
+            if not str(result.get("run_id") or ""):
+                raise PeerRunsHTTPError(
+                    "peer did not return a run id",
+                    retryable=True,
+                    ambiguous=True,
+                )
+            return result
+
         try:
             result = admit()
-        except PeerRunsHTTPError as exc:
-            if not exc.ambiguous:
+        except PeerRunsHTTPError as first_error:
+            if not first_error.ambiguous:
                 raise
-            result = admit()
+            try:
+                result = admit()
+            except PeerRunsHTTPError as replay_error:
+                raise PeerRunsHTTPError(
+                    str(replay_error),
+                    retryable=(first_error.retryable or replay_error.retryable),
+                    ambiguous=True,
+                    not_admitted=False,
+                    status_code=replay_error.status_code,
+                    error_code=replay_error.error_code,
+                ) from replay_error
         run_id = str(result.get("run_id") or "")
-        if not run_id:
-            raise PeerRunsHTTPError("peer did not return a run id")
         receipt = {
             "run_id": run_id, "session_id": session_id,
             **{field: getattr(checked, field) for field in _RECEIPT_SCOPE_FIELDS},

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -266,7 +266,7 @@ class HostedRoomService:
         if (
             recover is None or not isinstance(identity, driver.TaskIdentity)
             or not isinstance(payload, Mapping) or execution_generation < 1
-            or task.get("status") not in {"running", "indeterminate", "stopping"}):
+            or task.get("status") not in {"indeterminate", "stopping"}):
             return
         prompt = payload.get("prompt")
         source_event_seq = int(payload.get("source_event_seq") or 0)


### PR DESCRIPTION
## Keep accepted work from looking rejected after a lost reply

A remote Bot may accept a turn even when its response is lost. If an identical retry then fails before connecting, that later failure does not prove the first turn was rejected. This PR keeps that attempt unresolved instead of reporting a false rejection.

## Current runtime alignment

Updated for #106742 at `485d5f6848c25` through a normal merge, preserving the existing fix and its authored history. The runtime-relative diff is **six owner-only files, +285/−114**; no lower-layer implementation is bundled.

Current head: [`59a10872c92c`](https://github.com/dokterdok/hermes-agent/commit/59a10872c92c8f9b9529e89b67505558523a0af3). Tested runtime base: [`485d5f6848c25`](https://github.com/NousResearch/hermes-agent/commit/485d5f6848c2598ca00fa7704e50e8ae66d0983a).

## Contract preserved

- A definitively rejected first request remains rejected.
- Once admission is ambiguous, replay failure cannot turn it into `not_admitted`. Retryability remains monotonic and the replay's typed HTTP/error metadata is retained.
- Non-JSON, non-object and missing-`run_id` success responses take one identical replay, followed by bounded backoff if still unresolved.
- A fresh `running` task uses ordinary dispatch once. Admission recovery applies only to `indeterminate` or `stopping` work and retains the original task, generation, request body and idempotency key.

This fixes the existing scoped RoomLink HTTP-client path. It does not enable unfinished canonical RoomLink admissions, authorize retrying unknown execution, or certify full remote/native parity. #106742 remains the runtime dependency; route setup and consent stay with #100016.

## What changed in this refresh

The conflict was in a relocated test, not production logic. The current runtime's profile-discovery regression is preserved in the focused module, including valid profile identity markers, deleted-profile exclusion and rejection of marker-less cron directories. The stronger recovery test still checks that fresh running work does not enter admission recovery.

The HTTP implementation and its existing tests are unchanged from the previous #99960 head (`1fd3a90bdd56`); the service recovery restriction is also unchanged. All 45 remaining top-level definitions in the runtime's service test module are preserved. The largest touched file remains 1,992 lines.

## Verification

On exact head `59a10872c92c`, **17 selected cases passed across three files**, using `scripts/run_tests.sh`, two workers and zero retries. The parent rerun passed the same selection; these are not additive test totals. Coverage includes identical replay identity, ambiguous-to-rejected downgrade refusal, malformed success/backoff, definitive first rejection, fresh-running versus indeterminate recovery, and profile discovery. Source inspection, worker six-file Ruff and runtime-relative whitespace checks passed.

The HTTP checks use mocked responses/failures; service checks use temporary data and a fake peer. No service, model, real HTTP listener or production peer was started. Broader Stop/fault/unknown-resolution, native and live multi-gateway acceptance were not exercised. Historical 83-case and hosted-CI results belong to their original revisions. Current-head hosted CI and the maintainer's landing gate remain separate from this local verification.

## Related and attribution

#97681 tracks the full continuity composition. This normal-forward update retains `1fd3a90bdd56` as its first parent and the original reviewed `cbf598d408d1` history. The pre-recut history remains on `preserve/pr99960-before-main-refresh-20260906`; this does not replace the PR with the integration stack.
