### PR TITLE
fix(kanban-dashboard): label scheduled fallback column

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -94,6 +94,7 @@
   const FALLBACK_COLUMN_LABEL = {
     triage: "Triage",
     todo: "Todo",
+    scheduled: "Scheduled",
     ready: "Ready",
     running: "In Progress",
     blocked: "Blocked",
@@ -104,6 +105,7 @@
   const FALLBACK_COLUMN_HELP = {
     triage: "Raw ideas — a specifier will flesh out the spec",
     todo: "Waiting on dependencies or unassigned",
+    scheduled: "Parked until a scheduled time (waiting on the clock, not a human)",
     ready: "Dependencies satisfied; assign a profile to dispatch",
     running: "Claimed by a worker — in-flight",
     blocked: "Worker asked for human input",


### PR DESCRIPTION
## Evidence

`plugins/kanban/dashboard/plugin_api.py` ships `scheduled` as a first-class entry in `BOARD_COLUMNS`, but the dashboard's `FALLBACK_COLUMN_LABEL` and `FALLBACK_COLUMN_HELP` objects omit that status. When no translation is available, `getColumnLabel()` therefore falls back to the raw lowercase string `scheduled`, and `getColumnHelp()` returns an empty tooltip.

The `review` half of #41653 is already present on current `main`; this PR carries only the still-missing `scheduled` half.

## Change

- Add the `Scheduled` English fallback label.
- Add the existing scheduled-lane explanation as fallback help text.

## RED → GREEN

Before the change, a focused source assertion failed with:

```text
AssertionError: scheduled label fallback is missing
```

After the change, the same assertion reports:

```text
scheduled label and help fallbacks are present
```

Additional verification:

- `uv sync --extra all --extra dev`
- `node --check plugins/kanban/dashboard/dist/index.js`
- `.venv/bin/python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -o 'addopts=' -q` → `38 passed`
