### PR TITLE
feat(plugins): add temporal_context plugin — physical time grounding …

### DIFF
--- a/plugins/temporal_context/__init__.py
+++ b/plugins/temporal_context/__init__.py
@@ -1,0 +1,100 @@
+"""Temporal-context plugin — physical time grounding for long-running sessions.
+
+The context assembly pipeline models conversation history as an atemporal
+sequence: when a user returns hours or days later with "continue the
+troubleshooting" or "revert what we did just now", the model has no perception
+of how much physical time elapsed, so it misreads relative anchors and trusts
+stale runtime state (ports, PIDs, scratch files) that may be long gone.
+
+This plugin injects a compact temporal header once per user turn:
+
+    <!-- system:temporal_context (ephemeral) -->
+    [Current time: 2026-09-01 10:50 Tuesday]
+    [Turn interval: 3h12m since your previous turn]
+    <!-- end_temporal_context -->
+
+It is delivered through the ``pre_llm_call`` hook, so the text is appended to
+the *current user message* at API-call time only — never persisted to the
+session DB, never placed in the system prompt (the prompt-cache prefix stays
+byte-stable across turns). This is a self-contained, opt-in first cut of the
+idea in RFC #99942; the full RFC additionally proposes core session-store
+timestamps and multi-day timeline chunking.
+
+Note on the interval metric: it measures wall-clock time between the first LLM
+call of consecutive *user* turns for a session. That includes the previous
+turn's own agent-execution time, so for back-to-back turns it over-reads by a
+few seconds; for the return-from-idle case this plugin exists to serve (gaps of
+minutes to days) that overhead is negligible. A precise
+``user_sent_at - agent_finished_at`` delta needs the core timestamps the RFC
+proposes and is intentionally out of scope here.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from datetime import datetime
+from typing import Any, Optional
+
+# session_id -> unix timestamp of that session's previous user turn.
+# Process-local and best-effort: a gateway restart resets it (the next turn is
+# simply reported as the first in the session), which is the safe direction.
+_last_user_turn_at: "dict[str, float]" = {}
+_lock = threading.Lock()
+
+
+def _humanize(seconds: float) -> str:
+    """Render an elapsed duration compactly: 45s, 12m, 3h12m, 2d4h."""
+    total = int(max(0, seconds))
+    if total < 60:
+        return f"{total}s"
+    minutes, _ = divmod(total, 60)
+    if minutes < 60:
+        return f"{minutes}m"
+    hours, rem_min = divmod(minutes, 60)
+    if hours < 24:
+        return f"{hours}h{rem_min}m" if rem_min else f"{hours}h"
+    days, rem_hours = divmod(hours, 24)
+    return f"{days}d{rem_hours}h" if rem_hours else f"{days}d"
+
+
+def _temporal_header(session_id: str, now: float) -> str:
+    """Build the header for ``session_id`` at wall-clock ``now`` and advance its
+    last-turn marker. Split out from :func:`on_pre_llm_call` so the delta logic
+    is deterministically testable with injected timestamps."""
+    stamp = datetime.fromtimestamp(now).strftime("%Y-%m-%d %H:%M %A")
+    with _lock:
+        previous = _last_user_turn_at.get(session_id)
+        _last_user_turn_at[session_id] = now
+    if previous is None or now < previous:
+        interval = "first turn in this session"
+    else:
+        interval = f"{_humanize(now - previous)} since your previous turn"
+    return (
+        "<!-- system:temporal_context (ephemeral) -->\n"
+        f"[Current time: {stamp}]\n"
+        f"[Turn interval: {interval}]\n"
+        "<!-- end_temporal_context -->"
+    )
+
+
+def on_pre_llm_call(
+    *,
+    session_id: str = "",
+    turn_type: str = "user",
+    api_call_count: int = 0,
+    **kwargs: Any,
+) -> Optional[dict]:
+    """Inject the temporal header on the first LLM call of each user turn.
+
+    Skips internal tool-loop iterations (``api_call_count > 0``) so the header
+    is not repeated within a turn and the interval clock is measured per user
+    turn, and skips non-user turns (cron / goal continuations) whose cadence is
+    machine-driven rather than a human coming back from idle.
+    """
+    if turn_type != "user" or api_call_count:
+        return None
+    return {"context": _temporal_header(session_id or "", time.time())}
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)

--- a/plugins/temporal_context/plugin.yaml
+++ b/plugins/temporal_context/plugin.yaml
@@ -1,0 +1,6 @@
+name: temporal_context
+version: "1.0.0"
+description: "Injects a compact, ephemeral temporal header (current wall-clock time + how long since the user's previous turn) once per user turn, so long-running / return-from-idle sessions can ground relative time anchors ('just now', 'yesterday') and re-validate stale runtime state instead of trusting hours-old facts. Self-contained first implementation of the idea in RFC #99942, via the pre_llm_call hook — ephemeral, never persisted, never in the system prompt (prompt cache preserved). Opt-in: `hermes plugins enable temporal_context`."
+author: bsdnn
+provides_hooks:
+  - pre_llm_call

--- a/tests/plugins/test_temporal_context.py
+++ b/tests/plugins/test_temporal_context.py
@@ -1,0 +1,81 @@
+"""Temporal-context plugin: per-user-turn time header via pre_llm_call (#99942).
+
+Pins the behaviour that matters: the interval is measured per session, the
+header is injected only on the first LLM call of a user turn (not internal
+tool-loop iterations or machine-driven turns), and the duration rendering /
+clock-skew handling are correct.
+"""
+import importlib
+
+import pytest
+
+tc = importlib.import_module("plugins.temporal_context")
+
+
+@pytest.fixture(autouse=True)
+def _clear_state():
+    tc._last_user_turn_at.clear()
+    yield
+    tc._last_user_turn_at.clear()
+
+
+def test_humanize_scales():
+    assert tc._humanize(0) == "0s"
+    assert tc._humanize(45) == "45s"
+    assert tc._humanize(60) == "1m"
+    assert tc._humanize(3600) == "1h"
+    assert tc._humanize(3720) == "1h2m"
+    assert tc._humanize(90000) == "1d1h"
+    assert tc._humanize(172800) == "2d"
+
+
+def test_first_turn_reports_first_and_carries_clock():
+    header = tc._temporal_header("s1", 1_756_000_000.0)
+    assert "first turn in this session" in header
+    assert "[Current time:" in header
+    assert "temporal_context" in header
+
+
+def test_second_turn_reports_interval_since_previous():
+    now = 1_756_000_000.0
+    tc._temporal_header("s1", now)                 # first turn
+    header = tc._temporal_header("s1", now + 3 * 3600 + 12 * 60)  # +3h12m
+    assert "3h12m since your previous turn" in header
+    assert "first turn" not in header
+
+
+def test_interval_is_per_session():
+    now = 1_756_000_000.0
+    tc._temporal_header("a", now)
+    tc._temporal_header("b", now + 10)
+    # Session "a" advancing does not leak into "b" and vice versa.
+    ha = tc._temporal_header("a", now + 45)   # 45s since a's first turn
+    hb = tc._temporal_header("b", now + 25)   # 15s since b's first turn (now+10)
+    assert "45s since your previous turn" in ha
+    assert "15s since your previous turn" in hb
+
+
+def test_clock_skew_backwards_falls_back_to_first_turn():
+    now = 1_756_000_000.0
+    tc._temporal_header("s1", now)
+    header = tc._temporal_header("s1", now - 500)  # clock moved backwards
+    assert "first turn in this session" in header  # no negative interval, no crash
+
+
+def test_hook_injects_only_on_first_call_of_a_user_turn():
+    # Internal tool-loop iterations (api_call_count > 0) inject nothing.
+    assert tc.on_pre_llm_call(session_id="s1", turn_type="user", api_call_count=3) is None
+    # Non-user (cron / goal continuation) turns inject nothing.
+    assert tc.on_pre_llm_call(session_id="s1", turn_type="cron", api_call_count=0) is None
+    # First call of a user turn returns the header payload.
+    out = tc.on_pre_llm_call(session_id="s1", turn_type="user", api_call_count=0)
+    assert isinstance(out, dict) and "[Current time:" in out["context"]
+
+
+def test_hook_accepts_unknown_future_payload_keys():
+    # The hook payload evolves additively; the callback must tolerate extra keys.
+    out = tc.on_pre_llm_call(
+        session_id="s1", turn_type="user", api_call_count=0,
+        model="gpt-x", provider="openai", some_future_field=123,
+    )
+    assert isinstance(out, dict) and "context" in out


### PR DESCRIPTION
## What does this PR do?

A self-contained, opt-in plugin that injects a compact **temporal header** once
per user turn — the current wall-clock time and how long since the user's
previous turn — so long-running / return-from-idle sessions can ground relative
time anchors ("just now", "yesterday") and re-validate stale runtime state
instead of trusting hours-old facts.

It uses the existing `pre_llm_call` hook, so the text is appended to the current
user message at API-call time only — never persisted, never in the system prompt
(the prompt-cache prefix stays byte-stable). The interval is tracked per session;
internal tool-loop iterations (`api_call_count > 0`) and machine-driven
(cron/goal) turns are skipped, so the header appears once per human turn.

This is a **lightweight plugin-level first cut of the idea in RFC #99942** —
deliberately not the full RFC. It does not add the core session-store timestamps
(`user_sent_at` / `agent_finished_at`) or the multi-day timeline chunking the RFC
proposes; the interval it reports is wall-clock time between consecutive user
turns (documented in the module), which is exact enough for the idle-gap case it
serves. Offered as a minimal, opt-in alternative to the heavier subsystem
approach explored in #61837.

## Related Issue

Relates to #99942 (RFC) — a working plugin prototype of its core temporal-lens
idea, not a full implementation. Lighter-weight alternative to #61837.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/temporal_context/__init__.py` — new opt-in plugin; `pre_llm_call`
  hook computes and injects the per-turn temporal header, tracked per session.
- `plugins/temporal_context/plugin.yaml` — plugin manifest (`provides_hooks: [pre_llm_call]`).
- `tests/plugins/test_temporal_context.py` — duration rendering, per-session
  interval isolation, first-turn / clock-skew handling, and hook gating (only
  the first LLM call of a user turn injects).

## How to Test

1. `pytest tests/plugins/test_temporal_context.py -q` → 7 passed.
2. `python -c "from hermes_cli.plugin_dev import doctor_plugin; from pathlib import Path; r=doctor_plugin(Path('plugins/temporal_context')); print(r.ok, r.registered_hooks, r.findings)"` → `True ('pre_llm_call',) []`.
3. Enable it (`hermes plugins enable temporal_context`); after an idle gap, the
   model receives the header on the next user turn (see Logs).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`feat(plugins):`)
- [x] I searched existing PRs (this is distinct from the core-subsystem #61837 — it's an opt-in plugin, not a core subsystem)
- [x] My PR contains only changes related to this feature
- [x] I've run the plugin's tests + `plugins doctor` (both green). (Full `pytest tests/ -q` not run locally: the suite has pre-existing Windows-only env-dependency failures unrelated to this change.)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Docstrings document the behavior and the interval-metric caveat — README/docs N/A (opt-in plugin, self-describing)
- [x] `cli-config.yaml.example` — N/A (no config keys; opt-in via `plugins enable`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture/workflow change)
- [x] Cross-platform impact considered — pure stdlib (`time`, `datetime`, `threading`), platform-independent
- [x] Tool descriptions/schemas — N/A (no tools added/changed)

## Screenshots / Logs

Exact header the plugin injects (ephemeral, into the current user message):

First turn of a session:
```mermaid
flowchart TD
    A["User sends a message<br/>(user turn starts)"] --> B["Agent begins the turn"]
    B --> C["Assemble prompt<br/>system + history + current user message"]
    C --> D{{"pre_llm_call hooks fire"}}
    D --> E["temporal_context callback<br/>on_pre_llm_call(session_id, turn_type, api_call_count)"]
    E --> F{"turn_type == user<br/>AND api_call_count == 0 ?"}
    F -->|"yes: first LLM call of a user turn"| G["Build temporal header<br/>[Current time ...]<br/>[time since previous turn ...]<br/>track last_turn per session"]
    F -->|"no: internal tool loop / cron / goal"| H["return None — no injection"]
    G --> I["Header appended to the API copy of the<br/>current user message<br/>(ephemeral: not persisted, not in system prompt)"]
    H --> J["Call LLM API"]
    I --> J
    J --> K{"Model requests a tool?"}
    K -->|"yes"| L["Execute tool"]
    L --> M["api_call_count += 1"]
    M --> C
    K -->|"no"| N["Final response — turn ends"]
    N --> A

    style E fill:#2d6,stroke:#161,color:#000
    style G fill:#2d6,stroke:#161,color:#000
    style I fill:#bdf,stroke:#159,color:#000
```