### PR TITLE
fix(usage): retain Codex app-server turn usage

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -199,6 +199,9 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
     agent.session_cache_read_tokens += canonical_usage.cache_read_tokens
     agent.session_cache_write_tokens += canonical_usage.cache_write_tokens
     agent.session_reasoning_tokens += canonical_usage.reasoning_tokens
+    # Codex app-server turns bypass conversation_loop's sibling assignment.
+    # Preserve the same canonical usage for turn_finalizer's context-engine hook.
+    agent._last_turn_usage = dict(usage_dict)
 
     cost_result = estimate_usage_cost(
         agent.model,

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -136,6 +136,17 @@ class TestRunConversationCodexPath:
         assert agent.context_compressor.last_total_tokens == 130
         assert agent.context_compressor.context_length == 200000
 
+        assert getattr(agent, "_last_turn_usage", None) == {
+            "prompt_tokens": 100,
+            "completion_tokens": 25,
+            "total_tokens": 130,
+            "input_tokens": 80,
+            "output_tokens": 25,
+            "cache_read_tokens": 20,
+            "cache_write_tokens": 0,
+            "reasoning_tokens": 5,
+        }
+
     def test_native_codex_compaction_updates_bookkeeping(self, monkeypatch):
         def fake_run_turn(self, user_input: str, **kwargs):
             return TurnResult(


### PR DESCRIPTION
## Evidence

Codex app-server turns return before the chat-completions accounting branch that stores `agent._last_turn_usage`. `_record_codex_app_server_usage()` already builds the same eight-field canonical `usage_dict`, but a successful Codex turn left the snapshot as `None`.

Regression proof on current `main` (`21b2095d00`):

- Before the fix, the focused integration test failed with `assert None == {...}` after a successful Codex app-server turn.
- After the fix, the focused test passes: `1 passed`.
- The touched suites pass: `34 passed`.
- Ruff reports: `All checks passed!`.

## Change

Copy the Codex app-server path's canonical `usage_dict` into `_last_turn_usage`, matching the existing chat-completions path. No provider request, persistence, or token-accounting behavior changes.

This replaces the remaining Codex-only portion of #37418; the rest of that older PR is already present on `main` under `_last_turn_usage`.

## Test plan

- `uv sync --extra all --extra dev`
- `env HERMES_HOME=/tmp/hermes-codex-last-turn-usage-home uv run --frozen --extra all --extra dev python -m pytest tests/run_agent/test_codex_app_server_integration.py::TestRunConversationCodexPath::test_codex_app_server_token_usage_updates_session_accounting -q -o addopts=`
- `env HERMES_HOME=/tmp/hermes-codex-last-turn-usage-home uv run --frozen --extra all --extra dev python -m pytest tests/run_agent/test_codex_app_server_integration.py tests/agent/test_context_engine_on_turn_complete_usage.py tests/run_agent/test_session_reset_fix.py -q -o addopts=`
- `env HERMES_HOME=/tmp/hermes-codex-last-turn-usage-home uv run --frozen --extra all --extra dev ruff check agent/codex_runtime.py tests/run_agent/test_codex_app_server_integration.py`
