### PR TITLE
chore(tui): remove dead hermes_undo import

### DIFF
--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -520,12 +520,6 @@ class ComputeHost:
             except Exception:
                 pass
             try:
-                import hermes_undo
-
-                hermes_undo.on_user_message_appended(session["session_key"])
-            except Exception:
-                pass
-            try:
                 server._persist_branch_seed(session)
             except Exception:
                 pass


### PR DESCRIPTION
## Evidence

- Current `main` at `21b2095d00a98b8ad7b5c60b10587619c852cdb8` has no `hermes_undo` module (`importlib.util.find_spec("hermes_undo")` returns `None`, and the tracked tree has no matching path).
- `tui_gateway/compute_host.py` nevertheless imports it for every real compute-host turn, calls `on_user_message_appended`, and suppresses the inevitable failure with `except Exception: pass`.
- Before this change, `ty check tui_gateway/compute_host.py` reports `error[unresolved-import]` at the dead import. After the removal, that diagnostic is gone; the file retains three unrelated baseline type diagnostics.

## Change

Remove the unreachable import/callback block. No replacement is needed: the module and callback do not exist on `main`, so the block has always been a silent no-op.

## Verification

- `uv sync --extra all --extra dev`
- `scripts/run_tests.sh tests/tui_gateway/test_compute_host.py tests/tui_gateway/test_compute_host_phase1.py tests/tui_gateway/test_iso_certify_seam.py -q` — 15 passed, 0 failed
- `ruff check tui_gateway/compute_host.py` — passed

Baseline note: `tests/test_tui_gateway_server.py::test_model_options_preserves_canonical_custom_row_after_agent_init` fails identically under the canonical runner on this branch and on untouched `main` at the SHA above; it is unrelated to this one-file deletion.
