### PR TITLE
fix(desktop): fan out durable user prompts live

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1516,14 +1516,18 @@ def build_turn_context(
         else:
             with persist_lock:
                 _ensure_and_persist()
-        # The row is durable now. Gateway-attached agents use this optional
-        # hook to refresh peer clients immediately instead of waiting for the
-        # coarse state.db watcher. Keep notification failure independent from
-        # persistence: a disconnected observer must never fail the turn.
-        _on_user_message_persisted = getattr(
-            agent, "_on_user_message_persisted", None
+        # A normal return is not sufficient proof of durability: the lower DB
+        # helpers deliberately swallow some creation/append failures so the
+        # turn can recover later. The intrinsic marker is stamped only after a
+        # successful row append (or when a loaded row is materialized), making
+        # it the authoritative commit signal for this exact user-message dict.
+        _turn_user_is_durable = (
+            0 <= current_turn_user_idx < len(messages)
+            and isinstance(messages[current_turn_user_idx], dict)
+            and messages[current_turn_user_idx].get("_db_persisted") is True
         )
-        if callable(_on_user_message_persisted):
+        _on_user_message_persisted = getattr(agent, "_on_user_message_persisted", None)
+        if _turn_user_is_durable and callable(_on_user_message_persisted):
             try:
                 _on_user_message_persisted()
             except Exception:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1516,6 +1516,22 @@ def build_turn_context(
         else:
             with persist_lock:
                 _ensure_and_persist()
+        # The row is durable now. Gateway-attached agents use this optional
+        # hook to refresh peer clients immediately instead of waiting for the
+        # coarse state.db watcher. Keep notification failure independent from
+        # persistence: a disconnected observer must never fail the turn.
+        _on_user_message_persisted = getattr(
+            agent, "_on_user_message_persisted", None
+        )
+        if callable(_on_user_message_persisted):
+            try:
+                _on_user_message_persisted()
+            except Exception:
+                logger.debug(
+                    "User-message persistence notification failed for session=%s",
+                    agent.session_id or "none",
+                    exc_info=True,
+                )
     except Exception:
         logger.warning(
             "Early turn-start session persistence failed for session=%s",

--- a/apps/desktop/e2e/correction-session-switch.spec.ts
+++ b/apps/desktop/e2e/correction-session-switch.spec.ts
@@ -13,6 +13,8 @@ import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fi
 import { CORRECTION_SWITCH_TRIGGER, MOCK_REPLY } from './mock-server'
 
 const OTHER_SESSION_PROMPT = 'E2E persisted session used for a warm resume.'
+const OTHER_SESSION_TITLE = MOCK_REPLY.replace(/\.$/, '')
+const CURRENT_SESSION_TITLE = `${OTHER_SESSION_TITLE} #2`
 const ORIGINAL_PROMPT = `${CORRECTION_SWITCH_TRIGGER}: original prompt must remain singular after a correction.`
 const CORRECTION = 'E2E correction must stay after the original prompt.'
 const TOOL_STARTED = 'Checking the long-running task before I continue.'
@@ -20,6 +22,7 @@ const CORRECTED_REPLY = 'The corrected task finished.'
 const INFERENCE_SWITCH_TRIGGER = 'E2E_INFERENCE_SWITCH_TRIGGER'
 const INFERENCE_PROMPT = `${INFERENCE_SWITCH_TRIGGER}: original inference prompt must remain singular.`
 const INFERENCE_CORRECTION = `${INFERENCE_SWITCH_TRIGGER}: correction sent while inference is live.`
+const POST_CORRECTION_FOLLOW_UP = 'E2E normal follow-up after correction script'
 
 // Inactive tabs stay mounted under a data-pane-hidden ancestor. Match the
 // renderer's keep-alive visibility policy instead of relying on DOM order.
@@ -130,23 +133,18 @@ async function openFreshDraft(page: Page, priorSessionText: string): Promise<voi
 }
 
 async function openSidebarSession(page: Page, sidebarText: string, expectedTranscriptText: string): Promise<void> {
-  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: sidebarText }).first()
+  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: sidebarText }).last()
   await row.waitFor({ state: 'visible', timeout: 30_000 })
   await row.click()
   await waitForTranscriptText(page, expectedTranscriptText)
 }
 
 async function reopenOriginalSession(page: Page): Promise<void> {
-  // A still-running tool has not generated a final title yet, so the sidebar
-  // retains the source prompt as its provisional session title.
-  await openSidebarSession(page, ORIGINAL_PROMPT, ORIGINAL_PROMPT)
+  await openSidebarSession(page, CURRENT_SESSION_TITLE, ORIGINAL_PROMPT)
 }
 
 async function reopenInferenceSession(page: Page): Promise<void> {
-  const row = page.locator('[data-slot="sidebar"] button').filter({ hasText: INFERENCE_PROMPT }).first()
-  await row.waitFor({ state: 'visible', timeout: 30_000 })
-  await row.click()
-  await waitForTranscriptText(page, INFERENCE_PROMPT)
+  await openSidebarSession(page, CURRENT_SESSION_TITLE, INFERENCE_PROMPT)
 }
 
 function relevantOrder(messages: string[]): string[] {
@@ -209,7 +207,7 @@ test.describe('correction session switch', () => {
 
     // Reproduce the observed race: switch to another persisted session while
     // the foreground tool is live, then return before its redirect settles.
-    await openSidebarSession(page, MOCK_REPLY, OTHER_SESSION_PROMPT)
+    await openSidebarSession(page, OTHER_SESSION_TITLE, OTHER_SESSION_PROMPT)
     await reopenOriginalSession(page)
     await page.waitForTimeout(500)
     await page.screenshot({ path: testInfo.outputPath('correction-after-warm-resume.png') })
@@ -220,6 +218,11 @@ test.describe('correction session switch', () => {
 
     await waitForTranscriptText(page, CORRECTED_REPLY)
     expect(steerTurnOrder(await transcriptMessageOrder(page))).toEqual([ORIGINAL_PROMPT, CORRECTION, CORRECTED_REPLY])
+
+    // Historical correction markers remain in the request. Once every
+    // scripted turn is consumed, a new streamed prompt must route normally.
+    await send(page, POST_CORRECTION_FOLLOW_UP)
+    await waitForTranscriptText(page, MOCK_REPLY)
   })
 
   test('keeps an inference-time correction visible through a warm session switch', async ({}, testInfo: TestInfo) => {
@@ -236,7 +239,7 @@ test.describe('correction session switch', () => {
     await send(page, INFERENCE_CORRECTION)
     await waitForTranscriptText(page, INFERENCE_CORRECTION)
 
-    await openSidebarSession(page, MOCK_REPLY, OTHER_SESSION_PROMPT)
+    await openSidebarSession(page, OTHER_SESSION_TITLE, OTHER_SESSION_PROMPT)
     await reopenInferenceSession(page)
 
     expect(await textNodeOccurrences(page, INFERENCE_PROMPT)).toBe(1)

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -74,7 +74,10 @@ function stripCredentials(env: Record<string, string | undefined>): Record<strin
   const clean: Record<string, string> = {}
 
   for (const [key, value] of Object.entries(env)) {
-    if (!value) {
+    // Empty values can be semantically required. In particular, Git's
+    // GIT_CONFIG_COUNT/KEY_n/VALUE_n triplets permit an empty VALUE_n; dropping
+    // only that member leaves every Git command with malformed process config.
+    if (value === undefined) {
       continue
     }
 

--- a/apps/desktop/e2e/glyph-spinner.spec.ts
+++ b/apps/desktop/e2e/glyph-spinner.spec.ts
@@ -20,68 +20,89 @@
  * Prerequisite: `npm run build` must have been run so dist/ exists.
  */
 
-import { expect, type Page, test } from '@playwright/test'
+import { expect, type Locator, test } from '@playwright/test'
 
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { type BackgroundReleaseHandle, createBackgroundReleaseHandle, restartMockServer } from './mock-server'
 
-const STRIP = '.glyph-spinner__strip'
+const ACTIVE_SURFACE = '[data-composer-target]:not([data-pane-hidden] [data-composer-target])'
+const ACTIVE_STRIP = `${ACTIVE_SURFACE} [data-slot="composer-status-stack"] [role="status"][aria-label="Running"] .glyph-spinner__strip`
 
 /**
  * Send a message so a turn is in flight — the composer status stack mounts a
  * GlyphSpinner while the agent is working. Resolves once a frame strip is in
  * the DOM.
  */
-async function mountSpinner(page: Page): Promise<void> {
+async function mountSpinner(current: MockBackendFixture): Promise<Locator> {
+  const { page } = current
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('Emulation.setFocusEmulationEnabled', { enabled: true })
+  await page.evaluate(() => window.dispatchEvent(new FocusEvent('focus')))
+
   const composer = page.locator('[contenteditable="true"]').first()
   await composer.waitFor({ state: 'visible', timeout: 10_000 })
   await composer.click()
-  await composer.type('hello from the glyph spinner spec', { delay: 10 })
+  await composer.type('E2E_SIDEBAR_CROSS', { delay: 10 })
   await page.keyboard.press('Enter')
 
-  await page.waitForSelector(STRIP, { state: 'attached', timeout: 20_000 })
+  const statusStack = page.locator(`${ACTIVE_SURFACE} [data-slot="composer-status-stack"]`)
+  await expect(statusStack).toBeVisible({ timeout: 30_000 })
+  const backgroundGroup = statusStack.locator('button').filter({ hasText: /Background/i }).first()
+  await backgroundGroup.click()
+
+  const strip = page.locator(ACTIVE_STRIP).last()
+  await expect(strip).toBeVisible({ timeout: 20_000 })
+  await expect(strip.locator('..')).not.toHaveAttribute('data-paused', 'true')
+  await expect.poll(() => strip.evaluate(el => getComputedStyle(el).animationPlayState)).toBe('running')
+
+  return strip
 }
 
 test.describe('GlyphSpinner (compositor animation)', () => {
   let fixture: MockBackendFixture
+  let backgroundRelease: BackgroundReleaseHandle
 
-  test.beforeAll(async () => {
-    fixture = await setupMockBackend()
+  test.beforeEach(async () => {
+    restartMockServer()
+    backgroundRelease = createBackgroundReleaseHandle()
+    fixture = await setupMockBackend({
+      extraConfig: 'approvals:\n  mode: off',
+      mockServer: { backgroundReleasePath: backgroundRelease.path },
+    })
     await waitForAppReady(fixture)
   })
 
-  test.afterAll(async () => {
+  test.afterEach(async () => {
+    backgroundRelease?.release()
     await fixture?.cleanup()
+    backgroundRelease?.cleanup()
   })
 
   test('animates with a steps() transform keyframes animation, one step per frame', async () => {
-    const { page } = fixture
-    await mountSpinner(page)
+    const strip = await mountSpinner(fixture)
 
-    const observed = await page.evaluate(strip => {
-      const el = document.querySelector<HTMLElement>(strip)
-
-      if (!el) {
-        throw new Error('no frame strip in the DOM')
-      }
-
+    const observed = await strip.evaluate(el => {
       const style = getComputedStyle(el)
       const animations = el.getAnimations()
+      const frameCount = el.querySelectorAll('.glyph-spinner__frame').length
+      const frameHeight = el.querySelector<HTMLElement>('.glyph-spinner__frame')?.getBoundingClientRect().height ?? 0
+      const transforms = ((animations[0]?.effect as KeyframeEffect | undefined)?.getKeyframes() ?? [])
+        .map(k => String((k as Keyframe & { transform?: string }).transform ?? ''))
+      const travelPx = transforms.map(transform =>
+        Number(transform.match(/translateY\((-?\d+(?:\.\d+)?)px\)/)?.[1] ?? Number.NaN),
+      )
 
       return {
-        frameCount: el.querySelectorAll('.glyph-spinner__frame').length,
+        frameCount,
+        frameHeight,
         timingFunction: style.animationTimingFunction,
         iterationCount: style.animationIterationCount,
         durationMs: animations[0]?.effect?.getTiming().duration ?? null,
         names: animations.map(a => (a as CSSAnimation).animationName),
-        // A percentage translate makes the animation layout-dependent, which
-        // Chromium refuses to composite. Read the engine's own keyframes: a
-        // revert to translateY(-100%) shows up here, while the computed
-        // `style.transform` always serializes to a matrix and can't tell.
-        travel: ((animations[0]?.effect as KeyframeEffect | undefined)?.getKeyframes() ?? [])
-          .map(k => String((k as Keyframe & { transform?: string }).transform ?? ''))
-          .join(' | ')
+        transforms,
+        travelPx,
       }
-    }, STRIP)
+    })
 
     // The strip carries every frame; `steps(N)` parks on each one in turn.
     expect(observed.frameCount).toBeGreaterThan(1)
@@ -92,88 +113,58 @@ test.describe('GlyphSpinner (compositor animation)', () => {
     // One full cycle is frames x interval, so the duration must be a positive
     // multiple of the frame count — not the single-frame interval.
     expect(observed.durationMs).toBeGreaterThan(0)
-    // Length-typed travel, never a percentage: `translateY(-100%)` would keep
-    // the animation off the compositor.
-    expect(observed.travel).toContain('calc(')
-    expect(observed.travel).not.toContain('%')
+    // Absolute frame travel keeps the animation compositor-eligible and must
+    // equal every rendered frame stacked in the strip.
+    expect(observed.transforms.join(' | ')).not.toContain('%')
+    expect(observed.travelPx.every(Number.isFinite)).toBe(true)
+    const renderedTravel = observed.frameCount * observed.frameHeight
+    const keyframeTravel = Math.abs(observed.travelPx.at(-1)! - observed.travelPx[0]!)
+    expect(Math.abs(keyframeTravel - renderedTravel)).toBeLessThanOrEqual(1)
   })
 
   test('is promoted to a layer while running, and neither animates nor holds a layer when parked', async () => {
     const { page } = fixture
-    await mountSpinner(page)
+    const strip = await mountSpinner(fixture)
+    const retainedStrip = await strip.elementHandle()
+    expect(retainedStrip, 'The running production spinner should be mounted').toBeTruthy()
 
-    const running = await page.evaluate(strip => {
-      const el = document.querySelector<HTMLElement>(strip)!
-
-      return {
-        playState: getComputedStyle(el).animationPlayState,
-        willChange: getComputedStyle(el).willChange
-      }
-    }, STRIP)
+    const running = await strip.evaluate(el => ({
+      playState: getComputedStyle(el).animationPlayState,
+      willChange: getComputedStyle(el).willChange,
+    }))
 
     expect(running.playState).toBe('running')
     // Scoped to active spinners — a permanently promoted layer per parked
     // spinner is pure memory at fan-out breadth.
     expect(running.willChange).toBe('transform')
 
-    // 1. The per-spinner gate: a kept-alive but inactive pane, or an explicit
-    //    `paused` prop (ChatSwapOverlay's fade-out).
-    const parked = await page.evaluate(strip => {
-      const el = document.querySelector<HTMLElement>(strip)!
-      const viewport = el.closest<HTMLElement>('.glyph-spinner')!
-      const previous = viewport.getAttribute('data-paused')
+    // 1. Exercise the real global focus wiring instead of mutating its output
+    // attribute. A blurred renderer must pause every continuous spinner.
+    const cdp = await page.context().newCDPSession(page)
+    await cdp.send('Emulation.setFocusEmulationEnabled', { enabled: false })
+    await page.evaluate(() => window.dispatchEvent(new FocusEvent('blur')))
+    await expect(page.locator('html')).toHaveAttribute('data-renderer-animations-paused', '')
+    await expect.poll(() => strip.evaluate(el => getComputedStyle(el).animationPlayState)).toBe('paused')
 
-      viewport.setAttribute('data-paused', 'true')
-
-      const state = {
-        playState: getComputedStyle(el).animationPlayState,
-        willChange: getComputedStyle(el).willChange
-      }
-
-      if (previous === null) {
-        viewport.removeAttribute('data-paused')
-      } else {
-        viewport.setAttribute('data-paused', previous)
-      }
-
-      return state
-    }, STRIP)
-
-    expect(parked.playState).toBe('paused')
-    expect(parked.willChange).toBe('auto')
-
-    // 2. The global gate: window blur / minimize / document-hidden, which
-    //    main.tsx drives by arming this attribute on the root. The strip must
-    //    be named in that rule, or every spinner keeps animating behind an
-    //    inactive window — the CPU burn the original ticker's pause
-    //    controller existed to avoid.
-    const globallyPaused = await page.evaluate(strip => {
-      const root = document.documentElement
-      const had = root.hasAttribute('data-renderer-animations-paused')
-
-      root.setAttribute('data-renderer-animations-paused', '')
-      const playState = getComputedStyle(document.querySelector<HTMLElement>(strip)!).animationPlayState
-
-      if (!had) {
-        root.removeAttribute('data-renderer-animations-paused')
-      }
-
-      return playState
-    }, STRIP)
-
-    expect(globallyPaused).toBe('paused')
+    // Restore focus, then exercise usePaneVisible by parking the running
+    // surface behind a real new-session tab.
+    await cdp.send('Emulation.setFocusEmulationEnabled', { enabled: true })
+    await page.evaluate(() => window.dispatchEvent(new FocusEvent('focus')))
+    await expect(page.locator('html')).not.toHaveAttribute('data-renderer-animations-paused', '')
+    await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
+    await expect.poll(() => retainedStrip!.evaluate(el => el.parentElement?.getAttribute('data-paused'))).toBe('true')
+    expect(await retainedStrip!.evaluate(el => getComputedStyle(el).animationPlayState)).toBe('paused')
+    expect(await retainedStrip!.evaluate(el => getComputedStyle(el).willChange)).toBe('auto')
   })
 
   test('advances in discrete frames and creates no timer-driven DOM churn', async () => {
-    const { page } = fixture
-    await mountSpinner(page)
+    const strip = await mountSpinner(fixture)
 
     // Sample the resolved transform across one full cycle. A steps() animation
     // holds each value for a whole interval and jumps between them, so the
     // distinct values it visits must be bounded by the frame count — a linear
     // animation would produce a new value on every sample.
-    const sampled = await page.evaluate(async strip => {
-      const el = document.querySelector<HTMLElement>(strip)!
+    const sampled = await strip.evaluate(async el => {
       const frames = el.querySelectorAll('.glyph-spinner__frame').length
       const duration = Number(el.getAnimations()[0]?.effect?.getTiming().duration ?? 0)
       const seen = new Set<string>()
@@ -187,7 +178,7 @@ test.describe('GlyphSpinner (compositor animation)', () => {
       }
 
       return { distinct: seen.size, frames, textUnchanged: el.textContent === textAtStart }
-    }, STRIP)
+    })
 
     expect(sampled.distinct).toBeGreaterThan(1)
     expect(sampled.distinct).toBeLessThanOrEqual(sampled.frames + 1)

--- a/apps/desktop/e2e/hidden-history-messages.spec.ts
+++ b/apps/desktop/e2e/hidden-history-messages.spec.ts
@@ -140,6 +140,15 @@ test('live verify-on-stop continuations stay out of the transcript', async ({}, 
     ).toBe(true)
     expect(fs.existsSync(changedFile), 'The scripted write_file call should edit only the sandbox project').toBe(true)
     await expect(transcript).not.toContainText('[System: You edited code in this turn')
+
+    // The verification trigger remains in history. After the scripted
+    // continuation is exhausted, a later streamed turn must route normally.
+    const followUp = 'E2E normal follow-up after verification script'
+    await composer.click()
+    await composer.type(followUp)
+    await page.keyboard.press('Enter')
+    await expect(transcript).toContainText(MOCK_REPLY, { timeout: 30_000 })
+    expect(mock.receivedPrompts).toContain(followUp)
     await page.screenshot({ path: testInfo.outputPath('live-verification-nudge.png') })
   } finally {
     await fixture.cleanup()

--- a/apps/desktop/e2e/image-attachment-resume.spec.ts
+++ b/apps/desktop/e2e/image-attachment-resume.spec.ts
@@ -27,8 +27,6 @@ import { type MockServer, startMockServer } from './mock-server'
 import { RealSessionBuilder } from './real-session-builder'
 import { type ElectronApplication, expect, type Page, test } from './test'
 
-// A seeded session has no generated title, so every label falls back to the
-// session preview — the first 60 characters of the first user message.
 const SESSION_TITLE = 'E2E attached image session'
 const CAPTION = 'E2E attached image must survive a relaunch'
 const IMAGE_DIR = 'Application Support/e2e shots'
@@ -90,7 +88,7 @@ async function setupSeededDesktop(): Promise<SeededFixture> {
 }
 
 function sessionRow(page: Page) {
-  return page.locator('[data-slot="sidebar"] button').filter({ hasText: CAPTION }).first()
+  return page.locator('[data-slot="sidebar"] button').filter({ hasText: SESSION_TITLE }).first()
 }
 
 // Inactive tabs stay mounted under a data-pane-hidden ancestor. Match the
@@ -125,7 +123,15 @@ async function openSeededSession(page: Page): Promise<void> {
  * surface is empty rather than waiting for the old caption to leave the page.
  */
 async function openNewSession(page: Page): Promise<void> {
-  await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
+  const obstructingTooltip = page.getByRole('tooltip', { name: SESSION_TITLE })
+  const composer = page.getByRole('textbox', { name: 'Message' }).first()
+
+  await composer.hover()
+  await expect(obstructingTooltip).toHaveCount(0)
+
+  const newSession = page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first()
+  await newSession.focus()
+  await page.keyboard.press('Enter')
   await page.waitForFunction(
     ([expected, surfaceSelector]: [string, string]) => {
       const surfaces = document.querySelectorAll(surfaceSelector)
@@ -172,13 +178,11 @@ test.describe('attached image resume', () => {
     fixture = await setupSeededDesktop()
     await waitForAppReady(fixture, 120_000)
 
-    // The sidebar labels a session by its preview, so the caption has to lead
-    // the persisted turn — a leading directive reads as a truncated file path.
     const row = sessionRow(fixture.page)
     await row.waitFor({ state: 'visible', timeout: 60_000 })
 
     const label = (await row.textContent())?.trim() ?? ''
-    expect(label.startsWith(CAPTION), `sidebar label should open with the caption: ${label}`).toBe(true)
+    expect(label.startsWith(SESSION_TITLE), `sidebar label should open with the durable title: ${label}`).toBe(true)
 
     await openSeededSession(fixture.page)
     await assertRendersThumbnail(fixture.page, 'first open')

--- a/apps/desktop/e2e/interim-messages.spec.ts
+++ b/apps/desktop/e2e/interim-messages.spec.ts
@@ -29,13 +29,9 @@
  * Prerequisite: `npm run build` must have been run so dist/ exists.
  */
 
-import { expect, test, type Page } from '@playwright/test'
+import { expect, type Page, test } from '@playwright/test'
 
-import {
-  type MockBackendFixture,
-  setupMockBackend,
-  waitForAppReady,
-} from './fixtures'
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
 import { INTERIM_TEXTS, restartMockServer } from './mock-server'
 
 // ─── Helpers ──────────────────────────────────────────────────────────
@@ -43,37 +39,81 @@ import { INTERIM_TEXTS, restartMockServer } from './mock-server'
 /** Unique trigger keyword the mock server detects to switch to the script. */
 const TRIGGER = 'E2E_INTERIM_TRIGGER'
 
+async function observeGatewayCompletion(page: Page): Promise<{ dispose: () => void; done: Promise<void> }> {
+  const cdp = await page.context().newCDPSession(page)
+  await cdp.send('Network.enable')
+
+  let disposed = false
+  let timeout: ReturnType<typeof setTimeout>
+
+  const dispose = () => {
+    if (disposed) {
+      return
+    }
+
+    disposed = true
+    clearTimeout(timeout)
+    void cdp.detach().catch(() => undefined)
+  }
+
+  const done = new Promise<void>((resolve, reject) => {
+    let completionSeen = false
+
+    timeout = setTimeout(() => {
+      dispose()
+      reject(new Error('Timed out waiting for gateway message.complete and running:false frames'))
+    }, 90_000)
+
+    cdp.on('Network.webSocketFrameReceived', ({ response }) => {
+      const frame = response.payloadData
+
+      if (frame.includes('message.complete') && frame.includes(INTERIM_TEXTS.finalText)) {
+        completionSeen = true
+
+        return
+      }
+
+      if (!completionSeen || !frame.includes('session.info') || !/"running"\s*:\s*false/.test(frame)) {
+        return
+      }
+
+      dispose()
+      resolve()
+    })
+  })
+
+  return { dispose, done }
+}
+
 /**
- * Send a message and wait for BOTH the user's message and the agent's
- * final response to appear in the transcript. Returns when the final text
- * is visible, which means message.complete has fired and the transcript
- * has settled.
+ * Send the scripted message and wait for its actual gateway
+ * `message.complete` frame. Final text can appear earlier via message.delta.
  */
 async function sendInterimMessage(page: Page): Promise<void> {
+  const completion = await observeGatewayCompletion(page)
   const composer = page.locator('[contenteditable="true"]').first()
-  await composer.waitFor({ state: 'visible', timeout: 10_000 })
-  await composer.click()
-  await composer.type(TRIGGER, { delay: 20 })
-  await page.keyboard.press('Enter')
 
-  // Wait for the user's trigger message to appear.
-  await page.waitForFunction(
-    () => (document.body.textContent ?? '').includes('E2E_INTERIM_TRIGGER'),
-    undefined,
-    { timeout: 15_000 },
-  )
+  try {
+    await composer.waitFor({ state: 'visible', timeout: 10_000 })
+    await composer.click()
+    await composer.type(TRIGGER, { delay: 20 })
+    await page.keyboard.press('Enter')
 
-  // Wait for the agent's FINAL response (last turn). This means
-  // message.complete has fired and the transcript is settled.
-  await page.waitForFunction(
-    (finalText) => (document.body.textContent ?? '').includes(finalText),
-    INTERIM_TEXTS.finalText,
-    { timeout: 90_000 },
-  )
+    // Wait for the user's trigger message to appear.
+    await page.waitForFunction(() => (document.body.textContent ?? '').includes('E2E_INTERIM_TRIGGER'), undefined, {
+      timeout: 15_000
+    })
 
-  // Give the renderer a moment to settle any final state updates
-  // (hydration, session refresh) before asserting.
-  await page.waitForTimeout(2000)
+    await completion.done
+    await page.evaluate(
+      () =>
+        new Promise<void>(resolve => {
+          requestAnimationFrame(() => requestAnimationFrame(() => resolve()))
+        })
+    )
+  } finally {
+    completion.dispose()
+  }
 }
 
 /**
@@ -87,42 +127,41 @@ async function sendInterimMessage(page: Page): Promise<void> {
  * scoping the DOM walk to the viewport cleanly excludes them.
  */
 async function countTranscriptMessagesContaining(page: Page, text: string): Promise<number> {
-  return page.evaluate(
-    (search) => {
-      const viewport = document.querySelector('[data-slot="aui_thread-viewport"]')
-      if (!viewport) {
-        return 0
-      }
+  return page.evaluate(search => {
+    const viewport = document.querySelector('[data-slot="aui_thread-viewport"]')
 
-      let count = 0
-      const walker = document.createTreeWalker(
-        viewport,
-        NodeFilter.SHOW_ELEMENT,
-        {
-          acceptNode: (node) => {
-            const el = node as HTMLElement
-            const directText = el.textContent ?? ''
-            if (!directText.includes(search)) {
-              return NodeFilter.FILTER_SKIP
-            }
-            // Only count leaf-ish elements to avoid double-counting.
-            const hasChildWithText = Array.from(el.children).some(
-              (child) => (child.textContent ?? '').includes(search),
-            )
-            if (hasChildWithText) {
-              return NodeFilter.FILTER_SKIP
-            }
-            return NodeFilter.FILTER_ACCEPT
-          },
-        },
-      )
-      while (walker.nextNode()) {
-        count++
+    if (!viewport) {
+      return 0
+    }
+
+    let count = 0
+
+    const walker = document.createTreeWalker(viewport, NodeFilter.SHOW_ELEMENT, {
+      acceptNode: node => {
+        const el = node as HTMLElement
+        const directText = el.textContent ?? ''
+
+        if (!directText.includes(search)) {
+          return NodeFilter.FILTER_SKIP
+        }
+
+        // Only count leaf-ish elements to avoid double-counting.
+        const hasChildWithText = Array.from(el.children).some(child => (child.textContent ?? '').includes(search))
+
+        if (hasChildWithText) {
+          return NodeFilter.FILTER_SKIP
+        }
+
+        return NodeFilter.FILTER_ACCEPT
       }
-      return count
-    },
-    text,
-  )
+    })
+
+    while (walker.nextNode()) {
+      count++
+    }
+
+    return count
+  }, text)
 }
 
 // ─── Flag ON: interim_assistant_messages = true (default) ─────────────
@@ -151,19 +190,19 @@ test.describe('interim assistant messages — flag ON (default)', () => {
     // message.complete.
     for (const interimText of INTERIM_TEXTS.interims) {
       await expect
-        .poll(
-          () => countTranscriptMessagesContaining(page, interimText),
-          { timeout: 15_000, message: `interim text "${interimText}" should be visible` },
-        )
+        .poll(() => countTranscriptMessagesContaining(page, interimText), {
+          timeout: 15_000,
+          message: `interim text "${interimText}" should be visible`
+        })
         .toBeGreaterThanOrEqual(1)
     }
 
     // The final text must also be visible.
     await expect
-      .poll(
-        () => countTranscriptMessagesContaining(page, INTERIM_TEXTS.finalText),
-        { timeout: 15_000, message: 'final text should be visible' },
-      )
+      .poll(() => countTranscriptMessagesContaining(page, INTERIM_TEXTS.finalText), {
+        timeout: 15_000,
+        message: 'final text should be visible'
+      })
       .toBeGreaterThanOrEqual(1)
   })
 })
@@ -178,7 +217,7 @@ test.describe('interim assistant messages — flag OFF', () => {
   test.beforeAll(async () => {
     restartMockServer()
     fixture = await setupMockBackend({
-      extraDisplayConfig: '  interim_assistant_messages: false',
+      extraDisplayConfig: '  interim_assistant_messages: false'
     })
     await waitForAppReady(fixture, 120_000)
   })
@@ -193,10 +232,10 @@ test.describe('interim assistant messages — flag OFF', () => {
 
     // The final text must be visible.
     await expect
-      .poll(
-        () => countTranscriptMessagesContaining(page, INTERIM_TEXTS.finalText),
-        { timeout: 15_000, message: 'final text should be visible' },
-      )
+      .poll(() => countTranscriptMessagesContaining(page, INTERIM_TEXTS.finalText), {
+        timeout: 15_000,
+        message: 'final text should be visible'
+      })
       .toBeGreaterThanOrEqual(1)
 
     // NONE of the interim texts should be visible — with the flag off,

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -483,15 +483,22 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           if (userText) {
             _receivedUserTexts.push(userText)
           }
-          const isInterimTrigger = userText.includes('E2E_INTERIM_TRIGGER')
-          const isSidebarTrigger = userText.includes('E2E_SIDEBAR_TRIGGER')
-          const isSidebarCrossTrigger = userText.includes('E2E_SIDEBAR_CROSS')
+          const isInterimTrigger = stream && userText.includes('E2E_INTERIM_TRIGGER')
+          const isSidebarTrigger = stream && userText.includes('E2E_SIDEBAR_TRIGGER')
+          const isSidebarCrossTrigger = stream && userText.includes('E2E_SIDEBAR_CROSS')
           const isQueueStopTrigger = userText.includes('E2E_QUEUE_STOP_TRIGGER')
           const isTaskPanelResumeTrigger = userText.includes(TASK_PANEL_RESUME_TRIGGER)
-          const isVerificationStopTrigger = messages.some(
+          const verificationScript = verificationStopScript(
+            options.verificationWritePath ?? 'e2e-verification-target.py',
+          )
+          const isVerificationStopTrigger = stream
+            && _verificationStopIndex < verificationScript.length
+            && messages.some(
             message => typeof message?.content === 'string' && message.content.includes(VERIFICATION_STOP_TRIGGER),
           )
-          const isCorrectionSwitchTrigger = messages.some(
+          const isCorrectionSwitchTrigger = stream
+            && _correctionSwitchIndex < CORRECTION_SWITCH_SCRIPT.length
+            && messages.some(
             message => typeof message?.content === 'string' && message.content.includes(CORRECTION_SWITCH_TRIGGER),
           )
 
@@ -557,8 +564,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           }
 
           if (isVerificationStopTrigger) {
-            const script = verificationStopScript(options.verificationWritePath ?? 'e2e-verification-target.py')
-            const turn = script[_verificationStopIndex] ?? script[script.length - 1]
+            const turn = verificationScript[_verificationStopIndex]
             _verificationStopIndex++
             if (stream) {
               streamScriptedTurn(res, model, turn)
@@ -569,7 +575,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
           }
 
           if (isCorrectionSwitchTrigger) {
-            const turn = CORRECTION_SWITCH_SCRIPT[_correctionSwitchIndex] ?? CORRECTION_SWITCH_SCRIPT[CORRECTION_SWITCH_SCRIPT.length - 1]
+            const turn = CORRECTION_SWITCH_SCRIPT[_correctionSwitchIndex]
             _correctionSwitchIndex++
             if (stream) {
               streamScriptedTurn(res, model, turn)

--- a/apps/desktop/e2e/real-session-builder.ts
+++ b/apps/desktop/e2e/real-session-builder.ts
@@ -35,6 +35,8 @@ export interface RealSessionTurn {
 }
 
 export interface RealSessionSpec {
+  /** Workspace used by the real gateway session. Defaults to the repository root. */
+  cwd?: string
   /** Session label. The durable row stores no title, so clients fall back to
    * the preview (the first 60 characters of the first user message). */
   title: string
@@ -107,7 +109,7 @@ export class RealSessionBuilder {
 
     const created = await this.request<CreatedSession>('session.create', {
       cols: 120,
-      cwd: REPO_ROOT,
+      cwd: spec.cwd ?? REPO_ROOT,
       source: 'desktop',
       title: spec.title,
     })

--- a/apps/desktop/e2e/sidebar-states.spec.ts
+++ b/apps/desktop/e2e/sidebar-states.spec.ts
@@ -123,7 +123,9 @@ test.describe('sidebar states — subagent and background dot coexist', () => {
 
   test.beforeAll(async () => {
     restartMockServer()
-    fixture = await setupMockBackend()
+    fixture = await setupMockBackend({
+      extraConfig: 'approvals:\n  mode: off',
+    })
     await waitForAppReady(fixture, 120_000)
   })
 
@@ -190,6 +192,7 @@ test.describe('sidebar states — cross-session dot transition', () => {
   test.beforeAll(async () => {
     restartMockServer()
     fixture = await setupMockBackend({
+      extraConfig: 'approvals:\n  mode: off',
       mockServer: { backgroundReleasePath: bgRelease.path },
     })
     await waitForAppReady(fixture, 120_000)

--- a/apps/desktop/e2e/tile-unread-bug.spec.ts
+++ b/apps/desktop/e2e/tile-unread-bug.spec.ts
@@ -36,9 +36,11 @@ const BG_DOT_LABEL = 'Background task running'
 /** Foreground turn-running dot aria-label. */
 const SESSION_RUNNING_DOT_LABEL = 'Session running'
 
-/** Locate a session's sidebar row by its preview text. */
-function sessionRow(page: import('@playwright/test').Page, text: string) {
-  return page.locator('[data-slot="sidebar"] button').filter({ hasText: text }).first()
+function sessionRowWithIndicator(page: import('@playwright/test').Page, ariaLabel: string) {
+  return page
+    .locator('[data-slot="sidebar"] button')
+    .filter({ has: page.locator(`[aria-label="${ariaLabel}"]`) })
+    .first()
 }
 
 /** Common setup: start a turn with a held bg process + subagent, wait for
@@ -121,6 +123,7 @@ test.describe('sidebar states — tab (hidden) unread is correct', () => {
   test.beforeAll(async () => {
     restartMockServer()
     fixture = await setupMockBackend({
+      extraConfig: 'approvals:\n  mode: off',
       mockServer: { backgroundReleasePath: bgRelease.path },
     })
     await waitForAppReady(fixture, 120_000)
@@ -142,7 +145,7 @@ test.describe('sidebar states — tab (hidden) unread is correct', () => {
 
     // ⌃-click opens the session as a TAB (center dock = stacked, not visible
     // unless it's the active tab). The session is NOT on screen.
-    const row = sessionRow(page, SIDEBAR_CROSS_TEXTS.finalText)
+    const row = sessionRowWithIndicator(page, BG_DOT_LABEL)
     await row.click({ modifiers: ['Control'] })
     await page.waitForTimeout(2000)
 
@@ -182,6 +185,7 @@ test.describe.skip('sidebar states — split (visible) unread bug (RED)', () => 
   test.beforeAll(async () => {
     restartMockServer()
     fixture = await setupMockBackend({
+      extraConfig: 'approvals:\n  mode: off',
       mockServer: { backgroundReleasePath: bgRelease.path },
     })
     await waitForAppReady(fixture, 120_000)
@@ -204,7 +208,7 @@ test.describe.skip('sidebar states — split (visible) unread bug (RED)', () => 
     // Drag the session row from the sidebar to the right edge of the workspace
     // zone to create a SPLIT (side-by-side) tile. This triggers the real
     // startSessionDrag → onCommit → openSessionTile(id, 'right', anchor) path.
-    const row = sessionRow(page, SIDEBAR_CROSS_TEXTS.finalText)
+    const row = sessionRowWithIndicator(page, BG_DOT_LABEL)
     const rowBox = await row.boundingBox()
     expect(rowBox, 'session row must be visible').not.toBeNull()
 

--- a/apps/desktop/e2e/warm-resume-jitter.spec.ts
+++ b/apps/desktop/e2e/warm-resume-jitter.spec.ts
@@ -14,16 +14,10 @@
  * clicks the session (cold resume — populates the warm cache), navigates
  * away to a new chat, then clicks back (warm resume). Two detectors run:
  *
- * 1. A MutationObserver counts additive DOM mutation bursts (childList
- *    additions). More than 1 burst = the transcript was repainted.
- *
- * 2. A 2ms innerHTML-length poll counts "reconciles" — DOM content changes
- *    that happen AFTER the initial paint, while messages are already on
- *    screen. This catches the case where React reconciles by key without
- *    adding/removing nodes (same keys → in-place prop update → no
- *    MutationObserver burst), but `$messages` was still set twice.
- *
- * The test passes when bursts === 1 AND reconciles === 0.
+ * A MutationObserver counts additive DOM mutation bursts and snapshots the
+ * exact settled message nodes before reactivation. A valid virtualized reveal
+ * may add rows before the original head once; it may not replace, move, or
+ * mutate any settled message, nor add transcript content after the old head.
  * The sidebar "+" keeps the session warm in another tab. Its reactivation
  * follows the same contract: one additive paint and zero reconciles.
  *
@@ -79,6 +73,7 @@ function gibberish(rng: () => number): string {
 
 /** First user message — used as a wait target in the test. */
 const FIRST_USER_MSG = gibberish(mulberry32(RNG_SEED))
+const LAST_USER_MSG = generateSessionTurns().at(-1)!
 
 /**
  * Generate the user turns for a real session. The mock provider produces the
@@ -151,16 +146,7 @@ test.afterAll(async () => {
   fixture = null
 })
 
-/**
- * Install a MutationObserver + text-content poll on the thread viewport
- * to detect re-renders after the initial paint. Returns nothing — call
- * `readRenderCount` to stop and collect results.
- *
- * - MutationObserver: counts additive childList bursts (5ms coalescing).
- * - Text-content poll: counts "reconciles" — first-message text changes
- *   after the initial paint, catching key-based reconciles that don't
- *   add/remove nodes.
- */
+/** Observe a hidden warm transcript while preserving its settled node identities. */
 async function installRenderCounter(
   page: import('@playwright/test').Page,
   transcriptText?: string,
@@ -168,22 +154,35 @@ async function installRenderCounter(
   await page.evaluate(([visibleSelector, allSelector, expected]: [string, string, string | undefined]) => {
     const surfaces = [...document.querySelectorAll(expected ? allSelector : visibleSelector)]
     const surface = expected
-      ? surfaces.find(candidate =>
-          (candidate.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(expected),
-        )
+      ? surfaces.find(candidate => (candidate.textContent ?? '').includes(expected))
       : surfaces.at(-1)
     const viewport = surface?.querySelector('[data-slot="aui_thread-viewport"]')
     if (!viewport) {
       throw new Error('Thread viewport not found before warm resume')
     }
 
-    const state = { bursts: 0, mutations: 0, timeline: [] as number[], stopped: false, reconciles: 0 }
-    const debugWindow = window as unknown as {
-      __RENDER_COUNT__: typeof state
-      __RENDER_VIEWPORT__: Element
+    const content = viewport.querySelector('[data-slot="aui_thread-content"]') ?? viewport
+    const selectMessages = () => [...content.querySelectorAll('[data-role="message"], [data-message-id]')]
+    const initialMessages = selectMessages()
+    const initialTexts = initialMessages.map(message => message.textContent ?? '')
+    const head = initialMessages[0]
+    const tail = initialMessages.at(-1)
+
+    if (!head || !tail) {
+      throw new Error('Settled transcript messages not found before warm resume')
     }
-    debugWindow.__RENDER_COUNT__ = state
-    debugWindow.__RENDER_VIEWPORT__ = viewport
+
+    const state = {
+      bursts: 0,
+      currentBatch: 0,
+      identityViolations: 0,
+      invalidAdditions: 0,
+      lastMutationAt: performance.now(),
+      stopped: false,
+      viewport,
+    }
+    const monitorWindow = window as unknown as { __WARM_RESUME_MONITOR__: typeof state }
+    monitorWindow.__WARM_RESUME_MONITOR__ = state
 
     let currentBatch = 0
     let flushTimer: ReturnType<typeof setTimeout> | null = null
@@ -192,8 +191,8 @@ async function installRenderCounter(
       flushTimer = null
       if (currentBatch > 0 && !state.stopped) {
         state.bursts += 1
-        state.timeline.push(currentBatch)
         currentBatch = 0
+        state.currentBatch = 0
       }
     }
 
@@ -201,15 +200,37 @@ async function installRenderCounter(
       if (state.stopped) return
       let batchAdded = 0
       for (const record of records) {
-        state.mutations += 1
         if (record.type === 'childList' && record.addedNodes.length > 0) {
           batchAdded += 1
+          for (const added of record.addedNodes) {
+            if (initialMessages.some(message => message === added || message.contains(added))) {
+              state.identityViolations += 1
+              continue
+            }
+
+            const headFollowsAdded = Boolean(added.compareDocumentPosition(head) & Node.DOCUMENT_POSITION_FOLLOWING)
+            if (!headFollowsAdded) state.invalidAdditions += 1
+          }
         }
       }
+
+      const currentMessages = selectMessages()
+      const initialStart = currentMessages.indexOf(head)
+      const settledIdentityPreserved =
+        initialMessages.every((message, index) =>
+          message.isConnected
+          && message.textContent === initialTexts[index]
+          && currentMessages[initialStart + index] === message)
+        && currentMessages.at(-1) === tail
+
+      if (!settledIdentityPreserved) state.identityViolations += 1
+
       if (batchAdded > 0) {
         currentBatch += batchAdded
+        state.currentBatch = currentBatch
+        state.lastMutationAt = performance.now()
         if (flushTimer) clearTimeout(flushTimer)
-        flushTimer = setTimeout(flush, 5)
+        flushTimer = setTimeout(flush, 20)
       }
     })
 
@@ -217,34 +238,9 @@ async function installRenderCounter(
       childList: true,
       subtree: true,
       attributes: false,
-      characterData: false,
+      characterData: true,
     })
 
-    // Poll the first message's text content every 2ms. The MutationObserver
-    // only catches childList additions; React may reconcile by key without
-    // adding/removing nodes (same keys → in-place prop update → no childList
-    // mutation). The poll catches this by detecting text content changes in
-    // the first message after the initial paint. Metadata-only changes (model
-    // name, busy indicator) don't affect message text, so they don't produce
-    // false positives.
-    const contentEl = viewport.querySelector('[data-slot="aui_thread-content"]') ?? viewport
-    let lastFirstMsgText = ''
-    let hasMessages = false
-    const pollInterval = setInterval(() => {
-      if (state.stopped) {
-        clearInterval(pollInterval)
-        return
-      }
-      const firstMsg = contentEl.querySelector('[data-role="message"], [data-message-id]')
-      const firstMsgText = firstMsg?.textContent ?? ''
-      if (firstMsgText && firstMsgText !== lastFirstMsgText) {
-        if (hasMessages) {
-          state.reconciles = (state.reconciles ?? 0) + 1
-        }
-        lastFirstMsgText = firstMsgText
-        hasMessages = true
-      }
-    }, 2)
   }, [SURFACE, ALL_SURFACES, transcriptText] as [string, string, string | undefined])
 }
 
@@ -294,21 +290,50 @@ async function openNewSessionTab(page: import('@playwright/test').Page, priorTex
   await waitForActiveTranscriptWithoutText(page, priorText)
 }
 
-/** Stop the render counter and return the recorded burst/reconcile counts. */
+interface WarmResumeObservation {
+  bursts: number
+  identityViolations: number
+  invalidAdditions: number
+}
+
+/** Wait for the observer's additive burst to finish without a fixed delay. */
+async function waitForRenderQuiescence(page: import('@playwright/test').Page): Promise<void> {
+  await page.waitForFunction(
+    () => {
+      const monitor = (window as unknown as {
+        __WARM_RESUME_MONITOR__?: { bursts: number; currentBatch: number; lastMutationAt: number }
+      }).__WARM_RESUME_MONITOR__
+
+      return Boolean(
+        monitor
+        && monitor.bursts > 0
+        && monitor.currentBatch === 0
+        && performance.now() - monitor.lastMutationAt >= 250,
+      )
+    },
+    undefined,
+    { timeout: 10_000 },
+  )
+}
+
+/** Stop the observer and return the production-state invariants it recorded. */
 async function readRenderCount(page: import('@playwright/test').Page): Promise<{
   bursts: number
-  mutations: number
-  timeline: number[]
-  reconciles: number
+  identityViolations: number
+  invalidAdditions: number
 } | null> {
   return page.evaluate(() => {
-    type RenderCount = { bursts: number; mutations: number; timeline: number[]; stopped: boolean; reconciles: number }
-    const w = window as unknown as { __RENDER_COUNT__?: RenderCount }
-    const rc = w.__RENDER_COUNT__
-    if (rc) {
-      rc.stopped = true
+    type Monitor = WarmResumeObservation & { stopped: boolean }
+    const w = window as unknown as { __WARM_RESUME_MONITOR__?: Monitor }
+    const monitor = w.__WARM_RESUME_MONITOR__
+    if (!monitor) return null
+    monitor.stopped = true
+    delete w.__WARM_RESUME_MONITOR__
+    return {
+      bursts: monitor.bursts,
+      identityViolations: monitor.identityViolations,
+      invalidAdditions: monitor.invalidAdditions,
     }
-    return rc ? { bursts: rc.bursts, mutations: rc.mutations, timeline: rc.timeline, reconciles: rc.reconciles } : null
   })
 }
 
@@ -316,43 +341,49 @@ async function observedViewportIsActive(page: import('@playwright/test').Page): 
   return page.evaluate((surfaceSelector: string) => {
     const surfaces = document.querySelectorAll(surfaceSelector)
     const activeViewport = surfaces[surfaces.length - 1]?.querySelector('[data-slot="aui_thread-viewport"]')
-    const observedViewport = (window as unknown as { __RENDER_VIEWPORT__?: Element }).__RENDER_VIEWPORT__
+    const observedViewport = (window as unknown as {
+      __WARM_RESUME_MONITOR__?: { viewport: Element }
+    }).__WARM_RESUME_MONITOR__?.viewport
 
     return activeViewport === observedViewport
   }, SURFACE)
 }
 
-/** A kept-alive tab must become visible without rebuilding its transcript. */
-function assertNoRepaint(result: { bursts: number; mutations: number; timeline: number[]; reconciles: number } | null): void {
+/** A kept-alive tab reveals its pruned head once without reconciling the mounted tail. */
+function assertBoundedReveal(result: WarmResumeObservation | null): void {
   expect(result, 'MutationObserver should have recorded render data').toBeTruthy()
   expect(
     result!.bursts,
-    `Expected no additive render bursts for a kept-alive tab, but got ${result!.bursts}. ` +
-      `Mutation timeline: ${JSON.stringify(result!.timeline)}.`,
+    `Expected one bounded head-reveal burst for a kept-alive tab, but got ${result!.bursts}.`,
+  ).toBe(1)
+  expect(
+    result!.identityViolations,
+    'Reactivation replaced, moved, or changed a settled transcript message.',
   ).toBe(0)
   expect(
-    result!.reconciles,
-    `Expected no transcript reconciles for a kept-alive tab, but got ${result!.reconciles}.`,
+    result!.invalidAdditions,
+    'Reactivation added transcript messages outside the virtualized head backfill.',
   ).toBe(0)
 }
 
 /** Assert the render counter shows exactly one paint with no re-renders. */
-function assertNoJitter(result: { bursts: number; mutations: number; timeline: number[]; reconciles: number } | null): void {
+function assertNoJitter(result: WarmResumeObservation | null): void {
   expect(result, 'MutationObserver should have recorded render data').toBeTruthy()
   expect(
     result!.bursts,
-    `Expected 1 additive render burst (single paint), but got ${result!.bursts} bursts. ` +
-      `Mutation timeline: ${JSON.stringify(result!.timeline)}.`,
+    `Expected 1 additive render burst (single paint), but got ${result!.bursts} bursts.`,
   ).toBe(1)
   expect(
-    result!.reconciles,
-    `Expected 0 reconciles (no re-render after initial paint), but got ${result!.reconciles}. ` +
-      `This means the warm-route resume re-rendered the transcript after the initial paint ` +
-      `— the "warm resume jitter" bug is present.`,
+    result!.identityViolations,
+    'Warm resume replaced, moved, or changed a settled transcript message.',
+  ).toBe(0)
+  expect(
+    result!.invalidAdditions,
+    'Warm resume added transcript messages outside the virtualized head backfill.',
   ).toBe(0)
 }
 
-test('tab reactivation preserves the mounted transcript without repainting', async ({}, testInfo) => {
+test('tab reactivation preserves the mounted transcript with one bounded reveal', async () => {
   const page = fixture!.page
 
   // Wait for the sidebar to populate with our seeded session.
@@ -366,31 +397,26 @@ test('tab reactivation preserves the mounted transcript without repainting', asy
   // This populates the warm cache (runtimeIdByStoredSessionId + sessionStateByRuntimeId).
   await sessionRow.click()
 
-  // Wait for the transcript to appear — the first user message text confirms
-  // the cold-path prefetch painted.
-  await waitForActiveTranscriptText(page, FIRST_USER_MSG)
-
-  // Wait for the session to fully settle (cold-path RPC + reconciliation).
-  await page.waitForTimeout(2_000)
+  // The final seeded user message proves the durable cold-resume transcript,
+  // not merely its initially virtualized head, has arrived.
+  await waitForActiveTranscriptText(page, LAST_USER_MSG)
 
   // Stack a new tab, then observe the seeded transcript while it is hidden.
   // Installing after the switch isolates reactivation from mutations caused
   // while the new tab was being created.
   await openNewSessionTab(page, FIRST_USER_MSG)
-  await page.waitForTimeout(500)
-  await installRenderCounter(page, FIRST_USER_MSG)
+  await installRenderCounter(page, SESSION_TITLE)
 
   // Step 3: Click back and verify the same kept-alive viewport becomes active
   // without rebuilding or reconciling its transcript.
   await sessionRow.click()
 
   await waitForActiveTranscriptText(page, FIRST_USER_MSG)
-  await page.waitForTimeout(2_000)
+  await waitForRenderQuiescence(page)
   expect(await observedViewportIsActive(page), 'Reactivation should reveal the observed kept-alive viewport').toBe(true)
 
   const result = await readRenderCount(page)
-  await page.screenshot({ path: testInfo.outputPath('warm-resume-idle.png') })
-  assertNoRepaint(result)
+  assertBoundedReveal(result)
 })
 
 test('warm-route resume after background inference completes (no jitter)', async ({}, testInfo) => {

--- a/apps/desktop/e2e/worktree-branch-status.spec.ts
+++ b/apps/desktop/e2e/worktree-branch-status.spec.ts
@@ -12,10 +12,12 @@ import {
   writeMockProviderConfig,
 } from './fixtures'
 import { startMockServer } from './mock-server'
+import { RealSessionBuilder } from './real-session-builder'
 import { expect, test } from './test'
 import { expectVisualSnapshot } from './visual-snapshot'
 
 const BRANCH_NAME = 'e2e-composer-branch'
+const SESSION_TITLE = 'E2E Worktree Branch Status'
 
 /**
  * Enough branches to make both the base-branch popover and the convert-branch
@@ -54,9 +56,10 @@ function createGitRepo(root: string): string {
   return repo
 }
 
-function configureRepoCwd(hermesHome: string, mockUrl: string, repo: string): void {
+function configureRepoCwd(hermesHome: string, userDataDir: string, mockUrl: string, repo: string): void {
   writeMockProviderConfig(hermesHome, mockUrl)
   fs.appendFileSync(path.join(hermesHome, 'config.yaml'), `\nterminal:\n  cwd: ${repo}\n`, 'utf8')
+  fs.writeFileSync(path.join(userDataDir, 'project-dir.json'), JSON.stringify({ dir: repo }, null, 2), 'utf8')
   writeEnvFile(hermesHome)
 }
 
@@ -84,7 +87,18 @@ test.beforeAll(async () => {
   const repo = createGitRepo(sandbox.root)
   const mock = await startMockServer()
 
-  configureRepoCwd(sandbox.hermesHome, mock.url, repo)
+  configureRepoCwd(sandbox.hermesHome, sandbox.userDataDir, mock.url, repo)
+
+  const builder = await RealSessionBuilder.start(sandbox.hermesHome)
+  try {
+    await builder.createSession({
+      cwd: repo,
+      title: SESSION_TITLE,
+      turns: ['create a repo-backed e2e session'],
+    })
+  } finally {
+    await builder.close()
+  }
 
   const { app, page } = await launchDesktop(buildAppEnv(sandbox))
   fixture = {
@@ -102,18 +116,11 @@ test.beforeAll(async () => {
 
   await waitForAppReady(fixture, 120_000)
 
-  // The coding rail, and thus the ⌘⇧B worktree dialog, mounts only after the
-  // session resolves a cwd that holds a repo. This happens on the first turn.
-  const composer = page.locator('[contenteditable="true"]').first()
-  await composer.click()
-  await composer.type('create a repo-backed e2e session', { delay: 2 })
-  await page.keyboard.press('Enter')
-  await page.waitForFunction(
-    prompt => (document.querySelector('[data-slot="aui_thread-viewport"]')?.textContent ?? '').includes(prompt),
-    'create a repo-backed e2e session',
-    { timeout: 15_000 },
-  )
-  await expect(page.locator('.coding-status-bar')).toContainText('main')
+  // Resume a real session whose durable gateway metadata is pinned to the repo.
+  const sessionRow = page.locator('[data-slot="sidebar"] button').filter({ hasText: SESSION_TITLE }).first()
+  await sessionRow.click()
+  await expect(page.getByText('create a repo-backed e2e session', { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(page.locator('.coding-status-bar')).toContainText('main', { timeout: 30_000 })
 })
 
 test.afterAll(async () => {
@@ -205,6 +212,7 @@ test('creating a branch with ctrl-shift-b updates the composer git-status branch
 
   await page.getByRole('button', { name: 'New worktree' }).click()
 
+  await expect(page.getByText('create a repo-backed e2e session', { exact: true })).toHaveCount(0, { timeout: 15_000 })
   await expect(codingRow).toContainText(BRANCH_NAME, { timeout: 15_000 })
 
   // The dialog must close and stay closed. No empty second dialog can remain

--- a/apps/desktop/electron/remote-ws-headers.test.ts
+++ b/apps/desktop/electron/remote-ws-headers.test.ts
@@ -27,6 +27,13 @@ function createHarness(connection: RegistryGatewayWsConnection) {
   return { ensureBackend, handler, mintTicket, store }
 }
 
+function expectedWsHeaders(url: string, headers: Record<string, string> = {}) {
+  const parsed = new URL(url)
+  parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:'
+
+  return { ...headers, Origin: parsed.origin }
+}
+
 function expectRequestHeaders(
   store: ReturnType<typeof createRemoteWsHeaderStore>,
   url: string,
@@ -37,7 +44,9 @@ function expectRequestHeaders(
   applyRemoteRequestHeaders({ url, requestHeaders: { Origin: 'app://hermes' } }, callback, store.headersFor)
 
   expect(callback).toHaveBeenCalledOnce()
-  expect(callback).toHaveBeenCalledWith(expected ? { requestHeaders: { Origin: 'app://hermes', ...expected } } : {})
+  expect(callback).toHaveBeenCalledWith(
+    expected ? { requestHeaders: expectedWsHeaders(url, { Origin: 'app://hermes', ...expected }) } : {}
+  )
 }
 
 function expectNoHeadersForNearbyUrls(store: ReturnType<typeof createRemoteWsHeaderStore>, exactUrl: string) {
@@ -71,6 +80,24 @@ function expectNoHeadersForNearbyUrls(store: ReturnType<typeof createRemoteWsHea
 }
 
 describe('registry gateway WebSocket headers', () => {
+  it('replaces the local renderer origin for the exact remote WebSocket URL', () => {
+    const store = createRemoteWsHeaderStore()
+    const wsUrl = 'wss://gateway.example/proxy/9120/api/ws?ticket=one'
+    const callback = vi.fn()
+
+    store.remember(wsUrl)
+    applyRemoteRequestHeaders(
+      { url: wsUrl, requestHeaders: { Origin: 'app://hermes' } },
+      callback,
+      store.headersFor
+    )
+
+    expect(callback).toHaveBeenCalledWith({
+      requestHeaders: { Origin: 'https://gateway.example' }
+    })
+    expect(store.headersFor('wss://gateway.example/api/ws?ticket=one')).toEqual({})
+  })
+
   it('evicts the least recently accessed exact URL', () => {
     const store = createRemoteWsHeaderStore(2)
     const firstUrl = 'wss://gateway.example/api/ws?token=first&profile=research'
@@ -80,13 +107,13 @@ describe('registry gateway WebSocket headers', () => {
     store.remember(firstUrl, accessHeaders)
     store.remember(secondUrl, accessHeaders)
     expect(store.headersFor('wss://gateway.example/api/ws?token=missing&profile=research')).toEqual({})
-    expect(store.headersFor(firstUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(firstUrl)).toEqual(expectedWsHeaders(firstUrl, accessHeaders))
 
     store.remember(thirdUrl, accessHeaders)
 
-    expect(store.headersFor(firstUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(firstUrl)).toEqual(expectedWsHeaders(firstUrl, accessHeaders))
     expect(store.headersFor(secondUrl)).toEqual({})
-    expect(store.headersFor(thirdUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(thirdUrl)).toEqual(expectedWsHeaders(thirdUrl, accessHeaders))
   })
 
   it('updates headers without changing insertion recency', () => {
@@ -101,8 +128,8 @@ describe('registry gateway WebSocket headers', () => {
     store.remember(thirdUrl, accessHeaders)
 
     expect(store.headersFor(firstUrl)).toEqual({})
-    expect(store.headersFor(secondUrl)).toEqual(accessHeaders)
-    expect(store.headersFor(thirdUrl)).toEqual(accessHeaders)
+    expect(store.headersFor(secondUrl)).toEqual(expectedWsHeaders(secondUrl, accessHeaders))
+    expect(store.headersFor(thirdUrl)).toEqual(expectedWsHeaders(thirdUrl, accessHeaders))
   })
 
   it('token path binds headers to the exact profile scoped URL', async () => {
@@ -121,7 +148,7 @@ describe('registry gateway WebSocket headers', () => {
     expect(result).toBe(expectedUrl)
     expect(ensureBackend).toHaveBeenCalledWith('remote-one', 'research')
     expect(mintTicket).not.toHaveBeenCalled()
-    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expect(store.headersFor(result)).toEqual(expectedWsHeaders(result, accessHeaders))
     expectRequestHeaders(store, result, accessHeaders)
     expectNoHeadersForNearbyUrls(store, result)
   })
@@ -142,7 +169,7 @@ describe('registry gateway WebSocket headers', () => {
     expect(result).toBe(expectedUrl)
     expect(mintTicket).toHaveBeenCalledOnce()
     expect(mintTicket).toHaveBeenCalledWith('https://gateway.example', accessHeaders)
-    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expect(store.headersFor(result)).toEqual(expectedWsHeaders(result, accessHeaders))
     expectRequestHeaders(store, result, accessHeaders)
     expectNoHeadersForNearbyUrls(store, result)
   })
@@ -160,7 +187,7 @@ describe('registry gateway WebSocket headers', () => {
     const result = await handler({ connectionId: 'remote-one', profile: 'research' })
 
     expect(result).toBe('wss://gateway.example/api/ws?trace=one&token=secret')
-    expect(store.headersFor(result)).toEqual(accessHeaders)
+    expect(store.headersFor(result)).toEqual(expectedWsHeaders(result, accessHeaders))
     expectRequestHeaders(store, result, accessHeaders)
     expect(store.headersFor('wss://gateway.example/api/ws?token=secret&trace=one')).toEqual({})
   })

--- a/apps/desktop/electron/remote-ws-headers.ts
+++ b/apps/desktop/electron/remote-ws-headers.ts
@@ -27,11 +27,26 @@ export function createRemoteWsHeaderStore(limit = 100) {
   const headersByUrl = new Map<string, Record<string, string>>()
 
   const remember = (wsUrl: string, headers: Record<string, string> = {}) => {
-    if (!wsUrl || Object.keys(headers).length === 0) {
+    if (!wsUrl) {
       return
     }
 
-    headersByUrl.set(String(wsUrl), headers)
+    let origin: string
+
+    try {
+      const parsed = new URL(String(wsUrl))
+
+      if (parsed.protocol !== 'ws:' && parsed.protocol !== 'wss:') {
+        return
+      }
+
+      parsed.protocol = parsed.protocol === 'wss:' ? 'https:' : 'http:'
+      origin = parsed.origin
+    } catch {
+      return
+    }
+
+    headersByUrl.set(String(wsUrl), { ...headers, Origin: origin })
 
     while (headersByUrl.size > limit) {
       const oldest = headersByUrl.keys().next().value

--- a/apps/desktop/src/api/client.ts
+++ b/apps/desktop/src/api/client.ts
@@ -1,4 +1,4 @@
-import { JsonRpcGatewayClient } from '@hermes/shared'
+import { getOrCreateGatewayClientId, JsonRpcGatewayClient } from '@hermes/shared'
 
 import type { HermesApiRequest } from '@/global'
 
@@ -28,6 +28,11 @@ export const PROMPT_SUBMIT_REQUEST_TIMEOUT_MS = 1_800_000
 export class HermesGateway extends JsonRpcGatewayClient {
   constructor() {
     super({
+      clientAttachment: {
+        client_id: getOrCreateGatewayClientId('desktop', null),
+        protocol_version: 1,
+        surface: 'desktop'
+      },
       closedErrorMessage: 'Hermes gateway connection closed',
       connectErrorMessage: 'Could not connect to Hermes gateway',
       createRequestId: nextId => nextId,

--- a/apps/desktop/src/app/chat/composer/controls.test.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.test.tsx
@@ -138,10 +138,10 @@ describe('ComposerControls shortcut tooltips', () => {
     await expectShortcutTooltip('Send', '↵')
   })
 
-  it('keeps Send (not Steer) while a turn is running if there is a payload', async () => {
+  it('labels the primary action Steer while a turn is running with a steerable payload', async () => {
     renderControls({ busy: true, busyAction: 'steer' })
 
-    await expectShortcutTooltip('Send', '↵')
+    await expectShortcutTooltip('Steer the current run', '↵')
   })
 
   it('shows Stop only when the composer is empty mid-turn', async () => {
@@ -150,10 +150,10 @@ describe('ComposerControls shortcut tooltips', () => {
     await expectShortcutTooltip('Stop', '↵')
   })
 
-  it('shows Ctrl+Enter for Queue as the secondary mid-turn action', async () => {
+  it('shows Enter for Queue when queueing is the primary mid-turn action', async () => {
     renderControls({ busy: true, busyAction: 'queue' })
 
-    await expectShortcutTooltip('Queue message', 'Ctrl+↵')
+    await expectShortcutTooltip('Queue message', '↵')
   })
 })
 

--- a/apps/desktop/src/app/chat/composer/controls.tsx
+++ b/apps/desktop/src/app/chat/composer/controls.tsx
@@ -5,7 +5,18 @@ import { Codicon } from '@/components/ui/codicon'
 import { Tip, TipKeybindLabel } from '@/components/ui/tooltip'
 import { useI18n } from '@/i18n'
 import { triggerHaptic } from '@/lib/haptics'
-import { AudioLines, Ear, EarOff, iconSize, Layers3, Loader2, Square, Volume2, VolumeX } from '@/lib/icons'
+import {
+  AudioLines,
+  Ear,
+  EarOff,
+  iconSize,
+  Layers3,
+  Loader2,
+  Square,
+  SteeringWheel,
+  Volume2,
+  VolumeX
+} from '@/lib/icons'
 import { cn } from '@/lib/utils'
 import { $hudMode, closeHud, resetHudLayout } from '@/store/hud'
 import { $wakeWord, toggleWakeWord } from '@/store/wake-word'
@@ -73,10 +84,15 @@ export function ComposerControls({
   }
 
   const showVoicePrimary = !busy && !hasComposerPayload
-  // Steer is just send: a payload keeps the Send affordance mid-turn. Stop
-  // only when the composer is empty and a turn is running.
-  const showStop = busy && !hasComposerPayload
-  const showQueueButton = busyAction !== 'stop' && hasComposerPayload
+  const primaryAction = busy ? busyAction : 'send'
+  const showStop = primaryAction === 'stop'
+  const showSteer = primaryAction === 'steer'
+  const showQueuePrimary = primaryAction === 'queue'
+  // Queue is the secondary alternative while steering is available. When the
+  // turn can only queue (compaction/blocking prompt/attachment), Queue itself
+  // is the primary action and must not be duplicated beside itself.
+  const showQueueButton = showSteer && hasComposerPayload
+  const primaryLabel = showStop ? c.stop : showSteer ? c.steer : showQueuePrimary ? c.queueMessage : c.send
   // The HUD is a Spotlight bar a few hundred pixels wide, so the four separate
   // voice toggles fold into one menu there and leave the row to the input. A
   // narrow tile hits the same wall from the other direction and folds for the
@@ -145,21 +161,24 @@ export function ComposerControls({
       ) : (
         <Tip
           label={
-            showStop ? (
-              <TipKeybindLabel actionId="composer.send" text={c.stop} />
-            ) : (
-              <TipKeybindLabel actionId="composer.send" text={c.send} />
-            )
+            <TipKeybindLabel
+              actionId={showSteer ? 'composer.steer' : showQueuePrimary ? 'composer.queue' : 'composer.send'}
+              text={primaryLabel}
+            />
           }
         >
           <Button
-            aria-label={showStop ? c.stop : c.send}
+            aria-label={primaryLabel}
             className={PRIMARY_ICON_BTN}
             disabled={disabled || !canSubmit}
             type="submit"
           >
             {showStop ? (
               <span className="block size-2.5 rounded-[0.1875rem] bg-current" />
+            ) : showSteer ? (
+              <SteeringWheel className={iconSize.sm} />
+            ) : showQueuePrimary ? (
+              <Layers3 className={iconSize.sm} />
             ) : (
               <Codicon name="arrow-up" size="0.875rem" />
             )}

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -117,6 +117,7 @@ import {
   $messagingPlatformTotals,
   $messagingSessions,
   $messagingTruncated,
+  $newChatWorkspaceTarget,
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
@@ -150,6 +151,7 @@ import { SidebarLoadMoreRow } from './load-more-row'
 import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
+import { shouldSyncProjectCwd } from './project-cwd-sync'
 import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
@@ -426,6 +428,7 @@ export function ChatSidebar({
   const activeProjectId = useStore($activeProjectId)
   const projectScope = useStore($projectScope)
   const currentCwd = useStore($currentCwd)
+  const newChatWorkspaceTarget = useStore($newChatWorkspaceTarget)
   const gatewayState = useStore($gatewayState)
   const dismissedAutoProjects = useStore($dismissedAutoProjectIds)
   const newSessionCombo = useStore($bindings)['session.new']?.[0]
@@ -1075,11 +1078,14 @@ export function ChatSidebar({
     (project: SidebarProjectTree) => {
       const target = projectTreeCwd(project)
 
-      if (target && target !== currentCwd) {
+      if (
+        target &&
+        shouldSyncProjectCwd({ currentCwd, newChatWorkspaceTarget, projectTarget: target })
+      ) {
         setCurrentCwd(target)
       }
     },
-    [currentCwd]
+    [currentCwd, newChatWorkspaceTarget]
   )
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)

--- a/apps/desktop/src/app/chat/sidebar/project-cwd-sync.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-cwd-sync.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import { shouldSyncProjectCwd } from './project-cwd-sync'
+
+describe('shouldSyncProjectCwd', () => {
+  it('keeps an explicit linked-worktree target when project discovery enters its parent project', () => {
+    const worktree = '/repo/.worktrees/feature'
+
+    expect(
+      shouldSyncProjectCwd({
+        currentCwd: worktree,
+        newChatWorkspaceTarget: worktree,
+        projectTarget: '/repo',
+      }),
+    ).toBe(false)
+  })
+
+  it('selects the project checkout without an explicit draft target', () => {
+    expect(
+      shouldSyncProjectCwd({
+        currentCwd: '/other-repo',
+        newChatWorkspaceTarget: undefined,
+        projectTarget: '/repo',
+      }),
+    ).toBe(true)
+  })
+
+  it('selects the project checkout when the explicit target no longer owns the current cwd', () => {
+    expect(
+      shouldSyncProjectCwd({
+        currentCwd: '/other-repo',
+        newChatWorkspaceTarget: '/repo/.worktrees/feature',
+        projectTarget: '/repo',
+      }),
+    ).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/project-cwd-sync.ts
+++ b/apps/desktop/src/app/chat/sidebar/project-cwd-sync.ts
@@ -1,0 +1,29 @@
+import type { NewChatWorkspaceTarget } from '@/store/session'
+
+interface ProjectCwdSyncInput {
+  currentCwd: string
+  newChatWorkspaceTarget: NewChatWorkspaceTarget | undefined
+  projectTarget: string
+}
+
+/**
+ * Entering a project normally selects its default checkout. A fresh draft with
+ * an explicit workspace target is different: project discovery may enter the
+ * parent project after creating a linked worktree, but that must not re-anchor
+ * the draft from the worktree back to the project's default checkout.
+ */
+export function shouldSyncProjectCwd({
+  currentCwd,
+  newChatWorkspaceTarget,
+  projectTarget,
+}: ProjectCwdSyncInput): boolean {
+  const target = projectTarget.trim()
+
+  if (!target || target === currentCwd) {
+    return false
+  }
+
+  const explicitDraftTarget = typeof newChatWorkspaceTarget === 'string' ? newChatWorkspaceTarget.trim() : ''
+
+  return !explicitDraftTarget || explicitDraftTarget !== currentCwd
+}

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -77,6 +77,7 @@ function makeRefresh(resolveSession: ActiveTranscriptRefreshDeps['resolveSession
     reconcileActiveTranscript({
       activeSessionIdRef,
       busyRef,
+      getSessionState: sessionId => states.get(sessionId),
       requestSequenceRef,
       resolveSession,
       selectedStoredSessionIdRef,
@@ -260,6 +261,47 @@ describe('active transcript refresh', () => {
     // Behavior assertions:
     expect(updaterCallCount).toBeGreaterThan(0)
     expect(getLatestSessionMessages).toHaveBeenCalledWith(TILE_STORED_ID)
+  })
+
+  it('preserves an accepted correction when a hidden tile refreshes from lagging persisted history', async () => {
+    const runtimeId = 'runtime-correction-tile'
+    const storedId = 'stored-correction-tile'
+    const state = createClientSessionState(storedId)
+    state.messages = [
+      { id: 'stored-user', role: 'user', parts: [{ type: 'text', text: 'original prompt' }] },
+      {
+        id: 'assistant-stream-before-correction',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'work already shown' }],
+        interim: true
+      },
+      { id: 'user-correction', role: 'user', parts: [{ type: 'text', text: 'accepted correction' }] }
+    ]
+    const states = new Map([[runtimeId, state]])
+
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [{ content: 'original prompt', role: 'user', timestamp: 1 }],
+      session_id: storedId
+    } as never)
+
+    await reconcileTileTranscriptsForTest({
+      tiles: [{ runtimeId, storedSessionId: storedId }],
+      busyRef: { current: false },
+      requestSequenceRef: { current: 0 },
+      signatureRef: { current: new Map<string, string>() },
+      updateSessionState: (sessionId, updater) => {
+        const next = updater(states.get(sessionId) ?? createClientSessionState(storedId))
+        states.set(sessionId, next)
+
+        return next
+      }
+    })
+
+    expect(states.get(runtimeId)?.messages.map(message => message.parts[0])).toEqual([
+      expect.objectContaining({ text: 'original prompt' }),
+      expect.objectContaining({ text: 'work already shown' }),
+      expect.objectContaining({ text: 'accepted correction' })
+    ])
   })
 
   it('skips the tile fetch entirely when nothing changed (signature-gated)', async () => {
@@ -530,6 +572,46 @@ describe('reconcileActiveTranscript', () => {
     expect(fixture.updateSessionState).toHaveBeenCalledTimes(1)
   })
 
+  it('keeps the completed live final when durable tool history contains pre-tool commentary', async () => {
+    const fixture = makeRefresh()
+    fixture.state.messages = [
+      { id: 'user-live', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      {
+        completedAt: 4,
+        id: 'assistant-stream-live',
+        parts: [
+          { result: 'done', toolCallId: 'call-1', toolName: 'todo', type: 'tool-call' },
+          { text: 'Final answer.', type: 'text' }
+        ],
+        pending: false,
+        role: 'assistant'
+      }
+    ]
+    vi.mocked(getLatestSessionMessages).mockResolvedValue({
+      messages: [
+        { content: 'question', id: 1, role: 'user', timestamp: 1 },
+        {
+          content: 'First I will check.',
+          id: 2,
+          role: 'assistant',
+          timestamp: 2,
+          tool_calls: [{ function: { arguments: '{}', name: 'todo' }, id: 'call-1' }]
+        },
+        { content: 'done', role: 'tool', timestamp: 3, tool_call_id: 'call-1', tool_name: 'todo' },
+        { content: 'Final answer.', id: 3, role: 'assistant', timestamp: 4 }
+      ],
+      session_id: ACTIVE_STORED_ID
+    } as never)
+
+    await fixture.refresh()
+
+    const assistant = fixture.states.get(ACTIVE_RUNTIME_ID)?.messages.at(-1)
+
+    expect(assistant?.parts.map(part => part.type)).toEqual(['tool-call', 'text'])
+    expect(assistant?.parts.find(part => part.type === 'text')?.text).toBe('Final answer.')
+    expect(assistant?.rowId).toBe(2)
+  })
+
   it('preserves a local assistant error while hydrating authoritative messages', async () => {
     const fixture = makeRefresh()
     fixture.state.messages = [
@@ -575,6 +657,34 @@ describe('reconcileActiveTranscript', () => {
 
     expect(fixture.updateSessionState).not.toHaveBeenCalled()
   })
+
+  it('discards stored history when the live transcript changes in flight', async () => {
+    const fixture = makeRefresh()
+    let resolve: ((value: unknown) => void) | undefined
+    vi.mocked(getLatestSessionMessages).mockReturnValueOnce(
+      new Promise(currentResolve => {
+        resolve = currentResolve
+      }) as never
+    )
+
+    const request = fixture.refresh()
+
+    const completedMessages = [
+      { id: 'live-user', parts: [{ text: 'question', type: 'text' as const }], role: 'user' as const },
+      {
+        id: 'live-assistant',
+        parts: [{ text: 'authoritative final', type: 'text' as const }],
+        role: 'assistant' as const
+      }
+    ]
+
+    fixture.state.messages = completedMessages
+    resolve?.(transcript('stale streamed commentary'))
+    await request
+
+    expect(fixture.states.get(ACTIVE_RUNTIME_ID)?.messages).toBe(completedMessages)
+  })
+
 })
 
 describe('windowIsActivelyViewed', () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -2,6 +2,10 @@ import { useStore } from '@nanostores/react'
 import { type MutableRefObject, useCallback, useEffect, useRef } from 'react'
 
 import { graftRefreshedTailOntoBackfill } from '@/app/chat/transcript-backfill'
+import {
+  preserveLocalPendingTurnMessages,
+  reconcileResumeMessages
+} from '@/app/session/hooks/use-session-actions/utils'
 import { getLatestSessionMessages, type ProfileScope } from '@/hermes'
 import { preserveLocalAssistantErrors, sealOpenToolParts, toChatMessages } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
@@ -55,6 +59,7 @@ export function resolveActiveTranscriptSession(storedSessionId: string): ActiveT
 export interface ActiveTranscriptRefreshDeps {
   activeSessionIdRef: MutableRefObject<string | null>
   busyRef: MutableRefObject<boolean>
+  getSessionState: (sessionId: string) => ClientSessionState | undefined
   requestSequenceRef: MutableRefObject<number>
   selectedStoredSessionIdRef: MutableRefObject<string | null>
   resolveSession: (storedSessionId: string) => ActiveTranscriptSession | null | undefined
@@ -154,7 +159,10 @@ export async function reconcileTileTranscripts({
         state => ({
           ...state,
           messages: preserveLocalAssistantErrors(
-            graftRefreshedTailOntoBackfill(messages, state.messages),
+            preserveLocalPendingTurnMessages(
+              reconcileResumeMessages(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages),
+              state.messages
+            ),
             state.messages
           )
         }),
@@ -170,6 +178,7 @@ export async function reconcileTileTranscripts({
 export async function reconcileActiveTranscript({
   activeSessionIdRef,
   busyRef,
+  getSessionState,
   requestSequenceRef,
   resolveSession,
   selectedStoredSessionIdRef,
@@ -191,6 +200,7 @@ export async function reconcileActiveTranscript({
 
   const requestId = requestSequenceRef.current + 1
   requestSequenceRef.current = requestId
+  const baselineMessages = getSessionState(runtimeSessionId)?.messages
 
   try {
     const profileScope: ProfileScope = stored.ownerRoute
@@ -206,7 +216,8 @@ export async function reconcileActiveTranscript({
       requestId !== requestSequenceRef.current ||
       busyRef.current ||
       selectedStoredSessionIdRef.current !== storedSessionId ||
-      activeSessionIdRef.current !== runtimeSessionId
+      activeSessionIdRef.current !== runtimeSessionId ||
+      getSessionState(runtimeSessionId)?.messages !== baselineMessages
     ) {
       return
     }
@@ -237,7 +248,13 @@ export async function reconcileActiveTranscript({
         // The refresh re-reads only the newest tail page; graft it onto any
         // older pages "Show earlier" already backfilled instead of clobbering
         // them (see transcript-backfill).
-        messages: preserveLocalAssistantErrors(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages)
+        messages: preserveLocalAssistantErrors(
+          preserveLocalPendingTurnMessages(
+            reconcileResumeMessages(graftRefreshedTailOntoBackfill(messages, state.messages), state.messages),
+            state.messages
+          ),
+          state.messages
+        )
       }),
       storedSessionId
     )

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -383,7 +383,6 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       }
 
       const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
-
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
           const latest = await getLatestSessionMessages(storedSessionId, storedProfile)
@@ -430,13 +429,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       reconcileActiveTranscript({
         activeSessionIdRef,
         busyRef,
+        getSessionState: sessionId => sessionStateByRuntimeIdRef.current.get(sessionId),
         requestSequenceRef: activeTranscriptRequestSequenceRef,
         resolveSession: resolveActiveTranscriptSession,
         selectedStoredSessionIdRef,
         signatureRef: activeTranscriptSignatureRef,
         updateSessionState
       }),
-    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, updateSessionState]
+    [activeSessionIdRef, busyRef, selectedStoredSessionIdRef, sessionStateByRuntimeIdRef, updateSessionState]
   )
 
   const { handleGatewayEvent } = useMessageStream({

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -109,6 +109,24 @@ class FakeWebSocket {
       if (willOpen) {
         this.readyState = FakeWebSocket.OPEN
         this.emit('open', {})
+        this.emit('message', {
+          data: JSON.stringify({
+            jsonrpc: '2.0',
+            method: 'event',
+            params: {
+              type: 'gateway.ready',
+              payload: {
+                connection_id: 'fake-connection',
+                multi_client: {
+                  attachment_modes: ['observe', 'control'],
+                  methods: ['client.attach', 'session.attach'],
+                  protocol_version: 1
+                },
+                replay_epoch: 'fake-epoch'
+              }
+            }
+          })
+        })
       } else {
         this.readyState = FakeWebSocket.CLOSED
         this.emit('error', {})
@@ -141,6 +159,25 @@ class FakeWebSocket {
     try {
       frame = JSON.parse(data) as { id?: unknown; method?: string }
     } catch {
+      return
+    }
+
+    if (frame.method === 'client.attach') {
+      this.emit('message', {
+        data: JSON.stringify({
+          jsonrpc: '2.0',
+          id: frame.id,
+          result: {
+            capabilities: ['session.observe', 'session.control', 'session.replay'],
+            client_id: 'desktop:test',
+            connection_id: 'fake-connection',
+            idempotent: false,
+            protocol_version: 1,
+            surface: 'desktop'
+          }
+        })
+      })
+
       return
     }
 

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -3,6 +3,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { MessagingView } from './index'
+import { $settingsScopeOverride } from '@/store/settings-scope'
 import type { MessagingPlatformInfo } from '@/types/hermes'
 
 const getMessagingPlatforms = vi.fn()
@@ -75,7 +77,6 @@ afterEach(() => {
 })
 
 async function renderMessaging() {
-  const { MessagingView } = await import('./index')
   let result: ReturnType<typeof render>
   await act(async () => {
     result = render(
@@ -84,14 +85,11 @@ async function renderMessaging() {
       </MemoryRouter>
     )
   })
-
   return result!
 }
 
 describe('MessagingView profile scope', () => {
   it('follows the active profile instead of targeting primary when there is no override', async () => {
-    const { $settingsScopeOverride } = await import('@/store/settings-scope')
-
     $settingsScopeOverride.set(null)
     getMessagingPlatforms.mockResolvedValue({ platforms: [platform()] })
 
@@ -167,8 +165,9 @@ describe('MessagingView pairing', () => {
 
     await renderMessaging()
 
+    const approve = await screen.findByRole('button', { name: 'Approve' })
     await act(async () => {
-      fireEvent.click(await screen.findByRole('button', { name: 'Approve' }))
+      fireEvent.click(approve)
     })
 
     expect(await screen.findByRole('button', { name: 'Approve' })).toBeTruthy()

--- a/apps/desktop/src/app/messaging/index.test.tsx
+++ b/apps/desktop/src/app/messaging/index.test.tsx
@@ -3,9 +3,10 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import { MemoryRouter } from 'react-router'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { MessagingView } from './index'
 import { $settingsScopeOverride } from '@/store/settings-scope'
 import type { MessagingPlatformInfo } from '@/types/hermes'
+
+import { MessagingView } from './index'
 
 const getMessagingPlatforms = vi.fn()
 const updateMessagingPlatform = vi.fn()
@@ -85,6 +86,7 @@ async function renderMessaging() {
       </MemoryRouter>
     )
   })
+
   return result!
 }
 

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/message-stream.ts
@@ -2,6 +2,7 @@ import type { BillingBlock } from '@hermes/shared'
 
 import { burstVibeHearts } from '@/components/chat/vibe-hearts'
 import { translateNow } from '@/i18n'
+import { chatMessageText, textPart } from '@/lib/chat-messages'
 import { coerceGatewayText, coerceThinkingText } from '@/lib/chat-runtime'
 import { playCompletionSound } from '@/lib/completion-sound'
 import { parseErrorSurface } from '@/lib/error-surface'
@@ -79,6 +80,73 @@ export function handleMessageStreamEvent(ctx: GatewayEventContext): boolean {
     sessionStateByRuntimeIdRef,
     updateSessionState
   } = deps
+
+  if (event.type === 'message.user') {
+    if (!sessionId || payload?.display_kind === 'hidden') {
+      return true
+    }
+
+    const messageId = typeof payload?.message_id === 'string' ? payload.message_id.trim() : ''
+    const text = coerceGatewayText(payload?.text)
+    const attachmentRefs = Array.isArray(payload?.attachment_refs)
+      ? payload.attachment_refs.filter((ref): ref is string => typeof ref === 'string' && Boolean(ref))
+      : []
+
+    if (!messageId || (!text && !attachmentRefs.length)) {
+      return true
+    }
+
+    updateSessionState(sessionId, state => {
+      const normalizedText = text.replace(/\s+/g, ' ').trim()
+      const refsKey = attachmentRefs.join('\n')
+      const exact = state.messages.find(message => message.id === messageId)
+
+      if (exact) {
+        return state
+      }
+
+      const streamIndex = state.streamId
+        ? state.messages.findIndex(message => message.id === state.streamId && message.role === 'assistant')
+        : -1
+      // The state.db watcher can win the tiny persistence→event race. Only the
+      // row immediately before this turn's pending assistant (or the transcript
+      // tail when hydration replaced that placeholder) can be its equivalent.
+      // Searching all history would wrongly collapse a legitimate later turn
+      // when the user intentionally repeats the same prompt.
+      const equivalentCandidate = state.messages[streamIndex >= 0 ? streamIndex - 1 : state.messages.length - 1]
+      const equivalent =
+        equivalentCandidate?.role === 'user' &&
+        !equivalentCandidate.hidden &&
+        chatMessageText(equivalentCandidate).replace(/\s+/g, ' ').trim() === normalizedText &&
+        (equivalentCandidate.attachmentRefs ?? []).join('\n') === refsKey
+
+      if (equivalent) {
+        return state
+      }
+
+      const userMessage = {
+        id: messageId,
+        role: 'user' as const,
+        parts: text ? [textPart(text, occurredAt)] : [],
+        timestamp: occurredAt,
+        ...(attachmentRefs.length ? { attachmentRefs } : {})
+      }
+      const messages = [...state.messages]
+
+      // message.start is emitted when the gateway accepts the turn, before the
+      // agent persists the inbound row. Put the durable user event immediately
+      // before that turn's pending assistant placeholder.
+      if (streamIndex >= 0) {
+        messages.splice(streamIndex, 0, userMessage)
+      } else {
+        messages.push(userMessage)
+      }
+
+      return { ...state, messages }
+    })
+
+    return true
+  }
 
   if (event.type === 'message.start') {
     if (!sessionId) {

--- a/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/interim-sealing.test.tsx
@@ -65,6 +65,76 @@ describe('useMessageStream interim text sealing', () => {
     vi.restoreAllMocks()
   })
 
+  it('replaces unsealed commentary across tool turns with the authoritative final response', async () => {
+    mountStream()
+    await start()
+
+    const tool = async (id: string, content: string, status: 'in_progress' | 'completed') => {
+      const todo = { id, content, status }
+      await act(() =>
+        stream.handleEvent({
+          payload: { args: { todos: [todo] }, context: 'planning 1 task(s)', name: 'todo', tool_id: id },
+          session_id: SID,
+          type: 'tool.start'
+        })
+      )
+      await act(() =>
+        stream.handleEvent({
+          payload: {
+            args: { todos: [todo] },
+            duration_s: 0.01,
+            name: 'todo',
+            result: {
+              summary: {
+                cancelled: 0,
+                completed: status === 'completed' ? 1 : 0,
+                in_progress: status === 'in_progress' ? 1 : 0,
+                pending: 0,
+                total: 1
+              },
+              todos: [todo]
+            },
+            todos: [{ content, id }],
+            tool_id: id
+          },
+          session_id: SID,
+          type: 'tool.complete'
+        })
+      )
+    }
+
+    const reasoningAvailable = async (text: string) => {
+      await act(() =>
+        stream.handleEvent({
+          payload: { text },
+          session_id: SID,
+          type: 'reasoning.available'
+        })
+      )
+    }
+
+    await delta('Let me start by planning the approach.')
+    await reasoningAvailable('Let me start by planning the approach.')
+    await tool('tool-1', 'Plan', 'in_progress')
+    await delta('\n\nNow checking the details before answering.')
+    await reasoningAvailable('Now checking the details before answering.')
+    await tool('tool-2', 'Check details', 'in_progress')
+    await tool('tool-3', 'Silent step', 'completed')
+    await delta('\n\nFound something interesting worth noting.')
+    await reasoningAvailable('Found something interesting worth noting.')
+    await tool('tool-4', 'Note finding', 'completed')
+    await delta('\n\nAll done! Here is the complete summary.')
+    await reasoningAvailable('All done! Here is the complete summary.')
+    await complete('All done! Here is the complete summary.')
+
+    const visibleAssistantTextParts = getState()
+      .messages.filter(message => message.role === 'assistant' && !message.hidden)
+      .flatMap(message => message.parts)
+      .filter(part => part.type === 'text')
+      .map(part => part.text)
+    expect(visibleAssistantTextParts).toEqual(['All done! Here is the complete summary.'])
+  })
+
   it('preserves interim text that the final response does not include', async () => {
     mountStream()
     await start()

--- a/apps/desktop/src/app/session/hooks/use-message-stream/user-message-event.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/user-message-event.test.tsx
@@ -1,0 +1,86 @@
+import { act, cleanup } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { chatMessageText, textPart } from '@/lib/chat-messages'
+import { createClientSessionState } from '@/lib/chat-runtime'
+
+import { renderMessageStream } from './test-harness'
+
+const SID = 'shared-session'
+
+describe('durable user message events', () => {
+  afterEach(cleanup)
+
+  it('inserts the peer prompt before the live assistant tool turn', () => {
+    const stream = renderMessageStream(SID)
+
+    act(() => {
+      // Gateway accepts the turn before the agent has persisted its user row.
+      stream.handleEvent({ payload: { timestamp: 99 }, session_id: SID, type: 'message.start' })
+      stream.handleEvent({
+        payload: { message_id: 'user-pc1-123', text: 'search every file', timestamp: 100 },
+        session_id: SID,
+        type: 'message.user'
+      })
+      stream.handleEvent({
+        payload: { args: { pattern: '*.ts' }, name: 'search_files', timestamp: 102, tool_id: 'call-1' },
+        session_id: SID,
+        type: 'tool.start'
+      })
+    })
+
+    const messages = stream.state().messages
+
+    expect(messages.map(message => message.role)).toEqual(['user', 'assistant'])
+    expect(chatMessageText(messages[0])).toBe('search every file')
+    expect(messages[0].id).toBe('user-pc1-123')
+    expect(messages[1].parts.some(part => part.type === 'tool-call')).toBe(true)
+  })
+
+  it('reconciles the sender optimistic message and a watcher-hydrated equivalent without duplicates', () => {
+    const optimistic = createClientSessionState()
+    optimistic.messages = [
+      { id: 'user-pc1-123', parts: [textPart('search every file')], role: 'user', timestamp: 100 }
+    ]
+    const hydrated = createClientSessionState()
+    hydrated.messages = [
+      { id: '100-0-user', parts: [textPart('search every file')], role: 'user', rowId: 42, timestamp: 100 }
+    ]
+
+    for (const state of [optimistic, hydrated]) {
+      const states = new Map([[SID, state]])
+      const stream = renderMessageStream(SID, { states })
+
+      act(() =>
+        stream.handleEvent({
+          payload: { message_id: 'user-pc1-123', text: 'search every file', timestamp: 100 },
+          session_id: SID,
+          type: 'message.user'
+        })
+      )
+
+      expect(stream.state().messages.filter(message => message.role === 'user')).toHaveLength(1)
+    }
+  })
+
+  it('does not collapse an intentionally repeated prompt from an earlier turn', () => {
+    const state = createClientSessionState()
+    state.messages = [
+      { id: 'old-user', parts: [textPart('search every file')], role: 'user', timestamp: 90 },
+      { id: 'old-assistant', parts: [textPart('done')], role: 'assistant', timestamp: 91 }
+    ]
+    const stream = renderMessageStream(SID, { states: new Map([[SID, state]]) })
+
+    act(() => {
+      stream.handleEvent({ payload: { timestamp: 99 }, session_id: SID, type: 'message.start' })
+      stream.handleEvent({
+        payload: { message_id: 'new-user', text: 'search every file', timestamp: 100 },
+        session_id: SID,
+        type: 'message.user'
+      })
+    })
+
+    expect(stream.state().messages.filter(message => message.role === 'user')).toHaveLength(2)
+    expect(stream.state().messages.map(message => message.id)).toEqual(['old-user', 'old-assistant', 'new-user'])
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -756,6 +756,12 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
         const submitParams = (targetId: string) => ({
           session_id: targetId,
           text,
+          // Lets every attached client insert the durable user row immediately,
+          // while the sender reconciles the event against its optimistic bubble.
+          client_message_id: optimisticId,
+          display_text: bubbleText,
+          submitted_at: submittedAt,
+          ...(attachmentRefs.length && { attachment_refs: attachmentRefs }),
           ...(interrupted && { interrupted }),
           // Off-screen widget intent: the gateway types the persisted user
           // row display_kind=hidden so no client renders it as a bubble.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.test.ts
@@ -541,6 +541,38 @@ describe('reconcileResumeMessages', () => {
     expect(reconcileResumeMessages(next, [])).toBe(next)
   })
 
+  it('keeps a settled live final over the matching durable internal tool timeline', () => {
+    const previous = [
+      msg('user-live', 'user', 'question'),
+      msg('assistant-stream-live', 'assistant', '', {
+        completedAt: 30,
+        pending: false,
+        parts: [
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'todo', result: 'done' },
+          { type: 'text', text: 'Final answer.' }
+        ]
+      })
+    ]
+
+    const next = [
+      msg('user-durable', 'user', 'question', { rowId: 1 }),
+      msg('assistant-durable', 'assistant', '', {
+        rowId: 2,
+        parts: [
+          { type: 'text', text: 'First I will check.' },
+          { type: 'tool-call', toolCallId: 'call-1', toolName: 'todo', result: 'done' },
+          { type: 'text', text: 'Final answer.' }
+        ]
+      })
+    ]
+
+    const [, assistant] = reconcileResumeMessages(next, previous)
+
+    expect(chatMessageText(assistant)).toBe('Final answer.')
+    expect(assistant.parts.map(part => part.type)).toEqual(['tool-call', 'text'])
+    expect(assistant.rowId).toBe(2)
+  })
+
   it('re-grafts reasoning parts onto a matching assistant turn', () => {
     const next = [msg('a', 'assistant', 'answer')]
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -78,6 +78,38 @@ function isLiveTailRow(message: ChatMessage): boolean {
   )
 }
 
+function settledLiveToolTimelineSupersedes(authoritative: ChatMessage, local: ChatMessage): boolean {
+  if (
+    authoritative.role !== 'assistant' ||
+    local.role !== 'assistant' ||
+    local.pending === true ||
+    local.completedAt === undefined ||
+    local.error
+  ) {
+    return false
+  }
+
+  const authoritativeToolIds = authoritative.parts.flatMap(part =>
+    part.type === 'tool-call' ? [part.toolCallId] : []
+  )
+
+  const localToolIds = local.parts.flatMap(part => (part.type === 'tool-call' ? [part.toolCallId] : []))
+
+  if (
+    localToolIds.length === 0 ||
+    authoritativeToolIds.length !== localToolIds.length ||
+    authoritativeToolIds.some((id, index) => id !== localToolIds[index])
+  ) {
+    return false
+  }
+
+  const normalize = (value: string) => value.replace(/\s+/g, ' ').trim()
+  const authoritativeText = normalize(chatMessageText(authoritative))
+  const localText = normalize(chatMessageText(local))
+
+  return Boolean(localText && authoritativeText.endsWith(localText))
+}
+
 /**
  * True when `next` is a pure forward extension of the previous *answer* text.
  * Empty previous answer never accepts a dump as an extension — that is how the
@@ -337,6 +369,16 @@ export function reconcileResumeMessages(nextMessages: ChatMessage[], previousMes
     // localPendingSupersedes) so a different turn at the same ordinal cannot
     // hijack the slot.
     if (localPendingSupersedes(previous, message)) {
+      return withAuthoritativeTurnState(previous, message)
+    }
+
+    // A just-finished live tool turn has already replaced streamed pre-tool
+    // commentary with message.complete's authoritative final text. Persisted
+    // history still contains the model's internal assistant/tool cycles, and a
+    // background refresh coalesces those cycles into one durable row. Keep the
+    // settled live presentation when ordered tool-call identity proves this is
+    // the same turn and the durable row ends with the exact live final.
+    if (settledLiveToolTimelineSupersedes(message, previous)) {
       return withAuthoritativeTurnState(previous, message)
     }
 

--- a/apps/desktop/src/app/settings/gateway-settings.test.tsx
+++ b/apps/desktop/src/app/settings/gateway-settings.test.tsx
@@ -1,6 +1,8 @@
 import { cleanup, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { GatewaySettings } from './gateway-settings'
+
 const getConnectionConfig = vi.fn()
 const saveConnectionConfig = vi.fn()
 
@@ -37,8 +39,6 @@ afterEach(() => {
 
 describe('GatewaySettings', () => {
   it('loads the machine-level connection config (no profile scoping)', async () => {
-    const { GatewaySettings } = await import('./gateway-settings')
-
     render(<GatewaySettings />)
     expect(await screen.findByText('Local gateway')).toBeTruthy()
     expect(

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -52,6 +52,10 @@ export type GatewayEventPayload = {
   rendered?: string
   status?: string
   message?: string
+  // message.user — durable user row fanout for live multi-client sessions.
+  message_id?: string
+  attachment_refs?: string[]
+  display_kind?: string
   id?: string
   name?: string
   tool_id?: string

--- a/apps/desktop/src/lib/markdown-blocks.test.ts
+++ b/apps/desktop/src/lib/markdown-blocks.test.ts
@@ -133,7 +133,8 @@ describe('parseMarkdownIntoBlocksCached', () => {
   // 12 seeds × 500 growing prefixes is ~6000 full+cached lexes; it first trips
   // the pre-fix boundary at seed 11 / step 257, so the workload can't shrink
   // without gutting the guard. The work is bounded but exceeds one test's 5s
-  // default budget, so raise the timeout rather than weaken the coverage.
+  // default budget and takes ~31s on a loaded two-core CI worker, so raise the
+  // timeout rather than weaken the coverage.
   it('matches a full lex at every char-level streaming cut over noisy markdown (property fuzz)', () => {
     // Character-level append fuzz over the markdown control alphabet — the
     // harness that surfaced the setext-underline merge above. Growing a single
@@ -160,5 +161,5 @@ describe('parseMarkdownIntoBlocksCached', () => {
         expect(parseMarkdownIntoBlocksCached(text)).toEqual(parseMarkdownIntoBlocks(text))
       }
     }
-  }, 30_000)
+  }, 60_000)
 })

--- a/apps/desktop/src/store/session-unread-tile.test.ts
+++ b/apps/desktop/src/store/session-unread-tile.test.ts
@@ -62,7 +62,7 @@ describe('completed-unread dot follows the focused session', () => {
     // this path cleared the marker, so the dot stayed green.
     tree.noteActiveTreeGroup('grp-tile')
     expect(session.$unreadFinishedSessionIds.get()).toEqual([])
-  })
+  }, 30_000)
 
   it('never marks a tile that finishes while it is the focused one', async () => {
     const { finishTurn, session, tree } = await setup()

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -118,6 +118,14 @@ export default defineConfig(({ command }) => ({
     postcss: { plugins: [] }
   },
   build: {
+    // Electron loads the production renderer over file:// with webSecurity
+    // enabled. Emitting the full entry graph as modulepreload links launches
+    // dozens of concurrent file requests; Chromium starts failing the tail of
+    // that burst with net::ERR_FAILED and then reuses those failed preloads for
+    // the real module graph, leaving #root empty. Let native ESM imports load
+    // dependencies on demand instead. This keeps webSecurity enabled and does
+    // not affect Vite's development server.
+    modulePreload: false,
     // The renderer intentionally ships FEW chunks (not one, not thousands):
     //   · `codeSplitting: false` (the old setup) inlines every `lazy()` /
     //     dynamic import into the entry, so heavyweight lazy-only deps
@@ -161,7 +169,12 @@ export default defineConfig(({ command }) => ({
               name: 'shiki',
               test: /node_modules[\\/](shiki|@shikijs|react-shiki|@streamdown[\\/]code|oniguruma-to-es|oniguruma-parser|regex(-[^\\/]+)?)[\\/]/
             },
-            { name: 'katex', test: /node_modules[\\/]katex[\\/]/ }
+            { name: 'katex', test: /node_modules[\\/]katex[\\/]/ },
+            // Electron's secure file:// loader cannot reliably satisfy a boot
+            // graph containing ~100 concurrent static chunk imports. Merge the
+            // remaining initial dependency chain into one chunk, while the
+            // higher-priority groups above keep lazy heavyweight families split.
+            { name: 'initial', tags: ['$initial'] }
           ]
         }
       }

--- a/apps/shared/src/gateway-client-id.test.ts
+++ b/apps/shared/src/gateway-client-id.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+
+import { getOrCreateGatewayClientId } from './json-rpc-gateway'
+
+class MemoryStorage {
+  private readonly values = new Map<string, string>()
+
+  getItem(key: string): string | null {
+    return this.values.get(key) ?? null
+  }
+
+  setItem(key: string, value: string): void {
+    this.values.set(key, value)
+  }
+}
+
+describe('getOrCreateGatewayClientId', () => {
+  it('reuses one stable identity within a window storage', () => {
+    const storage = new MemoryStorage()
+    let sequence = 0
+    const createId = () => `generated-${++sequence}`
+
+    expect(getOrCreateGatewayClientId('desktop', storage, createId)).toBe('desktop:generated-1')
+    expect(getOrCreateGatewayClientId('desktop', storage, createId)).toBe('desktop:generated-1')
+    expect(sequence).toBe(1)
+  })
+
+  it('isolates identities across window stores', () => {
+    let sequence = 0
+    const createId = () => `generated-${++sequence}`
+
+    expect(getOrCreateGatewayClientId('web', new MemoryStorage(), createId)).toBe('web:generated-1')
+    expect(getOrCreateGatewayClientId('web', new MemoryStorage(), createId)).toBe('web:generated-2')
+  })
+
+  it('replaces malformed persisted identities', () => {
+    const storage = new MemoryStorage()
+    storage.setItem('hermes.gateway.client-id.web.v1', 'forged identity with spaces')
+
+    expect(getOrCreateGatewayClientId('web', storage, () => 'replacement')).toBe('web:replacement')
+  })
+})

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -47,15 +47,35 @@ export {
   DATA_URL_READ_MIN_MAX_MB
 } from './data-url-read-max'
 export {
+  type AttachmentCapability,
+  type AttachmentMode,
+  type ClientAttachParams,
+  type ClientAttachResult,
+  type ClientCapability,
   type ConnectionState,
+  type DurableResyncReason,
+  type DurableResyncRequest,
+  type GatewayClientIdStorage,
   type GatewayClientOptions,
   type GatewayEvent,
   type GatewayEventName,
+  type GatewayReadyPayload,
   type GatewayRequestId,
+  getOrCreateGatewayClientId,
   type JsonRpcErrorPayload,
   type JsonRpcFrame,
   JsonRpcGatewayClient,
   JsonRpcGatewayError,
+  type MultiClientMethod,
+  type SessionAttachmentSnapshot,
+  type SessionAttachmentsParams,
+  type SessionAttachmentsResult,
+  type SessionAttachParams,
+  type SessionAttachResult,
+  type SessionDetachParams,
+  type SessionDetachResult,
+  type SessionEventsSinceParams,
+  type SessionEventsSinceResult,
   type WebSocketLike
 } from './json-rpc-gateway'
 export { skillInvocationText } from './skill-scaffold'

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { JsonRpcGatewayClient } from './json-rpc-gateway'
+import { type GatewayClientOptions, JsonRpcGatewayClient } from './json-rpc-gateway'
 
 /**
  * Minimal EventTarget-based WebSocket stand-in so the seq-tracking and
@@ -26,7 +26,7 @@ class FakeWebSocket extends EventTarget {
 
   close(): void {
     this.readyState = 3
-    this.dispatchEvent(new CloseEvent('close'))
+    this.dispatchEvent(new Event('close'))
   }
 
   // Test drivers
@@ -48,8 +48,9 @@ class FakeWebSocket extends EventTarget {
 
 let sockets: FakeWebSocket[]
 
-const makeClient = () => {
+const makeClient = (options: GatewayClientOptions = {}) => {
   const client = new JsonRpcGatewayClient({
+    ...options,
     socketFactory: url => new FakeWebSocket(url) as unknown as WebSocket,
     heartbeatIntervalMs: 0,
     heartbeatDeadlineMs: 0,
@@ -65,6 +66,678 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     sockets = FakeWebSocket.instances as unknown as FakeWebSocket[]
   })
 
+  it('does not publish open before identity negotiation completes', async () => {
+    const client = makeClient({
+      clientAttachment: {
+        client_id: 'state-gated-client',
+        protocol_version: 1,
+        surface: 'desktop',
+        capabilities: ['session.observe']
+      }
+    })
+
+    const states: string[] = []
+    client.onState(state => states.push(state))
+
+    const connected = client.connect('ws://x')
+    const socket = sockets[0]
+    socket.open()
+    await Promise.resolve()
+
+    expect(client.connectionState).toBe('connecting')
+    expect(states).not.toContain('open')
+
+    socket.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          connection_id: 'connection-state-gated',
+          multi_client: {
+            protocol_version: 1,
+            attachment_modes: ['observe', 'control'],
+            methods: ['client.attach']
+          }
+        }
+      }
+    })
+    await vi.waitFor(() => expect(socket.lastRequest().method).toBe('client.attach'))
+    const request = socket.lastRequest()
+    socket.serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['session.observe'],
+        client_id: 'state-gated-client',
+        connection_id: 'connection-state-gated',
+        idempotent: false,
+        protocol_version: 1,
+        surface: 'desktop'
+      }
+    })
+
+    await connected
+    expect(client.connectionState).toBe('open')
+    expect(states).toEqual(['idle', 'connecting', 'open'])
+    client.close()
+  })
+
+  it('waits for ready and negotiates identity before connect resolves', async () => {
+    const client = makeClient({
+      clientAttachment: {
+        client_id: 'stable-desktop',
+        protocol_version: 1,
+        surface: 'desktop',
+        capabilities: ['session.observe', 'session.control', 'session.replay']
+      }
+    })
+
+    let resolved = false
+
+    const connected = client.connect('ws://x').then(() => {
+      resolved = true
+    })
+
+    sockets[0].open()
+    await Promise.resolve()
+    expect(resolved).toBe(false)
+    expect(sockets[0].sent).toHaveLength(0)
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          connection_id: 'connection-1',
+          replay_epoch: 'epoch-1',
+          runtime_host_id: 'host-1',
+          multi_client: {
+            protocol_version: 1,
+            attachment_modes: ['observe', 'control'],
+            methods: ['client.attach', 'session.attach', 'session.events.since']
+          }
+        }
+      }
+    })
+    await vi.waitFor(() => expect(sockets[0].lastRequest().method).toBe('client.attach'))
+    expect(resolved).toBe(false)
+    const request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['session.observe', 'session.control', 'session.replay'],
+        client_id: 'stable-desktop',
+        connection_id: 'connection-1',
+        idempotent: false,
+        protocol_version: 1,
+        surface: 'desktop'
+      }
+    })
+
+    await connected
+    expect(resolved).toBe(true)
+    client.close()
+  })
+
+  it('reattaches tracked sessions after identity negotiation on reconnect', async () => {
+    const client = makeClient({
+      clientAttachment: {
+        client_id: 'stable-web',
+        protocol_version: 1,
+        surface: 'web',
+        capabilities: ['session.observe', 'session.control', 'session.replay']
+      }
+    })
+
+    const ready = (socket: FakeWebSocket, connectionId: string) => {
+      socket.serverFrame({
+        jsonrpc: '2.0',
+        method: 'event',
+        params: {
+          type: 'gateway.ready',
+          payload: {
+            connection_id: connectionId,
+            replay_epoch: 'epoch-1',
+            runtime_host_id: 'host-1',
+            multi_client: {
+              protocol_version: 1,
+              attachment_modes: ['observe', 'control'],
+              methods: ['client.attach', 'session.attach', 'session.events.since']
+            }
+          }
+        }
+      })
+    }
+
+    const answerClientAttach = (socket: FakeWebSocket) => {
+      const request = socket.lastRequest()
+      socket.serverFrame({
+        jsonrpc: '2.0',
+        id: request.id,
+        result: {
+          capabilities: ['session.observe', 'session.control', 'session.replay'],
+          client_id: 'stable-web',
+          connection_id: 'connection',
+          idempotent: false,
+          protocol_version: 1,
+          surface: 'web'
+        }
+      })
+    }
+
+    const first = client.connect('ws://x')
+    let socket = sockets.at(-1)!
+    socket.open()
+    ready(socket, 'connection-1')
+    await vi.waitFor(() => expect(socket.lastRequest().method).toBe('client.attach'))
+    answerClientAttach(socket)
+    await first
+
+    const initialAttach = client.attachSession({
+      session_id: 'session-1',
+      mode: 'observe',
+      last_seen_seq: 0
+    })
+
+    let request = socket.lastRequest()
+    socket.serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-web',
+        epoch: 'epoch-1',
+        events: [],
+        latest_seq: 0,
+        mode: 'observe',
+        replay_epoch: 'epoch-1',
+        session_id: 'session-1',
+        truncated: false
+      }
+    })
+    await initialAttach
+    socket.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 'session-1', seq: 5, epoch: 'epoch-1' }
+    })
+
+    client.invalidate('drop')
+    let reconnected = false
+
+    const second = client.connect('ws://x').then(() => {
+      reconnected = true
+    })
+
+    socket = sockets.at(-1)!
+    socket.open()
+    ready(socket, 'connection-2')
+    await vi.waitFor(() => expect(socket.lastRequest().method).toBe('client.attach'))
+    answerClientAttach(socket)
+    await vi.waitFor(() => expect(socket.lastRequest().method).toBe('session.attach'))
+    expect(reconnected).toBe(false)
+    request = socket.lastRequest()
+    expect(request.params).toMatchObject({
+      session_id: 'session-1',
+      mode: 'observe',
+      last_seen_seq: 5
+    })
+    socket.serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-web',
+        epoch: 'epoch-1',
+        events: [],
+        latest_seq: 5,
+        mode: 'observe',
+        replay_epoch: 'epoch-1',
+        session_id: 'session-1',
+        truncated: false
+      }
+    })
+
+    await second
+    expect(reconnected).toBe(true)
+    client.close()
+  })
+
+  it('requests durable reconstruction when attach replay is truncated', async () => {
+    const resync = vi.fn()
+    const client = makeClient({ onDurableResyncRequired: resync })
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const attached = client.attachSession({
+      session_id: 'truncated-session',
+      mode: 'observe',
+      last_seen_seq: 42
+    })
+
+    const request = sockets[0].lastRequest()
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-client',
+        epoch: 'epoch-1',
+        events: [],
+        latest_seq: 90,
+        mode: 'observe',
+        replay_epoch: 'epoch-1',
+        session_id: 'truncated-session',
+        truncated: true
+      }
+    })
+    await attached
+
+    expect(resync).toHaveBeenCalledOnce()
+    expect(resync).toHaveBeenCalledWith({
+      reason: 'replay_truncated',
+      session_id: 'truncated-session'
+    })
+    client.close()
+  })
+
+  it('requests durable reconstruction when the canonical runtime owner is lost', async () => {
+    const resync = vi.fn()
+    const client = makeClient({ onDurableResyncRequired: resync })
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const attached = client.attachSession({ session_id: 'owner-session', mode: 'observe' })
+    const request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-client',
+        epoch: 'epoch-1',
+        events: [],
+        latest_seq: 0,
+        mode: 'observe',
+        replay_epoch: 'epoch-1',
+        session_id: 'owner-session',
+        truncated: false
+      }
+    })
+    await attached
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'message.delta',
+        session_id: 'owner-session',
+        seq: 9,
+        epoch: 'epoch-1'
+      }
+    })
+    expect(client.getSeqWatermarks()).toEqual({ 'owner-session': 9 })
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['owner-session', 'not-tracked'] }
+      }
+    })
+
+    expect(client.getSeqWatermarks()).toEqual({})
+    expect(resync).toHaveBeenCalledOnce()
+    expect(resync).toHaveBeenCalledWith({
+      reason: 'runtime_owner_lost',
+      session_id: 'owner-session'
+    })
+    client.close()
+  })
+
+  it('reconstructs a production resume from its durable id after owner loss', async () => {
+    const resync = vi.fn()
+    const client = makeClient({ onDurableResyncRequired: resync })
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const initial = client.request<{ session_id: string; session_key: string }>('session.resume', {
+      session_id: 'stored-session'
+    })
+
+    let request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-before-loss', session_key: 'stored-session', resumed: 'stored-session' }
+    })
+    await initial
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['live-before-loss'] }
+      }
+    })
+
+    await vi.waitFor(() => {
+      request = sockets[0].lastRequest()
+      expect(request.method).toBe('session.resume')
+      expect(request.params).toEqual({ session_id: 'stored-session' })
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-after-loss', session_key: 'stored-session', resumed: 'stored-session' }
+    })
+
+    await vi.waitFor(() => {
+      expect(resync).toHaveBeenCalledWith({
+        durable_session_id: 'stored-session',
+        reason: 'runtime_owner_lost',
+        session_id: 'live-before-loss'
+      })
+    })
+    client.close()
+  })
+
+  it('reconstructs a production create from stored_session_id after owner loss', async () => {
+    const client = makeClient()
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const initial = client.request('session.create', {})
+    let request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-created', stored_session_id: 'durable-created' }
+    })
+    await initial
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['live-created'] }
+      }
+    })
+
+    await vi.waitFor(() => {
+      request = sockets[0].lastRequest()
+      expect(request.method).toBe('session.resume')
+      expect(request.params).toEqual({ session_id: 'durable-created' })
+    })
+    client.close()
+  })
+
+  it('surfaces production owner-loss reconstruction failure', async () => {
+    const client = makeClient()
+    const errors = vi.fn()
+    client.on('error', errors)
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const initial = client.request('session.resume', { session_id: 'stored-session' })
+    let request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-before-loss', session_key: 'stored-session' }
+    })
+    await initial
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['live-before-loss'] }
+      }
+    })
+
+    await vi.waitFor(() => {
+      request = sockets[0].lastRequest()
+      expect(request.method).toBe('session.resume')
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      error: { code: -32072, message: 'takeover failed' }
+    })
+
+    await vi.waitFor(() => {
+      expect(errors).toHaveBeenCalledWith(expect.objectContaining({
+        type: 'error',
+        session_id: 'live-before-loss',
+        payload: expect.objectContaining({ code: 'runtime_recovery_failed' })
+      }))
+    })
+    client.close()
+  })
+
+  it('requests durable reconstruction when runtime host changes', async () => {
+    const resync = vi.fn()
+    const client = makeClient({ onDurableResyncRequired: resync })
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const attached = client.attachSession({ session_id: 'host-session', mode: 'observe' })
+    const request = sockets[0].lastRequest()
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-client',
+        epoch: 'epoch-1',
+        events: [],
+        latest_seq: 0,
+        mode: 'observe',
+        replay_epoch: 'epoch-1',
+        session_id: 'host-session',
+        truncated: false
+      }
+    })
+    await attached
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: { replay_epoch: 'epoch-1', runtime_host_id: 'host-a' }
+      }
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 'host-session', seq: 9, epoch: 'epoch-1' }
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: { replay_epoch: 'epoch-1', runtime_host_id: 'host-b' }
+      }
+    })
+
+    expect(client.getSeqWatermarks()).toEqual({})
+    expect(resync).toHaveBeenCalledWith({
+      reason: 'runtime_host_changed',
+      session_id: 'host-session'
+    })
+
+    resync.mockClear()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: { replay_epoch: 'epoch-2', runtime_host_id: 'host-b' }
+      }
+    })
+    expect(resync).toHaveBeenCalledOnce()
+    expect(resync).toHaveBeenCalledWith({
+      reason: 'replay_epoch_changed',
+      session_id: 'host-session'
+    })
+    client.close()
+  })
+
+  it('reconstructs durable sessions before attachment after runtime host takeover', async () => {
+    const client = makeClient({
+      clientAttachment: {
+        client_id: 'stable-web',
+        protocol_version: 1,
+        surface: 'web'
+      }
+    })
+
+    const connectFirst = client.connect('ws://x')
+    sockets[0].open()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          connection_id: 'first',
+          replay_epoch: 'epoch-a',
+          runtime_host_id: 'host-a',
+          multi_client: {
+            protocol_version: 1,
+            attachment_modes: ['observe', 'control'],
+            methods: ['client.attach', 'session.attach', 'session.events.since']
+          }
+        }
+      }
+    })
+    await vi.waitFor(() => expect(sockets[0].lastRequest().method).toBe('client.attach'))
+    let request = sockets[0].lastRequest()
+    sockets[0].serverFrame({ jsonrpc: '2.0', id: request.id, result: { client_id: 'stable-web' } })
+    await connectFirst
+
+    const initial = client.request('session.resume', { session_id: 'stored-session' })
+    request = sockets[0].lastRequest()
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-old', session_key: 'stored-session' }
+    })
+    await initial
+    client.close()
+
+    const connectSecond = client.connect('ws://x')
+    sockets[1].open()
+    sockets[1].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          connection_id: 'second',
+          replay_epoch: 'epoch-b',
+          runtime_host_id: 'host-b',
+          multi_client: {
+            protocol_version: 1,
+            attachment_modes: ['observe', 'control'],
+            methods: ['client.attach', 'session.attach', 'session.events.since']
+          }
+        }
+      }
+    })
+    await vi.waitFor(() => expect(sockets[1].lastRequest().method).toBe('client.attach'))
+    request = sockets[1].lastRequest()
+    sockets[1].serverFrame({ jsonrpc: '2.0', id: request.id, result: { client_id: 'stable-web' } })
+
+    await vi.waitFor(() => expect(sockets[1].lastRequest().method).toBe('session.resume'))
+    request = sockets[1].lastRequest()
+    expect(request.params).toEqual({ session_id: 'stored-session' })
+    sockets[1].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: { session_id: 'live-new', session_key: 'stored-session' }
+    })
+
+    await vi.waitFor(() => expect(sockets[1].lastRequest().method).toBe('session.attach'))
+    request = sockets[1].lastRequest()
+    expect(request.params.session_id).toBe('live-new')
+    sockets[1].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['observe'],
+        client_id: 'stable-web',
+        epoch: 'epoch-b',
+        events: [],
+        latest_seq: 0,
+        mode: 'control',
+        replay_epoch: 'epoch-b',
+        session_id: 'live-new',
+        truncated: false
+      }
+    })
+    await connectSecond
+    client.close()
+  })
+
+  it('sends a typed client attachment handshake', async () => {
+    const client = makeClient()
+    const connected = client.connect('ws://x')
+    sockets[0].open()
+    await connected
+
+    const attached = client.attachClient({
+      client_id: 'desktop-window-7',
+      protocol_version: 1,
+      surface: 'desktop',
+      capabilities: ['session.observe', 'session.control', 'session.replay']
+    })
+
+    const request = sockets[0].lastRequest()
+    expect(request).toMatchObject({
+      method: 'client.attach',
+      params: {
+        client_id: 'desktop-window-7',
+        protocol_version: 1,
+        surface: 'desktop'
+      }
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      id: request.id,
+      result: {
+        capabilities: ['session.observe', 'session.control', 'session.replay'],
+        client_id: 'desktop-window-7',
+        connection_id: 'connection-1',
+        idempotent: false,
+        protocol_version: 1,
+        surface: 'desktop'
+      }
+    })
+
+    await expect(attached).resolves.toMatchObject({
+      client_id: 'desktop-window-7',
+      connection_id: 'connection-1'
+    })
+    client.close()
+  })
+
   it('records per-session seq watermarks from live events', async () => {
     const client = makeClient()
     const p = client.connect('ws://x')
@@ -77,6 +750,34 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     sockets[0].serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'skin.changed' } }) // no sid/seq
 
     expect(client.getSeqWatermarks()).toEqual({ s1: 4, s2: 9 })
+    client.close()
+  })
+
+  it('resets watermarks when a live event starts a new replay epoch', async () => {
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'gateway.ready', payload: { replay_epoch: 'epoch-a' } }
+    })
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 10, epoch: 'epoch-a' }
+    })
+    expect(client.getSeqWatermarks()).toEqual({ s1: 10 })
+
+    sockets[0].serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 1, epoch: 'epoch-b' }
+    })
+
+    expect(client.getSeqWatermarks()).toEqual({ s1: 1 })
     client.close()
   })
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -24,6 +24,8 @@ export type GatewayEventName =
   | (string & {})
 
 export interface GatewayEvent<P = unknown> {
+  /** Opaque server numbering generation paired with seq. */
+  epoch?: string
   payload?: P
   /** Renderer-side source tag added by the Desktop gateway registry. */
   profile?: string
@@ -31,11 +33,188 @@ export interface GatewayEvent<P = unknown> {
    * absent for the local/legacy primary path). */
   connectionId?: string
   session_id?: string
+  seq?: number
   type: GatewayEventName
 }
 
 export type ConnectionState = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
+export type DurableResyncReason =
+  | 'replay_epoch_changed'
+  | 'replay_truncated'
+  | 'runtime_host_changed'
+  | 'runtime_owner_lost'
+export interface DurableResyncRequest {
+  durable_session_id?: string
+  reason: DurableResyncReason
+  session_id: string
+}
 export type GatewayRequestId = number | string
+export type AttachmentMode = 'observe' | 'control'
+export type AttachmentCapability =
+  | 'observe'
+  | 'prompt.submit'
+  | 'session.steer'
+  | 'session.interrupt'
+  | 'approval.respond'
+  | 'clarify.respond'
+  | 'ui.respond'
+export type ClientCapability = 'session.observe' | 'session.control' | 'session.replay'
+export type MultiClientMethod =
+  | 'client.attach'
+  | 'session.attach'
+  | 'session.detach'
+  | 'session.attachments'
+  | 'session.events.since'
+
+export interface GatewayReadyPayload {
+  capabilities?: MultiClientMethod[]
+  change_events?: boolean
+  connection_id: string
+  heartbeat?: boolean
+  multi_client?: {
+    attachment_modes: AttachmentMode[]
+    methods: MultiClientMethod[]
+    protocol_version: 1
+  }
+  multi_client_sessions?: 1
+  replay_epoch: string
+  /** Opaque canonical-runtime host generation. Optional for legacy gateways. */
+  runtime_host_id?: string
+  skin?: unknown
+}
+
+export interface ClientAttachParams {
+  capabilities?: ClientCapability[]
+  client_id: string
+  protocol_version: 1
+  surface: string
+}
+
+export interface GatewayClientIdStorage {
+  getItem(key: string): string | null
+  setItem(key: string, value: string): void
+}
+
+const GATEWAY_CLIENT_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._:-]{0,127}$/
+const GATEWAY_SURFACE_PATTERN = /^[a-z0-9][a-z0-9._-]{0,31}$/
+
+function randomGatewayClientId(): string {
+  try {
+    if (typeof globalThis.crypto?.randomUUID === 'function') {
+      return globalThis.crypto.randomUUID()
+    }
+  } catch {
+    // Fall through for restricted browser contexts.
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 14)}`
+}
+
+/** Stable per-window identity: sessionStorage survives reconnect/reload but is isolated across windows. */
+export function getOrCreateGatewayClientId(
+  surface: string,
+  storage?: GatewayClientIdStorage | null,
+  createId: () => string = randomGatewayClientId
+): string {
+  const normalizedSurface = surface.trim().toLowerCase()
+
+  if (!GATEWAY_SURFACE_PATTERN.test(normalizedSurface)) {
+    throw new TypeError('gateway client surface is invalid')
+  }
+
+  const key = `hermes.gateway.client-id.${normalizedSurface}.v1`
+
+  try {
+    const existing = storage?.getItem(key)
+
+    if (existing && GATEWAY_CLIENT_ID_PATTERN.test(existing)) {
+      return existing
+    }
+  } catch {
+    // Storage can be unavailable in private/restricted browser contexts.
+  }
+
+  const generated = `${normalizedSurface}:${createId()}`
+
+  if (!GATEWAY_CLIENT_ID_PATTERN.test(generated)) {
+    throw new TypeError('generated gateway client identity is invalid')
+  }
+
+  try {
+    storage?.setItem(key, generated)
+  } catch {
+    // The in-memory identity remains valid for this client instance.
+  }
+
+  return generated
+}
+
+export interface ClientAttachResult {
+  capabilities: ClientCapability[]
+  client_id: string
+  connection_id: string
+  idempotent: boolean
+  protocol_version: 1
+  surface: string
+}
+
+export interface SessionAttachmentSnapshot {
+  capabilities: AttachmentCapability[]
+  client_id: string
+  mode: AttachmentMode
+}
+
+export interface SessionAttachParams {
+  last_seen_seq?: number
+  mode: AttachmentMode
+  session_id: string
+}
+
+export interface SessionAttachResult extends SessionAttachmentSnapshot {
+  epoch: string
+  events: GatewayEvent[]
+  latest_seq: number
+  replay?: {
+    events: GatewayEvent[]
+    truncated: boolean
+  }
+  replay_epoch: string
+  session_id: string
+  truncated: boolean
+}
+
+export interface SessionDetachParams {
+  session_id: string
+}
+
+export interface SessionDetachResult {
+  detached: boolean
+  session_id: string
+}
+
+export interface SessionAttachmentsParams {
+  session_id: string
+}
+
+export interface SessionAttachmentsResult {
+  attachments: SessionAttachmentSnapshot[]
+  session_id: string
+}
+
+export interface SessionEventsSinceParams {
+  last_seen?: number
+  last_seen_seq?: number
+  session_id: string
+  since_seq?: number
+}
+
+export interface SessionEventsSinceResult {
+  count: number
+  epoch: string
+  events: GatewayEvent[]
+  latest_seq: number
+  truncated: boolean
+}
 
 export interface JsonRpcErrorPayload {
   code?: number
@@ -72,13 +251,21 @@ type PendingCall = {
   timer?: ReturnType<typeof setTimeout>
 }
 
+type TrackedSession = {
+  durableSessionId?: string
+  mode: AttachmentMode
+}
+
 export interface GatewayClientOptions {
+  /** Stable logical identity and capability request for negotiated multi-client gateways. */
+  clientAttachment?: ClientAttachParams
   closedErrorMessage?: string
   connectErrorMessage?: string
   connectTimeoutMs?: number
   createRequestId?: (nextId: number) => GatewayRequestId
   heartbeatDeadlineMs?: number
   heartbeatIntervalMs?: number
+  onDurableResyncRequired?: (request: DurableResyncRequest) => void
   /** Return true to intercept the default closed-state transition. */
   onSocketClose?: (event: CloseEvent) => boolean | void
   requestIdPrefix?: string
@@ -109,6 +296,8 @@ export class JsonRpcGatewayClient {
   private lastInboundAt = 0
   /** Last observed event seq per session_id — drives lossless reconnect replay. */
   private lastSeenSeq = new Map<string, number>()
+  /** Live sessions plus their durable resume ids, restored after reconnect/owner loss. */
+  private trackedSessions = new Map<string, TrackedSession>()
   /** Set while a post-reconnect replay fetch is in flight (dedup guard). */
   private replayInFlight = false
   /**
@@ -127,13 +316,23 @@ export class JsonRpcGatewayClient {
    * silently believe nothing was missed.
    */
   private replayEpoch: string | null = null
+  /** Canonical runtime host generation learned from gateway.ready. */
+  private runtimeHostId: string | null = null
+  private runtimeHostRecoveryPending = false
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
-  private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
-    Pick<GatewayClientOptions, 'socketFactory'>
+  private readonly options: Required<
+    Omit<GatewayClientOptions, 'clientAttachment' | 'onDurableResyncRequired' | 'socketFactory'>
+  > & Pick<GatewayClientOptions, 'clientAttachment' | 'onDurableResyncRequired' | 'socketFactory'>
+  private negotiatingConnect: {
+    reject: (error: Error) => void
+    resolve: () => void
+    socket: WebSocketLike
+  } | null = null
 
   constructor(options: GatewayClientOptions = {}) {
     this.options = {
+      clientAttachment: options.clientAttachment,
       closedErrorMessage: options.closedErrorMessage ?? 'WebSocket closed',
       connectErrorMessage: options.connectErrorMessage ?? 'WebSocket connection failed',
       connectTimeoutMs: options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS,
@@ -141,6 +340,7 @@ export class JsonRpcGatewayClient {
       heartbeatDeadlineMs: options.heartbeatDeadlineMs ?? DEFAULT_HEARTBEAT_DEADLINE_MS,
       heartbeatIntervalMs: options.heartbeatIntervalMs ?? DEFAULT_HEARTBEAT_INTERVAL_MS,
       notConnectedErrorMessage: options.notConnectedErrorMessage ?? 'gateway not connected',
+      onDurableResyncRequired: options.onDurableResyncRequired,
       onSocketClose: options.onSocketClose ?? (() => false),
       requestIdPrefix: options.requestIdPrefix ?? 'r',
       requestTimeoutMs: options.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
@@ -224,30 +424,68 @@ export class JsonRpcGatewayClient {
         socket.removeEventListener('error', onError)
       }
 
+      const complete = () => {
+        if (settled || this.socket !== socket) {
+          return
+        }
+
+        settled = true
+        this.setState('open')
+
+        if (this.negotiatingConnect?.socket === socket) {
+          this.negotiatingConnect = null
+        }
+
+        cleanup()
+        resolve()
+      }
+
+      const fail = (error: Error, updateState = true) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+
+        if (this.negotiatingConnect?.socket === socket) {
+          this.negotiatingConnect = null
+        }
+
+        cleanup()
+
+        if (updateState) {
+          this.setState('error')
+        }
+
+        reject(error)
+      }
+
       const onOpen = () => {
         if (settled || this.socket !== socket) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('open')
-        resolve()
-        // Lossless resume: drain events emitted while we were disconnected.
-        // Fire-and-forget so connect() latency is unaffected; only runs when
-        // we actually observed seq'd events before the drop.
+        if (this.options.clientAttachment) {
+          this.negotiatingConnect = {
+            reject: fail,
+            resolve: complete,
+            socket
+          }
+
+          return
+        }
+
+        complete()
+        // Legacy clients retain their pre-negotiation replay behavior.
         void this.fetchReplay()
       }
 
       const onError = () => {
-        if (settled || this.socket !== socket) {
+        if (this.socket !== socket) {
           return
         }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
+        fail(new Error(this.options.connectErrorMessage))
       }
 
       socket.addEventListener('open', onOpen, { once: true })
@@ -259,12 +497,11 @@ export class JsonRpcGatewayClient {
             return
           }
 
-          settled = true
-          cleanup()
+          const isCurrentSocket = this.socket === socket
 
-          // Drop the half-open socket so the next connect() starts clean
-          // instead of short-circuiting on a zombie 'connecting' state.
-          if (this.socket === socket) {
+          // Drop the half-open or unnegotiated socket so the next connect()
+          // starts clean instead of short-circuiting on a zombie state.
+          if (isCurrentSocket) {
             try {
               socket.close()
             } catch {
@@ -272,13 +509,48 @@ export class JsonRpcGatewayClient {
             }
 
             this.socket = null
-            this.setState('error')
           }
 
-          reject(new Error(this.options.connectErrorMessage))
+          fail(new Error(this.options.connectErrorMessage), isCurrentSocket)
         }, this.options.connectTimeoutMs)
       }
     })
+  }
+
+  attachClient(params: ClientAttachParams): Promise<ClientAttachResult> {
+    return this.request<ClientAttachResult>('client.attach', { ...params })
+  }
+
+  async attachSession(params: SessionAttachParams): Promise<SessionAttachResult> {
+    const result = await this.request<SessionAttachResult>('session.attach', { ...params })
+
+    const existing = this.trackedSessions.get(params.session_id)
+    this.trackedSessions.set(params.session_id, {
+      durableSessionId: existing?.durableSessionId,
+      mode: params.mode
+    })
+    this.applySessionAttachResult(result)
+
+    return result
+  }
+
+  async detachSession(params: SessionDetachParams): Promise<SessionDetachResult> {
+    const result = await this.request<SessionDetachResult>('session.detach', { ...params })
+
+    if (result.detached) {
+      this.trackedSessions.delete(params.session_id)
+      this.lastSeenSeq.delete(params.session_id)
+    }
+
+    return result
+  }
+
+  listSessionAttachments(params: SessionAttachmentsParams): Promise<SessionAttachmentsResult> {
+    return this.request<SessionAttachmentsResult>('session.attachments', { ...params })
+  }
+
+  getSessionEventsSince(params: SessionEventsSinceParams): Promise<SessionEventsSinceResult> {
+    return this.request<SessionEventsSinceResult>('session.events.since', { ...params })
   }
 
   close(): void {
@@ -370,6 +642,7 @@ export class JsonRpcGatewayClient {
       const pending: PendingCall = {
         resolve: value => {
           detach()
+          this.trackSuccessfulSessionRequest(method, params, value)
           resolve(value as T)
         },
         reject: error => {
@@ -428,6 +701,150 @@ export class JsonRpcGatewayClient {
     })
   }
 
+  private trackSuccessfulSessionRequest(
+    method: string,
+    params: Record<string, unknown>,
+    value: unknown
+  ): void {
+    if (method !== 'session.create' && method !== 'session.resume') {
+      return
+    }
+
+    const result = value as Record<string, unknown> | null
+    const liveSessionId = typeof result?.session_id === 'string' ? result.session_id : ''
+
+    if (!liveSessionId) {
+      return
+    }
+
+    const requested = typeof params.session_id === 'string' ? params.session_id : ''
+
+    const storedSessionId = typeof result?.stored_session_id === 'string'
+      ? result.stored_session_id
+      : ''
+
+    const resultKey = typeof result?.session_key === 'string' ? result.session_key : ''
+    const resumed = typeof result?.resumed === 'string' ? result.resumed : ''
+
+    const durableSessionId = method === 'session.resume'
+      ? (requested || resumed || resultKey || liveSessionId)
+      : (storedSessionId || resultKey || liveSessionId)
+
+    let mode: AttachmentMode = 'control'
+
+    for (const [sessionId, tracked] of this.trackedSessions) {
+      if (tracked.durableSessionId === durableSessionId) {
+        mode = tracked.mode
+        this.trackedSessions.delete(sessionId)
+        this.lastSeenSeq.delete(sessionId)
+      }
+    }
+
+    this.trackedSessions.set(liveSessionId, { durableSessionId, mode })
+  }
+
+  private async reconstructTrackedSessionsAfterHostChange(): Promise<void> {
+    const tracked = [...this.trackedSessions.entries()]
+
+    for (const [staleSessionId, session] of tracked) {
+      try {
+        await this.request('session.resume', { session_id: session.durableSessionId })
+      } catch (error: unknown) {
+        // Never attach a stale process-local id to a replacement runtime.
+        this.trackedSessions.delete(staleSessionId)
+        this.lastSeenSeq.delete(staleSessionId)
+        this.dispatchEvent({
+          type: 'error',
+          session_id: staleSessionId,
+          payload: {
+            code: 'runtime_recovery_failed',
+            message: error instanceof Error
+              ? `Session recovery failed: ${error.message}`
+              : 'Session recovery failed after runtime host takeover.'
+          }
+        })
+      }
+    }
+  }
+
+  private applySessionAttachResult(result: SessionAttachResult): void {
+    if (result.epoch) {
+      this.adoptReplayEpoch(result.epoch)
+    }
+
+    if (result.truncated) {
+      this.lastSeenSeq.delete(result.session_id)
+      this.options.onDurableResyncRequired?.({
+        reason: 'replay_truncated',
+        session_id: result.session_id
+      })
+
+      return
+    }
+
+    for (const event of result.events) {
+      if (event?.type) {
+        this.dispatchIfNewer(event)
+      }
+    }
+  }
+
+  private async negotiateReady(payload: unknown): Promise<void> {
+    const pending = this.negotiatingConnect
+    const attachment = this.options.clientAttachment
+
+    if (!pending || !attachment || pending.socket !== this.socket) {
+      return
+    }
+
+    const methods = (payload as GatewayReadyPayload | undefined)?.multi_client?.methods
+
+    try {
+      if (methods?.includes('client.attach')) {
+        await this.attachClient(attachment)
+
+        if (this.runtimeHostRecoveryPending) {
+          this.runtimeHostRecoveryPending = false
+          await this.reconstructTrackedSessionsAfterHostChange()
+        }
+
+        if (methods.includes('session.attach') && this.trackedSessions.size > 0) {
+          this.replayHold = new Map(
+            [...this.trackedSessions.keys()].map(sessionId => [sessionId, []])
+          )
+
+          try {
+            for (const [sessionId, tracked] of this.trackedSessions) {
+              const result = await this.request<SessionAttachResult>('session.attach', {
+                session_id: sessionId,
+                mode: tracked.mode,
+                last_seen_seq: this.lastSeenSeq.get(sessionId) ?? 0
+              })
+
+              this.applySessionAttachResult(result)
+            }
+          } finally {
+            this.flushReplayHold()
+          }
+        }
+      } else {
+        // Legacy gateway: identity negotiation is unavailable, so retain the
+        // previous best-effort replay path and let connect proceed.
+        void this.fetchReplay()
+      }
+
+      pending.resolve()
+    } catch (error) {
+      const failure = error instanceof Error ? error : new Error(String(error))
+
+      pending.reject(failure)
+
+      if (this.socket === pending.socket) {
+        this.invalidateSocket(pending.socket, failure)
+      }
+    }
+  }
+
   private handleMessage(raw: unknown): void {
     const text = typeof raw === 'string' ? raw : String(raw)
     let frame: JsonRpcFrame
@@ -462,6 +879,49 @@ export class JsonRpcGatewayClient {
     }
 
     if (frame.method === 'event' && frame.params?.type) {
+      if (frame.params.type === 'session.runtime_owner_lost') {
+        const payload = frame.params.payload as { session_ids?: unknown } | undefined
+        const sessionIds = Array.isArray(payload?.session_ids) ? payload.session_ids : []
+
+        for (const sessionId of sessionIds) {
+          if (typeof sessionId !== 'string' || !this.trackedSessions.has(sessionId)) {
+            continue
+          }
+
+          this.lastSeenSeq.delete(sessionId)
+          this.replayHold?.delete(sessionId)
+          const tracked = this.trackedSessions.get(sessionId)
+
+          const resync: DurableResyncRequest = {
+            reason: 'runtime_owner_lost',
+            session_id: sessionId
+          }
+
+          if (tracked?.durableSessionId) {
+            resync.durable_session_id = tracked.durableSessionId
+          }
+
+          this.options.onDurableResyncRequired?.(resync)
+
+          if (tracked?.durableSessionId) {
+            void this.request('session.resume', {
+              session_id: tracked.durableSessionId
+            }).catch((error: unknown) => {
+              this.dispatchEvent({
+                type: 'error',
+                session_id: sessionId,
+                payload: {
+                  code: 'runtime_recovery_failed',
+                  message: error instanceof Error
+                    ? `Session recovery failed: ${error.message}`
+                    : 'Session recovery failed after runtime owner loss.'
+                }
+              })
+            })
+          }
+        }
+      }
+
       if (frame.params.type === 'gateway.ready') {
         if (this.gatewayReadyAdvertisesHeartbeat(frame.params.payload)) {
           const socket = this.socket
@@ -471,11 +931,50 @@ export class JsonRpcGatewayClient {
           }
         }
 
-        const epoch = (frame.params.payload as { replay_epoch?: unknown } | undefined)?.replay_epoch
+        const ready = frame.params.payload as GatewayReadyPayload | undefined
+        const epoch = ready?.replay_epoch
+        const runtimeHostId = ready?.runtime_host_id
+        let hostChanged = false
+
+        if (typeof runtimeHostId === 'string' && runtimeHostId) {
+          if (this.runtimeHostId && this.runtimeHostId !== runtimeHostId) {
+            hostChanged = true
+            this.runtimeHostRecoveryPending = true
+            this.lastSeenSeq.clear()
+            this.replayHold = null
+
+            for (const sessionId of this.trackedSessions.keys()) {
+              this.options.onDurableResyncRequired?.({
+                reason: 'runtime_host_changed',
+                session_id: sessionId
+              })
+            }
+          }
+
+          this.runtimeHostId = runtimeHostId
+        }
 
         if (typeof epoch === 'string' && epoch) {
-          this.adoptReplayEpoch(epoch)
+          this.adoptReplayEpoch(epoch, !hostChanged)
         }
+
+        if (this.options.clientAttachment) {
+          void this.negotiateReady(frame.params.payload)
+        }
+
+        if (hostChanged && !this.negotiatingConnect) {
+          this.runtimeHostRecoveryPending = false
+          void this.reconstructTrackedSessionsAfterHostChange()
+        }
+      }
+
+      const eventEpoch = frame.params.epoch
+
+      if (typeof eventEpoch === 'string' && eventEpoch) {
+        // Counter metadata is bounded. A long-lived gateway may rotate its
+        // replay epoch without reconnecting; clear stale watermarks before
+        // evaluating this event's restarted sequence.
+        this.adoptReplayEpoch(eventEpoch)
       }
 
       const sid = frame.params.session_id
@@ -618,13 +1117,23 @@ export class JsonRpcGatewayClient {
    * seq watermarks describe a numbering that no longer exists — clear them
    * so the next reconnect doesn't silently believe it missed nothing.
    */
-  private adoptReplayEpoch(epoch: string): void {
+  private adoptReplayEpoch(epoch: string, notify = true): void {
     if (this.replayEpoch === epoch) {
       return
     }
 
     if (this.replayEpoch !== null) {
       this.lastSeenSeq.clear()
+      this.replayHold = null
+
+      if (notify) {
+        for (const sessionId of this.trackedSessions.keys()) {
+          this.options.onDurableResyncRequired?.({
+            reason: 'replay_epoch_changed',
+            session_id: sessionId
+          })
+        }
+      }
     }
 
     this.replayEpoch = epoch

--- a/docs/plans/2026-08-28-multi-client-live-sessions-feasibility.md
+++ b/docs/plans/2026-08-28-multi-client-live-sessions-feasibility.md
@@ -1,0 +1,653 @@
+# Hermes Multi-Client Live Session Feasibility Investigation
+
+Date: 2026-08-28
+
+## Scope and source baseline
+
+This is an investigation only. No Hermes source was modified.
+
+The detailed source audit uses the locally cloned upstream Hermes Agent `0.20.6` tree at commit `420e156`:
+
+`references/upstream/hermes-agent/`
+
+The Hermes installation currently deployed in this workspace is `0.19.0`. Its TUI Gateway is older: it has the same single `session["transport"]` event destination but does not contain upstream `0.20.6`'s `viewers` fallback registry. Any implementation should first pin and upgrade the workspace to the chosen upstream baseline; the newer cross-process durable turn-lease behavior must not be assumed to exist in deployed `0.19.0`.
+
+## Verdict
+
+**Significant but reasonable architectural refactor.**
+
+Read-only in-process fan-out is a reasonable incremental change. The complete target — one authoritative live runtime, many writable clients, reconnect, approvals, and a cross-process guarantee — is a larger but still well-localized refactor at the TUI Gateway/live-session/transport boundary.
+
+It does not require redesigning AIAgent reasoning, providers, tools, memory, MCP, skills, Kanban, STT/TTS, or the durable session schema.
+
+The most important qualification is scope:
+
+- Multiple clients connected to one TUI Gateway process can share one existing runtime without touching AIAgent.
+- Separate TUI Gateway processes still have separate `_sessions` tables and separate AIAgent objects.
+- Upstream `0.20.6` now serializes the durable load → run → flush region across processes with a SQLite-backed session turn lease. That prevents simultaneous transcript corruption, but it does **not** create one runtime or permit a client to observe/interrupt the runtime hosted by another process.
+- Therefore a true generic live-runtime feature should converge on a **single runtime host** rather than distributed runtime ownership.
+
+## 1. Current architecture
+
+### 1.1 Process-global live-session table
+
+`tui_gateway/server.py:144-166` defines:
+
+```python
+_sessions: dict[str, dict] = {}
+_sessions_lock = threading.RLock()
+_session_resume_lock = threading.Lock()
+```
+
+Every JSON-RPC request in a given process uses this same module-global table. WebSocket connections handled by `tui_gateway/ws.py` dispatch into the same imported `tui_gateway.server` module, so connections inside one server process share `_sessions`.
+
+A separately launched stdio TUI Gateway process imports its own module and therefore owns a separate `_sessions` table.
+
+### 1.2 The live-session object
+
+There is no `SessionRuntime` class in the TUI Gateway. The runtime is a mutable dictionary created by `_init_session()` in `tui_gateway/server.py:8632-8676`. Agent construction is performed by `_make_agent()` and can be started through `_start_agent_build()`.
+
+Important fields include:
+
+```text
+_sid
+session_key              durable SessionDB id, after persistence/resume
+agent                    live AIAgent
+history
+history_lock
+history_version
+running
+_run_thread
+inflight_turn
+queued_prompt
+queued_prompts
+_turn_cancel_requested
+transport                one authoritative event destination
+viewers                   fallback transports, not subscribers
+pending approval/input state
+notification poller
+agent build state
+compute-host metadata
+```
+
+This dictionary already performs most of the conceptual role proposed for `SessionRuntime`.
+
+### 1.3 AIAgent creation and lifetime
+
+The AIAgent is built in:
+
+- `tui_gateway/server.py:8444-8629` — `_make_agent()` calls `AIAgent(**kwargs)`.
+- `tui_gateway/server.py:3134-3205` — `_start_agent_build()` performs the deferred build and installs the result into the session record.
+- `tui_gateway/server.py:8632-8676` — `_init_session()` creates the live record and stores the supplied agent in `session["agent"]`.
+
+The same `session["agent"]` is reused across normal turns. `_run_prompt_submit()` reads it at `server.py:12232`, and invokes `agent.run_conversation()` at `server.py:12554` using the session history snapshot. Hermes may intentionally replace/reconfigure the agent during capability synchronization, model switching, compression rotation, or recovery, but it does not normally construct a fresh agent for every turn.
+
+The generic messaging gateway is a separate execution stack. `gateway/run.py:7102-7113` owns its own `GatewayRunner._sessions` and per-session turn-lease registry; `gateway/run.py:7185-7197` owns an AIAgent cache. These are not the same runtime objects as TUI Gateway `_sessions`.
+
+### 1.4 Durable-session-to-live-runtime reuse
+
+`session.resume` is implemented in `tui_gateway/methods_session.py:372-1038`.
+
+Within one TUI Gateway process:
+
+- `_find_live_session_by_key()` (`server.py:10333-10353`) scans `_sessions` by durable `session_key`/agent session id.
+- `_claim_or_reuse_live()` (`server.py:10089-10136`) resolves a race under `_session_resume_lock` and returns the existing live winner when possible.
+- The resume-local `_reuse_live_response()` (`methods_session.py:622-635`) returns the existing runtime payload.
+
+This means a single process already has the beginnings of a runtime manager and can host several independent sessions while avoiding duplicate live records for the same durable key in most resume races.
+
+It is not a cross-process runtime manager.
+
+### 1.5 Single transport ownership
+
+The authoritative event destination is stored directly on the live-session dictionary:
+
+```python
+session["transport"]
+```
+
+`write_json()` in `tui_gateway/server.py:2478-2508` routes any session-scoped event to:
+
+```python
+(_sessions.get(sid) or {}).get("transport")
+```
+
+It calls exactly one transport's `write()` method.
+
+`_event_frame()` / `_emit()` in `server.py:2511-2519` build and send:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "event",
+  "params": {
+    "type": "...",
+    "session_id": "...",
+    "payload": {}
+  }
+}
+```
+
+and passes it to `write_json()`.
+
+`event_replay.py:52-75` adds a process epoch and per-session monotonic `seq`, then stores the event in a bounded ring. The current envelope has `type`, `session_id`, `payload`, and `seq`; it does not consistently include `event_id`, `timestamp`, or `turn_id`.
+
+### 1.6 Viewer registry is not fan-out
+
+Upstream `0.20.6` has:
+
+```python
+session["viewers"] = {transport: last_seen_timestamp}
+```
+
+Relevant code:
+
+- `_live_session_payload()` — `server.py:10442-10466`
+- `_close_sessions_for_transport()` — `server.py:1494-1576`
+
+However, `_live_session_payload()` still does:
+
+```python
+session["transport"] = transport
+```
+
+The viewers map is consulted only when the current transport disconnects. Hermes chooses the most recently seen surviving viewer and assigns it back to the single `session["transport"]` slot.
+
+Tests explicitly encode this behavior:
+
+- `tests/test_tui_gateway_server.py:5153-5174` — closing the active transport rebinds to a remaining viewer.
+- `tests/test_tui_gateway_server.py:5222-5234` — resume/activate registers a viewer but also makes it the session transport.
+
+An isolated runtime probe against upstream source produced:
+
+```text
+active_transport: B
+viewers: [A, B]
+A_events: 0
+B_events: 1
+```
+
+Thus the registry fixes disconnect fallback, not simultaneous observation.
+
+### 1.7 Transport rebinding sites
+
+The single destination is rebound at least at these important points:
+
+- `_live_session_payload()` — resume/activate assigns the caller transport (`server.py:10442-10466`).
+- `prompt.submit` — every submit assigns `current_transport()` (`methods_prompt.py:360-364`).
+- `_enqueue_prompt()` stores the initiating transport in the queued input envelope (`server.py:9542-9560`).
+- `_drain_queued_prompt()` restores that queued transport as the session transport before running the queued turn (`server.py:9790-9793`).
+- `_close_sessions_for_transport()` chooses another viewer or the detached sentinel (`server.py:1494-1576`).
+
+This makes the latest resume, active submitter, queued submitter, or disconnect fallback the sole destination for later events.
+
+### 1.8 Event callback path
+
+AIAgent does not need to know about WebSockets.
+
+`_agent_cbs()` (`server.py:7731-7745`) and `_wire_callbacks()` (`server.py:7909-7986`) adapt AIAgent/tool callbacks into `_emit()` calls. Examples include:
+
+- `message.start`, `message.delta`, `message.interim`, `message.complete`
+- `tool.start`, `tool.complete`, and tool progress/status
+- `subagent.start`, `subagent.thinking`, `subagent.text`, `subagent.tool`, `subagent.complete`
+- `approval.request`
+- `clarify.request`
+- `sudo.request`, `secret.request`, `terminal.read.request`
+- `agent.terminal.output`, `terminal.close`
+- `error`, usage, session info/title/status events
+
+Terminal process output is bridged at `server.py:11917-11959`. Subagent events are bridged at `server.py:7578-7732`.
+
+Because these paths converge on `_emit()`, event fan-out can be inserted without modifying AIAgent or every tool.
+
+Hermes also contains two adjacent but non-equivalent fan-out mechanisms:
+
+- `_broadcast_global_event()` iterates every process-local live transport for session-less events (`server.py:2522-2565`).
+- Dashboard `/api/pub` → `/api/events` uses a per-channel subscriber registry for PTY-side best-effort sidebar events (`hermes_cli/web_server.py:16859-16920`, `17713-17792`).
+
+Both demonstrate useful delivery patterns, but neither is the authoritative per-session runtime event bus. The dashboard channel is a sidecar bridge and does not own turn, approval, interrupt, or replay semantics.
+
+### 1.9 Busy input, queue, steer, and interrupt
+
+`prompt.submit` uses `session["history_lock"]` and `session["running"]` to claim one turn (`methods_prompt.py:365-381` and `812-816`). A turn runs on one `_run_thread` (`methods_prompt.py:867-917`).
+
+Busy-input scheduling already exists in `_handle_busy_submit()` (`server.py:9674-9769`):
+
+- `steer` uses `agent.steer()` when supported.
+- `interrupt` prefers active-turn redirect; otherwise queues and interrupts.
+- `queue` preserves the turn without interrupting.
+
+`_enqueue_prompt()` and `_drain_queued_prompt()` (`server.py:9518-9560`, `9772-9870`) provide FIFO-like server-side queue handling, including separate image envelopes and merged adjacent text behavior.
+
+`session.interrupt` (`methods_session.py:3327-3637`) locates the session record, then interrupts its `agent` or compute-host turn.
+
+The existing scheduler should remain authoritative. Multi-client input needs origin/request metadata and removal of transport ownership, not a second scheduler.
+
+### 1.10 Approvals and clarification
+
+Blocking requests are runtime/process state, not durable frontend state:
+
+- `_block()` — `server.py:4523-4606`
+- `_respond()` — `server.py:13463-13490`
+- `clarify.respond` / `approval.respond` — `methods_prompt.py:1515-1693`
+- gateway approval registry — `tools/approval.py:2761-2910`
+
+The request is emitted as a session event and a process-global pending entry waits on a `threading.Event`.
+
+The gateway approval registry performs an atomic pop under a lock, so one gateway approval resolution wins. The generic `_respond()` path can still accept a second answer before the waiter removes the pending entry, overwriting `_answers[request_id]`. Multi-client support must make all blocking-request resolution atomic and return a deterministic `already_resolved`/`expired` result to late responders.
+
+There is no general `approval.responded` or `clarify.responded` fan-out today. That should be added so every client clears its pending UI from the authoritative runtime resolution.
+
+### 1.11 Disconnect behavior
+
+`tui_gateway/ws.py:558-582` calls `_close_sessions_for_transport()` when a WebSocket exits.
+
+Current behavior:
+
+- If another viewer exists, Hermes rebinds `session["transport"]` to that viewer.
+- If no viewer remains, it assigns `_detached_ws_transport` and schedules an orphan reap.
+- Depending on `close_on_disconnect`, active turns may be torn down immediately or interrupted/reaped after a grace period.
+
+The disconnect decision is tied to the transport-owner slot, not subscriber count. Multi-client detach must remove only that subscriber; orphan policy should run only after the subscriber registry is empty.
+
+### 1.12 Dashboard and Desktop process relationship
+
+`hermes_cli/web_server.py:17666-17710` exposes `/api/ws` and delegates to `tui_gateway.ws.handle_ws()`. WebSocket clients connected to one dashboard server therefore share that server process's TUI Gateway `_sessions` table.
+
+When dashboard turn isolation is enabled, `tui_gateway/host_supervisor.py:1-6` states that the dashboard process still owns sockets and JSON-RPC dispatch while one persistent compute-host child runs agent turns. The parent remains the natural event-hub/runtime-host boundary.
+
+A standalone stdio TUI Gateway or a second dashboard server process has separate process-local runtime state.
+
+## 2. Why multi-client currently fails
+
+This is source-verified, not inferred:
+
+1. `session.resume`/activate records both viewers but assigns the caller to the one `session["transport"]` slot.
+2. `prompt.submit` repeats that assignment for the submitting connection.
+3. `_emit()` calls `write_json()`.
+4. `write_json()` selects one session transport and performs one write.
+5. No code iterates `session["viewers"]` when emitting an event.
+6. Disconnect merely promotes one fallback viewer into the same exclusive slot.
+7. Queued prompts carry a transport and rebind ownership when drained.
+
+Therefore client B does not merely attach; it steals the asynchronous event destination from A. A remains connected but receives no new live session events.
+
+Across processes, each process can instantiate its own live session dictionary and AIAgent. Upstream's durable turn lease serializes their durable turns, but clients still cannot share one live event stream, approvals, steer target, or interrupt target. The second process is a separate runtime waiting behind, or later running after, the first.
+
+## 3. Recommended architecture
+
+### 3.1 Use the existing live record as the migration seam
+
+A `SessionRuntimeManager` is the correct end-state abstraction, but replacing every session dictionary access with a new class should not be Phase 1. `server.py` is large and the mutable record is referenced broadly.
+
+Recommended progression:
+
+1. Treat `_sessions` plus `_session_resume_lock` as the initial runtime manager.
+2. Add a focused `SessionEventHub`/`SubscriberRegistry` owned by each session record.
+3. Move asynchronous event destination logic from `session["transport"]` to that hub.
+4. Preserve implicit attach during `session.create`, `session.init`, and `session.resume` for backward compatibility.
+5. Add explicit `session.attach` and `session.detach` RPCs for clients that want clear lifecycle semantics.
+6. Extract a typed `SessionRuntime` and `SessionRuntimeManager` only after behavior is covered by tests.
+
+This minimizes churn while establishing the correct ownership model.
+
+### 3.2 Separate RPC responses from runtime events
+
+JSON-RPC method responses must remain point-to-point to the requesting connection.
+
+Only asynchronous frames with `method == "event"` should pass through the per-session event hub.
+
+Do not broadcast RPC return values or errors associated with one request id.
+
+### 3.3 Publish once, enqueue many
+
+The target path should be:
+
+```text
+AIAgent/tool/background callback
+          ↓
+       _emit()
+          ↓
+SessionEventHub.publish(event)
+          ↓
+assign one session seq/event id and record replay once
+          ↓
+non-blocking enqueue to each subscriber
+          ↓
+per-subscriber writer independently calls transport.write()
+```
+
+Important details:
+
+- Stamp and replay-record the event **once before fan-out**. Calling current `write_json()` once per subscriber would assign different sequence numbers and duplicate the replay entry.
+- Use a per-runtime publication lock to establish one order across callbacks arriving from agent, tool, subagent, and process-output threads.
+- Keep per-client bounded queues. Never perform socket writes while holding the publication lock or session history lock.
+- If a queue overflows, detach/close that subscriber and require replay/reconnect. Do not silently create an unobservable gap.
+- Preserve the existing epoch + `session.events.since` recovery contract; expand the envelope later with `event_id`, `timestamp`, and where available `turn_id`.
+- `tool_id`, approval `request_id`, subagent id, and terminal `process_id` already exist in relevant payloads and should remain stable.
+
+### 3.4 Attachment model
+
+A subscriber record should contain operational state only:
+
+```text
+client_id
+transport
+attached_at
+last_seen_at
+last_seen_seq
+capabilities
+permissions/read-only flag
+```
+
+It must not contain conversation history or duplicate approval state.
+
+`session.resume` should load/reuse the runtime and implicitly attach the caller. It must never detach or demote existing subscribers.
+
+`session.detach` removes only the current client. UI tab focus remains client-local; a client should attach/detach intentionally rather than server ownership following selected tabs.
+
+### 3.5 Input routing
+
+Reuse `prompt.submit`, `_handle_busy_submit`, `_enqueue_prompt`, `_drain_queued_prompt`, `agent.steer()`, and `session.interrupt`.
+
+Changes needed:
+
+- Resolve a durable/live session through the shared runtime manager.
+- Add `client_id`, `request_id`, and optional origin metadata to queued envelopes.
+- Remove queued `transport` as an event destination.
+- Keep RPC acknowledgment point-to-point.
+- Broadcast resulting runtime events to every subscriber.
+- Use the existing `history_lock`/`running` claim so only one turn starts.
+
+The current queue merges adjacent text inputs in some circumstances. If exact one-command-per-request semantics are required, preserve origin/request ids through a merge or disable merging for multi-client submissions. This must be decided explicitly and tested; otherwise two users' inputs could be combined into one user message.
+
+### 3.6 Approval and clarification ownership
+
+Pending requests remain session/run state.
+
+- Broadcast request to every attached readable client.
+- Keep subscriber membership separate from controller/approver authority.
+- Allow only clients carrying the explicit `approve` or `clarify` capability to respond; a read-only subscriber must never acquire authority merely by attaching.
+- Choose and expose an authority policy: one renewable controller lease by default, or first response among explicitly authorized approvers. Do not infer authority from “most recently resumed” transport.
+- Resolve using an atomic compare-and-set/pop.
+- First valid response wins.
+- Return deterministic `already_resolved` or `expired` to duplicates.
+- Broadcast a resolution event to all subscribers.
+
+Do not maintain one pending approval per client.
+
+Before multi-client exposure, also fix an existing approval validation discrepancy: TUI `approval.respond` forwards arbitrary `choice` values (`methods_prompt.py:1665-1690`), while downstream treats any resolved value other than `deny`/`None` as approved (`tools/approval.py:5662-5699`). The REST Runs API correctly allowlists `once|session|always|deny` (`gateway/platforms/api_server.py:8086-8097`). The TUI Gateway must apply the same exact allowlist before resolution.
+
+The gateway approval queue already resolves a request atomically under its lock (`tools/approval.py:2829-2868`). Generic clarification `_respond()` does not: a second response can overwrite `_answers[request_id]` after the event is set but before waiter cleanup (`server.py:13463-13490`). Clarification therefore needs compare-and-set resolution; approval should preserve its existing atomic behavior.
+
+### 3.7 Runtime lifetime
+
+Subscriber count and turn/delegation activity should drive lifecycle:
+
+- Any subscribers: runtime stays loaded.
+- No subscribers but active turn/delegation/blocking request: continue according to explicit orphan policy.
+- No subscribers and idle: start an idle timer.
+- Timer expiry: finalize and unload runtime, preserving durable session.
+
+The existing WS orphan-reap machinery can be adapted from “single transport is detached” to “subscriber count is zero.”
+
+## 4. Scope and compatibility
+
+### Primary server modules
+
+Likely modified:
+
+- `tui_gateway/server.py`
+  - `_sessions` lifecycle helpers
+  - `_init_session`, `_live_session_payload`, `_reuse_live_response`
+  - `write_json`, `_emit`
+  - `_close_sessions_for_transport`, orphan checks
+  - queued-input transport fields
+  - blocking request resolution events
+- `tui_gateway/methods_session.py`
+  - `session.resume`
+  - new attach/detach semantics
+  - structured `session.status`
+  - interrupt/status/replay integration
+- `tui_gateway/methods_prompt.py`
+  - stop rebinding on `prompt.submit`
+  - input origin metadata
+  - deterministic approval/clarify duplicate handling
+- `tui_gateway/transport.py`
+  - transport remains connection I/O; no runtime ownership
+  - global live-transport broadcast remains separate from per-session fan-out
+- `tui_gateway/ws.py`
+  - client identity
+  - disconnect detaches subscriptions
+  - per-client writer queue/cleanup
+- `tui_gateway/event_replay.py`
+  - stamp/record once before fan-out
+  - immutable/copy-safe replay entries
+- new focused module, e.g. `tui_gateway/session_events.py` or `runtime.py`
+
+### Tests
+
+Likely modified/added:
+
+- `tests/test_tui_gateway_server.py`
+- `tests/tui_gateway/test_protocol.py`
+- WebSocket integration tests
+- race tests for resume/attach, submit, approval, disconnect, queue overflow, and replay
+- process-level tests retaining the durable session turn lease
+
+### Modules probably not changed in the first implementation
+
+- `run_agent.py` / AIAgent reasoning loop
+- tool implementations
+- memory, MCP, skills, Kanban, STT/TTS
+- durable messages/session schema
+- `gateway/session.py`, `gateway/run.py`, `gateway/session_context.py`
+- `hermes_cli/active_sessions.py`
+- compute-host agent code
+
+The parent-side compute-host relay may need adaptation only at its event sink so relayed events enter the same hub.
+
+### Client compatibility
+
+Backward compatibility is achievable:
+
+- Existing stdio and WebSocket JSON-RPC clients can remain implicitly attached after create/init/resume.
+- Existing event frames can retain their current shape and add optional fields.
+- Unknown fields are already tolerated by the TUI.
+- Single-client behavior becomes a one-subscriber special case.
+- Existing clients need no new `session.attach` call until explicit attachment is desired.
+
+The main observable semantic change is beneficial: another client resuming/submitting no longer redirects the first client's stream.
+
+Migration difficulty is medium for in-process read-only fan-out and medium-high for the complete writable/reconnect/lifecycle feature because the current transport field is referenced in queue and disconnect behavior.
+
+## 5. Cross-process implications
+
+### 5.1 Existing protections
+
+There are two different lease systems and they must not be conflated.
+
+`hermes_cli/active_sessions.py` is a concurrency-cap/liveness registry. It does not enforce unique ownership by durable session id. A probe acquired two distinct active-session leases for the same `session_id` without error.
+
+Upstream `0.20.6` also has a durable SQLite session turn lease:
+
+- `hermes_state.py:7949-8111`
+- `run_agent.py:8684-8912`
+- `tests/state/test_session_turn_lease.py`
+
+It atomically serializes the full load → run → flush region across processes, refreshes a TTL, fences release by holder identity, waits/reloads latest history after contention, and fails closed on timeout/lost lease.
+
+This substantially reduces persistence-corruption risk in current upstream.
+
+It is not a complete linearizability guarantee for every higher-level gateway path. `GatewayRunner` can load history before `AIAgent.run_conversation()` acquires the durable lease (`gateway/run.py:19867-19874`), while the agent reloads after acquisition only when acquisition reported contention (`run_agent.py:8831-8846`). A process can load stale history, wait outside the lease while another process completes, then acquire immediately after release and skip the contention-triggered reload. This narrow race is another reason not to treat independent active/active gateway processes as equivalent to one runtime host.
+
+It does not enforce zero-or-one loaded AIAgent. Multiple processes can still hold idle live agents for the same durable session and cannot share in-memory approvals, events, interrupt state, queued input, or subagents.
+
+The durable lease is host-local protection, not distributed consensus. Holder identity contains a local PID, and dead-owner reclamation consults the local process table (`hermes_state.py:180-232`). Two hosts mounting the same `state.db` could misclassify one another's holders. Do not use shared-filesystem, multi-host runtime ownership; a canonical host must be the sole runtime writer for a Hermes home/profile.
+
+### 5.2 Preferred model: one runtime host
+
+Use Option A.
+
+One long-lived TUI Runtime Host should own:
+
+- `_sessions` / future `SessionRuntimeManager`
+- AIAgent instances
+- turns, queues, approvals, interruptions
+- event hubs and replay rings
+
+TUI, Desktop, VS Code, Control Center, and future voice clients connect to that host over the existing JSON-RPC WebSocket/stdio-compatible protocol.
+
+This is consistent with the dashboard architecture: its parent process already owns sockets/dispatch and can optionally delegate compute to one child.
+
+A standalone stdio TUI should eventually become a client/proxy to the canonical host rather than silently starting an independent runtime owner when a host is available.
+
+Keep the SQLite turn lease as defense-in-depth for old clients, CLI direct execution, crashes, mixed versions, and non-interactive processes during migration.
+
+### 5.3 Why distributed runtime ownership is not recommended
+
+A durable lock can tell process B that process A owns a runtime, but it cannot deliver A's events or route B's input. Distributed ownership also requires:
+
+- owner discovery and address publication
+- authenticated proxying
+- subscriber forwarding
+- failover and fencing
+- replay across owner death
+- approval/interrupt routing
+- split-brain handling
+
+No current Hermes abstraction provides that complete protocol. Building it before a single-host design would be disproportionate.
+
+### 5.4 Generic gateway/API relationship
+
+The TUI Gateway and `GatewayRunner` are separate runtime stacks. A first implementation can provide the capability to all interactive clients that speak TUI Gateway JSON-RPC.
+
+If the requirement later becomes “a Telegram/Discord gateway turn and a Desktop/TUI turn must literally share one in-memory AIAgent,” those adapters must submit/proxy through the canonical runtime host. Merely sharing SessionDB is insufficient. That would be a later migration, not part of read-only fan-out.
+
+## 6. Risk assessment
+
+### Persistence corruption — medium initially, low with controls
+
+Fan-out itself does not write persistence more than once because one runtime still performs one turn. The principal danger is accidentally starting one turn per subscriber or allowing two prompt claims. Keep execution and persistence exclusively on the runtime, never in subscriber handlers.
+
+Retain upstream's durable session turn lease for cross-process defense.
+
+### Event ordering — medium-high
+
+Callbacks arrive from multiple threads. Current `_stamp_event()` sequencing and the subsequent transport write are separate critical sections, so two threads can receive sequence numbers 1 and 2 but enter the transport in reverse order. Assign sequence/order and enqueue once under a per-runtime publication lock. Do not stamp independently per subscriber. Test byte-equivalent ordered event sequences for two clients.
+
+### Deadlocks — medium
+
+Never perform network writes while holding `history_lock`, `_session_resume_lock`, approval locks, or event publication lock. Subscriber queues must make publish non-blocking. Lock-order tests and forced slow transports are required.
+
+### Input races — high
+
+Two clients can submit simultaneously. Preserve the current claim-under-`history_lock` logic and scheduler. Test simultaneous first-turn submissions, busy queue/steer/interrupt, and exact persistence counts.
+
+The existing adjacent-text queue merge needs explicit multi-client semantics.
+
+### Transport backpressure — high without queues, low with queues
+
+`WSTransport.write()` can wait up to ten seconds for non-token frames. Direct sequential fan-out would let one dead socket delay every client and potentially the agent thread. Use bounded per-client queues and independent writer tasks/threads.
+
+### Approval/clarification races — high
+
+Preserve atomic gateway approval resolution and make generic clarification resolution atomic. First authorized, schema-valid response wins and emits a session-wide resolution event. Current generic `_respond()` can be overwritten during its wakeup window.
+
+Validate approval choices against exactly `once|session|always|deny` before resolution. Any other value must receive an exact rejection and must not wake or mutate the pending approval.
+
+### Replay/overflow — medium
+
+The ring is bounded to 512 events per session. Overflowed or long-disconnected clients may need full history/status refresh. A subscriber drop must be explicit; never pretend it remained gap-free.
+
+### Disconnect and lifecycle — medium-high
+
+Current orphan behavior is based on one transport. Rebase it on subscriber count plus active turn/delegation/blocking state. Test every combination of active/idle and one/many subscribers.
+
+### Backward compatibility — low-medium
+
+Implicit attachment and unchanged JSON-RPC event shapes preserve existing clients. Avoid making `session.attach` mandatory in the first release. Keep point-to-point method responses.
+
+### Security and permissions — medium
+
+A read-only observer must not automatically gain prompt/approval/interrupt authority. Today, any authenticated WS client that knows the session/request identifier can attempt `approval.respond` or `clarify.respond`; pending approval replay is a snapshot, not an ownership claim. Subscriber identity, explicit capabilities, and controller/approver authorization checks must be introduced before exposing the host beyond the existing trusted boundary.
+
+## 7. Smallest prototype recommendation
+
+Do not start with a full `SessionRuntimeManager` rewrite.
+
+Build a test-only/minimal `SessionEventHub` proof around one existing `_sessions[sid]` record.
+
+### Prototype changes
+
+1. Add a per-session subscriber collection with two fake/WebSocket transports.
+2. Make resume/create implicitly add the current connection without overwriting existing subscribers.
+3. Route only `_emit()` session events through the hub.
+4. Stamp/replay-record once, then enqueue to both subscribers.
+5. Keep prompt submission writable only from client A.
+6. Detach B on disconnect; keep A and runtime untouched.
+7. Leave cross-process behavior out of this prototype.
+
+### Required proof
+
+```text
+A creates session S
+B resumes/attaches S
+A submits one prompt
+A and B receive the same ordered seq/type/payload stream
+both receive message.delta, tool.start/progress/complete, message.complete
+B disconnects
+A continues receiving
+SessionDB contains one user message and one assistant message
+_sessions contains one live record for S
+one AIAgent.run_conversation invocation occurred
+```
+
+### Required failure injection
+
+- B's transport blocks or raises: A and agent execution remain unaffected.
+- B's queue fills: B is detached and told to replay/reconnect; A remains complete.
+- B attaches during an active stream: it receives subsequent live events and uses `session.events.since` for the prefix without duplicates.
+
+Before writable multi-client support, add focused tests for:
+
+- two authorized approval responders racing: one winner, one `already_resolved`;
+- two clarification responders racing: no answer overwrite;
+- an observer attempting submit/steer/interrupt/approve/clarify: exact authorization rejection;
+- invalid approval choices: exact schema rejection with the pending approval unchanged;
+- controller disconnect/lease expiry and deliberate authority transfer.
+
+### Tests before real clients
+
+Use fake transports first. They make exact ordering, queue behavior, and write counts deterministic. Then add a two-WebSocket integration test.
+
+## 8. Answers to the 20 feasibility questions
+
+1. **Where is TUI AIAgent instantiated?** `_make_agent()` / deferred build in `tui_gateway/server.py`, stored in the live session dictionary.
+2. **What represents a live session?** One mutable record in process-global `tui_gateway.server._sessions`.
+3. **Is one agent reused across turns?** Yes, normally `session["agent"]`; intentional rebuild/swap paths exist.
+4. **Where is transport stored?** `session["transport"]`.
+5. **What rebinds it?** Resume/activate payload, every prompt submit, queued prompt drain, and disconnect fallback.
+6. **How are events emitted?** AIAgent/tool/background callbacks → `_emit()` → `write_json()` → one session transport.
+7. **Can output be fanned out without touching AIAgent?** Yes. `_emit`/`write_json` is the convergence seam.
+8. **How are queued prompts handled?** Existing busy policy plus `queued_prompt`/`queued_prompts`, drained under `history_lock`; queued entries currently pin transport.
+9. **How do steer/interrupt find the agent?** They look up `_sessions[sid]`, then call its agent or compute-host supervisor.
+10. **How are approvals stored/resolved?** Process-global pending request/event maps plus the gateway approval registry; not per frontend.
+11. **What happens on disconnect?** Rebind to one remaining viewer or detach and orphan-reap/interrupt according to policy.
+12. **Can one process host several sessions?** Yes; `_sessions` is keyed by UI runtime id and each record owns an agent/build/turn state.
+13. **Do WebSockets share the session table?** Yes inside one server process; no across processes.
+14. **What does active_sessions.py do?** Concurrency accounting/liveness and caps, not unique runtime ownership by session id.
+15. **What prevents two processes resuming one durable session?** Nothing prevents two loaded agents. Upstream's SQLite turn lease prevents their durable turns from running concurrently.
+16. **Can the existing lease enforce runtime ownership?** Not as written. It is a per-turn serialization lease and has no event/proxy endpoint. Keep it as safety, not runtime-host discovery.
+17. **Does Dashboard use the TUI Gateway?** Yes, `/api/ws` calls `tui_gateway.ws.handle_ws()` in the dashboard process; turn isolation may use one compute child.
+18. **Is there pub/sub already?** There is global live-transport broadcast, dashboard `/api/pub` → `/api/events` channel fan-out, plugin-local event delivery, and per-session replay, but no authoritative per-session live subscriber hub. The `viewers` map is only failover metadata.
+19. **What stdio assumptions matter?** Stdio expects implicit session attachment and the existing event schema; those can remain. A separately spawned stdio gateway still creates a separate process/runtime unless converted to a host client.
+20. **Can it be incremental?** Yes: read-only hub → writable routing → approval/interrupt → reconnect → canonical host/cross-process migration.
+
+## Final recommendation
+
+Proceed with a read-only in-process fan-out prototype against a pinned upstream baseline.
+
+Treat the current session dictionary as the runtime for Phase 1, introduce a focused per-session event hub, and preserve all existing turn scheduling. Do not begin with distributed ownership or a full AIAgent/session rewrite.
+
+For the full invariant, make the TUI Gateway/dashboard server the canonical runtime host and have interactive clients attach to it. Retain the upstream SQLite session turn lease as a fail-closed safety net while older or independent Hermes processes still exist.

--- a/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
+++ b/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
@@ -621,25 +621,30 @@ No redesign of the Desktop UI is part of this PR.
 
 ## Task 15: Runtime-host boundary and cross-process behavior
 
-**Objective:** Make the supported ownership boundary explicit and prevent users from mistaking independent processes for shared clients.
+**Objective:** Enforce one canonical mutable runtime across authenticated local gateway processes while retaining safe process-local behavior where authenticated IPC is unavailable.
 
 **Files:**
-- Modify: TUI Gateway status/welcome metadata
-- Modify: relevant Dashboard/Desktop connection status types/tests
-- Modify: documentation
-- Modify cross-process lease tests only if behavior changes
+- Add: canonical runtime-owner registry and Unix proxy transport
+- Modify: TUI Gateway resume/dispatch/teardown paths
+- Modify: shared reconnect and durable-resync handling
+- Modify: owner/proxy protocol and spawned-process tests
 
 **Contract:**
 
-- `runtime_host_id` and replay epoch identify one live host instance.
-- Multiple clients get one shared runtime only when connected to the same host endpoint/profile.
-- Independent processes that directly resume the same durable session do not attempt event federation. The existing SQLite session turn lease remains the fail-closed writer fence.
-- If a client reconnects to a different host epoch, it treats live replay as unavailable and reconstructs from durable history/status.
-- Shared-filesystem active/active multi-host ownership remains unsupported because PID liveness and SQLite WAL are host-local.
+- `SessionDB.session_runtime_key()` resolves every compression/continuation segment to one canonical durable runtime root.
+- Registry ownership is keyed by both that root and the normalized Hermes profile/state home, so independent profiles cannot collide.
+- A process atomically claims the root before constructing an `AIAgent`; concurrent builders in the winning process additionally single-flight on the profile-scoped root.
+- Followers use a same-UID Unix-domain proxy bound to the exact owner ID and generation. Registry files contain routing/liveness metadata only, never credentials.
+- A same-UID process does not attest a browser identity. Proxy hello frames therefore reject `auth_identity`; locally verified principals scope stable reconnect routes without being forwarded as trusted owner metadata.
+- Negotiated capabilities cross the proxy and are owner-validated against the fixed allowlist. An omitted capability declaration preserves legacy full authority; an explicit empty list remains unprivileged.
+- Proxy event writes use independent bounded queues. Responses remain point-to-point, owner-stamped events are not restamped, stale owner generations cannot publish, and timeout/owner loss returns `-32072` with `outcome: unknown` and `retryable: false`.
+- Stable clients can replace a physical connection and recover remote routes only under the same locally verified principal. Replay truncation, epoch change, runtime-host change, and owner loss request durable reconstruction.
+- On platforms without authenticated Unix peer credentials (`SO_PEERCRED`), normal sessions remain process-local instead of claiming unsupported cross-process guarantees.
+- The SQLite turn lease remains defense in depth for persistence fencing; it is not the canonical runtime registry.
 
-**Test:** two process-local runtimes cannot corrupt one transcript; a changed host epoch triggers durable resync rather than replay stitching.
+**Test:** spawned-process claim races elect one owner; concurrent eager resumes build once; real Unix proxy tests cover response routing, event delivery, capabilities, reconnect, stale generations, timeout, owner loss, and profile isolation.
 
-A distributed broker or cross-host mutable AIAgent is explicitly out of scope because it would violate the chosen single-runtime-host architecture. “Whole multi-client support” means all clients connect to that host, not that one Python object is distributed across machines.
+A distributed broker, cross-machine mutable `AIAgent`, and unauthenticated network proxy are explicitly out of scope. The supported cross-process topology is authenticated local IPC to one canonical runtime owner.
 
 ---
 
@@ -660,8 +665,8 @@ Document:
 - replay and overflow behavior
 - disconnect/orphan policy
 - approval/clarification authority
-- same-host requirement and cross-process durable lease
-- backward compatibility for old clients/backends
+- canonical local-process owner/proxy topology and profile-scoped ownership
+- backward compatibility and authenticated-IPC platform fallback
 - no new `.env` settings
 
 Run documentation link/build checks required by repository CI.

--- a/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
+++ b/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
@@ -1,0 +1,730 @@
+# Multi-Client Live Sessions Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Let multiple simultaneous TUI Gateway clients observe and, when authorized, control one authoritative live Hermes runtime without event stealing, duplicate agent turns, duplicate persistence, or regressions in existing single-client behavior.
+
+**Architecture:** Evolve the existing process-local `_sessions` record into an explicit runtime/attachment boundary rather than rewriting `AIAgent`. A per-session event hub stamps each event once, records replay once, and sends it through bounded subscriber queues. Existing prompt admission remains the single input scheduler; connection identity and attachment capabilities control which clients may submit, steer, interrupt, approve, or answer clarification. One dashboard/TUI Gateway process is the runtime host; independent processes remain fenced by the durable SQLite turn lease and must connect to the same host to share live state.
+
+**Tech Stack:** Python 3.11, synchronous JSON-RPC TUI Gateway, FastAPI/WebSocket transport, threading/queues, existing `event_replay`, pytest through `scripts/run_tests.sh`, Ruff, shared TypeScript gateway client, Electron/Desktop and Web clients.
+
+**Source baseline:** fork `mineblow/hermes-agent`, commit `4e7eb39947f132f961923f9e3f600bc8e63066dd`, package version `0.20.6`.
+
+**Branch:** `feat/multi-client-live-sessions`.
+
+**Companion audit:** `docs/plans/2026-08-28-multi-client-live-sessions-feasibility.md`.
+
+---
+
+## Non-negotiable invariants
+
+1. One live TUI Gateway process owns at most one authoritative runtime record for a durable session key.
+2. One accepted prompt produces exactly one `AIAgent.run_conversation()` call and one persisted user/assistant turn, regardless of subscriber count.
+3. Runtime events are stamped and replay-recorded once, then delivered to all attached observers in the same per-session order.
+4. RPC responses and errors stay point-to-point to the requesting transport.
+5. A slow, failed, or disconnected subscriber cannot block the agent or another subscriber.
+6. Read-only observers cannot submit, steer, interrupt, approve, clarify, or answer UI-tool requests.
+7. Existing clients that do not send attachment metadata retain current full-control behavior.
+8. One client disconnect removes only that attachment. Runtime orphan/idle policy begins only when no attachments remain.
+9. Approval and clarification resolution is authorized, schema-valid, and exactly once.
+10. Existing durable session turn leases remain fail-closed defense-in-depth across independent processes.
+11. Event fan-out does not mutate conversation history or the system prompt and therefore does not affect prompt caching or role alternation.
+12. Existing TUI, Dashboard, Desktop, compute-host, terminal, tool, subagent, replay, and single-client tests remain green apart from documented clean-main baseline failures.
+
+## Baseline and quality gates
+
+Repository rules require `scripts/run_tests.sh`; never use direct `pytest` for acceptance.
+
+Recorded clean-main targeted baseline:
+
+```text
+629 passed, 1 unrelated failure
+failure: test_model_options_preserves_canonical_custom_row_after_agent_init
+```
+
+Every task follows RED → GREEN → REFACTOR:
+
+```bash
+scripts/run_tests.sh <test-file> -k <new-test> -q
+scripts/run_tests.sh <affected-test-files> -q
+.venv/bin/ruff check <changed-python-files>
+git diff --check
+```
+
+Final gates:
+
+```bash
+scripts/run_tests.sh tests/test_tui_gateway_server.py \
+  tests/test_tui_gateway_ws.py \
+  tests/test_tui_gateway_event_replay.py \
+  tests/test_tui_gateway_queue_on_busy.py -q
+scripts/run_tests.sh tests/tui_gateway/ -q
+scripts/run_tests.sh -q
+.venv/bin/ruff check .
+.venv/bin/ty check
+.venv/bin/python scripts/check-windows-footguns.py --all
+npm run check --workspace @hermes/shared
+npm run check --workspace hermes
+```
+
+Only new failures block the branch; the existing baseline failure must remain unchanged or be independently fixed on `main`, not folded into this PR.
+
+---
+
+## Protocol contract
+
+### Connection identity
+
+Every transport exposes a stable process-lifetime `client_id`:
+
+```text
+WSTransport.client_id = random UUID
+stdio transport client_id = "stdio"
+```
+
+The WebSocket welcome payload adds optional fields:
+
+```json
+{
+  "client_id": "uuid",
+  "capabilities": ["session.attach", "session.detach", "session.attachments"]
+}
+```
+
+Older clients ignore these fields.
+
+### Attachment modes
+
+Canonical modes and capabilities:
+
+```python
+ATTACHMENT_MODES = {
+    "observe": {"observe"},
+    "control": {
+        "observe",
+        "prompt.submit",
+        "session.steer",
+        "session.interrupt",
+        "approval.respond",
+        "clarify.respond",
+        "ui.respond",
+    },
+}
+```
+
+- `session.create`, `session.init`, and `session.resume` implicitly attach as `control` when no `attachment_mode` is supplied.
+- New clients may pass `attachment_mode: "observe"` to resume without briefly acquiring control.
+- A client may explicitly downgrade or upgrade through `session.attach`; authorization policy must approve the requested mode.
+- The initial local/trusted implementation permits authenticated clients to request `control`, matching existing behavior. The capability checks establish the boundary for stricter remote policy without adding speculative configuration.
+
+### New RPCs
+
+`session.attach`:
+
+```json
+{
+  "session_id": "live-sid",
+  "mode": "observe",
+  "last_seen_seq": 120
+}
+```
+
+Result:
+
+```json
+{
+  "session_id": "live-sid",
+  "client_id": "uuid",
+  "mode": "observe",
+  "capabilities": ["observe"],
+  "latest_seq": 123,
+  "replay_epoch": "...",
+  "replay": {"events": [], "truncated": false}
+}
+```
+
+`session.detach` removes only the requesting transport from one session.
+
+`session.attachments` is control-only and returns sanitized attachment metadata; it never exposes auth tokens or transport internals.
+
+### RPC errors
+
+Use existing JSON-RPC error helpers/codes where applicable and stable message/data contracts:
+
+```text
+invalid attachment mode       → invalid params
+not attached                  → session/client state error
+missing capability            → authorization error with required capability
+already resolved              → successful result status=already_resolved
+expired request               → successful result status=expired
+invalid approval choice       → invalid params; pending request unchanged
+subscriber overflow           → attachment removed; socket may reconnect/replay
+```
+
+### Approval choices
+
+The TUI Gateway must enforce exactly the same allowlist as the Runs API:
+
+```text
+once | session | always | deny
+```
+
+Any other choice is rejected before pending state changes.
+
+---
+
+## Task 1: Add a focused attachment/event-hub module
+
+**Objective:** Implement independently testable subscriber identity, capabilities, ordered fan-out, bounded queues, and cleanup without changing existing routing yet.
+
+**Files:**
+- Create: `tui_gateway/session_events.py`
+- Create: `tests/tui_gateway/test_session_events.py`
+
+**Step 1: Write failing tests**
+
+Cover:
+
+1. `AttachmentMode.parse("observe"|"control")` and invalid-mode rejection.
+2. Capabilities are immutable and match the protocol contract.
+3. Attaching the same transport/client twice is idempotent and updates mode rather than duplicating delivery.
+4. Publishing one event delivers the same immutable frame once to two fake transports.
+5. Concurrent publishers produce one monotonically ordered sequence observed identically by both clients.
+6. A failed writer is detached without affecting another subscriber.
+7. A full bounded queue detaches only the slow subscriber.
+8. Detach and `close()` stop writer workers without leaking threads.
+9. Metadata snapshots contain no transport object or credentials.
+
+Run and verify RED:
+
+```bash
+scripts/run_tests.sh tests/tui_gateway/test_session_events.py -q
+```
+
+Expected: import or symbol failures because the module does not exist.
+
+**Step 2: Implement the minimal module**
+
+Required public surface:
+
+```python
+class AttachmentMode(str, Enum): ...
+
+@dataclass(frozen=True)
+class AttachmentSnapshot: ...
+
+class SessionEventHub:
+    def attach(self, transport, *, client_id: str, mode: AttachmentMode) -> AttachmentSnapshot: ...
+    def detach(self, transport) -> bool: ...
+    def has_transport(self, transport) -> bool: ...
+    def require(self, transport, capability: str) -> None: ...
+    def publish(self, frame: dict) -> bool: ...
+    def snapshots(self) -> list[dict]: ...
+    def count(self) -> int: ...
+    def close(self) -> None: ...
+```
+
+Implementation constraints:
+
+- One publication lock determines event order.
+- One bounded queue + worker per attachment isolates transport writes.
+- Queue size is a module constant, not a new user-facing environment variable.
+- Deep-copy or immutable-copy frames per subscriber.
+- No network write while holding the publication or registry lock.
+- Publish returns after enqueueing, not after socket delivery.
+- Worker failure/overflow invokes an injected/session cleanup callback exactly once.
+
+**Step 3: Run GREEN and regression tests**
+
+```bash
+scripts/run_tests.sh tests/tui_gateway/test_session_events.py -q
+.venv/bin/ruff check tui_gateway/session_events.py tests/tui_gateway/test_session_events.py
+git diff --check
+```
+
+---
+
+## Task 2: Make event sequencing an atomic publish operation
+
+**Objective:** Stamp and replay-record each session event exactly once before subscriber fan-out, preserving existing replay schema and single-client behavior.
+
+**Files:**
+- Modify: `tui_gateway/event_replay.py`
+- Modify: `tui_gateway/server.py` around `write_json`, `_event_frame`, `_emit`
+- Modify: `tests/test_tui_gateway_event_replay.py`
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Step 1: Write failing tests**
+
+1. Two subscribers receive identical `seq`, epoch, type, session id, and payload.
+2. Replay ring receives one entry, not one per subscriber.
+3. Two concurrent `_emit()` calls cannot deliver `seq=2` before `seq=1` to any subscriber.
+4. JSON-RPC responses still go only to `current_transport()`.
+5. Sessions without a hub retain the legacy transport fallback during migration.
+
+Run RED with file and `-k` filters.
+
+**Step 2: Implement**
+
+- Expose a stamp-and-record operation that is safe to call once under the hub publication lock.
+- `write_json()` detects session event frames and delegates to the session hub when present.
+- Do not stamp independently in each worker.
+- Preserve existing event envelope and `session.events.since` response.
+
+**Step 3: Verify**
+
+```bash
+scripts/run_tests.sh tests/test_tui_gateway_event_replay.py tests/test_tui_gateway_server.py -q
+```
+
+Only the recorded unrelated clean-main failure may remain.
+
+---
+
+## Task 3: Attach clients during session lifecycle without transport stealing
+
+**Objective:** Initialize one hub per live runtime and make create/init/resume add an attachment rather than overwrite the sole event destination.
+
+**Files:**
+- Modify: `tui_gateway/server.py`
+- Modify: `tui_gateway/methods_session.py`
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Step 1: Write failing tests**
+
+1. Create implicitly attaches legacy caller as control.
+2. Resume from client B preserves client A and delivers to both.
+3. Repeated resume by B is idempotent.
+4. `attachment_mode="observe"` attaches read-only from the first resume operation.
+5. Simultaneous resumes construct/reuse exactly one live agent and attach both callers.
+6. Existing live payload fields remain unchanged; new attachment fields are additive.
+7. Callback closures still capture `sid`, not transport.
+
+**Step 2: Implement**
+
+Add focused helpers in `server.py` or the new module:
+
+```python
+_ensure_session_event_hub(sid, session)
+_attach_current_transport(sid, session, mode)
+_detach_transport_from_session(sid, session, transport)
+```
+
+Stop assigning `session["transport"]` as ownership in normal live payload paths. Keep a compatibility alias only where an untouched legacy code path requires it, and document every remaining assignment.
+
+**Step 3: Verify targeted server tests.**
+
+---
+
+## Task 4: Add explicit attach/detach/attachment-inspection RPCs
+
+**Objective:** Provide generic client subscription lifecycle while retaining implicit behavior for older clients.
+
+**Files:**
+- Modify: `tui_gateway/methods_session.py`
+- Modify: `tui_gateway/method_ctx.py` only if a shared helper is required
+- Modify: `tests/test_tui_gateway_server.py`
+- Modify: shared TypeScript protocol types under `apps/shared/src/`
+- Add/modify: shared gateway protocol tests
+
+**Step 1: Write failing Python and TypeScript tests**
+
+Cover exact request/result schemas, invalid mode, unknown session, idempotency, replay from `last_seen_seq`, detach-only-current-client, sanitized attachment list, and legacy clients.
+
+**Step 2: Implement RPCs and additive protocol types.**
+
+**Step 3: Run Python and shared package tests/typecheck.**
+
+---
+
+## Task 5: Give WebSocket and stdio transports stable client identity
+
+**Objective:** Make authorization and attachment idempotency connection-scoped without leaking authentication data.
+
+**Files:**
+- Modify: `tui_gateway/transport.py`
+- Modify: `tui_gateway/ws.py`
+- Modify: `tui_gateway/entry.py` if stdio initialization needs identity
+- Modify: `tests/test_tui_gateway_ws.py`
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Step 1: Write failing tests**
+
+1. Each WebSocket gets one UUID client id stable for its lifetime.
+2. Different WebSockets have different IDs.
+3. Welcome advertises additive identity/capability fields.
+4. No auth token/identity secret enters attachment snapshots or events.
+5. Stdio receives stable `stdio` identity and unchanged output format.
+
+**Step 2: Implement with UUID generation at connection creation.**
+
+Do not derive client ids from token, IP address, headers, or user-agent.
+
+---
+
+## Task 6: Isolate subscriber backpressure and cleanup
+
+**Objective:** Prove that slow/dead observers cannot stall tokens, tool progress, terminal activity, approvals, or completion for another client.
+
+**Files:**
+- Modify: `tui_gateway/session_events.py`
+- Modify: `tui_gateway/ws.py`
+- Modify: `tests/tui_gateway/test_session_events.py`
+- Modify: `tests/test_tui_gateway_ws.py`
+
+**Step 1: Write failing timing/cleanup tests**
+
+- Slow transport blocks longer than publish deadline; fast transport still receives completion.
+- Queue overflow detaches exactly one client.
+- Writer exception closes attachment once.
+- Shutdown leaves no worker thread.
+- Disconnect racing with publish neither deadlocks nor duplicates.
+
+Avoid brittle wall-clock assertions; use events/barriers and bounded safety timeouts.
+
+**Step 2: Implement deterministic detach callbacks and worker lifecycle.**
+
+---
+
+## Task 7: Enforce observer/control capabilities on all mutation RPCs
+
+**Objective:** Ensure read-only clients can observe everything but cannot mutate the runtime.
+
+**Files:**
+- Modify: `tui_gateway/methods_prompt.py`
+- Modify: `tui_gateway/methods_session.py`
+- Modify: `tui_gateway/server.py` shared response helper paths
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Mutation coverage:**
+
+- `prompt.submit`
+- `session.steer`
+- redirect/busy policies that mutate active input
+- `session.interrupt`
+- `approval.respond`
+- `clarify.respond`
+- terminal/preview/window/browser/UI response RPCs routed through `_respond()`
+
+**Step 1: Write one behavioral test per mutation family**
+
+Observer calls must return the exact authorization error, leave state unchanged, and not rebind event delivery. Control calls retain current behavior.
+
+**Step 2: Implement one shared capability check.**
+
+Do not copy authorization logic into every method. Authorization must use `current_transport()` attachment state for the target runtime.
+
+---
+
+## Task 8: Preserve one scheduler for simultaneous multi-client input
+
+**Objective:** Route every writable client through the existing atomic prompt admission, queue, steer, and interrupt paths with origin metadata but no transport ownership.
+
+**Files:**
+- Modify: `tui_gateway/methods_prompt.py`
+- Modify: `tui_gateway/server.py` queue helpers and runtime events
+- Modify: `tests/test_tui_gateway_queue_on_busy.py`
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Step 1: Write failing concurrency tests**
+
+1. Two clients submit simultaneously while idle: one turn starts and the other follows configured busy policy.
+2. Queue mode preserves FIFO request order and client/request origin.
+3. Adjacent messages from different clients are never silently merged into one persisted user message.
+4. Prompt versus interrupt has a deterministic result and clears queue as today.
+5. Steer from a control attachment targets the same agent and leftover steer queues once.
+6. Subscriber count never changes run/persistence counts.
+
+**Step 2: Implement**
+
+- Add `origin_client_id` and JSON-RPC `request_id` to queued envelopes and inflight snapshots.
+- Remove queued `transport` event-destination fields.
+- Disable text merging across different origin clients; preserve existing merging for one client where current behavior requires it.
+- Continue to claim `running` under `history_lock`.
+
+---
+
+## Task 9: Harden approval choices and exactly-once authorization
+
+**Objective:** Make approval safe under multiple authorized responders and close the existing arbitrary-choice discrepancy.
+
+**Files:**
+- Modify: `tui_gateway/methods_prompt.py`
+- Modify: `tools/approval.py` only if the existing atomic API cannot expose outcome details
+- Modify: `tests/test_tui_gateway_server.py`
+- Modify/add: approval-focused tests
+
+**Step 1: Write failing tests**
+
+1. Only `once|session|always|deny` is accepted.
+2. Invalid choice leaves pending approval unresolved.
+3. Observer gets authorization rejection.
+4. Two authorized responses race: one resolves; loser receives `already_resolved`.
+5. Resolution event broadcasts winning request id/choice/status without credentials or command secrets beyond existing redaction policy.
+6. Reconnect pending snapshot remains read-only and does not claim ownership.
+
+**Step 2: Implement validation before `resolve_gateway_approval()`.**
+
+Retain the existing lock-protected queue/pop behavior; do not replace it with a per-client approval.
+
+---
+
+## Task 10: Make clarification and generic UI responses exactly once
+
+**Objective:** Remove `_respond()`’s overwrite window and define deterministic duplicate/expired outcomes.
+
+**Files:**
+- Modify: `tui_gateway/server.py` `_block`/`_respond`
+- Modify: `tui_gateway/methods_prompt.py`
+- Modify: `tests/test_tui_gateway_server.py`
+
+**Step 1: Write failing race tests**
+
+- Two clarification answers race: first authorized answer remains final.
+- Batch clarification cannot be edited after final resolution.
+- Duplicate response returns `already_resolved`.
+- Timeout/late answer returns `expired` without recreating state.
+- Interrupt expires pending requests and broadcasts resolution/expiration.
+- Existing terminal/preview/window response behavior remains compatible.
+
+**Step 2: Implement lock-protected compare-and-set state.**
+
+Represent pending/resolved/expired explicitly enough to distinguish duplicate from unknown without unbounded memory. Use bounded/TTL cleanup if tombstones are required.
+
+---
+
+## Task 11: Rebase disconnect/orphan lifetime on attachment count
+
+**Objective:** Disconnect one client without changing runtime ownership or interrupting active work while others remain.
+
+**Files:**
+- Modify: `tui_gateway/server.py`
+- Modify: `tui_gateway/ws.py`
+- Modify: `tests/test_tui_gateway_server.py`
+- Modify: `tests/test_tui_gateway_ws.py`
+
+**Step 1: Replace old viewer-failover tests with compatibility-aware behavior tests**
+
+1. Owner/observer disconnect leaves remaining attachment and active turn untouched.
+2. Last attachment disconnect parks the runtime and starts current orphan grace.
+3. Reattach during grace cancels reap and replays missing events.
+4. Last disconnect with `close_on_disconnect` preserves existing explicit close semantics.
+5. Disconnect during approval/clarification does not strand runtime when another authorized client remains.
+6. Dead/overflowed attachment cleanup is idempotent.
+
+**Step 2: Implement zero-subscriber orphan checks.**
+
+Remove `viewers` only after all call sites and tests use hub attachments. If compatibility inspection still requires it, derive it rather than maintaining two authorities.
+
+---
+
+## Task 12: Verify complete event-family fan-out
+
+**Objective:** Prove every requested live event category goes through the session publisher.
+
+**Files:**
+- Modify: `tests/test_tui_gateway_server.py`
+- Modify/add: focused event contract tests under `tests/tui_gateway/`
+
+**Required event families:**
+
+- assistant start/delta/interim/complete
+- thinking/reasoning/status
+- tool start/progress/output-risk/complete/generating
+- terminal output/close
+- approval requested/resolved/expired
+- clarification requested/resolved/expired
+- subagent start/progress/child message/child tool/complete/error
+- runtime errors and cancellation
+- session usage/info/completion state
+
+Use parameterized behavioral tests over real `_emit()` paths where practical. Do not create change-detector tests that freeze the entire event-name list.
+
+---
+
+## Task 13: Add real two-WebSocket integration coverage
+
+**Objective:** Exercise authentication, dispatch, fan-out, replay, control enforcement, and disconnect through the actual ASGI WebSocket path.
+
+**Files:**
+- Modify: `tests/test_tui_gateway_ws.py`
+- Modify/add: dashboard integration tests if required
+
+**Scenario:**
+
+```text
+connect A and B
+A creates S
+B resumes S as observe
+A submits synthetic deterministic turn
+A and B receive equal ordered events
+B mutation is rejected
+B disconnects
+A receives completion
+B reconnects with watermark and receives no duplicate/gap
+assert one run_conversation and one persisted turn
+```
+
+Use synthetic/fake agent seams already provided by the repository; no network/model calls.
+
+---
+
+## Task 14: Update shared Web/Desktop clients
+
+**Objective:** Make current clients consume attachment metadata and replay safely while preserving older backend compatibility.
+
+**Files:**
+- Modify: `apps/shared/src/json-rpc-gateway.ts`
+- Modify: shared protocol/type exports
+- Modify: `apps/desktop/src/lib/gateway-events.ts` or current event integration only where needed
+- Modify: Web gateway client only where it independently defines the protocol
+- Add/modify: corresponding TypeScript tests
+- Follow: `apps/desktop/AGENTS.md`
+
+**Behavior:**
+
+- Parse optional welcome `client_id` and attachment capabilities.
+- Resume defaults to legacy control unless UI explicitly opens an observer/pop-out.
+- Observer windows request `attachment_mode="observe"` on resume.
+- Reconnect supplies `last_seen_seq`; live events are held while replay applies and deduplicated by watermark using existing logic.
+- UI exposes read-only state rather than allowing controls that will be rejected.
+- Older backend without `session.attach` continues through existing resume behavior.
+
+No redesign of the Desktop UI is part of this PR.
+
+---
+
+## Task 15: Runtime-host boundary and cross-process behavior
+
+**Objective:** Make the supported ownership boundary explicit and prevent users from mistaking independent processes for shared clients.
+
+**Files:**
+- Modify: TUI Gateway status/welcome metadata
+- Modify: relevant Dashboard/Desktop connection status types/tests
+- Modify: documentation
+- Modify cross-process lease tests only if behavior changes
+
+**Contract:**
+
+- `runtime_host_id` and replay epoch identify one live host instance.
+- Multiple clients get one shared runtime only when connected to the same host endpoint/profile.
+- Independent processes that directly resume the same durable session do not attempt event federation. The existing SQLite session turn lease remains the fail-closed writer fence.
+- If a client reconnects to a different host epoch, it treats live replay as unavailable and reconstructs from durable history/status.
+- Shared-filesystem active/active multi-host ownership remains unsupported because PID liveness and SQLite WAL are host-local.
+
+**Test:** two process-local runtimes cannot corrupt one transcript; a changed host epoch triggers durable resync rather than replay stitching.
+
+A distributed broker or cross-host mutable AIAgent is explicitly out of scope because it would violate the chosen single-runtime-host architecture. “Whole multi-client support” means all clients connect to that host, not that one Python object is distributed across machines.
+
+---
+
+## Task 16: Documentation and migration notes
+
+**Objective:** Document the public contract, compatibility behavior, operational topology, and testing instructions to upstream standards.
+
+**Files:**
+- Modify/add the authoritative TUI Gateway/API documentation under `website/docs/`
+- Modify shared protocol docs if present
+- Keep this implementation plan and feasibility audit under `docs/plans/`
+
+Document:
+
+- one runtime host / many attachments model
+- observer versus control mode
+- explicit RPCs and errors
+- replay and overflow behavior
+- disconnect/orphan policy
+- approval/clarification authority
+- same-host requirement and cross-process durable lease
+- backward compatibility for old clients/backends
+- no new `.env` settings
+
+Run documentation link/build checks required by repository CI.
+
+---
+
+## Task 17: Final regression, security, and independent review
+
+**Objective:** Produce PR-ready evidence that the full feature works and existing functions remain intact.
+
+**Step 1: Run focused Python suites**
+
+Use the commands in “Baseline and quality gates.” Record exact pass/fail totals.
+
+**Step 2: Run the full Python suite**
+
+```bash
+scripts/run_tests.sh -q
+```
+
+Compare failures to the clean-main baseline. No new failures allowed.
+
+**Step 3: Run TypeScript tests/typecheck/lint**
+
+Use package scripts discovered from current `package.json`; do not invent commands if names differ.
+
+**Step 4: Static/security review**
+
+Check:
+
+- no credential/token/auth identity in events or attachment snapshots
+- exact approval choice allowlist
+- no observer mutation bypass
+- bounded queues and bounded resolved-request tombstones
+- no network write under runtime/history/approval locks
+- no unbounded writer thread/process leaks
+- no replay duplication or event-order inversion
+- no debug prints/generated artifacts
+
+**Step 5: Independent reviews**
+
+Run separate spec-compliance and code-quality/security reviews. Resolve all critical and important findings and repeat review.
+
+**Step 6: Scope verification**
+
+```bash
+git diff --check
+git diff --name-only origin/main...HEAD
+git status --short
+```
+
+Every changed path must trace to this feature, its tests, or its documentation.
+
+**Step 7: Prepare commits/PR description**
+
+Use conventional, reviewable commits. Do not push or open the PR until explicitly requested. The PR body must include architecture, compatibility, test totals, known clean-main baseline failure, security decisions, and manual two-client test steps.
+
+---
+
+## Manual acceptance test
+
+After automated gates, run a local host and two clients against the same profile/runtime endpoint.
+
+1. Start one Hermes runtime host.
+2. Connect client A in control mode.
+3. Create a session and submit a prompt that streams and runs a visible terminal/tool operation.
+4. Connect client B to the same session in observe mode during the turn.
+5. Confirm B catches up through replay and then receives the same live sequence as A.
+6. Attempt submit, steer, interrupt, approval, and clarification responses from B; confirm exact authorization rejection.
+7. Upgrade B to control, submit a queued prompt from B, and confirm one ordered turn with origin metadata.
+8. Trigger an approval; race authorized responses and confirm one winner.
+9. Trigger clarification; race responses and confirm no overwrite.
+10. Disconnect A; confirm B continues receiving and controlling the same runtime.
+11. Reconnect A with its watermark; confirm no duplicates or gaps.
+12. Block/kill B’s socket; confirm A and the agent remain responsive.
+13. Inspect persisted history; confirm no duplicated messages.
+14. Stop the host and reconnect to a new epoch; confirm durable history reconstruction instead of invalid replay stitching.
+
+## Completion definition
+
+The feature is complete only when:
+
+- all 17 tasks are implemented;
+- same-host multi-client observation and writable control work through real WebSockets;
+- all requested event families fan out;
+- backpressure, replay, authorization, approval, clarification, input, interrupt, and disconnect races have automated tests;
+- one runtime/one persistence invariant is proven;
+- Python and TypeScript quality gates introduce no regressions;
+- documentation and manual test instructions are present;
+- independent reviews approve the diff;
+- the branch is ready for the user to push and open as an upstream PR.

--- a/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
+++ b/docs/plans/2026-08-28-multi-client-live-sessions-implementation.md
@@ -75,23 +75,43 @@ Only new failures block the branch; the existing baseline failure must remain un
 
 ### Connection identity
 
-Every transport exposes a stable process-lifetime `client_id`:
+Every transport has two identities:
 
 ```text
-WSTransport.client_id = random UUID
-stdio transport client_id = "stdio"
+connection_id = server-minted random UUID, unique per socket
+client_id     = opaque per-window identity, stable across reconnects
+stdio         = implicit legacy client_id/connection_id "stdio"
 ```
 
-The WebSocket welcome payload adds optional fields:
+`gateway.ready.payload` advertises the additive protocol without trusting an
+RPC-supplied identifier as authentication:
 
 ```json
 {
-  "client_id": "uuid",
-  "capabilities": ["session.attach", "session.detach", "session.attachments"]
+  "multi_client_sessions": 1,
+  "connection_id": "server-uuid",
+  "capabilities": ["client.attach", "session.attach", "session.detach", "session.attachments"]
 }
 ```
 
-Older clients ignore these fields.
+Negotiated clients then call `client.attach` once per socket:
+
+```json
+{
+  "protocol_version": 1,
+  "client_id": "opaque-stable-per-window-id",
+  "surface": "desktop",
+  "capabilities": ["session.observe", "session.control", "session.replay"]
+}
+```
+
+The server validates length/shape, intersects requested capabilities with its
+allowlist, and stores authority as `(server-verified auth principal, client_id,
+connection_id)`. It never authorizes from `client_id` alone. Unknown requested
+capabilities are ignored and the accepted set is returned. Desktop keeps the id
+for one renderer/window; browser clients use `sessionStorage`, never shared
+`localStorage`. Older clients that never negotiate receive an internal legacy
+identity and preserve current behavior.
 
 ### Attachment modes
 
@@ -316,9 +336,9 @@ Stop assigning `session["transport"]` as ownership in normal live payload paths.
 
 ---
 
-## Task 4: Add explicit attach/detach/attachment-inspection RPCs
+## Task 4: Add client negotiation and explicit session attachment RPCs
 
-**Objective:** Provide generic client subscription lifecycle while retaining implicit behavior for older clients.
+**Objective:** Provide stable reconnect identity and generic subscription lifecycle while retaining implicit behavior for older clients.
 
 **Files:**
 - Modify: `tui_gateway/methods_session.py`
@@ -329,7 +349,10 @@ Stop assigning `session["transport"]` as ownership in normal live payload paths.
 
 **Step 1: Write failing Python and TypeScript tests**
 
-Cover exact request/result schemas, invalid mode, unknown session, idempotency, replay from `last_seen_seq`, detach-only-current-client, sanitized attachment list, and legacy clients.
+Cover `client.attach` negotiation, malformed/oversized ids, capability
+intersection, auth-principal binding, exact session request/result schemas,
+invalid mode, unknown session, idempotency, replay from `last_seen_seq`,
+detach-only-current-client, sanitized attachment list, and legacy clients.
 
 **Step 2: Implement RPCs and additive protocol types.**
 
@@ -337,7 +360,7 @@ Cover exact request/result schemas, invalid mode, unknown session, idempotency, 
 
 ---
 
-## Task 5: Give WebSocket and stdio transports stable client identity
+## Task 5: Give transports server-minted connection identity and negotiated client identity
 
 **Objective:** Make authorization and attachment idempotency connection-scoped without leaking authentication data.
 
@@ -350,13 +373,15 @@ Cover exact request/result schemas, invalid mode, unknown session, idempotency, 
 
 **Step 1: Write failing tests**
 
-1. Each WebSocket gets one UUID client id stable for its lifetime.
-2. Different WebSockets have different IDs.
-3. Welcome advertises additive identity/capability fields.
-4. No auth token/identity secret enters attachment snapshots or events.
-5. Stdio receives stable `stdio` identity and unchanged output format.
+1. Each WebSocket gets one UUID `connection_id` stable for its lifetime.
+2. Different WebSockets have different connection IDs.
+3. `client.attach` installs a validated stable `client_id` bound to the authenticated principal.
+4. A reconnect may reuse its client id but gets a new connection id.
+5. Welcome advertises additive identity/capability fields.
+6. No auth token/identity secret enters attachment snapshots or events.
+7. Stdio receives stable implicit `stdio` identity and unchanged output format.
 
-**Step 2: Implement with UUID generation at connection creation.**
+**Step 2: Implement UUID connection identity plus validated negotiation.**
 
 Do not derive client ids from token, IP address, headers, or user-agent.
 

--- a/hermes_cli/dashboard_auth/login_page.py
+++ b/hermes_cli/dashboard_auth/login_page.py
@@ -405,8 +405,11 @@ an SSH tunnel or Tailscale.</p>
 
 
 # Inline script that wires every password provider form to POST JSON to
-# ``/auth/password-login`` and navigate on success. Emitted ONLY when at
-# least one ``supports_password`` provider is listed (OAuth-only login
+# the path-relative ``auth/password-login`` endpoint and navigate on success.
+# A relative URL preserves reverse-proxy prefixes (for example
+# ``/proxy/9120/login`` -> ``/proxy/9120/auth/password-login``) while still
+# resolving to ``/auth/password-login`` for root deployments. Emitted ONLY when
+# at least one ``supports_password`` provider is listed (OAuth-only login
 # pages stay script-free, preserving the no-JS contract for that case).
 #
 # Plain string (NOT run through ``str.format``), so braces are literal —
@@ -428,7 +431,7 @@ _PASSWORD_FORM_SCRIPT = """\
         password: (form.querySelector('input[name=password]') || {}).value || '',
         next: (form.querySelector('input[name=next]') || {}).value || ''
       };
-      fetch('/auth/password-login', {
+      fetch('auth/password-login', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -505,8 +508,8 @@ def _render_password_form(provider, next_path: str) -> str:
     """Render a username/password form for a ``supports_password`` provider.
 
     The form is wired by :data:`_PASSWORD_FORM_SCRIPT` (a single delegated
-    submit handler) to POST JSON to ``/auth/password-login`` and navigate
-    on success. ``next_path`` is carried in a hidden field; it has already
+    submit handler) to POST JSON to path-relative ``auth/password-login`` and
+    navigate on success. ``next_path`` is carried in a hidden field; it has
     been validated same-origin by the caller and is HTML-escaped here as
     defence in depth. The provider ``name`` is emitted in a ``data-``
     attribute (not a hidden input) so the script reads it without trusting

--- a/hermes_cli/live_runtime_owners.py
+++ b/hermes_cli/live_runtime_owners.py
@@ -1,0 +1,338 @@
+"""Cross-process canonical live-runtime ownership registry.
+
+The registry contains routing and liveness metadata only. It deliberately does
+not contain authentication credentials; local proxy peers authenticate through
+OS-owned IPC endpoints.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any, Literal
+
+from hermes_constants import get_hermes_home
+from hermes_cli.active_sessions import (
+    _FileLock,
+    _pid_liveness,
+    _process_start_time,
+)
+
+MAX_RUNTIME_OWNERS = 4096
+
+
+class RuntimeOwnerRegistryError(RuntimeError):
+    """The registry could not prove a safe canonical-owner decision."""
+
+
+@dataclass(frozen=True)
+class RuntimeOwner:
+    conversation_key: str
+    owner_id: str
+    generation: int
+    pid: int
+    process_start_time: float | None
+    endpoint: str
+    profile_home: str
+    surface: str
+    started_at: float
+
+
+@dataclass
+class RuntimeOwnerLease:
+    owner: RuntimeOwner
+    state_path: Path
+    lock_path: Path
+    released: bool = False
+
+    def release(self) -> bool:
+        return release_runtime_owner(self)
+
+
+@dataclass(frozen=True)
+class OwnerClaimResult:
+    kind: Literal["owned", "remote"]
+    owner: RuntimeOwner
+    lease: RuntimeOwnerLease | None
+
+
+def _home(registry_home: str | Path | None) -> Path:
+    return Path(registry_home) if registry_home is not None else Path(get_hermes_home())
+
+
+def _paths(registry_home: str | Path | None) -> tuple[Path, Path]:
+    runtime = _home(registry_home) / "runtime"
+    return runtime / "live_runtime_owners.json", runtime / "live_runtime_owners.lock"
+
+
+def _parse_owner(raw: Any, path: Path) -> RuntimeOwner:
+    if not isinstance(raw, dict):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry contains invalid entries: {path}"
+        )
+    required_strings = (
+        "conversation_key",
+        "owner_id",
+        "endpoint",
+        "profile_home",
+        "surface",
+    )
+    if any(
+        not isinstance(raw.get(key), str) or not raw[key].strip()
+        for key in required_strings
+    ):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry contains invalid owner metadata: {path}"
+        )
+    pid = raw.get("pid")
+    generation = raw.get("generation")
+    if (
+        isinstance(pid, bool)
+        or not isinstance(pid, int)
+        or pid <= 0
+        or isinstance(generation, bool)
+        or not isinstance(generation, int)
+        or generation <= 0
+    ):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry contains invalid identity: {path}"
+        )
+    process_start_time = raw.get("process_start_time")
+    if process_start_time is not None:
+        if isinstance(process_start_time, bool) or not isinstance(
+            process_start_time, (int, float)
+        ):
+            raise RuntimeOwnerRegistryError(
+                f"runtime owner registry contains invalid process start: {path}"
+            )
+        process_start_time = float(process_start_time)
+        if not math.isfinite(process_start_time):
+            raise RuntimeOwnerRegistryError(
+                f"runtime owner registry contains invalid process start: {path}"
+            )
+    started_at = raw.get("started_at")
+    if isinstance(started_at, bool) or not isinstance(started_at, (int, float)):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry contains invalid start time: {path}"
+        )
+    started_at = float(started_at)
+    if not math.isfinite(started_at):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry contains invalid start time: {path}"
+        )
+    return RuntimeOwner(
+        conversation_key=raw["conversation_key"],
+        owner_id=raw["owner_id"],
+        generation=generation,
+        pid=pid,
+        process_start_time=process_start_time,
+        endpoint=raw["endpoint"],
+        profile_home=raw["profile_home"],
+        surface=raw["surface"],
+        started_at=started_at,
+    )
+
+
+def _read(path: Path) -> list[RuntimeOwner]:
+    try:
+        with open(path, "r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except FileNotFoundError:
+        return []
+    except Exception as exc:
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry unreadable: {path}"
+        ) from exc
+    if (
+        not isinstance(payload, dict)
+        or payload.get("version") != 1
+        or not isinstance(payload.get("entries"), list)
+    ):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry has invalid shape: {path}"
+        )
+    parsed = [_parse_owner(item, path) for item in payload["entries"]]
+    keys = [owner.conversation_key for owner in parsed]
+    if len(set(keys)) != len(keys):
+        raise RuntimeOwnerRegistryError(
+            f"runtime owner registry has duplicate conversation keys: {path}"
+        )
+    return parsed
+
+
+def _write(path: Path, entries: list[RuntimeOwner]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary = path.with_name(f"{path.name}.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+    try:
+        with open(temporary, "w", encoding="utf-8") as handle:
+            json.dump(
+                {"version": 1, "entries": [asdict(owner) for owner in entries]},
+                handle,
+                sort_keys=True,
+            )
+        os.replace(temporary, path)
+    finally:
+        try:
+            temporary.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+
+def _owner_liveness(owner: RuntimeOwner) -> bool | None:
+    return _pid_liveness(owner.pid, owner.process_start_time)
+
+
+def _sweep_proven_dead(
+    entries: list[RuntimeOwner], *, preserve_key: str | None = None
+) -> tuple[list[RuntimeOwner], bool]:
+    retained: list[RuntimeOwner] = []
+    changed = False
+    for owner in entries:
+        if owner.conversation_key == preserve_key:
+            retained.append(owner)
+            continue
+        if _owner_liveness(owner) is False:
+            changed = True
+            continue
+        retained.append(owner)
+    return retained, changed
+
+
+def _lease(owner: RuntimeOwner, state_path: Path, lock_path: Path) -> RuntimeOwnerLease:
+    return RuntimeOwnerLease(owner=owner, state_path=state_path, lock_path=lock_path)
+
+
+def claim_runtime_owner(
+    *,
+    conversation_key: str,
+    owner_id: str,
+    endpoint: str,
+    surface: str,
+    registry_home: str | Path | None = None,
+    profile_home: str | Path | None = None,
+) -> OwnerClaimResult:
+    """Atomically own an absent/dead key or return its proven-live owner."""
+    values = (conversation_key, owner_id, endpoint, surface)
+    if any(not isinstance(value, str) or not value.strip() for value in values):
+        raise ValueError("runtime owner claim fields must be non-empty strings")
+    state_path, lock_path = _paths(registry_home)
+    profile = str(
+        Path(profile_home) if profile_home is not None else _home(registry_home)
+    )
+    with _FileLock(lock_path):
+        entries = _read(state_path)
+        existing = next(
+            (entry for entry in entries if entry.conversation_key == conversation_key),
+            None,
+        )
+        entries, swept = _sweep_proven_dead(
+            entries,
+            preserve_key=existing.conversation_key if existing is not None else None,
+        )
+        generation = 1
+        if existing is not None:
+            liveness = _owner_liveness(existing)
+            if liveness is None:
+                raise RuntimeOwnerRegistryError("runtime owner liveness is unknown")
+            if liveness:
+                if swept:
+                    _write(state_path, entries)
+                if (
+                    existing.owner_id == owner_id
+                    and existing.pid == os.getpid()
+                    and existing.endpoint == endpoint
+                ):
+                    return OwnerClaimResult(
+                        "owned", existing, _lease(existing, state_path, lock_path)
+                    )
+                return OwnerClaimResult("remote", existing, None)
+            generation = existing.generation + 1
+            entries.remove(existing)
+        if len(entries) >= MAX_RUNTIME_OWNERS:
+            if swept:
+                _write(state_path, entries)
+            raise RuntimeOwnerRegistryError("runtime owner registry capacity exceeded")
+        owner = RuntimeOwner(
+            conversation_key=conversation_key,
+            owner_id=owner_id,
+            generation=generation,
+            pid=os.getpid(),
+            process_start_time=_process_start_time(os.getpid()),
+            endpoint=endpoint,
+            profile_home=profile,
+            surface=surface,
+            started_at=time.time(),
+        )
+        entries.append(owner)
+        _write(state_path, entries)
+        return OwnerClaimResult("owned", owner, _lease(owner, state_path, lock_path))
+
+
+def lookup_runtime_owner(
+    *, conversation_key: str, registry_home: str | Path | None = None
+) -> RuntimeOwner | None:
+    state_path, lock_path = _paths(registry_home)
+    with _FileLock(lock_path):
+        entries, swept = _sweep_proven_dead(_read(state_path))
+        if swept:
+            _write(state_path, entries)
+        return next(
+            (owner for owner in entries if owner.conversation_key == conversation_key),
+            None,
+        )
+
+
+def assert_runtime_owner(lease: RuntimeOwnerLease) -> bool:
+    with _FileLock(lease.lock_path):
+        current = next(
+            (
+                owner
+                for owner in _read(lease.state_path)
+                if owner.conversation_key == lease.owner.conversation_key
+            ),
+            None,
+        )
+        return (
+            current is not None
+            and current == lease.owner
+            and _owner_liveness(current) is True
+        )
+
+
+def release_runtime_owner(lease: RuntimeOwnerLease) -> bool:
+    if lease.released:
+        return False
+    with _FileLock(lease.lock_path):
+        entries = _read(lease.state_path)
+        current = next(
+            (
+                owner
+                for owner in entries
+                if owner.conversation_key == lease.owner.conversation_key
+            ),
+            None,
+        )
+        if current is None or current != lease.owner:
+            return False
+        entries.remove(current)
+        _write(lease.state_path, entries)
+        lease.released = True
+        return True
+
+
+def release_process_runtime_owners(
+    owner_id: str, *, registry_home: str | Path | None = None
+) -> int:
+    state_path, lock_path = _paths(registry_home)
+    with _FileLock(lock_path):
+        entries = _read(state_path)
+        retained = [owner for owner in entries if owner.owner_id != owner_id]
+        removed = len(entries) - len(retained)
+        if removed:
+            _write(state_path, retained)
+        return removed

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -37,6 +37,7 @@ from pathlib import Path
 from agent.memory_manager import sanitize_context
 from agent.session_activity import ActivityProvenance
 from agent.message_sanitization import _sanitize_surrogates
+
 # Intrinsic persistence marker stamped on message dicts that are known-durable
 # (#92231). One shared constant with agent.context_compressor (this module
 # already imports agent.* at module level, and context_compressor is a
@@ -133,16 +134,12 @@ def _configured_transcript_limit(key: str, fallback: int) -> int:
 
 def resolved_max_resume_messages() -> int:
     """Config-resolved resume guard limit (0 disables the guard)."""
-    return _configured_transcript_limit(
-        "max_resume_messages", MAX_SAFE_RESUME_MESSAGES
-    )
+    return _configured_transcript_limit("max_resume_messages", MAX_SAFE_RESUME_MESSAGES)
 
 
 def resolved_max_export_messages() -> int:
     """Config-resolved in-memory export guard limit (0 disables the guard)."""
-    return _configured_transcript_limit(
-        "max_export_messages", MAX_SAFE_EXPORT_MESSAGES
-    )
+    return _configured_transcript_limit("max_export_messages", MAX_SAFE_EXPORT_MESSAGES)
 
 
 class SessionResumeTooLargeError(ValueError):
@@ -357,6 +354,7 @@ def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
         conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
     return ids
 
+
 T = TypeVar("T")
 
 DEFAULT_DB_PATH = get_hermes_home() / "state.db"
@@ -499,9 +497,7 @@ def _running_under_pytest() -> bool:
 #: Names that identify a pytest launcher in a process command line.  Matched
 #: against the *basename* of each argv token so ``/tmp/pytest-of-dev/...``
 #: paths — which do show up in real argv — cannot false-positive.
-_PYTEST_LAUNCHER_NAMES = frozenset(
-    {"pytest", "py.test", "pytest.exe", "py.test.exe"}
-)
+_PYTEST_LAUNCHER_NAMES = frozenset({"pytest", "py.test", "pytest.exe", "py.test.exe"})
 
 #: Memoised ancestry answer.  The process tree above us does not change in a
 #: way that matters here, and the walk must not cost anything on the hot path.
@@ -642,6 +638,7 @@ def _ensure_test_isolation(db_path: Path) -> None:
                 "its environment."
             )
 
+
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
 # ---------------------------------------------------------------------------
@@ -672,9 +669,9 @@ def _ensure_test_isolation(db_path: Path) -> None:
 # connections may still hold it open, and flipping journal_mode under them is
 # unsafe (same invariant as the NFS path below).
 _WAL_INCOMPAT_MARKERS = (
-    "locking protocol",       # SQLITE_PROTOCOL on NFS/SMB
-    "not authorized",         # Some FUSE mounts block WAL pragma outright
-    "disk i/o error",         # ZFS SHM corruption under concurrent connections
+    "locking protocol",  # SQLITE_PROTOCOL on NFS/SMB
+    "not authorized",  # Some FUSE mounts block WAL pragma outright
+    "disk i/o error",  # ZFS SHM corruption under concurrent connections
 )
 
 # Upper bound for the write-ahead log. SQLite defaults to -1 (unlimited),
@@ -705,6 +702,7 @@ _wal_reset_bug_warned_lock = threading.Lock()
 # Dedup ERROR for the "configured delete overridden by on-disk WAL" warning.
 _delete_overridden_warned_paths: set[str] = set()
 _delete_overridden_warned_lock = threading.Lock()
+
 
 def _set_last_init_error(msg: Optional[str]) -> None:
     """Record (or clear) the most recent state.db init failure.
@@ -840,7 +838,9 @@ def _strip_stale_tool_call_markers(
     return messages
 
 
-def format_session_db_unavailable(prefix: str = "Session database not available") -> str:
+def format_session_db_unavailable(
+    prefix: str = "Session database not available",
+) -> str:
     """Format a user-facing 'session DB unavailable' message with cause.
 
     When ``SessionDB()`` init fails, callers set ``_session_db = None`` and
@@ -1279,11 +1279,7 @@ def apply_wal_with_fallback(
                         raise
                     exc = retry_exc
                     continue
-                mode = (
-                    str(row[0]).strip().lower()
-                    if row and row[0] is not None
-                    else ""
-                )
+                mode = str(row[0]).strip().lower() if row and row[0] is not None else ""
                 if mode == "wal":
                     # Same flip, later door: a transient EIO cleared and the
                     # switch went through. The header rewrite is identical, so
@@ -1431,10 +1427,13 @@ def _wal_reset_repair_hint() -> str:
             recommended_update_command_for_method,
             get_project_root,
         )
+
         method = detect_install_method(get_project_root())
         cmd = recommended_update_command_for_method(method)
         if method in {"git", "unknown"}:
-            return f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            return (
+                f"Hermes-managed installs can repair the embedded runtime with `{cmd}`"
+            )
         if method == "docker":
             return f"update the container image with `{cmd}`"
         # nix/nixos
@@ -1868,8 +1867,8 @@ PERSISTENCE_ERROR_CAUSES = (
 # B-tree corruption gets reported to the user as "free some disk space"
 # (the misdiagnosis documented on #77386).
 _DB_CORRUPTION_MARKERS = (
-    "malformed",              # "database disk image is malformed" (SQLITE_CORRUPT)
-    "file is not a database", # SQLITE_NOTADB (also connection-level poisoning)
+    "malformed",  # "database disk image is malformed" (SQLITE_CORRUPT)
+    "file is not a database",  # SQLITE_NOTADB (also connection-level poisoning)
     "not a database",
     "database corruption",
 )
@@ -1931,10 +1930,7 @@ def classify_persistence_error(exc_or_str) -> str:
     # steal it and misdiagnose damage as space/contention.
     if any(marker in text for marker in _DB_CORRUPTION_MARKERS):
         return "corrupt"
-    if (
-        "locked" in text
-        or "busy" in text
-    ):
+    if "locked" in text or "busy" in text:
         return "locked"
     if (
         is_disk_full_error(exc_or_str)
@@ -2011,7 +2007,9 @@ def _cross_process_repair_lock(db_path: Path):
         # than refusing to repair a DB we could otherwise heal.
         logger.warning(
             "Could not open state.db repair lock %s (%s) — proceeding with "
-            "in-process serialisation only.", lock_path, exc,
+            "in-process serialisation only.",
+            lock_path,
+            exc,
         )
         yield True
         return
@@ -2041,7 +2039,8 @@ def _cross_process_repair_lock(db_path: Path):
                 "state.db repair lock %s held by another process for more "
                 "than %.0fs — skipping schema surgery in this process to "
                 "avoid racing the repairer.",
-                lock_path, _REPAIR_LOCK_TIMEOUT_SECONDS,
+                lock_path,
+                _REPAIR_LOCK_TIMEOUT_SECONDS,
             )
         yield acquired
     finally:
@@ -2141,6 +2140,7 @@ def _mask_volatile_header(head: bytes) -> bytes:
     for start, end in _FINGERPRINT_VOLATILE_HEADER_RANGES:
         buf[start:end] = b"\x00" * (end - start)
     return bytes(buf)
+
 
 # Free-space headroom for the pre-repair forensic backup. The backup is a
 # full raw copy of the damaged DB (plus its -wal/-shm sidecars), so a repair
@@ -2362,6 +2362,7 @@ def _backup_content_identity(db_path: Path) -> "Optional[str]":
             offline_file_access,
         )
     except ImportError:
+
         @contextmanager
         def offline_file_access(_path, **_kw):
             yield
@@ -2443,7 +2444,7 @@ def _persistent_repair_exhausted_error(db_path: Path) -> str:
         f"{_MAX_PERSISTENT_REPAIR_ATTEMPTS} times on this exact file — "
         "the corruption is beyond the schema/FTS repair strategies "
         "(likely b-tree page damage). Manual recovery required: restore "
-        f"a backup, or salvage with `sqlite3 {db_path} \".recover\"`. "
+        f'a backup, or salvage with `sqlite3 {db_path} ".recover"`. '
         f"Delete {_repair_ledger_path(db_path).name} to force another "
         "automatic attempt."
     )
@@ -2478,21 +2479,15 @@ def _record_repair_outcome(
                 # in-process claim and cross-process lock still bound this run.
                 return
             fp = recorded
-        attempts = (
-            int(ledger.get("failed_attempts", 0)) + 1 if recorded == fp else 1
-        )
+        attempts = int(ledger.get("failed_attempts", 0)) + 1 if recorded == fp else 1
         import datetime
 
         ledger_path.write_text(
-            json.dumps(
-                {
-                    "fingerprint": fp,
-                    "failed_attempts": attempts,
-                    "last_attempt": datetime.datetime.now().isoformat(
-                        timespec="seconds"
-                    ),
-                }
-            ),
+            json.dumps({
+                "fingerprint": fp,
+                "failed_attempts": attempts,
+                "last_attempt": datetime.datetime.now().isoformat(timespec="seconds"),
+            }),
             encoding="utf-8",
         )
     except Exception as exc:  # pragma: no cover - best effort
@@ -2506,8 +2501,7 @@ def _existing_malformed_backups(db_path: Path) -> "List[Path]":
         found = [
             p
             for p in db_path.parent.iterdir()
-            if p.name.startswith(prefix)
-            and not p.name.endswith(_DB_SIDECAR_SUFFIXES)
+            if p.name.startswith(prefix) and not p.name.endswith(_DB_SIDECAR_SUFFIXES)
         ]
     except OSError:
         return []
@@ -2616,10 +2610,14 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
             if existing_backups:
                 src_id = _backup_content_identity(db_path)
                 for existing in existing_backups:
-                    if src_id is not None and _backup_content_identity(existing) == src_id:
+                    if (
+                        src_id is not None
+                        and _backup_content_identity(existing) == src_id
+                    ):
                         logger.info(
                             "Reusing existing forensic backup %s (identical to the "
-                            "damaged DB).", existing,
+                            "damaged DB).",
+                            existing,
                         )
                         return existing, None
         except OSError:
@@ -2697,9 +2695,7 @@ def _backup_db_file(db_path: Path) -> "Tuple[Optional[Path], Optional[str]]":
                 shutil.copy2(sidecar, side_staging)
             # Publish sidecars first, main DB LAST (the commit marker), so a
             # mid-publish failure never leaves a countable-but-incomplete bundle.
-            publish_order = [
-                (s, d) for _src, s, d in staged_sidecars
-            ] + [main_pair]
+            publish_order = [(s, d) for _src, s, d in staged_sidecars] + [main_pair]
             for src, dst in publish_order:
                 os.replace(src, dst)
                 published.append(dst)
@@ -3309,9 +3305,7 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
             # owner is responsible for its outcome.
             attempted = bool(result.pop("_repair_attempted", False))
             if attempted or result.get("repaired"):
-                _record_repair_outcome(
-                    db_path, repaired=bool(result.get("repaired"))
-                )
+                _record_repair_outcome(db_path, repaired=bool(result.get("repaired")))
     return result
 
 
@@ -3333,7 +3327,9 @@ def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:
         return None
 
 
-def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]) -> None:
+def _restore_journal_mode_after_repair(
+    db_path: Path, before_mode: Optional[str]
+) -> None:
     """Re-apply the journal mode after schema surgery (#89674).
 
     A repaired/rebuilt SQLite file comes back in the default journal mode
@@ -3370,13 +3366,16 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
                 "(pre-surgery probe %r; restore resolved through "
                 "apply_wal_with_fallback per database.journal_mode and the "
                 "WAL-reset gate)",
-                before_mode, after, before_mode,
+                before_mode,
+                after,
+                before_mode,
             )
     except (sqlite3.Error, OSError) as exc:
         logger.warning(
             "state.db repair at %s: post-surgery journal-mode restore "
             "failed (%s); verify with PRAGMA journal_mode on the next open",
-            db_path, exc,
+            db_path,
+            exc,
         )
 
 
@@ -3473,9 +3472,7 @@ def _repair_state_db_schema_locked(
             # Reuse live_guard rather than opening a second source connection:
             # the guard owns the exclusion, so a second connection could be
             # blocked by our own EXCLUSIVE lock on some SQLite builds.
-            _copy_database_snapshot(
-                db_path, scratch, source_connection=live_guard
-            )
+            _copy_database_snapshot(db_path, scratch, source_connection=live_guard)
         except (OSError, sqlite3.Error, TimeoutError) as exc:
             report["error"] = (
                 f"could not stage a complete SQLite repair snapshot of {db_path}: {exc}"
@@ -3509,9 +3506,7 @@ def _repair_state_db_schema_locked(
                 except (OSError, sqlite3.Error, TimeoutError) as exc:
                     report["repaired"] = False
                     report["strategy"] = None
-                    report["_repair_attempted"] = _repair_failure_consumes_attempt(
-                        exc
-                    )
+                    report["_repair_attempted"] = _repair_failure_consumes_attempt(exc)
                     report["error"] = (
                         "repaired snapshot could not be promoted transactionally: "
                         f"{exc}"
@@ -3573,9 +3568,7 @@ def _unlink_db_triple(path: Path) -> Optional[str]:
     return "; ".join(failures) or None
 
 
-def _run_repair_strategies(
-    db_path: Path, report: Dict[str, Any]
-) -> Dict[str, Any]:
+def _run_repair_strategies(db_path: Path, report: Dict[str, Any]) -> Dict[str, Any]:
     """Escalating repair attempts, applied to *db_path* IN PLACE.
 
     Every strategy here mutates its argument — FTS rebuild, REINDEX,
@@ -3594,7 +3587,9 @@ def _run_repair_strategies(
             # best-effort (a tokenizer-less host skips it at the probe below).
             load_fts5_cjk_extension(conn)
             for table_name in (
-                "messages_fts", "messages_fts_trigram", "messages_fts_cjk"
+                "messages_fts",
+                "messages_fts_trigram",
+                "messages_fts_cjk",
             ):
                 try:
                     conn.execute(
@@ -3636,9 +3631,7 @@ def _run_repair_strategies(
         if _db_opens_cleanly(db_path) is None:
             report["repaired"] = True
             report["strategy"] = "reindex_btree"
-            logger.warning(
-                "state.db B-tree indexes rebuilt via REINDEX: %s", db_path
-            )
+            logger.warning("state.db B-tree indexes rebuilt via REINDEX: %s", db_path)
             return report
     except sqlite3.DatabaseError as exc:
         logger.warning("state.db REINDEX pass failed: %s", exc)
@@ -3669,7 +3662,8 @@ def _run_repair_strategies(
             report["strategy"] = "dedup_schema"
             logger.warning(
                 "state.db schema repaired by de-duplicating sqlite_master "
-                "(FTS index preserved): %s", db_path
+                "(FTS index preserved): %s",
+                db_path,
             )
             return report
     except sqlite3.DatabaseError as exc:
@@ -3704,7 +3698,8 @@ def _run_repair_strategies(
             report["strategy"] = "drop_fts_rebuild"
             logger.warning(
                 "state.db schema repaired by dropping FTS schema; indexes "
-                "will rebuild from messages on next open: %s", db_path
+                "will rebuild from messages on next open: %s",
+                db_path,
             )
             return report
         report["error"] = reason
@@ -3809,6 +3804,7 @@ BEGIN
 END;
 """
 
+
 def fts5_cjk_so_path() -> Path:
     """Location of the cjk_unicode61 loadable extension."""
     env = os.getenv("HERMES_FTS5_CJK_SO")
@@ -3820,7 +3816,10 @@ def fts5_cjk_so_path() -> Path:
 def _cjk_fts_config_enabled() -> bool:
     """config.yaml ``sessions.cjk_fts`` (default on), via its env bridge."""
     return os.getenv("HERMES_CJK_FTS", "1").strip().lower() not in (
-        "0", "false", "off", "no",
+        "0",
+        "false",
+        "off",
+        "no",
     )
 
 
@@ -3956,9 +3955,7 @@ def is_zeroed_state_db(
         return False
     from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
 
-    head = read_header_bytes_preopen(
-        path, length=max(16, probe_bytes), force=force
-    )
+    head = read_header_bytes_preopen(path, length=max(16, probe_bytes), force=force)
     if not head or head.startswith(b"SQLite format 3"):
         return False
     return all(byte == 0 for byte in head)
@@ -3982,6 +3979,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
         deadline = time.monotonic() + 5.0
         if platform.system() == "Windows":
             import msvcrt
+
             while True:
                 try:
                     handle.seek(0)
@@ -3994,6 +3992,7 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
                     time.sleep(0.020)
         else:
             import fcntl
+
             while True:
                 try:
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -4038,16 +4037,12 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             ts = "unknown"
         # Unique destination with PID suffix to avoid collision across
         # concurrent startups that somehow both enter the lock.
-        dest = path.with_name(
-            f"{path.name}.zeroed-{ts}-{os.getpid()}.bak"
-        )
+        dest = path.with_name(f"{path.name}.zeroed-{ts}-{os.getpid()}.bak")
         # Non-clobbering: if dest somehow exists, append a counter.
         n = 0
         while dest.exists():
             n += 1
-            dest = path.with_name(
-                f"{path.name}.zeroed-{ts}-{os.getpid()}-{n}.bak"
-            )
+            dest = path.with_name(f"{path.name}.zeroed-{ts}-{os.getpid()}-{n}.bak")
         try:
             path.rename(dest)
         except OSError as exc:
@@ -4067,10 +4062,12 @@ def quarantine_zeroed_state_db(path: Path) -> Optional[Path]:
             if acquired:
                 if platform.system() == "Windows":
                     import msvcrt
+
                     handle.seek(0)
                     msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
                 else:
                     import fcntl
+
                     fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         except (OSError, AttributeError):
             pass
@@ -4148,8 +4145,9 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
             timeout=2.0,
         )
     except Exception as exc:
-        logger.debug("collect_state_db_stats: cannot open %s read-only: %s",
-                     db_path, exc)
+        logger.debug(
+            "collect_state_db_stats: cannot open %s read-only: %s", db_path, exc
+        )
         return stats
 
     def _scalar(sql: str) -> Any:
@@ -4325,8 +4323,14 @@ def _read_proc_cmdline(pid: int) -> Optional[str]:
         return None
 
 
-_HERMES_CMDLINE_MARKERS = ("hermes_cli.main", "hermes_cli/main", "hermes serve",
-                           "hermes-agent", "hermes gateway", "hermes chat")
+_HERMES_CMDLINE_MARKERS = (
+    "hermes_cli.main",
+    "hermes_cli/main",
+    "hermes serve",
+    "hermes-agent",
+    "hermes gateway",
+    "hermes chat",
+)
 
 
 def _looks_like_hermes(cmdline: str) -> bool:
@@ -4435,8 +4439,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # refused rather than allowed to land a stale turn in a session whose
     # compression is genuinely long-running or wedged.
     _COMPRESSION_BUSY_WAIT_S = 5.0
-    _WRITE_RETRY_MIN_S = 0.020   # 20ms
-    _WRITE_RETRY_MAX_S = 0.150   # 150ms
+    _WRITE_RETRY_MIN_S = 0.020  # 20ms
+    _WRITE_RETRY_MAX_S = 0.150  # 150ms
     _WRITE_RETRY_SLOW_AFTER_S = 2.0
     _WRITE_RETRY_SLOW_MIN_S = 0.250  # 250ms
     _WRITE_RETRY_SLOW_MAX_S = 1.000  # 1s
@@ -4691,7 +4695,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 _set_last_init_error(msg)
                 # If quarantine failed, do not open the zeroed file (would fail
                 # opaquely or risk further damage). Raise with the clear message.
-                if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
+                if (
+                    qpath is None
+                    and self.db_path.exists()
+                    and is_zeroed_state_db(self.db_path)
+                ):
                     raise sqlite3.DatabaseError(msg)
 
             def _connect_and_init():
@@ -4764,11 +4772,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # place (backup first; canonical sessions/messages preserved),
                 # then reopen once. This is what lets Desktop/Dashboard
                 # self-heal instead of silently showing "no sessions".
-                if not is_malformed_schema_error(exc) or not _claim_repair_attempt(self.db_path):
+                if not is_malformed_schema_error(exc) or not _claim_repair_attempt(
+                    self.db_path
+                ):
                     raise
                 logger.error(
                     "state.db schema is malformed (%s) — attempting automatic "
-                    "repair (a backup copy is made first).", exc,
+                    "repair (a backup copy is made first).",
+                    exc,
                 )
                 try:
                     if self._conn is not None:
@@ -4889,7 +4900,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # writer connection still serves reads until the stamp expires.
             with self._read_conns_lock:
                 self._read_open_failed_at = time.monotonic()
-            logger.debug("read-only connection open failed for %s", self.db_path, exc_info=True)
+            logger.debug(
+                "read-only connection open failed for %s", self.db_path, exc_info=True
+            )
             self._read_permits.release()
             return None
         except BaseException:
@@ -5119,15 +5132,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
               and leave the stale breadcrumb (#self-heal). The table itself
               stays for a later capable open to rebuild.
         """
-        cjk_present = bool(cursor.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
-            "AND name = 'messages_fts_cjk'"
-        ).fetchone())
+        cjk_present = bool(
+            cursor.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name = 'messages_fts_cjk'"
+            ).fetchone()
+        )
 
         if not self._fts_cjk_loaded:
             if cjk_present:
                 live = [
-                    r[0] for r in cursor.execute(
+                    r[0]
+                    for r in cursor.execute(
                         "SELECT name FROM sqlite_master WHERE type = 'trigger' "
                         f"AND name IN ({','.join('?' for _ in _FTS_CJK_TRIGGERS)})",
                         _FTS_CJK_TRIGGERS,
@@ -5209,8 +5225,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # Includes "no such tokenizer: cjk_unicode61" if the extension
             # loaded but registration failed — degrade to trigram/LIKE.
             logger.warning(
-                "messages_fts_cjk ensure failed; CJK search stays on "
-                "trigram/LIKE", exc_info=True,
+                "messages_fts_cjk ensure failed; CJK search stays on trigram/LIKE",
+                exc_info=True,
             )
             self._fts_cjk_available = False
 
@@ -5350,12 +5366,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         "a large WAL checkpoint, or an older pre-update "
                         "process; the database itself is healthy)"
                     ) from exc
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    deadline, patience_s
+                ):
                     continue
                 # Non-lock error or patience exhausted — propagate.
                 raise
             except sqlite3.DatabaseError as exc:
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    deadline, patience_s
+                ):
                     continue
                 # Corrupt FTS shadow tables make every write raise the
                 # malformed/corrupt error class through the FTS sync triggers
@@ -5375,13 +5395,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # subclass) or another sqlite3.Error class outside the two
                 # handlers above. Message-scoped: anything else propagates
                 # untouched.
-                if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
+                if _is_no_more_rows(exc) and self._sleep_before_write_retry(
+                    deadline, patience_s
+                ):
                     continue
                 raise
 
-    def _sleep_before_write_retry(
-        self, deadline: float, patience_s: float
-    ) -> bool:
+    def _sleep_before_write_retry(self, deadline: float, patience_s: float) -> bool:
         """Sleep one jitter interval if the patience budget still allows it.
 
         Returns True when the caller should retry, False when *deadline* has
@@ -5487,7 +5507,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         # another Hermes instance, not every system daemon.
                         cmdline = _read_proc_cmdline(pid)
                         if cmdline is not None and _looks_like_hermes(cmdline):
-                            holders.append((pid, f"uninspectable holder: {cmdline[:80]}"))
+                            holders.append((
+                                pid,
+                                f"uninspectable holder: {cmdline[:80]}",
+                            ))
                         continue
                     for fd in fds:
                         try:
@@ -5557,7 +5580,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ppid=process.ppid(),
                     age_seconds=now - process.create_time(),
                     min_age_seconds=min_age_seconds,
-                    ephemeral_backend=_is_ephemeral_port_zero_backend(process.cmdline()),
+                    ephemeral_backend=_is_ephemeral_port_zero_backend(
+                        process.cmdline()
+                    ),
                     connection_statuses=statuses,
                 ):
                     continue
@@ -5632,7 +5657,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         logger.warning(
             "state.db write failed with an FTS-corruption error (%s) — "
             "attempting one-shot in-place FTS rebuild; canonical message "
-            "rows are preserved.", exc,
+            "rows are preserved.",
+            exc,
         )
         try:
             rebuilt = self.rebuild_fts()
@@ -5732,13 +5758,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         try:
             with self._lock:
-                result = self._conn.execute(
-                    "PRAGMA wal_checkpoint(PASSIVE)"
-                ).fetchone()
+                result = self._conn.execute("PRAGMA wal_checkpoint(PASSIVE)").fetchone()
                 if result and result[1] > 0:
                     logger.debug(
                         "WAL checkpoint: %d/%d pages checkpointed",
-                        result[2], result[1],
+                        result[2],
+                        result[1],
                     )
         except Exception as exc:
             logger.warning("WAL checkpoint (PASSIVE) failed: %s", exc)
@@ -5875,8 +5900,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     #      cycle unconditionally.
 
     _FTS_REBUILD_CHUNK_ROWS = 500
-    _FTS_REBUILD_DUTY_FACTOR = 4.0      # sleep >= 4x chunk cost (≤20% duty)
-    _FTS_REBUILD_MIN_PAUSE = 0.2        # seconds — floor between chunks
+    _FTS_REBUILD_DUTY_FACTOR = 4.0  # sleep >= 4x chunk cost (≤20% duty)
+    _FTS_REBUILD_MIN_PAUSE = 0.2  # seconds — floor between chunks
 
     # Demoted v22 FTS shadow tables awaiting teardown (see the v23 migration:
     # DROP of a multi-GB FTS vtable blocks for minutes, so the migration
@@ -5905,11 +5930,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _has_fts_trash(self, conn) -> bool:
         """True when demoted v22 shadow tables are still awaiting teardown.
         Caller must hold ``self._lock`` (or pass a migration-time cursor)."""
-        return bool(conn.execute(
-            "SELECT 1 FROM sqlite_master WHERE type = 'table' "
-            "AND name LIKE ? ESCAPE '\\' LIMIT 1",
-            (self._FTS_TRASH_PREFIX.replace("_", "\\_") + "%",),
-        ).fetchone())
+        return bool(
+            conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' "
+                "AND name LIKE ? ESCAPE '\\' LIMIT 1",
+                (self._FTS_TRASH_PREFIX.replace("_", "\\_") + "%",),
+            ).fetchone()
+        )
 
     # =========================================================================
     # Session lifecycle
@@ -5969,6 +5996,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         crash before the gateway re-records the peer can't strand the child
         without a recoverable routing mapping (#59527).
         """
+
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
@@ -6102,6 +6130,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        )""",
                     (session_id,),
                 )
+
         # Session-row creation is transcript-critical: if it fails, the
         # first flush of a new session fails and the turn is aborted as
         # session_persistence_failed. Ride out long sibling holds.
@@ -6178,18 +6207,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """
                 target_clause = "WHERE id IN (SELECT id FROM compression_lineage)"
                 query_params.append(session_id)
-            query_params.extend(
-                (
-                    session_key,
-                    source,
-                    user_id,
-                    chat_id,
-                    chat_type,
-                    thread_id,
-                    display_name,
-                    origin_json,
-                )
-            )
+            query_params.extend((
+                session_key,
+                source,
+                user_id,
+                chat_id,
+                chat_type,
+                thread_id,
+                display_name,
+                origin_json,
+            ))
             if not include_compression_ancestors:
                 query_params.append(session_id)
             conn.execute(
@@ -6696,11 +6723,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         conversation into another person's chat. Branch/delegate/tool rows
         are excluded outright — they are unkeyed by design, not by damage.
         """
-        gap = (
-            self._ORPHAN_ADOPTION_MAX_GAP_S
-            if max_gap_s is None
-            else float(max_gap_s)
-        )
+        gap = self._ORPHAN_ADOPTION_MAX_GAP_S if max_gap_s is None else float(max_gap_s)
         orphan_active = _sql_session_last_active("o")
         donor_active = _sql_session_last_active("d")
         donor_columns = (
@@ -6749,8 +6772,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ).fetchone()
                     if donor is None:
                         reason = (
-                            "parent session carries no gateway identity of "
-                            "this source"
+                            "parent session carries no gateway identity of this source"
                         )
                 else:
                     evidence = "contiguity"
@@ -6792,20 +6814,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     else:
                         donor = candidates[0]
 
-                records.append(
-                    {
-                        "orphan_id": orphan["id"],
-                        "source": orphan["source"],
-                        "message_count": orphan["message_count"],
-                        "started_at": orphan["started_at"],
-                        "last_active": orphan["last_active"],
-                        "donor_id": donor["id"] if donor else None,
-                        "session_key": donor["session_key"] if donor else None,
-                        "evidence": evidence if donor else "",
-                        "adoptable": donor is not None,
-                        "reason": reason,
-                    }
-                )
+                records.append({
+                    "orphan_id": orphan["id"],
+                    "source": orphan["source"],
+                    "message_count": orphan["message_count"],
+                    "started_at": orphan["started_at"],
+                    "last_active": orphan["last_active"],
+                    "donor_id": donor["id"] if donor else None,
+                    "session_key": donor["session_key"] if donor else None,
+                    "evidence": evidence if donor else "",
+                    "adoptable": donor is not None,
+                    "reason": reason,
+                })
 
         # Two unkeyed successors claiming the same predecessor means at most
         # one of them continues that chat, and nothing here says which.
@@ -6819,14 +6839,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if record["donor_id"] in contested:
                 record["adoptable"] = False
                 record["reason"] = (
-                    "ambiguous: more than one unkeyed session claims this "
-                    "predecessor"
+                    "ambiguous: more than one unkeyed session claims this predecessor"
                 )
         return records
 
-    def adopt_orphaned_gateway_session(
-        self, orphan_id: str, donor_id: str
-    ) -> bool:
+    def adopt_orphaned_gateway_session(self, orphan_id: str, donor_id: str) -> bool:
         """Stamp *orphan_id* with *donor_id*'s routing identity, retire *donor_id*.
 
         Re-verifies the pair inside the write transaction, so a concurrent
@@ -7000,8 +7017,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # refresh cannot resurrect it.
             now = time.time()
             lock_row = conn.execute(
-                "SELECT holder, expires_at FROM compression_locks "
-                "WHERE session_id = ?",
+                "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
             if lock_row is not None:
@@ -7070,6 +7086,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         rows in ``(watermark, watermark_ceiling]`` are foreign concurrent
         tail. ``None`` = unbounded (no internal flush happened).
         """
+
         def _do(conn):
             lock_row = conn.execute(
                 "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
@@ -7094,7 +7111,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if parent is None:
                 raise RuntimeError(f"Compression parent not found: {parent_session_id}")
             if parent["ended_at"] is not None:
-                raise RuntimeError(f"Compression parent already ended: {parent_session_id}")
+                raise RuntimeError(
+                    f"Compression parent already ended: {parent_session_id}"
+                )
             if not messages:
                 raise RuntimeError("Compression child handoff must not be empty")
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
@@ -7156,7 +7175,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     tail_ids = [int(r["id"]) for r in tail_rows]
                     placeholders = ",".join("?" for _ in tail_ids)
                     clone_cols = [
-                        c for c in self._message_column_names(conn)
+                        c
+                        for c in self._message_column_names(conn)
                         if c not in ("id", "session_id", "active", "compacted")
                     ]
                     col_list = ", ".join(clone_cols)
@@ -7171,8 +7191,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         raw = r["tool_calls"]
                         if raw:
                             try:
-                                parsed = json.loads(raw) if isinstance(raw, str) else raw
-                                total_tool_calls += len(parsed) if isinstance(parsed, list) else 0
+                                parsed = (
+                                    json.loads(raw) if isinstance(raw, str) else raw
+                                )
+                                total_tool_calls += (
+                                    len(parsed) if isinstance(parsed, list) else 0
+                                )
                             except (TypeError, ValueError):
                                 pass
             conn.execute(
@@ -7201,12 +7225,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with a different reason. Use ``reopen_session()`` first if you
         intentionally need to re-end a closed session with a new reason.
         """
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET ended_at = ?, end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
                 (time.time(), end_reason, session_id),
             )
+
         self._execute_write(_do)
 
     def reopen_session(self, session_id: str) -> None:
@@ -7215,6 +7241,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Before clearing a reset boundary, stabilize markerless legacy reset
         children that still depend on the parent's mutable end_reason.
         """
+
         def _do(conn):
             placeholders = ",".join("?" for _ in _RESET_END_REASONS)
             # WHERE shape shared with _RESET_CHILD_SQL's fallback arm via
@@ -7234,6 +7261,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET ended_at = NULL, end_reason = NULL WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def promote_to_session_reset(
@@ -7332,7 +7360,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if current is None:
                 return None
 
-            current_cwd = current["cwd"] if isinstance(current, sqlite3.Row) else current[0]
+            current_cwd = (
+                current["cwd"] if isinstance(current, sqlite3.Row) else current[0]
+            )
             sets = [
                 "cwd = ?",
                 "git_metadata_generation = COALESCE(git_metadata_generation, 0) + 1",
@@ -7348,16 +7378,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 sets.append("git_repo_root = ?")
                 params.append(repo_root)
             params.append(session_id)
-            conn.execute(
-                f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?", params
-            )
+            conn.execute(f"UPDATE sessions SET {', '.join(sets)} WHERE id = ?", params)
             row = conn.execute(
                 "SELECT git_metadata_generation FROM sessions WHERE id = ?",
                 (session_id,),
             ).fetchone()
             if row is None:
                 return None
-            value = row["git_metadata_generation"] if isinstance(row, sqlite3.Row) else row[0]
+            value = (
+                row["git_metadata_generation"]
+                if isinstance(row, sqlite3.Row)
+                else row[0]
+            )
             return int(value)
 
         return self._execute_write(_do)
@@ -7449,7 +7481,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error as exc:
             logger.warning(
                 "record_compression_failure_cooldown(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
 
     def get_compression_failure_cooldown(
@@ -7479,9 +7512,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if cooldown_until <= now:
             return None
         error = (
-            row["compression_failure_error"]
-            if isinstance(row, sqlite3.Row)
-            else row[1]
+            row["compression_failure_error"] if isinstance(row, sqlite3.Row) else row[1]
         )
         return {
             "cooldown_until": cooldown_until,
@@ -7516,9 +7547,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             else row[0]
         )
         error = (
-            row["compression_failure_error"]
-            if isinstance(row, sqlite3.Row)
-            else row[1]
+            row["compression_failure_error"] if isinstance(row, sqlite3.Row) else row[1]
         )
         return {
             "session_exists": True,
@@ -7592,7 +7621,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error as exc:
             logger.warning(
                 "clear_compression_failure_cooldown(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
 
     def get_compression_fallback_streak(self, session_id: str) -> int:
@@ -7777,7 +7807,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error as exc:
             logger.warning(
                 "refresh_compression_lock(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
             return False
 
@@ -7812,8 +7843,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         def _do(conn):
             reclaimed_holder = None
             row = conn.execute(
-                "SELECT holder, expires_at FROM compression_locks "
-                "WHERE session_id = ?",
+                "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
             if row is not None:
@@ -7823,9 +7853,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 current_expires_at = (
                     row["expires_at"] if isinstance(row, sqlite3.Row) else row[1]
                 )
-                if (
-                    current_expires_at < now
-                    or _compression_lock_holder_process_is_dead(current_holder)
+                if current_expires_at < now or _compression_lock_holder_process_is_dead(
+                    current_holder
                 ):
                     conn.execute(
                         "DELETE FROM compression_locks "
@@ -7845,17 +7874,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "SELECT holder FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
-            acquired = row is not None and (
-                row["holder"] if isinstance(row, sqlite3.Row) else row[0]
-            ) == holder
+            acquired = (
+                row is not None
+                and (row["holder"] if isinstance(row, sqlite3.Row) else row[0])
+                == holder
+            )
             return acquired, reclaimed_holder
 
         try:
             acquired, reclaimed_holder = self._execute_write(_do)
             if reclaimed_holder:
                 logger.warning(
-                    "Reclaimed stale compression lock for session=%s "
-                    "(holder=%s)",
+                    "Reclaimed stale compression lock for session=%s (holder=%s)",
                     session_id,
                     reclaimed_holder,
                 )
@@ -7863,7 +7893,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error as exc:
             logger.warning(
                 "try_acquire_compression_lock(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
             # Fail open: returning False makes the caller skip compression,
             # which is the safe behaviour when the lock subsystem is broken.
@@ -7882,8 +7913,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         def _do(conn):
             conn.execute(
-                "DELETE FROM compression_locks "
-                "WHERE session_id = ? AND holder = ?",
+                "DELETE FROM compression_locks WHERE session_id = ? AND holder = ?",
                 (session_id, holder),
             )
 
@@ -7892,7 +7922,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error as exc:
             logger.warning(
                 "release_compression_lock(%s) failed: %s",
-                session_id, exc,
+                session_id,
+                exc,
             )
 
     def _session_turn_lease_key_on_conn(self, conn, session_id: str) -> str:
@@ -7946,6 +7977,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         with self._read_ctx() as conn:
             return self._session_turn_lease_key_on_conn(conn, session_id)
 
+    def session_runtime_key(self, session_id: str) -> str:
+        """Return the canonical durable key shared by compression segments."""
+        return self._session_turn_lease_key(session_id)
+
     def try_acquire_session_turn_lease(
         self,
         session_id: str,
@@ -7976,10 +8011,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             if row is not None:
                 current_holder = row["holder"]
-                if (
-                    float(row["expires_at"]) <= now
-                    or _compression_lock_holder_process_is_dead(current_holder)
-                ):
+                if float(
+                    row["expires_at"]
+                ) <= now or _compression_lock_holder_process_is_dead(current_holder):
                     conn.execute(
                         "DELETE FROM session_turn_leases "
                         "WHERE conversation_id = ? AND holder = ?",
@@ -8204,11 +8238,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except sqlite3.Error:
             row = None
         if row is not None:
-            desc = row[0] if not isinstance(row, sqlite3.Row) else row["last_activity_description"]
-            prov = row[1] if not isinstance(row, sqlite3.Row) else row["last_activity_provenance"]
-            if not desc and (
-                not prov or prov == ActivityProvenance.UNKNOWN.value
-            ):
+            desc = (
+                row[0]
+                if not isinstance(row, sqlite3.Row)
+                else row["last_activity_description"]
+            )
+            prov = (
+                row[1]
+                if not isinstance(row, sqlite3.Row)
+                else row["last_activity_provenance"]
+            )
+            if not desc and (not prov or prov == ActivityProvenance.UNKNOWN.value):
                 return
 
         def _do(conn):
@@ -8257,12 +8297,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET model_config = ?, model = COALESCE(?, model) WHERE id = ?",
                 (model_config_json, model, session_id),
             )
+
         self._execute_write(_do)
 
     def update_system_prompt(
         self, session_id: str, system_prompt: Optional[str]
     ) -> None:
         """Store the full assembled system prompt snapshot."""
+
         def _do(conn):
             system_prompt_hash = self._store_system_prompt(conn, system_prompt)
             conn.execute(
@@ -8271,6 +8313,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (system_prompt_hash, session_id),
             )
             self._delete_unreferenced_system_prompts(conn)
+
         self._execute_write(_do)
 
     def update_session_model(
@@ -8322,6 +8365,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (model, merged, session_id),
             )
             self._delete_unreferenced_system_prompts(conn)
+
         self._execute_write(_do)
 
     def _merge_model_config_json(
@@ -8456,6 +8500,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (merged, model, session_id),
             )
             self._delete_unreferenced_system_prompts(conn)
+
         self._execute_write(_do)
 
     def set_session_yolo(self, session_id: str, enabled: bool) -> None:
@@ -8483,6 +8528,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET model_config = ? WHERE id = ?",
                 (merged, session_id),
             )
+
         self._execute_write(_do)
 
     @staticmethod
@@ -8504,7 +8550,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return bool(raw.get("yolo_mode"))
 
     @staticmethod
-    def session_gateway_runtime(session_meta: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    def session_gateway_runtime(
+        session_meta: Optional[Dict[str, Any]],
+    ) -> Dict[str, Any]:
         """Read the persisted runtime route off a session row dict.
 
         Accepts the dict returned by ``get_session`` (``model_config`` is a
@@ -8549,12 +8597,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         billing_provider = str(
             (session_meta or {}).get("billing_provider") or ""
         ).strip()
-        if (
-            billing_provider
-            and billing_provider.lower() not in _BARE_BILLING_PROVIDERS
-        ):
+        if billing_provider and billing_provider.lower() not in _BARE_BILLING_PROVIDERS:
             return {"provider": billing_provider}
-        return {k: v for k, v in (runtime or {}).items() if v is not None} if isinstance(runtime, dict) else {}
+        return (
+            {k: v for k, v in (runtime or {}).items() if v is not None}
+            if isinstance(runtime, dict)
+            else {}
+        )
 
     def update_session_billing_route(
         self,
@@ -8589,6 +8638,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (provider, base_url, billing_mode, session_id),
             )
             self._delete_unreferenced_system_prompts(conn)
+
         self._execute_write(_do)
 
     # ── Async token accounting ──
@@ -8609,13 +8659,22 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # last-non-None-wins — equality makes the merged UPDATE byte-for-byte
     # equivalent to applying the deltas sequentially.
     _TOKEN_DELTA_SUM_FIELDS = (
-        "input_tokens", "output_tokens", "cache_read_tokens",
-        "cache_write_tokens", "reasoning_tokens", "api_call_count",
+        "input_tokens",
+        "output_tokens",
+        "cache_read_tokens",
+        "cache_write_tokens",
+        "reasoning_tokens",
+        "api_call_count",
     )
     _TOKEN_DELTA_COST_FIELDS = ("estimated_cost_usd", "actual_cost_usd")
     _TOKEN_DELTA_ROUTE_FIELDS = (
-        "model", "cost_status", "cost_source", "pricing_version",
-        "billing_provider", "billing_base_url", "billing_mode",
+        "model",
+        "cost_status",
+        "cost_source",
+        "pricing_version",
+        "billing_provider",
+        "billing_base_url",
+        "billing_mode",
     )
 
     def queue_token_counts(self, session_id: str, **kwargs) -> None:
@@ -8702,9 +8761,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # "wait", never "drain alongside".
                 thread = self._token_writer_thread
                 if (
-                    (thread is None or not thread.is_alive())
-                    and not self._token_writer_busy
-                ):
+                    thread is None or not thread.is_alive()
+                ) and not self._token_writer_busy:
                     self._token_writer_busy = True
                     batch = list(self._token_queue)
                     self._token_queue.clear()
@@ -8761,8 +8819,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # can't be observed by callers). Fall back to applying the raw
             # batch delta-by-delta — the merge is an optimization only.
             logger.warning(
-                "async token accounting: coalesce failed, applying raw "
-                "batch: %s", exc,
+                "async token accounting: coalesce failed, applying raw batch: %s",
+                exc,
             )
             coalesced = batch
         for session_id, kwargs in coalesced:
@@ -8773,7 +8831,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # loss is logged, never raised into a turn.
                 logger.warning(
                     "async token accounting: apply failed (session=%s): %s",
-                    session_id, exc,
+                    session_id,
+                    exc,
                 )
 
     def _coalesce_token_deltas(
@@ -8821,7 +8880,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 logger.warning(
                     "async token accounting: writer did not stop within %.0fs; "
                     "%d queued delta(s) not persisted",
-                    join_timeout, len(self._token_queue),
+                    join_timeout,
+                    len(self._token_queue),
                 )
                 return
         # Writer exited (or never started) — apply leftovers synchronously.
@@ -8838,7 +8898,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     logger.warning(
                         "async token accounting: concurrent drain did not "
                         "finish within %.0fs; %d queued delta(s) not persisted",
-                        join_timeout, len(self._token_queue),
+                        join_timeout,
+                        len(self._token_queue),
                     )
                     return
                 self._token_queue_cond.wait(remaining)
@@ -8943,9 +9004,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                    api_call_count = COALESCE(api_call_count, 0) + ?
                    WHERE id = ?"""
         has_accounted_usage = bool(
-            input_tokens or output_tokens or cache_read_tokens
-            or cache_write_tokens or reasoning_tokens or api_call_count
-            or estimated_cost_usd or actual_cost_usd
+            input_tokens
+            or output_tokens
+            or cache_read_tokens
+            or cache_write_tokens
+            or reasoning_tokens
+            or api_call_count
+            or estimated_cost_usd
+            or actual_cost_usd
         )
         params = (
             input_tokens,
@@ -8980,8 +9046,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # cannot be split back into routes; Insights reconciles any positive
         # residual against the aggregate session row instead.
         record_model_usage = (not absolute) and (
-            input_tokens or output_tokens or cache_read_tokens
-            or cache_write_tokens or reasoning_tokens or api_call_count
+            input_tokens
+            or output_tokens
+            or cache_read_tokens
+            or cache_write_tokens
+            or reasoning_tokens
+            or api_call_count
             or estimated_cost_usd
         )
 
@@ -8992,7 +9062,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             ).fetchone()
             existing_model = row["model"] if row is not None else None
             existing_provider = row["billing_provider"] if row is not None else None
-            existing_api_calls = int((row["api_call_count"] if row is not None else 0) or 0)
+            existing_api_calls = int(
+                (row["api_call_count"] if row is not None else 0) or 0
+            )
 
             # Session creation records the requested primary route before any API
             # call. If it fails and fallback succeeds, the first accounted usage
@@ -9011,7 +9083,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        SET model = ?, billing_provider = ?,
                        billing_base_url = ?, billing_mode = ?
                        WHERE id = ?""",
-                    (model, billing_provider, billing_base_url, billing_mode, session_id),
+                    (
+                        model,
+                        billing_provider,
+                        billing_base_url,
+                        billing_mode,
+                        session_id,
+                    ),
                 )
             conn.execute(sql, params)
             if record_model_usage:
@@ -9033,6 +9111,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     cost_source=cost_source,
                     api_call_count=api_call_count,
                 )
+
         self._execute_write(_do)
 
     def _record_model_usage(
@@ -9207,11 +9286,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 actual_cost_usd=None,
                 cost_status=None,
                 cost_source=None,
-                api_call_count=(
-                    1 if api_call_count is None else int(api_call_count)
-                ),
+                api_call_count=(1 if api_call_count is None else int(api_call_count)),
                 task=task,
             )
+
         self._execute_write(_do)
 
     def prune_empty_ghost_sessions(self, sessions_dir: "Optional[Path]" = None) -> int:
@@ -9219,7 +9297,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         cutoff = time.time() - 86400  # Only sessions older than 24 hours
 
         def _do(conn):
-            rows = conn.execute("""
+            rows = conn.execute(
+                """
                 SELECT id FROM sessions
                 WHERE source = 'tui'
                   AND title IS NULL
@@ -9228,13 +9307,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   AND NOT EXISTS (
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id
                   )
-            """, (cutoff,)).fetchall()
+            """,
+                (cutoff,),
+            ).fetchall()
             ids = [r[0] if isinstance(r, (tuple, list)) else r["id"] for r in rows]
             if ids:
                 placeholders = ",".join("?" * len(ids))
-                conn.execute(
-                    f"DELETE FROM sessions WHERE id IN ({placeholders})", ids
-                )
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({placeholders})", ids)
                 self._delete_unreferenced_system_prompts(conn)
             return ids
 
@@ -9352,7 +9431,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         )
         hb_grace = (
             heartbeat_ownership_grace_seconds
-            if heartbeat_ownership_grace_seconds and heartbeat_ownership_grace_seconds >= 0
+            if heartbeat_ownership_grace_seconds
+            and heartbeat_ownership_grace_seconds >= 0
             else hb_staleness
         )
         cutoff = time.time() - max_idle_seconds
@@ -9437,6 +9517,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not backend_id:
             return
         ts = time.time() if last_heartbeat is None else float(last_heartbeat)
+
         def _do(conn):
             conn.execute(
                 "INSERT INTO gateway_heartbeats"
@@ -9448,9 +9529,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 " last_heartbeat = excluded.last_heartbeat,"
                 " profile = excluded.profile,"
                 " host = excluded.host",
-                (str(backend_id), int(pid), float(started_at), ts,
-                 str(profile), str(host)),
+                (
+                    str(backend_id),
+                    int(pid),
+                    float(started_at),
+                    ts,
+                    str(profile),
+                    str(host),
+                ),
             )
+
         self._execute_write(_do)
 
     def clear_backend_heartbeat(self, backend_id: str) -> bool:
@@ -9462,12 +9550,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """
         if not backend_id:
             return False
+
         def _do(conn):
             cur = conn.execute(
                 "DELETE FROM gateway_heartbeats WHERE backend_id = ?",
                 (str(backend_id),),
             )
             return cur.rowcount > 0
+
         return bool(self._execute_write(_do))
 
     def prune_stale_heartbeats(self, *, max_age_seconds: float) -> List[str]:
@@ -9478,6 +9568,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if max_age_seconds <= 0:
             return []
         cutoff = time.time() - max_age_seconds
+
         def _do(conn):
             cur = conn.execute(
                 "DELETE FROM gateway_heartbeats WHERE last_heartbeat < ?"
@@ -9485,6 +9576,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (cutoff,),
             )
             return [str(r[0]) for r in cur.fetchall()]
+
         return list(self._execute_write(_do) or [])
 
     def list_backend_heartbeats(self) -> List[Dict[str, Any]]:
@@ -9503,8 +9595,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 out.append({k: r[k] for k in r.keys()})
             else:
                 out.append({
-                    "backend_id": r[0], "pid": r[1], "started_at": r[2],
-                    "last_heartbeat": r[3], "profile": r[4], "host": r[5],
+                    "backend_id": r[0],
+                    "pid": r[1],
+                    "started_at": r[2],
+                    "last_heartbeat": r[3],
+                    "profile": r[4],
+                    "host": r[5],
                 })
         return out
 
@@ -9638,19 +9734,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Remove ASCII control characters (0x00-0x1F, 0x7F) but keep
         # whitespace chars (\t=0x09, \n=0x0A, \r=0x0D) so they can be
         # normalized to spaces by the whitespace collapsing step below
-        cleaned = re.sub(r'[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]', '', title)
+        cleaned = re.sub(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]", "", title)
 
         # Remove problematic Unicode control characters:
         # - Zero-width chars (U+200B-U+200F, U+FEFF)
         # - Directional overrides (U+202A-U+202E, U+2066-U+2069)
         # - Object replacement (U+FFFC), interlinear annotation (U+FFF9-U+FFFB)
         cleaned = re.sub(
-            r'[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]',
-            '', cleaned,
+            r"[\u200b-\u200f\u2028-\u202e\u2060-\u2069\ufeff\ufffc\ufff9-\ufffb]",
+            "",
+            cleaned,
         )
 
         # Collapse internal whitespace runs and strip
-        cleaned = re.sub(r'\s+', ' ', cleaned).strip()
+        cleaned = re.sub(r"\s+", " ", cleaned).strip()
 
         if not cleaned:
             return None
@@ -9816,9 +9913,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         This records ``user`` provenance, so auto-titling will never replace
         the result. Automatic callers must use :meth:`set_auto_title`.
         """
-        return self._set_session_title(
-            session_id, title, source=self.TITLE_SOURCE_USER
-        )
+        return self._set_session_title(session_id, title, source=self.TITLE_SOURCE_USER)
 
     def set_auto_title(self, session_id: str, title: str, *, source: str) -> bool:
         """Set an automatically generated title, honoring provenance precedence.
@@ -9837,9 +9932,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         by name. New code should call :meth:`set_auto_title` with an explicit
         source.
         """
-        return self.set_auto_title(
-            session_id, title, source=self.TITLE_SOURCE_LLM
-        )
+        return self.set_auto_title(session_id, title, source=self.TITLE_SOURCE_LLM)
 
     def get_session_title(self, session_id: str) -> Optional[str]:
         """Get the title for a session, or None."""
@@ -9931,6 +10024,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         displayed tip lets the still-unarchived root resurrect it on refresh.
         Returns True when at least one row was updated.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -9968,6 +10062,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if rowcount is None or rowcount < 0:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -10040,6 +10135,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         vice-versa) no matter which id the caller holds. Returns True when at
         least one row changed.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -10077,6 +10173,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if rowcount is None or rowcount < 0:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -10094,6 +10191,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         matter which id the caller holds. Returns True when at least one row
         changed.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -10131,6 +10229,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if rowcount is None or rowcount < 0:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -10154,6 +10253,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         tip clears the root (and vice-versa) no matter which id the caller
         holds. Returns True when at least one row changed.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -10191,6 +10291,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if rowcount is None or rowcount < 0:
                 rowcount = conn.execute("SELECT changes()").fetchone()[0]
             return rowcount
+
         rowcount = self._execute_write(_do)
         return rowcount > 0
 
@@ -10258,7 +10359,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         the highest existing number and increments.
         """
         # Strip existing #N suffix to find the true base
-        match = re.match(r'^(.*?) #(\d+)$', base_title)
+        match = re.match(r"^(.*?) #(\d+)$", base_title)
         if match:
             base = match.group(1)
         else:
@@ -10280,7 +10381,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Find the highest number
         max_num = 1  # The unnumbered original counts as #1
         for t in existing:
-            m = re.match(r'^.* #(\d+)$', t)
+            m = re.match(r"^.* #(\d+)$", t)
             if m:
                 max_num = max(max_num, int(m.group(1)))
 
@@ -10352,12 +10453,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     # the projection is derived from SCHEMA_SQL so columns added later via
     # declarative reconciliation are included automatically instead of
     # silently dropping out of list rows.
-    _SESSION_COMPACT_EXCLUDED = frozenset(
-        {"system_prompt", "system_prompt_hash", "git_metadata_generation"}
-    )
+    _SESSION_COMPACT_EXCLUDED = frozenset({
+        "system_prompt",
+        "system_prompt_hash",
+        "git_metadata_generation",
+    })
     _session_compact_cols_sql: Optional[str] = None
 
-    def usage_totals(self, *, min_message_count: int = 1, include_archived: bool = False) -> Dict[str, float]:
+    def usage_totals(
+        self, *, min_message_count: int = 1, include_archived: bool = False
+    ) -> Dict[str, float]:
         """Tokens and spend across this store, as one aggregate.
 
         The sidebar shows a profile's totals beside a page of its sessions, so
@@ -10379,7 +10484,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 SELECT COALESCE(SUM(COALESCE(input_tokens, 0) + COALESCE(output_tokens, 0)), 0),
                        COALESCE(SUM(COALESCE(actual_cost_usd, estimated_cost_usd, 0)), 0)
                   FROM sessions
-                 WHERE {' AND '.join(where)}
+                 WHERE {" AND ".join(where)}
                 """,
                 params,
             ).fetchone()
@@ -10516,11 +10621,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # them with LIMIT/OFFSET — the pinned back-fill reuses the same WHERE.
         base_where_params = list(params)
         prompt_select = (
-            "" if compact_rows
+            ""
+            if compact_rows
             else ", COALESCE(sp.prompt, s.system_prompt) AS _system_prompt_resolved"
         )
         prompt_join = (
-            "" if compact_rows
+            ""
+            if compact_rows
             else "LEFT JOIN system_prompts sp ON sp.hash = s.system_prompt_hash"
         )
 
@@ -10748,9 +10855,19 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # surface the tip's identity and activity data.
                 merged = dict(s)
                 for key in (
-                    "id", "ended_at", "end_reason", "message_count",
-                    "tool_call_count", "title", "last_active", "preview",
-                    "model", "system_prompt", "cwd", "git_branch", "git_repo_root",
+                    "id",
+                    "ended_at",
+                    "end_reason",
+                    "message_count",
+                    "tool_call_count",
+                    "title",
+                    "last_active",
+                    "preview",
+                    "model",
+                    "system_prompt",
+                    "cwd",
+                    "git_branch",
+                    "git_repo_root",
                 ):
                     if key in tip_row:
                         merged[key] = tip_row[key]
@@ -10767,9 +10884,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return sessions
 
-    def session_lifecycle_statuses(
-        self, session_ids: List[str]
-    ) -> Dict[str, str]:
+    def session_lifecycle_statuses(self, session_ids: List[str]) -> Dict[str, str]:
         """Classify each session's lifecycle state from its LAST message row.
 
         Returns ``{session_id: status}`` where status is one of:
@@ -10864,7 +10979,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         """Reverse :meth:`_encode_content`; returns scalars unchanged."""
         if isinstance(content, str) and content.startswith(cls._CONTENT_JSON_PREFIX):
             try:
-                return json.loads(content[len(cls._CONTENT_JSON_PREFIX):])
+                return json.loads(content[len(cls._CONTENT_JSON_PREFIX) :])
             except (json.JSONDecodeError, TypeError):
                 logger.warning(
                     "Failed to decode JSON-encoded message content; "
@@ -10936,15 +11051,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # fence opt-in so ordinary appends retain the watermark behavior.
         if reject_active_compression_lock:
             active_lock = conn.execute(
-                "SELECT holder, expires_at FROM compression_locks "
-                "WHERE session_id = ?",
+                "SELECT holder, expires_at FROM compression_locks WHERE session_id = ?",
                 (session_id,),
             ).fetchone()
             if active_lock is not None:
                 current_holder = active_lock["holder"]
-                if (
-                    float(active_lock["expires_at"]) <= time.time()
-                    or _compression_lock_holder_process_is_dead(current_holder)
+                if float(
+                    active_lock["expires_at"]
+                ) <= time.time() or _compression_lock_holder_process_is_dead(
+                    current_holder
                 ):
                     conn.execute(
                         "DELETE FROM compression_locks "
@@ -10985,10 +11100,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
             elif lease is not None:
                 current_holder = lease["holder"]
-                if (
-                    float(lease["expires_at"]) <= now
-                    or _compression_lock_holder_process_is_dead(current_holder)
-                ):
+                if float(
+                    lease["expires_at"]
+                ) <= now or _compression_lock_holder_process_is_dead(current_holder):
                     # Match acquisition semantics: an expired or provably dead
                     # owner is reclaimable. Deleting it inside this BEGIN IMMEDIATE
                     # transaction also fences a stale late flush after the mutation.
@@ -11133,7 +11247,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 else:
                     message_timestamp = float(timestamp)
             except (TypeError, ValueError):
-                logger.debug("Ignoring invalid explicit message timestamp: %r", timestamp)
+                logger.debug(
+                    "Ignoring invalid explicit message timestamp: %r", timestamp
+                )
 
         # Pre-compute tool call count
         num_tool_calls = 0
@@ -11174,8 +11290,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     1 if observed else 0,
                     1 if _compressed_summary else 0,
                     1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(display_kind) if isinstance(display_kind, str) else None,
+                    _scrub_surrogates(api_content)
+                    if isinstance(api_content, str)
+                    else None,
+                    _scrub_surrogates(display_kind)
+                    if isinstance(display_kind, str)
+                    else None,
                     display_metadata_json,
                 ),
             )
@@ -11200,9 +11320,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # a sibling process legitimately holding the write lock for seconds
         # (VACUUM, TRUNCATE checkpoint at close, an older pre-bounded-merge
         # process's FTS optimize) can't destroy a healthy turn (#74478).
-        return self._execute_write(
-            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
-        )
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 
     def append_messages_batch(
         self,
@@ -11248,7 +11366,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             for start in range(0, len(messages), chunk_rows):
                 inserted_total += self.append_messages_batch(
                     session_id,
-                    messages[start:start + chunk_rows],
+                    messages[start : start + chunk_rows],
                     compression_lock_holder=compression_lock_holder,
                     turn_lease_holder=turn_lease_holder,
                     turn_lease_ttl_seconds=turn_lease_ttl_seconds,
@@ -11281,12 +11399,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             return inserted
 
         # Same criticality as append_message: this IS the turn's transcript.
-        return self._execute_write(
-            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
-        )
+        return self._execute_write(_do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S)
 
     def set_latest_matching_message_display_kind(
-        self, session_id: str, *, role: str, content: str, display_kind: str,
+        self,
+        session_id: str,
+        *,
+        role: str,
+        content: str,
+        display_kind: str,
         display_metadata: Optional[Dict[str, Any]] = None,
     ) -> bool:
         """Stamp presentation metadata on this turn's freshly persisted row.
@@ -11367,12 +11488,16 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             # Tapping the live reaction again retracts it.
             toggling_off = (
-                emoji is not None and previous is not None and previous.get("emoji") == emoji
+                emoji is not None
+                and previous is not None
+                and previous.get("emoji") == emoji
             )
             if emoji and not toggling_off:
-                reactions.append(
-                    {"emoji": _scrub_surrogates(emoji), "author": author, "at": time.time()}
-                )
+                reactions.append({
+                    "emoji": _scrub_surrogates(emoji),
+                    "author": author,
+                    "at": time.time(),
+                })
 
             if reactions:
                 meta[self.REACTIONS_METADATA_KEY] = reactions
@@ -11406,7 +11531,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         meta = self._decode_display_metadata(row[0]) or {}
         reactions = meta.get(self.REACTIONS_METADATA_KEY)
 
-        return [r for r in reactions if isinstance(r, dict)] if isinstance(reactions, list) else []
+        return (
+            [r for r in reactions if isinstance(r, dict)]
+            if isinstance(reactions, list)
+            else []
+        )
 
     def take_unseen_reactions(
         self, session_id: str, *, author: str = "user"
@@ -11448,14 +11577,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     reaction["seen"] = True
                     changed = True
                     content = self._decode_content(row["content"])
-                    pending.append(
-                        {
-                            "row_id": row["id"],
-                            "role": row["role"],
-                            "emoji": reaction.get("emoji") or "",
-                            "text": content if isinstance(content, str) else "",
-                        }
-                    )
+                    pending.append({
+                        "row_id": row["id"],
+                        "role": row["role"],
+                        "emoji": reaction.get("emoji") or "",
+                        "text": content if isinstance(content, str) else "",
+                    })
 
                 if changed:
                     conn.execute(
@@ -11468,7 +11595,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._execute_write(_do) or []
 
     def latest_message_row_id(
-        self, session_id: str, *, role: str = "user", offset: int = 0, require_text: bool = True
+        self,
+        session_id: str,
+        *,
+        role: str = "user",
+        offset: int = 0,
+        require_text: bool = True,
     ) -> Optional[int]:
         """Row id of the most recent active message with *role*, or ``None``.
 
@@ -11527,7 +11659,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         return row[0] if row else None
 
-    def _insert_message_rows(self, conn, session_id: str, messages: List[Dict[str, Any]]) -> tuple[int, int]:
+    def _insert_message_rows(
+        self, conn, session_id: str, messages: List[Dict[str, Any]]
+    ) -> tuple[int, int]:
         """Insert *messages* as fresh active rows for *session_id*.
 
         Shared by :meth:`replace_messages` (delete-then-insert) and
@@ -11551,8 +11685,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     else:
                         message_timestamp = float(ts_value)
                 except (TypeError, ValueError):
-                    logger.debug("Ignoring invalid explicit message timestamp: %r", msg.get("timestamp"))
-            reasoning_details = msg.get("reasoning_details") if role == "assistant" else None
+                    logger.debug(
+                        "Ignoring invalid explicit message timestamp: %r",
+                        msg.get("timestamp"),
+                    )
+            reasoning_details = (
+                msg.get("reasoning_details") if role == "assistant" else None
+            )
             codex_reasoning_items = (
                 msg.get("codex_reasoning_items") if role == "assistant" else None
             )
@@ -11574,9 +11713,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             tool_calls_json = json.dumps(tool_calls) if tool_calls else None
             # Accept either `platform_message_id` (new explicit name) or
             # `message_id` (yuanbao's existing convention on message dicts).
-            platform_msg_id = (
-                msg.get("platform_message_id") or msg.get("message_id")
-            )
+            platform_msg_id = msg.get("platform_message_id") or msg.get("message_id")
 
             api_content = msg.get("api_content")
 
@@ -11597,8 +11734,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     message_timestamp,
                     msg.get("token_count"),
                     msg.get("finish_reason"),
-                    _scrub_surrogates(msg.get("reasoning")) if role == "assistant" else None,
-                    _scrub_surrogates(msg.get("reasoning_content")) if role == "assistant" else None,
+                    _scrub_surrogates(msg.get("reasoning"))
+                    if role == "assistant"
+                    else None,
+                    _scrub_surrogates(msg.get("reasoning_content"))
+                    if role == "assistant"
+                    else None,
                     reasoning_details_json,
                     codex_items_json,
                     codex_message_items_json,
@@ -11606,8 +11747,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     1 if msg.get("observed") else 0,
                     1 if msg.get("_compressed_summary") else 0,
                     1,
-                    _scrub_surrogates(api_content) if isinstance(api_content, str) else None,
-                    _scrub_surrogates(msg.get("display_kind")) if isinstance(msg.get("display_kind"), str) else None,
+                    _scrub_surrogates(api_content)
+                    if isinstance(api_content, str)
+                    else None,
+                    _scrub_surrogates(msg.get("display_kind"))
+                    if isinstance(msg.get("display_kind"), str)
+                    else None,
                     self._encode_display_metadata(msg.get("display_metadata")),
                 ),
             )
@@ -11850,7 +11995,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     if raw:
                         try:
                             parsed = json.loads(raw) if isinstance(raw, str) else raw
-                            tail_tool_calls += len(parsed) if isinstance(parsed, list) else 0
+                            tail_tool_calls += (
+                                len(parsed) if isinstance(parsed, list) else 0
+                            )
                         except (TypeError, ValueError):
                             pass
 
@@ -11876,7 +12023,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # field drift — new id, active=1, compacted=0, all else exact.
                 placeholders = ",".join("?" for _ in tail_ids)
                 clone_cols = [
-                    c for c in self._message_column_names(conn)
+                    c
+                    for c in self._message_column_names(conn)
                     if c not in ("id", "active", "compacted")
                 ]
                 col_list = ", ".join(clone_cols)
@@ -11991,7 +12139,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if after_id is not None and (latest or offset):
             raise ValueError("after_id is incompatible with latest/offset paging")
         if after_id is not None and include_compacted:
-            raise ValueError("after_id is incompatible with include_compacted (deduped display reads use offset paging)")
+            raise ValueError(
+                "after_id is incompatible with include_compacted (deduped display reads use offset paging)"
+            )
         if include_inactive:
             # Audit / debug reads: every row, including soft-deleted.
             active_clause = ""
@@ -12021,7 +12171,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             # then apply paging.
             with self._read_ctx() as conn:
                 cursor = conn.execute(
-                    "SELECT * FROM messages WHERE session_id = ?" + active_clause
+                    "SELECT * FROM messages WHERE session_id = ?"
+                    + active_clause
                     + " ORDER BY id ASC",
                     [session_id],
                 )
@@ -12042,9 +12193,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     }
                     handoff, live_view = split_user_originated_turn(candidate)
                     if handoff is not None and live_view is not None:
-                        dedupe_content = self._encode_content(
-                            live_view.get("content")
-                        )
+                        dedupe_content = self._encode_content(live_view.get("content"))
                 # Tool fields participate in the dedupe key: compaction copies
                 # them verbatim, so identical tool messages across generations
                 # still collapse, while distinct tool calls that happen to
@@ -12058,7 +12207,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     row["tool_name"],
                 )
                 cur = seen.get(key)
-                if cur is None or (row["active"], row["id"]) > (cur["active"], cur["id"]):
+                if cur is None or (row["active"], row["id"]) > (
+                    cur["active"],
+                    cur["id"],
+                ):
                     seen[key] = row
             rows = sorted(seen.values(), key=lambda r: r["id"])
             if latest:
@@ -12089,10 +12241,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 try:
                     msg["tool_calls"] = json.loads(msg["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in get_messages, falling back to []")
+                    logger.warning(
+                        "Failed to deserialize tool_calls in get_messages, falling back to []"
+                    )
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"]
+                )
             result.append(msg)
         return result
 
@@ -12188,7 +12344,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     msg["tool_calls"] = []
             if msg.get("display_metadata") is not None:
-                msg["display_metadata"] = self._decode_display_metadata(msg["display_metadata"])
+                msg["display_metadata"] = self._decode_display_metadata(
+                    msg["display_metadata"]
+                )
             result.append(msg)
 
         # before_rows includes the anchor itself; subtract 1 for the count of
@@ -12287,7 +12445,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     return session_id
                 if child_row is None:
                     break
-                child_id = child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                child_id = (
+                    child_row["id"] if hasattr(child_row, "keys") else child_row[0]
+                )
                 if not child_id or child_id in seen:
                     break
                 seen.add(child_id)
@@ -12438,7 +12598,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 try:
                     msg["tool_calls"] = json.loads(row["tool_calls"])
                 except (json.JSONDecodeError, TypeError):
-                    logger.warning("Failed to deserialize tool_calls in conversation replay, falling back to []")
+                    logger.warning(
+                        "Failed to deserialize tool_calls in conversation replay, falling back to []"
+                    )
                     msg["tool_calls"] = []
             # Surface the platform-side message id (e.g. yuanbao msg_id,
             # telegram update_id) so platform-specific flows like recall
@@ -12463,19 +12625,29 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     try:
                         msg["reasoning_details"] = json.loads(row["reasoning_details"])
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize reasoning_details, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize reasoning_details, falling back to None"
+                        )
                         msg["reasoning_details"] = None
                 if row["codex_reasoning_items"]:
                     try:
-                        msg["codex_reasoning_items"] = json.loads(row["codex_reasoning_items"])
+                        msg["codex_reasoning_items"] = json.loads(
+                            row["codex_reasoning_items"]
+                        )
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize codex_reasoning_items, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize codex_reasoning_items, falling back to None"
+                        )
                         msg["codex_reasoning_items"] = None
                 if row["codex_message_items"]:
                     try:
-                        msg["codex_message_items"] = json.loads(row["codex_message_items"])
+                        msg["codex_message_items"] = json.loads(
+                            row["codex_message_items"]
+                        )
                     except (json.JSONDecodeError, TypeError):
-                        logger.warning("Failed to deserialize codex_message_items, falling back to None")
+                        logger.warning(
+                            "Failed to deserialize codex_message_items, falling back to None"
+                        )
                         msg["codex_message_items"] = None
             if include_ancestors:
                 canonical_content, _is_composite = (
@@ -12777,7 +12949,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not raw_config:
             return False
         try:
-            config = json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+            config = (
+                json.loads(raw_config) if isinstance(raw_config, str) else raw_config
+            )
         except (json.JSONDecodeError, TypeError):
             return False
         return isinstance(config, dict) and bool(config.get("_branched_from"))
@@ -12794,7 +12968,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns *session_id* unchanged when it has no recorded parent.
         """
         chain = self._session_lineage_root_to_tip(session_id)
-        return (chain[0] if chain and chain[0] else session_id)
+        return chain[0] if chain and chain[0] else session_id
 
     def _session_lineage_root_to_tip(self, session_id: str) -> List[str]:
         if not session_id:
@@ -12881,12 +13055,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     SessionDB._canonical_replayed_user_content(prev)
                 )
                 if prev_content == content and (
-                    prefer_current
-                    or prev_is_composite
-                    or isinstance(content, str)
+                    prefer_current or prev_is_composite or isinstance(content, str)
                 ):
                     return index, prefer_current
-            if prev.get("role") == "assistant" and (prev.get("content") or prev.get("tool_calls")):
+            if prev.get("role") == "assistant" and (
+                prev.get("content") or prev.get("tool_calls")
+            ):
                 return None
         return None
 
@@ -12894,7 +13068,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _is_duplicate_replayed_user_message(
         messages: List[Dict[str, Any]], msg: Dict[str, Any]
     ) -> bool:
-        return SessionDB._find_duplicate_replayed_user_message(messages, msg) is not None
+        return (
+            SessionDB._find_duplicate_replayed_user_message(messages, msg) is not None
+        )
 
     # =========================================================================
     # Rewind (soft-delete) — see /rewind slash command + issue #21910
@@ -12920,8 +13096,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
     def _active_transcript_counts(conn, session_id: str) -> tuple[int, int]:
         """Return active message/tool-call counts inside the caller's txn."""
         rows = conn.execute(
-            "SELECT tool_calls FROM messages "
-            "WHERE session_id = ? AND active = 1",
+            "SELECT tool_calls FROM messages WHERE session_id = ? AND active = 1",
             (session_id,),
         ).fetchall()
         tool_call_count = 0
@@ -13091,13 +13266,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "SELECT MAX(id) FROM messages WHERE session_id = ? AND active = 1",
                 (session_id,),
             ).fetchone()
-            new_head_id = (
-                head_row[0] if head_row and head_row[0] is not None else None
-            )
+            new_head_id = head_row[0] if head_row and head_row[0] is not None else None
             return target_row, ids, new_head_id, replacement_message_id
 
-        target_row, rewound, new_head_id, replacement_message_id = (
-            self._execute_write(_do)
+        target_row, rewound, new_head_id, replacement_message_id = self._execute_write(
+            _do
         )
 
         # Decode content for callers (prefill the prompt buffer) without a
@@ -13120,6 +13293,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Intended for undo-of-rewind and test cleanup; not wired to a
         slash command in v1.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 "SELECT id FROM messages "
@@ -13248,7 +13422,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
 
         with self._lock:
-            cursor = self._conn.execute(f"SELECT COUNT(*) FROM sessions s{where_sql}", params)
+            cursor = self._conn.execute(
+                f"SELECT COUNT(*) FROM sessions s{where_sql}", params
+            )
             return cursor.fetchone()[0]
 
     def session_count_ge(self, n: int = 1) -> bool:
@@ -13429,14 +13605,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     def clear_messages(self, session_id: str) -> None:
         """Delete all messages for a session and reset its counters."""
+
         def _do(conn):
-            conn.execute(
-                "DELETE FROM messages WHERE session_id = ?", (session_id,)
-            )
+            conn.execute("DELETE FROM messages WHERE session_id = ?", (session_id,))
             conn.execute(
                 "UPDATE sessions SET message_count = 0, tool_call_count = 0 WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     @staticmethod
@@ -13561,6 +13737,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         spawned work is not "empty" even if its own transcript never
         flushed. Returns True if the session was deleted.
         """
+
         def _do(conn):
             cursor = conn.execute(
                 """
@@ -13768,9 +13945,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # message rows — but a row inserted between the SELECT and
                 # this statement would otherwise be left dangling, so we
                 # still leave a clean FK state.
-                conn.execute(
-                    "DELETE FROM messages WHERE session_id = ?", (sid,)
-                )
+                conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
                 conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
                 removed_ids.append(sid)
             self._delete_unreferenced_system_prompts(conn)
@@ -13901,14 +14076,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
             params.append(max_tokens)
         if min_cost is not None:
-            clauses.append(
-                "COALESCE(s.actual_cost_usd, s.estimated_cost_usd, 0) >= ?"
-            )
+            clauses.append("COALESCE(s.actual_cost_usd, s.estimated_cost_usd, 0) >= ?")
             params.append(min_cost)
         if max_cost is not None:
-            clauses.append(
-                "COALESCE(s.actual_cost_usd, s.estimated_cost_usd, 0) <= ?"
-            )
+            clauses.append("COALESCE(s.actual_cost_usd, s.estimated_cost_usd, 0) <= ?")
             params.append(max_cost)
         if min_tool_calls is not None:
             clauses.append("COALESCE(s.tool_call_count, 0) >= ?")
@@ -13939,9 +14110,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             and filters.get("started_before") is None
             and older_than_days is not None
         ):
-            filters["last_active_before"] = time.time() - (
-                older_than_days * 86400
-            )
+            filters["last_active_before"] = time.time() - (older_than_days * 86400)
 
     def list_prune_candidates(
         self,
@@ -14015,7 +14184,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ended_guard = "s.ended_at IS NOT NULL"
         if not where.startswith(ended_guard):
             raise RuntimeError("prune filter lost its ended-session safety guard")
-        open_where = f"s.ended_at IS NULL{where[len(ended_guard):]}"
+        open_where = f"s.ended_at IS NULL{where[len(ended_guard) :]}"
         with self._lock:
             cursor = self._conn.execute(
                 f"SELECT COUNT(*) FROM sessions s WHERE {open_where}", params
@@ -14214,7 +14383,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             affected: List[int] = []
             for row in cursor.fetchall():
                 content = row["content"]
-                if isinstance(content, str) and _STALE_TOOL_CALL_MARKER_RE.fullmatch(content.strip()):
+                if isinstance(content, str) and _STALE_TOOL_CALL_MARKER_RE.fullmatch(
+                    content.strip()
+                ):
                     affected.append(row["id"])
             return affected
 
@@ -14248,7 +14419,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             with self._lock:
                 self._conn.execute("VACUUM INTO ?", (str(dest),))
             backup_path = str(dest)
-            logger.info("Backed up state.db to %s before clean-markers write", backup_path)
+            logger.info(
+                "Backed up state.db to %s before clean-markers write", backup_path
+            )
 
         def _do(conn):
             ids = _find_affected(conn)
@@ -14316,6 +14489,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 (key, value),
             )
+
         self._execute_write(_do)
 
     def retag_kanban_worker_sessions(self, workspaces_root: str) -> int:
@@ -14384,6 +14558,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
           v2 — session_id FK gets ON DELETE CASCADE so session pruning
                automatically clears bindings.
         """
+
         def _do(conn):
             conn.executescript(
                 """
@@ -14427,7 +14602,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "SELECT value FROM state_meta WHERE key = ?",
                 ("telegram_dm_topic_schema_version",),
             ).fetchone()
-            current_version = int(current[0]) if current and str(current[0]).isdigit() else 0
+            current_version = (
+                int(current[0]) if current and str(current[0]).isdigit() else 0
+            )
             if current_version < 2:
                 fk_rows = conn.execute(
                     "PRAGMA foreign_key_list('telegram_dm_topic_bindings')"
@@ -14469,6 +14646,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
                 ("telegram_dm_topic_schema_version", "2"),
             )
+
         self._execute_write(_do)
 
     def enable_telegram_topic_mode(
@@ -14518,6 +14696,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     now,
                 ),
             )
+
         self._execute_write(_do)
 
     def disable_telegram_topic_mode(
@@ -14536,6 +14715,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Never creates the topic-mode tables from scratch; if they don't
         exist there is nothing to disable and the call is a no-op.
         """
+
         def _do(conn):
             try:
                 conn.execute(
@@ -14551,6 +14731,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             except sqlite3.OperationalError:
                 # Tables don't exist yet — nothing to disable.
                 return
+
         self._execute_write(_do)
 
     def is_telegram_topic_mode_enabled(self, *, chat_id: str, user_id: str) -> bool:
@@ -14746,10 +14927,20 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             ).fetchone()
             if existing_session is not None:
-                linked_chat = existing_session["chat_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[0]
-                linked_thread = existing_session["thread_id"] if isinstance(existing_session, sqlite3.Row) else existing_session[1]
+                linked_chat = (
+                    existing_session["chat_id"]
+                    if isinstance(existing_session, sqlite3.Row)
+                    else existing_session[0]
+                )
+                linked_thread = (
+                    existing_session["thread_id"]
+                    if isinstance(existing_session, sqlite3.Row)
+                    else existing_session[1]
+                )
                 if str(linked_chat) != chat_id or str(linked_thread) != thread_id:
-                    raise ValueError("session is already linked to another Telegram topic")
+                    raise ValueError(
+                        "session is already linked to another Telegram topic"
+                    )
 
             conn.execute(
                 """
@@ -14775,6 +14966,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     now,
                 ),
             )
+
         self._execute_write(_do)
 
     def is_telegram_session_linked_to_topic(self, *, session_id: str) -> bool:
@@ -15028,7 +15220,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             vacuum_due = True
             if last_vacuum_raw:
                 try:
-                    vacuum_due = (now - float(last_vacuum_raw)) >= min_vacuum_interval_days * 86400
+                    vacuum_due = (
+                        now - float(last_vacuum_raw)
+                    ) >= min_vacuum_interval_days * 86400
                 except (TypeError, ValueError):
                     vacuum_due = True
             if vacuum and pruned > 0 and vacuum_due:
@@ -15128,6 +15322,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns True if the row was found and not already in flight; False if
         the session is already in a non-terminal handoff state.
         """
+
         def _do(conn):
             cur = conn.execute(
                 "UPDATE sessions "
@@ -15139,6 +15334,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (platform, session_id),
             )
             return cur.rowcount > 0
+
         return self._execute_write(_do)
 
     def get_handoff_state(self, session_id: str) -> Optional[Dict[str, Any]]:
@@ -15184,6 +15380,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
     def claim_handoff(self, session_id: str) -> bool:
         """Atomically transition pending → running. Returns True if claimed."""
+
         def _do(conn):
             cur = conn.execute(
                 "UPDATE sessions SET handoff_state = 'running' "
@@ -15191,26 +15388,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             )
             return cur.rowcount > 0
+
         return self._execute_write(_do)
 
     def complete_handoff(self, session_id: str) -> None:
         """Mark a handoff as completed."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET handoff_state = 'completed', "
                 "handoff_error = NULL WHERE id = ?",
                 (session_id,),
             )
+
         self._execute_write(_do)
 
     def fail_handoff(self, session_id: str, error: str) -> None:
         """Mark a handoff as failed and record the reason."""
+
         def _do(conn):
             conn.execute(
                 "UPDATE sessions SET handoff_state = 'failed', "
                 "handoff_error = ? WHERE id = ?",
                 (error[:500], session_id),
             )
+
         self._execute_write(_do)
 
 

--- a/tests/agent/test_compression_review_76354.py
+++ b/tests/agent/test_compression_review_76354.py
@@ -228,8 +228,7 @@ class TestF2HostUnwindRevokesAdmission:
         fence = fence_box["fence"]
         assert not release.is_set()
         assert fence.is_cancelled, (
-            "host unwind must revoke commit admission while the worker "
-            "is still running"
+            "host unwind must revoke commit admission while the worker is still running"
         )
         # Now release the worker and prove its commit was refused.
         release.set()
@@ -237,8 +236,7 @@ class TestF2HostUnwindRevokesAdmission:
         while time.time() < deadline and "value" not in commit_admitted:
             time.sleep(0.01)
         assert commit_admitted.get("value") is False, (
-            "a worker surviving a host unwind must be denied the commit "
-            "boundary"
+            "a worker surviving a host unwind must be denied the commit boundary"
         )
         _drain_admission_slots()
 
@@ -318,6 +316,7 @@ class TestF6ExecutorSaturation:
                 return ([], "5th")
 
             fifth_msgs = [{"role": "user", "content": "fifth"}]
+
             # Round-2 #6: the fail-fast refusal must emit the standard
             # compression-attempt telemetry with failure_class=pool_saturated.
             class _TelemetryAgent:
@@ -340,9 +339,7 @@ class TestF6ExecutorSaturation:
                 def emit(self, record):
                     msg = record.getMessage()
                     if "compression attempt telemetry" in msg:
-                        self.payloads.append(
-                            _json.loads(msg.split(": ", 1)[1])
-                        )
+                        self.payloads.append(_json.loads(msg.split(": ", 1)[1]))
 
             capture = _CaptureHandler()
             _prev_level = cc.logger.level
@@ -371,7 +368,8 @@ class TestF6ExecutorSaturation:
             assert prompt == "fifth-fallback"
             assert not fifth_ran.is_set()
             saturated = [
-                p for p in capture.payloads
+                p
+                for p in capture.payloads
                 if p.get("failure_class") == "pool_saturated"
             ]
             assert saturated, (
@@ -460,16 +458,17 @@ class TestS3IdleChargedFromLastProgress:
     def test_silence_cannot_approach_double_idle_timeout(self):
         """Progress early in an interval must not extend silence to ~2x idle."""
         _drain_admission_slots()
-        idle = 0.4
+        idle = 1.0
         release = threading.Event()
+        progress_at: list[float] = []
 
         def worker(fence: CompressionCommitFence):
             time.sleep(0.05)
             fence.touch_progress()  # early progress, then total silence
+            progress_at.append(time.monotonic())
             assert release.wait(timeout=10)
             return ([], "late")
 
-        t0 = time.monotonic()
         try:
             msgs, prompt = run_compress_context_with_progress_timeout(
                 worker=worker,
@@ -479,12 +478,12 @@ class TestS3IdleChargedFromLastProgress:
                 total_ceiling_seconds=5.0,
             )
         finally:
-            elapsed = time.monotonic() - t0
+            elapsed = time.monotonic() - progress_at[0]
             release.set()
         assert prompt == "fb"
         # Old behavior waited a full interval from the CHECK (~2x idle ≈
-        # 0.85s+). New behavior times out ~idle after the last progress
-        # (~0.45s). Allow generous slack while still excluding ~2x.
+        # 2.05s+). New behavior times out ~idle after the last progress
+        # (~1.05s). Allow generous scheduler slack while still excluding ~2x.
         assert elapsed < idle * 1.8, (
             f"silence exceeded ~2x idle budget shape: {elapsed:.2f}s"
         )
@@ -507,14 +506,10 @@ class TestRound2MidCommitLeaseRelease:
         session_id = "R2_MID_COMMIT_LEASE"
         db.create_session(session_id, source="cli")
         holder = "pid:worker:original"
-        assert db.try_acquire_compression_lock(
-            session_id, holder, ttl_seconds=60
-        )
+        assert db.try_acquire_compression_lock(session_id, holder, ttl_seconds=60)
         return db, session_id, holder
 
-    def test_revoke_during_in_flight_commit_defers_lease_release(
-        self, tmp_path
-    ):
+    def test_revoke_during_in_flight_commit_defers_lease_release(self, tmp_path):
         """Event-gated fake commit; assertions run WHILE it is blocked."""
         db, session_id, holder = self._db_with_lease(tmp_path)
         fence = CompressionCommitFence()
@@ -551,10 +546,7 @@ class TestRound2MidCommitLeaseRelease:
         )
         assert not db.try_acquire_compression_lock(
             session_id, "pid:second:contender", ttl_seconds=60
-        ), (
-            "a second compressor acquired the durable lock DURING an "
-            "admitted commit"
-        )
+        ), "a second compressor acquired the durable lock DURING an admitted commit"
 
         # ── Release the commit; deferred release must fire promptly ──────
         release_commit.set()

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -299,6 +299,35 @@ def test_applies_agent_side_effects():
     assert agent._current_turn_id
 
 
+def test_user_message_persisted_callback_runs_after_successful_persistence():
+    """Attached clients may refresh only after the inbound row is durable."""
+    agent = _FakeAgent()
+    order: list[str] = []
+
+    def persist(*_args, **_kwargs):
+        order.append("persisted")
+        agent._persist_calls += 1
+
+    agent._persist_session = persist
+    agent._on_user_message_persisted = lambda: order.append("notified")
+
+    _build(agent)
+
+    assert order == ["persisted", "notified"]
+
+
+def test_user_message_persisted_callback_skips_failed_persistence():
+    """A refresh event must never race ahead of a row that failed to commit."""
+    agent = _FakeAgent()
+    notified = MagicMock()
+    agent._on_user_message_persisted = notified
+    agent._persist_session = MagicMock(side_effect=RuntimeError("disk unavailable"))
+
+    _build(agent)
+
+    notified.assert_not_called()
+
+
 
 
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -304,9 +304,10 @@ def test_user_message_persisted_callback_runs_after_successful_persistence():
     agent = _FakeAgent()
     order: list[str] = []
 
-    def persist(*_args, **_kwargs):
+    def persist(messages, *_args, **_kwargs):
         order.append("persisted")
         agent._persist_calls += 1
+        messages[-1]["_db_persisted"] = True
 
     agent._persist_session = persist
     agent._on_user_message_persisted = lambda: order.append("notified")
@@ -325,6 +326,20 @@ def test_user_message_persisted_callback_skips_failed_persistence():
 
     _build(agent)
 
+    notified.assert_not_called()
+
+
+def test_user_message_persisted_callback_skips_swallowed_persistence_failure():
+    """A normal return without the durable marker must remain fail-closed."""
+    agent = _FakeAgent()
+    notified = MagicMock()
+    agent._on_user_message_persisted = notified
+    # The real persistence stack may swallow DB failures and return normally.
+    agent._persist_session = MagicMock(return_value=None)
+
+    ctx = _build(agent)
+
+    assert ctx.messages[-1].get("_db_persisted") is not True
     notified.assert_not_called()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -548,6 +548,7 @@ def _hermetic_environment(tmp_path, monkeypatch):
     #    singleton might still be cached from a previous test).
     try:
         import hermes_cli.plugins as _plugins_mod
+
         monkeypatch.setattr(_plugins_mod, "_plugin_manager", None)
         # Also clear the keyed per-home manager cache (and any plugin
         # submodules it left in sys.modules) so a manager built for a
@@ -676,6 +677,7 @@ def _capture_real_kanban_root() -> Path:
         # honor it via the normal resolver (it may be a profile dir whose
         # root matters).
         from hermes_constants import get_default_hermes_root
+
         return get_default_hermes_root().resolve()
     # No pre-existing HERMES_HOME: the real root is the platform default,
     # NOT the sandbox tempdir now sitting in the env.
@@ -720,9 +722,7 @@ def _kanban_write_guard(_hermetic_environment, monkeypatch):
             resolved = Path(db_path).expanduser().resolve()
         else:
             resolved = (
-                _kdb.kanban_db_path(board=kwargs.get("board"))
-                .expanduser()
-                .resolve()
+                _kdb.kanban_db_path(board=kwargs.get("board")).expanduser().resolve()
             )
         try:
             resolved.relative_to(_REAL_KANBAN_ROOT)
@@ -769,12 +769,8 @@ def _state_db_write_guard(request, monkeypatch):
     if _PRE_SANDBOX_HERMES_HOME and not _hermes_home_points_at_production(
         _PRE_SANDBOX_HERMES_HOME
     ):
-        extra_roots.append(
-            Path(_PRE_SANDBOX_HERMES_HOME).expanduser().resolve()
-        )
-    monkeypatch.setattr(
-        _hs, "_STATE_DB_GUARD_EXTRA_DENY_ROOTS", tuple(extra_roots)
-    )
+        extra_roots.append(Path(_PRE_SANDBOX_HERMES_HOME).expanduser().resolve())
+    monkeypatch.setattr(_hs, "_STATE_DB_GUARD_EXTRA_DENY_ROOTS", tuple(extra_roots))
     yield
 
 
@@ -892,6 +888,29 @@ def _reset_tui_gateway_server_state():
             set_hermes_home_override(None)
     except Exception:
         pass
+
+
+# ── auxiliary runtime context isolation ─────────────────────────────────────
+#
+# The canonical parallel runner gives every test file a fresh interpreter, but
+# a direct ``pytest`` invocation shares ContextVars across files. A test that
+# exercises a live AIAgent turn can otherwise leave its main provider bound for
+# an unrelated provider-resolution test collected later.
+
+
+@pytest.fixture(autouse=True)
+def _reset_auxiliary_runtime_context():
+    mod = sys.modules.get("agent.auxiliary_client")
+    clear = getattr(mod, "clear_runtime_main", None) if mod is not None else None
+    if callable(clear):
+        clear()
+
+    yield
+
+    mod = sys.modules.get("agent.auxiliary_client")
+    clear = getattr(mod, "clear_runtime_main", None) if mod is not None else None
+    if callable(clear):
+        clear()
 
 
 @pytest.fixture()
@@ -1192,7 +1211,10 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
     # raises AttributeError at timer setup and the whole run aborts before any
     # test executes. Fall back to the thread-based timer on Windows so the
     # suite runs natively there (POSIX keeps the more reliable signal method).
-    if sys.platform == "win32" and getattr(config.option, "timeout_method", None) == "signal":
+    if (
+        sys.platform == "win32"
+        and getattr(config.option, "timeout_method", None) == "signal"
+    ):
         config.option.timeout_method = "thread"
 
 
@@ -1322,6 +1344,7 @@ def _live_system_guard(request, monkeypatch):
     # the live psutil walk below. Static set keeps the fast path cheap.
     try:
         import psutil as _psutil
+
         _initial_children = {
             c.pid for c in _psutil.Process(test_pid).children(recursive=True)
         }
@@ -1413,16 +1436,38 @@ def _live_system_guard(request, monkeypatch):
         "hermes gateway",
     )
     _MUTATING_VERBS = (
-        "restart", "start", "stop", "kill", "reload",
-        "reset-failed", "enable", "disable", "mask", "unmask",
-        "daemon-reload", "try-restart", "reload-or-restart",
+        "restart",
+        "start",
+        "stop",
+        "kill",
+        "reload",
+        "reset-failed",
+        "enable",
+        "disable",
+        "mask",
+        "unmask",
+        "daemon-reload",
+        "try-restart",
+        "reload-or-restart",
     )
     _PROCESS_KILLERS = ("pkill", "killall", "taskkill", "skill", "fuser")
     # Shell/launcher executables whose arguments are themselves commands —
     # argv[0]-only scanning must not exempt what they wrap.
     _WRAPPER_COMMANDS = (
-        "sh", "bash", "zsh", "dash", "env", "nohup", "setsid",
-        "timeout", "sudo", "xargs", "nice", "ionice", "stdbuf", "flock",
+        "sh",
+        "bash",
+        "zsh",
+        "dash",
+        "env",
+        "nohup",
+        "setsid",
+        "timeout",
+        "sudo",
+        "xargs",
+        "nice",
+        "ionice",
+        "stdbuf",
+        "flock",
     )
 
     def _cmd_to_string(cmd) -> str:
@@ -1548,6 +1593,7 @@ def _live_system_guard(request, monkeypatch):
         def _guarded(cmd, *args, **kwargs):
             _check_subprocess_cmd(name, cmd)
             return real(cmd, *args, **kwargs)
+
         _guarded.__name__ = f"_guarded_{name}"
         # Make the wrapper subscriptable like the wrapped callable when
         # the wrapped object is. ``subprocess.Popen[bytes]`` is used as
@@ -1617,6 +1663,7 @@ def _live_system_guard(request, monkeypatch):
     # pty.spawn — POSIX-only.
     try:
         import pty as _pty
+
         if hasattr(_pty, "spawn"):
             real_pty_spawn = _pty.spawn
 
@@ -1631,13 +1678,12 @@ def _live_system_guard(request, monkeypatch):
     # asyncio.create_subprocess_* — bypasses subprocess module entirely.
     try:
         import asyncio as _asyncio
+
         real_async_exec = _asyncio.create_subprocess_exec
         real_async_shell = _asyncio.create_subprocess_shell
 
         async def _guarded_async_exec(program, *args, **kwargs):
-            _check_subprocess_cmd(
-                "asyncio.create_subprocess_exec", [program, *args]
-            )
+            _check_subprocess_cmd("asyncio.create_subprocess_exec", [program, *args])
             return await real_async_exec(program, *args, **kwargs)
 
         async def _guarded_async_shell(cmd, *args, **kwargs):
@@ -1645,9 +1691,7 @@ def _live_system_guard(request, monkeypatch):
             return await real_async_shell(cmd, *args, **kwargs)
 
         monkeypatch.setattr(_asyncio, "create_subprocess_exec", _guarded_async_exec)
-        monkeypatch.setattr(
-            _asyncio, "create_subprocess_shell", _guarded_async_shell
-        )
+        monkeypatch.setattr(_asyncio, "create_subprocess_shell", _guarded_async_shell)
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_dashboard_auth_password_login.py
+++ b/tests/hermes_cli/test_dashboard_auth_password_login.py
@@ -206,7 +206,7 @@ class TestProviderListFlag:
         login = gated_app.get(resp.headers["location"])
         assert login.status_code == 200
         assert '<form class="provider-form" data-provider="testpw"' in login.text
-        assert "/auth/password-login" in login.text
+        assert "fetch('auth/password-login'" in login.text
 
 
     def test_oauth_provider_reports_false(self):
@@ -354,7 +354,8 @@ class TestLoginPageRender:
             assert 'name="password"' in html
             assert 'value="/sessions"' in html
             assert "<script>" in html
-            assert "/auth/password-login" in html
+            assert "fetch('auth/password-login'" in html
+            assert "fetch('/auth/password-login'" not in html
         finally:
             clear_providers()
 

--- a/tests/hermes_cli/test_live_runtime_owners.py
+++ b/tests/hermes_cli/test_live_runtime_owners.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+import multiprocessing
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import live_runtime_owners as owners
+
+
+def _claim_in_subprocess(home: str, owner_id: str, results, release) -> None:
+    from hermes_cli.live_runtime_owners import claim_runtime_owner
+
+    result = claim_runtime_owner(
+        conversation_key="raced-conversation-root",
+        owner_id=owner_id,
+        endpoint=f"/tmp/{owner_id}.sock",
+        surface="test",
+        registry_home=home,
+    )
+    results.put((result.kind, result.owner.owner_id, result.owner.generation))
+    release.wait(timeout=10)
+
+
+def _claim(home: Path, *, owner_id: str, endpoint: str = "/tmp/runtime.sock"):
+    return owners.claim_runtime_owner(
+        conversation_key="conversation-root",
+        owner_id=owner_id,
+        endpoint=endpoint,
+        surface="test",
+        registry_home=home,
+    )
+
+
+def test_same_conversation_key_has_exactly_one_cross_process_owner(tmp_path):
+    context = multiprocessing.get_context("spawn")
+    results = context.Queue()
+    release = context.Event()
+    processes = [
+        context.Process(
+            target=_claim_in_subprocess,
+            args=(str(tmp_path), f"owner-{index}", results, release),
+        )
+        for index in range(6)
+    ]
+    try:
+        for process in processes:
+            process.start()
+        claims = [results.get(timeout=15) for _ in processes]
+
+        owned = [claim for claim in claims if claim[0] == "owned"]
+        remote = [claim for claim in claims if claim[0] == "remote"]
+        assert len(owned) == 1
+        assert len(remote) == 5
+        assert {claim[1:] for claim in claims} == {owned[0][1:]}
+    finally:
+        release.set()
+        for process in processes:
+            process.join(timeout=10)
+            if process.is_alive():
+                process.terminate()
+                process.join(timeout=5)
+        results.close()
+
+
+def test_live_conversation_key_has_exactly_one_owner(tmp_path):
+    first = _claim(tmp_path, owner_id="owner-a", endpoint="/tmp/a.sock")
+    second = _claim(tmp_path, owner_id="owner-b", endpoint="/tmp/b.sock")
+
+    assert first.kind == "owned"
+    assert first.lease is not None
+    assert first.owner.owner_id == "owner-a"
+    assert first.owner.generation == 1
+    assert second.kind == "remote"
+    assert second.lease is None
+    assert second.owner == first.owner
+
+
+def test_dead_owner_is_reclaimed_with_incremented_generation(tmp_path, monkeypatch):
+    first = _claim(tmp_path, owner_id="owner-a", endpoint="/tmp/a.sock")
+    monkeypatch.setattr(owners, "_owner_liveness", lambda owner: False)
+
+    second = _claim(tmp_path, owner_id="owner-b", endpoint="/tmp/b.sock")
+
+    assert second.kind == "owned"
+    assert second.lease is not None
+    assert second.owner.owner_id == "owner-b"
+    assert second.owner.generation == first.owner.generation + 1
+
+
+def test_claim_sweeps_unrelated_proven_dead_owners(tmp_path, monkeypatch):
+    first = _claim(tmp_path, owner_id="owner-a", endpoint="/tmp/a.sock")
+    monkeypatch.setattr(
+        owners,
+        "_owner_liveness",
+        lambda owner: False if owner.owner_id == "owner-a" else True,
+    )
+
+    second = owners.claim_runtime_owner(
+        conversation_key="another-root",
+        owner_id="owner-b",
+        endpoint="/tmp/b.sock",
+        surface="test",
+        registry_home=tmp_path,
+    )
+
+    assert first.owner != second.owner
+    assert (
+        owners.lookup_runtime_owner(
+            conversation_key="conversation-root", registry_home=tmp_path
+        )
+        is None
+    )
+
+
+def test_registry_fails_closed_at_live_owner_bound(tmp_path, monkeypatch):
+    monkeypatch.setattr(owners, "MAX_RUNTIME_OWNERS", 1)
+    _claim(tmp_path, owner_id="owner-a", endpoint="/tmp/a.sock")
+
+    with pytest.raises(owners.RuntimeOwnerRegistryError, match="capacity"):
+        owners.claim_runtime_owner(
+            conversation_key="another-root",
+            owner_id="owner-b",
+            endpoint="/tmp/b.sock",
+            surface="test",
+            registry_home=tmp_path,
+        )
+
+
+def test_corrupt_owner_registry_fails_closed_without_overwrite(tmp_path):
+    state = tmp_path / "runtime" / "live_runtime_owners.json"
+    state.parent.mkdir(parents=True)
+    state.write_text("{not-json", encoding="utf-8")
+
+    with pytest.raises(owners.RuntimeOwnerRegistryError, match="unreadable"):
+        _claim(tmp_path, owner_id="owner-a")
+
+    assert state.read_text(encoding="utf-8") == "{not-json"
+
+
+def test_stale_release_cannot_delete_new_owner_generation(tmp_path, monkeypatch):
+    first = _claim(tmp_path, owner_id="owner-a", endpoint="/tmp/a.sock")
+    monkeypatch.setattr(owners, "_owner_liveness", lambda owner: False)
+    second = _claim(tmp_path, owner_id="owner-b", endpoint="/tmp/b.sock")
+    monkeypatch.setattr(owners, "_owner_liveness", lambda owner: owner == second.owner)
+
+    assert first.lease is not None
+    assert second.lease is not None
+    assert owners.release_runtime_owner(first.lease) is False
+    assert (
+        owners.lookup_runtime_owner(
+            conversation_key="conversation-root",
+            registry_home=tmp_path,
+        )
+        == second.owner
+    )
+
+    payload = json.loads(
+        (tmp_path / "runtime" / "live_runtime_owners.json").read_text(encoding="utf-8")
+    )
+    encoded = json.dumps(payload).lower()
+    assert "secret" not in encoded
+    assert "token" not in encoded
+    assert payload["version"] == 1
+    assert payload["entries"][0]["pid"] == os.getpid()

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -23,9 +23,7 @@ def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
 
     first_holder = f"pid={os.getpid()}:turn=first"
     second_holder = f"pid={os.getpid()}:turn=second"
-    assert first.try_acquire_session_turn_lease(
-        "shared", first_holder, ttl_seconds=5
-    )
+    assert first.try_acquire_session_turn_lease("shared", first_holder, ttl_seconds=5)
 
     released = threading.Event()
 
@@ -62,12 +60,8 @@ def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
 
     root_holder = f"pid={os.getpid()}:turn=root"
     child_holder = f"pid={os.getpid()}:turn=child"
-    assert db.try_acquire_session_turn_lease(
-        "root", root_holder, ttl_seconds=5
-    )
-    assert not db.try_acquire_session_turn_lease(
-        "child", child_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("root", root_holder, ttl_seconds=5)
+    assert not db.try_acquire_session_turn_lease("child", child_holder, ttl_seconds=5)
     db.release_session_turn_lease("child", root_holder)
 
 
@@ -84,12 +78,8 @@ def test_turn_lease_does_not_serialize_delegate_child_with_parent(tmp_path):
 
     parent_holder = f"pid={os.getpid()}:turn=parent"
     delegate_holder = f"pid={os.getpid()}:turn=delegate"
-    assert db.try_acquire_session_turn_lease(
-        "parent", parent_holder, ttl_seconds=5
-    )
-    assert db.try_acquire_session_turn_lease(
-        "delegate", delegate_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("parent", parent_holder, ttl_seconds=5)
+    assert db.try_acquire_session_turn_lease("delegate", delegate_holder, ttl_seconds=5)
 
 
 def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path):
@@ -130,13 +120,11 @@ def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path
         model_config={"_branched_from": "original-parent"},
     )
 
-    assert db._session_turn_lease_key("delegate-continuation") == "delegate"
-    assert db._session_turn_lease_key("branch-continuation") == "branch"
+    assert db.session_runtime_key("delegate-continuation") == "delegate"
+    assert db.session_runtime_key("branch-continuation") == "branch"
 
     delegate_holder = f"pid={os.getpid()}:turn=delegate"
-    assert db.try_acquire_session_turn_lease(
-        "delegate", delegate_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("delegate", delegate_holder, ttl_seconds=5)
     assert not db.try_acquire_session_turn_lease(
         "delegate-continuation",
         f"pid={os.getpid()}:turn=delegate-child",
@@ -147,9 +135,7 @@ def test_turn_lease_walks_compression_child_that_inherited_fork_markers(tmp_path
     )
 
     branch_holder = f"pid={os.getpid()}:turn=branch"
-    assert db.try_acquire_session_turn_lease(
-        "branch", branch_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("branch", branch_holder, ttl_seconds=5)
     assert not db.try_acquire_session_turn_lease(
         "branch-continuation",
         f"pid={os.getpid()}:turn=branch-child",
@@ -194,17 +180,13 @@ def test_turn_lease_write_txn_does_not_trust_fail_open_key_helper(
 
     monkeypatch.setattr(db, "_session_turn_lease_key", lambda sid: sid)
     holder = f"pid={os.getpid()}:turn=delegate"
-    assert db.try_acquire_session_turn_lease(
-        "delegate", holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("delegate", holder, ttl_seconds=5)
     assert not db.try_acquire_session_turn_lease(
         "delegate-continuation",
         f"pid={os.getpid()}:turn=child",
         ttl_seconds=5,
     )
-    assert db.refresh_session_turn_lease(
-        "delegate-continuation", holder, ttl_seconds=5
-    )
+    assert db.refresh_session_turn_lease("delegate-continuation", holder, ttl_seconds=5)
     db.release_session_turn_lease("delegate-continuation", holder)
     assert db.try_acquire_session_turn_lease(
         "delegate", f"pid={os.getpid()}:turn=next", ttl_seconds=5
@@ -259,24 +241,14 @@ def test_turn_lease_refresh_and_release_are_owner_fenced(tmp_path):
     current_holder = f"pid={os.getpid()}:turn=current"
     stale_holder = f"pid={os.getpid()}:turn=stale"
     next_holder = f"pid={os.getpid()}:turn=next"
-    assert db.try_acquire_session_turn_lease(
-        "shared", current_holder, ttl_seconds=5
-    )
-    assert not db.refresh_session_turn_lease(
-        "shared", stale_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("shared", current_holder, ttl_seconds=5)
+    assert not db.refresh_session_turn_lease("shared", stale_holder, ttl_seconds=5)
     db.release_session_turn_lease("shared", stale_holder)
-    assert not db.try_acquire_session_turn_lease(
-        "shared", next_holder, ttl_seconds=5
-    )
+    assert not db.try_acquire_session_turn_lease("shared", next_holder, ttl_seconds=5)
 
-    assert db.refresh_session_turn_lease(
-        "shared", current_holder, ttl_seconds=5
-    )
+    assert db.refresh_session_turn_lease("shared", current_holder, ttl_seconds=5)
     db.release_session_turn_lease("shared", current_holder)
-    assert db.try_acquire_session_turn_lease(
-        "shared", next_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("shared", next_holder, ttl_seconds=5)
 
 
 def test_expired_turn_lease_is_reclaimed(tmp_path):
@@ -302,9 +274,7 @@ def test_acquire_turn_lease_notifies_wait_callback(tmp_path):
 
     first_holder = f"pid={os.getpid()}:turn=first"
     second_holder = f"pid={os.getpid()}:turn=second"
-    assert first.try_acquire_session_turn_lease(
-        "shared", first_holder, ttl_seconds=5
-    )
+    assert first.try_acquire_session_turn_lease("shared", first_holder, ttl_seconds=5)
 
     notices = []
 
@@ -341,9 +311,7 @@ def test_acquire_turn_lease_honors_should_abort(tmp_path):
 
     first_holder = f"pid={os.getpid()}:turn=first"
     second_holder = f"pid={os.getpid()}:turn=second"
-    assert first.try_acquire_session_turn_lease(
-        "shared", first_holder, ttl_seconds=60
-    )
+    assert first.try_acquire_session_turn_lease("shared", first_holder, ttl_seconds=60)
 
     abort_checks = {"count": 0}
 
@@ -418,9 +386,10 @@ def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
     db.create_session("shared", source="test")
 
     dead_holder = "pid=424242:turn=dead:platform=test"
-    assert db.try_acquire_session_turn_lease(
-        "shared", dead_holder, ttl_seconds=300
-    ) is True
+    assert (
+        db.try_acquire_session_turn_lease("shared", dead_holder, ttl_seconds=300)
+        is True
+    )
 
     probed: list[int] = []
 
@@ -428,14 +397,13 @@ def test_non_expired_turn_lease_from_dead_pid_is_reclaimed(
         probed.append(pid)
         return False
 
-    monkeypatch.setattr(
-        hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists)
-    )
+    monkeypatch.setattr(hermes_state, "psutil", SimpleNamespace(pid_exists=pid_exists))
 
     fresh_holder = "pid=525252:turn=fresh:platform=test"
-    assert db.try_acquire_session_turn_lease(
-        "shared", fresh_holder, ttl_seconds=300
-    ) is True
+    assert (
+        db.try_acquire_session_turn_lease("shared", fresh_holder, ttl_seconds=300)
+        is True
+    )
     assert probed == [424242]
 
 
@@ -450,19 +418,18 @@ def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
     stale_holder = f"pid={os.getpid()}:turn=stale"
     next_holder = f"pid={os.getpid()}:turn=next"
 
-    assert db.try_acquire_session_turn_lease(
-        "shared", stale_holder, ttl_seconds=5
+    assert db.try_acquire_session_turn_lease("shared", stale_holder, ttl_seconds=5)
+    assert (
+        db.append_messages_batch(
+            "shared",
+            [{"role": "user", "content": "stale-owned"}],
+            turn_lease_holder=stale_holder,
+        )
+        == 1
     )
-    assert db.append_messages_batch(
-        "shared",
-        [{"role": "user", "content": "stale-owned"}],
-        turn_lease_holder=stale_holder,
-    ) == 1
 
     db.release_session_turn_lease("shared", stale_holder)
-    assert db.try_acquire_session_turn_lease(
-        "shared", next_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("shared", next_holder, ttl_seconds=5)
 
     with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
         db.append_messages_batch(
@@ -478,11 +445,14 @@ def test_turn_lease_fences_stale_transcript_flush_after_reclaim(tmp_path):
             turn_lease_holder=stale_holder,
         )
 
-    assert db.append_messages_batch(
-        "shared",
-        [{"role": "assistant", "content": "next reply"}],
-        turn_lease_holder=next_holder,
-    ) == 1
+    assert (
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "next reply"}],
+            turn_lease_holder=next_holder,
+        )
+        == 1
+    )
     assert [m["content"] for m in db.get_messages("shared")] == [
         "stale-owned",
         "next reply",
@@ -497,12 +467,15 @@ def test_turn_lease_revives_expired_row_still_owned_by_writer(tmp_path):
 
     assert db.try_acquire_session_turn_lease("shared", holder, ttl_seconds=0.05)
     time.sleep(0.12)
-    assert db.append_messages_batch(
-        "shared",
-        [{"role": "assistant", "content": "after ttl"}],
-        turn_lease_holder=holder,
-        turn_lease_ttl_seconds=0.2,
-    ) == 1
+    assert (
+        db.append_messages_batch(
+            "shared",
+            [{"role": "assistant", "content": "after ttl"}],
+            turn_lease_holder=holder,
+            turn_lease_ttl_seconds=0.2,
+        )
+        == 1
+    )
     assert not db.try_acquire_session_turn_lease(
         "shared", f"pid={os.getpid()}:turn=contender", ttl_seconds=5
     )
@@ -531,14 +504,15 @@ def test_turn_lease_fence_walks_compression_child_to_root(tmp_path):
 
     root_holder = f"pid={os.getpid()}:turn=root"
     stale_holder = f"pid={os.getpid()}:turn=stale"
-    assert db.try_acquire_session_turn_lease(
-        "root", root_holder, ttl_seconds=5
+    assert db.try_acquire_session_turn_lease("root", root_holder, ttl_seconds=5)
+    assert (
+        db.append_messages_batch(
+            "child",
+            [{"role": "user", "content": "owner on tip"}],
+            turn_lease_holder=root_holder,
+        )
+        == 1
     )
-    assert db.append_messages_batch(
-        "child",
-        [{"role": "user", "content": "owner on tip"}],
-        turn_lease_holder=root_holder,
-    ) == 1
     with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
         db.append_messages_batch(
             "child",
@@ -560,13 +534,9 @@ def test_lost_turn_lease_flush_fails_fast_without_patience_retry(
     db.create_session("shared", source="test")
     stale_holder = f"pid={os.getpid()}:turn=stale"
     next_holder = f"pid={os.getpid()}:turn=next"
-    assert db.try_acquire_session_turn_lease(
-        "shared", stale_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("shared", stale_holder, ttl_seconds=5)
     db.release_session_turn_lease("shared", stale_holder)
-    assert db.try_acquire_session_turn_lease(
-        "shared", next_holder, ttl_seconds=5
-    )
+    assert db.try_acquire_session_turn_lease("shared", next_holder, ttl_seconds=5)
 
     sleeps = []
     original = db._sleep_before_write_retry
@@ -628,14 +598,15 @@ def test_turn_lease_fence_walks_continuation_that_inherited_fork_markers(tmp_pat
     )
 
     delegate_holder = f"pid={os.getpid()}:turn=delegate"
-    assert db.try_acquire_session_turn_lease(
-        "delegate", delegate_holder, ttl_seconds=5
+    assert db.try_acquire_session_turn_lease("delegate", delegate_holder, ttl_seconds=5)
+    assert (
+        db.append_messages_batch(
+            "delegate-continuation",
+            [{"role": "user", "content": "owner on inherited tip"}],
+            turn_lease_holder=delegate_holder,
+        )
+        == 1
     )
-    assert db.append_messages_batch(
-        "delegate-continuation",
-        [{"role": "user", "content": "owner on inherited tip"}],
-        turn_lease_holder=delegate_holder,
-    ) == 1
     with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
         db.append_messages_batch(
             "delegate-continuation",
@@ -644,14 +615,15 @@ def test_turn_lease_fence_walks_continuation_that_inherited_fork_markers(tmp_pat
         )
 
     branch_holder = f"pid={os.getpid()}:turn=branch"
-    assert db.try_acquire_session_turn_lease(
-        "branch", branch_holder, ttl_seconds=5
+    assert db.try_acquire_session_turn_lease("branch", branch_holder, ttl_seconds=5)
+    assert (
+        db.append_messages_batch(
+            "branch-continuation",
+            [{"role": "user", "content": "branch owner on inherited tip"}],
+            turn_lease_holder=branch_holder,
+        )
+        == 1
     )
-    assert db.append_messages_batch(
-        "branch-continuation",
-        [{"role": "user", "content": "branch owner on inherited tip"}],
-        turn_lease_holder=branch_holder,
-    ) == 1
     with pytest.raises(SessionTurnLeaseLostError, match="turn lease lost"):
         db.append_messages_batch(
             "branch-continuation",

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -38,6 +38,7 @@ def test_stamp_adds_monotonic_seq_per_session():
     event_replay._stamp_event(f2)
 
     assert f1["params"]["seq"] == 1
+    assert f1["params"]["epoch"] == event_replay.replay_epoch()
     assert f2["params"]["seq"] == 2  # per-session counter, unaffected by s2
     assert other["params"]["seq"] == 1
 
@@ -100,6 +101,7 @@ def test_events_since_returns_defensive_copies():
             "session_id": "s1",
             "payload": {"items": [1]},
             "seq": 1,
+            "epoch": event_replay.replay_epoch(),
         }
     ]
 
@@ -130,21 +132,38 @@ def test_session_count_bounded_with_fifo_eviction():
     assert latest_seq(f"s{event_replay._REPLAY_SESSIONS_MAX + 9}") == 1
 
 
-def test_evicted_session_without_new_events_reports_truncation():
+def test_sequence_metadata_is_bounded_by_epoch_rollover():
+    initial_epoch = event_replay.replay_epoch()
+    for index in range(event_replay._REPLAY_SESSIONS_MAX + 1):
+        event_replay._stamp_event(_frame(f"rollover-{index}"))
+
+    stats = replay_stats()
+    assert stats["sequence_sessions"] <= event_replay._REPLAY_SESSIONS_MAX
+    assert event_replay.replay_epoch() != initial_epoch
+    assert all(
+        event["epoch"] == event_replay.replay_epoch()
+        for buffer in event_replay._replay_buffers.values()
+        for _seq, event in buffer
+    )
+
+
+def test_evicted_session_without_new_events_is_separated_by_epoch_rollover():
+    initial_epoch = event_replay.replay_epoch()
     event_replay._stamp_event(_frame("old-live"))
     for index in range(event_replay._REPLAY_SESSIONS_MAX):
         event_replay._stamp_event(_frame(f"new-{index}"))
 
     assert events_since("old-live", 0) == []
-    assert latest_seq("old-live") == 1
-    assert event_replay.is_truncated("old-live", 0) is True
-    assert event_replay.is_truncated("old-live", 1) is False
+    assert latest_seq("old-live") == 0
+    assert event_replay.replay_epoch() != initial_epoch
+    assert event_replay.is_truncated("old-live", 0) is False
 
 
-def test_sequence_does_not_restart_when_a_live_session_buffer_is_evicted():
+def test_sequence_restart_after_eviction_always_changes_epoch():
     first = _frame("old-live")
     event_replay._stamp_event(first)
     assert first["params"]["seq"] == 1
+    first_epoch = first["params"]["epoch"]
 
     for index in range(event_replay._REPLAY_SESSIONS_MAX):
         event_replay._stamp_event(_frame(f"new-{index}"))
@@ -153,8 +172,9 @@ def test_sequence_does_not_restart_when_a_live_session_buffer_is_evicted():
     resumed = _frame("old-live")
     event_replay._stamp_event(resumed)
 
-    assert resumed["params"]["seq"] == 2
-    assert [event["seq"] for event in events_since("old-live", 0)] == [2]
+    assert resumed["params"]["seq"] == 1
+    assert resumed["params"]["epoch"] != first_epoch
+    assert [event["seq"] for event in events_since("old-live", 0)] == [1]
 
 
 def test_release_session_reclaims_counter_and_buffer_state():

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -84,6 +84,26 @@ def test_events_since_returns_client_dispatchable_event_objects():
     assert "params" not in event
 
 
+def test_events_since_returns_defensive_copies():
+    frame = _frame("s1")
+    frame["params"]["payload"] = {"items": [1]}
+    event_replay._stamp_event(frame)
+
+    first = events_since("s1", 0)
+    first[0]["payload"]["items"].append(2)
+    first[0]["type"] = "mutated"
+
+    second = events_since("s1", 0)
+    assert second == [
+        {
+            "type": "message.delta",
+            "session_id": "s1",
+            "payload": {"items": [1]},
+            "seq": 1,
+        }
+    ]
+
+
 def test_unknown_session_returns_empty():
     assert events_since("nope", 0) == []
     assert latest_seq("nope") == 0
@@ -108,6 +128,45 @@ def test_session_count_bounded_with_fifo_eviction():
     assert stats["sessions"] == event_replay._REPLAY_SESSIONS_MAX
     assert events_since("s0", 0) == []  # oldest session fully evicted
     assert latest_seq(f"s{event_replay._REPLAY_SESSIONS_MAX + 9}") == 1
+
+
+def test_evicted_session_without_new_events_reports_truncation():
+    event_replay._stamp_event(_frame("old-live"))
+    for index in range(event_replay._REPLAY_SESSIONS_MAX):
+        event_replay._stamp_event(_frame(f"new-{index}"))
+
+    assert events_since("old-live", 0) == []
+    assert latest_seq("old-live") == 1
+    assert event_replay.is_truncated("old-live", 0) is True
+    assert event_replay.is_truncated("old-live", 1) is False
+
+
+def test_sequence_does_not_restart_when_a_live_session_buffer_is_evicted():
+    first = _frame("old-live")
+    event_replay._stamp_event(first)
+    assert first["params"]["seq"] == 1
+
+    for index in range(event_replay._REPLAY_SESSIONS_MAX):
+        event_replay._stamp_event(_frame(f"new-{index}"))
+
+    assert events_since("old-live", 0) == []
+    resumed = _frame("old-live")
+    event_replay._stamp_event(resumed)
+
+    assert resumed["params"]["seq"] == 2
+    assert [event["seq"] for event in events_since("old-live", 0)] == [2]
+
+
+def test_release_session_reclaims_counter_and_buffer_state():
+    frame = _frame("finished")
+    event_replay._stamp_event(frame)
+    assert latest_seq("finished") == 1
+
+    event_replay.release_session("finished")
+
+    assert latest_seq("finished") == 0
+    assert events_since("finished", 0) == []
+    assert event_replay.is_truncated("finished", 0) is False
 
 
 def test_concurrent_stamping_never_drops_or_duplicates_seq():

--- a/tests/test_tui_gateway_queue_on_busy.py
+++ b/tests/test_tui_gateway_queue_on_busy.py
@@ -33,6 +33,7 @@ def _session(agent=None, **extra):
 
 # ── _enqueue_prompt ────────────────────────────────────────────────────────
 
+
 def test_enqueue_pins_text_and_transport():
     session = _session()
     server._enqueue_prompt(session, "hello", "ws-1")
@@ -52,9 +53,8 @@ def test_enqueue_preserves_order_after_an_image_turn():
     ]
 
 
-
-
 # ── _handle_busy_submit (policy) ───────────────────────────────────────────
+
 
 def test_busy_interrupt_mode_redirects_active_turn(monkeypatch):
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
@@ -67,7 +67,10 @@ def test_busy_interrupt_mode_redirects_active_turn(monkeypatch):
         ),
     )
     session = _session(agent=agent, running=True)
-    session["inflight_turn"] = {"user": "original request", "assistant": "partial reply"}
+    session["inflight_turn"] = {
+        "user": "original request",
+        "assistant": "partial reply",
+    }
 
     resp = server._handle_busy_submit("r1", "sid", session, "redirect", "ws-1")
 
@@ -170,6 +173,79 @@ def test_enqueue_skips_text_duplicate_of_inflight_user():
         "text": "different follow-up",
         "transport": "ws-1",
     }
+
+
+def test_inflight_snapshot_keeps_request_origin():
+    session = _session()
+
+    server._start_inflight_turn(
+        session,
+        "hello",
+        origin_client_id="client-a",
+        request_id="request-a",
+    )
+
+    assert session["inflight_turn"]["origin_client_id"] == "client-a"
+    assert session["inflight_turn"]["request_id"] == "request-a"
+
+
+def test_enqueue_different_clients_preserves_fifo_without_merging():
+    session = _session()
+
+    server._enqueue_prompt(
+        session,
+        "from A",
+        "ws-a",
+        origin_client_id="client-a",
+        request_id="request-a",
+    )
+    server._enqueue_prompt(
+        session,
+        "from B",
+        "ws-b",
+        origin_client_id="client-b",
+        request_id="request-b",
+    )
+
+    assert session["queued_prompt"] == {
+        "text": "from A",
+        "origin_client_id": "client-a",
+        "request_id": "request-a",
+    }
+    assert session["queued_prompts"] == [
+        {
+            "text": "from B",
+            "origin_client_id": "client-b",
+            "request_id": "request-b",
+        }
+    ]
+
+
+def test_enqueue_same_client_can_merge_without_losing_request_origins():
+    session = _session()
+
+    server._enqueue_prompt(
+        session,
+        "first",
+        "ws-a",
+        origin_client_id="client-a",
+        request_id="request-a",
+    )
+    server._enqueue_prompt(
+        session,
+        "second",
+        "ws-a-reconnected",
+        origin_client_id="client-a",
+        request_id="request-b",
+    )
+
+    assert session["queued_prompt"] == {
+        "text": "first\n\nsecond",
+        "origin_client_id": "client-a",
+        "request_id": "request-a",
+        "request_ids": ["request-a", "request-b"],
+    }
+    assert "transport" not in session["queued_prompt"]
 
 
 def test_enqueue_followup_does_not_merge_stale_inflight_self_duplicate():
@@ -310,12 +386,6 @@ def test_compress_no_rotation_does_not_bump_queue_generation(monkeypatch):
     assert session["_queued_prompt_generation"] == 2
 
 
-
-
-
-
-
-
 def test_busy_interrupt_mode_ignores_completed_background_delegation(monkeypatch):
     """A terminal delegation must not suppress normal busy-turn interruption."""
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
@@ -344,11 +414,11 @@ def test_busy_interrupt_mode_ignores_completed_background_delegation(monkeypatch
     assert session["queued_prompt"]["text"] == "continue"
 
 
-
-
 def test_busy_steer_mode_injects_when_accepted(monkeypatch):
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "steer")
-    agent = types.SimpleNamespace(steer=lambda text: True, interrupt=lambda *a, **k: None)
+    agent = types.SimpleNamespace(
+        steer=lambda text: True, interrupt=lambda *a, **k: None
+    )
     session = _session(agent=agent, running=True)
 
     resp = server._handle_busy_submit("r1", "sid", session, "nudge", "ws-1")
@@ -358,6 +428,7 @@ def test_busy_steer_mode_injects_when_accepted(monkeypatch):
 
 
 # ── steer-mode burst preservation (#86134) ─────────────────────────────────
+
 
 def test_busy_steer_fallthrough_queues_without_interrupting(monkeypatch):
     """A steer-mode fall-through must keep queue semantics, never interrupt.
@@ -499,20 +570,12 @@ def test_busy_steer_fallthrough_burst_drains_all_texts_fifo(monkeypatch):
         assert text in joined, f"burst message dropped: {text!r}"
 
 
-
-
-
-
 def test_busy_helper_retries_when_turn_finished(monkeypatch):
     monkeypatch.setattr(server, "_load_busy_input_mode", lambda: "interrupt")
     session = _session(running=False)
 
     assert server._handle_busy_submit("r1", "sid", session, "run now", "ws-1") is None
     assert session.get("queued_prompt") is None
-
-
-
-
 
 
 def test_busy_interrupt_mode_queues_multimodal_payload_instead_of_redirect(monkeypatch):
@@ -559,11 +622,12 @@ def test_busy_submit_claims_attached_image_for_queued_turn(monkeypatch):
     assert redirected == []
     assert not interrupted.wait(0.1)
     assert session["attached_images"] == []
-    assert session["queued_prompt"] == {
-        "text": "is this B?",
-        "image_paths": ["/tmp/b.png"],
-        "transport": None,
-    }
+    queued = session["queued_prompt"]
+    assert queued["text"] == "is this B?"
+    assert queued["image_paths"] == ["/tmp/b.png"]
+    assert queued["request_id"] == "r1"
+    assert queued["origin_client_id"].startswith("legacy-transport-")
+    assert "transport" not in queued
 
 
 def test_busy_image_prompts_keep_b_and_c_attachments_in_submission_order(monkeypatch):
@@ -572,11 +636,18 @@ def test_busy_image_prompts_keep_b_and_c_attachments_in_submission_order(monkeyp
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda rid, sid, _session, text, **kwargs: dispatched.append((rid, sid, text, kwargs)),
+        lambda rid, sid, _session, text, **kwargs: dispatched.append((
+            rid,
+            sid,
+            text,
+            kwargs,
+        )),
     )
     agent = types.SimpleNamespace(
         _supports_active_turn_redirect=True,
-        redirect=lambda _text: (_ for _ in ()).throw(AssertionError("images must queue")),
+        redirect=lambda _text: (_ for _ in ()).throw(
+            AssertionError("images must queue")
+        ),
         interrupt=lambda: None,
     )
     session = _session(agent=agent, running=True, attached_images=["/tmp/b.png"])
@@ -588,9 +659,12 @@ def test_busy_image_prompts_keep_b_and_c_attachments_in_submission_order(monkeyp
         server._methods["prompt.submit"]("c", {"session_id": "sid", "text": "C"})
 
         assert session["queued_prompt"]["image_paths"] == ["/tmp/b.png"]
-        assert session["queued_prompts"] == [
-            {"text": "C", "image_paths": ["/tmp/c.png"], "transport": None}
-        ]
+        queued_c = session["queued_prompts"][0]
+        assert queued_c["text"] == "C"
+        assert queued_c["image_paths"] == ["/tmp/c.png"]
+        assert queued_c["request_id"] == "c"
+        assert queued_c["origin_client_id"].startswith("legacy-transport-")
+        assert "transport" not in queued_c
 
         session["running"] = False
         assert server._drain_queued_prompt("drain-b", "sid", session) is True
@@ -599,29 +673,33 @@ def test_busy_image_prompts_keep_b_and_c_attachments_in_submission_order(monkeyp
     finally:
         server._sessions.pop("sid", None)
 
-    assert dispatched == [
-        (
-            "drain-b",
-            "sid",
-            "B",
-            {"image_paths": ["/tmp/b.png"], "queued_prompt_generation": 0},
-        ),
-        (
-            "drain-c",
-            "sid",
-            "C",
-            {"image_paths": ["/tmp/c.png"], "queued_prompt_generation": 0},
-        ),
+    assert [(rid, sid, text) for rid, sid, text, _ in dispatched] == [
+        ("drain-b", "sid", "B"),
+        ("drain-c", "sid", "C"),
     ]
+    for (_, _, _, kwargs), image, request_id in zip(
+        dispatched,
+        ("/tmp/b.png", "/tmp/c.png"),
+        ("b", "c"),
+        strict=True,
+    ):
+        assert kwargs["image_paths"] == [image]
+        assert kwargs["queued_prompt_generation"] == 0
+        assert kwargs["request_id"] == request_id
+        assert kwargs["origin_client_id"].startswith("legacy-transport-")
 
 
 # ── _drain_queued_prompt ───────────────────────────────────────────────────
 
+
 def test_drain_fires_queued_prompt_and_claims_running(monkeypatch):
     fired = {}
     monkeypatch.setattr(
-        server, "_run_prompt_submit",
-        lambda rid, sid, session, text, **kwargs: fired.update(rid=rid, sid=sid, text=text),
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, session, text, **kwargs: fired.update(
+            rid=rid, sid=sid, text=text
+        ),
     )
     session = _session(queued_prompt={"text": "go", "transport": "ws-9"})
 
@@ -638,13 +716,19 @@ def test_drain_compute_host_forwards_queued_image_paths(monkeypatch):
     monkeypatch.setattr(
         server,
         "_submit_prompt_to_compute_host",
-        lambda rid, sid, session, text, **kwargs: captured.update(
-            rid=rid, sid=sid, text=text, image_paths=kwargs.get("image_paths")
-        )
-        or {"result": {"status": "started"}},
+        lambda rid, sid, session, text, **kwargs: (
+            captured.update(
+                rid=rid, sid=sid, text=text, image_paths=kwargs.get("image_paths")
+            )
+            or {"result": {"status": "started"}}
+        ),
     )
     session = _session(
-        queued_prompt={"text": "inspect", "image_paths": ["/tmp/b.png"], "transport": "ws-9"}
+        queued_prompt={
+            "text": "inspect",
+            "image_paths": ["/tmp/b.png"],
+            "transport": "ws-9",
+        }
     )
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
@@ -654,10 +738,6 @@ def test_drain_compute_host_forwards_queued_image_paths(monkeypatch):
         "text": "inspect",
         "image_paths": ["/tmp/b.png"],
     }
-
-
-
-
 
 
 def test_drain_preserves_queued_prompt_when_session_is_closing(monkeypatch):
@@ -681,6 +761,7 @@ def test_drain_preserves_queued_prompt_when_session_is_closing(monkeypatch):
 def test_drain_releases_running_on_dispatch_failure(monkeypatch):
     def _boom(*a, **k):
         raise RuntimeError("dispatch failed")
+
     monkeypatch.setattr(server, "_run_prompt_submit", _boom)
     session = _session(queued_prompt={"text": "go", "transport": None})
 
@@ -707,7 +788,9 @@ def test_drain_does_not_dispatch_a_prompt_cancelled_after_claim(monkeypatch):
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not dispatch")
+        ),
     )
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
@@ -728,7 +811,9 @@ def test_drain_restores_claimed_prompt_when_generation_bumps_mid_claim(monkeypat
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("must not dispatch")),
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("must not dispatch")
+        ),
     )
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
@@ -772,11 +857,12 @@ def test_drain_continues_with_later_queued_prompt_after_dispatch_failure(monkeyp
     monkeypatch.setattr(server, "_run_prompt_submit", _run)
     session = _session(
         queued_prompt={"text": "broken", "transport": None},
-        queued_prompts=[{"text": "next", "image_paths": ["/tmp/next.png"], "transport": None}],
+        queued_prompts=[
+            {"text": "next", "image_paths": ["/tmp/next.png"], "transport": None}
+        ],
     )
 
     assert server._drain_queued_prompt("r1", "sid", session) is True
     assert calls == ["broken", "next"]
     assert session["queued_prompt"] is None
     assert session.get("queued_prompts") is None
-

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17060,6 +17060,54 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
     ) in emitted
 
 
+def test_prompt_submit_fans_out_user_row_before_assistant_events(monkeypatch):
+    """A second attached client sees the durable user row without the 2s watcher."""
+    emitted: list[tuple[str, dict]] = []
+
+    class _Agent:
+        model = "gpt-5.6-sol"
+        provider = "openai-codex"
+        base_url = "https://chatgpt.example.test/backend-api/codex"
+        api_key = object()
+        api_mode = "codex_responses"
+
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
+            callback = getattr(self, "_on_user_message_persisted", None)
+            assert callable(callback), "gateway did not install a durable-user-row hook"
+            callback()
+            stream_callback("reply")
+            return {
+                "final_response": "reply",
+                "messages": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": "reply"},
+                ],
+            }
+
+    server._sessions["sid"] = _session(agent=_Agent())
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda kind, sid, payload=None, **kw: emitted.append((kind, payload or {})),
+    )
+    monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+    monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "hello from pc 1"},
+    })
+
+    event_names = [event for event, _payload in emitted]
+    assert "sessions.changed" in event_names
+    assert event_names.index("sessions.changed") < event_names.index("message.delta")
+
+
 def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     """When the backend fails with no visible response (e.g. invalid model slug
     → provider 4xx), the TUI must surface result['error'] as visible text

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17100,13 +17100,82 @@ def test_prompt_submit_fans_out_user_row_before_assistant_events(monkeypatch):
     server.handle_request({
         "id": "1",
         "method": "prompt.submit",
-        "params": {"session_id": "sid", "text": "hello from pc 1"},
+        "params": {
+            "session_id": "sid",
+            "text": "expanded model-facing prompt",
+            "display_text": "hello from pc 1",
+            "client_message_id": "user-pc1-123",
+            "submitted_at": 1234.5,
+        },
     })
 
     event_names = [event for event, _payload in emitted]
+    assert "message.user" in event_names
     assert "sessions.changed" in event_names
+    assert event_names.index("message.user") < event_names.index("sessions.changed")
     assert event_names.index("sessions.changed") < event_names.index("message.delta")
+    assert emitted[event_names.index("message.user")][1] == {
+        "message_id": "user-pc1-123",
+        "text": "hello from pc 1",
+        "timestamp": 1234.5,
+    }
     assert server._sessions["sid"]["agent"]._on_user_message_persisted is None
+
+
+def test_prompt_submit_forwards_user_event_metadata_to_isolated_host(monkeypatch):
+    """The production turn-isolation path must not drop peer-fanout metadata."""
+    captured = {}
+    server._sessions["sid"] = _session(agent=None)
+    monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+    monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_args: True)
+    monkeypatch.setattr(
+        server,
+        "_submit_prompt_to_compute_host",
+        lambda rid, sid, session, text, **kwargs: (
+            captured.update(text=text, **kwargs)
+            or server._ok(rid, {"status": "streaming"})
+        ),
+    )
+
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {
+            "session_id": "sid",
+            "text": "expanded model-facing prompt",
+            "display_text": "hello from pc 1",
+            "client_message_id": "user-pc1-123",
+            "submitted_at": 1234.5,
+            "attachment_refs": ["attachment://one"],
+        },
+    })
+
+    assert captured == {
+        "text": "expanded model-facing prompt",
+        "display_kind": None,
+        "client_message_id": "user-pc1-123",
+        "display_text": "hello from pc 1",
+        "submitted_at": 1234.5,
+        "attachment_refs": ["attachment://one"],
+    }
+
+
+def test_compute_host_turn_frame_carries_user_event_metadata():
+    frame = server._compute_host_turn_frame(
+        "r1",
+        "sid",
+        _session(),
+        "expanded model-facing prompt",
+        client_message_id="user-pc1-123",
+        display_text="hello from pc 1",
+        submitted_at=1234.5,
+        attachment_refs=["attachment://one"],
+    )
+
+    assert frame["client_message_id"] == "user-pc1-123"
+    assert frame["display_text"] == "hello from pc 1"
+    assert frame["submitted_at"] == 1234.5
+    assert frame["attachment_refs"] == ["attachment://one"]
 
 
 def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17,6 +17,7 @@ from hermes_cli.active_sessions import active_session_registry_snapshot
 from hermes_cli.browser_connect import ChromeDebugLaunch
 from tools import async_delegation as ad
 from tui_gateway import server
+from tui_gateway.session_events import AttachmentMode
 from tui_gateway.transport import bind_transport, reset_transport
 
 
@@ -35,6 +36,710 @@ def _dispatch_sync(req: dict, transport=None) -> dict | None:
         return server.handle_request(req)
     finally:
         reset_transport(token)
+
+
+class _LifecycleTransport:
+    """Thread-safe transport used by focused live-session attachment tests."""
+
+    def __init__(self, client_id: str | None):
+        self.client_id = client_id
+        self.connection_id = f"connection-{id(self):x}"
+        self.auth_identity = None
+        self.frames: list[dict] = []
+        self._lock = threading.Lock()
+
+    def write(self, obj: dict) -> bool:
+        with self._lock:
+            self.frames.append(obj)
+        return True
+
+    def close(self) -> None:
+        pass
+
+    def event_types(self) -> list[str]:
+        with self._lock:
+            return [
+                frame.get("params", {}).get("type")
+                for frame in self.frames
+                if frame.get("method") == "event"
+            ]
+
+
+def _wait_for_event(transport: _LifecycleTransport, event_type: str) -> None:
+    deadline = time.time() + 1.0
+    while event_type not in transport.event_types() and time.time() < deadline:
+        time.sleep(0.01)
+    assert event_type in transport.event_types()
+
+
+def test_session_create_implicitly_attaches_legacy_transport_as_control(
+    monkeypatch, tmp_path
+):
+    transport = _LifecycleTransport("legacy-window")
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+
+    response = _dispatch_sync(
+        {"id": "create", "method": "session.create", "params": {}},
+        transport,
+    )
+    sid = response["result"]["session_id"]
+    session = server._sessions[sid]
+    try:
+        hub = session["event_hub"]
+        assert hub.count() == 1
+        assert hub.has_transport(transport)
+        assert hub.snapshots() == [
+            {
+                "client_id": "legacy-window",
+                "mode": "control",
+                "capabilities": sorted({
+                    "observe",
+                    "prompt.submit",
+                    "session.steer",
+                    "session.interrupt",
+                    "approval.respond",
+                    "clarify.respond",
+                    "ui.respond",
+                }),
+            }
+        ]
+        # Untouched code may still read this compatibility alias.
+        assert session["transport"] is transport
+    finally:
+        server._sessions.pop(sid, None)
+        server._teardown_session(session)
+
+
+def test_live_unpersisted_resume_adds_observer_without_replacing_runtime(
+    monkeypatch, tmp_path
+):
+    class EmptyDB:
+        def get_session(self, _target):
+            return None
+
+        def get_session_by_title(self, _target):
+            return None
+
+    first = _LifecycleTransport("window-a")
+    second = _LifecycleTransport("window-b")
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_get_db", lambda: EmptyDB())
+
+    created = _dispatch_sync(
+        {"id": "create", "method": "session.create", "params": {}}, first
+    )
+    sid = created["result"]["session_id"]
+    session = server._sessions[sid]
+    agent_marker = session["agent_ready"]
+    hub = session["event_hub"]
+    params = {
+        "session_id": created["result"]["stored_session_id"],
+        "attachment_mode": "observe",
+    }
+    try:
+        resumed = _dispatch_sync(
+            {"id": "resume-1", "method": "session.resume", "params": params}, second
+        )
+        repeated = _dispatch_sync(
+            {"id": "resume-2", "method": "session.resume", "params": params}, second
+        )
+
+        assert resumed["result"]["session_id"] == sid
+        assert repeated["result"]["session_id"] == sid
+        assert server._sessions[sid] is session
+        assert session["agent_ready"] is agent_marker
+        assert session["event_hub"] is hub
+        assert hub.count() == 2
+        assert {item["client_id"]: item["mode"] for item in hub.snapshots()} == {
+            "window-a": "control",
+            "window-b": "observe",
+        }
+        # Compatibility remains last-attached while ownership lives in the hub.
+        assert session["transport"] is second
+
+        server._emit("lifecycle.probe", sid, {"ok": True})
+        _wait_for_event(first, "lifecycle.probe")
+        _wait_for_event(second, "lifecycle.probe")
+    finally:
+        server._sessions.pop(sid, None)
+        server._teardown_session(session)
+
+
+def test_init_and_deferred_runtime_records_get_one_implicit_hub(monkeypatch, tmp_path):
+    init_transport = _LifecycleTransport("compute-host")
+    deferred_transport = _LifecycleTransport("lazy-window")
+    monkeypatch.setattr(server, "_get_db", lambda: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_start_notification_poller", lambda *_args: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_mcp_late_refresh", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    agent = types.SimpleNamespace()
+
+    token = bind_transport(init_transport)
+    try:
+        server._init_session("init-sid", "init-key", agent, [], cwd=str(tmp_path))
+    finally:
+        reset_transport(token)
+    initialized = server._sessions["init-sid"]
+
+    token = bind_transport(deferred_transport)
+    try:
+        deferred = server._deferred_session_record(
+            "lazy-sid",
+            "lazy-key",
+            cols=80,
+            cwd=str(tmp_path),
+            history=[],
+            lease=None,
+            lazy=True,
+        )
+    finally:
+        reset_transport(token)
+
+    try:
+        assert initialized["event_hub"].count() == 1
+        assert initialized["event_hub"].has_transport(init_transport)
+        assert initialized["transport"] is init_transport
+        assert deferred["event_hub"].count() == 1
+        assert deferred["event_hub"].has_transport(deferred_transport)
+        assert deferred["transport"] is deferred_transport
+    finally:
+        server._sessions.pop("init-sid", None)
+        server._teardown_session(initialized)
+        server._teardown_session(deferred)
+
+
+def test_session_events_since_requires_attached_observer():
+    from tui_gateway import event_replay
+
+    owner = _LifecycleTransport("owner")
+    stranger = _LifecycleTransport("stranger")
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": owner,
+    }
+    hub = server._attach_current_transport(
+        "private-sid", session, "observe", transport=owner
+    )
+    server._sessions["private-sid"] = session
+    try:
+        server._emit("message.delta", "private-sid", {"text": "TOP_SECRET"})
+        _wait_for_event(owner, "message.delta")
+
+        denied = _dispatch_sync(
+            {
+                "id": "denied",
+                "method": "session.events.since",
+                "params": {"session_id": "private-sid", "last_seen_seq": 0},
+            },
+            stranger,
+        )
+        assert denied["error"]["code"] == 4003
+        assert "TOP_SECRET" not in json.dumps(denied)
+
+        allowed = _dispatch_sync(
+            {
+                "id": "allowed",
+                "method": "session.events.since",
+                "params": {"session_id": "private-sid", "last_seen_seq": 0},
+            },
+            owner,
+        )
+        assert allowed["result"]["events"][0]["payload"]["text"] == "TOP_SECRET"
+        assert hub.require(owner, "observe") is None
+    finally:
+        server._sessions.pop("private-sid", None)
+        server._teardown_session(session)
+        event_replay.release_session("private-sid")
+
+
+def test_client_attach_is_idempotent_and_connection_bound():
+    transport = _LifecycleTransport(None)
+
+    first = _dispatch_sync(
+        {
+            "id": "identity-1",
+            "method": "client.attach",
+            "params": {"client_id": "desktop-window-7"},
+        },
+        transport,
+    )
+    repeated = _dispatch_sync(
+        {
+            "id": "identity-2",
+            "method": "client.attach",
+            "params": {"client_id": "desktop-window-7"},
+        },
+        transport,
+    )
+    rebound = _dispatch_sync(
+        {
+            "id": "identity-3",
+            "method": "client.attach",
+            "params": {"client_id": "different-window"},
+        },
+        transport,
+    )
+
+    assert first["result"]["client_id"] == "desktop-window-7"
+    assert first["result"]["connection_id"] == transport.connection_id
+    assert first["result"]["idempotent"] is False
+    assert repeated["result"]["idempotent"] is True
+    assert rebound["error"]["code"] == 4003
+    assert transport.client_id == "desktop-window-7"
+
+
+def test_client_principal_registry_evicts_only_inactive_lru(monkeypatch):
+    active_transport = _LifecycleTransport(None)
+    active_transport.auth_identity = {"sub": "principal-a"}
+    inactive_transport = _LifecycleTransport(None)
+    inactive_transport.auth_identity = {"sub": "principal-a"}
+    newcomer = _LifecycleTransport(None)
+    newcomer.auth_identity = {"sub": "principal-a"}
+    attacker = _LifecycleTransport(None)
+    attacker.auth_identity = {"sub": "principal-b"}
+    session = {"history_lock": threading.Lock(), "transport": active_transport}
+    with server._client_identity_lock:
+        saved = dict(server._client_principals)
+        server._client_principals.clear()
+    monkeypatch.setattr(server, "_CLIENT_IDENTITIES_MAX", 2)
+    try:
+        server._bind_client_identity(active_transport, "active-client")
+        server._bind_client_identity(inactive_transport, "inactive-client")
+        server._attach_current_transport(
+            "principal-registry-sid",
+            session,
+            "control",
+            transport=active_transport,
+        )
+        server._sessions["principal-registry-sid"] = session
+
+        server._bind_client_identity(newcomer, "new-client")
+
+        with server._client_identity_lock:
+            assert set(server._client_principals) == {
+                "active-client",
+                "new-client",
+            }
+        with pytest.raises(PermissionError, match="another principal"):
+            server._bind_client_identity(attacker, "active-client")
+    finally:
+        server._sessions.pop("principal-registry-sid", None)
+        server._teardown_session(session)
+        with server._client_identity_lock:
+            server._client_principals.clear()
+            server._client_principals.update(saved)
+
+
+def test_client_capability_negotiation_intersects_session_mode():
+    owner = _LifecycleTransport("capability-owner")
+    negotiated = _LifecycleTransport(None)
+    session = {"history_lock": threading.Lock(), "transport": owner}
+    server._attach_current_transport(
+        "negotiated-sid", session, "control", transport=owner
+    )
+    server._sessions["negotiated-sid"] = session
+    try:
+        identity = _dispatch_sync(
+            {
+                "id": "negotiate-client",
+                "method": "client.attach",
+                "params": {
+                    "client_id": "negotiated-client",
+                    "capabilities": ["session.observe", "session.replay", "made.up"],
+                },
+            },
+            negotiated,
+        )
+        attached = _dispatch_sync(
+            {
+                "id": "negotiate-session",
+                "method": "session.attach",
+                "params": {"session_id": "negotiated-sid", "mode": "control"},
+            },
+            negotiated,
+        )
+
+        assert identity["result"]["capabilities"] == [
+            "session.observe",
+            "session.replay",
+        ]
+        assert attached["result"]["capabilities"] == ["observe"]
+        with pytest.raises(PermissionError):
+            session["event_hub"].require(negotiated, "prompt.submit")
+        assert session["event_hub"].require(negotiated, "observe") is None
+    finally:
+        server._sessions.pop("negotiated-sid", None)
+        server._teardown_session(session)
+
+
+def test_explicit_attach_list_and_detach_are_transport_scoped(monkeypatch, tmp_path):
+    controller = _LifecycleTransport("controller")
+    observer = _LifecycleTransport(None)
+    stranger = _LifecycleTransport(None)
+    monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    created = _dispatch_sync(
+        {"id": "create-explicit", "method": "session.create", "params": {}}, controller
+    )
+    sid = created["result"]["session_id"]
+    session = server._sessions[sid]
+    try:
+        _dispatch_sync(
+            {
+                "id": "client-observer",
+                "method": "client.attach",
+                "params": {"client_id": "observer-window"},
+            },
+            observer,
+        )
+        attached = _dispatch_sync(
+            {
+                "id": "attach-observer",
+                "method": "session.attach",
+                "params": {"session_id": sid, "mode": "observe"},
+            },
+            observer,
+        )
+        observer_list = _dispatch_sync(
+            {
+                "id": "list-observer",
+                "method": "session.attachments",
+                "params": {"session_id": sid},
+            },
+            observer,
+        )
+        listed = _dispatch_sync(
+            {
+                "id": "list-controller",
+                "method": "session.attachments",
+                "params": {"session_id": sid},
+            },
+            controller,
+        )
+        denied = _dispatch_sync(
+            {
+                "id": "list-stranger",
+                "method": "session.attachments",
+                "params": {"session_id": sid},
+            },
+            stranger,
+        )
+        detached = _dispatch_sync(
+            {
+                "id": "detach-observer",
+                "method": "session.detach",
+                "params": {"session_id": sid},
+            },
+            observer,
+        )
+
+        assert attached["result"]["mode"] == "observe"
+        assert attached["result"]["replay"] == {
+            "events": attached["result"]["events"],
+            "truncated": attached["result"]["truncated"],
+        }
+        assert attached["result"]["replay_epoch"] == attached["result"]["epoch"]
+        assert observer_list["error"]["code"] == 4003
+        assert {row["client_id"] for row in listed["result"]["attachments"]} == {
+            "controller",
+            "observer-window",
+        }
+        assert denied["error"]["code"] == 4003
+        assert detached["result"]["detached"] is True
+        assert session["event_hub"].count() == 1
+        assert session["event_hub"].has_transport(controller)
+    finally:
+        server._sessions.pop(sid, None)
+        server._teardown_session(session)
+
+
+def test_explicit_last_attachment_detach_starts_orphan_policy(monkeypatch):
+    controller = _LifecycleTransport("explicit-last-controller")
+    session = {"history_lock": threading.Lock(), "transport": controller}
+    server._attach_current_transport(
+        "explicit-last-sid", session, "control", transport=controller
+    )
+    server._sessions["explicit-last-sid"] = session
+    scheduled = []
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
+    )
+    try:
+        response = _dispatch_sync(
+            {
+                "id": "explicit-last-detach",
+                "method": "session.detach",
+                "params": {"session_id": "explicit-last-sid"},
+            },
+            controller,
+        )
+        assert response["result"]["detached"] is True
+        assert session["event_hub"].count() == 0
+        assert session["transport"] is server._detached_ws_transport
+        assert scheduled == ["explicit-last-sid"]
+    finally:
+        server._sessions.pop("explicit-last-sid", None)
+        server._teardown_session(session)
+
+
+@pytest.mark.parametrize("watermark", ["not-an-integer", -1, True])
+def test_session_attach_rejects_invalid_replay_watermark(watermark):
+    owner = _LifecycleTransport("watermark-owner")
+    client = _LifecycleTransport(None)
+    session = {"history_lock": threading.Lock(), "transport": owner}
+    server._attach_current_transport(
+        "watermark-sid", session, "control", transport=owner
+    )
+    server._sessions["watermark-sid"] = session
+    try:
+        _dispatch_sync(
+            {
+                "id": "watermark-client",
+                "method": "client.attach",
+                "params": {"client_id": "watermark-client"},
+            },
+            client,
+        )
+        response = _dispatch_sync(
+            {
+                "id": "watermark-attach",
+                "method": "session.attach",
+                "params": {
+                    "session_id": "watermark-sid",
+                    "mode": "observe",
+                    "last_seen_seq": watermark,
+                },
+            },
+            client,
+        )
+        assert response["error"]["code"] == -32602
+    finally:
+        server._sessions.pop("watermark-sid", None)
+        server._teardown_session(session)
+
+
+@pytest.mark.parametrize(
+    ("rpc_method", "capability"),
+    [
+        ("prompt.submit", "prompt.submit"),
+        ("session.steer", "session.steer"),
+        ("session.redirect", "session.steer"),
+        ("session.interrupt", "session.interrupt"),
+        ("approval.respond", "approval.respond"),
+        ("clarify.respond", "clarify.respond"),
+        ("terminal.read.respond", "ui.respond"),
+        ("preview.read.respond", "ui.respond"),
+        ("preview.act.respond", "ui.respond"),
+        ("window.read.respond", "ui.respond"),
+        ("tour.respond", "ui.respond"),
+        ("mcp.setup.respond", "ui.respond"),
+        ("sudo.respond", "ui.respond"),
+        ("secret.respond", "ui.respond"),
+    ],
+)
+def test_dispatch_enforces_attachment_capability_before_handler(rpc_method, capability):
+    observer = _LifecycleTransport(f"observer-{rpc_method}")
+    controller = _LifecycleTransport(f"controller-{rpc_method}")
+    session = {"history_lock": threading.Lock(), "transport": controller}
+    hub = server._attach_current_transport(
+        "capability-sid", session, "control", transport=controller
+    )
+    hub.attach(
+        observer,
+        client_id=observer.client_id,
+        mode=AttachmentMode.OBSERVE,
+    )
+    server._sessions["capability-sid"] = session
+    calls = []
+    original = server._methods[rpc_method]
+    server._methods[rpc_method] = lambda rid, params: (
+        calls.append((rid, params, capability)) or server._ok(rid, {"called": True})
+    )
+    try:
+        denied = _dispatch_sync(
+            {
+                "id": "denied-capability",
+                "method": rpc_method,
+                "params": {"session_id": "capability-sid"},
+            },
+            observer,
+        )
+        assert denied["error"]["code"] == 4003
+        assert calls == []
+
+        allowed = _dispatch_sync(
+            {
+                "id": "allowed-capability",
+                "method": rpc_method,
+                "params": {"session_id": "capability-sid"},
+            },
+            controller,
+        )
+        assert allowed["result"]["called"] is True
+        assert len(calls) == 1
+    finally:
+        server._methods[rpc_method] = original
+        server._sessions.pop("capability-sid", None)
+        server._teardown_session(session)
+
+
+def test_mutating_rpc_ingress_is_serialized_per_live_runtime():
+    first_controller = _LifecycleTransport("serialized-first")
+    second_controller = _LifecycleTransport("serialized-second")
+    session = {"history_lock": threading.Lock(), "transport": first_controller}
+    hub = server._attach_current_transport(
+        "serialized-sid", session, "control", transport=first_controller
+    )
+    hub.attach(
+        second_controller,
+        client_id=second_controller.client_id,
+        mode=AttachmentMode.CONTROL,
+    )
+    server._sessions["serialized-sid"] = session
+    first_entered = threading.Event()
+    release_first = threading.Event()
+    second_entered = threading.Event()
+    call_order = []
+    original = server._methods["session.steer"]
+
+    def handler(rid, params):
+        call_order.append(rid)
+        if rid == "first-control":
+            first_entered.set()
+            assert release_first.wait(timeout=3)
+        else:
+            second_entered.set()
+        return server._ok(rid, {"called": True})
+
+    server._methods["session.steer"] = handler
+    first_result = {}
+    second_result = {}
+
+    def invoke(target, rid, result):
+        result["response"] = _dispatch_sync(
+            {
+                "id": rid,
+                "method": "session.steer",
+                "params": {"session_id": "serialized-sid"},
+            },
+            target,
+        )
+
+    first_thread = threading.Thread(
+        target=invoke,
+        args=(first_controller, "first-control", first_result),
+    )
+    second_thread = threading.Thread(
+        target=invoke,
+        args=(second_controller, "second-control", second_result),
+    )
+    try:
+        first_thread.start()
+        assert first_entered.wait(timeout=3)
+        second_thread.start()
+        assert not second_entered.wait(timeout=0.2)
+        release_first.set()
+        first_thread.join(timeout=3)
+        second_thread.join(timeout=3)
+        assert call_order == ["first-control", "second-control"]
+        assert first_result["response"]["result"]["called"] is True
+        assert second_result["response"]["result"]["called"] is True
+    finally:
+        release_first.set()
+        first_thread.join(timeout=3)
+        second_thread.join(timeout=3)
+        server._methods["session.steer"] = original
+        server._sessions.pop("serialized-sid", None)
+        server._teardown_session(session)
+
+
+def test_approval_response_reports_atomic_winner_and_duplicate(monkeypatch):
+    controller = _LifecycleTransport("approval-race-controller")
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": controller,
+        "session_key": "approval-race-key",
+    }
+    server._attach_current_transport(
+        "approval-race-sid", session, "control", transport=controller
+    )
+    server._sessions["approval-race-sid"] = session
+    outcomes = iter((1, 0))
+    emitted = []
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval",
+        lambda *args, **kwargs: next(outcomes),
+    )
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda *args, **kwargs: emitted.append(args) or True,
+    )
+    try:
+        request = {
+            "method": "approval.respond",
+            "params": {
+                "session_id": "approval-race-sid",
+                "request_id": "approval-request-1",
+                "choice": "once",
+            },
+        }
+        first = _dispatch_sync({"id": "approval-first", **request}, controller)
+        second = _dispatch_sync({"id": "approval-second", **request}, controller)
+
+        assert first["result"]["status"] == "resolved"
+        assert second["result"]["status"] == "already_resolved"
+        assert first["result"]["choice"] == second["result"]["choice"] == "once"
+        assert [args[0] for args in emitted] == ["approval.resolved"]
+    finally:
+        server._sessions.pop("approval-race-sid", None)
+        server._teardown_session(session)
+
+
+def test_approval_respond_rejects_choice_outside_protocol_allowlist():
+    controller = _LifecycleTransport("approval-choice-controller")
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": controller,
+        "session_key": "approval-choice-key",
+    }
+    server._attach_current_transport(
+        "approval-choice-sid", session, "control", transport=controller
+    )
+    server._sessions["approval-choice-sid"] = session
+    try:
+        response = _dispatch_sync(
+            {
+                "id": "invalid-approval-choice",
+                "method": "approval.respond",
+                "params": {
+                    "session_id": "approval-choice-sid",
+                    "choice": "yes",
+                },
+            },
+            controller,
+        )
+        assert response["error"]["code"] == 4002
+        assert "once, session, always, or deny" in response["error"]["message"]
+    finally:
+        server._sessions.pop("approval-choice-sid", None)
+        server._teardown_session(session)
+
+
+def test_teardown_closes_session_event_hub():
+    transport = _LifecycleTransport("closing-window")
+    session = {"transport": transport}
+    hub = server._attach_current_transport("close-sid", session, "control")
+
+    server._teardown_session(session)
+
+    assert hub.count() == 0
+    assert hub.publish({"jsonrpc": "2.0", "method": "event", "params": {}}) is False
 
 
 @pytest.fixture(autouse=True)
@@ -109,7 +814,9 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
         server._cfg_path = None
         _clear_server_sessions()
         monkeypatch.setattr(server, "_start_agent_build", lambda *args, **kwargs: None)
-        monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
+        monkeypatch.setattr(
+            server, "_completion_cwd", lambda params=None: str(tmp_path)
+        )
 
         # Opening a chat must NOT take a slot. Every tile paint and every
         # background reconnect-resume calls session.create, and an unprompted
@@ -135,7 +842,9 @@ def test_session_slot_is_claimed_on_first_turn_not_on_create(monkeypatch, tmp_pa
         assert closed["result"]["closed"] is True
         assert active_session_registry_snapshot() == []
 
-        assert server._ensure_active_session_slot(other, server._sessions[other]) is None
+        assert (
+            server._ensure_active_session_slot(other, server._sessions[other]) is None
+        )
     finally:
         _clear_server_sessions()
         server._cfg_cache = None
@@ -201,13 +910,19 @@ def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     try:
         pending = FakeDb("pending")
         monkeypatch.setattr(server, "_session_db", lambda _session: DbContext(pending))
-        result = server._methods["handoff.fail"]("r1", {"session_id": sid, "error": "timed out"})
+        result = server._methods["handoff.fail"](
+            "r1", {"session_id": sid, "error": "timed out"}
+        )
         assert result["result"] == {"failed": True, "state": "failed"}
         assert pending.failed_with == "timed out"
 
         completed = FakeDb("completed")
-        monkeypatch.setattr(server, "_session_db", lambda _session: DbContext(completed))
-        result = server._methods["handoff.fail"]("r2", {"session_id": sid, "error": "late timeout"})
+        monkeypatch.setattr(
+            server, "_session_db", lambda _session: DbContext(completed)
+        )
+        result = server._methods["handoff.fail"](
+            "r2", {"session_id": sid, "error": "late timeout"}
+        )
         assert result["result"] == {"failed": False, "state": "completed"}
         assert completed.failed_with is None
     finally:
@@ -257,7 +972,9 @@ def test_default_config_seeds_dashboard_process_isolation_keys():
     assert dashboard["compute_host_respawn_max"] == 3
 
 
-def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(monkeypatch):
+def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(
+    monkeypatch,
+):
     class FakeSupervisor:
         def __init__(self):
             self.frames = []
@@ -293,16 +1010,16 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
             "persist_seed", parent_writes["persist_seed"] + 1
         ),
     )
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake_supervisor)
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: fake_supervisor
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "submit",
-                "method": "prompt.submit",
-                "params": {"session_id": "iso-sid", "text": "hello"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "submit",
+            "method": "prompt.submit",
+            "params": {"session_id": "iso-sid", "text": "hello"},
+        })
         assert resp["result"] == {"status": "streaming", "turn_isolation": True}
         assert fake_supervisor.frames[0]["type"] == "turn.start"
         assert fake_supervisor.frames[0]["sid"] == "iso-sid"
@@ -312,14 +1029,12 @@ def test_prompt_submit_dispatches_to_compute_host_when_turn_isolation_enabled(mo
         assert parent_writes == {"ensure_session": 0, "persist_seed": 0}
         assert server._sessions["iso-sid"]["running"] is True
 
-        fake_supervisor.callback(
-            {
-                "type": "turn.end",
-                "sid": "iso-sid",
-                "request_id": "submit",
-                "history_version": 1,
-            }
-        )
+        fake_supervisor.callback({
+            "type": "turn.end",
+            "sid": "iso-sid",
+            "request_id": "submit",
+            "history_version": 1,
+        })
         assert server._sessions["iso-sid"]["running"] is False
         assert server._sessions["iso-sid"]["history_version"] == 1
     finally:
@@ -332,7 +1047,9 @@ def test_compute_host_explicit_images_do_not_clear_later_attachment(monkeypatch)
             session["attached_images"].append("/tmp/c.png")
 
     session = _session(attached_images=[])
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor())
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _Supervisor()
+    )
 
     response = server._submit_prompt_to_compute_host(
         "r1", "sid", session, "B", image_paths=["/tmp/b.png"]
@@ -355,13 +1072,11 @@ def test_prompt_submit_unknown_session_logs_warning(caplog):
     server._sessions.clear()
 
     with caplog.at_level(logging.WARNING, logger="tui_gateway.server"):
-        resp = _dispatch_sync(
-            {
-                "id": "r1",
-                "method": "prompt.submit",
-                "params": {"session_id": "gone-sid", "text": "hello"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "r1",
+            "method": "prompt.submit",
+            "params": {"session_id": "gone-sid", "text": "hello"},
+        })
 
     assert resp == {
         "jsonrpc": "2.0",
@@ -376,23 +1091,19 @@ def test_prompt_submit_unknown_session_logs_warning(caplog):
     # identify WHICH client call is looping on a stale runtime id — the gap
     # that made a 5s `process.list` poll storm (18,614 rejections against one
     # id) unattributable from the logs alone.
-    assert any(
-        "method=prompt.submit" in rec.message for rec in caplog.records
-    )
+    assert any("method=prompt.submit" in rec.message for rec in caplog.records)
 
 
 def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monkeypatch):
     class _BrokenSupervisor:
         def submit_turn(self, frame, *, on_complete=None):
             if on_complete is not None:
-                on_complete(
-                    {
-                        "type": "turn.error",
-                        "request_id": frame["request_id"],
-                        "reason": "send_failed",
-                        "message": "broken pipe",
-                    }
-                )
+                on_complete({
+                    "type": "turn.error",
+                    "request_id": frame["request_id"],
+                    "reason": "send_failed",
+                    "message": "broken pipe",
+                })
             raise BrokenPipeError("broken pipe")
 
     class _ImmediateThread:
@@ -406,29 +1117,37 @@ def test_prompt_submit_fails_open_inline_when_compute_host_dispatch_breaks(monke
     session = _session(agent=None, agent_ready=threading.Event())
     server._sessions["iso-fallback"] = session
     inline_calls = []
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
-    monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _BrokenSupervisor())
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
+    monkeypatch.setattr(
+        server, "_get_compute_host_supervisor", lambda _cfg=None: _BrokenSupervisor()
+    )
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
     monkeypatch.setattr(server, "_start_agent_build", lambda _sid, _session: None)
     monkeypatch.setattr(server, "_wait_agent", lambda _session, _rid: None)
     # The deferred inline-fallback thread now waits via the patient variant.
-    monkeypatch.setattr(server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None)
+    monkeypatch.setattr(
+        server, "_wait_agent_for_prompt", lambda _session, _rid, _sid: None
+    )
     monkeypatch.setattr(
         server,
         "_run_prompt_submit",
-        lambda rid, sid, _session, text, **_kwargs: inline_calls.append((rid, sid, text)),
+        lambda rid, sid, _session, text, **_kwargs: inline_calls.append((
+            rid,
+            sid,
+            text,
+        )),
     )
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "fallback-turn",
-                "method": "prompt.submit",
-                "params": {"session_id": "iso-fallback", "text": "hello"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "fallback-turn",
+            "method": "prompt.submit",
+            "params": {"session_id": "iso-fallback", "text": "hello"},
+        })
     finally:
         server._sessions.pop("iso-fallback", None)
 
@@ -457,7 +1176,11 @@ def test_compute_host_turn_end_updates_metadata_mirror(monkeypatch):
     )
     server._sessions["iso-sid"] = session
     emitted = []
-    monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: emitted.append((event, sid, payload)))
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, sid, payload)),
+    )
 
     try:
         server._on_compute_host_turn_done(
@@ -524,22 +1247,34 @@ def test_slash_exec_compress_flag_on_applies_host_control_mirror(monkeypatch):
             }
 
     fake = _FakeSupervisor()
-    session = _session(agent=None, agent_ready=threading.Event(), _compute_host_active=True)
+    session = _session(
+        agent=None, agent_ready=threading.Event(), _compute_host_active=True
+    )
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
     monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: fake)
     monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
-    monkeypatch.setattr(server, "_compress_session_history", lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent compressed")))
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent identity guard ran")))
+    monkeypatch.setattr(
+        server,
+        "_compress_session_history",
+        lambda *a, **k: (_ for _ in ()).throw(AssertionError("parent compressed")),
+    )
+    monkeypatch.setattr(
+        server,
+        "_sync_session_key_after_compress",
+        lambda *a, **k: (_ for _ in ()).throw(
+            AssertionError("parent identity guard ran")
+        ),
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "slash.exec",
-                "params": {"command": "compress focus", "session_id": "sid"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"command": "compress focus", "session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -575,7 +1310,9 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         def clear_interrupt(self):
             return None
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             if stream_callback is not None:
                 stream_callback("hi")
             return {
@@ -586,12 +1323,18 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
                 ],
             }
 
-    fixed_info = {"model": "gold-model", "provider": "gold-provider", "usage": {"total": 15}}
+    fixed_info = {
+        "model": "gold-model",
+        "provider": "gold-provider",
+        "usage": {"total": 15},
+    }
     usage = server._get_usage(_Agent())
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
     monkeypatch.setattr(server, "_persist_branch_seed", lambda _session: None)
-    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: dict(fixed_info))
+    monkeypatch.setattr(
+        server, "_session_info", lambda _agent, _session=None: dict(fixed_info)
+    )
     monkeypatch.setattr(server, "make_stream_renderer", lambda _cols: None)
     monkeypatch.setattr(server, "render_message", lambda _raw, _cols: None)
     fake_title = types.ModuleType("agent.title_generator")
@@ -600,15 +1343,24 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_off():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
-        monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}})
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, sid, payload=None: events.append((event, sid, payload)),
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": False}}
+        )
         server._sessions["sid"] = _session(
-            agent=_Agent(), model_override={"model": "gold-model", "provider": "gold-provider"}
+            agent=_Agent(),
+            model_override={"model": "gold-model", "provider": "gold-provider"},
         )
         try:
-            response = server.handle_request(
-                {"id": "turn-1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-            )
+            response = server.handle_request({
+                "id": "turn-1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
             assert response["result"]["status"] == "streaming"
             return events
         finally:
@@ -616,32 +1368,42 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
 
     def run_flag_on():
         events = []
-        monkeypatch.setattr(server, "_emit", lambda event, sid, payload=None: events.append((event, sid, payload)))
-        monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+        monkeypatch.setattr(
+            server,
+            "_emit",
+            lambda event, sid, payload=None: events.append((event, sid, payload)),
+        )
+        monkeypatch.setattr(
+            server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+        )
 
         class _FakeSupervisor:
             def submit_turn(self, frame, *, on_complete=None):
                 sid = frame["sid"]
                 server._emit("message.start", sid)
                 server._emit("message.delta", sid, {"text": "hi"})
-                server._emit("message.complete", sid, {"text": "hi", "usage": usage, "status": "complete"})
+                server._emit(
+                    "message.complete",
+                    sid,
+                    {"text": "hi", "usage": usage, "status": "complete"},
+                )
                 server._emit("session.info", sid, dict(fixed_info))
                 if on_complete is not None:
-                    on_complete(
-                        {
-                            "type": "turn.end",
-                            "sid": sid,
-                            "request_id": frame["request_id"],
-                            "session_key": "session-key",
-                            "history_version": 1,
-                            "message_count": 2,
-                            "session_info": dict(fixed_info),
-                            "session_info_emitted": True,
-                        }
-                    )
+                    on_complete({
+                        "type": "turn.end",
+                        "sid": sid,
+                        "request_id": frame["request_id"],
+                        "session_key": "session-key",
+                        "history_version": 1,
+                        "message_count": 2,
+                        "session_info": dict(fixed_info),
+                        "session_info_emitted": True,
+                    })
                 return frame["request_id"]
 
-        monkeypatch.setattr(server, "_get_compute_host_supervisor", lambda _cfg=None: _FakeSupervisor())
+        monkeypatch.setattr(
+            server, "_get_compute_host_supervisor", lambda _cfg=None: _FakeSupervisor()
+        )
         session = _session(
             agent=None,
             agent_ready=threading.Event(),
@@ -651,9 +1413,11 @@ def test_prompt_submit_golden_transcript_matches_flag_off_and_on(monkeypatch):
         session["agent"] = None
         server._sessions["sid"] = session
         try:
-            response = server.handle_request(
-                {"id": "turn-1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-            )
+            response = server.handle_request({
+                "id": "turn-1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
             assert response["result"]["status"] == "streaming"
             return events
         finally:
@@ -702,9 +1466,7 @@ def test_profile_scoped_mcp_discovery_uses_target_home(monkeypatch, tmp_path):
     profile_home.mkdir(parents=True)
 
     (profile_home / "config.yaml").write_text(
-        "mcp_servers:\n"
-        "  bluesky_sheepyr:\n"
-        "    command: test-command\n",
+        "mcp_servers:\n  bluesky_sheepyr:\n    command: test-command\n",
         encoding="utf-8",
     )
 
@@ -757,8 +1519,7 @@ def test_profile_scoped_agent_build_starts_mcp_discovery_in_profile_home(
     monkeypatch.setattr(
         server,
         "_make_agent",
-        lambda *args, **kwargs: built.set()
-        or type("Agent", (), {"model": "test"})(),
+        lambda *args, **kwargs: built.set() or type("Agent", (), {"model": "test"})(),
     )
     monkeypatch.setattr(
         "tui_gateway.entry.ensure_mcp_discovery_started",
@@ -808,9 +1569,7 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
 
     profile_home = tmp_path / "profiles" / "grace"
     profile_home.mkdir(parents=True)
-    (profile_home / ".env").write_text(
-        "PROXMOX_TOKEN=grace-secret\n", encoding="utf-8"
-    )
+    (profile_home / ".env").write_text("PROXMOX_TOKEN=grace-secret\n", encoding="utf-8")
 
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / "default"))
 
@@ -824,9 +1583,7 @@ def test_profile_scoped_agent_build_installs_secret_scope(monkeypatch, tmp_path)
         return type("Agent", (), {"model": "test"})()
 
     monkeypatch.setattr(server, "_make_agent", _fake_make_agent)
-    monkeypatch.setattr(
-        "tui_gateway.entry.ensure_mcp_discovery_started", lambda: None
-    )
+    monkeypatch.setattr("tui_gateway.entry.ensure_mcp_discovery_started", lambda: None)
     monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
     monkeypatch.setattr(server, "_SlashWorker", lambda *args: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *args: None)
@@ -908,7 +1665,9 @@ def test_completion_cwd_prefers_launch_config_over_stale_env(monkeypatch, tmp_pa
     stale.mkdir()
 
     monkeypatch.setenv("TERMINAL_CWD", str(stale))
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}}
+    )
     monkeypatch.setattr(server, "_profile_home", lambda _name: None)
 
     assert server._completion_cwd({}) == str(configured)
@@ -924,7 +1683,9 @@ def test_default_session_cwd_prefers_launch_config(monkeypatch, tmp_path):
     stale.mkdir()
 
     monkeypatch.setenv("TERMINAL_CWD", str(stale))
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"terminal": {"cwd": str(configured)}}
+    )
 
     assert server._default_session_cwd() == str(configured)
 
@@ -1083,11 +1844,14 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
     monkeypatch.setattr(server, "_real_stdout", out)
     server._sessions["detached-sid"] = {"transport": server._detached_ws_transport}
     try:
-        assert server.write_json({
-            "jsonrpc": "2.0",
-            "method": "event",
-            "params": {"session_id": "detached-sid", "type": "message.delta"},
-        }) is False
+        assert (
+            server.write_json({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {"session_id": "detached-sid", "type": "message.delta"},
+            })
+            is False
+        )
         assert out.parts == []
     finally:
         server._sessions.pop("detached-sid", None)
@@ -1128,20 +1892,20 @@ def test_write_json_fans_out_one_stamped_order_to_all_session_attachments():
     def _publish(source):
         start.wait(timeout=5)
         for index in range(20):
-            assert server.write_json(
-                {
-                    "jsonrpc": "2.0",
-                    "method": "event",
-                    "params": {
-                        "type": "message.delta",
-                        "session_id": sid,
-                        "payload": {"source": source, "index": index},
-                    },
-                }
-            )
+            assert server.write_json({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "message.delta",
+                    "session_id": sid,
+                    "payload": {"source": source, "index": index},
+                },
+            })
 
     try:
-        workers = [threading.Thread(target=_publish, args=(source,)) for source in ("a", "b")]
+        workers = [
+            threading.Thread(target=_publish, args=(source,)) for source in ("a", "b")
+        ]
         for worker in workers:
             worker.start()
         start.wait(timeout=5)
@@ -1154,9 +1918,12 @@ def test_write_json_fans_out_one_stamped_order_to_all_session_attachments():
 
         assert left.frames == right.frames
         assert [frame["params"]["seq"] for frame in left.frames] == list(range(1, 41))
-        assert [event["seq"] for event in event_replay.events_since(sid, 0)] == list(
-            range(1, 41)
-        )
+        assert {frame["params"]["epoch"] for frame in left.frames} == {
+            event_replay.replay_epoch()
+        }
+        replayed = event_replay.events_since(sid, 0)
+        assert [event["seq"] for event in replayed] == list(range(1, 41))
+        assert {event["epoch"] for event in replayed} == {event_replay.replay_epoch()}
     finally:
         hub.close()
         server._sessions.pop(sid, None)
@@ -1188,17 +1955,15 @@ def test_write_json_keeps_legacy_delivery_in_replay_sequence_order():
     server._sessions[sid] = {"transport": transport}
 
     def publish(index):
-        server.write_json(
-            {
-                "jsonrpc": "2.0",
-                "method": "event",
-                "params": {
-                    "type": "message.delta",
-                    "session_id": sid,
-                    "payload": {"index": index},
-                },
-            }
-        )
+        server.write_json({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "message.delta",
+                "session_id": sid,
+                "payload": {"index": index},
+            },
+        })
 
     first = threading.Thread(target=publish, args=(1,))
     second = threading.Thread(target=publish, args=(2,))
@@ -1250,7 +2015,9 @@ def test_usage_ticker_emits_wrapped_usage_payload(monkeypatch):
     # …) silently drops every live tick on the client side.
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     snapshot = {"input": 1200, "total": 1280}
     monkeypatch.setattr(server, "_get_usage", lambda agent: dict(snapshot))
@@ -1427,13 +2194,11 @@ def test_run_prompt_submit_never_ticks_after_message_complete(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -1536,13 +2301,11 @@ def test_run_prompt_submit_joins_ticker_without_timeout(monkeypatch):
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -1599,7 +2362,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
 
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1608,7 +2373,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
     )
 
     server._on_tool_start("redaction-test", "tool-1", "terminal", {"command": "pwd"})
-    server._on_tool_complete("redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    server._on_tool_complete(
+        "redaction-test", "tool-1", "terminal", {"command": "pwd"}, "done"
+    )
 
     assert events[0][0] == "tool.start"
     assert events[1][0] == "tool.complete"
@@ -1619,7 +2386,9 @@ def test_tui_verbose_tool_events_omit_details_when_redaction_fails(monkeypatch):
 def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1639,24 +2408,28 @@ def test_tui_tool_output_risk_event_exposes_metadata_without_raw_output(monkeypa
         },
     )
 
-    assert events == [(
-        "tool.output_risk",
-        "risk-test",
-        {
-            "tool_id": "tool-1",
-            "name": "web_extract",
-            "risk": "high",
-            "findings": ["prompt_injection"],
-            "redacted": False,
-        },
-    )]
+    assert events == [
+        (
+            "tool.output_risk",
+            "risk-test",
+            {
+                "tool_id": "tool-1",
+                "name": "web_extract",
+                "risk": "high",
+                "findings": ["prompt_injection"],
+                "redacted": False,
+            },
+        )
+    ]
     assert "result" not in events[0][2]
 
 
 def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1668,7 +2441,9 @@ def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     result = '{"question":"Pick one","choices_offered":["A","B"],"user_response":"A"}'
 
     server._on_tool_start("clarify-off-test", "tool-clarify", "clarify", args)
-    server._on_tool_complete("clarify-off-test", "tool-clarify", "clarify", args, result)
+    server._on_tool_complete(
+        "clarify-off-test", "tool-clarify", "clarify", args, result
+    )
 
     assert [event[0] for event in events] == ["tool.start", "tool.complete"]
     assert events[0][2]["name"] == "clarify"
@@ -1676,10 +2451,14 @@ def test_tui_clarify_lifecycle_events_emit_when_tool_progress_off(monkeypatch):
     assert events[1][2]["result"]["user_response"] == "A"
 
 
-def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(monkeypatch):
+def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(
+    monkeypatch,
+):
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     monkeypatch.setitem(
         server._sessions,
@@ -1688,7 +2467,9 @@ def test_tui_non_interactive_tool_lifecycle_stays_hidden_when_tool_progress_off(
     )
 
     server._on_tool_start("terminal-off-test", "tool-1", "terminal", {"command": "pwd"})
-    server._on_tool_complete("terminal-off-test", "tool-1", "terminal", {"command": "pwd"}, "done")
+    server._on_tool_complete(
+        "terminal-off-test", "tool-1", "terminal", {"command": "pwd"}, "done"
+    )
 
     assert events == []
 
@@ -1758,9 +2539,11 @@ def test_config_set_battery_toggles_and_persists(monkeypatch):
         server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
     )
 
-    resp = server.dispatch(
-        {"id": "c1", "method": "config.set", "params": {"key": "battery", "value": ""}}
-    )
+    resp = server.dispatch({
+        "id": "c1",
+        "method": "config.set",
+        "params": {"key": "battery", "value": ""},
+    })
 
     assert resp["result"] == {"key": "battery", "value": "on"}
     assert writes == {"display.battery": True}
@@ -1773,13 +2556,11 @@ def test_config_set_battery_explicit_off(monkeypatch):
         server, "_write_config_key", lambda k, v: writes.__setitem__(k, v)
     )
 
-    resp = server.dispatch(
-        {
-            "id": "c2",
-            "method": "config.set",
-            "params": {"key": "battery", "value": "off"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "c2",
+        "method": "config.set",
+        "params": {"key": "battery", "value": "off"},
+    })
 
     assert resp["result"] == {"key": "battery", "value": "off"}
     assert writes == {"display.battery": False}
@@ -1805,12 +2586,16 @@ def test_voice_toggle_returns_configured_record_key(monkeypatch):
     # review on #19835).
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    on_resp = _dispatch_sync(
-        {"id": "voice-on", "method": "voice.toggle", "params": {"action": "on"}}
-    )
-    status_resp = _dispatch_sync(
-        {"id": "voice-status", "method": "voice.toggle", "params": {"action": "status"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
+    status_resp = _dispatch_sync({
+        "id": "voice-status",
+        "method": "voice.toggle",
+        "params": {"action": "status"},
+    })
 
     assert on_resp["result"]["record_key"] == "ctrl+o"
     assert status_resp["result"]["record_key"] == "ctrl+o"
@@ -1831,9 +2616,11 @@ def test_voice_toggle_on_carries_stop_hint(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    on_resp = _dispatch_sync(
-        {"id": "voice-on", "method": "voice.toggle", "params": {"action": "on"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
     assert on_resp["result"]["stop_hint"] == 'Say "halt" to end the voice chat.'
 
     # Disabled stop phrases → empty hint, clients show nothing.
@@ -1845,15 +2632,19 @@ def test_voice_toggle_on_carries_stop_hint(monkeypatch):
             voice_stop_hint=lambda: "",
         ),
     )
-    on_resp = _dispatch_sync(
-        {"id": "voice-on2", "method": "voice.toggle", "params": {"action": "on"}}
-    )
+    on_resp = _dispatch_sync({
+        "id": "voice-on2",
+        "method": "voice.toggle",
+        "params": {"action": "on"},
+    })
     assert on_resp["result"]["stop_hint"] == ""
 
     # off carries no hint text (mode is ending).
-    off_resp = _dispatch_sync(
-        {"id": "voice-off", "method": "voice.toggle", "params": {"action": "off"}}
-    )
+    off_resp = _dispatch_sync({
+        "id": "voice-off",
+        "method": "voice.toggle",
+        "params": {"action": "off"},
+    })
     assert off_resp["result"]["stop_hint"] == ""
 
 
@@ -1877,17 +2668,15 @@ def test_voice_toggle_handles_non_dict_voice_cfg(monkeypatch):
     for bad in (True, "cmd+b", None, 42, ["ctrl+b"]):
         monkeypatch.setattr(server, "_load_cfg", lambda b=bad: {"voice": b})
 
-        status_resp = _dispatch_sync(
-            {
-                "id": "voice-status",
-                "method": "voice.toggle",
-                "params": {"action": "status"},
-            }
-        )
+        status_resp = _dispatch_sync({
+            "id": "voice-status",
+            "method": "voice.toggle",
+            "params": {"action": "status"},
+        })
 
-        assert (
-            status_resp["result"]["record_key"] == "ctrl+b"
-        ), f"voice.record_key fell back to default for voice={bad!r}"
+        assert status_resp["result"]["record_key"] == "ctrl+b", (
+            f"voice.record_key fell back to default for voice={bad!r}"
+        )
 
     # Round-4 follow-up: the YAML root itself may be a non-dict. A
     # hand-edit that collapses config.yaml to a scalar / list would
@@ -1896,17 +2685,15 @@ def test_voice_toggle_handles_non_dict_voice_cfg(monkeypatch):
     for bad_root in (True, None, [], "ctrl+b", 42):
         monkeypatch.setattr(server, "_load_cfg", lambda r=bad_root: r)
 
-        status_resp = _dispatch_sync(
-            {
-                "id": "voice-status-root",
-                "method": "voice.toggle",
-                "params": {"action": "status"},
-            }
-        )
+        status_resp = _dispatch_sync({
+            "id": "voice-status-root",
+            "method": "voice.toggle",
+            "params": {"action": "status"},
+        })
 
-        assert (
-            status_resp["result"]["record_key"] == "ctrl+b"
-        ), f"voice.record_key fell back to default for root={bad_root!r}"
+        assert status_resp["result"]["record_key"] == "ctrl+b", (
+            f"voice.record_key fell back to default for root={bad_root!r}"
+        )
 
 
 def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
@@ -1937,22 +2724,19 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda b=bad: {"voice": b})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
-        assert (
-            "result" in resp
-        ), f"voice.record raised for voice={bad!r}: {resp.get('error')}"
+        assert "result" in resp, (
+            f"voice.record raised for voice={bad!r}: {resp.get('error')}"
+        )
         assert resp["result"]["status"] == "recording"
         assert captured["silence_threshold"] == 200
         assert captured["silence_duration"] == 3.0
         assert captured["auto_restart"] is False
-
 
     # Round-12 Copilot review regression on #19835: ``bool`` is a subclass
     # of ``int``, so the naive ``isinstance(threshold, (int, float))``
@@ -1966,21 +2750,19 @@ def test_voice_record_start_handles_non_dict_voice_cfg(monkeypatch):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda c=bad_bool_cfg: {"voice": c})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record-bool",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record-bool",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
         assert "result" in resp, f"voice.record raised for bool cfg={bad_bool_cfg!r}"
-        assert (
-            captured["silence_threshold"] == 200
-        ), f"bool silence_threshold leaked through for {bad_bool_cfg!r}"
-        assert (
-            captured["silence_duration"] == 3.0
-        ), f"bool silence_duration leaked through for {bad_bool_cfg!r}"
+        assert captured["silence_threshold"] == 200, (
+            f"bool silence_threshold leaked through for {bad_bool_cfg!r}"
+        )
+        assert captured["silence_duration"] == 3.0, (
+            f"bool silence_duration leaked through for {bad_bool_cfg!r}"
+        )
         assert captured["auto_restart"] is False
 
 
@@ -1992,7 +2774,9 @@ def test_prompt_submit_typed_stop_phrase_ends_voice_chat(monkeypatch):
     calls = {"stop_continuous": 0}
     emitted = []
     monkeypatch.setattr(
-        server, "_emit", lambda event, sid, payload=None: emitted.append((event, payload))
+        server,
+        "_emit",
+        lambda event, sid, payload=None: emitted.append((event, payload)),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -2014,13 +2798,11 @@ def test_prompt_submit_typed_stop_phrase_ends_voice_chat(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
     monkeypatch.setenv("HERMES_VOICE_TTS", "1")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-stop",
-            "method": "prompt.submit",
-            "params": {"session_id": "any-sid", "text": "Stop."},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-stop",
+        "method": "prompt.submit",
+        "params": {"session_id": "any-sid", "text": "Stop."},
+    })
 
     assert resp["result"] == {"voice_stopped": True}
     assert os.environ["HERMES_VOICE"] == "0"
@@ -2043,13 +2825,11 @@ def test_prompt_submit_typed_stop_passes_through_when_voice_off(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "0")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-stop-off",
-            "method": "prompt.submit",
-            "params": {"session_id": "missing-sid", "text": "stop"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-stop-off",
+        "method": "prompt.submit",
+        "params": {"session_id": "missing-sid", "text": "stop"},
+    })
 
     # The submit proceeds into normal handling (here: unknown session error),
     # NOT the voice_stopped consumption path.
@@ -2057,7 +2837,7 @@ def test_prompt_submit_typed_stop_passes_through_when_voice_off(monkeypatch):
 
 
 def test_prompt_submit_longer_text_not_consumed_in_voice_mode(monkeypatch):
-    """"stop the build" while voice is on must reach the agent path."""
+    """ "stop the build" while voice is on must reach the agent path."""
     monkeypatch.setitem(
         sys.modules,
         "tools.voice_mode",
@@ -2067,13 +2847,11 @@ def test_prompt_submit_longer_text_not_consumed_in_voice_mode(monkeypatch):
     )
     monkeypatch.setenv("HERMES_VOICE", "1")
 
-    resp = server.dispatch(
-        {
-            "id": "typed-long",
-            "method": "prompt.submit",
-            "params": {"session_id": "missing-sid", "text": "stop the build"},
-        }
-    )
+    resp = server.dispatch({
+        "id": "typed-long",
+        "method": "prompt.submit",
+        "params": {"session_id": "missing-sid", "text": "stop the build"},
+    })
 
     assert resp.get("result") != {"voice_stopped": True}
 
@@ -2116,22 +2894,32 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
         voice_callbacks.update(callbacks)
         return True
 
-    monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: {
-        "enabled": True,
-        "phrase": "hey hermes",
-        "surface": "auto",
-        "start_new_session": True,
-    })
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
-        "available": True,
-        "phrase": "hey hermes",
-        "provider": "test",
-        "hint": "",
-    })
+    monkeypatch.setattr(
+        wake_word,
+        "load_wake_word_config",
+        lambda: {
+            "enabled": True,
+            "phrase": "hey hermes",
+            "surface": "auto",
+            "start_new_session": True,
+        },
+    )
+    monkeypatch.setattr(
+        wake_word,
+        "check_wake_word_requirements",
+        lambda _cfg: {
+            "available": True,
+            "phrase": "hey hermes",
+            "provider": "test",
+            "hint": "",
+        },
+    )
     monkeypatch.setattr(wake_word, "start_listening", start_listening)
     monkeypatch.setattr(wake_word, "pause_listening", pause_listening)
     monkeypatch.setattr(wake_word, "stop_listening", stop_listening)
-    monkeypatch.setattr(wake_word, "owns_listener", lambda owner: state["owner"] is owner)
+    monkeypatch.setattr(
+        wake_word, "owns_listener", lambda owner: state["owner"] is owner
+    )
     monkeypatch.setattr(
         wake_word,
         "is_listening",
@@ -2158,33 +2946,48 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
     monkeypatch.setattr(
         server,
         "_emit",
-        lambda event, sid, payload: emitted.append(
-            (event, sid, payload, server.current_transport())
-        ),
+        lambda event, sid, payload: emitted.append((
+            event,
+            sid,
+            payload,
+            server.current_transport(),
+        )),
     )
     server._wake_owner_transport = None
     server._wake_owner_surface = ""
     try:
-        started = _dispatch_sync({
-            "id": "wake-1",
-            "method": "wake.start",
-            "params": {"surface": "gui", "session_id": "first-session"},
-        }, transport=first)
-        denied = _dispatch_sync({
-            "id": "wake-2",
-            "method": "wake.start",
-            "params": {"surface": "tui", "session_id": "second-session"},
-        }, transport=second)
-        denied_stop = server.dispatch({
-            "id": "wake-stop-2",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=second)
-        denied_voice_stop = _dispatch_sync({
-            "id": "voice-stop-2",
-            "method": "voice.record",
-            "params": {"action": "stop"},
-        }, transport=second)
+        started = _dispatch_sync(
+            {
+                "id": "wake-1",
+                "method": "wake.start",
+                "params": {"surface": "gui", "session_id": "first-session"},
+            },
+            transport=first,
+        )
+        denied = _dispatch_sync(
+            {
+                "id": "wake-2",
+                "method": "wake.start",
+                "params": {"surface": "tui", "session_id": "second-session"},
+            },
+            transport=second,
+        )
+        denied_stop = server.dispatch(
+            {
+                "id": "wake-stop-2",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=second,
+        )
+        denied_voice_stop = _dispatch_sync(
+            {
+                "id": "voice-stop-2",
+                "method": "voice.record",
+                "params": {"action": "stop"},
+            },
+            transport=second,
+        )
 
         assert started["result"]["started"] is True
         assert denied["result"] == {
@@ -2203,39 +3006,50 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
         }
 
         state["callback"]()
-        assert emitted == [(
-            "wake.detected",
-            "first-session",
-            {"phrase": "hey hermes", "profile": None, "start_new_session": True},
-            first,
-        )]
+        assert emitted == [
+            (
+                "wake.detected",
+                "first-session",
+                {"phrase": "hey hermes", "profile": None, "start_new_session": True},
+                first,
+            )
+        ]
         assert state["paused"] is True
 
-        voice_started = _dispatch_sync({
-            "id": "voice-start-1",
-            "method": "voice.record",
-            "params": {"action": "start", "session_id": "first-session"},
-        }, transport=first)
+        voice_started = _dispatch_sync(
+            {
+                "id": "voice-start-1",
+                "method": "voice.record",
+                "params": {"action": "start", "session_id": "first-session"},
+            },
+            transport=first,
+        )
         assert voice_started["result"]["status"] == "recording"
         voice_callbacks["on_status"]("idle")
         assert state["paused"] is False
 
-        stopped = server.dispatch({
-            "id": "wake-stop-1",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=first)
+        stopped = server.dispatch(
+            {
+                "id": "wake-stop-1",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=first,
+        )
         assert stopped["result"] == {
             "stopped": True,
             "reason": None,
             "disabled_persisted": False,
         }
 
-        reclaimed = _dispatch_sync({
-            "id": "wake-reclaim-2",
-            "method": "wake.start",
-            "params": {"surface": "tui", "session_id": "second-session"},
-        }, transport=second)
+        reclaimed = _dispatch_sync(
+            {
+                "id": "wake-reclaim-2",
+                "method": "wake.start",
+                "params": {"surface": "tui", "session_id": "second-session"},
+            },
+            transport=second,
+        )
         assert reclaimed["result"]["started"] is True
         assert state["owner"] is second
 
@@ -2247,11 +3061,14 @@ def test_wake_owner_is_sticky_and_routes_detection_to_first_transport(monkeypatc
             second,
         )
 
-        stopped_again = server.dispatch({
-            "id": "wake-stop-2-after-reclaim",
-            "method": "wake.stop",
-            "params": {},
-        }, transport=second)
+        stopped_again = server.dispatch(
+            {
+                "id": "wake-stop-2-after-reclaim",
+                "method": "wake.stop",
+                "params": {},
+            },
+            transport=second,
+        )
         assert stopped_again["result"] == {
             "stopped": True,
             "reason": None,
@@ -2266,8 +3083,12 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
     """The ear toggle / /wake on|off write wake_word.enabled; auto-arm never does."""
     from tools import wake_word
 
-    config = {"enabled": False, "phrase": "hey hermes", "surface": "auto",
-              "start_new_session": True}
+    config = {
+        "enabled": False,
+        "phrase": "hey hermes",
+        "surface": "auto",
+        "start_new_session": True,
+    }
     persisted = []
 
     def fake_persist(enabled):
@@ -2277,65 +3098,85 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
 
     monkeypatch.setattr(server, "_persist_wake_enabled", fake_persist)
     monkeypatch.setattr(wake_word, "load_wake_word_config", lambda: dict(config))
-    monkeypatch.setattr(wake_word, "check_wake_word_requirements", lambda _cfg: {
-        "available": True,
-        "phrase": "hey hermes",
-        "provider": "test",
-        "hint": "",
-    })
+    monkeypatch.setattr(
+        wake_word,
+        "check_wake_word_requirements",
+        lambda _cfg: {
+            "available": True,
+            "phrase": "hey hermes",
+            "provider": "test",
+            "hint": "",
+        },
+    )
     listener = {"owner": None}
     monkeypatch.setattr(
-        wake_word, "start_listening",
+        wake_word,
+        "start_listening",
         lambda callback, *, owner, config, external_audio=False: listener.update(
             owner=owner, external_audio=bool(external_audio)
         ),
     )
     monkeypatch.setattr(
-        wake_word, "stop_listening",
+        wake_word,
+        "stop_listening",
         lambda *, owner: listener["owner"] is owner and not listener.update(owner=None),
     )
-    monkeypatch.setattr(wake_word, "owns_listener", lambda owner: listener["owner"] is owner)
+    monkeypatch.setattr(
+        wake_word, "owns_listener", lambda owner: listener["owner"] is owner
+    )
 
     transport = types.SimpleNamespace(_closed=False)
     server._wake_owner_transport = None
     server._wake_owner_surface = ""
     try:
         # Passive auto-arm (no persist): refused, config untouched.
-        passive = _dispatch_sync({
-            "id": "wake-passive",
-            "method": "wake.start",
-            "params": {"surface": "gui"},
-        }, transport=transport)
+        passive = _dispatch_sync(
+            {
+                "id": "wake-passive",
+                "method": "wake.start",
+                "params": {"surface": "gui"},
+            },
+            transport=transport,
+        )
         assert passive["result"] == {"started": False, "reason": "disabled"}
         assert persisted == []
 
         # Explicit gesture: enables in config AND arms.
-        clicked = _dispatch_sync({
-            "id": "wake-click",
-            "method": "wake.start",
-            "params": {"surface": "gui", "persist": True},
-        }, transport=transport)
+        clicked = _dispatch_sync(
+            {
+                "id": "wake-click",
+                "method": "wake.start",
+                "params": {"surface": "gui", "persist": True},
+            },
+            transport=transport,
+        )
         assert clicked["result"]["started"] is True
         assert clicked["result"]["enabled_persisted"] is True
         assert persisted == [True]
 
         # Explicit stop: disables in config.
-        stopped = server.dispatch({
-            "id": "wake-click-off",
-            "method": "wake.stop",
-            "params": {"persist": True},
-        }, transport=transport)
+        stopped = server.dispatch(
+            {
+                "id": "wake-click-off",
+                "method": "wake.stop",
+                "params": {"persist": True},
+            },
+            transport=transport,
+        )
         assert stopped["result"]["stopped"] is True
         assert stopped["result"]["disabled_persisted"] is True
         assert persisted == [True, False]
 
         # persist does NOT override an explicit surface scoping.
         config.update(enabled=True, surface="tui")
-        scoped = _dispatch_sync({
-            "id": "wake-scoped",
-            "method": "wake.start",
-            "params": {"surface": "gui", "persist": True},
-        }, transport=transport)
+        scoped = _dispatch_sync(
+            {
+                "id": "wake-scoped",
+                "method": "wake.start",
+                "params": {"surface": "gui", "persist": True},
+            },
+            transport=transport,
+        )
         assert scoped["result"] == {"started": False, "reason": "disabled_for_surface"}
         assert persisted == [True, False]
     finally:
@@ -2343,7 +3184,9 @@ def test_wake_toggle_persists_enabled_flag_only_on_explicit_gesture(monkeypatch)
         server._wake_owner_surface = ""
 
 
-def test_wake_status_reports_configured_input_device_and_windows_silence_hint(monkeypatch):
+def test_wake_status_reports_configured_input_device_and_windows_silence_hint(
+    monkeypatch,
+):
     from tools import wake_word
 
     config = {
@@ -2424,29 +3267,29 @@ def test_voice_record_start_forwards_max_recording_seconds(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
 
     for cfg, expected in (
-        ({"max_recording_seconds": 45}, 45),        # explicit cap forwarded as-is
-        ({"max_recording_seconds": 0}, 0.0),        # explicit 0 = disabled
-        ({"max_recording_seconds": -5}, 0.0),       # negative = disabled
-        ({}, 120.0),                                # missing = documented default
-        ({"max_recording_seconds": True}, 120.0),   # bool must not become 1s cap
-        ({"max_recording_seconds": "long"}, 120.0), # garbage = documented default
+        ({"max_recording_seconds": 45}, 45),  # explicit cap forwarded as-is
+        ({"max_recording_seconds": 0}, 0.0),  # explicit 0 = disabled
+        ({"max_recording_seconds": -5}, 0.0),  # negative = disabled
+        ({}, 120.0),  # missing = documented default
+        ({"max_recording_seconds": True}, 120.0),  # bool must not become 1s cap
+        ({"max_recording_seconds": "long"}, 120.0),  # garbage = documented default
     ):
         captured.clear()
         monkeypatch.setattr(server, "_load_cfg", lambda c=cfg: {"voice": c})
 
-        resp = _dispatch_sync(
-            {
-                "id": "voice-record-cap",
-                "method": "voice.record",
-                "params": {"action": "start"},
-            }
-        )
+        resp = _dispatch_sync({
+            "id": "voice-record-cap",
+            "method": "voice.record",
+            "params": {"action": "start"},
+        })
 
-        assert "result" in resp, f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        assert "result" in resp, (
+            f"voice.record raised for cfg={cfg!r}: {resp.get('error')}"
+        )
         assert resp["result"]["status"] == "recording"
-        assert (
-            captured["max_recording_seconds"] == expected
-        ), f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+        assert captured["max_recording_seconds"] == expected, (
+            f"cfg={cfg!r} forwarded {captured.get('max_recording_seconds')!r}, expected {expected!r}"
+        )
 
 
 def test_voice_record_stop_forces_transcription(monkeypatch):
@@ -2464,13 +3307,11 @@ def test_voice_record_stop_forces_transcription(monkeypatch):
         ),
     )
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-stop",
-            "method": "voice.record",
-            "params": {"action": "stop"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-stop",
+        "method": "voice.record",
+        "params": {"action": "stop"},
+    })
 
     assert resp["result"]["status"] == "stopped"
     assert captured["force_transcribe"] is True
@@ -2487,13 +3328,11 @@ def test_voice_record_stop_updates_event_session_id(monkeypatch):
     )
     monkeypatch.setattr(server, "_voice_event_sid", "old-session")
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-stop-session",
-            "method": "voice.record",
-            "params": {"action": "stop", "session_id": "new-session"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-stop-session",
+        "method": "voice.record",
+        "params": {"action": "stop", "session_id": "new-session"},
+    })
 
     assert resp["result"]["status"] == "stopped"
     assert server._voice_event_sid == "new-session"
@@ -2511,13 +3350,11 @@ def test_voice_record_start_reports_busy_when_stop_is_in_progress(monkeypatch):
     monkeypatch.setenv("HERMES_VOICE", "1")
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {}})
 
-    resp = _dispatch_sync(
-        {
-            "id": "voice-record-busy",
-            "method": "voice.record",
-            "params": {"action": "start"},
-        }
-    )
+    resp = _dispatch_sync({
+        "id": "voice-record-busy",
+        "method": "voice.record",
+        "params": {"action": "start"},
+    })
 
     assert resp["result"]["status"] == "busy"
 
@@ -2549,9 +3386,11 @@ def test_voice_toggle_tts_branch_also_carries_record_key(monkeypatch):
     # later test in the file (which now spins up the streaming TTS pipeline).
     monkeypatch.setenv("HERMES_VOICE_TTS", "0")
 
-    tts_resp = _dispatch_sync(
-        {"id": "voice-tts", "method": "voice.toggle", "params": {"action": "tts"}}
-    )
+    tts_resp = _dispatch_sync({
+        "id": "voice-tts",
+        "method": "voice.toggle",
+        "params": {"action": "tts"},
+    })
 
     assert tts_resp["result"]["record_key"] == "ctrl+space"
     assert tts_resp["result"]["tts"] is True
@@ -2785,12 +3624,10 @@ def test_history_to_messages_drops_pure_compaction_scaffolding():
         f"{_SUMMARY_END_MARKER}"
     )
 
-    assert server._history_to_messages(
-        [
-            {"role": "user", "content": summary},
-            {"role": "assistant", "content": "real answer"},
-        ]
-    ) == [{"role": "assistant", "text": "real answer"}]
+    assert server._history_to_messages([
+        {"role": "user", "content": summary},
+        {"role": "assistant", "content": "real answer"},
+    ]) == [{"role": "assistant", "text": "real answer"}]
 
 
 def test_history_to_messages_preserves_live_ask_without_compaction_scaffolding():
@@ -2807,16 +3644,14 @@ def test_history_to_messages_preserves_live_ask_without_compaction_scaffolding()
         "test the browser controller"
     )
 
-    assert server._history_to_messages(
-        [
-            {
-                "role": "user",
-                "content": carrier,
-                "tool_calls": [{"id": "stale"}],
-                "reasoning": "internal compaction reasoning",
-            }
-        ]
-    ) == [{"role": "user", "text": "test the browser controller"}]
+    assert server._history_to_messages([
+        {
+            "role": "user",
+            "content": carrier,
+            "tool_calls": [{"id": "stale"}],
+            "reasoning": "internal compaction reasoning",
+        }
+    ]) == [{"role": "user", "text": "test the browser controller"}]
 
 
 def test_history_to_messages_unwraps_merged_assistant_carrier():
@@ -2837,16 +3672,14 @@ def test_history_to_messages_unwraps_merged_assistant_carrier():
         f"{_SUMMARY_END_MARKER}"
     )
 
-    assert server._history_to_messages(
-        [
-            {
-                "role": "assistant",
-                "content": carrier,
-                "tool_calls": [{"id": "stale"}],
-                "reasoning_details": [{"summary": "internal"}],
-            }
-        ]
-    ) == [{"role": "assistant", "text": "real completed answer"}]
+    assert server._history_to_messages([
+        {
+            "role": "assistant",
+            "content": carrier,
+            "tool_calls": [{"id": "stale"}],
+            "reasoning_details": [{"summary": "internal"}],
+        }
+    ]) == [{"role": "assistant", "text": "real completed answer"}]
 
 
 def test_history_to_messages_ships_full_tool_args():
@@ -2879,9 +3712,9 @@ def test_history_to_messages_ships_full_tool_args():
     assert rows[1]["context"]
 
     # A tool row with no recorded args keeps the old small shape.
-    argless = server._history_to_messages(
-        [{"role": "tool", "content": "{}", "tool_call_id": "missing"}]
-    )
+    argless = server._history_to_messages([
+        {"role": "tool", "content": "{}", "tool_call_id": "missing"}
+    ])
     assert "args" not in argless[0]
 
 
@@ -2892,7 +3725,9 @@ def test_tool_start_ships_full_args(monkeypatch):
     # every client, so tool.start does too. There is no per-client gate.
     events: list[tuple[str, str, dict]] = []
     monkeypatch.setattr(
-        server, "_emit", lambda event_type, sid, payload: events.append((event_type, sid, payload))
+        server,
+        "_emit",
+        lambda event_type, sid, payload: events.append((event_type, sid, payload)),
     )
     long_command = "echo " + "y" * 200
     monkeypatch.setitem(
@@ -2914,11 +3749,16 @@ def test_tool_ctx_sends_an_arg_preview_not_a_phrased_label():
     # `Terminal("<ctx>")` and the desktop prepends "Running"/"Ran". Sending a
     # pre-phrased label made both stutter ("Ran Running sleep 70 + 2 commands")
     # and stood in for the real command in the desktop's `$` transcript.
-    assert server._tool_ctx("terminal", {"command": 'sleep 70; echo "a"; echo "b"'}) == (
-        "sleep 70 + 2 commands"
+    assert server._tool_ctx(
+        "terminal", {"command": 'sleep 70; echo "a"; echo "b"'}
+    ) == ("sleep 70 + 2 commands")
+    assert (
+        server._tool_ctx("read_file", {"path": "/tmp/demo/package.json"})
+        == "package.json"
     )
-    assert server._tool_ctx("read_file", {"path": "/tmp/demo/package.json"}) == "package.json"
-    assert server._tool_ctx("web_search", {"query": "weather in NYC"}) == "weather in NYC"
+    assert (
+        server._tool_ctx("web_search", {"query": "weather in NYC"}) == "weather in NYC"
+    )
 
 
 def test_history_to_messages_keeps_reasoning_only_assistant_turn():
@@ -2966,7 +3806,10 @@ def test_history_to_messages_renders_multimodal_content():
             "role": "user",
             "content": [
                 {"type": "text", "text": "look here"},
-                {"type": "image_url", "image_url": {"url": "data:image/png;base64,abc"}},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": "data:image/png;base64,abc"},
+                },
             ],
         },
         {"role": "assistant", "content": "saw it"},
@@ -3204,9 +4047,11 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
             include_row_ids=False,
             **_kwargs,
         ):
-            captured.setdefault("history_calls", []).append(
-                (target, include_ancestors, include_row_ids)
-            )
+            captured.setdefault("history_calls", []).append((
+                target,
+                include_ancestors,
+                include_row_ids,
+            ))
             return (
                 [
                     {"role": "user", "content": "root prompt"},
@@ -3231,7 +4076,9 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
         lambda agent, *a: {"model": "test", "tools": {}, "skills": {}},
     )
     monkeypatch.setattr(
-        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80, **_kwargs: None,
     )
     # The deferred pre-warm timer is neutered module-wide by the autouse
     # _neuter_agent_prewarm_timer fixture; this test only asserts the
@@ -3240,21 +4087,31 @@ def test_session_resume_uses_parent_lineage_for_display(monkeypatch, omit_messag
     params = {"session_id": target}
     if omit_messages:
         params["omit_messages"] = True
-    resp = server.handle_request(
-        {"id": "1", "method": "session.resume", "params": params}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": params,
+    })
 
-    expected = [] if omit_messages else [
-        {"role": "user", "text": "root prompt"},
-        {"role": "assistant", "text": "root answer"},
-    ]
+    expected = (
+        []
+        if omit_messages
+        else [
+            {"role": "user", "text": "root prompt"},
+            {"role": "assistant", "text": "root answer"},
+        ]
+    )
     assert resp["result"]["messages"] == expected
     assert resp["result"]["message_count"] == (1 if omit_messages else 2)
     assert resp["result"]["messages_omitted"] is omit_messages
-    expected_calls = [(target, False, True)] if omit_messages else [
-        (target, False, False),
-        (target, True, False),
-    ]
+    expected_calls = (
+        [(target, False, True)]
+        if omit_messages
+        else [
+            (target, False, False),
+            (target, True, False),
+        ]
+    )
     assert captured["history_calls"] == expected_calls
 
 
@@ -3278,8 +4135,11 @@ def test_live_visible_history_prefers_db_display_with_candidate():
     # Persisted display lineage: the candidate (substantive answer) survives.
     display_with_candidate = [
         {"role": "user", "content": "do the thing"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
     ]
 
@@ -3298,11 +4158,15 @@ def test_live_visible_history_prefers_db_display_with_candidate():
 def test_live_visible_history_falls_back_without_db_or_key():
     in_memory = [{"role": "user", "content": "hi"}]
     # No DB handle available.
-    assert server._live_visible_history({"session_key": "s"}, None, in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, None, in_memory) == in_memory
+    )
 
     # DB available but the session has no persist key yet.
     class DB:
-        def get_messages_as_conversation(self, *a, **k):  # pragma: no cover - not reached
+        def get_messages_as_conversation(
+            self, *a, **k
+        ):  # pragma: no cover - not reached
             raise AssertionError("must not query without a session_key")
 
     assert server._live_visible_history({}, DB(), in_memory) == in_memory
@@ -3317,17 +4181,26 @@ def test_live_visible_history_falls_back_when_db_empty():
         def get_messages_as_conversation(self, *a, **k):
             return []
 
-    assert server._live_visible_history({"session_key": "s"}, EmptyDB(), in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, EmptyDB(), in_memory)
+        == in_memory
+    )
 
 
 def test_live_visible_history_falls_back_when_db_raises():
-    in_memory = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+    in_memory = [
+        {"role": "user", "content": "hi"},
+        {"role": "assistant", "content": "yo"},
+    ]
 
     class BrokenDB:
         def get_messages_as_conversation(self, *a, **k):
             raise RuntimeError("db exploded")
 
-    assert server._live_visible_history({"session_key": "s"}, BrokenDB(), in_memory) == in_memory
+    assert (
+        server._live_visible_history({"session_key": "s"}, BrokenDB(), in_memory)
+        == in_memory
+    )
 
 
 def test_live_visible_history_keeps_candidate_and_fresh_tail():
@@ -3336,8 +4209,11 @@ def test_live_visible_history_keeps_candidate_and_fresh_tail():
     # Persisted display: has the verification candidate, lags the newest turn.
     db_display = [
         {"role": "user", "content": "turn 1"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
     ]
     # In-memory model history: candidate collapsed out, but has a fresh turn 2.
@@ -3349,14 +4225,19 @@ def test_live_visible_history_keeps_candidate_and_fresh_tail():
     ]
 
     class DB:
-        def get_messages_as_conversation(self, key, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, key, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return list(db_display)
 
     result = server._live_visible_history({"session_key": "s1"}, DB(), in_memory)
     assert result == [
         {"role": "user", "content": "turn 1"},
-        {"role": "assistant", "content": "long substantive answer",
-         "finish_reason": "verification_required"},
+        {
+            "role": "assistant",
+            "content": "long substantive answer",
+            "finish_reason": "verification_required",
+        },
         {"role": "assistant", "content": "terse verified reply"},
         {"role": "user", "content": "turn 2 not flushed"},
         {"role": "assistant", "content": "turn 2 reply not flushed"},
@@ -3392,24 +4273,33 @@ def test_live_visible_history_matches_eager_resume_with_real_db(tmp_path):
     db.create_session("s1", source="tui")
     db.append_message("s1", role="user", content="do the thing")
     db.append_message(
-        "s1", role="assistant", content="long substantive answer",
+        "s1",
+        role="assistant",
+        content="long substantive answer",
         finish_reason="verification_required",
     )
     db.append_message(
-        "s1", role="assistant", content="terse verified reply", finish_reason="stop",
+        "s1",
+        role="assistant",
+        content="terse verified reply",
+        finish_reason="stop",
     )
 
     model_history, display_history = db.get_resume_conversations("s1")
 
     # The divergence #65919 introduced: candidate absent from the model
     # projection, present in the display projection.
-    assert not any("long substantive" in (m.get("content") or "") for m in model_history)
+    assert not any(
+        "long substantive" in (m.get("content") or "") for m in model_history
+    )
     assert any("long substantive" in (m.get("content") or "") for m in display_history)
 
     # Eager session.resume serves the display projection.
     eager_messages = server._history_to_messages(display_history)
     # Warm/live reuse: in-memory history is the collapsed model projection.
-    live_history = server._live_visible_history({"session_key": "s1"}, db, list(model_history))
+    live_history = server._live_visible_history(
+        {"session_key": "s1"}, db, list(model_history)
+    )
     # They must agree — the candidate survives the warm switch.
     assert server._history_to_messages(live_history) == eager_messages
     assert any(m.get("text") == "long substantive answer" for m in eager_messages)
@@ -3424,15 +4314,23 @@ def test_live_visible_history_keeps_candidate_and_new_flushed_turn_real_db(tmp_p
     db.create_session("s1", source="tui")
     db.append_message("s1", role="user", content="turn 1")
     db.append_message(
-        "s1", role="assistant", content="candidate answer",
+        "s1",
+        role="assistant",
+        content="candidate answer",
         finish_reason="verification_required",
     )
-    db.append_message("s1", role="assistant", content="verified reply", finish_reason="stop")
+    db.append_message(
+        "s1", role="assistant", content="verified reply", finish_reason="stop"
+    )
     db.append_message("s1", role="user", content="turn 2")
-    db.append_message("s1", role="assistant", content="turn 2 reply", finish_reason="stop")
+    db.append_message(
+        "s1", role="assistant", content="turn 2 reply", finish_reason="stop"
+    )
 
     model_history, display_history = db.get_resume_conversations("s1")
-    live_history = server._live_visible_history({"session_key": "s1"}, db, list(model_history))
+    live_history = server._live_visible_history(
+        {"session_key": "s1"}, db, list(model_history)
+    )
     texts = [m.get("text") for m in server._history_to_messages(live_history)]
 
     assert texts == [
@@ -3478,7 +4376,9 @@ def test_live_session_payload_reads_profile_db_not_launch_db(monkeypatch, tmp_pa
         finish_reason="stop",
     )
     model_history, display_history = profile_db.get_resume_conversations("s-profile")
-    assert not any("long substantive" in (m.get("content") or "") for m in model_history)
+    assert not any(
+        "long substantive" in (m.get("content") or "") for m in model_history
+    )
     assert any("long substantive" in (m.get("content") or "") for m in display_history)
 
     session = {
@@ -3500,10 +4400,14 @@ def test_live_session_payload_reads_profile_db_not_launch_db(monkeypatch, tmp_pa
     texts = [m.get("text") for m in payload.get("messages") or []]
 
     assert "long substantive answer" in texts
-    assert texts == [m.get("text") for m in server._history_to_messages(display_history)]
+    assert texts == [
+        m.get("text") for m in server._history_to_messages(display_history)
+    ]
 
 
-def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch, tmp_path):
+def test_lazy_child_watch_resume_serves_candidate_inclusive_display(
+    monkeypatch, tmp_path
+):
     """The delegated-child watch-window cold resume (lazy=True) must serve the
     verbatim display projection so a persisted verification candidate is not
     collapsed out of the watch window (#65919 sibling of the warm-payload fix).
@@ -3514,11 +4418,16 @@ def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch,
     db.create_session("child1", source="tui")
     db.append_message("child1", role="user", content="child prompt")
     db.append_message(
-        "child1", role="assistant", content="child substantive answer",
+        "child1",
+        role="assistant",
+        content="child substantive answer",
         finish_reason="verification_required",
     )
     db.append_message(
-        "child1", role="assistant", content="child terse reply", finish_reason="stop",
+        "child1",
+        role="assistant",
+        content="child terse reply",
+        finish_reason="stop",
     )
 
     lease = types.SimpleNamespace(session_id="child1", release=lambda: None)
@@ -3533,15 +4442,15 @@ def test_lazy_child_watch_resume_serves_candidate_inclusive_display(monkeypatch,
     )
     monkeypatch.setattr(server, "_claim_or_reuse_live", lambda *a, **k: None)
     monkeypatch.setattr(server, "_child_run_active", lambda *a, **k: False)
-    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.resume",
-            "params": {"session_id": "child1", "lazy": True},
-        }
+    monkeypatch.setattr(
+        server, "_schedule_session_cap_enforcement", lambda *a, **k: None
     )
+
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": {"session_id": "child1", "lazy": True},
+    })
 
     assert "error" not in resp, resp
     texts = [m.get("text") for m in resp["result"]["messages"]]
@@ -3589,9 +4498,11 @@ def test_session_resume_deferred_history_acknowledges_and_reuses(monkeypatch):
     monkeypatch.setattr(
         server,
         "_maybe_schedule_auto_continue",
-        lambda sid, session, stored_id: auto_continue_calls.append(
-            (sid, session, stored_id)
-        ),
+        lambda sid, session, stored_id: auto_continue_calls.append((
+            sid,
+            session,
+            stored_id,
+        )),
     )
 
     try:
@@ -3780,13 +4691,17 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     base = int(time.time()) - 10_000
     db.create_session("parent_root", source="tui")
     db.append_message(
-        "parent_root", role="user", content="pre-compression turn",
+        "parent_root",
+        role="user",
+        content="pre-compression turn",
         timestamp=base + 10,
     )
     db.end_session("parent_root", "compression")
     db.create_session("cont_tip", source="tui", parent_session_id="parent_root")
     db.append_message(
-        "cont_tip", role="assistant", content="post-compression reply",
+        "cont_tip",
+        role="assistant",
+        content="post-compression reply",
         timestamp=base + 110,
     )
     conn = db._conn
@@ -3795,7 +4710,9 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
         "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = 'parent_root'",
         (base, base + 50),
     )
-    conn.execute("UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,))
+    conn.execute(
+        "UPDATE sessions SET started_at = ? WHERE id = 'cont_tip'", (base + 100,)
+    )
     conn.commit()
 
     captured = {}
@@ -3813,19 +4730,25 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
     monkeypatch.setattr(
-        server, "_session_info", lambda agent, *a: {"model": "test", "tools": {}, "skills": {}}
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": "test", "tools": {}, "skills": {}},
     )
     monkeypatch.setattr(
-        server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80, **_kwargs: None,
     )
 
     try:
         # eager_build: this asserts the synchronously-built agent binds to the
         # resolved tip (captured["agent_session_id"]); the compression-tip
         # resolution itself runs before the build and is mode-agnostic.
-        resp = server.handle_request(
-            {"id": "1", "method": "session.resume", "params": {"session_id": "parent_root", "eager_build": True}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.resume",
+            "params": {"session_id": "parent_root", "eager_build": True},
+        })
     finally:
         db.close()
 
@@ -3835,6 +4758,168 @@ def test_session_resume_follows_compression_tip(monkeypatch, tmp_path):
     assert captured["agent_session_id"] == "cont_tip"
     texts = [m.get("text") for m in resp["result"]["messages"]]
     assert "post-compression reply" in texts
+
+
+def test_concurrent_eager_resumes_build_one_runtime_per_canonical_root(monkeypatch):
+    target = "continuation-tip"
+    canonical_root = "compression-root"
+    build_started = threading.Event()
+    release_build = threading.Event()
+    build_calls = []
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            pass
+
+        def get_resume_conversations(self, _target):
+            history = [{"role": "user", "content": "hello"}]
+            return history, history
+
+        def get_ancestor_display_prefix(self, _target):
+            return []
+
+        def session_runtime_key(self, _target):
+            return canonical_root
+
+    class Lease:
+        def release(self):
+            pass
+
+    def fake_make_agent(*_args, **_kwargs):
+        build_calls.append(object())
+        build_started.set()
+        assert release_build.wait(timeout=2)
+        return types.SimpleNamespace(model="test", provider="test")
+
+    def fake_init_session(sid, key, agent, _history, **_kwargs):
+        server._sessions[sid] = {
+            "agent": agent,
+            "session_key": key,
+            "created_at": time.time(),
+            "cwd": "",
+        }
+
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(server, "_claim_local_runtime_owner", lambda *_args: Lease())
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_init_session", fake_init_session)
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda _agent, *_args: {"model": "test", "tools": {}, "skills": {}},
+    )
+    monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *_args: None)
+    monkeypatch.setattr(
+        server,
+        "_live_session_payload",
+        lambda sid, _session, **_kwargs: {
+            "session_id": sid,
+            "message_count": 0,
+            "messages": [],
+        },
+    )
+
+    responses = []
+
+    def resume(request_id):
+        responses.append(
+            server._methods["session.resume"](
+                request_id,
+                {"session_id": target, "eager_build": True},
+            )
+        )
+
+    first = threading.Thread(target=resume, args=("r1",))
+    second = threading.Thread(target=resume, args=("r2",))
+    try:
+        first.start()
+        assert build_started.wait(timeout=1)
+        second.start()
+        time.sleep(0.05)
+        assert len(build_calls) == 1
+        release_build.set()
+        first.join(timeout=2)
+        second.join(timeout=2)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert len(build_calls) == 1
+        assert len(responses) == 2
+        assert len({response["result"]["session_id"] for response in responses}) == 1
+    finally:
+        release_build.set()
+        first.join(timeout=1)
+        second.join(timeout=1)
+        server._sessions.clear()
+
+
+@pytest.mark.parametrize("failure_stage", ["make_agent", "init_session"])
+def test_eager_resume_failure_releases_runtime_owner_lease(monkeypatch, failure_stage):
+    target = "failed-resume"
+    released = []
+
+    class FakeDB:
+        def get_session(self, session_id):
+            return {"id": session_id, "message_count": 1}
+
+        def get_session_by_title(self, _target):
+            return None
+
+        def reopen_session(self, _target):
+            pass
+
+        def get_resume_conversations(self, _target):
+            history = [{"role": "user", "content": "hello"}]
+            return history, history
+
+        def get_ancestor_display_prefix(self, _target):
+            return []
+
+        def session_runtime_key(self, _target):
+            return "failed-root"
+
+    class RuntimeOwnerLease:
+        def release(self):
+            released.append(True)
+            return True
+
+    def fake_make_agent(*_args, **_kwargs):
+        if failure_stage == "make_agent":
+            raise RuntimeError("make failed")
+        return types.SimpleNamespace(model="test", provider="test")
+
+    def fake_init_session(*_args, **_kwargs):
+        if failure_stage == "init_session":
+            raise RuntimeError("init failed")
+
+    monkeypatch.setattr(server, "_sessions", {})
+    monkeypatch.setattr(server, "_get_db", lambda: FakeDB())
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
+    monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
+    monkeypatch.setattr(
+        server, "_claim_local_runtime_owner", lambda *_args: RuntimeOwnerLease()
+    )
+    monkeypatch.setattr(server, "_make_agent", fake_make_agent)
+    monkeypatch.setattr(server, "_init_session", fake_init_session)
+
+    response = server._methods["session.resume"](
+        "resume-failure",
+        {"session_id": target, "eager_build": True},
+    )
+
+    assert response["error"]["code"] == 5000
+    assert released == [True]
+    assert server._sessions == {}
 
 
 def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
@@ -3861,7 +4946,9 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, target, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, target, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return [{"role": "user", "content": "hello"}]
 
     def fake_make_agent(sid, key, session_id=None, session_db=None, **kwargs):
@@ -3873,7 +4960,11 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     monkeypatch.setattr(server, "_set_session_context", lambda target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda tokens: None)
     monkeypatch.setattr(server, "_make_agent", fake_make_agent)
-    monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": agent.model, "provider": agent.provider})
+    monkeypatch.setattr(
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": agent.model, "provider": agent.provider},
+    )
 
     def fake_init_session(sid, key, agent, history, cols=80, **_kwargs):
         server._sessions[sid] = {"agent": agent, "session_key": key}
@@ -3883,9 +4974,11 @@ def test_session_resume_passes_stored_runtime_to_agent(monkeypatch):
     # eager_build: this asserts the synchronous build contract (stored runtime
     # overrides reach _make_agent, info comes from _session_info). The deferred
     # default restores the same overrides via _start_agent_build off-thread.
-    resp = server.handle_request(
-        {"id": "1", "method": "session.resume", "params": {"session_id": "stored-session", "eager_build": True}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": {"session_id": "stored-session", "eager_build": True},
+    })
 
     assert resp["result"]["info"] == {"model": "gpt-5.4", "provider": "openai-codex"}
     assert captured["model_override"] == {
@@ -3930,7 +5023,9 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, _target, include_ancestors=False, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, _target, include_ancestors=False, repair_alternation=False, **_kwargs
+        ):
             return [{"role": "user", "content": "hello"}]
 
         def update_session_cwd(self, *_args):
@@ -3982,13 +5077,11 @@ def test_session_resume_profile_uses_profile_db_cwd(monkeypatch, tmp_path):
     try:
         # eager_build: asserts the synchronous build receives the profile's db
         # (the deferred default builds with the same db via _start_agent_build).
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.resume",
-                "params": {"session_id": target, "profile": "worker", "eager_build": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.resume",
+            "params": {"session_id": target, "profile": "worker", "eager_build": True},
+        })
 
         assert "error" not in resp
         sid = resp["result"]["session_id"]
@@ -4009,7 +5102,9 @@ def test_session_cwd_set_profile_session_updates_profile_db(monkeypatch, tmp_pat
     captured = {}
 
     class ProfileDB:
-        def update_session_cwd(self, session_id, cwd, git_branch=None, git_repo_root=None):
+        def update_session_cwd(
+            self, session_id, cwd, git_branch=None, git_repo_root=None
+        ):
             captured["profile_update"] = (session_id, cwd)
 
         def close(self):
@@ -4046,34 +5141,43 @@ def test_stored_session_runtime_overrides_skips_bare_billing_provider():
     `model_config.provider`, is still restored.
     """
     # Bare "custom" bucket, no explicit model_config.provider: no provider override restored.
-    ov = server._stored_session_runtime_overrides({"model": "my-model", "billing_provider": "custom"})
+    ov = server._stored_session_runtime_overrides({
+        "model": "my-model",
+        "billing_provider": "custom",
+    })
     assert "provider_override" not in ov
     assert ov["model_override"]["provider"] is None
 
     for bare in ("auto", "custom"):
-        ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": bare})
+        ov = server._stored_session_runtime_overrides({
+            "model": "m",
+            "billing_provider": bare,
+        })
         assert "provider_override" not in ov
 
     # A real provider in billing_provider is still restored.
-    ov = server._stored_session_runtime_overrides({"model": "m", "billing_provider": "anthropic"})
+    ov = server._stored_session_runtime_overrides({
+        "model": "m",
+        "billing_provider": "anthropic",
+    })
     assert ov["provider_override"] == "anthropic"
     assert ov["model_override"]["provider"] == "anthropic"
 
     # An explicit routable provider in model_config wins over the bare billing bucket.
-    ov = server._stored_session_runtime_overrides(
-        {"model": "m", "billing_provider": "custom", "model_config": {"provider": "custom:myendpoint"}}
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "m",
+        "billing_provider": "custom",
+        "model_config": {"provider": "custom:myendpoint"},
+    })
     assert ov["provider_override"] == "custom:myendpoint"
     assert ov["model_override"]["provider"] == "custom:myendpoint"
 
 
 def test_stored_session_runtime_overrides_restores_explicit_normal_tier():
-    overrides = server._stored_session_runtime_overrides(
-        {
-            "model": "gpt-5.4",
-            "model_config": {"service_tier": "normal"},
-        }
-    )
+    overrides = server._stored_session_runtime_overrides({
+        "model": "gpt-5.4",
+        "model_config": {"service_tier": "normal"},
+    })
 
     assert "service_tier_override" in overrides
     assert overrides["service_tier_override"] == ""
@@ -4087,22 +5191,24 @@ def test_openrouter_session_resume_restores_provider():
     # OpenRouter session with no explicit model_config.provider (the common case
     # for sessions that never used /model): billing_provider="openrouter" should
     # be restored as the provider override.
-    ov = server._stored_session_runtime_overrides(
-        {"model": "anthropic/claude-opus-4.8", "billing_provider": "openrouter"}
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "anthropic/claude-opus-4.8",
+        "billing_provider": "openrouter",
+    })
     assert ov["provider_override"] == "openrouter"
     assert ov["model_override"]["provider"] == "openrouter"
     assert ov["model_override"]["model"] == "anthropic/claude-opus-4.8"
 
     # When an explicit model_config.provider exists, it takes precedence over
     # billing_provider (this path was already correct).
-    ov = server._stored_session_runtime_overrides(
-        {
-            "model": "anthropic/claude-opus-4.8",
-            "billing_provider": "openrouter",
-            "model_config": {"provider": "openrouter", "base_url": "https://openrouter.ai/api/v1"},
-        }
-    )
+    ov = server._stored_session_runtime_overrides({
+        "model": "anthropic/claude-opus-4.8",
+        "billing_provider": "openrouter",
+        "model_config": {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+        },
+    })
     assert ov["provider_override"] == "openrouter"
 
 
@@ -4127,7 +5233,10 @@ def test_persist_live_session_runtime_preserves_resume_metadata(monkeypatch):
         _session_db=FakeDB(),
     )
 
-    server._persist_live_session_runtime({"agent": agent, "session_key": "stored-session"})
+    server._persist_live_session_runtime({
+        "agent": agent,
+        "session_key": "stored-session",
+    })
 
     assert "model" not in updates
     assert updates["meta"] == (
@@ -4165,13 +5274,11 @@ def test_persist_live_session_runtime_preserves_explicit_normal_tier():
         _session_db=FakeDB(),
     )
 
-    server._persist_live_session_runtime(
-        {
-            "agent": agent,
-            "session_key": "stored-session",
-            "create_service_tier_override": "",
-        }
-    )
+    server._persist_live_session_runtime({
+        "agent": agent,
+        "session_key": "stored-session",
+        "create_service_tier_override": "",
+    })
 
     assert updates["config"]["service_tier"] == "normal"
 
@@ -4360,7 +5467,9 @@ def test_config_sync_config_wins_over_env_seed(monkeypatch):
     # the per-turn sync must follow config.yaml edits, not stay pinned to it.
     monkeypatch.setenv("HERMES_INFERENCE_MODEL", "seed/model")
     monkeypatch.delenv("HERMES_MODEL", raising=False)
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "new/model"}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"model": {"default": "new/model"}}
+    )
     session = _sync_test_session(config_model_seen=("seed/model", ""))
     calls = []
     monkeypatch.setattr(
@@ -4422,15 +5531,14 @@ def test_apply_model_switch_persist_override_false_never_persists(monkeypatch):
         model_info=None,
         error_message="",
     )
-    monkeypatch.setattr(
-        "hermes_cli.model_switch.switch_model", lambda **kw: result
-    )
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **kw: result)
     monkeypatch.setattr(
         "hermes_cli.model_switch.resolve_persist_behavior",
         lambda *a: pytest.fail("persist_override must bypass resolve_persist_behavior"),
     )
     monkeypatch.setattr(
-        server, "_persist_model_switch",
+        server,
+        "_persist_model_switch",
         lambda _r: pytest.fail("persist_override=False must not persist"),
     )
     monkeypatch.setattr(
@@ -4668,9 +5776,11 @@ def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.close",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["closed"] is True
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
@@ -4694,13 +5804,11 @@ def test_session_close_releases_resume_lock_before_slow_teardown(monkeypatch):
 
     def _close():
         response.update(
-            server.handle_request(
-                {
-                    "id": "close",
-                    "method": "session.close",
-                    "params": {"session_id": "slow-close"},
-                }
-            )
+            server.handle_request({
+                "id": "close",
+                "method": "session.close",
+                "params": {"session_id": "slow-close"},
+            })
         )
 
     thread = threading.Thread(target=_close)
@@ -4742,19 +5850,15 @@ def test_session_close_settles_active_turn_before_teardown(monkeypatch):
     session["_run_thread"] = run_thread
     server._sessions["settle-close"] = session
     monkeypatch.setattr(server, "_teardown_session", _teardown)
-    monkeypatch.setattr(
-        server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 1.0, raising=False
-    )
+    monkeypatch.setattr(server, "_TURN_SETTLE_BEFORE_CLOSE_SECONDS", 1.0, raising=False)
 
     close_thread = threading.Thread(
         target=lambda: response.update(
-            server.handle_request(
-                {
-                    "id": "close",
-                    "method": "session.close",
-                    "params": {"session_id": "settle-close"},
-                }
-            )
+            server.handle_request({
+                "id": "close",
+                "method": "session.close",
+                "params": {"session_id": "settle-close"},
+            })
         )
     )
     run_thread.start()
@@ -4908,13 +6012,11 @@ def test_session_resume_does_not_rebind_after_client_gone_interrupt_claim(monkey
     monkeypatch.setattr(server, "current_transport", lambda: live_transport)
 
     try:
-        response = server.handle_request(
-            {
-                "id": "resume-after-claim",
-                "method": "session.resume",
-                "params": {"session_id": "stored-sid"},
-            }
-        )
+        response = server.handle_request({
+            "id": "resume-after-claim",
+            "method": "session.resume",
+            "params": {"session_id": "stored-sid"},
+        })
 
         assert response is not None
         assert response["error"]["code"] == 4009
@@ -4959,7 +6061,9 @@ def test_ws_orphan_reap_defers_running_turn_for_active_delegation(monkeypatch):
         "_session_has_active_delegations",
         lambda *_args, **_kwargs: next(delegation_active),
     )
-    monkeypatch.setattr(server, "_teardown_popped_session", lambda *_args, **_kwargs: True)
+    monkeypatch.setattr(
+        server, "_teardown_popped_session", lambda *_args, **_kwargs: True
+    )
 
     try:
         server._schedule_ws_orphan_reap("delegating-turn")
@@ -5032,7 +6136,9 @@ def test_ws_disconnect_running_sidecar_still_closes_without_orphan_timer(monkeyp
     monkeypatch.setattr(
         server,
         "_teardown_popped_session",
-        lambda session, *, end_reason: closed.append((session["_sid"], end_reason)) or True,
+        lambda session, *, end_reason: (
+            closed.append((session["_sid"], end_reason)) or True
+        ),
     )
     monkeypatch.setattr(
         server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
@@ -5141,9 +6247,10 @@ def test_ws_orphan_reap_reschedules_while_mid_turn_then_reaps(monkeypatch):
     monkeypatch.setattr(
         server,
         "_teardown_session",
-        lambda session, *, end_reason="tui_close": torn_down.append(
-            (session, end_reason)
-        ),
+        lambda session, *, end_reason="tui_close": torn_down.append((
+            session,
+            end_reason,
+        )),
     )
     live = _session(
         transport=server._detached_ws_transport,
@@ -5189,9 +6296,10 @@ def test_ws_orphan_reap_waits_for_active_delegation_then_reaps(monkeypatch):
     monkeypatch.setattr(
         server,
         "_teardown_session",
-        lambda session, *, end_reason="tui_close": torn_down.append(
-            (session, end_reason)
-        ),
+        lambda session, *, end_reason="tui_close": torn_down.append((
+            session,
+            end_reason,
+        )),
     )
     server._sessions["delegating-sid"] = _session(
         transport=server._detached_ws_transport,
@@ -5243,15 +6351,14 @@ def test_ws_orphan_reap_retries_when_delegation_lookup_fails(monkeypatch):
 
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0.01)
     monkeypatch.setattr(server.threading, "Timer", _Timer)
-    monkeypatch.setattr(
-        async_delegation, "has_live_for_session", _raise_lookup_error
-    )
+    monkeypatch.setattr(async_delegation, "has_live_for_session", _raise_lookup_error)
     monkeypatch.setattr(
         server,
         "_teardown_session",
-        lambda session, *, end_reason="tui_close": torn_down.append(
-            (session, end_reason)
-        ),
+        lambda session, *, end_reason="tui_close": torn_down.append((
+            session,
+            end_reason,
+        )),
     )
     server._sessions["lookup-error-sid"] = _session(
         transport=server._detached_ws_transport,
@@ -5300,11 +6407,170 @@ def test_finalize_session_closes_slash_worker(monkeypatch):
     assert closed["count"] == 1
 
 
+def test_steer_authority_accepts_non_alias_controller_attachment():
+    controller = _LifecycleTransport("steer-controller")
+    observer = _LifecycleTransport("steer-observer")
+    session = {"history_lock": threading.Lock(), "transport": controller}
+    server._attach_current_transport(
+        "steer-authority-sid", session, "control", transport=controller
+    )
+    server._attach_current_transport(
+        "steer-authority-sid", session, "observe", transport=observer
+    )
+    server._sessions["steer-authority-sid"] = session
+    transport_token = bind_transport(controller)
+    runtime_token = server._current_runtime_session_record.set(session)
+    try:
+        assert server._current_session_steer_authority("steer-authority-sid") == (
+            controller,
+            session,
+        )
+    finally:
+        server._current_runtime_session_record.reset(runtime_token)
+        reset_transport(transport_token)
+        server._sessions.pop("steer-authority-sid", None)
+        server._teardown_session(session)
+
+
+def test_claim_parked_runtime_uses_zero_attachment_count():
+    stale_transport = _LifecycleTransport("stale-alias")
+    stale = {
+        "history_lock": threading.Lock(),
+        "transport": stale_transport,
+        "session_key": "parked-session-key",
+    }
+    server._ensure_session_event_hub("parked-old-sid", stale)
+    server._sessions["parked-old-sid"] = stale
+    try:
+        claimed = server._claim_parked_runtimes(
+            "parked-session-key", keep_sid="parked-new-sid"
+        )
+        assert claimed == [("parked-old-sid", stale)]
+        assert "parked-old-sid" not in server._sessions
+    finally:
+        server._sessions.pop("parked-old-sid", None)
+        server._teardown_session(stale)
+
+
+def test_live_attachment_overrides_stale_detached_transport_alias(monkeypatch):
+    transport = _LifecycleTransport("live-alias-override")
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": server._detached_ws_transport,
+        "running": False,
+        "last_active": 0.0,
+        "created_at": 0.0,
+    }
+    monkeypatch.setattr(server, "_session_has_active_delegations", lambda *args: False)
+    monkeypatch.setattr(server, "_SESSION_TTL_S", 1)
+    hub = server._ensure_session_event_hub("alias-override-sid", session)
+    hub.attach(
+        transport,
+        client_id=transport.client_id,
+        mode=AttachmentMode.CONTROL,
+    )
+    try:
+        assert server._ws_session_is_detached(session) is False
+        assert server._ws_session_is_orphaned(session) is False
+        assert (
+            server._session_is_evictable("alias-override-sid", session, time.time())
+            is False
+        )
+        assert server._session_is_lru_evictable("alias-override-sid", session) is False
+    finally:
+        server._teardown_session(session)
+
+
+def test_failed_final_attachment_starts_orphan_policy(monkeypatch):
+    class FailingTransport(_LifecycleTransport):
+        def write(self, obj: dict) -> bool:
+            return False
+
+    transport = FailingTransport("failed-final")
+    session = {"history_lock": threading.Lock(), "transport": transport}
+    hub = server._attach_current_transport(
+        "failed-final-sid", session, "control", transport=transport
+    )
+    server._sessions["failed-final-sid"] = session
+    scheduled = []
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
+    )
+    try:
+        server._emit("status.update", "failed-final-sid", {"status": "running"})
+        deadline = time.time() + 2
+        while hub.count() and time.time() < deadline:
+            time.sleep(0.01)
+        assert hub.count() == 0
+        assert session["transport"] is server._detached_ws_transport
+        assert scheduled == ["failed-final-sid"]
+    finally:
+        server._sessions.pop("failed-final-sid", None)
+        server._teardown_session(session)
+
+
+def test_last_attachment_disconnect_schedules_orphan_once(monkeypatch):
+    transport = _LifecycleTransport("disconnect-last")
+    session = {"history_lock": threading.Lock(), "transport": transport}
+    server._attach_current_transport(
+        "disconnect-last-sid", session, "control", transport=transport
+    )
+    server._sessions["disconnect-last-sid"] = session
+    scheduled = []
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
+    )
+    try:
+        assert server._close_sessions_for_transport(transport) == (0, 1)
+        assert session["event_hub"].count() == 0
+        assert session["transport"] is server._detached_ws_transport
+        assert scheduled == ["disconnect-last-sid"]
+    finally:
+        server._sessions.pop("disconnect-last-sid", None)
+        server._teardown_session(session)
+
+
+def test_disconnect_non_alias_attachment_is_removed_without_orphaning(monkeypatch):
+    first = _LifecycleTransport("disconnect-first")
+    survivor = _LifecycleTransport("disconnect-survivor")
+    session = {
+        "history_lock": threading.Lock(),
+        "transport": first,
+        "running": True,
+        "queued_prompt": {"text": "preserve"},
+    }
+    hub = server._attach_current_transport(
+        "disconnect-sid", session, "control", transport=first
+    )
+    server._attach_current_transport(
+        "disconnect-sid", session, "control", transport=survivor
+    )
+    server._sessions["disconnect-sid"] = session
+    scheduled = []
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: scheduled.append(sid)
+    )
+    try:
+        assert session["transport"] is survivor
+        assert server._close_sessions_for_transport(first) == (0, 0)
+        assert hub.count() == 1
+        assert not hub.has_transport(first)
+        assert hub.has_transport(survivor)
+        assert session["running"] is True
+        assert session["queued_prompt"] == {"text": "preserve"}
+        assert scheduled == []
+    finally:
+        server._sessions.pop("disconnect-sid", None)
+        server._teardown_session(session)
+
+
 def test_close_transport_rebinds_session_to_remaining_viewer(monkeypatch):
     """Closing a pop-out window's transport must re-bind the session to a
     still-open window instead of stranding it on the drop sentinel (#83716)."""
     reap_calls = []
-    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid)
+    )
 
     class _LiveTransport:
         def write(self, *a, **k):
@@ -5328,7 +6594,9 @@ def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
     """The last viewer closing still lands the session on the drop sentinel
     and schedules the grace reap (unchanged single-window behavior)."""
     reap_calls = []
-    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid)
+    )
 
     class _LiveTransport:
         def write(self, *a, **k):
@@ -5349,7 +6617,9 @@ def test_close_transport_detaches_when_no_viewers_remain(monkeypatch):
 def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
     """A viewer whose socket is already dead must not win the re-bind."""
     reap_calls = []
-    monkeypatch.setattr(server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid))
+    monkeypatch.setattr(
+        server, "_schedule_ws_orphan_reap", lambda sid: reap_calls.append(sid)
+    )
 
     class _LiveTransport:
         def write(self, *a, **k):
@@ -5372,6 +6642,7 @@ def test_close_transport_skips_dead_remaining_viewers(monkeypatch):
 def test_live_session_payload_registers_transport_as_viewer():
     """Resume/activate through _live_session_payload must register the caller
     as a viewer so the disconnect path has something to re-bind to (#83716)."""
+
     class _LiveTransport:
         def write(self, *a, **k):
             return True
@@ -5674,7 +6945,9 @@ def test_ws_orphan_reap_still_fires_when_never_resumed(monkeypatch):
         server._pending_ws_reaps.pop("lonely-sid", None)
 
 
-def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(monkeypatch):
+def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(
+    monkeypatch,
+):
     """A detached desktop session with live background delegation is parked.
 
     Regression for Desktop session switches / transient WS detaches: the parent
@@ -5704,7 +6977,9 @@ def test_ws_orphan_reap_spares_detached_session_with_running_async_delegation(mo
         server,
         "_teardown_popped_session",
         lambda session, *, end_reason="tui_close": (
-            closed.append((session["_sid"], end_reason)) if session is not None else None
+            closed.append((session["_sid"], end_reason))
+            if session is not None
+            else None
         ),
     )
 
@@ -5853,13 +7128,11 @@ def test_session_title_creates_row_and_sets_immediately_when_not_ready(monkeypat
     monkeypatch.setattr(server, "_ensure_session_db_row", _fake_ensure_row)
     monkeypatch.setattr(server, "_session_db", _fake_session_db)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "my-custom-name"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "my-custom-name"},
+        })
 
         # No longer queued — the row is created and the title set immediately.
         assert set_resp["result"]["pending"] is False
@@ -5869,9 +7142,11 @@ def test_session_title_creates_row_and_sets_immediately_when_not_ready(monkeypat
         assert server._sessions["sid"]["pending_title"] is None
 
         # A subsequent read reflects the persisted title.
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "my-custom-name"
     finally:
         server._sessions.pop("sid", None)
@@ -5912,21 +7187,21 @@ def test_session_title_falls_back_to_queue_when_row_create_fails(monkeypatch):
     monkeypatch.setattr(server, "_ensure_session_db_row", _fake_ensure_row)
     monkeypatch.setattr(server, "_session_db", _fake_session_db)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "queued title"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "queued title"},
+        })
 
         assert set_resp["result"]["pending"] is True
         assert set_resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] == "queued title"
 
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "queued title"
     finally:
         server._sessions.pop("sid", None)
@@ -5939,14 +7214,30 @@ def test_notification_event_routing_by_session_key(monkeypatch):
     monkeypatch.setattr(server, "_sessions", {"a": mine, "b": other})
 
     # My own event → handle it.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "mine"}) is False
+    assert (
+        server._notification_event_belongs_elsewhere("a", mine, {"session_key": "mine"})
+        is False
+    )
     # Global/system event with no owner → handle it.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": ""}) is False
+    assert (
+        server._notification_event_belongs_elsewhere("a", mine, {"session_key": ""})
+        is False
+    )
     assert server._notification_event_belongs_elsewhere("a", mine, {}) is False
     # Owned by another *live* session → defer to that session's poller.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "other"}) is True
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "a", mine, {"session_key": "other"}
+        )
+        is True
+    )
     # Owner is gone (not in _sessions) → handle as fallback so it isn't lost.
-    assert server._notification_event_belongs_elsewhere("a", mine, {"session_key": "ghost"}) is False
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "a", mine, {"session_key": "ghost"}
+        )
+        is False
+    )
 
 
 def test_async_delegation_event_prefers_origin_ui_session(monkeypatch):
@@ -5967,14 +7258,18 @@ def test_async_delegation_event_prefers_origin_ui_session(monkeypatch):
     }
 
     assert server._notification_event_belongs_elsewhere("other-sid", other, evt) is True
-    assert server._notification_event_belongs_elsewhere("origin-sid", mine, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere("origin-sid", mine, evt) is False
+    )
 
 
 def test_notification_event_follows_compression_continuation(monkeypatch):
     """Events keyed to a compressed parent route to the live continuation."""
     old_parent = _session(session_key="old-parent")
     live_tip = _session(session_key="new-tip")
-    monkeypatch.setattr(server, "_sessions", {"old-sid": old_parent, "tip-sid": live_tip})
+    monkeypatch.setattr(
+        server, "_sessions", {"old-sid": old_parent, "tip-sid": live_tip}
+    )
 
     class _DB:
         def resolve_resume_session_id(self, session_id):
@@ -5983,8 +7278,12 @@ def test_notification_event_follows_compression_continuation(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     evt = {"type": "async_delegation", "session_key": "old-parent"}
 
-    assert server._notification_event_belongs_elsewhere("old-sid", old_parent, evt) is True
-    assert server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere("old-sid", old_parent, evt) is True
+    )
+    assert (
+        server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    )
     # A third session must leave it alone for the continuation's poller.
     third = _session(session_key="third")
     monkeypatch.setattr(
@@ -6016,8 +7315,15 @@ def test_finalized_origin_ui_session_falls_back_to_live_continuation(monkeypatch
         "origin_ui_session_id": "origin-sid",
     }
 
-    assert server._notification_event_belongs_elsewhere("origin-sid", finalized_origin, evt) is True
-    assert server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    assert (
+        server._notification_event_belongs_elsewhere(
+            "origin-sid", finalized_origin, evt
+        )
+        is True
+    )
+    assert (
+        server._notification_event_belongs_elsewhere("tip-sid", live_tip, evt) is False
+    )
 
 
 def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
@@ -6054,25 +7360,27 @@ def test_prompt_submit_rejects_negative_truncate_ordinal(monkeypatch):
     # If the guard ever lets a negative ordinal through, these would run and the
     # session would be marked busy; failing here makes that regression loud.
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "trunc-sid",
-                    "text": "next",
-                    "truncate_before_user_ordinal": -1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "trunc-sid",
+                "text": "next",
+                "truncate_before_user_ordinal": -1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp["error"]["code"] == 4018
         # History and the DB are left exactly as they were — no silent loss.
         assert server._sessions["trunc-sid"]["history"] == history
@@ -6098,25 +7406,27 @@ def test_prompt_submit_refuses_boolean_ordinal(monkeypatch):
     ]
     server._sessions["bool-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bool-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_user_ordinal": True,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bool-trunc-sid",
+                "text": "new turn",
+                "truncate_before_user_ordinal": True,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "must be an integer" in resp["error"]["message"]
@@ -6139,24 +7449,26 @@ def test_prompt_submit_refuses_confirm_truncate_without_target(monkeypatch):
     ]
     server._sessions["bare-confirm-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bare-confirm-sid",
-                    "text": "new turn",
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bare-confirm-sid",
+                "text": "new turn",
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "confirm_truncate requires" in resp["error"]["message"]
@@ -6198,25 +7510,27 @@ def test_prompt_submit_refuses_unconfirmed_nonempty_truncation(monkeypatch):
     server._sessions["unconfirmed-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     def _submit(**extra):
-        return server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "unconfirmed-trunc-sid",
-                    "text": "an ordinary typed message",
-                    "truncate_before_user_ordinal": 2,
-                    **extra,
-                },
-            }
-        )
+        return server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "unconfirmed-trunc-sid",
+                "text": "an ordinary typed message",
+                "truncate_before_user_ordinal": 2,
+                **extra,
+            },
+        })
 
     try:
         resp = _submit()
@@ -6260,26 +7574,20 @@ def test_prompt_submit_truncates_by_message_id(monkeypatch):
     ]
     server._sessions["msg-id-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
-    monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: None
-    )
-    monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: None
-    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "msg-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_message_id": "msg-2",
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "msg-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_message_id": "msg-2",
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result") is not None
         assert len(replaced) == 1
         assert replaced[0][1] == history[:2]
@@ -6323,19 +7631,17 @@ def test_prompt_submit_truncation_falls_back_to_sid_when_session_key_null(monkey
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "null-key-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "null-key-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result") is not None
         assert len(replaced) == 1
         # Keyed by the session id, never None (the FK-violating value).
@@ -6355,26 +7661,28 @@ def test_prompt_submit_refuses_ordinal_and_message_id_mismatch(monkeypatch):
     ]
     server._sessions["mismatch-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "mismatch-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_message_id": "msg-2",  # ordinal index 1
-                    "truncate_before_user_ordinal": 0,      # mismatch (stale 0)
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "mismatch-trunc-sid",
+                "text": "new turn",
+                "truncate_before_message_id": "msg-2",  # ordinal index 1
+                "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
         assert "does not match" in resp["error"]["message"]
@@ -6406,25 +7714,27 @@ def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch
     server._sessions["ordinal-only-durable-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "ordinal-only-durable-sid",
-                    "text": "retry",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "ordinal-only-durable-sid",
+                "text": "retry",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp["error"]["code"] == 4004
         assert "truncate_before_row_id" in resp["error"]["message"]
@@ -6435,7 +7745,9 @@ def test_prompt_submit_refuses_ordinal_only_when_history_has_row_ids(monkeypatch
         server._sessions.pop("ordinal-only-durable-sid", None)
 
 
-def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(monkeypatch):
+def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(
+    monkeypatch,
+):
     """Durability comes from state.db, not optional stamps on the live copy."""
     replaced = []
     history = [
@@ -6449,33 +7761,40 @@ def test_prompt_submit_refuses_ordinal_only_when_durable_history_is_unstamped(mo
         def get_messages_as_conversation(self, key, **kwargs):
             assert key == "session-key"
             assert kwargs["include_row_ids"] is True
-            return [dict(message, _row_id=100 + index) for index, message in enumerate(history)]
+            return [
+                dict(message, _row_id=100 + index)
+                for index, message in enumerate(history)
+            ]
 
-        def replace_messages(self, key, messages, active_only=False, archive_dropped=False):
+        def replace_messages(
+            self, key, messages, active_only=False, archive_dropped=False
+        ):
             replaced.append((key, list(messages)))
 
     server._sessions["unstamped-durable-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "unstamped-durable-sid",
-                    "text": "retry",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "unstamped-durable-sid",
+                "text": "retry",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp["error"]["code"] == 4004
         assert "truncate_before_row_id" in resp["error"]["message"]
@@ -6510,24 +7829,20 @@ def test_prompt_submit_truncates_by_row_id(monkeypatch):
     server._sessions["row-id-trunc-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     started = []
-    monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: started.append(k)
-    )
+    monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: started.append(k))
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "row-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "row-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None
         assert len(sess["history"]) == 2
         assert sess["history"][-1]["content"] == "reply 1"
@@ -6564,18 +7879,16 @@ def test_prompt_submit_truncates_by_string_row_id(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "str-row-id-trunc-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 103,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "str-row-id-trunc-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 103,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None
         assert len(sess["history"]) == 2
     finally:
@@ -6592,23 +7905,23 @@ def test_prompt_submit_refuses_ordinal_and_row_id_mismatch(monkeypatch):
     ]
     server._sessions["row-mismatch-sid"] = _session(history=list(history))
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "row-mismatch-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 203,  # user turn ordinal 1
-                    "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "row-mismatch-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 203,  # user turn ordinal 1
+                "truncate_before_user_ordinal": 0,  # mismatch (stale 0)
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
         assert "does not match" in resp["error"]["message"]
@@ -6624,18 +7937,16 @@ def test_prompt_submit_refuses_boolean_row_id(monkeypatch):
     ]
     server._sessions["bool-row-sid"] = _session(history=list(history))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "bool-row-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": True,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "bool-row-sid",
+                "text": "new turn",
+                "truncate_before_row_id": True,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4004
         assert "must be an integer" in resp["error"]["message"]
@@ -6650,18 +7961,16 @@ def test_prompt_submit_row_id_not_found(monkeypatch):
     ]
     server._sessions["missing-row-sid"] = _session(history=list(history))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "missing-row-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 999,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "missing-row-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 999,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert "no longer in session history" in resp["error"]["message"]
@@ -6685,7 +7994,7 @@ def test_prompt_submit_row_id_ignores_platform_id_fallback(monkeypatch):
                 "text": "new turn",
                 "truncate_before_row_id": 999,
                 "confirm_truncate": True,
-            }
+            },
         })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
@@ -6722,16 +8031,34 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
     server._sessions["empty-trunc-sid"] = _session(history=list(history))
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Missing confirm → refuse.
-        resp = server.handle_request(
-            {
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "empty-trunc-sid",
+                "text": "fresh typed message",
+                "truncate_before_row_id": 101,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+            },
+        })
+        assert resp["error"]["code"] == 4028
+        assert "confirm_empty_truncate" in resp["error"]["message"]
+        # Explicit falsey values must not satisfy the opt-in either.
+        for falsey in (False, 0, "", "false", "no"):
+            resp = server.handle_request({
                 "id": "1",
                 "method": "prompt.submit",
                 "params": {
@@ -6740,27 +8067,9 @@ def test_prompt_submit_refuses_empty_truncation_without_confirm(monkeypatch):
                     "truncate_before_row_id": 101,
                     "truncate_before_user_ordinal": 0,
                     "confirm_truncate": True,
+                    "confirm_empty_truncate": falsey,
                 },
-            }
-        )
-        assert resp["error"]["code"] == 4028
-        assert "confirm_empty_truncate" in resp["error"]["message"]
-        # Explicit falsey values must not satisfy the opt-in either.
-        for falsey in (False, 0, "", "false", "no"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "prompt.submit",
-                    "params": {
-                        "session_id": "empty-trunc-sid",
-                        "text": "fresh typed message",
-                        "truncate_before_row_id": 101,
-                        "truncate_before_user_ordinal": 0,
-                        "confirm_truncate": True,
-                        "confirm_empty_truncate": falsey,
-                    },
-                }
-            )
+            })
             assert resp["error"]["code"] == 4028, falsey
         assert server._sessions["empty-trunc-sid"]["history"] == history
         assert server._sessions["empty-trunc-sid"]["running"] is False
@@ -6826,20 +8135,18 @@ def test_prompt_submit_empty_truncation_allowed_with_confirm(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "confirm-empty-sid",
-                    "text": "first",
-                    "truncate_before_row_id": 101,
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "confirm-empty-sid",
+                "text": "first",
+                "truncate_before_row_id": 101,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert seen["prompt"] == "first"
         assert seen["history"] == []
@@ -6892,12 +8199,10 @@ def test_notification_poller_live_loop_requeues_foreign_completion_for_owner(
         session["running"] = False
 
     monkeypatch.setattr(server, "_run_prompt_submit", _deliver)
-    server._sessions.update(
-        {
-            "sid-a-live-handoff": session_a,
-            "sid-b-live-handoff": session_b,
-        }
-    )
+    server._sessions.update({
+        "sid-a-live-handoff": session_a,
+        "sid-b-live-handoff": session_b,
+    })
     process_registry._completion_consumed.discard(event["session_id"])
 
     try:
@@ -6969,9 +8274,7 @@ def test_completion_ownership_lineage_lookup_failure_fails_closed(monkeypatch):
         {"origin_ui_session_id": "missing-owner-sid"},
     ],
 )
-def test_notification_poller_live_loop_drops_addressed_orphan(
-    monkeypatch, routing
-):
+def test_notification_poller_live_loop_drops_addressed_orphan(monkeypatch, routing):
     """A live poll never injects an addressed event whose owner is gone."""
     import queue as _queue_mod
 
@@ -7044,16 +8347,14 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_ghost")
-    isolated_queue.put(
-        {
-            "type": "completion",
-            "session_id": "proc_ghost",
-            "command": "echo from ghost",
-            "exit_code": 0,
-            "output": "ghost output",
-            **routing,
-        }
-    )
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc_ghost",
+        "command": "echo from ghost",
+        "exit_code": 0,
+        "output": "ghost output",
+        **routing,
+    })
 
     stop = threading.Event()
     stop.set()
@@ -7083,9 +8384,7 @@ def test_notification_poller_drops_orphaned_events(monkeypatch, routing):
         ({"session_key": "old-parent-key"}, "session-a"),
     ],
 )
-def test_notification_poller_delivers_owned_events(
-    monkeypatch, routing, resolved_key
-):
+def test_notification_poller_delivers_owned_events(monkeypatch, routing, resolved_key):
     """Direct, UI-origin, and compression-lineage owners are delivered."""
     import queue as _queue_mod
 
@@ -7110,16 +8409,14 @@ def test_notification_poller_delivers_owned_events(
     isolated_queue: _queue_mod.Queue = _queue_mod.Queue()
     monkeypatch.setattr(process_registry, "completion_queue", isolated_queue)
     process_registry._completion_consumed.discard("proc_mine")
-    isolated_queue.put(
-        {
-            "type": "completion",
-            "session_id": "proc_mine",
-            "command": "echo mine",
-            "exit_code": 0,
-            "output": "mine",
-            **routing,
-        }
-    )
+    isolated_queue.put({
+        "type": "completion",
+        "session_id": "proc_mine",
+        "command": "echo mine",
+        "exit_code": 0,
+        "output": "mine",
+        **routing,
+    })
 
     stop = threading.Event()
     stop.set()
@@ -7138,16 +8435,16 @@ def test_notification_poller_delivers_owned_events(
             process_registry.completion_queue.get_nowait()
 
 
-def _configure_immediate_prompt_run(
-    monkeypatch, tmp_path, *, immediate_threads=True
-):
+def _configure_immediate_prompt_run(monkeypatch, tmp_path, *, immediate_threads=True):
     class _ImmediateThread:
-        def __init__(self, target=None, daemon=None, **_kwargs):
+        def __init__(self, target=None, args=(), kwargs=None, daemon=None, **_kwargs):
             self._target = target
+            self._args = args
+            self._kwargs = kwargs or {}
 
         def start(self):
-            if self._target is not None:
-                self._target()
+            if self._target is not None and self._target.__name__ != "_write_events":
+                self._target(*self._args, **self._kwargs)
 
         def is_alive(self):
             return False
@@ -7235,7 +8532,9 @@ class _RecordingAgent:
     def clear_interrupt(self):
         return None
 
-    def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+    def run_conversation(
+        self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+    ):
         self._turns.append(prompt)
         return {"final_response": "", "messages": []}
 
@@ -7379,9 +8678,7 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
 
     from tools.process_registry import process_registry
 
-    _configure_immediate_prompt_run(
-        monkeypatch, tmp_path, immediate_threads=False
-    )
+    _configure_immediate_prompt_run(monkeypatch, tmp_path, immediate_threads=False)
     real_thread_class = threading.Thread
     threads = []
     nested_started = threading.Event()
@@ -7394,7 +8691,9 @@ def test_run_prompt_submit_requeues_all_unstarted_notifications_with_real_thread
         return thread
 
     class _BlockingNotificationAgent(_RecordingAgent):
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             if "proc_batch_1" in prompt:
                 nested_started.set()
@@ -7566,8 +8865,6 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         server._sessions.pop("sid_b", None)
         process_registry._completion_consumed.discard(event["session_id"])
 
-
-
     """session.create must NOT eagerly write a DB row.
 
     Every TUI/desktop launch opens a session here just to paint the composer;
@@ -7588,9 +8885,11 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         lambda *a, **k: types.SimpleNamespace(daemon=False, start=lambda: None),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     sid = resp["result"]["session_id"]
     try:
         assert resp["result"]["stored_session_id"]
@@ -7599,25 +8898,72 @@ def test_run_prompt_submit_prefers_origin_ui_session_id(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_session_create_rejects_invalid_attachment_mode_before_claiming_or_inserting(
+    monkeypatch,
+):
+    claimed: list[str] = []
+    before = set(server._sessions)
+
+    monkeypatch.setattr(
+        server,
+        "_claim_local_runtime_owner",
+        lambda key, _home: claimed.append(key),
+    )
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda *_args, **_kwargs: None)
+
+    with pytest.raises(ValueError, match="invalid attachment mode"):
+        server.handle_request({
+            "id": "invalid-mode",
+            "method": "session.create",
+            "params": {"attachment_mode": "admin"},
+        })
+
+    assert claimed == []
+    assert set(server._sessions) == before
+
+
 def test_ensure_session_db_row_persists_explicit_cwd(monkeypatch, tmp_path):
     """An explicitly chosen workspace is persisted as the session cwd."""
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
     monkeypatch.delenv("HERMES_DESKTOP", raising=False)
     monkeypatch.delenv("HERMES_DESKTOP_TERMINAL", raising=False)
 
-    server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path), "explicit_cwd": True})
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "cwd": str(tmp_path),
+        "explicit_cwd": True,
+    })
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
+        {
+            "key": "k1",
+            "source": "tui",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": str(tmp_path),
+        }
     ]
 
 
@@ -7625,10 +8971,23 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
@@ -7636,7 +8995,13 @@ def test_ensure_session_db_row_persists_session_source(monkeypatch):
     server._ensure_session_db_row({"session_key": "k1", "source": "tool"})
 
     assert created == [
-        {"key": "k1", "source": "tool", "model": "test-model", "model_config": None, "cwd": None}
+        {
+            "key": "k1",
+            "source": "tool",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": None,
+        }
     ]
 
 
@@ -7650,10 +9015,23 @@ def test_ensure_session_db_row_records_a_terminal_workspace(monkeypatch, tmp_pat
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
@@ -7663,7 +9041,13 @@ def test_ensure_session_db_row_records_a_terminal_workspace(monkeypatch, tmp_pat
     server._ensure_session_db_row({"session_key": "k1", "cwd": str(tmp_path)})
 
     assert created == [
-        {"key": "k1", "source": "tui", "model": "test-model", "model_config": None, "cwd": str(tmp_path)}
+        {
+            "key": "k1",
+            "source": "tui",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": str(tmp_path),
+        }
     ]
 
 
@@ -7673,18 +9057,41 @@ def test_ensure_session_db_row_defaults_desktop_to_no_workspace(monkeypatch, tmp
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "source": source, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "source": source,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    server._ensure_session_db_row({"session_key": "k1", "source": "desktop", "cwd": str(tmp_path)})
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "source": "desktop",
+        "cwd": str(tmp_path),
+    })
 
     assert created == [
-        {"key": "k1", "source": "desktop", "model": "test-model", "model_config": None, "cwd": None}
+        {
+            "key": "k1",
+            "source": "desktop",
+            "model": "test-model",
+            "model_config": None,
+            "cwd": None,
+        }
     ]
 
 
@@ -7700,22 +9107,32 @@ def test_ensure_session_db_row_persists_session_model_override(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
-            created.append(
-                {"key": key, "model": model, "model_config": model_config, "cwd": cwd}
-            )
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
+            created.append({
+                "key": key,
+                "model": model,
+                "model_config": model_config,
+                "cwd": cwd,
+            })
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(server, "_resolve_model", lambda: "global/default")
 
-    server._ensure_session_db_row(
-        {
-            "session_key": "k1",
-            "model_override": {"model": "openai/gpt-5.5", "provider": "openrouter"},
-            "create_reasoning_override": {"effort": "high"},
-            "create_service_tier_override": "priority",
-        }
-    )
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "model_override": {"model": "openai/gpt-5.5", "provider": "openrouter"},
+        "create_reasoning_override": {"effort": "high"},
+        "create_service_tier_override": "priority",
+    })
 
     assert len(created) == 1
     row = created[0]
@@ -7732,7 +9149,16 @@ def test_ensure_session_db_row_no_override_uses_global(monkeypatch):
     created = []
 
     class _FakeDB:
-        def create_session(self, key, source=None, model=None, model_config=None, parent_session_id=None, cwd=None, profile_name=None):
+        def create_session(
+            self,
+            key,
+            source=None,
+            model=None,
+            model_config=None,
+            parent_session_id=None,
+            cwd=None,
+            profile_name=None,
+        ):
             created.append({"model": model, "model_config": model_config})
 
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
@@ -7764,9 +9190,10 @@ def test_ensure_session_db_row_stamps_profile_name(monkeypatch, tmp_path):
     monkeypatch.setattr("hermes_state.SessionDB", _ProfileDB)
     monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
 
-    server._ensure_session_db_row(
-        {"session_key": "k1", "profile_home": str(profile_home)}
-    )
+    server._ensure_session_db_row({
+        "session_key": "k1",
+        "profile_home": str(profile_home),
+    })
 
     assert created and created[0]["key"] == "k1"
     assert created[0]["profile_name"] == "mlperf"
@@ -7794,13 +9221,11 @@ def test_session_title_clears_pending_after_persist(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "fresh"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "fresh"},
+        })
 
         assert resp["result"]["pending"] is False
         assert resp["result"]["title"] == "fresh"
@@ -7829,13 +9254,11 @@ def test_session_title_does_not_queue_noop_when_row_exists(monkeypatch):
     server._sessions["sid"] = _session(pending_title="stale")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "same title"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "same title"},
+        })
 
         assert resp["result"]["pending"] is False
         assert resp["result"]["title"] == "same title"
@@ -7852,9 +9275,11 @@ def test_session_title_get_falls_back_to_pending_when_db_read_throws(monkeypatch
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
     finally:
         server._sessions.pop("sid", None)
@@ -7879,9 +9304,11 @@ def test_session_title_get_retries_persist_for_pending_title(monkeypatch):
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] is None
     finally:
@@ -7907,9 +9334,11 @@ def test_session_title_get_retries_pending_even_when_db_has_title(monkeypatch):
     server._sessions["sid"] = _session(pending_title="queued title")
     monkeypatch.setattr(server, "_get_db", lambda: db)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert resp["result"]["title"] == "queued title"
         assert server._sessions["sid"]["pending_title"] is None
     finally:
@@ -7924,13 +9353,11 @@ def test_session_title_rejects_empty_title_with_specific_error_code(monkeypatch)
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "   "},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "   "},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 4021
     finally:
@@ -7951,13 +9378,11 @@ def test_session_title_set_maps_valueerror_to_user_error(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "dup"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "dup"},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 4022
         assert "already in use" in resp["error"]["message"]
@@ -7979,13 +9404,11 @@ def test_session_title_set_errors_when_row_lookup_fails_after_noop(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "fresh"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "fresh"},
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 5007
         assert "row lookup failed" in resp["error"]["message"]
@@ -8052,9 +9475,11 @@ def test_session_create_drops_pending_title_on_valueerror(monkeypatch):
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
 
     try:
-        server.handle_request(
-            {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hello"}}
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert session["pending_title"] is None
     finally:
         server._sessions.pop("sid", None)
@@ -8065,23 +9490,19 @@ def test_config_set_yolo_toggles_session_scope():
 
     server._sessions["sid"] = _session()
     try:
-        resp_on = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "yolo"},
-            }
-        )
+        resp_on = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "yolo"},
+        })
         assert resp_on["result"]["value"] == "1"
         assert is_session_yolo_enabled("session-key") is True
 
-        resp_off = server.handle_request(
-            {
-                "id": "2",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "yolo"},
-            }
-        )
+        resp_off = server.handle_request({
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "yolo"},
+        })
         assert resp_off["result"]["value"] == "0"
         assert is_session_yolo_enabled("session-key") is False
     finally:
@@ -8097,24 +9518,20 @@ def test_config_set_yolo_global_scope_writes_approvals_mode(tmp_path, monkeypatc
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp_on = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global"},
-        }
-    )
+    resp_on = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global"},
+    })
     assert resp_on["result"]["value"] == "1"
     assert resp_on["result"]["scope"] == "global"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
-    resp_off = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global"},
-        }
-    )
+    resp_off = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global"},
+    })
     assert resp_off["result"]["value"] == "0"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "manual"
 
@@ -8133,9 +9550,11 @@ def test_config_get_approval_mode_uses_smart_default_when_key_is_missing(
         yaml.safe_dump({"approvals": {"timeout": 15}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "smart"
 
 
@@ -8154,9 +9573,11 @@ def test_config_get_approval_mode_fails_safe_to_manual_for_invalid_explicit_valu
         yaml.safe_dump({"approvals": {"mode": "sometimes"}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "manual"
 
 
@@ -8171,9 +9592,11 @@ def test_config_get_approval_mode_normalizes_yaml_off(tmp_path, monkeypatch):
         yaml.safe_dump({"approvals": {"mode": False}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "approvals.mode"}}
-    )
+    response = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "approvals.mode"},
+    })
     assert response["result"]["value"] == "off"
 
 
@@ -8192,18 +9615,19 @@ def test_config_set_approval_mode_persists_three_way_value_and_emits_live_status
     server._sessions["sid"] = {"agent": object(), "session_key": "profile-session"}
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"key": "approvals.mode", "value": "manual"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "approvals.mode", "value": "manual"},
+        })
     finally:
         server._sessions.clear()
 
     assert resp["result"] == {"key": "approvals.mode", "value": "manual"}
-    assert yaml.safe_load((tmp_path / "config.yaml").read_text())["approvals"]["mode"] == "manual"
+    assert (
+        yaml.safe_load((tmp_path / "config.yaml").read_text())["approvals"]["mode"]
+        == "manual"
+    )
     assert emitted and emitted[0][0:2] == ("session.info", "sid")
     assert emitted[0][2]["approval_mode"] == "manual"
 
@@ -8223,9 +9647,7 @@ def test_pet_gallery_quoted_false_enabled_reports_disabled(tmp_path, monkeypatch
         yaml.safe_dump({"display": {"pet": {"enabled": "false"}}})
     )
 
-    response = server.handle_request(
-        {"id": "1", "method": "pet.gallery", "params": {}}
-    )
+    response = server.handle_request({"id": "1", "method": "pet.gallery", "params": {}})
     assert response["result"]["enabled"] is False
 
 
@@ -8254,22 +9676,30 @@ def test_pet_info_known_revision_elides_spritesheet(monkeypatch):
         "scale": 0.33,
     }
 
-    monkeypatch.setattr(server, "_pet_active_selection", lambda: (True, _FakePet(), 0.33))
-    monkeypatch.setattr(server, "_pet_sprite_payload", lambda pet, *, scale: dict(payload))
+    monkeypatch.setattr(
+        server, "_pet_active_selection", lambda: (True, _FakePet(), 0.33)
+    )
+    monkeypatch.setattr(
+        server, "_pet_sprite_payload", lambda pet, *, scale: dict(payload)
+    )
 
     # Matching revision: bytes elided, unchanged marker set.
-    resp = server.handle_request(
-        {"id": "1", "method": "pet.info", "params": {"knownRevision": "123:456"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pet.info",
+        "params": {"knownRevision": "123:456"},
+    })
     assert resp["result"]["enabled"] is True
     assert "spritesheetBase64" not in resp["result"]
     assert resp["result"]["spritesheetUnchanged"] is True
     assert resp["result"]["spritesheetRevision"] == "123:456"
 
     # Stale revision: full payload still flows.
-    resp = server.handle_request(
-        {"id": "2", "method": "pet.info", "params": {"knownRevision": "999:999"}}
-    )
+    resp = server.handle_request({
+        "id": "2",
+        "method": "pet.info",
+        "params": {"knownRevision": "999:999"},
+    })
     assert resp["result"]["spritesheetBase64"] == "A" * 1024
     assert "spritesheetUnchanged" not in resp["result"]
 
@@ -8283,13 +9713,11 @@ def test_desktop_contract_includes_approval_mode_rpc():
 
 
 def test_config_set_approval_mode_rejects_unknown_value():
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "approvals.mode", "value": "sometimes"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "approvals.mode", "value": "sometimes"},
+    })
 
     assert resp["error"]["code"] == 4002
 
@@ -8302,24 +9730,20 @@ def test_config_set_yolo_global_scope_honors_explicit_value(tmp_path, monkeypatc
     cfg_path.write_text(yaml.safe_dump({"approvals": {"mode": "manual"}}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global", "value": "1"},
+    })
     assert resp["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
     # Setting it on again is idempotent — stays off.
-    resp_again = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "yolo", "scope": "global", "value": "1"},
-        }
-    )
+    resp_again = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "yolo", "scope": "global", "value": "1"},
+    })
     assert resp_again["result"]["value"] == "1"
     assert yaml.safe_load(cfg_path.read_text())["approvals"]["mode"] == "off"
 
@@ -8351,13 +9775,11 @@ def test_config_set_fast_updates_live_agent_session_scoped(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["result"]["value"] == "fast"
         assert agent.service_tier == "priority"
         assert agent.request_overrides == {
@@ -8368,13 +9790,11 @@ def test_config_set_fast_updates_live_agent_session_scoped(monkeypatch):
         assert writes == []
         assert ("session.info", "sid", {"model": "x"}) in emits
 
-        resp_normal = server.handle_request(
-            {
-                "id": "2",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "normal"},
-            }
-        )
+        resp_normal = server.handle_request({
+            "id": "2",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "normal"},
+        })
         assert resp_normal["result"]["value"] == "normal"
         assert agent.service_tier is None
         assert agent.request_overrides == {"foo": "bar"}
@@ -8398,13 +9818,11 @@ def test_config_set_fast_status_is_non_mutating(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "status"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "status"},
+        })
         assert resp["result"]["value"] == "fast"
         assert writes == []
         assert emits == []
@@ -8430,13 +9848,11 @@ def test_config_set_fast_rejects_unsupported_model(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["error"]["code"] == 4002
         assert "not available" in resp["error"]["message"]
         assert agent.service_tier is None
@@ -8460,13 +9876,11 @@ def test_config_set_fast_rejects_missing_model(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "fast", "value": "fast"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "fast", "value": "fast"},
+        })
         assert resp["error"]["code"] == 4002
         assert "without a selected model" in resp["error"]["message"]
         assert agent.service_tier is None
@@ -8488,18 +9902,18 @@ def test_config_busy_get_and_set(monkeypatch):
         server, "_write_config_key", lambda path, value: writes.append((path, value))
     )
 
-    get_resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "busy"}}
-    )
+    get_resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "busy"},
+    })
     assert get_resp["result"]["value"] == "steer"
 
-    set_resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "busy", "value": "interrupt"},
-        }
-    )
+    set_resp = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "busy", "value": "interrupt"},
+    })
     assert set_resp["result"]["value"] == "interrupt"
     assert ("display.busy_input_mode", "interrupt") in writes
 
@@ -8507,13 +9921,11 @@ def test_config_busy_get_and_set(monkeypatch):
 def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeypatch):
     monkeypatch.setenv("HERMES_YOLO_MODE", "false")
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "yolo"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "yolo"},
+    })
 
     assert resp["result"]["value"] == "1"
     assert os.environ.get("HERMES_YOLO_MODE") == "1"
@@ -8522,9 +9934,11 @@ def test_config_set_yolo_process_scope_treats_false_like_env_as_disabled(monkeyp
 def test_config_get_statusbar_survives_non_dict_display(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": "broken"})
 
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "statusbar"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "statusbar"},
+    })
 
     assert resp["result"]["value"] == "top"
 
@@ -8532,9 +9946,11 @@ def test_config_get_statusbar_survives_non_dict_display(monkeypatch):
 def test_config_get_busy_survives_non_dict_display(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": "broken"})
 
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "busy"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "busy"},
+    })
 
     assert resp["result"]["value"] == "interrupt"
 
@@ -8546,13 +9962,11 @@ def test_config_set_statusbar_survives_non_dict_display(tmp_path, monkeypatch):
     cfg_path.write_text(yaml.safe_dump({"display": "broken"}))
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "statusbar", "value": "bottom"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "statusbar", "value": "bottom"},
+    })
 
     assert resp["result"]["value"] == "bottom"
     saved = yaml.safe_load(cfg_path.read_text())
@@ -8564,19 +9978,17 @@ def test_config_set_details_mode_pins_all_sections(tmp_path, monkeypatch):
 
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
-        yaml.safe_dump(
-            {"display": {"sections": {"tools": "expanded", "activity": "hidden"}}}
-        )
+        yaml.safe_dump({
+            "display": {"sections": {"tools": "expanded", "activity": "hidden"}}
+        })
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode", "value": "collapsed"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode", "value": "collapsed"},
+    })
 
     assert resp["result"] == {"key": "details_mode", "value": "collapsed"}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -8595,13 +10007,11 @@ def test_config_set_section_writes_per_section_override(tmp_path, monkeypatch):
     cfg_path = tmp_path / "config.yaml"
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.activity", "value": "hidden"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.activity", "value": "hidden"},
+    })
 
     assert resp["result"] == {"key": "details_mode.activity", "value": "hidden"}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -8613,19 +10023,17 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
 
     cfg_path = tmp_path / "config.yaml"
     cfg_path.write_text(
-        yaml.safe_dump(
-            {"display": {"sections": {"activity": "hidden", "tools": "expanded"}}}
-        )
+        yaml.safe_dump({
+            "display": {"sections": {"activity": "hidden", "tools": "expanded"}}
+        })
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.activity", "value": ""},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.activity", "value": ""},
+    })
 
     assert resp["result"] == {"key": "details_mode.activity", "value": ""}
     saved = yaml.safe_load(cfg_path.read_text())
@@ -8635,22 +10043,18 @@ def test_config_set_section_clears_override_on_empty_value(tmp_path, monkeypatch
 def test_config_set_section_rejects_unknown_section_or_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    bad_section = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "details_mode.bogus", "value": "hidden"},
-        }
-    )
+    bad_section = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "details_mode.bogus", "value": "hidden"},
+    })
     assert bad_section["error"]["code"] == 4002
 
-    bad_mode = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "details_mode.tools", "value": "maximised"},
-        }
-    )
+    bad_mode = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "details_mode.tools", "value": "maximised"},
+    })
     assert bad_mode["error"]["code"] == 4002
 
 
@@ -8663,29 +10067,37 @@ def test_config_mouse_uses_documented_key_with_legacy_fallback(monkeypatch):
         server, "_write_config_key", lambda path, value: writes.append((path, value))
     )
 
-    get_legacy = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_legacy = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     assert get_legacy["result"]["value"] == "off"
 
-    set_toggle = server.handle_request(
-        {"id": "2", "method": "config.set", "params": {"key": "mouse"}}
-    )
+    set_toggle = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "mouse"},
+    })
     # /mouse (no arg) toggles between 'all' and 'off'. Starting from
     # tui_mouse: False (→ 'off'), the toggle flips to 'all'.
     assert set_toggle["result"] == {"key": "mouse", "value": "all"}
     assert writes == [("display.mouse_tracking", "all")]
 
     cfg["display"] = {"mouse_tracking": 0, "tui_mouse": True}
-    get_canonical = server.handle_request(
-        {"id": "3", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_canonical = server.handle_request({
+        "id": "3",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     assert get_canonical["result"]["value"] == "off"
 
     cfg["display"] = {"mouse_tracking": None, "tui_mouse": False}
-    get_null = server.handle_request(
-        {"id": "4", "method": "config.get", "params": {"key": "mouse"}}
-    )
+    get_null = server.handle_request({
+        "id": "4",
+        "method": "config.get",
+        "params": {"key": "mouse"},
+    })
     # mouse_tracking present-but-None defers neither to tui_mouse nor to
     # the legacy off bucket: it falls through to the 'all' default.
     assert get_null["result"]["value"] == "all"
@@ -8701,35 +10113,29 @@ def test_config_mouse_accepts_preset_strings_and_aliases(monkeypatch):
     )
 
     # Direct preset.
-    set_wheel = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "wheel"},
-        }
-    )
+    set_wheel = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "wheel"},
+    })
     assert set_wheel["result"] == {"key": "mouse", "value": "wheel"}
     assert writes[-1] == ("display.mouse_tracking", "wheel")
 
     # Alias for buttons.
-    set_click = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "click"},
-        }
-    )
+    set_click = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "click"},
+    })
     assert set_click["result"] == {"key": "mouse", "value": "buttons"}
     assert writes[-1] == ("display.mouse_tracking", "buttons")
 
     # Unknown value → 4002.
-    bad = server.handle_request(
-        {
-            "id": "3",
-            "method": "config.set",
-            "params": {"key": "mouse", "value": "rainbows"},
-        }
-    )
+    bad = server.handle_request({
+        "id": "3",
+        "method": "config.set",
+        "params": {"key": "mouse", "value": "rainbows"},
+    })
     assert bad["error"]["code"] == 4002
 
 
@@ -8778,7 +10184,11 @@ def test_setup_runtime_check_rejects_empty_runtime_key(monkeypatch):
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"] == {
         "ok": False,
@@ -8800,7 +10210,11 @@ def test_setup_runtime_check_allows_no_key_custom_runtime(monkeypatch):
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"]["ok"] is True
     assert resp["result"]["provider"] == "custom"
@@ -8817,7 +10231,11 @@ def test_setup_runtime_check_rejects_implicit_bedrock_when_unconfigured(monkeypa
         },
     )
 
-    resp = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    resp = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
 
     assert resp["result"]["ok"] is False
     assert resp["result"]["provider"] == "bedrock"
@@ -8845,13 +10263,19 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
         fake_resolve,
     )
 
-    scoped = server.handle_request(
-        {"id": "1", "method": "setup.runtime_check", "params": {"provider": "nous"}}
-    )
+    scoped = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {"provider": "nous"},
+    })
     assert scoped["result"]["ok"] is True
     assert scoped["result"]["provider"] == "nous"
 
-    default = server.handle_request({"id": "1", "method": "setup.runtime_check", "params": {}})
+    default = server.handle_request({
+        "id": "1",
+        "method": "setup.runtime_check",
+        "params": {},
+    })
     assert default["result"]["ok"] is False
     assert default["result"]["provider"] == "anthropic"
 
@@ -8859,16 +10283,20 @@ def test_setup_runtime_check_honors_requested_provider(monkeypatch):
 def test_complete_slash_drops_removed_provider_alias():
     # `/provider` was folded into a single `/model` command, so autocomplete
     # must no longer offer the dead alias...
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/pro"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/pro"},
+    })
 
     assert not any(item["text"] == "provider" for item in resp["result"]["items"])
 
     # ...while `/model` stays the canonical command.
-    resp_model = server.handle_request(
-        {"id": "2", "method": "complete.slash", "params": {"text": "/mod"}}
-    )
+    resp_model = server.handle_request({
+        "id": "2",
+        "method": "complete.slash",
+        "params": {"text": "/mod"},
+    })
 
     assert any(item["text"] == "model" for item in resp_model["result"]["items"])
 
@@ -8878,9 +10306,11 @@ def test_complete_slash_returns_plain_string_fields():
     # display/display_meta; the TUI's CompletionItem contract is plain
     # strings, and shipping the raw list trips Ink's row layout into
     # 1-char truncation of the next column (/goal → /goa).
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/g"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/g"},
+    })
 
     items = resp["result"]["items"]
     goal = next((it for it in items if it["text"] == "goal"), None)
@@ -8894,35 +10324,41 @@ def test_complete_slash_returns_plain_string_fields():
 
 
 def test_complete_slash_includes_tui_details_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/det"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/det"},
+    })
 
     assert any(item["text"] == "/details" for item in resp["result"]["items"])
 
 
 def test_complete_slash_includes_tui_mouse_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/mou"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/mou"},
+    })
 
     assert any(item["text"] == "/mouse" for item in resp["result"]["items"])
 
 
 def test_complete_slash_details_args():
-    resp_root = server.handle_request(
-        {"id": "0", "method": "complete.slash", "params": {"text": "/details"}}
-    )
-    resp_section = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/details t"}}
-    )
-    resp_mode = server.handle_request(
-        {
-            "id": "2",
-            "method": "complete.slash",
-            "params": {"text": "/details thinking e"},
-        }
-    )
+    resp_root = server.handle_request({
+        "id": "0",
+        "method": "complete.slash",
+        "params": {"text": "/details"},
+    })
+    resp_section = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/details t"},
+    })
+    resp_mode = server.handle_request({
+        "id": "2",
+        "method": "complete.slash",
+        "params": {"text": "/details thinking e"},
+    })
 
     assert resp_root["result"]["replace_from"] == len("/details")
     assert any(item["text"] == " thinking" for item in resp_root["result"]["items"])
@@ -8931,9 +10367,11 @@ def test_complete_slash_details_args():
 
 
 def test_complete_slash_reasoning_includes_current_efforts_and_global_scope():
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": "/reasoning "}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": "/reasoning "},
+    })
 
     values = {item["text"] for item in resp["result"]["items"]}
     assert {"max", "ultra", "--global"} <= values
@@ -8969,9 +10407,11 @@ def _slash_skill_fixtures(monkeypatch):
 
 
 def _slash_completions(text: str) -> list[dict]:
-    resp = server.handle_request(
-        {"id": "1", "method": "complete.slash", "params": {"text": text}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "complete.slash",
+        "params": {"text": text},
+    })
     return resp["result"]["items"]
 
 
@@ -8993,7 +10433,9 @@ def test_complete_slash_ranks_skills_by_recorded_usage(monkeypatch):
     _slash_skill_fixtures(monkeypatch)
 
     skills = [
-        item["text"].strip() for item in _slash_completions("/") if item["kind"] == "skill"
+        item["text"].strip()
+        for item in _slash_completions("/")
+        if item["kind"] == "skill"
     ]
 
     assert skills[:3] == ["work", "research", "clean"]
@@ -9029,69 +10471,66 @@ def test_complete_slash_leaves_argument_stages_alone(monkeypatch):
 
 def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypatch):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+    )
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
 
-    resp_effort = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "reasoning",
-                "value": "low",
-            },
-        }
-    )
+    resp_effort = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "reasoning",
+            "value": "low",
+        },
+    })
     assert resp_effort["result"]["value"] == "low"
     assert agent.reasoning_config == {"enabled": True, "effort": "low"}
-    assert server._sessions["sid"]["create_reasoning_override"] == {"enabled": True, "effort": "low"}
+    assert server._sessions["sid"]["create_reasoning_override"] == {
+        "enabled": True,
+        "effort": "low",
+    }
     assert server._load_cfg()["agent"]["reasoning_effort"] == "medium"
 
-    resp_status = server.handle_request(
-        {
-            "id": "5",
-            "method": "config.get",
-            "params": {"session_id": "sid", "key": "reasoning"},
-        }
-    )
+    resp_status = server.handle_request({
+        "id": "5",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert resp_status["result"]["value"] == "low"
 
-    resp_global_status = server.handle_request(
-        {"id": "6", "method": "config.get", "params": {"key": "reasoning"}}
-    )
+    resp_global_status = server.handle_request({
+        "id": "6",
+        "method": "config.get",
+        "params": {"key": "reasoning"},
+    })
     assert resp_global_status["result"]["value"] == "medium"
 
     del server._sessions["sid"]["create_reasoning_override"]
     agent.reasoning_config = {"enabled": True, "effort": "high"}
-    resp_agent_status = server.handle_request(
-        {
-            "id": "7",
-            "method": "config.get",
-            "params": {"session_id": "sid", "key": "reasoning"},
-        }
-    )
+    resp_agent_status = server.handle_request({
+        "id": "7",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert resp_agent_status["result"]["value"] == "high"
 
-    resp_show = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "show"},
-        }
-    )
+    resp_show = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "show"},
+    })
     assert resp_show["result"]["value"] == "show"
     assert server._sessions["sid"]["show_reasoning"] is True
     assert server._load_cfg()["display"]["sections"]["thinking"] == "expanded"
 
-    resp_hide = server.handle_request(
-        {
-            "id": "3",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "hide"},
-        }
-    )
+    resp_hide = server.handle_request({
+        "id": "3",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "hide"},
+    })
     assert resp_hide["result"]["value"] == "hide"
     assert server._sessions["sid"]["show_reasoning"] is False
     assert server._load_cfg()["display"]["sections"]["thinking"] == "hidden"
@@ -9099,58 +10538,61 @@ def test_config_set_reasoning_updates_live_session_and_agent(tmp_path, monkeypat
     # /reasoning full | clamp — parity with the classic CLI reasoning_full
     # toggle. In the TUI these map to the thinking section's expand/collapse
     # rendering (no fixed 10-line recap exists here).
-    resp_full = server.handle_request(
-        {
-            "id": "4",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "full"},
-        }
-    )
+    resp_full = server.handle_request({
+        "id": "4",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "full"},
+    })
     assert resp_full["result"]["value"] == "full"
     cfg_full = server._load_cfg()
     assert cfg_full["display"]["reasoning_full"] is True
     assert cfg_full["display"]["sections"]["thinking"] == "expanded"
 
-    resp_clamp = server.handle_request(
-        {
-            "id": "5",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "reasoning", "value": "clamp"},
-        }
-    )
+    resp_clamp = server.handle_request({
+        "id": "5",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "reasoning", "value": "clamp"},
+    })
     assert resp_clamp["result"]["value"] == "clamp"
     cfg_clamp = server._load_cfg()
     assert cfg_clamp["display"]["reasoning_full"] is False
     assert cfg_clamp["display"]["sections"]["thinking"] == "collapsed"
 
 
-def test_config_set_reasoning_global_scope_clears_session_override(tmp_path, monkeypatch):
+def test_config_set_reasoning_global_scope_clears_session_override(
+    tmp_path, monkeypatch
+):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
-    (tmp_path / "config.yaml").write_text("agent:\n  reasoning_effort: medium\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "agent:\n  reasoning_effort: medium\n", encoding="utf-8"
+    )
     agent = types.SimpleNamespace(reasoning_config=None)
     server._sessions["sid"] = _session(agent=agent)
-    server._sessions["sid"]["create_reasoning_override"] = {"enabled": True, "effort": "low"}
+    server._sessions["sid"]["create_reasoning_override"] = {
+        "enabled": True,
+        "effort": "low",
+    }
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "reasoning",
-                "value": "high",
-                "scope": "global",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "reasoning",
+            "value": "high",
+            "scope": "global",
+        },
+    })
 
     assert resp["result"]["value"] == "high"
     assert server._load_cfg()["agent"]["reasoning_effort"] == "high"
     assert "create_reasoning_override" not in server._sessions["sid"]
 
-    status = server.handle_request(
-        {"id": "2", "method": "config.get", "params": {"session_id": "sid", "key": "reasoning"}}
-    )
+    status = server.handle_request({
+        "id": "2",
+        "method": "config.get",
+        "params": {"session_id": "sid", "key": "reasoning"},
+    })
     assert status["result"]["value"] == "high"
 
 
@@ -9159,18 +10601,15 @@ def test_config_set_verbose_updates_session_mode_and_agent(tmp_path, monkeypatch
     agent = types.SimpleNamespace(verbose_logging=False)
     server._sessions["sid"] = _session(agent=agent)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "verbose", "value": "cycle"},
+    })
 
     assert resp["result"]["value"] == "verbose"
     assert server._sessions["sid"]["tool_progress_mode"] == "verbose"
     assert agent.verbose_logging is True
-
 
 
 def test_config_set_model_waits_for_lazy_agent_before_switch(monkeypatch):
@@ -9201,18 +10640,17 @@ def test_config_set_model_waits_for_lazy_agent_before_switch(monkeypatch):
     monkeypatch.setattr(server, "_apply_model_switch", fake_apply)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "model", "value": "new/model"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "model", "value": "new/model"},
+        })
 
         assert resp["result"]["value"] == "new/model"
         assert calls == [("start", "sid"), ("apply", "sid", agent, "new/model")]
     finally:
         server._sessions.pop("sid", None)
+
 
 def test_config_set_model_uses_live_switch_path(monkeypatch):
     server._sessions["sid"] = _session()
@@ -9223,13 +10661,11 @@ def test_config_set_model_uses_live_switch_path(monkeypatch):
         return {"value": "new/model", "warning": "catalog unreachable"}
 
     monkeypatch.setattr(server, "_apply_model_switch", _fake_apply)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "model", "value": "new/model"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "model", "value": "new/model"},
+    })
 
     assert resp["result"]["value"] == "new/model"
     assert resp["result"]["warning"] == "catalog unreachable"
@@ -9270,34 +10706,30 @@ def test_config_set_model_requires_confirmation_for_expensive_model(monkeypatch)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda sid, session: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "openai/gpt-5.5-pro --provider openrouter",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "openai/gpt-5.5-pro --provider openrouter",
+        },
+    })
 
     assert resp["result"]["confirm_required"] is True
     assert "did you mean to select openai/gpt-5.5?" in resp["result"]["confirm_message"]
     assert agent.switched is False
 
-    confirmed = server.handle_request(
-        {
-            "id": "2",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "openai/gpt-5.5-pro --provider openrouter",
-                "confirm_expensive_model": True,
-            },
-        }
-    )
+    confirmed = server.handle_request({
+        "id": "2",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "openai/gpt-5.5-pro --provider openrouter",
+            "confirm_expensive_model": True,
+        },
+    })
 
     assert confirmed["result"]["confirm_required"] is False
     assert confirmed["result"]["value"] == "openai/gpt-5.5-pro"
@@ -9336,19 +10768,20 @@ def test_config_set_model_global_persists(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     # _persist_model_switch uses targeted save_config_value writes (#48305) so it
     # preserves sibling model.* keys instead of rewriting the whole block.
-    monkeypatch.setattr("cli.save_config_value", lambda key, value: saved_values.__setitem__(key, value) or True)
-
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "session_id": "sid",
-                "key": "model",
-                "value": "anthropic/claude-sonnet-4.6 --global",
-            },
-        }
+    monkeypatch.setattr(
+        "cli.save_config_value",
+        lambda key, value: saved_values.__setitem__(key, value) or True,
     )
+
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "session_id": "sid",
+            "key": "model",
+            "value": "anthropic/claude-sonnet-4.6 --global",
+        },
+    })
 
     assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
     assert seen["is_global"] is True
@@ -9362,9 +10795,19 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
     session = _session()
     session["agent"] = None
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "broken/model", "provider": "openrouter"}})
-    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: seen.__setitem__("build", seen["build"] + 1))
-    monkeypatch.setattr(server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "broken/model", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: seen.__setitem__("build", seen["build"] + 1),
+    )
+    monkeypatch.setattr(
+        server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1)
+    )
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "_restart_slash_worker", lambda *args, **kwargs: None)
 
@@ -9380,20 +10823,20 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
             }
         raise RuntimeError(f"unexpected provider {requested}")
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["result"]["value"] == "claude-sonnet-4-6"
         assert seen["build"] == 0
@@ -9405,14 +10848,26 @@ def test_config_set_model_explicit_provider_skips_broken_default_init(monkeypatc
         server._sessions.pop("sid", None)
 
 
-def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(monkeypatch):
+def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(
+    monkeypatch,
+):
     seen = {"build": 0, "wait": 0}
     session = _session()
     session["agent"] = None
     server._sessions["sid"] = session
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"model": {"default": "broken/model", "provider": "openrouter"}})
-    monkeypatch.setattr(server, "_start_agent_build", lambda *_args: seen.__setitem__("build", seen["build"] + 1))
-    monkeypatch.setattr(server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1))
+    monkeypatch.setattr(
+        server,
+        "_load_cfg",
+        lambda: {"model": {"default": "broken/model", "provider": "openrouter"}},
+    )
+    monkeypatch.setattr(
+        server,
+        "_start_agent_build",
+        lambda *_args: seen.__setitem__("build", seen["build"] + 1),
+    )
+    monkeypatch.setattr(
+        server, "_wait_agent", lambda *_args: seen.__setitem__("wait", seen["wait"] + 1)
+    )
 
     def fake_runtime_provider(*, requested=None, **_kwargs):
         if requested is None:
@@ -9421,20 +10876,20 @@ def test_config_set_model_explicit_provider_surfaces_selected_provider_errors(mo
             raise RuntimeError("missing anthropic API key")
         raise RuntimeError(f"unexpected provider {requested}")
 
-    monkeypatch.setattr("hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider)
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", fake_runtime_provider
+    )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["error"]["code"] == 5001
         assert "anthropic" in resp["error"]["message"].lower()
@@ -9485,17 +10940,15 @@ def test_config_set_model_does_not_leak_inference_provider_env(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         # Shared process env is UNCHANGED (the contamination vector is gone).
         assert os.environ["HERMES_INFERENCE_PROVIDER"] == "openrouter"
@@ -9546,17 +10999,15 @@ def test_config_set_model_records_per_session_override_not_env(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "deepseek-v4-pro --provider custom:xuanji",
-                },
-            }
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "deepseek-v4-pro --provider custom:xuanji",
+            },
+        })
 
         # No process-global env mutation.
         assert "HERMES_TUI_PROVIDER" not in os.environ
@@ -9612,9 +11063,11 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
             self.system_prompt = system_prompt
 
         def append_message(self, session_id, role, content=None, **_kwargs):
-            self.messages.append(
-                {"session_id": session_id, "role": role, "content": content}
-            )
+            self.messages.append({
+                "session_id": session_id,
+                "role": role,
+                "content": content,
+            })
 
     agent = Agent()
     db = SessionDB()
@@ -9641,17 +11094,15 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
     monkeypatch.setattr("hermes_cli.model_switch.switch_model", fake_switch_model)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "anthropic/claude-sonnet-4.6 --provider anthropic",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "anthropic/claude-sonnet-4.6 --provider anthropic",
+            },
+        })
 
         assert resp["result"]["value"] == "anthropic/claude-sonnet-4.6"
         # Agent switched in place...
@@ -9669,7 +11120,10 @@ def test_config_set_model_switches_agent_without_touching_env(monkeypatch):
         )
         assert agent._cached_system_prompt == db.system_prompt
         assert session["history"][-1]["role"] == "user"
-        assert "changed to anthropic/claude-sonnet-4.6" in session["history"][-1]["content"]
+        assert (
+            "changed to anthropic/claude-sonnet-4.6"
+            in session["history"][-1]["content"]
+        )
         assert db.messages[-1] == {
             "session_id": "session-key",
             "role": "user",
@@ -9721,17 +11175,15 @@ def test_config_set_model_once_keeps_env_and_records_restore(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "claude-sonnet-4.6 --provider anthropic --once",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "claude-sonnet-4.6 --provider anthropic --once",
+            },
+        })
 
         assert resp["result"]["scope"] == "once"
         assert seen["is_global"] is False
@@ -9749,16 +11201,14 @@ def test_config_set_model_once_requires_live_session(monkeypatch):
         lambda **_: (_ for _ in ()).throw(AssertionError("switch should not run")),
     )
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {
-                "key": "model",
-                "value": "claude-sonnet-4.6 --provider anthropic --once",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {
+            "key": "model",
+            "value": "claude-sonnet-4.6 --provider anthropic --once",
+        },
+    })
 
     assert resp["error"]["code"] == 5001
     assert "/model --once requires a live session" in resp["error"]["message"]
@@ -9791,22 +11241,22 @@ def test_config_set_model_session_switch_clears_pending_once_restore(monkeypatch
     session = _session(agent=Agent())
     session["one_turn_model_restore"] = {"model": "old/model"}
     server._sessions["sid"] = session
-    monkeypatch.setattr("hermes_cli.model_switch.switch_model", lambda **_kwargs: result)
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.switch_model", lambda **_kwargs: result
+    )
     monkeypatch.setattr(server, "_restart_slash_worker", lambda *args, **kwargs: None)
     monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "new/model --provider openrouter --session",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "new/model --provider openrouter --session",
+            },
+        })
 
         assert resp["result"]["scope"] == "session"
         assert "one_turn_model_restore" not in session
@@ -9853,13 +11303,11 @@ def test_config_set_personality_rejects_unknown_name(monkeypatch):
         "_available_personalities",
         lambda cfg=None: {"helpful": "You are helpful."},
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "personality", "value": "bogus"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "personality", "value": "bogus"},
+    })
 
     assert "error" in resp
     assert "Unknown personality" in resp["error"]["message"]
@@ -9884,7 +11332,9 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
         lambda cfg=None: {"helpful": "You are helpful."},
     )
     monkeypatch.setattr(
-        server, "_session_info", lambda agent, *a: {"model": getattr(agent, "model", "?")}
+        server,
+        "_session_info",
+        lambda agent, *a: {"model": getattr(agent, "model", "?")},
     )
     monkeypatch.setattr(server, "_emit", lambda *args: emits.append(args))
     # Persistence now flows through the single owner (hermes_cli.personality),
@@ -9902,13 +11352,11 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
         lambda path, value: writes.append((path, value)),
     )
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"session_id": "sid", "key": "personality", "value": "helpful"},
+    })
 
     assert resp["result"]["history_reset"] is False
     assert resp["result"]["info"] == {"model": "?"}
@@ -10002,9 +11450,11 @@ def test_session_compress_uses_compress_helper(monkeypatch):
     monkeypatch.setattr(server, "_session_info", lambda _agent, *a: {"model": "x"})
 
     with patch("tui_gateway.server._emit") as emit:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
 
     assert resp["result"]["removed"] == 2
     assert resp["result"]["usage"]["total"] == 42
@@ -10022,21 +11472,32 @@ def test_session_compress_normalizes_messages_for_desktop_transcript(monkeypatch
             "tool_calls": [
                 {
                     "id": "call-1",
-                    "function": {"name": "read_file", "arguments": '{"path":"secret.txt"}'},
+                    "function": {
+                        "name": "read_file",
+                        "arguments": '{"path":"secret.txt"}',
+                    },
                 }
             ],
         },
-        {"role": "tool", "tool_call_id": "call-1", "content": "very sensitive tool output"},
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "very sensitive tool output",
+        },
     ]
     agent = types.SimpleNamespace()
     server._sessions["sid"] = _session(agent=agent, history=history)
-    monkeypatch.setattr(server, "_compress_session_history", lambda *_args, **_kwargs: (0, {}))
+    monkeypatch.setattr(
+        server, "_compress_session_history", lambda *_args, **_kwargs: (0, {})
+    )
     monkeypatch.setattr(server, "_session_info", lambda *_args: {})
 
     try:
-        response = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        response = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10054,12 +11515,16 @@ def test_session_compress_returns_compute_host_history(monkeypatch):
         "session_info": {"usage": {"total": 42}},
     }
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda _session: True)
-    monkeypatch.setattr(server, "_send_compute_host_control", lambda *args, **kwargs: ack)
+    monkeypatch.setattr(
+        server, "_send_compute_host_control", lambda *args, **kwargs: ack
+    )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10094,9 +11559,11 @@ def test_session_compress_forwards_120_second_budget_to_compute_host(monkeypatch
     monkeypatch.setattr(server, "_send_compute_host_control", send_control)
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10142,9 +11609,11 @@ def test_session_compress_preserves_compute_host_aborted_summary(monkeypatch):
     )
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10180,13 +11649,11 @@ def test_session_compress_reports_aborted_summary_without_success(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
 
         result = resp["result"]
         assert result["status"] == "aborted"
@@ -10237,13 +11704,11 @@ def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
 
         assert server._sessions["sid"]["session_key"] == "rotated-id"
         assert server._sessions["sid"]["pending_title"] is None
@@ -10285,13 +11750,11 @@ def test_session_compress_sync_failure_discards_lcm_notification(monkeypatch):
 
     try:
         with patch("tui_gateway.server._emit"):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "session.compress",
-                    "params": {"session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "session.compress",
+                "params": {"session_id": "sid"},
+            })
         assert resp["error"]["code"] == 5005
         assert events == []
     finally:
@@ -10301,7 +11764,9 @@ def test_session_compress_sync_failure_discards_lcm_notification(monkeypatch):
 def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
     class _ExplodingWorker:
         def __init__(self, *args, **kwargs):
-            raise AssertionError("slash worker should not run for isolated read commands")
+            raise AssertionError(
+                "slash worker should not run for isolated read commands"
+            )
 
     history_from_db = [
         {"role": "user", "content": "live question from state db"},
@@ -10327,7 +11792,9 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, key, include_ancestors=True, repair_alternation=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, key, include_ancestors=True, repair_alternation=False, **_kwargs
+        ):
             assert key == "session-key"
             assert include_ancestors is True
             return list(history_from_db)
@@ -10360,7 +11827,9 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
     )
     monkeypatch.setattr(server, "_SlashWorker", _ExplodingWorker)
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"dashboard": {"turn_isolation": True}}
+    )
 
     cases = {
         "usage": "Total tokens:                 140",
@@ -10374,13 +11843,11 @@ def test_slash_exec_r7_read_commands_use_metadata_mirror_flag_on(monkeypatch):
 
     try:
         for command, expected in cases.items():
-            resp = server.handle_request(
-                {
-                    "id": command,
-                    "method": "slash.exec",
-                    "params": {"command": command, "session_id": "sid"},
-                }
-            )
+            resp = server.handle_request({
+                "id": command,
+                "method": "slash.exec",
+                "params": {"command": command, "session_id": "sid"},
+            })
             assert "result" in resp, (command, resp)
             assert expected in resp["result"]["output"]
             assert "stale parent mirror" not in resp["result"]["output"]
@@ -10395,7 +11862,9 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["session_key"] = get_current_session_key(default="")
             return {
                 "final_response": "ok",
@@ -10415,13 +11884,11 @@ def test_prompt_submit_sets_approval_session_key(monkeypatch):
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "ping"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "ping"},
+    })
 
     assert resp["result"]["status"] == "streaming"
     assert captured["session_key"] == "session-key"
@@ -10435,7 +11902,9 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
         base_url = ""
         api_key = ""
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["prompt"] = prompt
             return {
                 "final_response": "ok",
@@ -10450,8 +11919,8 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
             self._target()
 
     fake_ctx = types.ModuleType("agent.context_references")
-    fake_ctx.preprocess_context_references = (
-        lambda message, **kwargs: types.SimpleNamespace(
+    fake_ctx.preprocess_context_references = lambda message, **kwargs: (
+        types.SimpleNamespace(
             blocked=False,
             message="expanded prompt",
             warnings=[],
@@ -10470,13 +11939,11 @@ def test_prompt_submit_expands_context_refs(monkeypatch):
     monkeypatch.setitem(sys.modules, "agent.context_references", fake_ctx)
     monkeypatch.setitem(sys.modules, "agent.model_metadata", fake_meta)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "@diff"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "@diff"},
+    })
 
     assert captured["prompt"] == "expanded prompt"
 
@@ -10495,13 +11962,11 @@ def test_image_attach_appends_local_image(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach",
-            "params": {"session_id": "sid", "path": "/tmp/cat.png"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach",
+        "params": {"session_id": "sid", "path": "/tmp/cat.png"},
+    })
 
     assert resp["result"]["attached"] is True
     assert resp["result"]["name"] == "cat.png"
@@ -10526,13 +11991,11 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach",
-            "params": {"session_id": "sid", "path": str(screenshot)},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach",
+        "params": {"session_id": "sid", "path": str(screenshot)},
+    })
 
     assert resp["result"]["attached"] is True
     assert resp["result"]["path"] == str(screenshot)
@@ -10558,18 +12021,16 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {
-                    "session_id": "sid",
-                    "path": "/Users/alice/Downloads/report.txt",
-                    "name": "report.txt",
-                    "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {
+                "session_id": "sid",
+                "path": "/Users/alice/Downloads/report.txt",
+                "name": "report.txt",
+                "data_url": "data:text/plain;base64,aGVsbG8gd29ybGQ=",
+            },
+        })
 
         stored = home / "attachments" / "report.txt"
         assert resp["result"]["attached"] is True
@@ -10581,7 +12042,9 @@ def test_file_attach_uploads_remote_file_into_session_workspace(monkeypatch, tmp
         server._sessions.pop("sid", None)
 
 
-def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, tmp_path):
+def test_file_attach_copies_gateway_visible_file_outside_workspace(
+    monkeypatch, tmp_path
+):
     """Local case: gateway can see the file but it's outside the workspace → copy in."""
     workspace = tmp_path / "workspace"
     workspace.mkdir()
@@ -10597,13 +12060,11 @@ def test_file_attach_copies_gateway_visible_file_outside_workspace(monkeypatch, 
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": str(source)},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": str(source)},
+        })
 
         stored = home / "attachments" / "outside.txt"
         assert resp["result"]["attached"] is True
@@ -10629,13 +12090,11 @@ def test_file_attach_uses_in_workspace_file_without_copying(monkeypatch, tmp_pat
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": str(source)},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": str(source)},
+        })
 
         assert resp["result"]["attached"] is True
         assert resp["result"]["uploaded"] is False
@@ -10661,13 +12120,11 @@ def test_file_attach_errors_when_unresolvable_and_no_bytes(monkeypatch, tmp_path
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {"session_id": "sid", "path": "/Users/alice/missing.txt"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {"session_id": "sid", "path": "/Users/alice/missing.txt"},
+        })
 
         assert "error" in resp
         assert "no data_url" in resp["error"]["message"]
@@ -10684,21 +12141,21 @@ def test_file_attach_quotes_ref_with_spaces(monkeypatch, tmp_path):
     fake_cli._split_path_input = lambda raw: (raw, "")
     fake_cli._resolve_attachment_path = lambda raw: None
 
-    server._sessions["sid"] = _session(cwd=str(workspace), profile_home=str(tmp_path / "home"))
+    server._sessions["sid"] = _session(
+        cwd=str(workspace), profile_home=str(tmp_path / "home")
+    )
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "file.attach",
-                "params": {
-                    "session_id": "sid",
-                    "name": "my exam schedule.csv",
-                    "data_url": "data:text/csv;base64,YSxiCg==",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "file.attach",
+            "params": {
+                "session_id": "sid",
+                "name": "my exam schedule.csv",
+                "data_url": "data:text/csv;base64,YSxiCg==",
+            },
+        })
 
         stored = tmp_path / "home" / "attachments" / "my exam schedule.csv"
         assert resp["result"]["attached"] is True
@@ -10725,9 +12182,11 @@ def test_commands_catalog_surfaces_quick_commands(monkeypatch):
         },
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     assert "npm run build" in pairs["/build"]
@@ -10770,9 +12229,11 @@ def test_commands_catalog_ranks_skill_commands_by_recorded_usage(monkeypatch):
         },
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     skills = resp["result"]["skills"]
     assert skills["/work"] == {"usage": 172, "origin": "local"}
@@ -10793,9 +12254,11 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
         lambda: (_ for _ in ()).throw(OSError("sidecar is gone")),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     assert "error" not in resp
     assert all(
@@ -10805,9 +12268,11 @@ def test_commands_catalog_survives_an_unreadable_usage_sidecar(monkeypatch):
 
 
 def test_commands_catalog_includes_tui_mouse_command():
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     tui_cat = next(c for c in resp["result"]["categories"] if c["name"] == "TUI")
@@ -10822,29 +12287,29 @@ def test_commands_catalog_has_no_duplicate_or_alias_colliding_names():
     shadow an alias of a different command (e.g. the historical /compact
     collision where the registry aliased compact -> compress while the TUI
     also registered its own /compact display toggle; see #57133)."""
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     names = [name for name, _ in resp["result"]["pairs"]]
     dupes = {n for n in names if names.count(n) > 1}
     assert not dupes, f"duplicate commands advertised in catalog: {sorted(dupes)}"
 
     canon = resp["result"]["canon"]
-    colliding = {
-        name
-        for name in names
-        if canon.get(name.lower(), name) != name
-    }
+    colliding = {name for name in names if canon.get(name.lower(), name) != name}
     assert not colliding, (
         f"catalog commands shadow aliases of other commands: {sorted(colliding)}"
     )
 
 
 def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible():
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     pairs = dict(resp["result"]["pairs"])
     canon = resp["result"]["canon"]
@@ -10869,15 +12334,19 @@ def test_commands_catalog_filters_gateway_only_commands_and_keeps_status_visible
 
 
 def test_commands_catalog_includes_desktop_meta_without_skills():
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     commands = resp["result"]["commands"]
     assert commands["/review"] == {"argument_mode": "text", "desktop": None}
     assert commands["/clear"]["desktop"] == "terminal"
     assert commands["/model"]["desktop"] == "hidden"
-    assert commands["/compact"]["argument_mode"] == commands["/compress"]["argument_mode"]
+    assert (
+        commands["/compact"]["argument_mode"] == commands["/compress"]["argument_mode"]
+    )
 
     for skill in resp["result"]["skills"]:
         assert skill not in commands
@@ -10895,9 +12364,11 @@ def test_commands_catalog_includes_plugin_commands(monkeypatch):
         },
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "commands.catalog", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "commands.catalog",
+        "params": {},
+    })
 
     assert resp["result"]["commands"]["/lcm"] == {
         "argument_mode": "text",
@@ -10930,9 +12401,11 @@ def test_session_status_reads_live_gateway_agent(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.status",
+            "params": {"session_id": "sid"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -10972,24 +12445,20 @@ def test_skills_reload_runs_in_gateway_process(monkeypatch):
 def test_snapshot_restore_is_blocked_from_tui_worker():
     server._sessions["sid"] = _session()
     try:
-        worker_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "slash.exec",
-                "params": {"command": "snapshot restore latest", "session_id": "sid"},
-            }
-        )
-        dispatch_resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "command.dispatch",
-                "params": {
-                    "arg": "restore latest",
-                    "name": "snapshot",
-                    "session_id": "sid",
-                },
-            }
-        )
+        worker_resp = server.handle_request({
+            "id": "1",
+            "method": "slash.exec",
+            "params": {"command": "snapshot restore latest", "session_id": "sid"},
+        })
+        dispatch_resp = server.handle_request({
+            "id": "2",
+            "method": "command.dispatch",
+            "params": {
+                "arg": "restore latest",
+                "name": "snapshot",
+                "session_id": "sid",
+            },
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11017,9 +12486,11 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
         ),
     )
 
-    resp = server.handle_request(
-        {"id": "1", "method": "command.dispatch", "params": {"name": "boom"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "command.dispatch",
+        "params": {"name": "boom"},
+    })
 
     assert "error" in resp
     assert "failed" in resp["error"]["message"]
@@ -11027,9 +12498,11 @@ def test_command_dispatch_exec_nonzero_surfaces_error(monkeypatch):
 
 def test_plugins_list_surfaces_loader_error(monkeypatch):
     with patch("hermes_cli.plugins.get_plugin_manager", side_effect=Exception("boom")):
-        resp = server.handle_request(
-            {"id": "1", "method": "plugins.list", "params": {}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "plugins.list",
+            "params": {},
+        })
 
     assert "error" in resp
     assert "boom" in resp["error"]["message"]
@@ -11040,9 +12513,11 @@ def test_complete_slash_surfaces_completer_error(monkeypatch):
         "hermes_cli.commands.SlashCommandCompleter",
         side_effect=Exception("no completer"),
     ):
-        resp = server.handle_request(
-            {"id": "1", "method": "complete.slash", "params": {"text": "/mo"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "complete.slash",
+            "params": {"text": "/mo"},
+        })
 
     assert "error" in resp
     assert "no completer" in resp["error"]["message"]
@@ -11059,13 +12534,11 @@ def test_input_detect_drop_attaches_image(monkeypatch):
     server._sessions["sid"] = _session()
     monkeypatch.setitem(sys.modules, "cli", fake_cli)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": "/tmp/cat.png"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": "/tmp/cat.png"},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -11080,13 +12553,11 @@ def test_input_detect_drop_path_with_spaces(tmp_path):
 
     server._sessions["sid"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": str(img)},
-        }
-    )
+    resp = server.handle_request({
+        "id": "2",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": str(img)},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -11105,13 +12576,11 @@ def test_input_detect_drop_path_with_spaces_and_remainder(tmp_path):
     server._sessions["sid"] = _session()
 
     user_input = f"{img} describe this image"
-    resp = server.handle_request(
-        {
-            "id": "3",
-            "method": "input.detect_drop",
-            "params": {"session_id": "sid", "text": user_input},
-        }
-    )
+    resp = server.handle_request({
+        "id": "3",
+        "method": "input.detect_drop",
+        "params": {"session_id": "sid", "text": user_input},
+    })
 
     assert resp["result"]["matched"] is True
     assert resp["result"]["is_image"] is True
@@ -11137,13 +12606,11 @@ def test_rollback_restore_resolves_number_and_file_path():
     server._sessions["sid"] = _session(
         agent=types.SimpleNamespace(_checkpoint_mgr=_Mgr()), history=[]
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "rollback.restore",
-            "params": {"session_id": "sid", "hash": "2", "file_path": "src/app.tsx"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "rollback.restore",
+        "params": {"session_id": "sid", "hash": "2", "file_path": "src/app.tsx"},
+    })
 
     assert resp["result"]["success"] is True
     assert calls["args"][1] == "bbb222"
@@ -11182,13 +12649,11 @@ def test_rollback_restore_truncates_from_real_user_turn_not_marker(monkeypatch):
         session_key="",
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc123"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc123"},
+        })
 
         assert resp["result"]["success"] is True
         assert resp["result"]["history_removed"] == 3  # q2 + a2 + marker
@@ -11243,13 +12708,11 @@ def test_rollback_restore_skips_legacy_compaction_handoff(monkeypatch):
         session_key="",
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc123"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc123"},
+        })
 
         assert resp["result"]["success"] is True
         # Truncation lands on "second question", not the handoff row.
@@ -11306,13 +12769,11 @@ def test_rollback_restore_preserves_composite_carrier_scaffold(monkeypatch, tmp_
     )
     monkeypatch.setattr(server, "_get_db", lambda: db)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc123"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc123"},
+        })
 
         assert "result" in resp, resp
         assert resp["result"]["success"] is True
@@ -11322,9 +12783,7 @@ def test_rollback_restore_preserves_composite_carrier_scaffold(monkeypatch, tmp_
         assert remaining[0]["display_kind"] == "hidden"
         assert SUMMARY_PREFIX in remaining[0]["content"]
         assert "REAL ASK" not in remaining[0]["content"]
-        cold = db.get_messages_as_conversation(
-            "rollback-carrier", include_row_ids=True
-        )
+        cold = db.get_messages_as_conversation("rollback-carrier", include_row_ids=True)
         assert len(cold) == 1
         assert cold[0]["content"] == remaining[0]["content"]
         assert cold[0]["display_kind"] == "hidden"
@@ -11358,13 +12817,11 @@ def test_session_steer_calls_agent_steer_when_agent_supports_it():
 
     server._sessions["sid"] = _session(agent=_Agent())
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "also check auth.log"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "also check auth.log"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11380,13 +12837,11 @@ def test_session_steer_rejects_empty_text():
         agent=types.SimpleNamespace(steer=lambda t: True)
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "   "},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "   "},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11397,13 +12852,11 @@ def test_session_steer_rejects_empty_text():
 def test_session_steer_errors_when_agent_has_no_steer_method():
     server._sessions["sid"] = _session(agent=types.SimpleNamespace())  # no steer()
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.steer",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.steer",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11418,17 +12871,18 @@ def test_session_redirect_calls_capable_core_agent(monkeypatch):
         redirect=lambda text: calls.append(text) or True,
     )
     session = _session(agent=agent)
-    session["inflight_turn"] = {"user": "original request", "assistant": "partial reply"}
+    session["inflight_turn"] = {
+        "user": "original request",
+        "assistant": "partial reply",
+    }
     server._sessions["sid"] = session
     try:
         before = session.get("last_active")
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "use Postgres"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "use Postgres"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11473,16 +12927,14 @@ def test_session_redirect_rpc_drops_queued_duplicate_of_inflight_user():
     ]
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {
-                    "session_id": "sid",
-                    "text": "what about the pricing instead?",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {
+                "session_id": "sid",
+                "text": "what about the pricing instead?",
+            },
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11513,13 +12965,11 @@ def test_session_redirect_build_window_scrubs_stale_p_when_queuing_q():
     session["queued_prompt"] = {"text": original, "transport": "ws-1"}
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "correction Q"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "correction Q"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11619,13 +13069,11 @@ def test_session_redirect_queues_during_agent_build_window(monkeypatch):
     session["agent"] = None
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "wait, use SQLite"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "wait, use SQLite"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11640,13 +13088,11 @@ def test_session_redirect_rejects_when_idle_without_agent(monkeypatch):
     session["agent"] = None
     server._sessions["sid"] = session
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.redirect",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.redirect",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -11664,7 +13110,9 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     fake_mod.get_mcp_status = lambda: fake_status
     monkeypatch.setitem(sys.modules, "tools.mcp_tool", fake_mod)
 
-    info = server._session_info(types.SimpleNamespace(tools=[], model="", provider="openai-codex"))
+    info = server._session_info(
+        types.SimpleNamespace(tools=[], model="", provider="openai-codex")
+    )
 
     assert info["provider"] == "openai-codex"
     assert info["mcp_servers"] == fake_status
@@ -11745,9 +13193,11 @@ def test_session_undo_rejects_while_running():
         ],
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.undo",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("error"), "session.undo should reject while running"
         assert resp["error"]["code"] == 4009
         assert "session busy" in resp["error"]["message"]
@@ -11768,9 +13218,11 @@ def test_session_undo_allowed_when_idle():
         ],
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.undo",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert resp["result"]["removed"] == 2
         assert server._sessions["sid"]["history"] == []
@@ -11781,9 +13233,11 @@ def test_session_undo_allowed_when_idle():
 def test_session_compress_rejects_while_running(monkeypatch):
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.compress", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("error")
         assert resp["error"]["code"] == 4009
     finally:
@@ -11794,13 +13248,11 @@ def test_rollback_restore_rejects_full_history_while_running(monkeypatch):
     """Full-history rollback must reject; file-scoped rollback still allowed."""
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "rollback.restore",
-                "params": {"session_id": "sid", "hash": "abc"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "rollback.restore",
+            "params": {"session_id": "sid", "hash": "abc"},
+        })
         assert resp.get("error"), "full-history rollback should reject while running"
         assert resp["error"]["code"] == 4009
     finally:
@@ -11817,7 +13269,9 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
     session_ref = {"s": None}
 
     class _RacyAgent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             # Simulate: something external bumped history_version
             # while we were running.
             with session_ref["s"]["history_lock"]:
@@ -11843,13 +13297,11 @@ def test_prompt_submit_history_version_mismatch_surfaces_warning(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # History should NOT contain the agent's output (version mismatch)
@@ -11900,7 +13352,9 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
         def __init__(self, new_history_state: list):
             self._new_history_state = new_history_state
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             # Simulate _append_model_switch_marker: strip prior markers, append new one.
             with session_ref["s"]["history_lock"]:
                 hist = session_ref["s"]["history"]
@@ -11910,7 +13364,8 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             # result["messages"] = conversation_history + user msg + assistant reply
             return {
                 "final_response": "agent reply",
-                "messages": list(conversation_history) + [
+                "messages": list(conversation_history)
+                + [
                     {"role": "user", "content": "hi"},
                     {"role": "assistant", "content": "agent reply"},
                 ],
@@ -11918,6 +13373,7 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
 
     def _is_marker(entry) -> bool:
         from tui_gateway.server import _is_model_switch_marker
+
         return _is_model_switch_marker(entry)
 
     class _ImmediateThread:
@@ -11930,11 +13386,14 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
     # Test both: no prior marker, and prior marker present
     for label, prior_history in [
         ("no prior marker", [{"role": "user", "content": "hello"}]),
-        ("with prior marker", [
-            {"role": "user", "content": "hello"},
-            _make_marker("old-model"),
-            {"role": "assistant", "content": "hi there"},
-        ]),
+        (
+            "with prior marker",
+            [
+                {"role": "user", "content": "hello"},
+                _make_marker("old-model"),
+                {"role": "assistant", "content": "hi there"},
+            ],
+        ),
     ]:
         server._sessions["sid"] = _session(
             agent=_MarkerAgent([]),
@@ -11948,21 +13407,21 @@ def test_prompt_submit_merges_on_model_switch_marker(monkeypatch):
             monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
             monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "prompt.submit",
-                    "params": {"session_id": "sid", "text": "hi"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hi"},
+            })
             assert resp.get("result"), f"[{label}] got error: {resp.get('error')}"
 
             final_history = server._sessions["sid"]["history"]
 
             # The agent's new messages must be present in the persisted history.
             assistant_msgs = [
-                e for e in final_history
-                if isinstance(e, dict) and e.get("role") == "assistant"
+                e
+                for e in final_history
+                if isinstance(e, dict)
+                and e.get("role") == "assistant"
                 and e.get("content") == "agent reply"
             ]
             assert len(assistant_msgs) == 1, (
@@ -12039,13 +13498,11 @@ def test_prompt_submit_merges_on_personality_pivot_marker(monkeypatch):
         monkeypatch.setattr(server, "_session_info", lambda *a, **k: {})
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         final_history = server._sessions["sid"]["history"]
@@ -12082,7 +13539,9 @@ def test_prompt_submit_sanitizes_bracketed_paste_before_agent(monkeypatch):
     captured: dict[str, str] = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["prompt"] = prompt
             return {
                 "final_response": "ok",
@@ -12107,13 +13566,11 @@ def test_prompt_submit_sanitizes_bracketed_paste_before_agent(monkeypatch):
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda *a, **k: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda *a, **k: None)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": corrupted},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": corrupted},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert captured["prompt"] == "hello"
     finally:
@@ -12124,7 +13581,9 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
     """Regression guard: the backstop does not affect the happy path."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [{"role": "assistant", "content": "reply"}],
@@ -12145,13 +13604,11 @@ def test_prompt_submit_history_version_match_persists_normally(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result")
 
         # History was written
@@ -12208,13 +13665,16 @@ def test_prompt_submit_snapshots_history_after_pending_model_switch(monkeypatch)
         monkeypatch.setattr(server, "render_message", lambda *_a: "")
         monkeypatch.setattr(server, "_emit", lambda *a: emits.append(a))
 
-        server.handle_request(
-            {"id": "1", "method": "prompt.submit", "params": {"session_id": "sid", "text": "hi"}}
-        )
+        server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
 
         assert seen["history"] == [marker]
         assert server._sessions["sid"]["history"][-1] == {
-            "role": "assistant", "content": "reply"
+            "role": "assistant",
+            "content": "reply",
         }
         complete = [a for a in emits if a[0] == "message.complete"]
         assert "warning" not in complete[0][2]
@@ -12228,7 +13688,9 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -12281,18 +13743,16 @@ def test_prompt_submit_can_truncate_before_user_ordinal(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited second",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited second",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         assert seen["prompt"] == "edited second"
@@ -12341,28 +13801,33 @@ def test_prompt_submit_refuses_turn_when_truncate_persist_fails(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _FailDb())
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "trunc-fail-sid",
-                    "text": "edited second",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "trunc-fail-sid",
+                "text": "edited second",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert "error" in resp
         assert resp["error"]["code"] == 5008
-        assert "truncat" in resp["error"]["message"].lower() or "persist" in resp["error"]["message"].lower()
+        assert (
+            "truncat" in resp["error"]["message"].lower()
+            or "persist" in resp["error"]["message"].lower()
+        )
         # Memory left intact — same list contents as before the refused cut.
         assert sess["history"] == original_history
         assert sess["history_version"] == 0
@@ -12392,7 +13857,9 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -12452,18 +13919,16 @@ def test_prompt_submit_truncate_ordinal_skips_display_kind_rows(monkeypatch):
 
         # ordinal=1 means "truncate before the 2nd-from-last real user turn"
         # which is "first". The display_kind marker must NOT shift the ordinal.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited first",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited first",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # With display_kind filter: user_indices = [0, 2] (indices of "first" and "second").
@@ -12492,7 +13957,9 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
     seen = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             seen["prompt"] = prompt
             seen["history"] = conversation_history
             return {
@@ -12561,18 +14028,16 @@ def test_prompt_submit_truncate_translates_display_prefix_ordinal(monkeypatch):
         monkeypatch.setattr(server, "_emit", lambda *a: None)
         monkeypatch.setattr(server, "_get_db", lambda: stub_db)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edited post B",
-                    "truncate_before_user_ordinal": desktop_ordinal_for_post_b,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edited post B",
+                "truncate_before_user_ordinal": desktop_ordinal_for_post_b,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert seen["prompt"] == "edited post B"
         assert seen["history"] == tip_history[:2]
@@ -12600,20 +14065,20 @@ def test_prompt_submit_truncate_oor_includes_structured_user_turn_count(monkeypa
 
     try:
         monkeypatch.setattr(
-            server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+            server,
+            "_start_inflight_turn",
+            lambda *a, **k: pytest.fail("must not start a turn"),
         )
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "sid",
-                    "text": "edit ancestor",
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "sid",
+                "text": "edit ancestor",
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+            },
+        })
         err = resp.get("error") or {}
         assert err.get("code") == 4018
         assert "no longer in session history" in (err.get("message") or "")
@@ -12683,21 +14148,19 @@ def test_prompt_submit_row_id_accepts_full_lineage_ordinal(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "lineage-row-sid",
-                    "text": "edited post B",
-                    # Row id resolves to tip ordinal 1; the client counted the
-                    # 2 ancestor user turns, so its lineage ordinal is 3.
-                    "truncate_before_row_id": 503,
-                    "truncate_before_user_ordinal": 3,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "lineage-row-sid",
+                "text": "edited post B",
+                # Row id resolves to tip ordinal 1; the client counted the
+                # 2 ancestor user turns, so its lineage ordinal is 3.
+                "truncate_before_row_id": 503,
+                "truncate_before_user_ordinal": 3,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, f"got error: {resp.get('error')}"
         assert sess["history"] == tip_history[:2]
     finally:
@@ -12708,22 +14171,22 @@ def test_prompt_submit_row_id_accepts_full_lineage_ordinal(monkeypatch):
     sess2 = _session(history=list(tip_history), display_history_prefix=display_prefix)
     server._sessions["lineage-row-sid-2"] = sess2
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "lineage-row-sid-2",
-                    "text": "edited post B",
-                    "truncate_before_row_id": 503,
-                    "truncate_before_user_ordinal": 2,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "lineage-row-sid-2",
+                "text": "edited post B",
+                "truncate_before_row_id": 503,
+                "truncate_before_user_ordinal": 2,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4030
     finally:
@@ -12761,13 +14224,11 @@ def test_interrupt_only_clears_own_session_pending():
         server._answers.clear()
 
         # Interrupt session A.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.interrupt",
-                "params": {"session_id": "sid_a"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid_a"},
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         # Session A's pending must be released to empty.
@@ -12804,9 +14265,11 @@ def test_interrupt_clears_multiple_own_pending():
         server._pending["r1"] = ("sid", ev1)
         server._pending["r2"] = ("sid", ev2)
 
-        resp = server.handle_request(
-            {"id": "1", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert resp.get("result")
         assert ev1.is_set() and ev2.is_set()
         assert server._answers.get("r1") == "" and server._answers.get("r2") == ""
@@ -12851,9 +14314,11 @@ def test_run_prompt_submit_registers_turn_thread_for_interrupt(monkeypatch):
         server._run_prompt_submit("1", "sid", session, "hello")
 
         assert session.get("_run_thread") is not None
-        resp = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert calls["interrupted"] is True
@@ -12875,15 +14340,23 @@ def test_interrupt_drops_queued_prompt_for_session():
         ),
         running=True,
         queued_prompt={"text": "next prompt", "transport": None},
-        queued_prompts=[{"text": "later prompt", "image_paths": ["/tmp/later.png"], "transport": None}],
+        queued_prompts=[
+            {
+                "text": "later prompt",
+                "image_paths": ["/tmp/later.png"],
+                "transport": None,
+            }
+        ],
         _run_thread=_LiveThread(),
     )
     server._sessions["sid"] = session
 
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert calls["interrupted"] is True
@@ -12928,20 +14401,20 @@ def test_interrupt_before_agent_ready_prevents_late_turn_start(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
         assert len(threads) == 1
 
-        stop = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        stop = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert stop.get("result"), f"got error: {stop.get('error')}"
 
         threads[0].target()
@@ -12985,7 +14458,9 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -12998,20 +14473,20 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
 
         # User hits Stop while the agent is still building.
-        stop = server.handle_request(
-            {"id": "2", "method": "session.interrupt", "params": {"session_id": "sid"}}
-        )
+        stop = server.handle_request({
+            "id": "2",
+            "method": "session.interrupt",
+            "params": {"session_id": "sid"},
+        })
         assert stop.get("result"), f"got error: {stop.get('error')}"
         assert session.get("_turn_cancel_requested") is True
 
@@ -13023,7 +14498,11 @@ def test_cancelled_turn_before_agent_ready_emits_error_event(monkeypatch):
         assert session["running"] is False
         assert session.get("inflight_turn") is None
         # Exactly one error event addressed to this session.
-        error_events = [e for e in emitted if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"]
+        error_events = [
+            e
+            for e in emitted
+            if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"
+        ]
         assert len(error_events) == 1, f"expected one error event, got: {emitted}"
         msg = error_events[0][2].get("message", "")
         assert "cancelled" in msg.lower(), f"unexpected message: {msg}"
@@ -13057,7 +14536,9 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -13070,13 +14551,11 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hello"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hello"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
         assert session["running"] is True
 
@@ -13089,7 +14568,11 @@ def test_session_not_running_before_agent_ready_emits_error_event(monkeypatch):
 
         assert calls["run_prompt"] == 0
         assert session.get("inflight_turn") is None
-        error_events = [e for e in emitted if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"]
+        error_events = [
+            e
+            for e in emitted
+            if e and len(e) >= 2 and e[0] == "error" and e[1] == "sid"
+        ]
         assert len(error_events) == 1, f"expected one error event, got: {emitted}"
         msg = error_events[0][2].get("message", "")
         assert "no longer running" in msg.lower(), f"unexpected message: {msg}"
@@ -13143,7 +14626,9 @@ def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -13155,13 +14640,11 @@ def test_slow_agent_build_delivers_prompt_instead_of_timing_out(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
@@ -13218,7 +14701,9 @@ def test_slow_agent_build_emits_keyed_progress_notice(monkeypatch):
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
         # Every wait slice lands past the slow threshold.
         monkeypatch.setattr(server, "_AGENT_BUILD_SLOW_NOTICE_AFTER", 0.0)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -13230,24 +14715,29 @@ def test_slow_agent_build_emits_keyed_progress_notice(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
 
         assert calls["run_prompt"] == 1
-        shows = [e for e in emitted if e and e[0] == "notification.show" and e[1] == "sid"]
-        clears = [e for e in emitted if e and e[0] == "notification.clear" and e[1] == "sid"]
+        shows = [
+            e for e in emitted if e and e[0] == "notification.show" and e[1] == "sid"
+        ]
+        clears = [
+            e for e in emitted if e and e[0] == "notification.clear" and e[1] == "sid"
+        ]
         # Exactly one keyed notice, replaced-in-place semantics, then cleared.
         assert len(shows) == 1, f"expected one slow-build notice, got: {shows}"
         assert shows[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
-        assert len(clears) == 1 and clears[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
+        assert (
+            len(clears) == 1
+            and clears[0][2].get("key") == server._AGENT_BUILD_SLOW_NOTICE_KEY
+        )
     finally:
         server._sessions.pop("sid", None)
 
@@ -13280,7 +14770,9 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
 
     try:
         monkeypatch.setattr(server.threading, "Thread", _FakeThread)
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         monkeypatch.setattr(server, "_ensure_session_db_row", lambda session: None)
         monkeypatch.setattr(server, "_persist_branch_seed", lambda session: None)
         monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
@@ -13292,13 +14784,11 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
             ),
         )
 
-        submit = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "first message"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "first message"},
+        })
         assert submit.get("result"), f"got error: {submit.get('error')}"
 
         threads[0].target()
@@ -13322,7 +14812,9 @@ def test_agent_build_failure_surfaces_error_and_drops_turn(monkeypatch):
                 or "No LLM provider configured" in str(e[2].get("text", ""))
             )
         ]
-        assert len(failure_frames) == 1, f"expected one visible failure frame, got: {emitted}"
+        assert len(failure_frames) == 1, (
+            f"expected one visible failure frame, got: {emitted}"
+        )
         frame = failure_frames[0]
         if frame[0] == "message.complete":
             assert frame[2].get("status") == "error"
@@ -13349,7 +14841,9 @@ def test_dead_build_thread_fails_fast_not_full_cap(monkeypatch):
     server._sessions["sid"] = session
 
     try:
-        monkeypatch.setattr(server, "_emit", lambda *args, **kwargs: emitted.append(args))
+        monkeypatch.setattr(
+            server, "_emit", lambda *args, **kwargs: emitted.append(args)
+        )
         # Short slices so the test is fast; the dead-thread check fires on the
         # first empty slice, far below the cap.
         monkeypatch.setattr(server, "_AGENT_BUILD_WAIT_SLICE", 0.01)
@@ -13398,22 +14892,29 @@ def test_wait_agent_for_prompt_honors_cancel_mid_wait(monkeypatch):
 def test_agent_build_wait_cap_config_override(monkeypatch):
     """agent.build_wait_timeout in config.yaml overrides the default cap;
     invalid/absent values fall back to 600s."""
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 90}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 90}}
+    )
     assert server._agent_build_wait_cap() == 90.0
 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {}})
     assert server._agent_build_wait_cap() == 600.0
 
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 0}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": 0}}
+    )
     assert server._agent_build_wait_cap() == 600.0
 
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": "nonsense"}})
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"build_wait_timeout": "nonsense"}}
+    )
     assert server._agent_build_wait_cap() == 600.0
 
 
 def test_wait_agent_for_prompt_expires_at_cap(monkeypatch):
     """A genuinely hung build (thread alive, never ready) still fails at the
     bounded cap with a message that tells the user their text was not sent."""
+
     class _AliveThread:
         def is_alive(self):
             return True
@@ -13459,13 +14960,11 @@ def test_respond_unpacks_sid_tuple_correctly():
     ev = threading.Event()
     server._pending["rid-x"] = ("sid_x", ev)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "clarify.respond",
-                "params": {"request_id": "rid-x", "answer": "the answer"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "clarify.respond",
+            "params": {"request_id": "rid-x", "answer": "the answer"},
+        })
         assert resp.get("result")
         assert ev.is_set()
         assert server._answers.get("rid-x") == "the answer"
@@ -13498,17 +14997,15 @@ def test_config_set_model_defers_while_running(monkeypatch):
 
     server._sessions["sid"] = _session(running=True)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {
-                    "session_id": "sid",
-                    "key": "model",
-                    "value": "anthropic/claude-sonnet-4.6",
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {
+                "session_id": "sid",
+                "key": "model",
+                "value": "anthropic/claude-sonnet-4.6",
+            },
+        })
         assert not resp.get("error")
         result = resp["result"]
         assert result["deferred"] is True
@@ -13562,13 +15059,11 @@ def test_config_set_model_allowed_when_idle(monkeypatch):
 
     server._sessions["sid"] = _session(running=False)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"session_id": "sid", "key": "model", "value": "newmodel"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"session_id": "sid", "key": "model", "value": "newmodel"},
+        })
         assert resp.get("result")
         assert resp["result"]["value"] == "newmodel"
         assert seen["called"]
@@ -13606,9 +15101,9 @@ def test_mirror_slash_side_effects_rejects_mutating_commands_while_running(monke
         ("/compress", "compress"),
     ]:
         warning = server._mirror_slash_side_effects("sid", session, cmd)
-        assert (
-            "session busy" in warning
-        ), f"{cmd} should have returned busy warning, got: {warning!r}"
+        assert "session busy" in warning, (
+            f"{cmd} should have returned busy warning, got: {warning!r}"
+        )
         assert f"/{expected_name}" in warning
 
     # None of the mutating side-effect helpers should have fired.
@@ -13663,10 +15158,10 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
 
     session = _session(running=False)
-    session["history"] = [
-        {"role": "user", "content": f"m{i}"} for i in range(6)
-    ]
-    session["agent"] = types.SimpleNamespace(model="x", _cached_system_prompt="", tools=None)
+    session["history"] = [{"role": "user", "content": f"m{i}"} for i in range(6)]
+    session["agent"] = types.SimpleNamespace(
+        model="x", _cached_system_prompt="", tools=None
+    )
 
     warning = server._mirror_slash_side_effects("sid", session, "/compress")
 
@@ -13788,17 +15283,17 @@ def test_session_compress_rpc_honors_here_argument(monkeypatch):
     server._sessions["sid"] = session
 
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.compress",
-                "params": {"session_id": "sid", "focus_topic": "here 1"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.compress",
+            "params": {"session_id": "sid", "focus_topic": "here 1"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -13820,17 +15315,17 @@ def test_command_dispatch_compress_honors_here_argument(monkeypatch):
 
     monkeypatch.setattr(server, "_session_uses_compute_host", lambda *_a, **_kw: False)
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "command.dispatch",
-                "params": {"session_id": "sid", "name": "compress", "arg": "here 1"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "command.dispatch",
+            "params": {"session_id": "sid", "name": "compress", "arg": "here 1"},
+        })
     finally:
         server._sessions.pop("sid", None)
 
@@ -13850,7 +15345,9 @@ def test_mirror_slash_compress_honors_here_argument(monkeypatch):
     session["history"] = list(_PARTIAL_FAKE_HISTORY)
 
     monkeypatch.setattr(server, "_session_info", lambda *_a, **_kw: {"model": "x"})
-    monkeypatch.setattr(server, "_sync_session_key_after_compress", lambda *a, **kw: None)
+    monkeypatch.setattr(
+        server, "_sync_session_key_after_compress", lambda *a, **kw: None
+    )
     monkeypatch.setattr(server, "_emit", lambda *args: None)
 
     warning = server._mirror_slash_side_effects("sid", session, "/compress here 1")
@@ -13944,13 +15441,11 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
 
     # Start: session.create spawns _build thread, returns synchronously
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.create",
-            "params": {"cols": 80},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     assert resp.get("result"), f"got error: {resp.get('error')}"
     sid = resp["result"]["session_id"]
     own_key = resp["result"]["stored_session_id"]
@@ -13965,13 +15460,11 @@ def test_session_create_close_race_does_not_orphan_worker(monkeypatch):
     # Build thread is blocked in _slow_make_agent.  Close the session
     # NOW — this pops _sessions[sid] before _build can install the
     # worker/notify.
-    close_resp = server.handle_request(
-        {
-            "id": "2",
-            "method": "session.close",
-            "params": {"session_id": sid},
-        }
-    )
+    close_resp = server.handle_request({
+        "id": "2",
+        "method": "session.close",
+        "params": {"session_id": sid},
+    })
     assert close_resp.get("result", {}).get("closed") is True
 
     # At this point session.close saw slash_worker=None (never eagerly
@@ -14028,7 +15521,9 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
             self.base_url = ""
             self.api_key = ""
 
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent())
+    monkeypatch.setattr(
+        server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent()
+    )
     monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
     monkeypatch.setattr(
         server,
@@ -14060,13 +15555,11 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
     server._sessions.clear()
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.create",
-                "params": {"cols": 80},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80},
+        })
         sid = resp["result"]["session_id"]
 
         # Wait for the build to finish (ready event inside session dict).
@@ -14086,12 +15579,12 @@ def test_session_create_no_race_keeps_worker_alive(monkeypatch):
         own_key = session["session_key"]
         own_closed = [k for k in closed_workers if k == own_key]
         own_unregistered = [k for k in unregistered_keys if k == own_key]
-        assert (
-            own_closed == []
-        ), f"build thread closed its own worker despite no race: {own_closed}"
-        assert (
-            own_unregistered == []
-        ), f"build thread unregistered its own notify despite no race: {own_unregistered}"
+        assert own_closed == [], (
+            f"build thread closed its own worker despite no race: {own_closed}"
+        )
+        assert own_unregistered == [], (
+            f"build thread unregistered its own notify despite no race: {own_unregistered}"
+        )
 
         # No pre-warmed worker: slash.exec spawns on demand, so a fresh
         # session that hasn't run a worker-routed command carries None.
@@ -14136,7 +15629,9 @@ def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
 
     emits = []
 
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent())
+    monkeypatch.setattr(
+        server, "_make_agent", lambda sid, key, session_db=None, **_kwargs: _FakeAgent()
+    )
     monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_session_info", lambda _a, *a2: {"model": "x"})
@@ -14149,9 +15644,11 @@ def test_session_create_continues_when_state_db_is_unavailable(monkeypatch):
     monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
     monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     sid = resp["result"]["session_id"]
     session = server._sessions[sid]
     session["agent_ready"].wait(timeout=2.0)
@@ -14180,9 +15677,11 @@ def test_session_create_lazy_info_reports_desktop_contract(monkeypatch):
     monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **kw: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.create", "params": {"cols": 80}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.create",
+        "params": {"cols": 80},
+    })
     info = resp["result"]["info"]
 
     assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
@@ -14211,13 +15710,11 @@ def test_session_activate_lazy_info_reports_desktop_contract():
         "transport": server._stdio_transport,
     }
     try:
-        resp = server.handle_request(
-            {
-                "id": "activate-lazy",
-                "method": "session.activate",
-                "params": {"session_id": sid},
-            }
-        )
+        resp = server.handle_request({
+            "id": "activate-lazy",
+            "method": "session.activate",
+            "params": {"session_id": sid},
+        })
         info = resp["result"]["info"]
         assert info["lazy"] is True
         assert info["desktop_contract"] == server.DESKTOP_BACKEND_CONTRACT
@@ -14261,9 +15758,11 @@ def test_session_delete_returns_db_unavailable_when_no_db(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr(server, "_db_error", "locked")
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "abc"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "abc"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -14282,13 +15781,11 @@ def test_session_delete_refuses_active_session(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     monkeypatch.setitem(server._sessions, "live", {"session_key": "key-live"})
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.delete",
-                "params": {"session_id": "key-live"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.delete",
+            "params": {"session_id": "key-live"},
+        })
     finally:
         server._sessions.pop("live", None)
 
@@ -14315,9 +15812,11 @@ def test_session_delete_fails_closed_when_active_snapshot_raises(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
     monkeypatch.setattr(server, "_sessions", _ExplodingDict())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "x"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "x"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -14331,9 +15830,11 @@ def test_session_delete_returns_4007_when_missing(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "ghost"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "ghost"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 4007
@@ -14346,9 +15847,11 @@ def test_session_delete_propagates_db_exception(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "x"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "x"},
+    })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5036
@@ -14369,9 +15872,11 @@ def test_session_delete_success_returns_deleted_id(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.delete", "params": {"session_id": "old-1"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "old-1"},
+    })
 
     assert "result" in resp, resp
     assert resp["result"] == {"deleted": "old-1"}
@@ -14382,8 +15887,6 @@ def test_session_delete_success_returns_deleted_id(monkeypatch):
     # /sessions to it.
     assert captured["sessions_dir"] is not None
     assert str(captured["sessions_dir"]).endswith("sessions")
-
-
 
 
 # --------------------------------------------------------------------------
@@ -14423,17 +15926,17 @@ def test_session_list_honors_params_profile_opens_profile_db(monkeypatch, tmp_pa
         def close(self):
             seen["closed"] = True
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.list",
-            "params": {"profile": "mlperf", "limit": 5},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.list",
+        "params": {"profile": "mlperf", "limit": 5},
+    })
     assert "result" in resp, resp
     assert resp["result"]["sessions"][0]["id"] == "ml-1"
     assert seen.get("profile") is True
@@ -14449,7 +15952,9 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
 
     class LaunchDB:
         def list_sessions_rich(self, **kwargs):
-            return [{"id": "launch-tip", "source": "tui", "title": "L", "started_at": 9}]
+            return [
+                {"id": "launch-tip", "source": "tui", "title": "L", "started_at": 9}
+            ]
 
     class ProfileDB2:
         def __init__(self, db_path=None):
@@ -14464,17 +15969,17 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
         def close(self):
             pass
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB2)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.most_recent",
-            "params": {"profile": "mlperf"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {"profile": "mlperf"},
+    })
     assert resp["result"]["session_id"] == "ml-tip"
 
 
@@ -14490,14 +15995,22 @@ def test_session_create_reports_requested_profile_name(monkeypatch, tmp_path):
 
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(
+        server, "_schedule_session_cap_enforcement", lambda *a, **k: None
+    )
     monkeypatch.setattr(server, "_completion_cwd", lambda params=None: str(tmp_path))
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
     _clear()
     try:
-        resp = server._methods["session.create"]("r1", {"profile": "mlperf", "cols": 80})
+        resp = server._methods["session.create"](
+            "r1", {"profile": "mlperf", "cols": 80}
+        )
         assert "result" in resp, resp
         assert resp["result"]["info"]["profile_name"] == "mlperf"
         sid = resp["result"]["session_id"]
@@ -14524,17 +16037,17 @@ def test_session_delete_honors_params_profile_sessions_dir(monkeypatch, tmp_path
         def close(self):
             captured["closed"] = True
 
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "mlperf" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "mlperf" else None
+    )
     monkeypatch.setattr(server, "_get_db", lambda: None)
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "session.delete",
-            "params": {"session_id": "old-ml", "profile": "mlperf"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.delete",
+        "params": {"session_id": "old-ml", "profile": "mlperf"},
+    })
     assert "result" in resp, resp
     assert resp["result"] == {"deleted": "old-ml"}
     assert str(captured["db_path"]).endswith("state.db")
@@ -14595,22 +16108,22 @@ def test_session_title_uses_session_profile_db_not_launch(monkeypatch, tmp_path)
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        set_resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.title",
-                "params": {"session_id": "sid", "title": "profile-title"},
-            }
-        )
+        set_resp = server.handle_request({
+            "id": "1",
+            "method": "session.title",
+            "params": {"session_id": "sid", "title": "profile-title"},
+        })
         assert "result" in set_resp, set_resp
         assert set_resp["result"]["title"] == "profile-title"
         assert seen.get("profile_write") is True
         assert seen.get("launch_write") is None
         assert str(seen.get("db_path")).endswith("state.db")
 
-        get_resp = server.handle_request(
-            {"id": "2", "method": "session.title", "params": {"session_id": "sid"}}
-        )
+        get_resp = server.handle_request({
+            "id": "2",
+            "method": "session.title",
+            "params": {"session_id": "sid"},
+        })
         assert get_resp["result"]["title"] == "profile-title"
         assert seen.get("launch_read") is None
     finally:
@@ -14652,9 +16165,11 @@ def test_session_history_uses_session_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.history", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.history",
+            "params": {"session_id": "sid"},
+        })
         assert "result" in resp, resp
         assert seen.get("profile") is True
         assert seen.get("launch") is None
@@ -14674,7 +16189,9 @@ def test_session_history_ships_durable_row_ids(monkeypatch):
     seen: dict = {}
 
     class _Db:
-        def get_messages_as_conversation(self, _key, include_ancestors=False, include_row_ids=False, **_kwargs):
+        def get_messages_as_conversation(
+            self, _key, include_ancestors=False, include_row_ids=False, **_kwargs
+        ):
             seen["include_row_ids"] = include_row_ids
 
             return [
@@ -14693,9 +16210,11 @@ def test_session_history_ships_durable_row_ids(monkeypatch):
     }
     monkeypatch.setattr(server, "_get_db", lambda: _Db())
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.history", "params": {"session_id": "rowid-hist-sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.history",
+            "params": {"session_id": "rowid-hist-sid"},
+        })
         assert "result" in resp, resp
         assert seen.get("include_row_ids") is True
         user_rows = [m for m in resp["result"]["messages"] if m.get("role") == "user"]
@@ -14739,9 +16258,11 @@ def test_session_status_uses_session_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.status", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.status",
+            "params": {"session_id": "sid"},
+        })
         assert "result" in resp, resp
         assert "profile-title" in resp["result"]["output"]
         assert seen.get("profile") is True
@@ -14873,7 +16394,9 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
 
     def _fake_make_agent(*a, **k):
         seen["agent_session_db"] = k.get("session_db")
@@ -14887,13 +16410,11 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "name": "forked"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "name": "forked"},
+        })
         assert "result" in resp, resp
         assert seen.get("created")
         assert seen.get("parent") == "parent-key"
@@ -14989,7 +16510,9 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: ProfileDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *a, **k: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *a, **k: (None, None)
+    )
 
     def _fake_make_agent(*a, **k):
         scope = current_secret_scope()
@@ -15004,13 +16527,11 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
     monkeypatch.setattr(server, "_register_session_cwd", lambda *a, **k: None)
     monkeypatch.setattr(server, "_attach_worker", lambda *a, **k: None)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "name": "forked"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "name": "forked"},
+        })
         assert "result" in resp, resp
         assert seen.get("scope") == {"PROXMOX_TOKEN": "mlperf-secret"}
     finally:
@@ -15018,7 +16539,9 @@ def test_session_branch_installs_parent_profile_secret_scope(monkeypatch, tmp_pa
             server._sessions.pop(k, None)
 
 
-def test_session_branch_uses_persisted_display_history_after_compaction(monkeypatch, tmp_path):
+def test_session_branch_uses_persisted_display_history_after_compaction(
+    monkeypatch, tmp_path
+):
     """A live branch must copy the complete visible transcript, not the compacted model tail."""
     profile_home = tmp_path / "profiles" / "mlperf"
     profile_home.mkdir(parents=True)
@@ -15106,7 +16629,9 @@ def test_session_branch_uses_persisted_display_history_after_compaction(monkeypa
     server._sessions["parent"] = parent
     monkeypatch.setattr(server, "_get_db", lambda: LaunchDB())
     monkeypatch.setattr("hermes_state.SessionDB", ProfileDB)
-    monkeypatch.setattr(server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None))
+    monkeypatch.setattr(
+        server, "_claim_active_session_slot", lambda *args, **kwargs: (None, None)
+    )
     monkeypatch.setattr(server, "_make_agent", lambda *args, **kwargs: FakeAgent())
     monkeypatch.setattr(server, "_set_session_context", lambda *args, **kwargs: {})
     monkeypatch.setattr(server, "_clear_session_context", lambda *args, **kwargs: None)
@@ -15116,13 +16641,11 @@ def test_session_branch_uses_persisted_display_history_after_compaction(monkeypa
     monkeypatch.setattr(server, "_attach_worker", lambda *args, **kwargs: None)
 
     try:
-        response = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.branch",
-                "params": {"session_id": "parent", "count": 4},
-            }
-        )
+        response = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "parent", "count": 4},
+        })
 
         assert "result" in response, response
         assert [message["content"] for message in seen["msgs"]] == [
@@ -15356,8 +16879,16 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
         "hermes_cli.auth.is_provider_explicitly_configured",
         lambda _slug: False,
     )
-    monkeypatch.setattr("hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr("hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        "hermes_cli.inventory._anthropic_oauth_credentials_present",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory._apply_pricing", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        "hermes_cli.inventory._apply_capabilities", lambda *_args, **_kwargs: None
+    )
 
     resp = server._methods["model.options"](
         102,
@@ -15480,7 +17011,9 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
         api_key = object()
         api_mode = "codex_responses"
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "Rome was founded in 753 BC.",
                 "messages": [
@@ -15494,19 +17027,19 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
     emitted = []
     monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
     monkeypatch.setattr(
-        server, "_emit", lambda kind, sid, payload=None, **kw: emitted.append((kind, payload))
+        server,
+        "_emit",
+        lambda kind, sid, payload=None, **kw: emitted.append((kind, payload)),
     )
     monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "Tell me about Rome"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "Tell me about Rome"},
+    })
 
     hook = getattr(agent, "_on_session_title", None)
     assert callable(hook), "gateway did not install a live title-rename hook"
@@ -15515,7 +17048,9 @@ def test_prompt_submit_wires_live_title_rename_callback(monkeypatch):
     # the lanes that spend a rate-limited remote rename filter by stage.
     hook("tell me about rome", "derived")
     hook("Founding of Rome", "llm")
-    assert [payload["title"] for kind, payload in emitted if kind == "session.title"] == [
+    assert [
+        payload["title"] for kind, payload in emitted if kind == "session.title"
+    ] == [
         "tell me about rome",
         "Founding of Rome",
     ]
@@ -15531,7 +17066,9 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     instead of emitting a blank message.complete turn."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": None,
                 "messages": [],
@@ -15554,13 +17091,11 @@ def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "hello"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "hello"},
+    })
 
     complete_events = [e for e in emitted if e[0] == "message.complete"]
     assert complete_events, "expected message.complete to be emitted"
@@ -15576,7 +17111,9 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     semantics owned by downstream handlers."""
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": None,
                 "messages": [],
@@ -15597,13 +17134,11 @@ def test_prompt_submit_preserves_empty_response_without_error(monkeypatch):
     monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    server.handle_request(
-        {
-            "id": "1",
-            "method": "prompt.submit",
-            "params": {"session_id": "sid", "text": "hello"},
-        }
-    )
+    server.handle_request({
+        "id": "1",
+        "method": "prompt.submit",
+        "params": {"session_id": "sid", "text": "hello"},
+    })
 
     complete_events = [e for e in emitted if e[0] == "message.complete"]
     assert complete_events, "expected message.complete to be emitted"
@@ -15642,13 +17177,11 @@ def test_session_active_list_reports_live_sessions(monkeypatch):
         last_active=30.0,
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.active_list",
-                "params": {"current_session_id": "sid-b"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.active_list",
+            "params": {"current_session_id": "sid-b"},
+        })
     finally:
         server._sessions.clear()
         server._sessions.update(previous_sessions)
@@ -15685,6 +17218,7 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
     until a gateway restart. A live session on the real stdio transport (the
     standalone ``hermes --tui`` case) must still be reported.
     """
+
     class _DB:
         def get_session_title(self, key):
             return {"key-live": "Live", "key-dead": "Dead"}.get(key, "")
@@ -15709,20 +17243,17 @@ def test_session_active_list_excludes_finalized_sessions(monkeypatch):
     dead["_finalized"] = True
     server._sessions["sid-dead"] = dead
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.active_list",
-                "params": {},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.active_list",
+            "params": {},
+        })
     finally:
         server._sessions.clear()
         server._sessions.update(previous_sessions)
 
     session_rows = resp["result"]["sessions"]
     assert [row["id"] for row in session_rows] == ["sid-live"]
-
 
 
 def test_session_activate_returns_inflight_stream_before_completion(monkeypatch):
@@ -15739,7 +17270,9 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     class _Agent:
         model = "model-live"
 
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             assert prompt == "write a long answer"
             assert conversation_history == []
             stream_callback("partial ")
@@ -15767,23 +17300,19 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
     monkeypatch.setattr(server, "_emit", _emit)
 
     try:
-        submit = server.handle_request(
-            {
-                "id": "submit",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid-live", "text": "write a long answer"},
-            }
-        )
+        submit = server.handle_request({
+            "id": "submit",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid-live", "text": "write a long answer"},
+        })
         assert submit["result"]["status"] == "streaming"
         assert started.wait(2), "fake model did not stream before activation"
 
-        resp = server.handle_request(
-            {
-                "id": "activate",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "activate",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
 
         inflight = resp["result"].get("inflight")
         assert inflight == {
@@ -15792,19 +17321,20 @@ def test_session_activate_returns_inflight_stream_before_completion(monkeypatch)
             "user": "write a long answer",
         }
         turn_started_at = resp["result"]["turn_started_at"]
-        assert turn_started_at == server._sessions["sid-live"]["inflight_turn"]["started_at"]
+        assert (
+            turn_started_at
+            == server._sessions["sid-live"]["inflight_turn"]["started_at"]
+        )
         assert turn_started_at > 0
         assert resp["result"]["messages"] == []
 
         release.set()
         assert done.wait(2), "fake model turn did not complete"
-        completed = server.handle_request(
-            {
-                "id": "activate-done",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        completed = server.handle_request({
+            "id": "activate-done",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
         assert completed["result"].get("inflight") is None
         assert completed["result"]["turn_started_at"] is None
         assert completed["result"]["messages"] == [
@@ -15843,13 +17373,11 @@ def test_session_activate_returns_prompt_queued_during_busy_turn(monkeypatch):
         )
         assert queued["result"]["status"] == "queued"
 
-        activated = server.handle_request(
-            {
-                "id": "activate",
-                "method": "session.activate",
-                "params": {"session_id": "sid-live"},
-            }
-        )
+        activated = server.handle_request({
+            "id": "activate",
+            "method": "session.activate",
+            "params": {"session_id": "sid-live"},
+        })
 
         assert activated["result"]["queued"] == {"user": "newest prompt"}
         assert "transport" not in activated["result"]["queued"]
@@ -15874,9 +17402,11 @@ def test_session_activate_switches_live_session_without_closing_siblings(monkeyp
         session_key="key-b",
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.activate", "params": {"session_id": "sid-b"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.activate",
+            "params": {"session_id": "sid-b"},
+        })
 
         assert "sid-a" in server._sessions
         assert "sid-b" in server._sessions
@@ -15905,13 +17435,11 @@ def test_session_activate_can_omit_duplicate_desktop_transcript(monkeypatch):
         session_key="key-large",
     )
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "session.activate",
-                "params": {"session_id": "sid-large", "omit_messages": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.activate",
+            "params": {"session_id": "sid-large", "omit_messages": True},
+        })
 
         assert resp["result"]["messages"] == []
         assert resp["result"]["message_count"] == 2
@@ -15928,7 +17456,14 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [
                 {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
@@ -15936,9 +17471,11 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] == "tui-1"
     assert resp["result"]["title"] == "real"
@@ -15947,14 +17484,23 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             return [{"id": "tool-1", "source": "tool", "started_at": 1}]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] is None
 
@@ -15965,14 +17511,23 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200, order_by_last_active=False, compact_rows=False):
+        def list_sessions_rich(
+            self,
+            *,
+            source=None,
+            limit=200,
+            order_by_last_active=False,
+            compact_rows=False,
+        ):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert "error" not in resp
     assert resp["result"]["session_id"] is None
@@ -15981,9 +17536,11 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
 def test_session_most_recent_handles_db_unavailable(monkeypatch):
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
-    resp = server.handle_request(
-        {"id": "1", "method": "session.most_recent", "params": {}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.most_recent",
+        "params": {},
+    })
 
     assert resp["result"]["session_id"] is None
 
@@ -15994,7 +17551,9 @@ def test_session_most_recent_handles_db_unavailable(monkeypatch):
 def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
     profile_home = tmp_path / "profiles" / "verify"
     profile_home.mkdir(parents=True)
-    monkeypatch.setattr(server, "_profile_home", lambda p: profile_home if p == "verify" else None)
+    monkeypatch.setattr(
+        server, "_profile_home", lambda p: profile_home if p == "verify" else None
+    )
     token = set_hermes_home_override(profile_home)
     project = tmp_path / "project"
     project.mkdir()
@@ -16015,13 +17574,11 @@ def test_verification_status_returns_recorded_evidence(tmp_path, monkeypatch):
             output="green",
         )
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "verification.status",
-                "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "verification.status",
+            "params": {"cwd": str(project), "session_id": "sid", "profile": "verify"},
+        })
     finally:
         reset_hermes_home_override(token)
 
@@ -16046,13 +17603,11 @@ def test_verification_status_outside_workspace_is_not_applicable(monkeypatch, tm
     home.mkdir()
     token = set_hermes_home_override(home)
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "verification.status",
-                "params": {"cwd": str(tmp_path), "session_id": "sid"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "verification.status",
+            "params": {"cwd": str(tmp_path), "session_id": "sid"},
+        })
     finally:
         reset_hermes_home_override(token)
 
@@ -16112,9 +17667,11 @@ def test_browser_manage_status_reads_env_var(monkeypatch):
     """Status returns the env var verbatim (no network I/O)."""
     monkeypatch.setenv("BROWSER_CDP_URL", "http://127.0.0.1:9222")
 
-    resp = server.handle_request(
-        {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "status"},
+    })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16129,9 +17686,11 @@ def test_browser_manage_status_falls_back_to_config_cdp_url(monkeypatch):
         read_raw_config=lambda: {"browser": {"cdp_url": "http://lan:9222"}}
     )
     with patch.dict(sys.modules, {"hermes_cli.config": fake_cfg}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "status"},
+        })
 
     assert resp["result"] == {"connected": True, "url": "http://lan:9222"}
 
@@ -16148,9 +17707,11 @@ def test_browser_manage_status_does_not_call_get_cdp_override(monkeypatch):
         )
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "status"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "status"},
+        })
 
     assert resp["result"]["connected"] is True
 
@@ -16172,13 +17733,11 @@ def test_browser_manage_connect_sets_env_and_cleans_twice(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://127.0.0.1:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://127.0.0.1:9222"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16198,9 +17757,11 @@ def test_browser_manage_connect_defaults_to_loopback(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         urls = _stub_urlopen_capture(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16234,23 +17795,24 @@ def test_browser_manage_connect_default_local_reports_launch_hint(monkeypatch):
                 return_value=ChromeDebugLaunch(),
             ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=False),
-            patch("hermes_cli.browser_connect.manual_chrome_debug_command", return_value=None),
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
+            ),
             patch(
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
         ):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {
-                        "action": "connect",
-                        "session_id": "sess-1",
-                        "url": "http://localhost:9222",
-                    },
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {
+                    "action": "connect",
+                    "session_id": "sess-1",
+                    "url": "http://localhost:9222",
+                },
+            })
 
     assert resp["result"]["connected"] is False
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16292,19 +17854,20 @@ def test_browser_manage_connect_no_session_skips_progress_events(monkeypatch):
                 "hermes_cli.browser_connect.launch_chrome_debug",
                 return_value=ChromeDebugLaunch(),
             ),
-            patch("hermes_cli.browser_connect.manual_chrome_debug_command", return_value=None),
+            patch(
+                "hermes_cli.browser_connect.manual_chrome_debug_command",
+                return_value=None,
+            ),
             patch(
                 "hermes_cli.browser_connect.get_chrome_debug_candidates",
                 return_value=[],
             ),
         ):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": "http://localhost:9222"},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": "http://localhost:9222"},
+            })
 
     assert resp["result"]["connected"] is False
     assert resp["result"]["messages"]  # bundled list still populated
@@ -16322,13 +17885,11 @@ def test_browser_manage_connect_handles_null_url(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": None},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": None},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16336,13 +17897,11 @@ def test_browser_manage_connect_handles_null_url(monkeypatch):
 
 def test_browser_manage_connect_rejects_non_string_url(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": 9222},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": 9222},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "must be a string" in resp["error"]["message"]
@@ -16390,9 +17949,11 @@ def test_browser_manage_connect_default_local_retries_after_launch(monkeypatch):
             ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=False),
         ):
-            resp = server.handle_request(
-                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect"},
+            })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16431,9 +17992,11 @@ def test_browser_manage_connect_finds_ipv6_only_browser(monkeypatch):
 
     monkeypatch.setattr(urllib.request, "urlopen", _opener)
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://[::1]:9222"
@@ -16476,19 +18039,25 @@ def test_browser_manage_connect_squatted_port_launches_on_alternate(monkeypatch)
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with (
-            patch("hermes_cli.browser_connect.launch_chrome_debug", side_effect=_launch),
+            patch(
+                "hermes_cli.browser_connect.launch_chrome_debug", side_effect=_launch
+            ),
             patch("hermes_cli.browser_connect.local_port_in_use", return_value=True),
             patch("hermes_cli.browser_connect.find_free_debug_port", return_value=9223),
         ):
-            resp = server.handle_request(
-                {"id": "1", "method": "browser.manage", "params": {"action": "connect"}}
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect"},
+            })
 
     assert launch_ports == [9223]
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9223"
     assert os.environ["BROWSER_CDP_URL"] == "http://127.0.0.1:9223"
-    assert any("occupied by another application" in m for m in resp["result"]["messages"])
+    assert any(
+        "occupied by another application" in m for m in resp["result"]["messages"]
+    )
 
 
 def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):
@@ -16503,13 +18072,11 @@ def test_browser_manage_connect_rejects_unreachable_endpoint(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=False)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://unreachable:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://unreachable:9222"},
+        })
 
     assert "error" in resp
     # Env preserved; nothing reaped.
@@ -16528,13 +18095,11 @@ def test_browser_manage_connect_normalizes_bare_host_port(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "127.0.0.1:9222"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "127.0.0.1:9222"},
+        })
 
     assert resp["result"]["connected"] is True
     # Bare host:port got promoted to a full URL with explicit scheme.
@@ -16554,13 +18119,11 @@ def test_browser_manage_connect_strips_discovery_path(monkeypatch):
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         _stub_urlopen(monkeypatch, ok=True)
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "browser.manage",
-                "params": {"action": "connect", "url": "http://127.0.0.1:9222/json"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "connect", "url": "http://127.0.0.1:9222/json"},
+        })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == "http://127.0.0.1:9222"
@@ -16592,13 +18155,11 @@ def test_browser_manage_connect_preserves_devtools_browser_endpoint(monkeypatch)
             "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
         ):
             with patch("socket.create_connection", return_value=_OkSocket()):
-                resp = server.handle_request(
-                    {
-                        "id": "1",
-                        "method": "browser.manage",
-                        "params": {"action": "connect", "url": concrete},
-                    }
-                )
+                resp = server.handle_request({
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": concrete},
+                })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == concrete
@@ -16625,13 +18186,11 @@ def test_browser_manage_connect_local_devtools_ws_preserves_path(monkeypatch):
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch("socket.create_connection", return_value=_OkSocket()):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": concrete},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": concrete},
+            })
 
     assert resp["result"]["connected"] is True
     assert resp["result"]["url"] == concrete
@@ -16640,13 +18199,11 @@ def test_browser_manage_connect_local_devtools_ws_preserves_path(monkeypatch):
 
 def test_browser_manage_connect_rejects_invalid_port(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": "http://localhost:abc"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": "http://localhost:abc"},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "invalid port" in resp["error"]["message"]
@@ -16655,13 +18212,11 @@ def test_browser_manage_connect_rejects_invalid_port(monkeypatch):
 
 def test_browser_manage_connect_rejects_missing_host(monkeypatch):
     monkeypatch.delenv("BROWSER_CDP_URL", raising=False)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "browser.manage",
-            "params": {"action": "connect", "url": "http://:9222"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "browser.manage",
+        "params": {"action": "connect", "url": "http://:9222"},
+    })
 
     assert resp["error"]["code"] == 4015
     assert "missing host" in resp["error"]["message"]
@@ -16699,13 +18254,11 @@ def test_browser_manage_connect_concrete_ws_skips_http_probe(monkeypatch):
             "urllib.request.urlopen", side_effect=AssertionError("urlopen called")
         ):
             with patch("socket.create_connection", side_effect=_fake_create_connection):
-                resp = server.handle_request(
-                    {
-                        "id": "1",
-                        "method": "browser.manage",
-                        "params": {"action": "connect", "url": concrete},
-                    }
-                )
+                resp = server.handle_request({
+                    "id": "1",
+                    "method": "browser.manage",
+                    "params": {"action": "connect", "url": concrete},
+                })
 
     assert resp["result"] == {"connected": True, "url": concrete}
     # wss → port 443, host preserved verbatim.
@@ -16725,13 +18278,11 @@ def test_browser_manage_connect_concrete_ws_tcp_unreachable(monkeypatch):
 
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
         with patch("socket.create_connection", side_effect=OSError("ECONNREFUSED")):
-            resp = server.handle_request(
-                {
-                    "id": "1",
-                    "method": "browser.manage",
-                    "params": {"action": "connect", "url": concrete},
-                }
-            )
+            resp = server.handle_request({
+                "id": "1",
+                "method": "browser.manage",
+                "params": {"action": "connect", "url": concrete},
+            })
 
     assert "error" in resp
     assert resp["error"]["code"] == 5031
@@ -16747,9 +18298,11 @@ def test_browser_manage_disconnect_drops_env_and_cleans(monkeypatch):
         _get_cdp_override=lambda: os.environ.get("BROWSER_CDP_URL", ""),
     )
     with patch.dict(sys.modules, {"tools.browser_tool": fake}):
-        resp = server.handle_request(
-            {"id": "1", "method": "browser.manage", "params": {"action": "disconnect"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "browser.manage",
+            "params": {"action": "disconnect"},
+        })
 
     assert resp["result"] == {"connected": False}
     assert "BROWSER_CDP_URL" not in os.environ
@@ -16764,9 +18317,11 @@ def test_config_get_indicator_returns_known_value_verbatim(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": "emoji"}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "emoji"}
 
 
@@ -16779,9 +18334,11 @@ def test_config_get_indicator_normalizes_casing_and_whitespace(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": " EMOJI "}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "emoji"}
 
 
@@ -16791,17 +18348,21 @@ def test_config_get_indicator_falls_back_to_default_for_unknown(monkeypatch):
     monkeypatch.setattr(
         server, "_load_cfg", lambda: {"display": {"tui_status_indicator": "rainbow"}}
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "kaomoji"}
 
 
 def test_config_get_indicator_falls_back_when_unset(monkeypatch):
     monkeypatch.setattr(server, "_load_cfg", lambda: {"display": {}})
-    resp = server.handle_request(
-        {"id": "1", "method": "config.get", "params": {"key": "indicator"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.get",
+        "params": {"key": "indicator"},
+    })
     assert resp["result"] == {"value": "kaomoji"}
 
 
@@ -16815,13 +18376,11 @@ def test_config_set_indicator_accepts_known_value(monkeypatch):
         "_write_config_key",
         lambda k, v: written.update({k: v}),
     )
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "indicator", "value": "EMOJI"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "indicator", "value": "EMOJI"},
+    })
     assert resp["result"] == {"key": "indicator", "value": "emoji"}
     assert written == {"display.tui_status_indicator": "emoji"}
 
@@ -16833,13 +18392,11 @@ def test_config_set_indicator_falsy_non_string_surfaces_in_error(monkeypatch):
     monkeypatch.setattr(server, "_write_config_key", lambda *a, **k: None)
 
     for bad in (0, False, []):
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "config.set",
-                "params": {"key": "indicator", "value": bad},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "config.set",
+            "params": {"key": "indicator", "value": bad},
+        })
         assert "error" in resp
         msg = resp["error"]["message"]
         assert "unknown indicator" in msg
@@ -16852,13 +18409,11 @@ def test_config_set_indicator_falsy_non_string_surfaces_in_error(monkeypatch):
 def test_config_set_indicator_none_keeps_blank_repr(monkeypatch):
     """`None` is the genuine 'no value' case — empty raw is acceptable."""
     monkeypatch.setattr(server, "_write_config_key", lambda *a, **k: None)
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "config.set",
-            "params": {"key": "indicator", "value": None},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "config.set",
+        "params": {"key": "indicator", "value": None},
+    })
     assert "error" in resp
     assert "unknown indicator: ''" in resp["error"]["message"]
 
@@ -17005,7 +18560,10 @@ def test_make_agent_uses_session_runtime_overrides(monkeypatch):
     assert resolved == {"requested": "openai-codex", "target_model": "gpt-5.4"}
     assert mock_agent.call_args.kwargs["model"] == "gpt-5.4"
     assert mock_agent.call_args.kwargs["provider"] == "openai-codex"
-    assert mock_agent.call_args.kwargs["reasoning_config"] == {"enabled": True, "effort": "high"}
+    assert mock_agent.call_args.kwargs["reasoning_config"] == {
+        "enabled": True,
+        "effort": "high",
+    }
     assert mock_agent.call_args.kwargs["service_tier"] == "priority"
 
 
@@ -17099,7 +18657,9 @@ def test_notification_poller_delivers_completion(monkeypatch):
     emitted = []
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             return {
                 "final_response": "ok",
@@ -17109,6 +18669,7 @@ def test_notification_poller_delivers_completion(monkeypatch):
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None):
             self._target = target
+
         def start(self):
             self._target()
 
@@ -17154,7 +18715,10 @@ def test_notification_poller_delivers_completion(monkeypatch):
 
         # Should have triggered an agent turn
         assert len(turns) == 1
-        assert "[IMPORTANT: Background process proc_poller_test completed normally" in turns[0]
+        assert (
+            "[IMPORTANT: Background process proc_poller_test completed normally"
+            in turns[0]
+        )
     finally:
         server._sessions.pop("sid_poll", None)
         while not process_registry.completion_queue.empty():
@@ -17170,13 +18734,16 @@ def test_notification_poller_skips_consumed(monkeypatch):
     turns = []
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             turns.append(prompt)
             return {"final_response": "ok", "messages": []}
 
     class _ImmediateThread:
         def __init__(self, target=None, daemon=None):
             self._target = target
+
         def start(self):
             self._target()
 
@@ -17266,7 +18833,9 @@ def test_notification_poller_requeues_when_busy(monkeypatch):
             process_registry.completion_queue.get_nowait()
 
 
-def test_session_save_writes_under_hermes_home_with_system_prompt(monkeypatch, tmp_path):
+def test_session_save_writes_under_hermes_home_with_system_prompt(
+    monkeypatch, tmp_path
+):
     """TUI /save (session.save RPC) must snapshot under the Hermes profile
     home — not the project/workspace CWD — and include the system prompt,
     mirroring the classic CLI /save and the dashboard save export.
@@ -17435,9 +19004,9 @@ def test_notification_event_dedup_key_keeps_completions_one_shot():
         "output": "different output should not change completion key",
     }
 
-    assert server._notification_event_dedup_key(first) == server._notification_event_dedup_key(
-        replay
-    )
+    assert server._notification_event_dedup_key(
+        first
+    ) == server._notification_event_dedup_key(replay)
 
 
 # --- image.attach_bytes / pdf.attach (remote-client byte upload) -------------
@@ -17461,17 +19030,15 @@ def test_image_attach_bytes_writes_to_gateway_dir(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx",
-                "content_base64": _PNG_1X1_B64,
-                "filename": "shot.png",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx",
+            "content_base64": _PNG_1X1_B64,
+            "filename": "shot.png",
+        },
+    })
 
     res = resp["result"]
     assert res["attached"] is True
@@ -17488,16 +19055,14 @@ def test_image_attach_bytes_accepts_data_url_prefix(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx2"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx2",
-                "content_base64": f"data:image/png;base64,{_PNG_1X1_B64}",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx2",
+            "content_base64": f"data:image/png;base64,{_PNG_1X1_B64}",
+        },
+    })
     assert resp["result"]["attached"] is True
 
 
@@ -17507,13 +19072,11 @@ def test_image_attach_bytes_data_alias_and_magic_sniff(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx3"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx3", "data": _PNG_1X1_B64},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx3", "data": _PNG_1X1_B64},
+    })
     res = resp["result"]
     assert res["attached"] is True
     assert Path(res["path"]).suffix == ".png"  # sniffed from magic bytes
@@ -17524,13 +19087,11 @@ def test_image_attach_bytes_rejects_invalid_base64(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
     server._sessions["abx4"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx4", "content_base64": "!!!not base64!!!"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx4", "content_base64": "!!!not base64!!!"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4017
 
@@ -17544,13 +19105,11 @@ def test_image_attach_bytes_rejects_oversize(monkeypatch, tmp_path):
     server._sessions["abx5"] = _session()
 
     big = _b64.b64encode(b"\x89PNG\r\n\x1a\n" + b"0" * 100).decode("ascii")
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {"session_id": "abx5", "content_base64": big},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {"session_id": "abx5", "content_base64": big},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4018
 
@@ -17561,17 +19120,15 @@ def test_image_attach_bytes_rejects_unsupported_extension(monkeypatch, tmp_path)
     server._sessions["abx6"] = _session()
 
     # filename hint forces a non-image extension; magic sniff is bypassed by hint
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "image.attach_bytes",
-            "params": {
-                "session_id": "abx6",
-                "content_base64": _PNG_1X1_B64,
-                "filename": "evil.exe",
-            },
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "image.attach_bytes",
+        "params": {
+            "session_id": "abx6",
+            "content_base64": _PNG_1X1_B64,
+            "filename": "evil.exe",
+        },
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4016
 
@@ -17583,13 +19140,11 @@ def test_pdf_attach_requires_poppler(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _name: None)
     server._sessions["pdf1"] = _session()
 
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "pdf.attach",
-            "params": {"session_id": "pdf1", "content_base64": "JVBERi0xLjQK"},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf1", "content_base64": "JVBERi0xLjQK"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 5028
 
@@ -17603,13 +19158,11 @@ def test_pdf_attach_rejects_non_pdf_bytes(monkeypatch, tmp_path):
     server._sessions["pdf2"] = _session()
 
     not_pdf = _b64.b64encode(b"this is not a pdf").decode("ascii")
-    resp = server.handle_request(
-        {
-            "id": "1",
-            "method": "pdf.attach",
-            "params": {"session_id": "pdf2", "content_base64": not_pdf},
-        }
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf2", "content_base64": not_pdf},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4017
 
@@ -17620,9 +19173,11 @@ def test_pdf_attach_requires_path_or_bytes(monkeypatch, tmp_path):
     monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/pdftoppm")
     server._sessions["pdf3"] = _session()
 
-    resp = server.handle_request(
-        {"id": "1", "method": "pdf.attach", "params": {"session_id": "pdf3"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "pdf.attach",
+        "params": {"session_id": "pdf3"},
+    })
     assert "error" in resp
     assert resp["error"]["code"] == 4015
 
@@ -17633,11 +19188,16 @@ def test_decode_attach_base64_helper():
     raw = _b64.b64encode(b"hello").decode("ascii")
     assert server._decode_attach_base64(raw, mime_prefix="image/") == b"hello"
     assert (
-        server._decode_attach_base64(f"data:image/png;base64,{raw}", mime_prefix="image/")
+        server._decode_attach_base64(
+            f"data:image/png;base64,{raw}", mime_prefix="image/"
+        )
         == b"hello"
     )
     # whitespace inside payload is tolerated
-    assert server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/") == b"hello"
+    assert (
+        server._decode_attach_base64(raw[:4] + "\n" + raw[4:], mime_prefix="image/")
+        == b"hello"
+    )
     assert server._decode_attach_base64("@@@", mime_prefix="image/") is None
 
 
@@ -17715,7 +19275,8 @@ def test_close_session_by_id_is_idempotent_and_full(monkeypatch):
     monkeypatch.setattr(server, "_finalize_session", _fake_finalize)
     monkeypatch.setattr(
         "tools.approval.unregister_gateway_notify",
-        lambda key: calls.__setitem__("unreg", calls["unreg"] + 1), raising=False,
+        lambda key: calls.__setitem__("unreg", calls["unreg"] + 1),
+        raising=False,
     )
     server._sessions["sid-1"] = {"session_key": "k1", "agent": A(), "slash_worker": W()}
 
@@ -17856,13 +19417,11 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
 
     def _exec(n):
         barrier.wait()
-        resp = server.handle_request(
-            {
-                "id": str(n),
-                "method": "slash.exec",
-                "params": {"command": "/context", "session_id": "race-spawn"},
-            }
-        )
+        resp = server.handle_request({
+            "id": str(n),
+            "method": "slash.exec",
+            "params": {"command": "/context", "session_id": "race-spawn"},
+        })
         results.append(resp)
 
     try:
@@ -17884,15 +19443,19 @@ def test_slash_exec_concurrent_first_use_spawns_single_worker(monkeypatch):
 def test_session_close_rpc_claims_then_tears_down(monkeypatch):
     seen = []
     claimed = {"session_key": "k"}
-    monkeypatch.setattr(server, "_pop_session_by_id", lambda sid: seen.append(sid) or claimed)
+    monkeypatch.setattr(
+        server, "_pop_session_by_id", lambda sid: seen.append(sid) or claimed
+    )
     monkeypatch.setattr(
         server,
         "_teardown_popped_session",
         lambda session, *, end_reason: seen.append((session, end_reason)) or True,
     )
-    resp = server.handle_request(
-        {"id": "1", "method": "session.close", "params": {"session_id": "s9"}}
-    )
+    resp = server.handle_request({
+        "id": "1",
+        "method": "session.close",
+        "params": {"session_id": "s9"},
+    })
     assert resp["result"] == {"closed": True}
     assert seen == ["s9", (claimed, "tui_close")]
 
@@ -17902,7 +19465,9 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     monkeypatch.setattr(
         server,
         "_teardown_popped_session",
-        lambda session, *, end_reason: seen.append((session["_sid"], end_reason)) or True,
+        lambda session, *, end_reason: (
+            seen.append((session["_sid"], end_reason)) or True
+        ),
     )
     # Detached session "b" would schedule a real grace-reap threading.Timer that
     # outlives the test; grace=0 short-circuits it so no thread lingers.
@@ -17914,7 +19479,9 @@ def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):
     try:
         server._close_sessions_for_transport(transport, end_reason="ws_disconnect")
         assert seen == [("a", "ws_disconnect")]  # only the flagged one closed
-        assert server._sessions["b"]["transport"] is server._detached_ws_transport  # re-pointed
+        assert (
+            server._sessions["b"]["transport"] is server._detached_ws_transport
+        )  # re-pointed
     finally:
         server._sessions.clear()
 
@@ -17985,12 +19552,16 @@ def test_session_create_records_close_on_disconnect_flag(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     server._sessions.clear()
     try:
-        on = server.handle_request(
-            {"id": "1", "method": "session.create", "params": {"close_on_disconnect": True}}
-        )["result"]["session_id"]
-        off = server.handle_request(
-            {"id": "2", "method": "session.create", "params": {}}
-        )["result"]["session_id"]
+        on = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"close_on_disconnect": True},
+        })["result"]["session_id"]
+        off = server.handle_request({
+            "id": "2",
+            "method": "session.create",
+            "params": {},
+        })["result"]["session_id"]
         assert server._sessions[on]["close_on_disconnect"]
         assert not server._sessions[off]["close_on_disconnect"]
     finally:
@@ -18001,9 +19572,11 @@ def test_session_create_records_source(monkeypatch):
     monkeypatch.setattr(server, "_start_agent_build", lambda sid, session: None)
     server._sessions.clear()
     try:
-        sid = server.handle_request(
-            {"id": "1", "method": "session.create", "params": {"source": "tool"}}
-        )["result"]["session_id"]
+        sid = server.handle_request({
+            "id": "1",
+            "method": "session.create",
+            "params": {"source": "tool"},
+        })["result"]["session_id"]
         assert server._sessions[sid]["source"] == "tool"
     finally:
         server._sessions.clear()
@@ -18012,7 +19585,8 @@ def test_session_create_records_source(monkeypatch):
 def test_shutdown_sessions_closes_every_session_via_helper(monkeypatch):
     seen = []
     monkeypatch.setattr(
-        server, "_close_session_by_id",
+        server,
+        "_close_session_by_id",
         lambda sid, *, end_reason: seen.append((sid, end_reason)),
     )
     server._sessions.clear()
@@ -18076,7 +19650,8 @@ def test_reap_idle_sessions_closes_only_evictable(monkeypatch):
     closed = []
     monkeypatch.setattr(server, "_session_pending_kind", lambda sid: "")
     monkeypatch.setattr(
-        server, "_close_session_by_id",
+        server,
+        "_close_session_by_id",
         lambda sid, *, end_reason, predicate=None: closed.append((sid, end_reason)),
     )
     now = time.time()
@@ -18103,7 +19678,8 @@ def test_reap_idle_sessions_calls_periodic_trim(monkeypatch):
     import hermes_cli.mem_trim as mem_trim
 
     monkeypatch.setattr(
-        mem_trim, "trim_memory",
+        mem_trim,
+        "trim_memory",
         lambda **kw: trim_calls.append(kw.get("reason", "")) or True,
     )
 
@@ -18123,7 +19699,11 @@ def test_reap_idle_sessions_logs_trim_failure(monkeypatch, caplog):
     monkeypatch.setattr(server, "_reclaim_orphaned_leases", lambda: None)
     import hermes_cli.mem_trim as mem_trim
 
-    monkeypatch.setattr(mem_trim, "trim_memory", lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")))
+    monkeypatch.setattr(
+        mem_trim,
+        "trim_memory",
+        lambda **_kw: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
     server._sessions.clear()
     try:
         with caplog.at_level("DEBUG", logger="tui_gateway.server"):
@@ -18246,11 +19826,16 @@ def test_lru_reaper_revalidates_and_tries_next_candidate(monkeypatch):
 
     def _reattach_oldest_after_scan(sid, session):
         evictable = original_is_evictable(sid, session)
-        if sid == "lru-race" and session.get("transport") is server._detached_ws_transport:
+        if (
+            sid == "lru-race"
+            and session.get("transport") is server._detached_ws_transport
+        ):
             session["transport"] = live_transport
         return evictable
 
-    monkeypatch.setattr(server, "_session_is_lru_evictable", _reattach_oldest_after_scan)
+    monkeypatch.setattr(
+        server, "_session_is_lru_evictable", _reattach_oldest_after_scan
+    )
     now = time.time()
     server._sessions.clear()
     server._sessions["lru-race"] = _idle_evictable_session(now) | {
@@ -18289,7 +19874,10 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
         )
         sid = resp["result"]["session_id"]
         sess = server._sessions[sid]
-        assert sess["model_override"] == {"model": "claude-sonnet-4.6", "provider": "anthropic"}
+        assert sess["model_override"] == {
+            "model": "claude-sonnet-4.6",
+            "provider": "anthropic",
+        }
         assert sess["create_reasoning_override"] is not None
         assert sess["create_service_tier_override"] == "priority"
         # The immediate response reflects the override (not the global default) so
@@ -18299,9 +19887,7 @@ def test_session_create_records_ui_model_as_session_override(monkeypatch):
 
         # Explicit false is not the same as omission: it must suppress a Fast
         # profile default for this session's first request.
-        normal = server._methods["session.create"](
-            "r2", {"cols": 80, "fast": False}
-        )
+        normal = server._methods["session.create"]("r2", {"cols": 80, "fast": False})
         normal_sess = server._sessions[normal["result"]["session_id"]]
         assert normal_sess["create_service_tier_override"] == ""
 
@@ -18485,12 +20071,12 @@ class _BillingHeaders:
         (429, "rate_limited", None),
     ],
 )
-def test_billing_error_serialization_preserves_server_code(
-    status, error, retry_after
-):
+def test_billing_error_serialization_preserves_server_code(status, error, retry_after):
     import hermes_cli.nous_billing as nb
 
-    headers = _BillingHeaders({"Retry-After": str(retry_after)}) if retry_after else None
+    headers = (
+        _BillingHeaders({"Retry-After": str(retry_after)}) if retry_after else None
+    )
     with pytest.raises(nb.BillingTransient) as ei:
         nb._raise_for_error(status, {"error": error}, headers)
 
@@ -18517,7 +20103,9 @@ def test_billing_rate_limit_without_error_defaults_wire_code():
 def _sub_rpc(method, params):
     # These RPCs are in _LONG_HANDLERS (pool-routed → dispatch returns None and the
     # worker writes via the transport), so drive the inline handler directly.
-    return server.handle_request({"id": "1", "method": method, "params": params})["result"]
+    return server.handle_request({"id": "1", "method": method, "params": params})[
+        "result"
+    ]
 
 
 def test_subscription_preview_serializes_quote(monkeypatch):
@@ -18572,7 +20160,11 @@ def test_subscription_change_cancellation(monkeypatch):
     def _put(*, subscription_type_id=None, cancel=False):
         seen["tier"] = subscription_type_id
         seen["cancel"] = cancel
-        return {"rail": "stripe", "cancelAtPeriodEnd": True, "message": "Scheduled to cancel."}
+        return {
+            "rail": "stripe",
+            "cancelAtPeriodEnd": True,
+            "message": "Scheduled to cancel.",
+        }
 
     monkeypatch.setattr(nb, "put_subscription_pending_change", _put)
     res = _sub_rpc("subscription.change", {"cancel": True})
@@ -18589,7 +20181,12 @@ def test_subscription_change_tier_downgrade(monkeypatch):
     def _put(*, subscription_type_id=None, cancel=False):
         seen["tier"] = subscription_type_id
         seen["cancel"] = cancel
-        return {"rail": "stripe", "changeType": "downgrade", "targetTierName": "Plus", "message": "Scheduled."}
+        return {
+            "rail": "stripe",
+            "changeType": "downgrade",
+            "targetTierName": "Plus",
+            "message": "Scheduled.",
+        }
 
     monkeypatch.setattr(nb, "put_subscription_pending_change", _put)
     res = _sub_rpc("subscription.change", {"subscription_type_id": "plus"})
@@ -18623,10 +20220,17 @@ def test_subscription_upgrade_echoes_status_and_idempotency(monkeypatch):
 
     def _upgrade(*, subscription_type_id, idempotency_key):
         seen["key"] = idempotency_key
-        return {"status": "upgraded", "targetTierId": "ultra", "targetTierName": "Ultra"}
+        return {
+            "status": "upgraded",
+            "targetTierId": "ultra",
+            "targetTierName": "Ultra",
+        }
 
     monkeypatch.setattr(nb, "post_subscription_upgrade", _upgrade)
-    res = _sub_rpc("subscription.upgrade", {"subscription_type_id": "ultra", "idempotency_key": "k-1"})
+    res = _sub_rpc(
+        "subscription.upgrade",
+        {"subscription_type_id": "ultra", "idempotency_key": "k-1"},
+    )
     assert res["ok"] is True
     assert res["status"] == "upgraded"
     assert res["target_tier_name"] == "Ultra"
@@ -18652,6 +20256,8 @@ def test_subscription_upgrade_requires_action_surfaces_recovery(monkeypatch):
     assert res["status"] == "requires_action"
     assert res["recovery_url"].startswith("https://portal.example")
     assert res["idempotency_key"]  # minted when the caller omits one
+
+
 # ── _get_usage active_subagents (TUI status-bar ⛓ indicator) ──────────────
 # Mirrors the classic CLI status bar: _get_usage embeds a live count of
 # background/async subagents from tools.async_delegation.active_count() so the
@@ -18668,6 +20274,7 @@ class _BareAgent:
 
 def test_get_usage_includes_active_subagents(monkeypatch):
     import tools.async_delegation as ad_mod
+
     monkeypatch.setattr(ad_mod, "active_count", lambda: 4)
     usage = server._get_usage(_BareAgent())
     assert usage["active_subagents"] == 4
@@ -18675,6 +20282,7 @@ def test_get_usage_includes_active_subagents(monkeypatch):
 
 def test_get_usage_active_subagents_zero(monkeypatch):
     import tools.async_delegation as ad_mod
+
     monkeypatch.setattr(ad_mod, "active_count", lambda: 0)
     usage = server._get_usage(_BareAgent())
     assert usage["active_subagents"] == 0
@@ -18769,6 +20377,7 @@ def test_persist_model_switch_clears_stale_base_url(tmp_path, monkeypatch):
 # _resolve_runtime_with_fallback — init-time provider fallback
 # ---------------------------------------------------------------------------
 
+
 class TestResolveRuntimeWithFallback:
     """Tests for _resolve_runtime_with_fallback(): init-time provider
     fallback when the primary provider raises AuthError."""
@@ -18780,9 +20389,7 @@ class TestResolveRuntimeWithFallback:
             "hermes_cli.runtime_provider.resolve_runtime_provider",
             lambda **kw: expected,
         )
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai"}
-        )
+        resolution = server._resolve_runtime_with_fallback({"requested": "openai"})
         assert resolution.runtime == expected
         assert resolution.selected_model is None
         assert resolution.used_fallback is False
@@ -18840,9 +20447,9 @@ class TestResolveRuntimeWithFallback:
             ],
         )
 
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai-codex"}
-        )
+        resolution = server._resolve_runtime_with_fallback({
+            "requested": "openai-codex"
+        })
 
         assert requested == ["openai-codex", "openrouter"]
         assert resolution.runtime == fallback_runtime
@@ -18879,9 +20486,9 @@ class TestResolveRuntimeWithFallback:
                 }
             ],
         )
-        resolution = server._resolve_runtime_with_fallback(
-            {"requested": "openai-codex"}
-        )
+        resolution = server._resolve_runtime_with_fallback({
+            "requested": "openai-codex"
+        })
         assert resolution.used_fallback is True
         assert captured.get("explicit_api_key") == "env-resolved-key"
 
@@ -18979,7 +20586,9 @@ class TestResolveRuntimeWithFallback:
             fake_resolve,
         )
         monkeypatch.setattr("run_agent.AIAgent", fake_agent)
-        monkeypatch.setattr(server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"])
+        monkeypatch.setattr(
+            server, "_load_enabled_toolsets", lambda *_a, **_kw: ["file"]
+        )
         monkeypatch.setattr(server, "_get_db", lambda: None)
 
         agent = server._make_agent(
@@ -19061,7 +20670,10 @@ def test_get_usage_clamps_post_compression_sentinel():
 # Streaming TTS — per-turn pipeline + barge-in
 # ---------------------------------------------------------------------------
 
-def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, listen=None, transcribe=None):
+
+def _fake_tts_modules(
+    monkeypatch, *, requirements=True, playback_stops=None, listen=None, transcribe=None
+):
     """Install lightweight tools.tts_tool / tools.voice_mode fakes."""
     started = {}
 
@@ -19091,11 +20703,14 @@ def _fake_tts_modules(monkeypatch, *, requirements=True, playback_stops=None, li
         sys.modules,
         "tools.voice_mode",
         types.SimpleNamespace(
-            stop_playback=lambda: (playback_stops.append(True) if playback_stops is not None else None),
+            stop_playback=lambda: (
+                playback_stops.append(True) if playback_stops is not None else None
+            ),
             listen_for_speech=listen or default_listen,
             full_duplex_listen=listen or default_fd_listen,
             is_audio_output_active=lambda: False,
-            transcribe_recording=transcribe or (lambda path, model=None: {"success": True, "transcript": ""}),
+            transcribe_recording=transcribe
+            or (lambda path, model=None: {"success": True, "transcript": ""}),
         ),
     )
     # Fresh listener slot per test — the arm is idempotent per process.
@@ -19185,7 +20800,9 @@ def test_tts_stream_stop_after_natural_finish_does_not_latch(monkeypatch):
     assert ts.take_speech_interrupted() is False
 
 
-def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, tmp_path):
+def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(
+    monkeypatch, tmp_path
+):
     """User speech during playback cuts TTS at the moment of detection
     (voice.interrupted), then the captured interruption is transcribed and
     emitted as voice.transcript so the TUI submits it — complete from its
@@ -19199,7 +20816,9 @@ def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, 
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "barge.wav"
@@ -19212,7 +20831,10 @@ def test_tts_stream_vad_barge_in_cuts_pipeline_and_submits_capture(monkeypatch, 
     _fake_tts_modules(
         monkeypatch,
         listen=fake_listen,
-        transcribe=lambda path, model=None: {"success": True, "transcript": "stop, actually—"},
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "stop, actually—",
+        },
     )
 
     server._tts_stream_begin()
@@ -19239,7 +20861,9 @@ def test_full_duplex_generation_phase_interrupts_running_turn(monkeypatch, tmp_p
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "interject.wav"
@@ -19258,7 +20882,10 @@ def test_full_duplex_generation_phase_interrupts_running_turn(monkeypatch, tmp_p
     _fake_tts_modules(
         monkeypatch,
         listen=fake_listen,
-        transcribe=lambda path, model=None: {"success": True, "transcript": "wait, try another way"},
+        transcribe=lambda path, model=None: {
+            "success": True,
+            "transcript": "wait, try another way",
+        },
     )
 
     server._arm_full_duplex_listener()
@@ -19279,7 +20906,9 @@ def test_full_duplex_stop_phrase_mid_generation_ends_voice_chat(monkeypatch, tmp
     monkeypatch.setattr(server, "_load_cfg", lambda: {"voice": {"barge_in": True}})
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "stop.wav"
@@ -19301,13 +20930,15 @@ def test_full_duplex_stop_phrase_mid_generation_ends_voice_chat(monkeypatch, tmp
         transcribe=lambda path, model=None: {"success": True, "transcript": "stop"},
     )
     # is_voice_stop_phrase lives in the faked tools.voice_mode namespace.
-    sys.modules["tools.voice_mode"].is_voice_stop_phrase = (
-        lambda text: text.strip().lower() == "stop"
+    sys.modules["tools.voice_mode"].is_voice_stop_phrase = lambda text: (
+        text.strip().lower() == "stop"
     )
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.voice",
-        types.SimpleNamespace(stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None),
+        types.SimpleNamespace(
+            stop_continuous=lambda **_kw: None, speak_text=lambda *a, **k: None
+        ),
     )
 
     server._arm_full_duplex_listener()
@@ -19338,7 +20969,9 @@ def test_speak_text_with_barge_arms_monitor_and_cuts_playback(monkeypatch, tmp_p
     )
     events: list = []
     monkeypatch.setattr(
-        server, "_voice_emit", lambda event, payload=None: events.append((event, payload))
+        server,
+        "_voice_emit",
+        lambda event, payload=None: events.append((event, payload)),
     )
 
     wav = tmp_path / "barge.wav"
@@ -19374,7 +21007,10 @@ def test_speak_text_with_barge_arms_monitor_and_cuts_playback(monkeypatch, tmp_p
     server._speak_text_with_barge("a long spoken reply")
 
     deadline = time.monotonic() + 5.0
-    while time.monotonic() < deadline and ("voice.transcript", {"text": "hang on"}) not in events:
+    while (
+        time.monotonic() < deadline
+        and ("voice.transcript", {"text": "hang on"}) not in events
+    ):
         time.sleep(0.01)
     release_speak.set()
 
@@ -19465,7 +21101,9 @@ def test_clarify_callback_multi_select_hint(monkeypatch):
     ("configured", "expected"),
     [(0, None), (-1, None), (42, 42)],
 )
-def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(monkeypatch, configured, expected):
+def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(
+    monkeypatch, configured, expected
+):
     """A ``<= 0`` clarify timeout means unlimited and reaches _block as None
     (ev.wait(None) waits forever) rather than an immediate ev.wait(0) skip."""
     monkeypatch.setattr("tools.clarify_gateway.get_clarify_timeout", lambda: configured)
@@ -19476,18 +21114,25 @@ def test_clarify_timeout_seconds_maps_non_positive_to_unlimited(monkeypatch, con
 def test_build_persist_message_with_image_refs_without_images_returns_text(monkeypatch):
     """#70720: when no images are attached the persisted message is the raw
     prompt — no @image directive prefix is introduced."""
-    assert server._build_persist_message_with_image_refs("what is this?", []) == "what is this?"
+    assert (
+        server._build_persist_message_with_image_refs("what is this?", [])
+        == "what is this?"
+    )
     assert server._build_persist_message_with_image_refs("", []) == ""
 
 
-def test_build_persist_message_with_image_refs_appends_existing_paths(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_appends_existing_paths(
+    monkeypatch, tmp_path
+):
     """Attached images that still exist on disk are persisted as trailing
     ``@image:<path>`` directive lines so the desktop renders them after a
     restart (instead of the vision-only enrichment that silently breaks)."""
     img = tmp_path / "cat.png"
     img.write_bytes(b"\x89PNG")
 
-    result = server._build_persist_message_with_image_refs("what is in this photo?", [str(img)])
+    result = server._build_persist_message_with_image_refs(
+        "what is in this photo?", [str(img)]
+    )
 
     assert result == f"what is in this photo?\n@image:{img}"
 
@@ -19499,30 +21144,40 @@ def test_build_persist_message_keeps_the_caption_on_the_first_line(tmp_path):
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
 
-    result = server._build_persist_message_with_image_refs("what is in this photo?", [str(img)])
+    result = server._build_persist_message_with_image_refs(
+        "what is in this photo?", [str(img)]
+    )
 
     assert result.split("\n", 1)[0] == "what is in this photo?"
 
 
-def test_build_persist_message_with_image_refs_skips_missing_paths(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_skips_missing_paths(
+    monkeypatch, tmp_path
+):
     """Only paths that still exist are persisted; a missing file must not
     inject a dangling @image ref into the transcript."""
     existing = tmp_path / "a.png"
     existing.write_bytes(b"png")
     missing = str(tmp_path / "gone.png")
 
-    result = server._build_persist_message_with_image_refs("compare them", [str(existing), missing])
+    result = server._build_persist_message_with_image_refs(
+        "compare them", [str(existing), missing]
+    )
 
     assert result == f"compare them\n@image:{existing}"
 
 
-def test_build_persist_message_with_image_refs_without_text_is_refs_only(monkeypatch, tmp_path):
+def test_build_persist_message_with_image_refs_without_text_is_refs_only(
+    monkeypatch, tmp_path
+):
     """A stand-alone attachment (no caption) persists as just the directive
     line, so a bare image survives in history and is not dropped as empty."""
     img = tmp_path / "only.png"
     img.write_bytes(b"png")
 
-    assert server._build_persist_message_with_image_refs("", [str(img)]) == f"@image:{img}"
+    assert (
+        server._build_persist_message_with_image_refs("", [str(img)]) == f"@image:{img}"
+    )
 
 
 def test_build_persist_message_quotes_paths_containing_spaces(tmp_path):
@@ -19547,12 +21202,20 @@ def test_persist_user_message_mirrors_the_shape_sent_to_the_model(tmp_path):
     silently dropped and the attachment never reaches history."""
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
-    image_part = {"type": "image_url", "image_url": {"url": "data:image/png;base64,AAAA"}}
+    image_part = {
+        "type": "image_url",
+        "image_url": {"url": "data:image/png;base64,AAAA"},
+    }
     native_parts = [{"type": "text", "text": "api-only text"}, image_part]
 
-    override = server._build_persist_user_message("what is this?", [str(img)], native_parts)
+    override = server._build_persist_user_message(
+        "what is this?", [str(img)], native_parts
+    )
 
-    assert override == [{"type": "text", "text": f"what is this?\n@image:{img}"}, image_part]
+    assert override == [
+        {"type": "text", "text": f"what is this?\n@image:{img}"},
+        image_part,
+    ]
 
 
 def test_persist_user_message_stays_a_string_for_text_mode(tmp_path):
@@ -19561,7 +21224,9 @@ def test_persist_user_message_stays_a_string_for_text_mode(tmp_path):
     img = tmp_path / "cat.png"
     img.write_bytes(b"png")
 
-    override = server._build_persist_user_message("what is this?", [str(img)], "enriched api-only text")
+    override = server._build_persist_user_message(
+        "what is this?", [str(img)], "enriched api-only text"
+    )
 
     assert override == f"what is this?\n@image:{img}"
 
@@ -19585,7 +21250,9 @@ def test_native_vision_turn_persists_a_renderable_image_ref(tmp_path):
             "0557bfabd40000000049454e44ae426082"
         )
     )
-    native_parts, skipped = build_native_content_parts("what is in this photo?", [str(img)])
+    native_parts, skipped = build_native_content_parts(
+        "what is in this photo?", [str(img)]
+    )
     assert not skipped
 
     agent = AIAgent.__new__(AIAgent)
@@ -19605,11 +21272,15 @@ def test_native_vision_turn_persists_a_renderable_image_ref(tmp_path):
 
     agent._flush_messages_to_session_db([{"role": "user", "content": native_parts}], [])
 
-    written = agent._session_db.append_messages_batch.call_args.kwargs["messages"][0]["content"]
+    written = agent._session_db.append_messages_batch.call_args.kwargs["messages"][0][
+        "content"
+    ]
     assert f"@image:`{img}`" in written
     assert "what is in this photo?" in written
     # The model keeps the pixels for the rest of the session.
-    assert any(part.get("type") == "image_url" for part in agent._persist_user_message_override)
+    assert any(
+        part.get("type") == "image_url" for part in agent._persist_user_message_override
+    )
 
 
 def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
@@ -19619,7 +21290,9 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             captured["persist_user_message"] = _kwargs.get("persist_user_message")
             return {
                 "final_response": "reply",
@@ -19640,13 +21313,11 @@ def test_prompt_submit_passes_persist_user_message_to_agent(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_emit", lambda *a: None)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid", "text": "hi"},
+        })
         assert resp.get("result")
 
         # Without attachments the persist form equals the raw prompt.
@@ -19712,13 +21383,11 @@ def test_prompt_submit_releases_old_history_before_heap_trim(monkeypatch):
         )
         monkeypatch.setattr("hermes_cli.mem_trim.trim_memory", _inspect_trim_frame)
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": "sid_trim", "text": "hi"},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": "sid_trim", "text": "hi"},
+        })
 
         assert resp is not None and resp.get("result")
         assert not observed["history"]
@@ -19887,9 +21556,11 @@ def test_session_branch_keeps_reasoning_fields(monkeypatch, tmp_path):
         )
         monkeypatch.setattr(server, "_init_session", lambda *args, **kwargs: None)
 
-        resp = server.handle_request(
-            {"id": "1", "method": "session.branch", "params": {"session_id": "sid"}}
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "session.branch",
+            "params": {"session_id": "sid"},
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assistant = _branched_assistant(db, "branch-key")
@@ -19933,12 +21604,10 @@ def test_save_cfg_preserves_user_comments(tmp_path, monkeypatch):
     )
     monkeypatch.setattr(server, "_hermes_home", tmp_path)
 
-    server._save_cfg(
-        {
-            "model": {"default": "claude-opus-4-7"},
-            "display": {"skin": "mono"},
-        }
-    )
+    server._save_cfg({
+        "model": {"default": "claude-opus-4-7"},
+        "display": {"skin": "mono"},
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     assert "# top of file note" in text
@@ -19970,20 +21639,20 @@ def test_save_cfg_preserves_top_level_key_order(tmp_path, monkeypatch):
 
     # Caller's dict iteration order is intentionally alphabetical to confirm
     # the helper consults disk order, not caller order.
-    server._save_cfg(
-        {
-            "agent": {"max_turns": 90},
-            "display": {"skin": "mono"},
-            "model": {"default": "claude-opus-4-7"},
-            "toolsets": ["hermes-cli"],
-        }
-    )
+    server._save_cfg({
+        "agent": {"max_turns": 90},
+        "display": {"skin": "mono"},
+        "model": {"default": "claude-opus-4-7"},
+        "toolsets": ["hermes-cli"],
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     top_keys = [
         line.split(":", 1)[0]
         for line in text.splitlines()
-        if line and not line.startswith(" ") and not line.startswith("-")
+        if line
+        and not line.startswith(" ")
+        and not line.startswith("-")
         and not line.startswith("#")
     ]
     assert top_keys == ["model", "toolsets", "agent", "display"]
@@ -19996,7 +21665,7 @@ def test_save_cfg_keeps_unicode_personalities_readable(tmp_path, monkeypatch):
     cfg_path.write_text(
         "agent:\n"
         "  personalities:\n"
-        "    catgirl: \"nya (=^･ω･^=) 你好\"\n"
+        '    catgirl: "nya (=^･ω･^=) 你好"\n'
         "display:\n"
         "  skin: default\n",
         encoding="utf-8",
@@ -20005,12 +21674,10 @@ def test_save_cfg_keeps_unicode_personalities_readable(tmp_path, monkeypatch):
 
     # Simulate an unrelated /skin write — must not corrupt the catgirl
     # personality string sitting in agent.personalities.
-    server._save_cfg(
-        {
-            "agent": {"personalities": {"catgirl": "nya (=^･ω･^=) 你好"}},
-            "display": {"skin": "mono"},
-        }
-    )
+    server._save_cfg({
+        "agent": {"personalities": {"catgirl": "nya (=^･ω･^=) 你好"}},
+        "display": {"skin": "mono"},
+    })
 
     text = cfg_path.read_text(encoding="utf-8")
     assert "你好" in text
@@ -20035,7 +21702,9 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
     """
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [
@@ -20089,17 +21758,17 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
         )
 
         marker = session["history"][-1]
-        assert marker["role"] == "user", "provider compatibility: pivot rides as a user turn"
+        assert marker["role"] == "user", (
+            "provider compatibility: pivot rides as a user turn"
+        )
 
         # Two more real turns land after the personality change.
-        session["history"].extend(
-            [
-                {"role": "user", "content": "second"},
-                {"role": "assistant", "content": "second reply"},
-                {"role": "user", "content": "third"},
-                {"role": "assistant", "content": "third reply"},
-            ]
-        )
+        session["history"].extend([
+            {"role": "user", "content": "second"},
+            {"role": "assistant", "content": "second reply"},
+            {"role": "user", "content": "third"},
+            {"role": "assistant", "content": "third reply"},
+        ])
         history_before = list(session["history"])
         third_index = history_before.index({"role": "user", "content": "third"})
 
@@ -20110,18 +21779,16 @@ def test_personality_marker_does_not_shift_truncate_ordinal(monkeypatch):
 
         # The client counts three user bubbles (first=0, second=1, third=2) —
         # it never sees the pivot. Rewinding to "third" must cut exactly there.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "personality-ordinal-sid",
-                    "text": "third, reworded",
-                    "truncate_before_user_ordinal": 2,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "personality-ordinal-sid",
+                "text": "third, reworded",
+                "truncate_before_user_ordinal": 2,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("result"), f"got error: {resp.get('error')}"
 
         expected = history_before[:third_index]
@@ -20155,7 +21822,9 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
     captured = {}
 
     class _Agent:
-        def run_conversation(self, prompt, conversation_history=None, stream_callback=None, **_kwargs):
+        def run_conversation(
+            self, prompt, conversation_history=None, stream_callback=None, **_kwargs
+        ):
             return {
                 "final_response": "reply",
                 "messages": [
@@ -20206,18 +21875,16 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
         monkeypatch.setattr(server, "render_message", lambda _t, _c: "")
         monkeypatch.setattr(server, "_get_db", lambda: _StubDb())
 
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "archive-trunc-sid",
-                    "text": "second, reworded",
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "archive-trunc-sid",
+                "text": "second, reworded",
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
 
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert captured.get("archive_dropped") is True, (
@@ -20233,6 +21900,7 @@ def test_prompt_submit_truncation_archives_instead_of_deleting(monkeypatch):
 def test_insert_message_rows_sets_row_id_on_fresh_dicts(tmp_path):
     """#82959: _insert_message_rows must assign _row_id on freshly inserted message dicts."""
     from hermes_state import SessionDB
+
     db = SessionDB(db_path=tmp_path / "state.db")
     db.create_session("fresh-msg-row-id-sid", "cli")
     msg = {"role": "user", "content": "fresh turn without pre-existing _row_id"}
@@ -20267,24 +21935,24 @@ def test_prompt_submit_unmatched_row_id_refuses_even_with_ordinal(monkeypatch):
     server._sessions["fallback-row-id-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Stale row_id 999 not in history — even with a valid ordinal, refuse.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "fallback-row-id-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 999,
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "fallback-row-id-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 999,
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert replaced == []
@@ -20319,24 +21987,24 @@ def test_prompt_submit_unmatched_message_id_refuses_even_with_ordinal(monkeypatc
     server._sessions["synthetic-msg-id-sid"] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "synthetic-msg-id-sid",
-                    "text": "fresh start",
-                    "truncate_before_message_id": "user-1723456789-0",
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "synthetic-msg-id-sid",
+                "text": "fresh start",
+                "truncate_before_message_id": "user-1723456789-0",
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert replaced == []
@@ -20373,7 +22041,9 @@ def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypat
         ):
             replaced.append((key, list(messages)))
 
-        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+        def get_messages_as_conversation(
+            self, key, repair_alternation=False, include_row_ids=False
+        ):
             assert include_row_ids is True
             return list(durable_history)
 
@@ -20383,18 +22053,16 @@ def test_prompt_submit_row_id_resolves_via_db_when_memory_lacks_stamps(monkeypat
     monkeypatch.setattr(server, "_start_agent_build", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": "db-row-resolve-sid",
-                    "text": "new turn",
-                    "truncate_before_row_id": 503,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": "db-row-resolve-sid",
+                "text": "new turn",
+                "truncate_before_row_id": 503,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         assert len(sess["history"]) == 2
         assert sess["history"][-1]["content"] == "reply 1"
@@ -20447,19 +22115,17 @@ def test_prompt_submit_row_id_real_sessiondb_resolve_without_memory_stamps(
 
     try:
         # Cut before second user turn (row_ids[2]) — leave first exchange only.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second",
-                    "truncate_before_row_id": row_ids[2],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second",
+                "truncate_before_row_id": row_ids[2],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         assert len(sess["history"]) == 2
         assert sess["history"][0]["content"] == "first"
@@ -20503,28 +22169,30 @@ def test_prompt_submit_row_id_real_sessiondb_unknown_refuses_despite_ordinal(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     n_before = len(db.get_messages_as_conversation(session_key))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "stale durable id",
-                    "truncate_before_row_id": 999_999_999,
-                    "truncate_before_user_ordinal": 0,
-                    "confirm_truncate": True,
-                    "confirm_empty_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "stale durable id",
+                "truncate_before_row_id": 999_999_999,
+                "truncate_before_user_ordinal": 0,
+                "confirm_truncate": True,
+                "confirm_empty_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         assert len(sess["history"]) == 4
@@ -20571,27 +22239,29 @@ def test_prompt_submit_row_id_misaligned_memory_refuses_content_swap(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: db)
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     n_before = len(db.get_messages_as_conversation(session_key))
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind B",
-                    "truncate_before_row_id": rid_b,
-                    "rebind_survivor_row_ids": [*original_row_ids, 999_999],
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind B",
+                "truncate_before_row_id": rid_b,
+                "rebind_survivor_row_ids": [*original_row_ids, 999_999],
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is not None
         assert resp["error"]["code"] == 4018
         # Fail-closed: nothing stamped onto the misaligned dicts, nothing cut.
@@ -20642,19 +22312,17 @@ def test_prompt_submit_row_id_misaligned_memory_role_shift_targets_real_turn(
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind B",
-                    "truncate_before_row_id": rid_b,
-                    "rebind_survivor_row_ids": [*original_row_ids, 999_999],
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind B",
+                "truncate_before_row_id": rid_b,
+                "rebind_survivor_row_ids": [*original_row_ids, 999_999],
+                "confirm_truncate": True,
+            },
+        })
         assert resp.get("error") is None, resp
         # The addressed turn ("B") is dropped exactly; earlier live turns
         # survive untouched. Before the guard, a positional zip-stamp put a
@@ -20717,7 +22385,9 @@ def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
         ):
             replaced.append((key, list(messages)))
 
-        def get_messages_as_conversation(self, key, repair_alternation=False, include_row_ids=False):
+        def get_messages_as_conversation(
+            self, key, repair_alternation=False, include_row_ids=False
+        ):
             return [dict(m) for m in durable_history]
 
     sess = _session(history=list(live_history), session_key="db-fallback-verify-key")
@@ -20725,25 +22395,27 @@ def test_prompt_submit_row_id_db_fallback_ordinal_mapping_verifies_content(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _FakeDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewind to second",
-                    "truncate_before_row_id": 604,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewind to second",
+                "truncate_before_row_id": 604,
+                "confirm_truncate": True,
+            },
+        })
         # Mapped live turn ("follow-up") does not match durable target
         # ("second") — refuse instead of cutting the wrong turn.
         assert resp.get("error") is not None
@@ -20801,20 +22473,18 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
     try:
         # Rewind 1: cut before "third" (last user turn). Survivors: turns
         # "first" + "second" (+ assistant replies) — re-inserted as NEW rows.
-        resp1 = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound third",
-                    "truncate_before_row_id": original_row_ids[4],
-                    "truncate_before_user_ordinal": 2,
-                    "rebind_survivor_row_ids": [*original_row_ids, 999_999],
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp1 = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound third",
+                "truncate_before_row_id": original_row_ids[4],
+                "truncate_before_user_ordinal": 2,
+                "rebind_survivor_row_ids": [*original_row_ids, 999_999],
+                "confirm_truncate": True,
+            },
+        })
         assert resp1.get("error") is None, resp1
         assert "survivor_user_row_ids" not in resp1["result"]
         row_id_map = resp1["result"].get("survivor_row_id_map")
@@ -20837,37 +22507,33 @@ def test_prompt_submit_consecutive_rewinds_with_returned_survivor_row_ids(
         sess["running"] = False
 
         # Rewind 2a: the STALE pre-rewind id for "second" must fail closed.
-        stale_resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second (stale id)",
-                    "truncate_before_row_id": original_row_ids[2],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        stale_resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second (stale id)",
+                "truncate_before_row_id": original_row_ids[2],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert stale_resp.get("error") is not None
         assert stale_resp["error"]["code"] == 4018
         assert len(sess["history"]) == 4  # nothing cut
 
         # Rewind 2b: the RETURNED survivor id for "second" must succeed.
-        resp2 = server.handle_request(
-            {
-                "id": "3",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "rewound second (fresh id)",
-                    "truncate_before_row_id": survivors[1],
-                    "truncate_before_user_ordinal": 1,
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        resp2 = server.handle_request({
+            "id": "3",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "rewound second (fresh id)",
+                "truncate_before_row_id": survivors[1],
+                "truncate_before_user_ordinal": 1,
+                "confirm_truncate": True,
+            },
+        })
         assert resp2.get("error") is None, resp2
         assert len(sess["history"]) == 2
         assert sess["history"][0]["content"] == "first"
@@ -20919,19 +22585,17 @@ def test_prompt_submit_rebind_map_clears_active_row_hidden_by_sequence_repair(
     monkeypatch.setattr(server, "_start_inflight_turn", lambda *a, **k: None)
 
     try:
-        response = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "retry target",
-                    "truncate_before_row_id": physical_ids[3],
-                    "rebind_survivor_row_ids": [*physical_ids, 999_999],
-                    "confirm_truncate": True,
-                },
-            }
-        )
+        response = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "retry target",
+                "truncate_before_row_id": physical_ids[3],
+                "rebind_survivor_row_ids": [*physical_ids, 999_999],
+                "confirm_truncate": True,
+            },
+        })
         assert response.get("error") is None, response
         row_id_map = response["result"]["survivor_row_id_map"]
         assert row_id_map[str(physical_ids[1])] is None
@@ -20970,47 +22634,45 @@ def test_prompt_submit_unconfirmed_truncation_refuses_before_target_resolution(
     server._sessions[sid] = sess
     monkeypatch.setattr(server, "_get_db", lambda: _SpyDB())
     monkeypatch.setattr(
-        server, "_start_agent_build", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_agent_build",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
     monkeypatch.setattr(
-        server, "_start_inflight_turn", lambda *a, **k: pytest.fail("must not start a turn")
+        server,
+        "_start_inflight_turn",
+        lambda *a, **k: pytest.fail("must not start a turn"),
     )
 
     try:
         # Unconfirmed row_id: 4029, no DB read, no heal stamps on history.
-        resp = server.handle_request(
-            {
-                "id": "1",
-                "method": "prompt.submit",
-                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": 3},
-            }
-        )
+        resp = server.handle_request({
+            "id": "1",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "x", "truncate_before_row_id": 3},
+        })
         assert (resp.get("error") or {}).get("code") == 4029, resp
         assert db_reads == []
         assert all("_row_id" not in m for m in sess["history"])
 
         # Malformed param still beats consent: bool row_id is 4004.
-        resp = server.handle_request(
-            {
-                "id": "2",
-                "method": "prompt.submit",
-                "params": {"session_id": sid, "text": "x", "truncate_before_row_id": True},
-            }
-        )
+        resp = server.handle_request({
+            "id": "2",
+            "method": "prompt.submit",
+            "params": {"session_id": sid, "text": "x", "truncate_before_row_id": True},
+        })
         assert (resp.get("error") or {}).get("code") == 4004, resp
 
         # Unconfirmed out-of-range ordinal: 4029 (consent), not 4018 (range).
-        resp = server.handle_request(
-            {
-                "id": "3",
-                "method": "prompt.submit",
-                "params": {
-                    "session_id": sid,
-                    "text": "x",
-                    "truncate_before_user_ordinal": 99,
-                },
-            }
-        )
+        resp = server.handle_request({
+            "id": "3",
+            "method": "prompt.submit",
+            "params": {
+                "session_id": sid,
+                "text": "x",
+                "truncate_before_user_ordinal": 99,
+            },
+        })
         assert (resp.get("error") or {}).get("code") == 4029, resp
         assert len(sess["history"]) == 4
     finally:
@@ -21039,6 +22701,7 @@ def test_persist_live_session_system_prompt_uses_profile_home(monkeypatch, tmp_p
 
         def _build_system_prompt(self, system_message=None):
             from hermes_constants import get_hermes_home
+
             home = get_hermes_home()
             built_homes.append(str(home))
             soul = (
@@ -21072,12 +22735,14 @@ def test_persist_live_session_system_prompt_uses_profile_home(monkeypatch, tmp_p
 
     # The override must have been reset after the call.
     from hermes_constants import get_hermes_home_override
+
     assert get_hermes_home_override() is None
 
 
 def test_persist_live_session_system_prompt_no_profile_is_unchanged(monkeypatch):
     """Sessions without a profile_home must not set/clear any override —
     the function should behave identically to before the fix."""
+
     class FakeAgent:
         model = "test"
         _cached_system_prompt = None
@@ -21128,6 +22793,7 @@ def test_persist_live_session_system_prompt_restores_pre_existing_override(tmp_p
 
         def _build_system_prompt(self, system_message=None):
             from hermes_constants import get_hermes_home
+
             built_homes.append(str(get_hermes_home()))
             return "inner prompt"
 
@@ -21234,7 +22900,9 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
         def get_session(self, session_id):
             return {"id": session_id}
 
-        def update_session_cwd(self, session_id, cwd, branch=None, root=None, replace_git_meta=True):
+        def update_session_cwd(
+            self, session_id, cwd, branch=None, root=None, replace_git_meta=True
+        ):
             captured["row_update"] = (session_id, cwd)
 
         def close(self):
@@ -21258,7 +22926,11 @@ def test_workspace_move_rehomes_running_session(monkeypatch, tmp_path):
         lambda cwd: str(new_cwd),
     )
 
-    live = {"session_key": target, "running": True, "cwd": str(tmp_path / "old-project")}
+    live = {
+        "session_key": target,
+        "running": True,
+        "cwd": str(tmp_path / "old-project"),
+    }
     server._sessions["live-sid"] = live
     monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -17106,6 +17106,7 @@ def test_prompt_submit_fans_out_user_row_before_assistant_events(monkeypatch):
     event_names = [event for event, _payload in emitted]
     assert "sessions.changed" in event_names
     assert event_names.index("sessions.changed") < event_names.index("message.delta")
+    assert server._sessions["sid"]["agent"]._on_user_message_persisted is None
 
 
 def test_prompt_submit_surfaces_backend_error_as_visible_text(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1093,6 +1093,156 @@ def test_write_json_drops_detached_ws_frames(monkeypatch):
         server._sessions.pop("detached-sid", None)
 
 
+def test_write_json_fans_out_one_stamped_order_to_all_session_attachments():
+    from tui_gateway import event_replay
+    from tui_gateway.session_events import AttachmentMode, SessionEventHub
+
+    class _RecordingTransport:
+        def __init__(self):
+            self.frames = []
+            self.condition = threading.Condition()
+
+        def write(self, frame):
+            with self.condition:
+                self.frames.append(frame)
+                self.condition.notify_all()
+            return True
+
+        def wait_for_count(self, count):
+            with self.condition:
+                assert self.condition.wait_for(
+                    lambda: len(self.frames) >= count,
+                    timeout=5,
+                )
+
+    sid = "multi-client-order"
+    event_replay.reset_replay_state()
+    hub = SessionEventHub()
+    left = _RecordingTransport()
+    right = _RecordingTransport()
+    hub.attach(left, client_id="left", mode=AttachmentMode.CONTROL)
+    hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
+    server._sessions[sid] = {"event_hub": hub, "transport": left}
+    start = threading.Barrier(3)
+
+    def _publish(source):
+        start.wait(timeout=5)
+        for index in range(20):
+            assert server.write_json(
+                {
+                    "jsonrpc": "2.0",
+                    "method": "event",
+                    "params": {
+                        "type": "message.delta",
+                        "session_id": sid,
+                        "payload": {"source": source, "index": index},
+                    },
+                }
+            )
+
+    try:
+        workers = [threading.Thread(target=_publish, args=(source,)) for source in ("a", "b")]
+        for worker in workers:
+            worker.start()
+        start.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=5)
+            assert not worker.is_alive()
+
+        left.wait_for_count(40)
+        right.wait_for_count(40)
+
+        assert left.frames == right.frames
+        assert [frame["params"]["seq"] for frame in left.frames] == list(range(1, 41))
+        assert [event["seq"] for event in event_replay.events_since(sid, 0)] == list(
+            range(1, 41)
+        )
+    finally:
+        hub.close()
+        server._sessions.pop(sid, None)
+        event_replay.reset_replay_state()
+
+
+def test_write_json_keeps_legacy_delivery_in_replay_sequence_order():
+    from tui_gateway import event_replay
+
+    class _LegacyRaceTransport:
+        def __init__(self):
+            self.first_entered = threading.Event()
+            self.release_first = threading.Event()
+            self.frames: list[dict] = []
+            self.lock = threading.Lock()
+
+        def write(self, obj):
+            seq = obj["params"]["seq"]
+            if seq == 1:
+                self.first_entered.set()
+                assert self.release_first.wait(timeout=5)
+            with self.lock:
+                self.frames.append(json.loads(json.dumps(obj)))
+            return True
+
+    sid = "legacy-ordered-sid"
+    transport = _LegacyRaceTransport()
+    event_replay.reset_replay_state()
+    server._sessions[sid] = {"transport": transport}
+
+    def publish(index):
+        server.write_json(
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "message.delta",
+                    "session_id": sid,
+                    "payload": {"index": index},
+                },
+            }
+        )
+
+    first = threading.Thread(target=publish, args=(1,))
+    second = threading.Thread(target=publish, args=(2,))
+    try:
+        first.start()
+        assert transport.first_entered.wait(timeout=5)
+        second.start()
+        # Give the competing publisher an opportunity to overtake the blocked
+        # first writer. The production lock must keep it behind seq=1.
+        second.join(timeout=0.1)
+        transport.release_first.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert [frame["params"]["seq"] for frame in transport.frames] == [1, 2]
+        assert [event["seq"] for event in event_replay.events_since(sid, 0)] == [1, 2]
+    finally:
+        transport.release_first.set()
+        first.join(timeout=5)
+        second.join(timeout=5)
+        server._sessions.pop(sid, None)
+        event_replay.reset_replay_state()
+
+
+def test_teardown_popped_session_releases_replay_state(monkeypatch):
+    from tui_gateway import event_replay
+
+    sid = "finished-runtime"
+    event_replay.reset_replay_state()
+    frame = {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {"type": "session.info", "session_id": sid, "payload": {}},
+    }
+    event_replay._stamp_event(frame)
+    monkeypatch.setattr(server, "_teardown_session", lambda *_args, **_kwargs: None)
+
+    assert server._teardown_popped_session({"_sid": sid}) is True
+    assert event_replay.latest_seq(sid) == 0
+    assert event_replay.events_since(sid, 0) == []
+
+
 def test_usage_ticker_emits_wrapped_usage_payload(monkeypatch):
     # The live ticker must nest the snapshot under a "usage" key, matching the
     # message.complete / session.info payloads the desktop & TUI handlers read

--- a/tests/test_tui_gateway_ws.py
+++ b/tests/test_tui_gateway_ws.py
@@ -3,12 +3,11 @@ import concurrent.futures
 import json
 import threading
 import time
+import uuid
 
 from hermes_cli import mcp_startup
 from tui_gateway import server
 from tui_gateway import ws as ws_mod
-
-
 
 
 def _run_disconnect(monkeypatch, seed):
@@ -35,8 +34,11 @@ def _run_disconnect(monkeypatch, seed):
     created = []
     real_transport = ws_mod.WSTransport
     monkeypatch.setattr(
-        ws_mod, "WSTransport",
-        lambda ws, loop, **kw: created.append(real_transport(ws, loop, **kw)) or created[-1],
+        ws_mod,
+        "WSTransport",
+        lambda ws, loop, **kw: (
+            created.append(real_transport(ws, loop, **kw)) or created[-1]
+        ),
     )
 
     class FakeWS:
@@ -82,9 +84,9 @@ def test_ws_disconnect_reaps_flagged_session_and_closes_worker(monkeypatch):
         server._sessions.clear()
 
 
-
-
-def test_ws_connection_registers_then_disconnect_unregisters_live_transport(monkeypatch):
+def test_ws_connection_registers_then_disconnect_unregisters_live_transport(
+    monkeypatch,
+):
     """A connected client must be tracked in the live-transport registry so a
     session-less global broadcast (skin.changed from the background watcher)
     reaches it, and dropped on disconnect so no stale write targets a dead peer.
@@ -120,8 +122,6 @@ def test_ws_disconnect_releases_wake_word_owner(monkeypatch):
     assert released == created
 
 
-
-
 def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     import tui_gateway.entry as entry
 
@@ -129,7 +129,9 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
     events = []
 
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
-    monkeypatch.setattr(entry, "ensure_mcp_discovery_started", lambda: calls.append("mcp"))
+    monkeypatch.setattr(
+        entry, "ensure_mcp_discovery_started", lambda: calls.append("mcp")
+    )
 
     class FakeWS:
         async def accept(self):
@@ -155,18 +157,14 @@ def test_ws_starts_mcp_discovery_before_ready(monkeypatch):
 
 def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
     sent = []
-    inbound = iter(
-        [
-            json.dumps(
-                {
-                    "jsonrpc": "2.0",
-                    "id": "heartbeat-1",
-                    "method": "gateway.ping",
-                    "params": {},
-                }
-            )
-        ]
-    )
+    inbound = iter([
+        json.dumps({
+            "jsonrpc": "2.0",
+            "id": "heartbeat-1",
+            "method": "gateway.ping",
+            "params": {},
+        })
+    ])
     monkeypatch.setattr(server, "_WS_ORPHAN_REAP_GRACE_S", 0)
 
     class FakeWS:
@@ -190,6 +188,26 @@ def test_ws_ready_advertises_heartbeat_and_ping_is_inline(monkeypatch):
     ready = sent[0]["params"]
     assert ready["type"] == "gateway.ready"
     assert ready["payload"]["heartbeat"] is True
+    uuid.UUID(hex=ready["payload"]["connection_id"])
+    assert ready["payload"]["runtime_host_id"] == server._backend_id_for_this_process()
+    assert ready["payload"]["multi_client_sessions"] == 1
+    assert ready["payload"]["capabilities"] == [
+        "client.attach",
+        "session.attach",
+        "session.detach",
+        "session.attachments",
+    ]
+    assert ready["payload"]["multi_client"] == {
+        "protocol_version": 1,
+        "attachment_modes": ["observe", "control"],
+        "methods": [
+            "client.attach",
+            "session.attach",
+            "session.detach",
+            "session.attachments",
+            "session.events.since",
+        ],
+    }
     assert sent[1] == {
         "jsonrpc": "2.0",
         "result": {"ok": True},
@@ -234,6 +252,30 @@ def test_ws_transport_serializes_concurrent_sends():
         loop.close()
 
 
+def test_ws_transport_mints_unique_connection_identity():
+    loop = asyncio.new_event_loop()
+    try:
+        first = ws_mod.WSTransport(object(), loop)
+        second = ws_mod.WSTransport(object(), loop)
+
+        uuid.UUID(hex=first.connection_id)
+        uuid.UUID(hex=second.connection_id)
+        assert first.connection_id != second.connection_id
+        assert first.client_id is None
+        assert second.client_id is None
+    finally:
+        loop.close()
+
+
+def test_stdio_transport_has_stable_implicit_identity():
+    from tui_gateway.transport import StdioTransport
+
+    transport = StdioTransport(lambda: None, threading.Lock())
+
+    assert transport.connection_id == "stdio"
+    assert transport.client_id == "stdio"
+
+
 def test_ws_transport_preserves_cross_batch_order():
     async def scenario():
         entered = []
@@ -270,5 +312,3 @@ def test_ws_transport_preserves_cross_batch_order():
         assert entered == ["A1", "A2", "B1", "B2"]
 
     asyncio.run(scenario())
-
-

--- a/tests/tui_gateway/test_compute_host.py
+++ b/tests/tui_gateway/test_compute_host.py
@@ -126,3 +126,57 @@ def test_compute_host_interrupt_uses_explicit_stop_compatibility(kind):
 
     assert calls == ["hard" if kind == "hard-only" else "legacy"]
     assert emitted[-1]["applied"] is True
+
+
+def test_real_turn_forwards_user_event_metadata_to_gateway_runner(monkeypatch):
+    from tui_gateway import server
+
+    captured = {}
+    session = {
+        "history_lock": threading.RLock(),
+        "history": [],
+        "history_version": 0,
+        "running": False,
+        "session_key": "session-key",
+        "agent": None,
+    }
+    host = ComputeHost(heartbeat_secs=0)
+    host.emit = lambda _frame: None
+    monkeypatch.setattr(host, "_ensure_server_session", lambda _server, _frame: session)
+    monkeypatch.setattr(server, "_start_inflight_turn", lambda *_args: None)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda *_args: None)
+    monkeypatch.setattr(server, "_persist_branch_seed", lambda *_args: None)
+    monkeypatch.setattr(server, "_session_info", lambda *_args: {})
+    monkeypatch.setattr(
+        server,
+        "_run_prompt_submit",
+        lambda rid, sid, session, text, **kwargs: captured.update(
+            rid=rid, sid=sid, text=text, **kwargs
+        ),
+    )
+
+    try:
+        host._run_real_turn({
+            "type": "turn.start",
+            "sid": "sid",
+            "request_id": "r1",
+            "session_key": "session-key",
+            "text": "expanded model-facing prompt",
+            "client_message_id": "user-pc1-123",
+            "display_text": "hello from pc 1",
+            "submitted_at": 1234.5,
+            "attachment_refs": ["attachment://one"],
+        })
+    finally:
+        host.close()
+
+    assert captured == {
+        "rid": "r1",
+        "sid": "sid",
+        "text": "expanded model-facing prompt",
+        "display_kind": None,
+        "client_message_id": "user-pc1-123",
+        "display_text": "hello from pc 1",
+        "submitted_at": 1234.5,
+        "attachment_refs": ["attachment://one"],
+    }

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -28,13 +28,19 @@ def server():
     # e.g. hermes_cli.active_sessions would bind the mocked get_hermes_home
     # (a fixed shared path) forever, leaking active-session registry entries
     # across every later test in the process. Scope the patch to the import.
-    with patch.dict("sys.modules", {
-        "hermes_constants": MagicMock(get_hermes_home=MagicMock(return_value="/tmp/hermes_test")),
-        "hermes_cli.env_loader": MagicMock(),
-        "hermes_cli.banner": MagicMock(),
-        "hermes_state": MagicMock(),
-    }):
+    with patch.dict(
+        "sys.modules",
+        {
+            "hermes_constants": MagicMock(
+                get_hermes_home=MagicMock(return_value="/tmp/hermes_test")
+            ),
+            "hermes_cli.env_loader": MagicMock(),
+            "hermes_cli.banner": MagicMock(),
+            "hermes_state": MagicMock(),
+        },
+    ):
         import importlib
+
         mod = importlib.import_module("tui_gateway.server")
 
     # Snapshot the RPC registry: several tests below stub handlers
@@ -109,13 +115,17 @@ def test_unknown_method(server):
 
 def test_ok_envelope(server):
     assert server._ok("r1", {"x": 1}) == {
-        "jsonrpc": "2.0", "id": "r1", "result": {"x": 1},
+        "jsonrpc": "2.0",
+        "id": "r1",
+        "result": {"x": 1},
     }
 
 
 def test_err_envelope(server):
     assert server._err("r2", 4001, "nope") == {
-        "jsonrpc": "2.0", "id": "r2", "error": {"code": 4001, "message": "nope"},
+        "jsonrpc": "2.0",
+        "id": "r2",
+        "error": {"code": 4001, "message": "nope"},
     }
 
 
@@ -199,7 +209,9 @@ def test_live_session_payload_replays_pending_approval(server, monkeypatch):
         approval._ApprovalEntry(first),
         approval._ApprovalEntry(second),
     ]
-    monkeypatch.setattr(server, "_approval_request_payload", lambda data: dict(data or {}))
+    monkeypatch.setattr(
+        server, "_approval_request_payload", lambda data: dict(data or {})
+    )
 
     try:
         payload = server._live_session_payload("runtime-session", session)
@@ -295,7 +307,9 @@ def test_block_and_respond(capture):
     result = [None]
 
     threading.Thread(
-        target=lambda: result.__setitem__(0, server._block("test.prompt", "s1", {"q": "?"}, timeout=5)),
+        target=lambda: result.__setitem__(
+            0, server._block("test.prompt", "s1", {"q": "?"}, timeout=5)
+        ),
     ).start()
 
     for _ in range(100):
@@ -343,13 +357,11 @@ def test_late_prompt_response_is_idempotent(server, method, value_key):
     """All four blocking bridges tolerate a late reply after their request has
     expired — the `*.respond` returns a graceful `{"status": "expired"}` instead
     of the raw 4009 protocol error a client would otherwise surface verbatim."""
-    response = server.handle_request(
-        {
-            "id": "late-response",
-            "method": method,
-            "params": {"request_id": "expired-request", value_key: ""},
-        }
-    )
+    response = server.handle_request({
+        "id": "late-response",
+        "method": method,
+        "params": {"request_id": "expired-request", value_key: ""},
+    })
 
     assert response["result"] == {"status": "expired"}
 
@@ -390,7 +402,8 @@ def test_clarify_batch_resolves_when_all_questions_locked(capture):
     thread, box, rid = _drain_batch_block(server, ["q0", "q1"])
 
     first = server.handle_request({
-        "id": "a1", "method": "clarify.respond",
+        "id": "a1",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q1", "answer": "beta"},
     })
     assert first["result"]["status"] == "ok"
@@ -398,7 +411,8 @@ def test_clarify_batch_resolves_when_all_questions_locked(capture):
     assert thread.is_alive()  # one question left — still blocking
 
     second = server.handle_request({
-        "id": "a2", "method": "clarify.respond",
+        "id": "a2",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "alpha"},
     })
     assert second["result"]["status"] == "ok"
@@ -409,24 +423,135 @@ def test_clarify_batch_resolves_when_all_questions_locked(capture):
     assert json.loads(box["answer"]) == {"answers": {"q0": "alpha", "q1": "beta"}}
 
 
-def test_clarify_batch_answer_update_overwrites_before_completion(server):
+def test_clarify_batch_first_locked_answer_wins(server):
     thread, box, rid = _drain_batch_block(server, ["q0", "q1"])
 
-    server.handle_request({
-        "id": "a1", "method": "clarify.respond",
+    first = server.handle_request({
+        "id": "a1",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "first"},
     })
-    server.handle_request({
-        "id": "a2", "method": "clarify.respond",
+    second = server.handle_request({
+        "id": "a2",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "changed"},
     })
     server.handle_request({
-        "id": "a3", "method": "clarify.respond",
+        "id": "a3",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q1", "answer": "done"},
     })
 
+    assert first["result"]["status"] == "ok"
+    assert second["result"]["status"] == "already_resolved"
     thread.join(timeout=5)
-    assert json.loads(box["answer"])["answers"]["q0"] == "changed"
+    assert json.loads(box["answer"])["answers"]["q0"] == "first"
+
+
+def test_clarify_first_response_wins_before_waiter_cleanup(server):
+    request_id = "clarify-race"
+    event = threading.Event()
+    with server._prompt_lock:
+        server._pending[request_id] = ("missing-live-session", event)
+    try:
+        first = server.handle_request({
+            "id": "first",
+            "method": "clarify.respond",
+            "params": {"request_id": request_id, "answer": "alpha"},
+        })
+        second = server.handle_request({
+            "id": "second",
+            "method": "clarify.respond",
+            "params": {"request_id": request_id, "answer": "beta"},
+        })
+
+        assert first["result"]["status"] == "ok"
+        assert second["result"]["status"] == "already_resolved"
+        assert server._answers[request_id] == "alpha"
+    finally:
+        with server._prompt_lock:
+            server._pending.pop(request_id, None)
+            server._answers.pop(request_id, None)
+
+
+def test_clarify_winner_emits_one_resolution_event(server, monkeypatch):
+    request_id = "clarify-resolution-event"
+    event = threading.Event()
+    emitted = []
+    monkeypatch.setattr(
+        server,
+        "_emit",
+        lambda event_type, sid, payload=None, **_kwargs: (
+            emitted.append((event_type, sid, payload)) or True
+        ),
+    )
+    with server._prompt_lock:
+        server._pending[request_id] = ("clarify-event-sid", event)
+    try:
+        first = server.handle_request({
+            "id": "winner",
+            "method": "clarify.respond",
+            "params": {"request_id": request_id, "answer": "winner"},
+        })
+        duplicate = server.handle_request({
+            "id": "duplicate",
+            "method": "clarify.respond",
+            "params": {"request_id": request_id, "answer": "loser"},
+        })
+
+        assert first["result"]["status"] == "ok"
+        assert duplicate["result"]["status"] == "already_resolved"
+        assert emitted == [
+            (
+                "clarify.resolved",
+                "clarify-event-sid",
+                {
+                    "request_id": request_id,
+                    "question_id": None,
+                    "status": "resolved",
+                },
+            )
+        ]
+    finally:
+        with server._prompt_lock:
+            server._pending.pop(request_id, None)
+            server._answers.pop(request_id, None)
+
+
+def test_clarify_duplicate_after_waiter_cleanup_is_already_resolved(server):
+    payload = {}
+    box = {}
+
+    def wait_for_answer():
+        box["answer"] = server._block(
+            "clarify.request",
+            "clarify-cleanup-sid",
+            payload,
+            timeout=2,
+        )
+
+    thread = threading.Thread(target=wait_for_answer)
+    thread.start()
+    deadline = time.time() + 2
+    while "request_id" not in payload and time.time() < deadline:
+        time.sleep(0.01)
+    request_id = payload["request_id"]
+
+    first = server.handle_request({
+        "id": "first-cleanup",
+        "method": "clarify.respond",
+        "params": {"request_id": request_id, "answer": "authoritative"},
+    })
+    thread.join(timeout=5)
+    duplicate = server.handle_request({
+        "id": "duplicate-cleanup",
+        "method": "clarify.respond",
+        "params": {"request_id": request_id, "answer": "changed"},
+    })
+
+    assert first["result"]["status"] == "ok"
+    assert box["answer"] == "authoritative"
+    assert duplicate["result"]["status"] == "already_resolved"
 
 
 def test_clarify_batch_empty_answer_is_a_locked_skip(server):
@@ -435,11 +560,13 @@ def test_clarify_batch_empty_answer_is_a_locked_skip(server):
     thread, box, rid = _drain_batch_block(server, ["q0", "q1"])
 
     server.handle_request({
-        "id": "a1", "method": "clarify.respond",
+        "id": "a1",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": ""},
     })
     server.handle_request({
-        "id": "a2", "method": "clarify.respond",
+        "id": "a2",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q1", "answer": "kept"},
     })
 
@@ -451,13 +578,15 @@ def test_clarify_batch_unknown_question_id_rejected(server):
     thread, box, rid = _drain_batch_block(server, ["q0"])
 
     response = server.handle_request({
-        "id": "bad", "method": "clarify.respond",
+        "id": "bad",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q9", "answer": "x"},
     })
     assert response["error"]["code"] == 4002
 
     server.handle_request({
-        "id": "ok", "method": "clarify.respond",
+        "id": "ok",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "fine"},
     })
     thread.join(timeout=5)
@@ -470,7 +599,8 @@ def test_clarify_batch_timeout_keeps_locked_answers(capture):
     thread, box, rid = _drain_batch_block(server, ["q0", "q1"], timeout=1)
 
     server.handle_request({
-        "id": "a1", "method": "clarify.respond",
+        "id": "a1",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "kept"},
     })
 
@@ -488,7 +618,8 @@ def test_clarify_batch_cancel_all_returns_empty(server):
     thread, box, rid = _drain_batch_block(server, ["q0", "q1"])
 
     server.handle_request({
-        "id": "cancel", "method": "clarify.respond",
+        "id": "cancel",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "answer": ""},
     })
 
@@ -498,7 +629,8 @@ def test_clarify_batch_cancel_all_returns_empty(server):
 
 def test_clarify_batch_late_question_respond_is_idempotent(server):
     response = server.handle_request({
-        "id": "late", "method": "clarify.respond",
+        "id": "late",
+        "method": "clarify.respond",
         "params": {"request_id": "gone", "question_id": "q0", "answer": "x"},
     })
     assert response["result"] == {"status": "expired"}
@@ -507,7 +639,8 @@ def test_clarify_batch_late_question_respond_is_idempotent(server):
 def test_clarify_batch_state_cleared_after_resolution(server):
     thread, box, rid = _drain_batch_block(server, ["q0"])
     server.handle_request({
-        "id": "a", "method": "clarify.respond",
+        "id": "a",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "x"},
     })
     thread.join(timeout=5)
@@ -523,8 +656,11 @@ def test_clarify_block_helper_builds_batch_payload(capture):
     server, buf = capture
     normalized = [
         {
-            "qid": "q0", "id": "approach", "question": "Which?",
-            "choices": ["a (Recommended)", "b"], "choices_offered": ["a", "b"],
+            "qid": "q0",
+            "id": "approach",
+            "question": "Which?",
+            "choices": ["a (Recommended)", "b"],
+            "choices_offered": ["a", "b"],
             "multi_select": False,
         },
     ]
@@ -545,7 +681,8 @@ def test_clarify_block_helper_builds_batch_payload(capture):
     assert rid
 
     server.handle_request({
-        "id": "a", "method": "clarify.respond",
+        "id": "a",
+        "method": "clarify.respond",
         "params": {"request_id": rid, "question_id": "q0", "answer": "a"},
     })
     thread.join(timeout=5)
@@ -563,11 +700,17 @@ def test_approval_pending_replays_unresolved_requests(server, monkeypatch):
 
     server._sessions["ui-1"] = {"session_key": "agent-1", "history": []}
     pending = [{"request_id": "req-1", "command": "danger"}]
-    monkeypatch.setattr(approval, "list_gateway_approvals", lambda key: pending if key == "agent-1" else [])
-
-    response = server.handle_request(
-        {"id": "r1", "method": "approval.pending", "params": {"session_id": "ui-1"}}
+    monkeypatch.setattr(
+        approval,
+        "list_gateway_approvals",
+        lambda key: pending if key == "agent-1" else [],
     )
+
+    response = server.handle_request({
+        "id": "r1",
+        "method": "approval.pending",
+        "params": {"session_id": "ui-1"},
+    })
 
     assert response["result"] == {"approvals": pending}
 
@@ -583,13 +726,11 @@ def test_approval_received_acknowledges_exact_request(server, monkeypatch):
         lambda key, request_id: calls.append((key, request_id)) or True,
     )
 
-    response = server.handle_request(
-        {
-            "id": "r2",
-            "method": "approval.received",
-            "params": {"session_id": "ui-1", "request_id": "req-1"},
-        }
-    )
+    response = server.handle_request({
+        "id": "r2",
+        "method": "approval.received",
+        "params": {"session_id": "ui-1", "request_id": "req-1"},
+    })
 
     assert response["result"] == {"acknowledged": True}
     assert calls == [("agent-1", "req-1")]
@@ -606,15 +747,18 @@ def test_approval_response_correlates_request_id(server, monkeypatch):
         lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
     )
 
-    response = server.handle_request(
-        {
-            "id": "r3",
-            "method": "approval.respond",
-            "params": {"session_id": "ui-1", "request_id": "req-1", "choice": "once"},
-        }
-    )
+    response = server.handle_request({
+        "id": "r3",
+        "method": "approval.respond",
+        "params": {"session_id": "ui-1", "request_id": "req-1", "choice": "once"},
+    })
 
-    assert response["result"] == {"resolved": 1}
+    assert response["result"] == {
+        "resolved": 1,
+        "status": "resolved",
+        "request_id": "req-1",
+        "choice": "once",
+    }
     assert calls == [("agent-1", "once", {"resolve_all": False, "request_id": "req-1"})]
 
 
@@ -637,19 +781,22 @@ def test_approval_respond_falls_back_to_request_id_lookup(server, monkeypatch):
         lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
     )
 
-    response = server.handle_request(
-        {
-            "id": "r-fallback",
-            "method": "approval.respond",
-            "params": {
-                "session_id": "gone-sid",
-                "request_id": "req-91684",
-                "choice": "once",
-            },
-        }
-    )
+    response = server.handle_request({
+        "id": "r-fallback",
+        "method": "approval.respond",
+        "params": {
+            "session_id": "gone-sid",
+            "request_id": "req-91684",
+            "choice": "once",
+        },
+    })
 
-    assert response["result"] == {"resolved": 1}
+    assert response["result"] == {
+        "resolved": 1,
+        "status": "resolved",
+        "request_id": "req-91684",
+        "choice": "once",
+    }
     assert calls == [
         ("agent-live", "once", {"resolve_all": False, "request_id": "req-91684"})
     ]
@@ -669,15 +816,18 @@ def test_approval_respond_falls_back_to_stored_session_id(server, monkeypatch):
         lambda key, choice, **kwargs: calls.append((key, choice, kwargs)) or 1,
     )
 
-    response = server.handle_request(
-        {
-            "id": "r-stored",
-            "method": "approval.respond",
-            "params": {"session_id": "stored-91684", "choice": "deny"},
-        }
-    )
+    response = server.handle_request({
+        "id": "r-stored",
+        "method": "approval.respond",
+        "params": {"session_id": "stored-91684", "choice": "deny"},
+    })
 
-    assert response["result"] == {"resolved": 1}
+    assert response["result"] == {
+        "resolved": 1,
+        "status": "resolved",
+        "request_id": None,
+        "choice": "deny",
+    }
     assert calls == [
         ("stored-91684", "deny", {"resolve_all": False, "request_id": None})
     ]
@@ -687,13 +837,11 @@ def test_approval_respond_4001_when_nothing_resolves(server, monkeypatch):
     from tools import approval
 
     monkeypatch.setattr(approval, "list_gateway_approvals", lambda key: [])
-    response = server.handle_request(
-        {
-            "id": "r-nope",
-            "method": "approval.respond",
-            "params": {"session_id": "nope", "request_id": "req-x", "choice": "once"},
-        }
-    )
+    response = server.handle_request({
+        "id": "r-nope",
+        "method": "approval.respond",
+        "params": {"session_id": "nope", "request_id": "req-x", "choice": "once"},
+    })
 
     assert response["error"]["code"] == 4001
 
@@ -739,7 +887,9 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
         def get_ancestor_display_prefix(self, _sid):
             return []
 
-        def get_messages_as_conversation(self, _sid, include_ancestors=False, repair_alternation=False):
+        def get_messages_as_conversation(
+            self, _sid, include_ancestors=False, repair_alternation=False
+        ):
             return [
                 {"role": "user", "content": "hello"},
                 {"role": "assistant", "content": "yo", "reasoning": "thoughts"},
@@ -750,19 +900,31 @@ def test_session_resume_returns_hydrated_messages(server, monkeypatch):
             ]
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
-    monkeypatch.setattr(server, "_make_agent", lambda sid, key, session_id=None, session_db=None, **_kwargs: object())
-    monkeypatch.setattr(server, "_init_session", lambda sid, key, agent, history, cols=80, **_kwargs: None)
-    monkeypatch.setattr(server, "_session_info", lambda _agent, _session=None: {"model": "test/model"})
-
-    resp = server.handle_request(
-        {
-            "id": "r1",
-            "method": "session.resume",
-            # eager_build: exercise the synchronous build path (this test
-            # monkeypatches _make_agent/_init_session/_session_info).
-            "params": {"session_id": "20260409_010101_abc123", "cols": 100, "eager_build": True},
-        }
+    monkeypatch.setattr(
+        server,
+        "_make_agent",
+        lambda sid, key, session_id=None, session_db=None, **_kwargs: object(),
     )
+    monkeypatch.setattr(
+        server,
+        "_init_session",
+        lambda sid, key, agent, history, cols=80, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        server, "_session_info", lambda _agent, _session=None: {"model": "test/model"}
+    )
+
+    resp = server.handle_request({
+        "id": "r1",
+        "method": "session.resume",
+        # eager_build: exercise the synchronous build path (this test
+        # monkeypatches _make_agent/_init_session/_session_info).
+        "params": {
+            "session_id": "20260409_010101_abc123",
+            "cols": 100,
+            "eager_build": True,
+        },
+    })
 
     assert "error" not in resp
     assert resp["result"]["message_count"] == 3
@@ -791,16 +953,14 @@ def test_session_resume_rejects_runaway_transcript_before_history_load(
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    response = server.handle_request(
-        {
-            "id": "r1",
-            "method": "session.resume",
-            "params": {
-                "session_id": "runaway-session",
-                "omit_messages": True,
-            },
-        }
-    )
+    response = server.handle_request({
+        "id": "r1",
+        "method": "session.resume",
+        "params": {
+            "session_id": "runaway-session",
+            "omit_messages": True,
+        },
+    })
 
     assert response["error"]["code"] == 4130
     assert "safe resume limit is 20000" in response["error"]["message"]
@@ -829,16 +989,14 @@ def test_session_resume_guard_failure_fails_open(server, monkeypatch):
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
-    response = server.handle_request(
-        {
-            "id": "r-open",
-            "method": "session.resume",
-            "params": {
-                "session_id": "transient-guard-session",
-                "omit_messages": True,
-            },
-        }
-    )
+    response = server.handle_request({
+        "id": "r-open",
+        "method": "session.resume",
+        "params": {
+            "session_id": "transient-guard-session",
+            "omit_messages": True,
+        },
+    })
 
     # The guard must not block: no 4130, and any downstream failure must not
     # be the guard's own "resume safety check failed" error. Reopen being
@@ -849,12 +1007,14 @@ def test_session_resume_guard_failure_fails_open(server, monkeypatch):
     assert reopened == ["transient-guard-session"]
 
 
-def test_session_resume_active_turn_payload_matches_desktop_fixture(server, monkeypatch):
+def test_session_resume_active_turn_payload_matches_desktop_fixture(
+    server, monkeypatch
+):
     """A live resume serializes the exact timer payload consumed by Desktop."""
     fixture = json.loads(
-        (Path(__file__).parents[1] / "fixtures" / "session-resume-active-turn.json").read_text(
-            encoding="utf-8"
-        )
+        (
+            Path(__file__).parents[1] / "fixtures" / "session-resume-active-turn.json"
+        ).read_text(encoding="utf-8")
     )
 
     class _DB:
@@ -889,13 +1049,11 @@ def test_session_resume_active_turn_payload_matches_desktop_fixture(server, monk
     # faithful to what the gateway actually serializes, not a copied shape.
     response = json.loads(
         json.dumps(
-            server.handle_request(
-                {
-                    "id": "resume-running",
-                    "method": "session.resume",
-                    "params": {"session_id": fixture["session_key"]},
-                }
-            )
+            server.handle_request({
+                "id": "resume-running",
+                "method": "session.resume",
+                "params": {"session_id": fixture["session_key"]},
+            })
         )
     )
     result = response["result"]
@@ -926,19 +1084,29 @@ def test_enforce_session_cap_evicts_oldest_detached_only(server, monkeypatch):
     live = object()  # no _closed attr -> live transport, never evictable
 
     server._sessions.clear()
-    server._sessions.update(
-        {
-            "old_detached": {"transport": detached, "last_active": 100.0, "agent_ready": _ready()},
-            "new_detached": {"transport": detached, "last_active": 300.0, "agent_ready": _ready()},
-            "running_detached": {
-                "transport": detached,
-                "last_active": 50.0,
-                "running": True,
-                "agent_ready": _ready(),
-            },
-            "focused_live": {"transport": live, "last_active": 200.0, "agent_ready": _ready()},
-        }
-    )
+    server._sessions.update({
+        "old_detached": {
+            "transport": detached,
+            "last_active": 100.0,
+            "agent_ready": _ready(),
+        },
+        "new_detached": {
+            "transport": detached,
+            "last_active": 300.0,
+            "agent_ready": _ready(),
+        },
+        "running_detached": {
+            "transport": detached,
+            "last_active": 50.0,
+            "running": True,
+            "agent_ready": _ready(),
+        },
+        "focused_live": {
+            "transport": live,
+            "last_active": 200.0,
+            "agent_ready": _ready(),
+        },
+    })
 
     server._enforce_session_cap()
 
@@ -1012,8 +1180,12 @@ def test_make_agent_accepts_list_system_prompt(server, monkeypatch):
             }
         ),
     )
-    monkeypatch.setattr(server, "_load_cfg", lambda: {"agent": {"system_prompt": ["one", "two"]}})
-    monkeypatch.setattr(server, "_resolve_startup_runtime", lambda: ("test/model", "test"))
+    monkeypatch.setattr(
+        server, "_load_cfg", lambda: {"agent": {"system_prompt": ["one", "two"]}}
+    )
+    monkeypatch.setattr(
+        server, "_resolve_startup_runtime", lambda: ("test/model", "test")
+    )
     monkeypatch.setattr(server, "_get_db", lambda: None)
 
     server._make_agent("sid", "session-key", session_id="session-key")
@@ -1033,13 +1205,16 @@ def test_config_roundtrip(server, tmp_path):
 # ── _cli_exec_blocked ────────────────────────────────────────────────
 
 
-@pytest.mark.parametrize("argv", [
-    [],
-    ["setup"],
-    ["gateway"],
-    ["sessions", "browse"],
-    ["config", "edit"],
-])
+@pytest.mark.parametrize(
+    "argv",
+    [
+        [],
+        ["setup"],
+        ["gateway"],
+        ["sessions", "browse"],
+        ["config", "edit"],
+    ],
+)
 def test_cli_exec_blocked(server, argv):
     assert server._cli_exec_blocked(argv) is not None
 
@@ -1054,7 +1229,9 @@ def test_slash_exec_rejects_skill_commands(server):
     server._sessions[sid] = {"session_key": sid, "agent": None}
 
     # Mock scan_skill_commands to return a known skill
-    fake_skills = {"/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}}
+    fake_skills = {
+        "/hermes-agent-dev": {"name": "hermes-agent-dev", "description": "Dev workflow"}
+    }
 
     with patch("agent.skill_commands.get_skill_commands", return_value=fake_skills):
         resp = server.handle_request({
@@ -1130,7 +1307,11 @@ def test_command_dispatch_queue_sends_message(server):
     resp = server.handle_request({
         "id": "r1",
         "method": "command.dispatch",
-        "params": {"name": "queue", "arg": "tell me about quantum computing", "session_id": sid},
+        "params": {
+            "name": "queue",
+            "arg": "tell me about quantum computing",
+            "session_id": sid,
+        },
     })
 
     assert "error" not in resp
@@ -1140,10 +1321,14 @@ def test_command_dispatch_queue_sends_message(server):
 
 
 def test_skills_manage_search_uses_tools_hub_sources(server):
-    result = type("Result", (), {
-        "description": "Build better terminal demos",
-        "name": "showroom",
-    })()
+    result = type(
+        "Result",
+        (),
+        {
+            "description": "Build better terminal demos",
+            "name": "showroom",
+        },
+    )()
     auth = MagicMock(return_value="auth")
     router = MagicMock(return_value=["source"])
     search = MagicMock(return_value=[result])
@@ -1166,7 +1351,9 @@ def test_skills_manage_search_uses_tools_hub_sources(server):
     }
     auth.assert_called_once_with()
     router.assert_called_once_with("auth")
-    search.assert_called_once_with("showroom", ["source"], source_filter="all", limit=20)
+    search.assert_called_once_with(
+        "showroom", ["source"], source_filter="all", limit=20
+    )
 
 
 # ── dispatch(): pool routing for long handlers (#12546) ──────────────
@@ -1229,16 +1416,22 @@ def test_skin_live_switch_end_to_end(server, tmp_path, monkeypatch):
     server._cfg_cache = server._cfg_mtime = server._cfg_path = None
 
     emitted = []
-    monkeypatch.setattr(server, "_emit", lambda ev, sid, payload=None: emitted.append((ev, payload)))
+    monkeypatch.setattr(
+        server, "_emit", lambda ev, sid, payload=None: emitted.append((ev, payload))
+    )
 
     # Baseline (default) — seeds the signature.
-    (tmp_path / "config.yaml").write_text("display:\n  skin: default\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  skin: default\n", encoding="utf-8"
+    )
     server._broadcast_skin_if_changed()
     emitted.clear()
 
     # Activate midnight, as `hermes config set display.skin midnight` would.
     time.sleep(0.01)  # ensure the config mtime moves
-    (tmp_path / "config.yaml").write_text("display:\n  skin: midnight\n", encoding="utf-8")
+    (tmp_path / "config.yaml").write_text(
+        "display:\n  skin: midnight\n", encoding="utf-8"
+    )
     server._broadcast_skin_if_changed()
 
     assert [ev for ev, _ in emitted] == ["skin.changed"]
@@ -1253,7 +1446,9 @@ def test_broadcast_skin_if_changed_on_any_signature_move(server, monkeypatch):
     emitted = []
     # switch, no-op, switch, then a color edit (same name, bumped mtime).
     sigs = iter([("neon", 1.0), ("neon", 1.0), ("forest", 1.0), ("forest", 2.0)])
-    monkeypatch.setattr(server, "_emit", lambda ev, sid, payload=None: emitted.append((ev, payload)))
+    monkeypatch.setattr(
+        server, "_emit", lambda ev, sid, payload=None: emitted.append((ev, payload))
+    )
     monkeypatch.setattr(server, "_last_skin_sig", None, raising=False)
     monkeypatch.setattr(server, "_skin_sig", lambda: next(sigs))
     monkeypatch.setattr(server, "resolve_skin", lambda: {"name": "x", "colors": {}})

--- a/tests/tui_gateway/test_runtime_proxy_dispatch.py
+++ b/tests/tui_gateway/test_runtime_proxy_dispatch.py
@@ -1,0 +1,385 @@
+from __future__ import annotations
+
+from hermes_cli.live_runtime_owners import OwnerClaimResult, RuntimeOwner
+from tui_gateway import runtime_proxy
+from tui_gateway import server
+
+
+class _DB:
+    def __init__(self):
+        self.closed = False
+
+    def get_session(self, session_id):
+        return {"id": session_id} if session_id == "stored-session" else None
+
+    def get_session_by_title(self, title):
+        return None
+
+    def resolve_resume_session_id(self, session_id):
+        assert session_id == "stored-session"
+        return "compression-tip"
+
+    def session_runtime_key(self, session_id):
+        assert session_id == "compression-tip"
+        return "conversation-root"
+
+    def close(self):
+        self.closed = True
+
+
+class _Coordinator:
+    def __init__(self):
+        self.calls = []
+        self.routed = []
+
+    def prepare_resume(self, **kwargs):
+        self.calls.append(kwargs)
+        return {
+            "jsonrpc": "2.0",
+            "id": kwargs["request"]["id"],
+            "result": {"proxied": True},
+        }
+
+    def has_remote_route(self, transport, session_id):
+        return session_id == "canonical-live"
+
+    def route_request(self, request, transport):
+        self.routed.append((request, transport))
+        return {"jsonrpc": "2.0", "id": request["id"], "result": {"routed": True}}
+
+    def detach_transport(self, transport):
+        self.detached = transport
+
+
+class _Transport:
+    def __init__(self):
+        self.writes = []
+
+    def write(self, frame):
+        self.writes.append(frame)
+        return True
+
+
+class _InlinePool:
+    def submit(self, callback):
+        callback()
+
+
+def test_teardown_releases_owner_after_agent_close(monkeypatch):
+    order = []
+
+    class Agent:
+        def close(self):
+            order.append("agent.close")
+
+    class Lease:
+        released = False
+
+        def release(self):
+            order.append("lease.release")
+            self.released = True
+            return True
+
+    session = {"agent": Agent(), "runtime_owner_lease": Lease()}
+    monkeypatch.setattr(server, "_finalize_session", lambda *args, **kwargs: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *args: None)
+
+    server._teardown_session(session)
+
+    assert order == ["agent.close", "lease.release"]
+    assert "runtime_owner_lease" not in session
+
+
+def test_deferred_record_detach_closes_live_sid_and_releases_owner_before_build(
+    monkeypatch, tmp_path
+):
+    class Lease:
+        released = False
+
+        def release(self):
+            self.released = True
+            return True
+
+    lease = Lease()
+    transport = _Transport()
+    sessions = {}
+    monkeypatch.setattr(server, "_sessions", sessions)
+    monkeypatch.setattr(server, "_finalize_session", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(server, "_announce_session_reclaimed", lambda *_args: None)
+
+    token = server.bind_transport(transport)
+    try:
+        record = server._deferred_session_record(
+            "live-session",
+            "stored-session",
+            cols=80,
+            cwd=str(tmp_path),
+            history=[],
+            lease=None,
+            runtime_owner_lease=lease,
+            close_on_disconnect=True,
+        )
+    finally:
+        server.reset_transport(token)
+    sessions["live-session"] = record
+
+    assert record["event_hub"].detach(transport) is True
+    assert sessions == {}
+    assert lease.released is True
+
+
+def test_released_owner_lease_is_removed_from_coordinator(monkeypatch, tmp_path):
+    class Lease:
+        released = False
+
+        def release(self):
+            self.released = True
+            return True
+
+    lease = Lease()
+    owner = RuntimeOwner(
+        conversation_key="scoped-root",
+        owner_id="owner-a",
+        generation=1,
+        pid=1,
+        process_start_time=None,
+        endpoint=str(tmp_path / "runtime.sock"),
+        profile_home=str(tmp_path),
+        surface="test",
+        started_at=1.0,
+    )
+    monkeypatch.setattr(
+        runtime_proxy,
+        "claim_runtime_owner",
+        lambda **_kwargs: OwnerClaimResult(kind="owned", owner=owner, lease=lease),
+    )
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "runtime.sock",
+        owner_id="owner-a",
+        surface="test",
+        dispatch=lambda _request, _transport: None,
+    )
+
+    claimed = coordinator.claim_local(conversation_key="root", profile_home=tmp_path)
+    assert coordinator._local_leases
+
+    assert claimed.release() is True
+    assert lease.released is True
+    assert coordinator._local_leases == {}
+
+
+def test_deferred_build_uses_stored_compression_root(monkeypatch, tmp_path):
+    lease = object()
+    claimed = []
+    monkeypatch.setattr(
+        server,
+        "_claim_local_runtime_owner",
+        lambda key, home: claimed.append((key, home)) or lease,
+    )
+    session = {
+        "session_key": "compression-tip",
+        "runtime_owner_key": "compression-root",
+        "profile_home": str(tmp_path),
+    }
+
+    server._ensure_runtime_owner_for_session(session)
+
+    assert claimed == [("compression-root", tmp_path)]
+    assert session["runtime_owner_lease"] is lease
+
+
+def test_live_runtime_lookup_is_profile_scoped(monkeypatch, tmp_path):
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+    sessions = {
+        "a": {"runtime_owner_key": "shared-root", "profile_home": str(profile_a)},
+        "b": {"runtime_owner_key": "shared-root", "profile_home": str(profile_b)},
+    }
+    monkeypatch.setattr(server, "_sessions", sessions)
+
+    assert server._find_live_session_by_runtime_key("shared-root", profile_a) == (
+        "a",
+        sessions["a"],
+    )
+    assert server._find_live_session_by_runtime_key("shared-root", profile_b) == (
+        "b",
+        sessions["b"],
+    )
+
+
+def test_session_create_claims_owner_before_scheduling_agent(monkeypatch, tmp_path):
+    order = []
+    lease = object()
+    sessions = {}
+
+    def claim(conversation_key, profile_home):
+        order.append(("claim", conversation_key, profile_home))
+        return lease
+
+    def schedule(session_id):
+        assert sessions[session_id]["runtime_owner_lease"] is lease
+        order.append(("schedule", session_id))
+
+    monkeypatch.setattr(server, "_sessions", sessions)
+    monkeypatch.setattr(server, "_new_session_key", lambda: "new-conversation-key")
+    monkeypatch.setattr(server, "_coerce_seed_history", lambda messages: [])
+    monkeypatch.setattr(server, "_completion_cwd", lambda params: str(tmp_path))
+    monkeypatch.setattr(server, "_resolve_session_source", lambda source: "desktop")
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_profile_home", lambda profile: tmp_path)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "compact")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(server, "_attach_current_transport", lambda *args: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", schedule)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_history_to_messages", lambda history: [])
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: None)
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
+    monkeypatch.setattr(server, "_response_profile_name", lambda profile: "ops")
+    monkeypatch.setattr(server, "_claim_local_runtime_owner", claim)
+
+    response = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "create-1",
+        "method": "session.create",
+        "params": {"profile": "ops", "source": "desktop"},
+    })
+
+    live_id = response["result"]["session_id"]
+    assert sessions[live_id]["runtime_owner_lease"] is lease
+    assert order == [
+        ("claim", "new-conversation-key", tmp_path),
+        ("schedule", live_id),
+    ]
+
+
+def test_session_create_without_cross_process_transport_uses_registry_fencing(
+    monkeypatch, tmp_path
+):
+    sessions = {}
+
+    monkeypatch.setattr(server, "_sessions", sessions)
+    monkeypatch.setattr(server, "_cross_process_runtime_proxy_supported", lambda: False)
+    monkeypatch.setattr(
+        server,
+        "_get_runtime_proxy_coordinator",
+        lambda: (_ for _ in ()).throw(AssertionError("proxy coordinator started")),
+    )
+    monkeypatch.setattr(server, "_new_session_key", lambda: "windows-local-session")
+    monkeypatch.setattr(server, "_coerce_seed_history", lambda _messages: [])
+    monkeypatch.setattr(server, "_completion_cwd", lambda _params: str(tmp_path))
+    monkeypatch.setattr(server, "_resolve_session_source", lambda _source: "desktop")
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_profile_home", lambda _profile: None)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "compact")
+    monkeypatch.setattr(server, "_register_session_cwd", lambda _session: None)
+    monkeypatch.setattr(server, "_attach_current_transport", lambda *_args: None)
+    monkeypatch.setattr(server, "_schedule_agent_build", lambda _sid: None)
+    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda: None)
+    monkeypatch.setattr(server, "_history_to_messages", lambda _history: [])
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test-model")
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda _cwd: None)
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda _cwd: None)
+    monkeypatch.setattr(server, "_response_profile_name", lambda _profile: "default")
+
+    response = server.handle_request({
+        "jsonrpc": "2.0",
+        "id": "create-local",
+        "method": "session.create",
+        "params": {"source": "desktop"},
+    })
+
+    assert "error" not in response
+    live_id = response["result"]["session_id"]
+    lease = sessions[live_id]["runtime_owner_lease"]
+    assert lease.owner.endpoint.startswith("process-local:")
+    assert lease.owner.surface == "tui_gateway_process_local"
+    assert lease.release() is True
+
+
+def test_cross_process_runtime_proxy_requires_so_peercred(monkeypatch):
+    monkeypatch.delattr(server.socket, "SO_PEERCRED", raising=False)
+
+    assert server._cross_process_runtime_proxy_supported() is False
+
+
+def test_disconnect_detaches_remote_transport(monkeypatch):
+    coordinator = _Coordinator()
+    transport = _Transport()
+    monkeypatch.setattr(server, "_runtime_proxy_coordinator", coordinator)
+
+    server.detach_runtime_proxy_transport(transport)
+
+    assert coordinator.detached is transport
+
+
+def test_dispatch_routes_retained_session_to_owner_without_local_handler(monkeypatch):
+    coordinator = _Coordinator()
+    transport = _Transport()
+    request = {
+        "jsonrpc": "2.0",
+        "id": "interrupt-1",
+        "method": "session.interrupt",
+        "params": {"session_id": "canonical-live"},
+    }
+    monkeypatch.setattr(server, "_runtime_proxy_coordinator", coordinator)
+    monkeypatch.setattr(server, "_pool", _InlinePool())
+    monkeypatch.setattr(
+        server,
+        "handle_request",
+        lambda request: (_ for _ in ()).throw(AssertionError("local handler called")),
+    )
+
+    assert server.dispatch(request, transport) is None
+    assert coordinator.routed == [(request, transport)]
+    assert transport.writes[0]["result"] == {"routed": True}
+
+
+def test_dispatch_answers_when_selected_remote_route_disappears(monkeypatch):
+    coordinator = _Coordinator()
+    transport = _Transport()
+    request = {
+        "jsonrpc": "2.0",
+        "id": "compress-1",
+        "method": "session.compress",
+        "params": {"session_id": "canonical-live"},
+    }
+    coordinator.route_request = lambda _request, _transport: None
+    monkeypatch.setattr(server, "_runtime_proxy_coordinator", coordinator)
+    monkeypatch.setattr(server, "_pool", _InlinePool())
+
+    assert server.dispatch(request, transport) is None
+    assert len(transport.writes) == 1
+    response = transport.writes[0]
+    assert response["id"] == "compress-1"
+    assert response["error"]["code"] == -32072
+    assert response["error"]["data"] == {"outcome": "unknown", "retryable": False}
+
+
+def test_resume_proxy_resolves_compression_root_before_local_handler(
+    monkeypatch, tmp_path
+):
+    db = _DB()
+    coordinator = _Coordinator()
+    transport = object()
+    request = {
+        "jsonrpc": "2.0",
+        "id": "resume-1",
+        "method": "session.resume",
+        "params": {"session_id": "stored-session"},
+    }
+    monkeypatch.setattr(server, "_db_for_profile", lambda profile: (db, True))
+    monkeypatch.setattr(server, "_profile_home", lambda profile: tmp_path)
+    monkeypatch.setattr(server, "_get_runtime_proxy_coordinator", lambda: coordinator)
+
+    response = server._prepare_runtime_resume_proxy(request, transport)
+
+    assert response["result"] == {"proxied": True}
+    assert coordinator.calls[0]["conversation_key"] == "conversation-root"
+    assert coordinator.calls[0]["profile_home"] == tmp_path
+    assert coordinator.calls[0]["transport"] is transport
+    assert db.closed is True

--- a/tests/tui_gateway/test_runtime_proxy_protocol.py
+++ b/tests/tui_gateway/test_runtime_proxy_protocol.py
@@ -1,0 +1,1098 @@
+from __future__ import annotations
+
+import io
+import json
+import multiprocessing
+import os
+import socket
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.live_runtime_owners import RuntimeOwner
+from tui_gateway import runtime_proxy
+from tui_gateway.session_events import SessionEventHub
+
+
+def _run_cross_process_runtime_owner(registry_home: str, endpoint: str, ready) -> None:
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=registry_home,
+        endpoint=Path(endpoint),
+        owner_id=f"owner-{os.getpid()}",
+        surface="cross-process-test",
+        dispatch=lambda request, _transport: {
+            "jsonrpc": "2.0",
+            "id": request.get("id"),
+            "result": {"owner_pid": os.getpid()},
+        },
+    )
+    if not coordinator.start():
+        ready.put(RuntimeError("owner proxy failed to start"))
+        return
+    lease = coordinator.claim_local(
+        conversation_key="durable-root",
+        profile_home=registry_home,
+    )
+    ready.put(lease.owner)
+    while True:
+        time.sleep(1)
+
+
+@pytest.mark.skipif(
+    os.name != "posix" or not hasattr(socket, "SO_PEERCRED"),
+    reason="authenticated Unix runtime proxy is unavailable",
+)
+def test_cross_process_owner_proxy_crash_and_single_winner_takeover(tmp_path):
+    from hermes_cli.live_runtime_owners import claim_runtime_owner
+
+    context = multiprocessing.get_context("fork")
+    ready = context.Queue()
+    endpoint = tmp_path / "owner.sock"
+    owner_process = context.Process(
+        target=_run_cross_process_runtime_owner,
+        args=(str(tmp_path), str(endpoint), ready),
+    )
+    owner_process.start()
+    owner = ready.get(timeout=5)
+    assert isinstance(owner, RuntimeOwner)
+
+    client = runtime_proxy.RuntimeProxyClient(
+        owner=owner,
+        client_id="cross-process-client",
+        on_event=lambda _frame: None,
+    )
+    try:
+        client.connect()
+        response = client.request({
+            "jsonrpc": "2.0",
+            "id": "cross-process-request",
+            "method": "session.get",
+            "params": {"session_id": "live-session"},
+        })
+        assert response["result"]["owner_pid"] == owner_process.pid
+    finally:
+        client.close()
+
+    owner_process.terminate()
+    owner_process.join(timeout=5)
+    assert not owner_process.is_alive()
+
+    barrier = threading.Barrier(3)
+    claims = []
+
+    def contend(index: int) -> None:
+        barrier.wait()
+        claims.append(
+            claim_runtime_owner(
+                conversation_key=owner.conversation_key,
+                owner_id=f"takeover-{index}",
+                endpoint=str(tmp_path / f"takeover-{index}.sock"),
+                surface="cross-process-takeover",
+                registry_home=tmp_path,
+                profile_home=tmp_path,
+            )
+        )
+
+    contenders = [threading.Thread(target=contend, args=(index,)) for index in range(2)]
+    for contender in contenders:
+        contender.start()
+    barrier.wait()
+    for contender in contenders:
+        contender.join(timeout=5)
+        assert not contender.is_alive()
+
+    assert sorted(claim.kind for claim in claims) == ["owned", "remote"]
+    winner = next(claim for claim in claims if claim.kind == "owned")
+    assert winner.owner.generation == owner.generation + 1
+    assert winner.lease is not None
+    assert winner.lease.release() is True
+
+
+def test_repeated_local_claim_reuses_lease_without_deleting_registry(tmp_path):
+    from hermes_cli.live_runtime_owners import lookup_runtime_owner
+
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "owner.sock",
+        owner_id="same-owner",
+        surface="test",
+        dispatch=lambda request, _transport: request,
+    )
+    assert coordinator.start()
+    try:
+        first = coordinator.claim_local(
+            conversation_key="durable-root", profile_home=tmp_path
+        )
+        second = coordinator.claim_local(
+            conversation_key="durable-root", profile_home=tmp_path
+        )
+
+        assert second is first
+        assert (
+            lookup_runtime_owner(
+                conversation_key=first.owner.conversation_key,
+                registry_home=tmp_path,
+            )
+            == first.owner
+        )
+    finally:
+        coordinator.stop()
+
+
+def test_concurrent_local_claims_share_one_current_lease(tmp_path, monkeypatch):
+    from hermes_cli.live_runtime_owners import lookup_runtime_owner
+
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "owner.sock",
+        owner_id="same-owner",
+        surface="test",
+        dispatch=lambda request, _transport: request,
+    )
+    real_claim = runtime_proxy.claim_runtime_owner
+    rendezvous = threading.Event()
+    registry_calls = 0
+    calls_lock = threading.Lock()
+
+    def synchronized_claim(**kwargs):
+        nonlocal registry_calls
+        result = real_claim(**kwargs)
+        with calls_lock:
+            registry_calls += 1
+            if registry_calls == 2:
+                rendezvous.set()
+        rendezvous.wait(timeout=0.2)
+        return result
+
+    monkeypatch.setattr(runtime_proxy, "claim_runtime_owner", synchronized_claim)
+    assert coordinator.start()
+    leases: list[runtime_proxy._TrackedRuntimeOwnerLease] = []
+
+    def claim() -> None:
+        leases.append(
+            coordinator.claim_local(
+                conversation_key="durable-root", profile_home=tmp_path
+            )
+        )
+
+    threads = [threading.Thread(target=claim) for _ in range(2)]
+    try:
+        for thread in threads:
+            thread.start()
+        for thread in threads:
+            thread.join(timeout=2)
+
+        assert all(not thread.is_alive() for thread in threads)
+        assert registry_calls == 1
+        assert len(leases) == 2
+        assert leases[0] is leases[1]
+        assert leases[0].is_current()
+        assert (
+            lookup_runtime_owner(
+                conversation_key=leases[0].owner.conversation_key,
+                registry_home=tmp_path,
+            )
+            == leases[0].owner
+        )
+    finally:
+        coordinator.stop()
+
+
+def test_stop_serializes_with_inflight_local_claim(tmp_path, monkeypatch):
+    from hermes_cli.live_runtime_owners import lookup_runtime_owner
+
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "proxy.sock",
+        owner_id="owner-a",
+        surface="test",
+        dispatch=lambda _request, _transport: None,
+    )
+    claimed = threading.Event()
+    unblock = threading.Event()
+    real_claim = runtime_proxy.claim_runtime_owner
+
+    def delayed_claim(**kwargs):
+        result = real_claim(**kwargs)
+        claimed.set()
+        assert unblock.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(runtime_proxy, "claim_runtime_owner", delayed_claim)
+    returned = []
+    claim_thread = threading.Thread(
+        target=lambda: returned.append(
+            coordinator.claim_local(
+                conversation_key="conversation-1",
+                profile_home=tmp_path,
+            )
+        )
+    )
+    claim_thread.start()
+    assert claimed.wait(timeout=2)
+    stop_thread = threading.Thread(target=coordinator.stop)
+    stop_thread.start()
+    unblock.set()
+    claim_thread.join(timeout=2)
+    stop_thread.join(timeout=2)
+
+    owner_key = runtime_proxy._profile_scoped_conversation_key(
+        "conversation-1", tmp_path
+    )
+    assert len(returned) == 1
+    assert returned[0].released is True
+    assert coordinator._local_leases == {}
+    assert (
+        lookup_runtime_owner(
+            conversation_key=owner_key,
+            registry_home=tmp_path,
+        )
+        is None
+    )
+
+
+def test_stop_serializes_with_inflight_resume_claim(tmp_path, monkeypatch):
+    from hermes_cli.live_runtime_owners import lookup_runtime_owner
+
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "proxy.sock",
+        owner_id="owner-a",
+        surface="test",
+        dispatch=lambda _request, _transport: None,
+    )
+    claimed = threading.Event()
+    unblock = threading.Event()
+    real_claim = runtime_proxy.claim_runtime_owner
+
+    def delayed_claim(**kwargs):
+        result = real_claim(**kwargs)
+        claimed.set()
+        assert unblock.wait(timeout=2)
+        return result
+
+    monkeypatch.setattr(runtime_proxy, "claim_runtime_owner", delayed_claim)
+    resumed = []
+    resume_thread = threading.Thread(
+        target=lambda: resumed.append(
+            coordinator.prepare_resume(
+                conversation_key="conversation-1",
+                profile_home=tmp_path,
+                request={
+                    "jsonrpc": "2.0",
+                    "id": "resume-1",
+                    "method": "session.resume",
+                },
+                transport=type(
+                    "Transport",
+                    (),
+                    {
+                        "connection_id": "frontend",
+                        "client_id": "client",
+                        "auth_identity": "user",
+                    },
+                )(),
+            )
+        )
+    )
+    resume_thread.start()
+    assert claimed.wait(timeout=2)
+    stop_thread = threading.Thread(target=coordinator.stop)
+    stop_thread.start()
+    unblock.set()
+    resume_thread.join(timeout=2)
+    stop_thread.join(timeout=2)
+
+    owner_key = runtime_proxy._profile_scoped_conversation_key(
+        "conversation-1", tmp_path
+    )
+    assert resumed == [None]
+    assert coordinator._local_leases == {}
+    assert (
+        lookup_runtime_owner(
+            conversation_key=owner_key,
+            registry_home=tmp_path,
+        )
+        is None
+    )
+
+
+def _owner(
+    *, owner_id: str = "owner-a", generation: int = 3, endpoint: str = "/tmp/owner.sock"
+) -> RuntimeOwner:
+    return RuntimeOwner(
+        conversation_key="root-session",
+        owner_id=owner_id,
+        generation=generation,
+        pid=os.getpid(),
+        process_start_time=None,
+        endpoint=endpoint,
+        profile_home="/tmp/profile",
+        surface="test",
+        started_at=1.0,
+    )
+
+
+def test_stable_routes_are_lru_bounded(tmp_path, monkeypatch):
+    monkeypatch.setattr(runtime_proxy, "MAX_STABLE_RUNTIME_ROUTES", 2)
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "owner.sock",
+        owner_id="owner",
+        surface="test",
+        dispatch=lambda request, _transport: request,
+    )
+    coordinator._remember_stable_route(("client", "session-1"), _owner())
+    coordinator._remember_stable_route(("client", "session-2"), _owner())
+    assert coordinator._stable_route_owner(("client", "session-1")) is not None
+    coordinator._remember_stable_route(("client", "session-3"), _owner())
+
+    assert list(coordinator._stable_routes) == [
+        ("client", "session-1"),
+        ("client", "session-3"),
+    ]
+
+
+def test_handshake_rejects_owner_id_or_generation_mismatch():
+    owner = _owner()
+    for payload in (
+        runtime_proxy.handshake_frame(_owner(owner_id="wrong"), client_id="client-a"),
+        runtime_proxy.handshake_frame(_owner(generation=4), client_id="client-a"),
+    ):
+        with pytest.raises(
+            runtime_proxy.RuntimeProxyProtocolError, match="owner identity mismatch"
+        ):
+            runtime_proxy.validate_handshake(
+                payload, expected_owner=owner, current_owner=owner
+            )
+
+
+def test_handshake_rejects_unattested_auth_identity():
+    owner = _owner()
+    payload = runtime_proxy.handshake_frame(owner, client_id="client-a")
+    payload["auth_identity"] = {"subject": "forged-admin"}
+
+    with pytest.raises(
+        runtime_proxy.RuntimeProxyProtocolError, match="unattested auth identity"
+    ):
+        runtime_proxy.validate_handshake(
+            payload,
+            expected_owner=owner,
+            current_owner=owner,
+        )
+
+
+def test_handshake_rejects_unknown_negotiated_capability():
+    owner = _owner()
+    payload = runtime_proxy.handshake_frame(owner, client_id="client-a")
+    payload["negotiated_capabilities"] = ["observe", "runtime.admin"]
+
+    with pytest.raises(
+        runtime_proxy.RuntimeProxyProtocolError,
+        match="invalid negotiated capabilities",
+    ):
+        runtime_proxy.validate_handshake(
+            payload,
+            expected_owner=owner,
+            current_owner=owner,
+        )
+
+
+def test_handshake_preserves_legacy_absence_separately_from_empty_capabilities():
+    owner = _owner()
+
+    legacy = runtime_proxy.handshake_frame(owner, client_id="legacy-client")
+    explicit_empty = runtime_proxy.handshake_frame(
+        owner, client_id="restricted-client", negotiated_capabilities=frozenset()
+    )
+
+    assert runtime_proxy.validate_handshake(
+        legacy, expected_owner=owner, current_owner=owner
+    ) == ("legacy-client", None)
+    assert runtime_proxy.validate_handshake(
+        explicit_empty, expected_owner=owner, current_owner=owner
+    ) == ("restricted-client", frozenset())
+
+
+def test_handshake_rejects_claim_no_longer_current():
+    expected = _owner()
+    payload = runtime_proxy.handshake_frame(expected, client_id="client-a")
+
+    with pytest.raises(
+        runtime_proxy.RuntimeProxyProtocolError, match="claim is no longer current"
+    ):
+        runtime_proxy.validate_handshake(
+            payload,
+            expected_owner=expected,
+            current_owner=_owner(generation=4),
+        )
+
+
+def test_protocol_round_trips_megabyte_resume_payload():
+    frame = {
+        "kind": "rpc.response",
+        "frame": {
+            "jsonrpc": "2.0",
+            "id": "large-resume",
+            "result": {
+                "messages": [{"role": "assistant", "content": "x" * (1024 * 1024)}]
+            },
+        },
+    }
+
+    encoded = runtime_proxy.encode_frame(frame)
+
+    assert runtime_proxy.read_frame(io.BytesIO(encoded)) == frame
+
+
+def test_protocol_rejects_oversized_or_malformed_frame_without_dispatch():
+    oversized = io.BytesIO(b"x" * (runtime_proxy.MAX_FRAME_BYTES + 1) + b"\n")
+    malformed = io.BytesIO(b"not-json\n")
+
+    with pytest.raises(runtime_proxy.RuntimeProxyProtocolError, match="too large"):
+        runtime_proxy.read_frame(oversized)
+    with pytest.raises(runtime_proxy.RuntimeProxyProtocolError, match="malformed"):
+        runtime_proxy.read_frame(malformed)
+
+
+def test_posix_peer_uid_is_verified_before_rpc():
+    if not hasattr(socket, "SO_PEERCRED"):
+        pytest.skip("SO_PEERCRED is unavailable")
+    left, right = socket.socketpair()
+    try:
+        assert runtime_proxy.require_posix_peer_uid(left) == os.getuid()
+        with pytest.raises(
+            runtime_proxy.RuntimeProxyProtocolError, match="uid mismatch"
+        ):
+            runtime_proxy.require_posix_peer_uid(left, expected_uid=os.getuid() + 1)
+    finally:
+        left.close()
+        right.close()
+
+
+def test_proxy_principal_is_derived_from_kernel_attested_process():
+    first = runtime_proxy.proxy_peer_auth_identity(peer_pid=101, peer_uid=1000)
+    second = runtime_proxy.proxy_peer_auth_identity(peer_pid=202, peer_uid=1000)
+
+    assert first == {
+        "provider": "runtime-proxy-peer",
+        "peer_pid": 101,
+        "peer_uid": 1000,
+    }
+    assert first != second
+
+
+def test_proxy_client_id_is_scoped_to_locally_authenticated_principal():
+    class Transport:
+        client_id = "same-browser-id"
+        connection_id = "connection"
+
+        def __init__(self, user_id: str) -> None:
+            self.auth_identity = {"provider": "oidc", "user_id": user_id}
+
+    alice = runtime_proxy.proxy_scoped_client_id(Transport("alice"))
+    alice_reconnect = runtime_proxy.proxy_scoped_client_id(Transport("alice"))
+    bob = runtime_proxy.proxy_scoped_client_id(Transport("bob"))
+
+    assert alice == alice_reconnect
+    assert alice != bob
+    assert "same-browser-id" not in alice
+    assert "alice" not in alice
+
+
+def test_proxy_transport_can_acknowledge_physical_sender_completion():
+    entered = threading.Event()
+    release = threading.Event()
+    completed = threading.Event()
+
+    def blocked_send(_frame):
+        entered.set()
+        release.wait(timeout=2)
+        return True
+
+    transport = runtime_proxy.ProxyTransport(
+        client_id="ordered-client", send=blocked_send
+    )
+
+    def write() -> None:
+        assert transport.write_and_wait({"jsonrpc": "2.0", "method": "event"}) is True
+        completed.set()
+
+    try:
+        worker = threading.Thread(target=write)
+        worker.start()
+        assert entered.wait(timeout=1)
+        assert not completed.is_set()
+        release.set()
+        assert completed.wait(timeout=1)
+        worker.join(timeout=1)
+        assert not worker.is_alive()
+    finally:
+        release.set()
+        transport.close()
+
+
+@pytest.mark.parametrize("resolution_type", ["approval.resolved", "clarify.resolved"])
+def test_resolution_event_bytes_precede_rpc_response_over_proxy(resolution_type):
+    sender, receiver = socket.socketpair()
+    stream = receiver.makefile("rb", buffering=0)
+
+    def send(envelope):
+        sender.sendall(runtime_proxy.encode_frame(envelope))
+        return True
+
+    transport = runtime_proxy.ProxyTransport(client_id="ordered-client", send=send)
+    hub = SessionEventHub()
+    hub.attach(transport, client_id="ordered-client", mode="control")
+    try:
+        assert hub.publish(
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {"type": resolution_type, "session_id": "ordered-session"},
+            },
+            wait_for_delivery=True,
+        )
+        sender.sendall(
+            runtime_proxy.encode_frame({
+                "kind": "rpc.response",
+                "frame": {
+                    "jsonrpc": "2.0",
+                    "id": "response",
+                    "result": {"status": "ok"},
+                },
+            })
+        )
+
+        first = runtime_proxy.read_frame(stream)
+        second = runtime_proxy.read_frame(stream)
+        assert first["kind"] == "event"
+        assert first["frame"]["params"]["type"] == resolution_type
+        assert second["kind"] == "rpc.response"
+    finally:
+        hub.close()
+        transport.close()
+        stream.close()
+        receiver.close()
+        sender.close()
+
+
+def test_proxy_transport_fails_closed_when_slow_sender_fills_bounded_queue():
+    sending = threading.Event()
+    release = threading.Event()
+
+    def blocked_send(_frame):
+        sending.set()
+        release.wait(timeout=2)
+        return True
+
+    transport = runtime_proxy.ProxyTransport(
+        client_id="slow-client",
+        send=blocked_send,
+        outbound_queue_size=1,
+    )
+    frame = {"jsonrpc": "2.0", "method": "event", "params": {"seq": 1}}
+    try:
+        started = time.monotonic()
+        assert transport.write(frame) is True
+        assert time.monotonic() - started < 0.1
+        assert sending.wait(timeout=1)
+        assert transport.write(frame) is True
+        assert transport.write(frame) is False
+        assert transport.closed is True
+    finally:
+        release.set()
+        transport.close()
+
+
+def test_proxy_responses_are_point_to_point_and_events_are_not_restamped():
+    sent_a = []
+    sent_b = []
+    transport_a = runtime_proxy.ProxyTransport(
+        client_id="client-a",
+        send=sent_a.append,
+        auth_identity={"subject": "user-a"},
+    )
+    transport_b = runtime_proxy.ProxyTransport(
+        client_id="client-b",
+        send=sent_b.append,
+        auth_identity={"subject": "user-b"},
+    )
+    response = {"jsonrpc": "2.0", "id": "request-a", "result": {"ok": True}}
+    event = {
+        "jsonrpc": "2.0",
+        "method": "event",
+        "params": {
+            "type": "message.delta",
+            "session_id": "live-session",
+            "seq": 17,
+            "epoch": "owner-epoch",
+            "payload": {"text": "hello"},
+        },
+    }
+
+    assert transport_a.write(response) is True
+    assert sent_b == []
+    deadline = time.monotonic() + 1
+    while not sent_a and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert sent_a == [{"kind": "rpc.response", "frame": response}]
+
+    assert transport_b.write(event) is True
+    deadline = time.monotonic() + 1
+    while not sent_b and time.monotonic() < deadline:
+        time.sleep(0.001)
+    assert sent_b == [{"kind": "event", "frame": event}]
+    assert sent_b[0]["frame"] is event
+    assert transport_a.connection_id != transport_b.connection_id
+
+
+def test_unix_proxy_routes_response_and_preserves_async_event(tmp_path):
+    if os.name == "nt":
+        pytest.skip("Unix socket integration")
+    endpoint = tmp_path / "runtime.sock"
+    owner = _owner(endpoint=str(endpoint))
+    received_event = threading.Event()
+    events = []
+
+    def dispatch(request, transport):
+        assert transport.auth_identity == {
+            "provider": "runtime-proxy-peer",
+            "peer_pid": os.getpid(),
+            "peer_uid": os.getuid(),
+        }
+        assert transport.negotiated_capabilities == frozenset({"observe"})
+        transport.write({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "message.delta",
+                "session_id": "live-session",
+                "seq": 8,
+                "epoch": "owner-epoch",
+            },
+        })
+        return {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"owner": owner.owner_id},
+        }
+
+    server = runtime_proxy.RuntimeProxyServer(
+        endpoint=endpoint,
+        owner_lookup=lambda key: owner if key == owner.conversation_key else None,
+        dispatch=dispatch,
+    )
+    assert server.start() is True
+    client = runtime_proxy.RuntimeProxyClient(
+        owner=owner,
+        client_id="remote-client",
+        negotiated_capabilities=frozenset({"observe"}),
+        on_event=lambda frame: (events.append(frame), received_event.set()),
+    )
+    try:
+        client.connect()
+        response = client.request({
+            "jsonrpc": "2.0",
+            "id": "rpc-1",
+            "method": "session.attach",
+        })
+        assert response == {
+            "jsonrpc": "2.0",
+            "id": "rpc-1",
+            "result": {"owner": "owner-a"},
+        }
+        assert received_event.wait(timeout=2)
+        assert events[0]["params"]["seq"] == 8
+        assert events[0]["params"]["epoch"] == "owner-epoch"
+    finally:
+        client.close()
+        server.stop()
+
+
+def test_concurrent_proxy_connect_installs_one_client_and_ignores_loser_disconnect(
+    monkeypatch, tmp_path
+):
+    owner = _owner(endpoint=str(tmp_path / "remote.sock"))
+    connect_barrier = threading.Barrier(2)
+    candidates = []
+
+    class Claim:
+        kind = "remote"
+        lease = None
+
+        def __init__(self):
+            self.owner = owner
+
+    class FakeClient:
+        def __init__(self, *, on_disconnect, **_kwargs):
+            self._on_disconnect = on_disconnect
+            self.closed = False
+            candidates.append(self)
+
+        def connect(self):
+            connect_barrier.wait(timeout=2)
+
+        def request(self, frame):
+            return {
+                "jsonrpc": "2.0",
+                "id": frame["id"],
+                "result": {"session_id": "live-session"},
+            }
+
+        def close(self):
+            self.closed = True
+
+    class Transport:
+        connection_id = "frontend-connection"
+        client_id = "stable-client"
+        auth_identity = None
+
+        def __init__(self):
+            self.writes = []
+
+        def write(self, frame):
+            self.writes.append(frame)
+            return True
+
+    monkeypatch.setattr(runtime_proxy, "claim_runtime_owner", lambda **_kwargs: Claim())
+    monkeypatch.setattr(runtime_proxy, "RuntimeProxyClient", FakeClient)
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "local.sock",
+        owner_id="local-owner",
+        surface="test",
+        dispatch=lambda _request, _transport: None,
+    )
+    transport = Transport()
+    responses = []
+
+    def prepare(request_id):
+        responses.append(
+            coordinator.prepare_resume(
+                conversation_key=owner.conversation_key,
+                request={
+                    "jsonrpc": "2.0",
+                    "id": request_id,
+                    "method": "session.resume",
+                },
+                transport=transport,
+                profile_home=tmp_path,
+            )
+        )
+
+    first = threading.Thread(target=prepare, args=("r1",))
+    second = threading.Thread(target=prepare, args=("r2",))
+    first.start()
+    second.start()
+    first.join(timeout=2)
+    second.join(timeout=2)
+
+    assert not first.is_alive()
+    assert not second.is_alive()
+    assert len(responses) == 2
+    assert len(candidates) == 2
+    assert sum(candidate.closed for candidate in candidates) == 1
+    assert len(coordinator._clients) == 1
+    winner = next(iter(coordinator._clients.values()))
+    loser = next(candidate for candidate in candidates if candidate is not winner)
+    loser._on_disconnect()
+    assert next(iter(coordinator._clients.values())) is winner
+    assert coordinator.has_remote_route(transport, "live-session") is True
+    assert transport.writes == []
+
+
+def test_runtime_owner_keys_are_profile_scoped(tmp_path):
+    coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path / "registry",
+        endpoint=tmp_path / "runtime.sock",
+        owner_id="local-owner",
+        surface="test",
+        dispatch=lambda _request, _transport: None,
+    )
+    profile_a = tmp_path / "profiles" / "a"
+    profile_b = tmp_path / "profiles" / "b"
+
+    lease_a = coordinator.claim_local(
+        conversation_key="shared-root", profile_home=profile_a
+    )
+    lease_b = coordinator.claim_local(
+        conversation_key="shared-root", profile_home=profile_b
+    )
+
+    assert lease_a.owner.conversation_key != lease_b.owner.conversation_key
+    assert lease_a.owner.profile_home == str(profile_a.resolve())
+    assert lease_b.owner.profile_home == str(profile_b.resolve())
+    key_a = runtime_proxy._profile_scoped_conversation_key("shared-root", profile_a)
+    assert key_a == runtime_proxy._profile_scoped_conversation_key(
+        "shared-root", profile_a / "."
+    )
+    assert lease_a.release() is True
+    assert lease_b.release() is True
+
+
+def test_proxy_timeout_returns_unknown_non_retryable_and_fences_connection(tmp_path):
+    endpoint = tmp_path / "runtime.sock"
+    owner = _owner(endpoint=str(endpoint))
+    release = threading.Event()
+    disconnected = threading.Event()
+    dispatch_calls = []
+
+    def dispatch(request, _transport):
+        dispatch_calls.append(request["id"])
+        release.wait(timeout=2)
+        return {"jsonrpc": "2.0", "id": request["id"], "result": {"ok": True}}
+
+    server = runtime_proxy.RuntimeProxyServer(
+        endpoint=endpoint,
+        owner_lookup=lambda _key: owner,
+        dispatch=dispatch,
+    )
+    client = runtime_proxy.RuntimeProxyClient(
+        owner=owner,
+        client_id="timeout-client",
+        on_event=lambda _frame: None,
+        on_disconnect=disconnected.set,
+    )
+    try:
+        assert server.start() is True
+        client.connect()
+        response = client.request(
+            {"jsonrpc": "2.0", "id": "slow-mutation", "method": "session.compress"},
+            timeout=0.05,
+        )
+        assert response["id"] == "slow-mutation"
+        assert response["error"]["code"] == -32072
+        assert response["error"]["data"]["outcome"] == "unknown"
+        assert response["error"]["data"]["retryable"] is False
+        assert client._closed is True
+        assert disconnected.wait(timeout=1)
+        assert dispatch_calls == ["slow-mutation"]
+    finally:
+        release.set()
+        client.close()
+        server.stop()
+
+
+def test_stale_owner_generation_cannot_publish_async_event(tmp_path):
+    endpoint = tmp_path / "runtime.sock"
+    owner = _owner(endpoint=str(endpoint))
+    current = [owner]
+    captured = []
+    lost = threading.Event()
+
+    def dispatch(request, transport):
+        captured.append(transport)
+        return {"jsonrpc": "2.0", "id": request["id"], "result": {"ok": True}}
+
+    server = runtime_proxy.RuntimeProxyServer(
+        endpoint=endpoint,
+        owner_lookup=lambda _key: current[0],
+        dispatch=dispatch,
+    )
+    client = runtime_proxy.RuntimeProxyClient(
+        owner=owner,
+        client_id="client-a",
+        on_event=lambda _frame: None,
+        on_disconnect=lost.set,
+    )
+    try:
+        assert server.start() is True
+        client.connect()
+        assert client.request({"jsonrpc": "2.0", "id": 1, "method": "session.resume"})[
+            "result"
+        ] == {"ok": True}
+        current[0] = _owner(generation=owner.generation + 1, endpoint=str(endpoint))
+
+        assert (
+            captured[0].write({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {"seq": 8},
+            })
+            is True
+        )
+        assert lost.wait(timeout=2)
+        assert captured[0].closed is True
+        assert (
+            captured[0].write({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {"seq": 9},
+            })
+            is False
+        )
+    finally:
+        client.close()
+        server.stop()
+
+
+def test_owner_loss_fails_pending_request_without_retry_and_notifies_once(tmp_path):
+    owner = _owner(endpoint=str(tmp_path / "owner.sock"))
+    lost = []
+    client = runtime_proxy.RuntimeProxyClient(
+        owner=owner,
+        client_id="stable-client",
+        on_event=lambda _frame: None,
+        on_disconnect=lambda: lost.append(True),
+    )
+    local, remote = socket.socketpair()
+    client._socket = local
+    client._stream = local.makefile("rwb", buffering=0)
+    client._reader_thread = threading.Thread(target=client._read_loop, daemon=True)
+    client._reader_thread.start()
+    response = []
+
+    requester = threading.Thread(
+        target=lambda: response.append(
+            client.request({
+                "jsonrpc": "2.0",
+                "id": "pending",
+                "method": "session.interrupt",
+                "params": {"session_id": "live"},
+            })
+        )
+    )
+    requester.start()
+    runtime_proxy.read_frame(remote.makefile("rb", buffering=0))
+    remote.close()
+    requester.join(timeout=2)
+    client._reader_thread.join(timeout=2)
+
+    assert response[0]["error"]["code"] == -32072
+    assert response[0]["error"]["data"]["outcome"] == "unknown"
+    assert response[0]["error"]["data"]["retryable"] is False
+    assert lost == [True]
+    client.close()
+
+
+def test_coordinator_routes_remote_resume_without_local_dispatch(tmp_path):
+    if os.name == "nt":
+        pytest.skip("Unix socket integration")
+    owner_calls = []
+    local_calls = []
+
+    def owner_dispatch(request, _transport):
+        owner_calls.append(request)
+        return {
+            "jsonrpc": "2.0",
+            "id": request["id"],
+            "result": {"session_id": "canonical-live", "resumed": "stored-session"},
+        }
+
+    owner_coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "owner.sock",
+        owner_id="owner-process",
+        surface="test",
+        dispatch=owner_dispatch,
+    )
+    remote_coordinator = runtime_proxy.RuntimeProxyCoordinator(
+        registry_home=tmp_path,
+        endpoint=tmp_path / "remote.sock",
+        owner_id="remote-process",
+        surface="test",
+        dispatch=lambda request, transport: local_calls.append(request),
+    )
+    owner_transport = runtime_proxy.ProxyTransport(
+        client_id="owner-ui", send=lambda frame: True
+    )
+    remote_frames = []
+
+    class FrontendTransport:
+        client_id = "remote-ui"
+
+        def __init__(self, connection_id, auth_identity):
+            self.connection_id = connection_id
+            self.auth_identity = auth_identity
+
+        def write(self, frame):
+            remote_frames.append(frame)
+            return True
+
+    principal = {"provider": "oidc", "user_id": "user-a"}
+    remote_transport = FrontendTransport("remote-connection", principal)
+    request = {
+        "jsonrpc": "2.0",
+        "id": "resume-1",
+        "method": "session.resume",
+        "params": {"session_id": "stored-session"},
+    }
+    try:
+        assert owner_coordinator.start() is True
+        assert remote_coordinator.start() is True
+        assert (
+            owner_coordinator.prepare_resume(
+                conversation_key="conversation-root",
+                request=request,
+                transport=owner_transport,
+                profile_home=tmp_path,
+            )
+            is None
+        )
+        response = remote_coordinator.prepare_resume(
+            conversation_key="conversation-root",
+            request=request,
+            transport=remote_transport,
+            profile_home=tmp_path,
+        )
+
+        assert response["result"]["session_id"] == "canonical-live"
+        assert owner_calls == [request]
+        assert local_calls == []
+        assert remote_coordinator.has_remote_route(remote_transport, "canonical-live")
+
+        remote_coordinator.detach_transport(remote_transport)
+        reconnected = FrontendTransport("reconnected-physical", principal)
+        different_principal = FrontendTransport(
+            "other-principal", {"provider": "oidc", "user_id": "user-b"}
+        )
+        attach = {
+            "jsonrpc": "2.0",
+            "id": "attach-1",
+            "method": "session.attach",
+            "params": {"session_id": "canonical-live", "mode": "control"},
+        }
+        assert remote_coordinator.has_remote_route(reconnected, "canonical-live")
+        assert not remote_coordinator.has_remote_route(
+            different_principal, "canonical-live"
+        )
+        assert remote_coordinator.route_request(attach, reconnected)["id"] == "attach-1"
+        assert owner_calls == [request, attach]
+        assert local_calls == []
+
+        owner_coordinator.stop()
+        deadline = time.monotonic() + 2
+        while time.monotonic() < deadline and not remote_frames:
+            time.sleep(0.01)
+        assert (
+            remote_coordinator.has_remote_route(reconnected, "canonical-live") is False
+        )
+        assert remote_frames == [
+            {
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "session.runtime_owner_lost",
+                    "payload": {
+                        "session_ids": ["canonical-live"],
+                        "owner_id": "owner-process",
+                        "generation": 1,
+                        "outcome": "unknown",
+                    },
+                },
+            }
+        ]
+    finally:
+        remote_coordinator.stop()
+        owner_coordinator.stop()
+
+
+def test_encoded_registry_handshake_contains_no_credentials():
+    encoded = json.dumps(
+        runtime_proxy.handshake_frame(_owner(), client_id="client-a")
+    ).lower()
+    assert "secret" not in encoded
+    assert "token" not in encoded

--- a/tests/tui_gateway/test_session_events.py
+++ b/tests/tui_gateway/test_session_events.py
@@ -1,0 +1,441 @@
+"""Tests for the per-session attachment event hub."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import FrozenInstanceError
+
+import pytest
+
+from tui_gateway.session_events import (
+    ATTACHMENT_QUEUE_MAX,
+    AttachmentMode,
+    AttachmentSnapshot,
+    SessionEventHub,
+)
+
+
+class RecordingTransport:
+    def __init__(self) -> None:
+        self.frames: list[dict] = []
+        self.written = threading.Event()
+        self._condition = threading.Condition()
+
+    def write(self, frame: dict) -> bool:
+        with self._condition:
+            self.frames.append(frame)
+            self._condition.notify_all()
+        self.written.set()
+        return True
+
+    def wait_for_count(self, count: int) -> None:
+        with self._condition:
+            assert self._condition.wait_for(
+                lambda: len(self.frames) >= count, timeout=5,
+            ), f"transport received fewer than {count} frames"
+
+
+class BlockingTransport(RecordingTransport):
+    def __init__(self) -> None:
+        super().__init__()
+        self.release = threading.Event()
+
+    def write(self, frame: dict) -> bool:
+        self.written.set()
+        assert self.release.wait(timeout=5), "blocked writer was not released"
+        return super().write(frame)
+
+
+def _wait(event: threading.Event, message: str) -> None:
+    assert event.wait(timeout=5), message
+
+
+def test_attachment_modes_parse_and_reject_invalid_values():
+    assert AttachmentMode.parse("observe") is AttachmentMode.OBSERVE
+    assert AttachmentMode.parse("control") is AttachmentMode.CONTROL
+
+    with pytest.raises(ValueError, match="invalid attachment mode"):
+        AttachmentMode.parse("admin")
+
+
+def test_capabilities_are_immutable_and_match_protocol_contract():
+    assert AttachmentMode.OBSERVE.capabilities == frozenset({"observe"})
+    assert AttachmentMode.CONTROL.capabilities == frozenset(
+        {
+            "observe",
+            "prompt.submit",
+            "session.steer",
+            "session.interrupt",
+            "approval.respond",
+            "clarify.respond",
+            "ui.respond",
+        }
+    )
+    assert isinstance(AttachmentMode.CONTROL.capabilities, frozenset)
+
+    supplied_capabilities = {"observe"}
+    snapshot = AttachmentSnapshot(
+        client_id="client", mode=AttachmentMode.OBSERVE,
+        capabilities=supplied_capabilities,  # type: ignore[arg-type]
+    )
+    supplied_capabilities.add("mutated")
+    assert snapshot.capabilities == frozenset({"observe"})
+    with pytest.raises(FrozenInstanceError):
+        snapshot.client_id = "changed"  # type: ignore[misc]
+
+
+def test_attach_is_idempotent_and_updates_mode_without_duplicate_delivery():
+    hub = SessionEventHub()
+    transport = RecordingTransport()
+    try:
+        first = hub.attach(
+            transport, client_id="client-a", mode=AttachmentMode.OBSERVE,
+        )
+        second = hub.attach(
+            transport, client_id="client-a", mode=AttachmentMode.CONTROL,
+        )
+
+        assert first.mode is AttachmentMode.OBSERVE
+        assert second.mode is AttachmentMode.CONTROL
+        assert hub.count() == 1
+        hub.require(transport, "prompt.submit")
+        assert hub.publish({"event": 1}) is True
+        _wait(transport.written, "updated attachment did not receive an event")
+        assert transport.frames == [{"event": 1}]
+    finally:
+        hub.close()
+
+
+def test_require_rejects_missing_transport_or_capability():
+    hub = SessionEventHub()
+    observer = RecordingTransport()
+    stranger = RecordingTransport()
+    try:
+        hub.attach(observer, client_id="observer", mode=AttachmentMode.OBSERVE)
+
+        with pytest.raises(PermissionError, match="prompt.submit"):
+            hub.require(observer, "prompt.submit")
+        with pytest.raises(PermissionError, match="not attached"):
+            hub.require(stranger, "observe")
+    finally:
+        hub.close()
+
+
+def test_publish_copies_one_frame_per_subscriber_and_returns_before_delivery():
+    hub = SessionEventHub()
+    blocked = BlockingTransport()
+    recording = RecordingTransport()
+    frame = {"payload": {"items": [1]}}
+    try:
+        hub.attach(blocked, client_id="blocked", mode=AttachmentMode.OBSERVE)
+        hub.attach(recording, client_id="recording", mode=AttachmentMode.OBSERVE)
+
+        assert hub.publish(frame) is True
+        _wait(blocked.written, "blocking writer was not entered")
+        frame["payload"]["items"].append(2)
+        blocked.release.set()
+        _wait(recording.written, "recording transport did not receive frame")
+        blocked.wait_for_count(1)
+
+        assert recording.frames == [{"payload": {"items": [1]}}]
+        assert blocked.frames == [{"payload": {"items": [1]}}]
+        assert recording.frames[0] is not blocked.frames[0]
+        recording.frames[0]["payload"]["items"].append(3)
+        assert blocked.frames[0] == {"payload": {"items": [1]}}
+    finally:
+        blocked.release.set()
+        hub.close()
+
+
+def test_concurrent_publishers_have_one_identical_delivery_order():
+    hub = SessionEventHub()
+    left = RecordingTransport()
+    right = RecordingTransport()
+    start = threading.Barrier(3)
+    publication_count = 40
+
+    def publish(source: str) -> None:
+        start.wait(timeout=5)
+        for index in range(publication_count):
+            assert hub.publish({"source": source, "index": index})
+
+    try:
+        hub.attach(left, client_id="left", mode=AttachmentMode.OBSERVE)
+        hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
+        workers = [
+            threading.Thread(target=publish, args=(source,))
+            for source in ("a", "b")
+        ]
+        for worker in workers:
+            worker.start()
+        start.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=5)
+            assert not worker.is_alive()
+
+        left.wait_for_count(publication_count * 2)
+        right.wait_for_count(publication_count * 2)
+
+        assert left.frames == right.frames
+        assert len(left.frames) == publication_count * 2
+        for source in ("a", "b"):
+            assert [
+                frame["index"] for frame in left.frames if frame["source"] == source
+            ] == list(range(publication_count))
+    finally:
+        hub.close()
+
+
+def test_prepare_runs_inside_the_total_publication_order_before_fanout():
+    hub = SessionEventHub()
+    left = RecordingTransport()
+    right = RecordingTransport()
+    start = threading.Barrier(3)
+    next_sequence = 0
+
+    def prepare(frame: dict) -> None:
+        nonlocal next_sequence
+        next_sequence += 1
+        frame["seq"] = next_sequence
+
+    def publish(source: str) -> None:
+        start.wait(timeout=5)
+        for index in range(20):
+            assert hub.publish(
+                {"source": source, "index": index},
+                prepare=prepare,
+            )
+
+    try:
+        hub.attach(left, client_id="left", mode=AttachmentMode.OBSERVE)
+        hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
+        workers = [
+            threading.Thread(target=publish, args=(source,))
+            for source in ("a", "b")
+        ]
+        for worker in workers:
+            worker.start()
+        start.wait(timeout=5)
+        for worker in workers:
+            worker.join(timeout=5)
+            assert not worker.is_alive()
+
+        left.wait_for_count(40)
+        right.wait_for_count(40)
+
+        assert left.frames == right.frames
+        assert [frame["seq"] for frame in left.frames] == list(range(1, 41))
+    finally:
+        hub.close()
+
+
+def test_failed_writer_detaches_once_without_affecting_other_subscriber():
+    cleanup_calls: list[object] = []
+    cleaned = threading.Event()
+
+    def cleanup(transport: object) -> None:
+        cleanup_calls.append(transport)
+        cleaned.set()
+
+    class FailedTransport:
+        def write(self, frame: dict) -> bool:
+            raise RuntimeError("peer failed")
+
+    hub = SessionEventHub(on_detach=cleanup)
+    failed = FailedTransport()
+    healthy = RecordingTransport()
+    try:
+        hub.attach(failed, client_id="failed", mode=AttachmentMode.OBSERVE)
+        hub.attach(healthy, client_id="healthy", mode=AttachmentMode.OBSERVE)
+        assert hub.publish({"event": 1})
+
+        _wait(cleaned, "failed writer was not cleaned up")
+        _wait(healthy.written, "healthy writer was affected by peer failure")
+        assert not hub.has_transport(failed)
+        assert hub.has_transport(healthy)
+        assert healthy.frames == [{"event": 1}]
+
+        hub.detach(failed)
+        hub.close()
+        assert cleanup_calls.count(failed) == 1
+    finally:
+        hub.close()
+
+
+def test_queue_overflow_detaches_only_slow_subscriber(monkeypatch):
+    monkeypatch.setattr("tui_gateway.session_events.ATTACHMENT_QUEUE_MAX", 1)
+    cleanup_calls: list[object] = []
+    cleaned = threading.Event()
+
+    def cleanup(transport: object) -> None:
+        cleanup_calls.append(transport)
+        cleaned.set()
+
+    hub = SessionEventHub(on_detach=cleanup)
+    slow = BlockingTransport()
+    healthy = RecordingTransport()
+    try:
+        hub.attach(slow, client_id="slow", mode=AttachmentMode.OBSERVE)
+        hub.attach(healthy, client_id="healthy", mode=AttachmentMode.OBSERVE)
+        assert hub.publish({"event": 1})
+        _wait(slow.written, "slow writer did not consume the first queue item")
+        healthy.wait_for_count(1)
+        assert hub.publish({"event": 2})
+        healthy.wait_for_count(2)
+        assert hub.publish({"event": 3})
+
+        # Cleanup is deferred until the in-flight write exits, and a stale
+        # detach generation cannot race a reattach of the same transport.
+        with pytest.raises(RuntimeError, match="cleanup is still in progress"):
+            hub.attach(slow, client_id="slow-again", mode=AttachmentMode.OBSERVE)
+        slow.release.set()
+        _wait(cleaned, "overflowed subscriber was not cleaned up")
+        healthy.wait_for_count(3)
+
+        assert cleanup_calls == [slow]
+        assert not hub.has_transport(slow)
+        assert hub.has_transport(healthy)
+        assert healthy.frames == [{"event": 1}, {"event": 2}, {"event": 3}]
+
+        hub.attach(slow, client_id="slow-again", mode=AttachmentMode.OBSERVE)
+        assert hub.has_transport(slow)
+    finally:
+        slow.release.set()
+        hub.close()
+
+
+def test_detach_reports_a_writer_that_does_not_stop(monkeypatch):
+    monkeypatch.setattr(
+        "tui_gateway.session_events._WORKER_JOIN_TIMEOUT_SECONDS",
+        0.05,
+    )
+    cleaned = threading.Event()
+    hub = SessionEventHub(on_detach=lambda _transport: cleaned.set())
+    blocked = BlockingTransport()
+    hub.attach(blocked, client_id="blocked", mode=AttachmentMode.OBSERVE)
+    assert hub.publish({"event": 1})
+    _wait(blocked.written, "blocking writer was not entered")
+
+    with pytest.raises(RuntimeError, match="writer did not stop"):
+        hub.detach(blocked)
+    assert not cleaned.is_set()
+    with pytest.raises(RuntimeError, match="cleanup is still in progress"):
+        hub.attach(blocked, client_id="blocked", mode=AttachmentMode.OBSERVE)
+
+    blocked.release.set()
+    _wait(cleaned, "deferred cleanup did not run after writer exit")
+    hub.close()
+
+
+def test_frame_normalization_runs_custom_hooks_outside_publication_lock():
+    hub = SessionEventHub()
+    transport = RecordingTransport()
+    deepcopy_called = False
+
+    class ReentrantFrame(dict):
+        def __deepcopy__(self, memo):
+            nonlocal deepcopy_called
+            deepcopy_called = True
+            hub.publish({"reentrant": True})
+            return dict(self)
+
+    try:
+        hub.attach(transport, client_id="plain-json", mode=AttachmentMode.OBSERVE)
+        assert hub.publish(ReentrantFrame({"event": 1}))
+        transport.wait_for_count(1)
+
+        assert deepcopy_called is False
+        assert transport.frames == [{"event": 1}]
+    finally:
+        hub.close()
+
+
+def test_invalid_frame_fails_before_any_subscriber_receives_it():
+    hub = SessionEventHub()
+    left = RecordingTransport()
+    right = RecordingTransport()
+    try:
+        hub.attach(left, client_id="left", mode=AttachmentMode.OBSERVE)
+        hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
+
+        with pytest.raises(TypeError):
+            hub.publish({"not-json": object()})
+
+        assert left.frames == []
+        assert right.frames == []
+        assert hub.publish({"valid": True})
+        left.wait_for_count(1)
+        right.wait_for_count(1)
+    finally:
+        hub.close()
+
+
+def test_detach_and_close_stop_workers_and_are_idempotent():
+    hub = SessionEventHub()
+    first = RecordingTransport()
+    second = RecordingTransport()
+    hub.attach(first, client_id="worker-cleanup-first", mode=AttachmentMode.OBSERVE)
+    hub.attach(second, client_id="worker-cleanup-second", mode=AttachmentMode.CONTROL)
+
+    assert hub.detach(first) is True
+    assert hub.detach(first) is False
+    hub.close()
+    hub.close()
+
+    assert hub.count() == 0
+    assert hub.publish({"ignored": True}) is False
+    assert not any(
+        thread.is_alive() and thread.name.startswith("session-event-writer-worker-cleanup")
+        for thread in threading.enumerate()
+    )
+
+
+def test_writes_do_not_hold_registry_or_publication_locks():
+    hub = SessionEventHub()
+    reentered = threading.Event()
+
+    class ReentrantTransport:
+        def write(self, frame: dict) -> bool:
+            assert hub.has_transport(self)
+            if frame == {"event": 1}:
+                assert hub.publish({"event": 2})
+                reentered.set()
+            return True
+
+    transport = ReentrantTransport()
+    try:
+        hub.attach(transport, client_id="reentrant", mode=AttachmentMode.CONTROL)
+        assert hub.publish({"event": 1})
+        _wait(reentered, "transport write blocked on a hub lock")
+    finally:
+        hub.close()
+
+
+def test_snapshots_are_sanitized_plain_metadata():
+    hub = SessionEventHub()
+
+    class CredentialTransport(RecordingTransport):
+        token = "secret-token"
+
+    transport = CredentialTransport()
+    try:
+        hub.attach(transport, client_id="safe-id", mode=AttachmentMode.CONTROL)
+
+        snapshots = hub.snapshots()
+
+        assert snapshots == [
+            {
+                "client_id": "safe-id",
+                "mode": "control",
+                "capabilities": sorted(AttachmentMode.CONTROL.capabilities),
+            }
+        ]
+        assert transport not in snapshots[0].values()
+        assert "secret-token" not in repr(snapshots)
+    finally:
+        hub.close()
+
+
+def test_queue_bound_is_a_fixed_positive_module_constant():
+    assert isinstance(ATTACHMENT_QUEUE_MAX, int)
+    assert ATTACHMENT_QUEUE_MAX > 0

--- a/tests/tui_gateway/test_session_events.py
+++ b/tests/tui_gateway/test_session_events.py
@@ -31,7 +31,8 @@ class RecordingTransport:
     def wait_for_count(self, count: int) -> None:
         with self._condition:
             assert self._condition.wait_for(
-                lambda: len(self.frames) >= count, timeout=5,
+                lambda: len(self.frames) >= count,
+                timeout=5,
             ), f"transport received fewer than {count} frames"
 
 
@@ -60,22 +61,21 @@ def test_attachment_modes_parse_and_reject_invalid_values():
 
 def test_capabilities_are_immutable_and_match_protocol_contract():
     assert AttachmentMode.OBSERVE.capabilities == frozenset({"observe"})
-    assert AttachmentMode.CONTROL.capabilities == frozenset(
-        {
-            "observe",
-            "prompt.submit",
-            "session.steer",
-            "session.interrupt",
-            "approval.respond",
-            "clarify.respond",
-            "ui.respond",
-        }
-    )
+    assert AttachmentMode.CONTROL.capabilities == frozenset({
+        "observe",
+        "prompt.submit",
+        "session.steer",
+        "session.interrupt",
+        "approval.respond",
+        "clarify.respond",
+        "ui.respond",
+    })
     assert isinstance(AttachmentMode.CONTROL.capabilities, frozenset)
 
     supplied_capabilities = {"observe"}
     snapshot = AttachmentSnapshot(
-        client_id="client", mode=AttachmentMode.OBSERVE,
+        client_id="client",
+        mode=AttachmentMode.OBSERVE,
         capabilities=supplied_capabilities,  # type: ignore[arg-type]
     )
     supplied_capabilities.add("mutated")
@@ -89,10 +89,14 @@ def test_attach_is_idempotent_and_updates_mode_without_duplicate_delivery():
     transport = RecordingTransport()
     try:
         first = hub.attach(
-            transport, client_id="client-a", mode=AttachmentMode.OBSERVE,
+            transport,
+            client_id="client-a",
+            mode=AttachmentMode.OBSERVE,
         )
         second = hub.attach(
-            transport, client_id="client-a", mode=AttachmentMode.CONTROL,
+            transport,
+            client_id="client-a",
+            mode=AttachmentMode.CONTROL,
         )
 
         assert first.mode is AttachmentMode.OBSERVE
@@ -147,6 +151,31 @@ def test_publish_copies_one_frame_per_subscriber_and_returns_before_delivery():
         hub.close()
 
 
+def test_publish_can_wait_until_every_transport_write_completes():
+    hub = SessionEventHub()
+    blocked = BlockingTransport()
+    completed = threading.Event()
+
+    def publish() -> None:
+        assert hub.publish({"event": "resolved"}, wait_for_delivery=True) is True
+        completed.set()
+
+    try:
+        hub.attach(blocked, client_id="blocked", mode=AttachmentMode.OBSERVE)
+        worker = threading.Thread(target=publish)
+        worker.start()
+        _wait(blocked.written, "blocking writer was not entered")
+        assert not completed.is_set()
+        blocked.release.set()
+        _wait(completed, "synchronous publication did not acknowledge delivery")
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert blocked.frames == [{"event": "resolved"}]
+    finally:
+        blocked.release.set()
+        hub.close()
+
+
 def test_concurrent_publishers_have_one_identical_delivery_order():
     hub = SessionEventHub()
     left = RecordingTransport()
@@ -163,8 +192,7 @@ def test_concurrent_publishers_have_one_identical_delivery_order():
         hub.attach(left, client_id="left", mode=AttachmentMode.OBSERVE)
         hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
         workers = [
-            threading.Thread(target=publish, args=(source,))
-            for source in ("a", "b")
+            threading.Thread(target=publish, args=(source,)) for source in ("a", "b")
         ]
         for worker in workers:
             worker.start()
@@ -210,8 +238,7 @@ def test_prepare_runs_inside_the_total_publication_order_before_fanout():
         hub.attach(left, client_id="left", mode=AttachmentMode.OBSERVE)
         hub.attach(right, client_id="right", mode=AttachmentMode.OBSERVE)
         workers = [
-            threading.Thread(target=publish, args=(source,))
-            for source in ("a", "b")
+            threading.Thread(target=publish, args=(source,)) for source in ("a", "b")
         ]
         for worker in workers:
             worker.start()
@@ -225,6 +252,69 @@ def test_prepare_runs_inside_the_total_publication_order_before_fanout():
 
         assert left.frames == right.frames
         assert [frame["seq"] for frame in left.frames] == list(range(1, 41))
+    finally:
+        hub.close()
+
+
+def test_reconnect_does_not_wait_for_blocked_stale_writer():
+    hub = SessionEventHub()
+    stale = BlockingTransport()
+    replacement = RecordingTransport()
+    attach_done = threading.Event()
+    attach_error = []
+    try:
+        hub.attach(stale, client_id="stable-blocked", mode=AttachmentMode.OBSERVE)
+        assert hub.publish({"event": "block-stale"})
+        _wait(stale.written, "stale transport did not enter write")
+
+        def reconnect() -> None:
+            try:
+                hub.attach(
+                    replacement,
+                    client_id="stable-blocked",
+                    mode=AttachmentMode.CONTROL,
+                )
+            except Exception as exc:
+                attach_error.append(exc)
+            finally:
+                attach_done.set()
+
+        worker = threading.Thread(target=reconnect)
+        worker.start()
+        assert attach_done.wait(timeout=1), "reconnect waited for stale writer shutdown"
+        assert attach_error == []
+        assert hub.has_transport(replacement)
+        stale.release.set()
+        worker.join(timeout=5)
+    finally:
+        stale.release.set()
+        hub.close()
+
+
+def test_reconnect_replaces_transport_by_stable_client_id():
+    cleaned = []
+    cleanup_done = threading.Event()
+
+    def cleanup(transport: object) -> None:
+        cleaned.append(transport)
+        cleanup_done.set()
+
+    hub = SessionEventHub(on_detach=cleanup)
+    stale = RecordingTransport()
+    replacement = RecordingTransport()
+    try:
+        hub.attach(stale, client_id="stable-window", mode=AttachmentMode.OBSERVE)
+        hub.attach(replacement, client_id="stable-window", mode=AttachmentMode.CONTROL)
+
+        assert hub.count() == 1
+        assert hub.has_transport(stale) is False
+        assert hub.has_transport(replacement) is True
+        _wait(cleanup_done, "stale reconnect generation was not cleaned up")
+        assert cleaned == [stale]
+        assert hub.publish({"event": "after-reconnect"})
+        replacement.wait_for_count(1)
+        assert stale.frames == []
+        assert replacement.frames == [{"event": "after-reconnect"}]
     finally:
         hub.close()
 
@@ -385,7 +475,8 @@ def test_detach_and_close_stop_workers_and_are_idempotent():
     assert hub.count() == 0
     assert hub.publish({"ignored": True}) is False
     assert not any(
-        thread.is_alive() and thread.name.startswith("session-event-writer-worker-cleanup")
+        thread.is_alive()
+        and thread.name.startswith("session-event-writer-worker-cleanup")
         for thread in threading.enumerate()
     )
 
@@ -407,6 +498,27 @@ def test_writes_do_not_hold_registry_or_publication_locks():
         hub.attach(transport, client_id="reentrant", mode=AttachmentMode.CONTROL)
         assert hub.publish({"event": 1})
         _wait(reentered, "transport write blocked on a hub lock")
+    finally:
+        hub.close()
+
+
+def test_capability_lookup_is_bound_to_attached_transport():
+    hub = SessionEventHub()
+    observer = RecordingTransport()
+    controller = RecordingTransport()
+    stranger = RecordingTransport()
+    try:
+        hub.attach(observer, client_id="observer", mode=AttachmentMode.OBSERVE)
+        hub.attach(controller, client_id="controller", mode=AttachmentMode.CONTROL)
+
+        observer_capabilities = hub.require(observer, "observe")
+        controller_capabilities = hub.require(controller, "prompt.submit")
+        assert observer_capabilities is None
+        assert controller_capabilities is None
+        with pytest.raises(PermissionError, match="requires capability"):
+            hub.require(observer, "prompt.submit")
+        with pytest.raises(PermissionError, match="not attached"):
+            hub.require(stranger, "observe")
     finally:
         hub.close()
 

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -100,7 +100,9 @@ def profile_dbs(monkeypatch, tmp_path):
     monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
     monkeypatch.setattr(server, "_find_live_session_by_key", lambda _key: None)
     monkeypatch.setattr(server, "_schedule_agent_build", lambda *a, **k: None)
-    monkeypatch.setattr(server, "_schedule_session_cap_enforcement", lambda *a, **k: None)
+    monkeypatch.setattr(
+        server, "_schedule_session_cap_enforcement", lambda *a, **k: None
+    )
     monkeypatch.setattr(server, "_maybe_schedule_auto_continue", lambda *a, **k: None)
     monkeypatch.setattr(server, "_default_session_cwd", lambda *a, **k: str(tmp_path))
     known = set(server._sessions)
@@ -111,9 +113,11 @@ def profile_dbs(monkeypatch, tmp_path):
 
 
 def _resume(**params):
-    return server.handle_request(
-        {"id": "1", "method": "session.resume", "params": params}
-    )
+    return server.handle_request({
+        "id": "1",
+        "method": "session.resume",
+        "params": params,
+    })
 
 
 def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
@@ -171,11 +175,13 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
     live_session = {}
     with server._sessions_lock:
         server._sessions["live-sid"] = live_session
-    monkeypatch.setattr(
-        server,
-        "_find_live_session_by_key",
-        lambda _key: ("live-sid", live_session),
-    )
+    runtime_lookups = []
+
+    def _find_runtime(runtime_key, profile_home=None):
+        runtime_lookups.append((runtime_key, profile_home))
+        return "live-sid", live_session
+
+    monkeypatch.setattr(server, "_find_live_session_by_runtime_key", _find_runtime)
     monkeypatch.setattr(
         server,
         "_live_session_payload",
@@ -186,6 +192,7 @@ def test_resume_closes_profile_db_on_live_session_fast_path(profile_dbs, monkeyp
     resp = _resume(session_id="s1", profile="work")
 
     assert resp["result"]["resumed"] == "s1"
+    assert runtime_lookups and runtime_lookups[0][0] == "s1"
     assert profile_dbs[0].closed == 1
 
 
@@ -241,9 +248,7 @@ def test_resume_hands_profile_db_to_deferred_history_worker(profile_dbs, monkeyp
     monkeypatch.setattr(server, "_start_agent_build", lambda *_args, **_kwargs: None)
 
     try:
-        resp = _resume(
-            session_id="s1", profile="work", defer_history=True
-        )
+        resp = _resume(session_id="s1", profile="work", defer_history=True)
         sid = resp["result"]["session_id"]
         db = profile_dbs[0]
         assert history_started.wait(timeout=1.0)
@@ -257,7 +262,9 @@ def test_resume_hands_profile_db_to_deferred_history_worker(profile_dbs, monkeyp
         release_history.set()
 
 
-def test_resume_keeps_profile_db_open_after_ownership_transfer(profile_dbs, monkeypatch):
+def test_resume_keeps_profile_db_open_after_ownership_transfer(
+    profile_dbs, monkeypatch
+):
     """A COMPLETED resume transfers the handle to the agent — do not close it.
 
     Guards the other direction: closing here would hand the live session a dead
@@ -374,9 +381,7 @@ def test_resume_eager_never_transfers_shared_launch_db(profile_dbs, monkeypatch)
     monkeypatch.setattr(server, "_init_session", _fake_init_session)
     monkeypatch.setattr(server, "_set_session_context", lambda _target: [])
     monkeypatch.setattr(server, "_clear_session_context", lambda _tokens: None)
-    monkeypatch.setattr(
-        server, "_stored_session_runtime_overrides", lambda _found: {}
-    )
+    monkeypatch.setattr(server, "_stored_session_runtime_overrides", lambda _found: {})
     monkeypatch.setattr(server, "_session_info", lambda agent, *a: {"model": "test"})
 
     resp = _resume(session_id="s1", eager_build=True)

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -490,6 +490,12 @@ class ComputeHost:
                 session,
                 text,
                 display_kind=frame.get("display_kind") or None,
+                client_message_id=frame.get("client_message_id") or None,
+                display_text=(
+                    frame.get("display_text") if "display_text" in frame else None
+                ),
+                submitted_at=frame.get("submitted_at"),
+                attachment_refs=frame.get("attachment_refs"),
             )
             run_thread = session.get("_run_thread")
             if run_thread is not None and hasattr(run_thread, "join"):

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -44,12 +44,21 @@ _replay_lock = threading.Lock()
 # ``params`` dict (bare event: type/session_id/seq/payload) — the exact shape
 # the client's dispatch path consumes.
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
-_replay_next_seq: dict[str, int] = {}
+_replay_next_seq: "OrderedDict[str, int]" = OrderedDict()
 
 
 def replay_epoch() -> str:
     """Opaque token identifying this server process's seq numbering."""
     return _REPLAY_EPOCH
+
+
+def _roll_replay_epoch_locked() -> None:
+    """Start a new bounded numbering epoch and update retained snapshots."""
+    global _REPLAY_EPOCH
+    _REPLAY_EPOCH = uuid.uuid4().hex
+    for buffer in _replay_buffers.values():
+        for _seq, event in buffer:
+            event["epoch"] = _REPLAY_EPOCH
 
 
 def _stamp_event(obj: dict) -> None:
@@ -69,19 +78,26 @@ def _stamp_event(obj: dict) -> None:
     # hooks from running while replay state is locked.
     recorded_params = json.loads(json.dumps(params, ensure_ascii=False))
     with _replay_lock:
+        if (
+            sid not in _replay_next_seq
+            and len(_replay_next_seq) >= _REPLAY_SESSIONS_MAX
+        ):
+            oldest_sid, _oldest_seq = _replay_next_seq.popitem(last=False)
+            _replay_buffers.pop(oldest_sid, None)
+            # A bounded counter map necessarily permits numbering to restart
+            # for an evicted runtime. Rotate the explicit epoch first so no
+            # client can mistake the new seq=1 for an old event.
+            _roll_replay_epoch_locked()
         seq = _replay_next_seq.get(sid, 0) + 1
         _replay_next_seq[sid] = seq
         params["seq"] = seq
+        params["epoch"] = _REPLAY_EPOCH
         recorded_params["seq"] = seq
+        recorded_params["epoch"] = _REPLAY_EPOCH
         buf = _replay_buffers.get(sid)
         if buf is None:
             buf = deque(maxlen=_REPLAY_BUFFER_MAX)
             _replay_buffers[sid] = buf
-            while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
-                _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
-                # Keep the sequence counter for the life of this replay epoch.
-                # Reusing seq=1 after buffer eviction would make clients with a
-                # prior watermark silently ignore every future event.
         buf.append((seq, recorded_params))
 
 
@@ -143,6 +159,7 @@ def replay_stats() -> dict:
     with _replay_lock:
         return {
             "sessions": len(_replay_buffers),
+            "sequence_sessions": len(_replay_next_seq),
             "events": sum(len(b) for b in _replay_buffers.values()),
             "max_per_session": _REPLAY_BUFFER_MAX,
         }

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -9,15 +9,18 @@ replays everything newer from the buffer, then live events resume seamlessly.
 Design constraints honored:
 - stdio TUI path unaffected: frames gain a ``seq`` field only on event frames;
   Ink ignores unknown params keys.
-- Thread safety: a single module lock guards counters + buffers; write_json
-  already serializes per-transport writes, so stamping under the lock cannot
-  reorder frames relative to each other.
+- Thread safety: a single module lock guards counters + buffers. Multi-client
+  sessions call stamping from SessionEventHub's publication boundary so seq,
+  replay, and fan-out delivery share one total order; the legacy single-sink
+  path retains its historical transport serialization.
 - Memory bound: _REPLAY_BUFFER_MAX events / _REPLAY_SESSIONS_MAX sessions,
   oldest session evicted FIFO.
 """
 
 from __future__ import annotations
 
+import copy
+import json
 import threading
 import uuid
 from collections import OrderedDict, deque
@@ -61,18 +64,25 @@ def _stamp_event(obj: dict) -> None:
         # Session-less global events (skin.changed etc.) are re-fetchable via
         # their own RPCs; no replay contract for them.
         return
+    # Normalize before entering the replay lock. Besides making the ring a
+    # defensive snapshot, this keeps arbitrary mapping/value serialization
+    # hooks from running while replay state is locked.
+    recorded_params = json.loads(json.dumps(params, ensure_ascii=False))
     with _replay_lock:
         seq = _replay_next_seq.get(sid, 0) + 1
         _replay_next_seq[sid] = seq
         params["seq"] = seq
+        recorded_params["seq"] = seq
         buf = _replay_buffers.get(sid)
         if buf is None:
             buf = deque(maxlen=_REPLAY_BUFFER_MAX)
             _replay_buffers[sid] = buf
             while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
                 _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
-                _replay_next_seq.pop(_oldest_sid, None)
-        buf.append((seq, params))
+                # Keep the sequence counter for the life of this replay epoch.
+                # Reusing seq=1 after buffer eviction would make clients with a
+                # prior watermark silently ignore every future event.
+        buf.append((seq, recorded_params))
 
 
 def events_since(sid: str, last_seen: int) -> list[dict]:
@@ -88,7 +98,7 @@ def events_since(sid: str, last_seen: int) -> list[dict]:
         buf = _replay_buffers.get(sid or "")
         if not buf:
             return []
-        return [event for seq, event in buf if seq > last_seen]
+        return [copy.deepcopy(event) for seq, event in buf if seq > last_seen]
 
 
 def is_truncated(sid: str, last_seen: int) -> bool:
@@ -98,14 +108,27 @@ def is_truncated(sid: str, last_seen: int) -> bool:
     with _replay_lock:
         buf = _replay_buffers.get(sid or "")
         if not buf:
-            return False
-        return last_seen + 1 < buf[0][0]
+            # A missing buffer can mean "never emitted" or "fully evicted".
+            # The retained counter distinguishes them so reconnecting clients
+            # are told to resync instead of silently accepting an empty gap.
+            return _replay_next_seq.get(sid or "", 0) > last_seen
+        earliest = buf[0][0]
+        return last_seen + 1 < earliest
 
 
 def latest_seq(sid: str) -> int:
     """Current highest stamped seq for *sid* (0 when unknown)."""
     with _replay_lock:
         return _replay_next_seq.get(sid or "", 0)
+
+
+def release_session(sid: str) -> None:
+    """Discard replay state after the live runtime has been fully torn down."""
+    if not sid:
+        return
+    with _replay_lock:
+        _replay_buffers.pop(sid, None)
+        _replay_next_seq.pop(sid, None)
 
 
 def reset_replay_state() -> None:

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -18,9 +18,7 @@ def _history_user_indices(history: list) -> list:
     from agent.context_compressor import user_originated_turn_view
 
     return [
-        i
-        for i, m in enumerate(history)
-        if user_originated_turn_view(m) is not None
+        i for i, m in enumerate(history) if user_originated_turn_view(m) is not None
     ]
 
 
@@ -61,15 +59,14 @@ def _mem_db_pair_agrees(mem, db_msg) -> bool:
         if (mem_view is None) != (db_view is None):
             return False
         if mem_view is None:
-            return bool(mem.get("display_kind")) == bool(
-                db_msg.get("display_kind")
-            )
+            return bool(mem.get("display_kind")) == bool(db_msg.get("display_kind"))
         mem_content = mem_view.get("content")
         db_content = db_view.get("content")
         if isinstance(mem_content, str) and isinstance(db_content, str):
-            if sanitize_context(mem_content).strip() != sanitize_context(
-                db_content
-            ).strip():
+            if (
+                sanitize_context(mem_content).strip()
+                != sanitize_context(db_content).strip()
+            ):
                 return False
         return True
     if bool(mem.get("display_kind")) != bool(db_msg.get("display_kind")):
@@ -141,8 +138,7 @@ def _resolve_truncate_row_id(session: dict, history: list, target_row_id: int):
     # durable row. Stamp only when EVERY pair agrees (all-or-nothing): roles
     # must match on every pair, and addressable user turns must match content.
     if len(db_history) == len(history) and all(
-        _mem_db_pair_agrees(mem, db_msg)
-        for mem, db_msg in zip(history, db_history)
+        _mem_db_pair_agrees(mem, db_msg) for mem, db_msg in zip(history, db_history)
     ):
         for mem, db_msg in zip(history, db_history):
             db_rid = _message_row_id(db_msg) if isinstance(db_msg, dict) else None
@@ -186,7 +182,12 @@ def _coerce_truncate_int(rid, value, param_name="truncate_before_user_ordinal"):
 
 
 def _reconcile_client_ordinal(
-    rid, sid, client_ordinal, msg_ordinal, param_name, target_repr,
+    rid,
+    sid,
+    client_ordinal,
+    msg_ordinal,
+    param_name,
+    target_repr,
     prefix_user_count=0,
 ):
     """Cross-check a client ordinal against a resolved durable target.
@@ -250,7 +251,9 @@ def _pending_reaction_notes(session: dict) -> str:
     # model hears nothing, even about reactions set while it was on.
     try:
         display = _load_cfg().get("display")
-        if not (isinstance(display, dict) and bool(display.get("message_reactions", False))):
+        if not (
+            isinstance(display, dict) and bool(display.get("message_reactions", False))
+        ):
             return ""
     except Exception:
         return ""
@@ -290,7 +293,9 @@ def _(rid, params: dict) -> dict:
 
     sid = params.get("session_id", "")
     raw_text = params.get("text", "")
-    text = sanitize_user_prompt_text(raw_text) if isinstance(raw_text, str) else raw_text
+    text = (
+        sanitize_user_prompt_text(raw_text) if isinstance(raw_text, str) else raw_text
+    )
     # Off-screen sends (widget intents): type the persisted user row so no
     # client renders it as a bubble. Whitelisted to "hidden" — display_kind
     # is a DB-only sidecar and this RPC must not mint arbitrary kinds.
@@ -374,8 +379,13 @@ def _(rid, params: dict) -> dict:
             else:
                 break
         busy_response = _handle_busy_submit(
-            rid, sid, session, text, busy_transport,
+            rid,
+            sid,
+            session,
+            text,
+            busy_transport,
             queued=bool(params.get("queued")),
+            origin_client_id=_legacy_client_id_for_transport(busy_transport),
         )
         if busy_response is not None:
             return busy_response
@@ -404,7 +414,9 @@ def _(rid, params: dict) -> dict:
         # racing the in-flight child on the same stored session (interleaved
         # transcript, stale fork). After the run completes, submitting is fine:
         # the upgrade resumes the child's transcript as a normal conversation.
-        if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
+        if session.get("lazy") and _child_run_active(
+            str(session.get("session_key") or "")
+        ):
             return _err(rid, 4009, "subagent still running — wait for it to finish")
         truncate_message_id = params.get("truncate_before_message_id")
         truncate_row_id = params.get("truncate_before_row_id")
@@ -424,9 +436,7 @@ def _(rid, params: dict) -> dict:
             or truncate_message_id is not None
             or truncate_row_id is not None
         ):
-            history = _history_without_ephemeral_scaffolding(
-                session.get("history", [])
-            )
+            history = _history_without_ephemeral_scaffolding(session.get("history", []))
 
             # Malformed params refuse first (4004), regardless of consent —
             # the historical ordinal-path precedence.
@@ -484,9 +494,7 @@ def _(rid, params: dict) -> dict:
             # of loading ancestors into the tip (which would duplicate
             # compressed history on later resumes).
             prefix_user_count = len(
-                _history_user_indices(
-                    session.get("display_history_prefix") or []
-                )
+                _history_user_indices(session.get("display_history_prefix") or [])
             )
 
             user_indices = _history_user_indices(history)
@@ -515,9 +523,7 @@ def _(rid, params: dict) -> dict:
                 # client ordinal cut (#82959 / #82766 review). Unknown id refuses
                 # without touching data; stale ordinal with a *resolved* row_id
                 # is a separate 4030 mismatch below.
-                found_match = _resolve_truncate_row_id(
-                    session, history, target_row_id
-                )
+                found_match = _resolve_truncate_row_id(session, history, target_row_id)
 
                 if found_match is None:
                     logger.warning(
@@ -535,8 +541,12 @@ def _(rid, params: dict) -> dict:
 
                 msg_ordinal, _ = found_match
                 ordinal, err = _reconcile_client_ordinal(
-                    rid, sid, client_ordinal, msg_ordinal,
-                    "truncate_before_row_id", target_row_id,
+                    rid,
+                    sid,
+                    client_ordinal,
+                    msg_ordinal,
+                    "truncate_before_row_id",
+                    target_row_id,
                     prefix_user_count=prefix_user_count,
                 )
                 if err is not None:
@@ -546,7 +556,10 @@ def _(rid, params: dict) -> dict:
                 found_match = None
                 for u_ord, h_idx in enumerate(user_indices):
                     msg = history[h_idx]
-                    if msg.get("id") == msg_id_str or msg.get("message_id") == msg_id_str:
+                    if (
+                        msg.get("id") == msg_id_str
+                        or msg.get("message_id") == msg_id_str
+                    ):
                         found_match = (u_ord, h_idx)
                         break
 
@@ -569,8 +582,12 @@ def _(rid, params: dict) -> dict:
 
                 msg_ordinal, _ = found_match
                 ordinal, err = _reconcile_client_ordinal(
-                    rid, sid, client_ordinal, msg_ordinal,
-                    "truncate_before_message_id", msg_id_str,
+                    rid,
+                    sid,
+                    client_ordinal,
+                    msg_ordinal,
+                    "truncate_before_message_id",
+                    msg_id_str,
                     prefix_user_count=prefix_user_count,
                 )
                 if err is not None:
@@ -716,9 +733,7 @@ def _(rid, params: dict) -> dict:
                         old_active_row_ids = {
                             row_id
                             for message in history
-                            if isinstance(
-                                (row_id := _message_row_id(message)), int
-                            )
+                            if isinstance((row_id := _message_row_id(message)), int)
                         }
                         if requested_rebind_ids is not None:
                             # Row-id fallback can resolve a durable target even
@@ -728,12 +743,10 @@ def _(rid, params: dict) -> dict:
                             # authoritative un-repaired pre-write active-id set so
                             # a rewritten row is never mistaken for an untouched
                             # archived/ancestor row by the bounded client map.
-                            durable_rebind_history = (
-                                _load_durable_truncation_history(
-                                    session,
-                                    truncation_key,
-                                    repair_alternation=False,
-                                )
+                            durable_rebind_history = _load_durable_truncation_history(
+                                session,
+                                truncation_key,
+                                repair_alternation=False,
                             )
                             if durable_rebind_history is None:
                                 raise RuntimeError(
@@ -742,9 +755,7 @@ def _(rid, params: dict) -> dict:
                             old_active_row_ids.update(
                                 row_id
                                 for message in durable_rebind_history
-                                if isinstance(
-                                    (row_id := _message_row_id(message)), int
-                                )
+                                if isinstance((row_id := _message_row_id(message)), int)
                             )
                         old_survivor_row_ids = [
                             _message_row_id(message) for message in truncated
@@ -792,10 +803,7 @@ def _(rid, params: dict) -> dict:
                             str(old_row_id): new_row_id
                             for old_row_id, new_row_id in zip(
                                 old_survivor_row_ids,
-                                (
-                                    _message_row_id(message)
-                                    for message in truncated
-                                ),
+                                (_message_row_id(message) for message in truncated),
                             )
                             if isinstance(old_row_id, int)
                             and isinstance(new_row_id, int)
@@ -804,15 +812,20 @@ def _(rid, params: dict) -> dict:
                         for dropped_row_id in requested_rebind_ids.intersection(
                             old_active_row_ids
                         ):
-                            survivor_row_id_map.setdefault(
-                                str(dropped_row_id), None
-                            )
+                            survivor_row_id_map.setdefault(str(dropped_row_id), None)
             session["history"] = truncated
             session["history_version"] = int(session.get("history_version", 0)) + 1
         session["running"] = True
         session["_turn_cancel_requested"] = False
         session["last_active"] = time.time()
-        _start_inflight_turn(session, text)
+        _start_inflight_turn(
+            session,
+            text,
+            origin_client_id=_legacy_client_id_for_transport(
+                t or session.get("transport")
+            ),
+            request_id=str(rid),
+        )
 
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(
@@ -823,9 +836,9 @@ def _(rid, params: dict) -> dict:
                 # The truncation already happened inline above (memory + DB),
                 # before compute-host dispatch — the rebind payload applies to
                 # this path exactly as it does to the inline one.
-                isolated_response["result"][
-                    "survivor_user_row_ids"
-                ] = survivor_user_row_ids
+                isolated_response["result"]["survivor_user_row_ids"] = (
+                    survivor_user_row_ids
+                )
             if survivor_row_id_map is not None:
                 isolated_response["result"]["survivor_row_id_map"] = survivor_row_id_map
             return isolated_response
@@ -881,7 +894,11 @@ def _(rid, params: dict) -> dict:
                 (err.get("error") or {}).get("message", "agent initialization failed"),
                 # Agent construction never reached the provider: this is a
                 # local-runtime failure (env/config/venv), not an API error.
-                error_surface={"layer": "runtime", "code": "agent_init_failed", "retryable": True},
+                error_surface={
+                    "layer": "runtime",
+                    "code": "agent_init_failed",
+                    "retryable": True,
+                },
             )
             with session["history_lock"]:
                 session["running"] = False
@@ -921,8 +938,7 @@ def _(rid, params: dict) -> dict:
             "status": "streaming",
             **(
                 {"survivor_user_row_ids": survivor_user_row_ids}
-                if survivor_user_row_ids is not None
-                and requested_rebind_ids is None
+                if survivor_user_row_ids is not None and requested_rebind_ids is None
                 else {}
             ),
             **(
@@ -1049,7 +1065,9 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4017, "image is empty")
     if len(img_bytes) > _ATTACH_BYTES_MAX_BYTES:
         mb = _ATTACH_BYTES_MAX_BYTES // (1024 * 1024)
-        return _err(rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)")
+        return _err(
+            rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)"
+        )
 
     filename = str(params.get("filename", "") or "")
     ext_hint = str(params.get("ext", "") or "").strip().lower()
@@ -1099,7 +1117,9 @@ def _(rid, params: dict) -> dict:
         return err
 
     if shutil.which("pdftoppm") is None:
-        return _err(rid, 5028, "pdftoppm not installed (poppler-utils package required)")
+        return _err(
+            rid, 5028, "pdftoppm not installed (poppler-utils package required)"
+        )
 
     raw_path = str(params.get("path", "") or "").strip()
     raw_b64 = str(params.get("content_base64") or params.get("data") or "").strip()
@@ -1116,9 +1136,13 @@ def _(rid, params: dict) -> dict:
                 return _err(rid, 4017, "decoded PDF is empty")
             if len(pdf_bytes) > _PDF_ATTACH_MAX_BYTES:
                 mb = _PDF_ATTACH_MAX_BYTES // (1024 * 1024)
-                return _err(rid, 4018, f"PDF too large ({len(pdf_bytes)} bytes; cap is {mb} MB)")
+                return _err(
+                    rid, 4018, f"PDF too large ({len(pdf_bytes)} bytes; cap is {mb} MB)"
+                )
             if pdf_bytes[:5] != b"%PDF-":
-                return _err(rid, 4017, "payload is not a PDF (missing %PDF- magic bytes)")
+                return _err(
+                    rid, 4017, "payload is not a PDF (missing %PDF- magic bytes)"
+                )
             pdf_path = td_path / "input.pdf"
             pdf_path.write_bytes(pdf_bytes)
             display_name = str(params.get("filename", "") or "uploaded.pdf")
@@ -1153,22 +1177,38 @@ def _(rid, params: dict) -> dict:
         if last_page < first_page:
             return _err(rid, 4015, "last_page must be >= first_page")
         if last_page - first_page + 1 > _PDF_ATTACH_MAX_PAGES:
-            return _err(rid, 4019, f"page range exceeds cap of {_PDF_ATTACH_MAX_PAGES} pages per attach call")
+            return _err(
+                rid,
+                4019,
+                f"page range exceeds cap of {_PDF_ATTACH_MAX_PAGES} pages per attach call",
+            )
 
         out_prefix = td_path / "page"
         argv = [
-            "pdftoppm", "-png", "-r", "150",
-            "-f", str(first_page), "-l", str(last_page),
-            str(pdf_path), str(out_prefix),
+            "pdftoppm",
+            "-png",
+            "-r",
+            "150",
+            "-f",
+            str(first_page),
+            "-l",
+            str(last_page),
+            str(pdf_path),
+            str(out_prefix),
         ]
         from hermes_cli._subprocess_compat import windows_hide_flags
 
         try:
             res = subprocess.run(
-                argv, capture_output=True, text=True, timeout=120, stdin=subprocess.DEVNULL,
+                argv,
+                capture_output=True,
+                text=True,
+                timeout=120,
+                stdin=subprocess.DEVNULL,
                 # Force UTF-8 + lossy decode so non-UTF-8 child output can't
                 # crash the gateway thread on locale-mismatched Windows (#53137).
-                encoding="utf-8", errors="replace",
+                encoding="utf-8",
+                errors="replace",
                 creationflags=windows_hide_flags(),
             )
         except subprocess.TimeoutExpired:
@@ -1188,8 +1228,14 @@ def _(rid, params: dict) -> dict:
                 page_int = int(page_num)
             except ValueError:
                 page_int = first_page + len(attached_pages)
-            dst = _queue_attached_image(session, src.read_bytes(), ".png", prefix=f"pdf_p{page_num}")
-            attached_pages.append({"path": str(dst), "page": page_int, **_image_meta(dst)})
+            dst = _queue_attached_image(
+                session, src.read_bytes(), ".png", prefix=f"pdf_p{page_num}"
+            )
+            attached_pages.append({
+                "path": str(dst),
+                "page": page_int,
+                **_image_meta(dst),
+            })
 
         return _ok(
             rid,
@@ -1442,7 +1488,9 @@ def _(rid, params: dict) -> dict:
     def run():
         # Pin the validated preview cwd, else the parent workspace — never an
         # invalid client path, which would silently fall back to the launch dir.
-        session_tokens = _set_session_context(task_id, cwd=(preview_cwd or _session_cwd(session)))
+        session_tokens = _set_session_context(
+            task_id, cwd=(preview_cwd or _session_cwd(session))
+        )
         try:
             from run_agent import AIAgent
             from tools.terminal_tool import register_task_env_overrides
@@ -1458,7 +1506,10 @@ def _(rid, params: dict) -> dict:
             _emit(
                 "preview.restart.progress",
                 parent,
-                {"task_id": task_id, "text": f"Starting hidden restart agent{history_note}"},
+                {
+                    "task_id": task_id,
+                    "text": f"Starting hidden restart agent{history_note}",
+                },
             )
             # Bug #50233: ephemeral preview-restart agent threads don't inherit
             # the session's HERMES_HOME override (the ContextVar set on the
@@ -1492,7 +1543,9 @@ def _(rid, params: dict) -> dict:
                 if isinstance(result, dict)
                 else str(result)
             )
-            _emit("preview.restart.complete", parent, {"task_id": task_id, "text": text})
+            _emit(
+                "preview.restart.complete", parent, {"task_id": task_id, "text": text}
+            )
         except Exception as e:
             _emit(
                 "preview.restart.complete",
@@ -1646,9 +1699,7 @@ def _approval_respond_session_fallback(params: dict):
                     if str(pending.get("request_id") or "") == request_id:
                         return session
         except Exception:
-            logger.debug(
-                "approval.respond request_id fallback failed", exc_info=True
-            )
+            logger.debug("approval.respond request_id fallback failed", exc_info=True)
     target = str(params.get("session_id") or "")
     if target:
         try:
@@ -1656,14 +1707,15 @@ def _approval_respond_session_fallback(params: dict):
             if live is not None:
                 return live[1]
         except Exception:
-            logger.debug(
-                "approval.respond stored-id fallback failed", exc_info=True
-            )
+            logger.debug("approval.respond stored-id fallback failed", exc_info=True)
     return None
 
 
 @method("approval.respond")
 def _(rid, params: dict) -> dict:
+    choice = params.get("choice", "deny")
+    if choice not in {"once", "session", "always", "deny"}:
+        return _err(rid, 4002, "choice must be once, session, always, or deny")
     session, err = _sess(params, rid)
     if err:
         # Session-not-found (4001) only: the client may hold a stale live
@@ -1678,17 +1730,51 @@ def _(rid, params: dict) -> dict:
     try:
         from tools.approval import resolve_gateway_approval
 
-        return _ok(
-            rid,
-            {
-                "resolved": resolve_gateway_approval(
+        request_id = str(params.get("request_id") or "")
+        outcome_key = (str(session["session_key"]), request_id)
+        should_emit = False
+        with _approval_resolution_lock:
+            previous_choice = (
+                _approval_resolution_outcomes.get(outcome_key) if request_id else None
+            )
+            if previous_choice is not None:
+                resolved = 0
+                status = "already_resolved"
+                selected_choice = previous_choice
+            else:
+                resolved = resolve_gateway_approval(
                     session["session_key"],
-                    params.get("choice", "deny"),
+                    choice,
                     resolve_all=params.get("all", False),
-                    request_id=params.get("request_id"),
+                    request_id=request_id or None,
                 )
-            },
-        )
+                status = "resolved" if resolved else "expired"
+                selected_choice = choice
+                if resolved and request_id:
+                    _approval_resolution_outcomes[outcome_key] = choice
+                    while (
+                        len(_approval_resolution_outcomes)
+                        > _APPROVAL_RESOLUTION_OUTCOMES_MAX
+                    ):
+                        _approval_resolution_outcomes.pop(
+                            next(iter(_approval_resolution_outcomes))
+                        )
+                    should_emit = True
+        payload = {
+            "request_id": request_id or None,
+            "choice": selected_choice,
+            "status": status,
+            "resolved": resolved,
+        }
+        if should_emit:
+            if not _emit(
+                "approval.resolved",
+                str(params.get("session_id") or ""),
+                payload,
+                wait_for_delivery=True,
+            ):
+                return _err(rid, 5004, "approval resolved but event delivery failed")
+        return _ok(rid, payload)
     except Exception as e:
         return _err(rid, 5004, str(e))
 

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -300,6 +300,32 @@ def _(rid, params: dict) -> dict:
     # client renders it as a bubble. Whitelisted to "hidden" — display_kind
     # is a DB-only sidecar and this RPC must not mint arbitrary kinds.
     display_kind = "hidden" if params.get("display_kind") == "hidden" else None
+    client_message_id = params.get("client_message_id")
+    if not isinstance(client_message_id, str) or not client_message_id.strip():
+        client_message_id = None
+    else:
+        client_message_id = client_message_id.strip()[:256]
+    raw_display_text = params.get("display_text")
+    display_text = (
+        sanitize_user_prompt_text(raw_display_text)
+        if isinstance(raw_display_text, str)
+        else None
+    )
+    submitted_at = params.get("submitted_at")
+    if not isinstance(submitted_at, (int, float)) or isinstance(submitted_at, bool):
+        submitted_at = None
+    elif not 0 < submitted_at <= 4_102_444_800:
+        # Reject NaN/infinity and implausible dates before JSON event encoding.
+        submitted_at = None
+    attachment_refs = params.get("attachment_refs")
+    if isinstance(attachment_refs, list):
+        attachment_refs = [
+            ref[:4096]
+            for ref in attachment_refs[:128]
+            if isinstance(ref, str) and ref
+        ]
+    else:
+        attachment_refs = None
     # Typed bare stop phrase while backend voice mode is active ends the
     # voice chat instead of sending "stop" to the agent — the typed twin of
     # the spoken stop phrase (PR #73106), applied at the ONE server-side
@@ -829,7 +855,15 @@ def _(rid, params: dict) -> dict:
 
     if turn_isolation:
         isolated_response = _submit_prompt_to_compute_host(
-            rid, sid, session, text, display_kind=display_kind
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            client_message_id=client_message_id,
+            display_text=display_text,
+            submitted_at=submitted_at,
+            attachment_refs=attachment_refs,
         )
         if not isolated_response.get("error"):
             if survivor_user_row_ids is not None and requested_rebind_ids is None:
@@ -925,7 +959,17 @@ def _(rid, params: dict) -> dict:
                     },
                 )
                 return
-        _run_prompt_submit(rid, sid, session, text, display_kind=display_kind)
+        _run_prompt_submit(
+            rid,
+            sid,
+            session,
+            text,
+            display_kind=display_kind,
+            client_message_id=client_message_id,
+            display_text=display_text,
+            submitted_at=submitted_at,
+            attachment_refs=attachment_refs,
+        )
 
     run_thread = threading.Thread(target=run_after_agent_ready, daemon=True)
     # Keep a handle so session.interrupt can tell a live turn from a stuck

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -28,11 +28,16 @@ def _(rid, params: dict) -> dict:
     # workspace" instead of whatever folder the desktop launched in.
     raw_cwd = str(params.get("cwd") or "").strip()
     try:
-        explicit_cwd = bool(raw_cwd) and os.path.isdir(os.path.abspath(os.path.expanduser(raw_cwd)))
+        explicit_cwd = bool(raw_cwd) and os.path.isdir(
+            os.path.abspath(os.path.expanduser(raw_cwd))
+        )
     except Exception:
         explicit_cwd = False
     resolved_cwd = _completion_cwd(params)
     source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+    from tui_gateway.session_events import AttachmentMode
+
+    attachment_mode = AttachmentMode.parse(params.get("attachment_mode", "control"))
     _enable_gateway_prompts()
 
     # ``profile`` (app-global remote mode): a new chat started under a non-launch
@@ -49,7 +54,10 @@ def _(rid, params: dict) -> dict:
     # (resolved at build).
     create_model = str(params.get("model") or "").strip()
     session_model_override = (
-        {"model": create_model, "provider": str(params.get("provider") or "").strip() or None}
+        {
+            "model": create_model,
+            "provider": str(params.get("provider") or "").strip() or None,
+        }
         if create_model
         else None
     )
@@ -70,6 +78,9 @@ def _(rid, params: dict) -> dict:
             "priority" if is_truthy_value(params.get("fast")) else ""
         )
 
+    runtime_owner_lease = _claim_local_runtime_owner(
+        key, profile_home or Path(_hermes_home)
+    )
     ready = threading.Event()
     now = time.time()
     lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
@@ -80,7 +91,9 @@ def _(rid, params: dict) -> dict:
             "agent_error": None,
             "agent_ready": ready,
             "attached_images": [],
-            "close_on_disconnect": is_truthy_value(params.get("close_on_disconnect", False)),
+            "close_on_disconnect": is_truthy_value(
+                params.get("close_on_disconnect", False)
+            ),
             "active_session_lease": lease,
             "cols": cols,
             "created_at": now,
@@ -101,6 +114,7 @@ def _(rid, params: dict) -> dict:
             "pending_hidden": is_truthy_value(params.get("hidden", False)),
             "profile_home": str(profile_home) if profile_home is not None else None,
             "running": False,
+            "runtime_owner_lease": runtime_owner_lease,
             "session_key": key,
             "show_reasoning": _load_show_reasoning(),
             "source": source,
@@ -110,6 +124,11 @@ def _(rid, params: dict) -> dict:
             "transport": current_transport() or _stdio_transport,
         }
         _register_session_cwd(_sessions[sid])
+    _attach_current_transport(
+        sid,
+        _sessions[sid],
+        attachment_mode,
+    )
 
     # NOTE: we intentionally do NOT persist a DB row here. Every TUI/desktop
     # launch (and every "New agent" / draft) opens a session here just to paint
@@ -393,6 +412,7 @@ def _(rid, params: dict) -> dict:
     # that returns before that transfer must close it. Otherwise reuse the
     # shared launch db, which outlives the RPC and is never closed here.
     owns_db = False
+    runtime_build_guard = None
     if profile_home is not None:
         from hermes_state import SessionDB
 
@@ -409,7 +429,9 @@ def _(rid, params: dict) -> dict:
             found = db.get_session_by_title(target)
             if found:
                 target = found["id"]
-            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(target):
+            elif is_truthy_value(params.get("lazy", False)) and _child_run_active(
+                target
+            ):
                 # Race: a watch window opened on a freshly-spawned subagent. The
                 # child relays `subagent.start` (which carries child_session_id and
                 # triggers the window) BEFORE its first run_conversation() flushes
@@ -464,9 +486,12 @@ def _(rid, params: dict) -> dict:
                     # unpersisted sibling of the storm-killer paths (#91276).
                     transport = current_transport()
                     if transport is not None:
-                        with live.setdefault("history_lock", threading.Lock()):
-                            live["transport"] = transport
-                            live.setdefault("viewers", {})[transport] = time.time()
+                        _attach_current_transport(
+                            live_sid,
+                            live,
+                            params.get("attachment_mode", "control"),
+                            transport=transport,
+                        )
                     _cancel_ws_orphan_reap(live_sid)
                     history = live.get("history") or []
                     return _ok(
@@ -475,7 +500,9 @@ def _(rid, params: dict) -> dict:
                             "session_id": live_sid,
                             "stored_session_id": str(live.get("session_key") or ""),
                             "message_count": len(history),
-                            "messages": [] if omit_messages else _history_to_messages(history),
+                            "messages": []
+                            if omit_messages
+                            else _history_to_messages(history),
                             "info": {
                                 "model": _resolve_model(),
                                 "lazy": True,
@@ -588,11 +615,19 @@ def _(rid, params: dict) -> dict:
             # to lose access to a session. Only a genuine over-limit blocks.
             logger.warning(
                 "resume safety check failed for %s (proceeding without guard): %s",
-                target, exc,
+                target,
+                exc,
             )
 
-        profile_resume_cwd = str(found.get("cwd") or "").strip() or _profile_configured_cwd(
-            profile_home
+        profile_resume_cwd = str(
+            found.get("cwd") or ""
+        ).strip() or _profile_configured_cwd(profile_home)
+        runtime_key_resolver = getattr(db, "session_runtime_key", None)
+        runtime_key = str(
+            runtime_key_resolver(target) if callable(runtime_key_resolver) else target
+        )
+        runtime_build_key = _profile_scoped_runtime_key(
+            runtime_key, profile_home or Path(_hermes_home)
         )
 
         def _reuse_live_payload(sid: str, session: dict) -> dict:
@@ -602,6 +637,7 @@ def _(rid, params: dict) -> dict:
                 cols=cols,
                 touch=True,
                 transport=current_transport() or _stdio_transport,
+                attachment_mode=params.get("attachment_mode", "control"),
                 omit_messages=omit_messages,
             )
             payload["resumed"] = target
@@ -637,9 +673,9 @@ def _(rid, params: dict) -> dict:
                 _cancel_ws_orphan_reap(sid)
                 return _ok(rid, _reuse_live_payload(sid, session))
 
-        # Fast path: if the session is already live, reuse it under the lock.
+        # Fast path: if the canonical runtime is already live in this profile, reuse it.
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_runtime_key(runtime_key, profile_home)
         if live is not None:
             return _reuse_live_response(*live)
 
@@ -652,8 +688,12 @@ def _(rid, params: dict) -> dict:
         # (resume_session_id keeps the upgrade on the stored conversation).
         if is_truthy_value(params.get("lazy", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             try:
                 db.reopen_session(target)
                 # The child's OWN conversation only — include_ancestors would prepend
@@ -670,16 +710,24 @@ def _(rid, params: dict) -> dict:
                     lease.release()
                 return _err(rid, 5000, f"resume failed: {e}")
             cwd = profile_resume_cwd or _default_session_cwd()
+            runtime_owner_lease = _claim_local_runtime_owner(
+                runtime_key, profile_home or Path(_hermes_home)
+            )
             record = _deferred_session_record(
+                sid,
                 target,
                 cols=cols,
                 cwd=cwd,
                 history=history,
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 profile_home=profile_home,
                 lazy=True,
+                runtime_owner_key=runtime_key,
+                runtime_owner_lease=runtime_owner_lease,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -697,7 +745,9 @@ def _(rid, params: dict) -> dict:
                     target, repair_alternation=False, include_row_ids=True
                 )
             except Exception:
-                logger.debug("child-watch display projection read failed", exc_info=True)
+                logger.debug(
+                    "child-watch display projection read failed", exc_info=True
+                )
                 display_history = history
             messages = [] if omit_messages else _history_to_messages(display_history)
             return _ok(
@@ -705,7 +755,9 @@ def _(rid, params: dict) -> dict:
                 {
                     "session_id": sid,
                     "resumed": target,
-                    "message_count": len(display_history) if omit_messages else len(messages),
+                    "message_count": len(display_history)
+                    if omit_messages
+                    else len(messages),
                     "messages": messages,
                     "messages_omitted": omit_messages,
                     "info": _lazy_resume_info(cwd, profile=profile),
@@ -731,23 +783,35 @@ def _(rid, params: dict) -> dict:
         # governs the response shape of the non-deferred paths.
         if defer_history and not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             _enable_gateway_prompts()
             overrides = _stored_session_runtime_overrides(found) or {}
             model_override = overrides.get("model_override") or {}
             cwd = profile_resume_cwd or _default_session_cwd()
+            runtime_owner_lease = _claim_local_runtime_owner(
+                runtime_key, profile_home or Path(_hermes_home)
+            )
             record = _deferred_session_record(
+                sid,
                 target,
                 cols=cols,
                 cwd=cwd,
                 history=[],
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                runtime_owner_key=runtime_key,
+                runtime_owner_lease=runtime_owner_lease,
             )
             record["resume_history_ready"] = threading.Event()
             record["resume_hydrating"] = True
@@ -798,8 +862,12 @@ def _(rid, params: dict) -> dict:
         # session's persisted runtime identity, and is a real (upgradable) session.
         if not is_truthy_value(params.get("eager_build", False)):
             sid = uuid.uuid4().hex[:8]
-            source = _resolve_session_source(str(params.get("source") or "").strip() or None)
-            lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            source = _resolve_session_source(
+                str(params.get("source") or "").strip() or None
+            )
+            lease = (
+                None  # claimed lazily on the first turn (_ensure_active_session_slot)
+            )
             # Interactive resume routes approvals/clarify through gateway prompts;
             # the deferred build wires the remaining per-session callbacks.
             _enable_gateway_prompts()
@@ -832,18 +900,26 @@ def _(rid, params: dict) -> dict:
             overrides = _stored_session_runtime_overrides(found) or {}
             model_override = overrides.get("model_override") or {}
             cwd = profile_resume_cwd or _default_session_cwd()
+            runtime_owner_lease = _claim_local_runtime_owner(
+                runtime_key, profile_home or Path(_hermes_home)
+            )
             record = _deferred_session_record(
+                sid,
                 target,
                 cols=cols,
                 cwd=cwd,
                 history=history,
                 lease=lease,
                 source=source,
-                close_on_disconnect=is_truthy_value(params.get("close_on_disconnect", False)),
+                close_on_disconnect=is_truthy_value(
+                    params.get("close_on_disconnect", False)
+                ),
                 display_history_prefix=prefix,
                 profile_home=profile_home,
                 model_override=overrides.get("model_override"),
                 resume_runtime_overrides=overrides or None,
+                runtime_owner_key=runtime_key,
+                runtime_owner_lease=runtime_owner_lease,
             )
             if (live := _claim_or_reuse_live(sid, target, record, lease)) is not None:
                 return _reuse_live_response(*live)
@@ -880,11 +956,17 @@ def _(rid, params: dict) -> dict:
         # _session_resume_lock across it would stall session.close on the main
         # dispatch thread (it's not a _LONG_HANDLER), blocking fast-path RPCs.
         sid = uuid.uuid4().hex[:8]
-        source = _resolve_session_source(str(params.get("source") or "").strip() or None)
+        source = _resolve_session_source(
+            str(params.get("source") or "").strip() or None
+        )
         lease = None  # claimed lazily on the first turn (_ensure_active_session_slot)
+        runtime_owner_lease = None
+        runtime_owner_transferred = False
         _enable_gateway_prompts()
         home_token = (
-            set_hermes_home_override(str(profile_home)) if profile_home is not None else None
+            set_hermes_home_override(str(profile_home))
+            if profile_home is not None
+            else None
         )
         secret_token = (
             set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
@@ -915,6 +997,15 @@ def _(rid, params: dict) -> dict:
             )
             history = sanitize_replay_history(raw_history)
             messages = [] if omit_messages else _history_to_messages(display_history)
+            runtime_build_guard = _runtime_build_singleflight(runtime_build_key)
+            runtime_build_guard.__enter__()
+            with _session_resume_lock:
+                live = _find_live_session_by_runtime_key(runtime_key, profile_home)
+            if live is not None:
+                return _reuse_live_response(*live)
+            runtime_owner_lease = _claim_local_runtime_owner(
+                runtime_key, profile_home or Path(_hermes_home)
+            )
             tokens = _set_session_context(target)
             try:
                 # Pass the profile's db so the agent persists turns to the right
@@ -936,6 +1027,8 @@ def _(rid, params: dict) -> dict:
         except Exception as e:
             if lease is not None:
                 lease.release()
+            if runtime_owner_lease is not None and not runtime_owner_transferred:
+                runtime_owner_lease.release()
             return _err(rid, 5000, f"resume failed: {e}")
         finally:
             if home_token is not None:
@@ -949,6 +1042,8 @@ def _(rid, params: dict) -> dict:
         with _session_resume_lock:
             live = _find_live_session_by_key(target)
             if live is not None:
+                if runtime_owner_lease is not None:
+                    live[1].setdefault("runtime_owner_lease", runtime_owner_lease)
                 try:
                     if hasattr(agent, "close"):
                         agent.close()
@@ -964,7 +1059,9 @@ def _(rid, params: dict) -> dict:
                     else None
                 )
                 init_secret_token = (
-                    set_secret_scope(build_profile_secret_scope(Path(str(profile_home))))
+                    set_secret_scope(
+                        build_profile_secret_scope(Path(str(profile_home)))
+                    )
                     if profile_home is not None
                     else None
                 )
@@ -1026,6 +1123,9 @@ def _(rid, params: dict) -> dict:
                     if profile_home is not None:
                         _sessions[sid]["profile_home"] = str(profile_home)
                     _sessions[sid]["active_session_lease"] = lease
+                    _sessions[sid]["runtime_owner_key"] = runtime_key
+                    _sessions[sid]["runtime_owner_lease"] = runtime_owner_lease
+                    runtime_owner_transferred = True
             except Exception as e:
                 # _init_session registers _sessions[sid] BEFORE its first read
                 # through this handle. If it raised in between — "database is
@@ -1041,9 +1141,13 @@ def _(rid, params: dict) -> dict:
                         _sessions.pop(sid, None)
                 if lease is not None:
                     lease.release()
+                if runtime_owner_lease is not None and not runtime_owner_transferred:
+                    runtime_owner_lease.release()
                 return _err(rid, 5000, f"resume failed: {e}")
             session = _sessions.get(sid) or {}
     finally:
+        if runtime_build_guard is not None:
+            runtime_build_guard.__exit__(None, None, None)
         # Every return that does NOT reach the transfer above abandons this
         # handle — session-not-found, both "resume failed" paths, the live-session
         # fast path (the hot one: reconnects re-resume live chats through it), the
@@ -1093,12 +1197,16 @@ def _(rid, params: dict) -> dict:
     except ValueError as e:
         return _err(rid, 4017, str(e))
     agent = session.get("agent")
-    info = _session_info(agent, session) if agent is not None else {
-        "cwd": cwd,
-        "branch": _git_branch_for_cwd(cwd),
-        "project": _project_info_for_cwd(cwd),
-        "lazy": True,
-    }
+    info = (
+        _session_info(agent, session)
+        if agent is not None
+        else {
+            "cwd": cwd,
+            "branch": _git_branch_for_cwd(cwd),
+            "project": _project_info_for_cwd(cwd),
+            "lazy": True,
+        }
+    )
     _emit("session.info", params.get("session_id", ""), info)
     return _ok(rid, info)
 
@@ -1167,12 +1275,16 @@ def _(rid, params: dict) -> dict:
         except ValueError as e:
             return _err(rid, 4017, str(e))
         agent = live.get("agent")
-        info = _session_info(agent, live) if agent is not None else {
-            "cwd": resolved,
-            "branch": branch,
-            "project": _project_info_for_cwd(resolved),
-            "lazy": True,
-        }
+        info = (
+            _session_info(agent, live)
+            if agent is not None
+            else {
+                "cwd": resolved,
+                "branch": branch,
+                "project": _project_info_for_cwd(resolved),
+                "lazy": True,
+            }
+        )
         _emit("session.info", live_sid, info)
 
     return _ok(rid, {"cwd": resolved, "branch": branch, "git_repo_root": root})
@@ -1310,7 +1422,9 @@ def _(rid, params: dict) -> dict:
                         resolved_title = fallback
                     else:
                         existing_row = db.get_session(key)
-                        existing_title = ((existing_row or {}).get("title") or "").strip()
+                        existing_title = (
+                            (existing_row or {}).get("title") or ""
+                        ).strip()
                         if existing_title == fallback:
                             session["pending_title"] = None
                             resolved_title = fallback
@@ -1362,7 +1476,9 @@ def _(rid, params: dict) -> dict:
             with _session_db(session) as scoped_db:
                 if scoped_db is not None and scoped_db.set_session_title(key, title):
                     session["pending_title"] = None
-                    _emit_session_info_for_session(params.get("session_id", ""), session)
+                    _emit_session_info_for_session(
+                        params.get("session_id", ""), session
+                    )
                     return _ok(rid, {"pending": False, "title": title})
             # Row creation didn't take (DB unavailable, or a concurrent writer) —
             # fall back to queuing so the post-turn apply block can still recover.
@@ -1418,7 +1534,11 @@ def _(rid, params: dict) -> dict:
         if db is None:
             return _db_unavailable_error(rid, code=5007)
         try:
-            resolved = db.resolve_session_id(target) if hasattr(db, "resolve_session_id") else target
+            resolved = (
+                db.resolve_session_id(target)
+                if hasattr(db, "resolve_session_id")
+                else target
+            )
             if not resolved:
                 return err
             db.set_session_hidden(resolved, hidden)
@@ -1494,7 +1614,9 @@ def _(rid, params: dict) -> dict:
     template = (params.get("template") or "").strip() or None
     instructions = params.get("instructions") or ""
     user_input = params.get("input") or ""
-    variables = params.get("variables") if isinstance(params.get("variables"), dict) else {}
+    variables = (
+        params.get("variables") if isinstance(params.get("variables"), dict) else {}
+    )
     task = (params.get("task") or "title_generation").strip() or "title_generation"
 
     try:
@@ -1717,7 +1839,9 @@ def _(rid, params: dict) -> dict:
                 "context_max": usage.get("context_max", 0) or 0,
                 "context_percent": usage.get("context_percent", 0) or 0,
                 "context_used": usage.get("context_used", 0) or 0,
-                "estimated_total": usage.get("context_used", 0) or usage.get("total", 0) or 0,
+                "estimated_total": usage.get("context_used", 0)
+                or usage.get("total", 0)
+                or 0,
                 "model": _metadata_mirror(session).get("model", ""),
             },
         )
@@ -1811,8 +1935,12 @@ def _(rid, params: dict) -> dict:
             from hermes_cli.config import load_config
 
             cfg = load_config()
-            display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
-            pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            display = (
+                cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
+            )
+            pet_cfg = (
+                display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            )
         except Exception:
             pet_cfg = {}
 
@@ -1824,8 +1952,12 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"enabled": False})
 
         state = str(params.get("state") or constants.PetState.IDLE.value)
-        scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
-        cols = int(params.get("cols") or 0) or constants.resolve_cols(scale, pet_cfg.get("unicode_cols", 0))
+        scale = float(
+            pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+        )
+        cols = int(params.get("cols") or 0) or constants.resolve_cols(
+            scale, pet_cfg.get("unicode_cols", 0)
+        )
 
         # Graphics path: when the TUI is attached to a real TTY (``graphics``)
         # and the terminal speaks the kitty protocol, return a Unicode-
@@ -1836,7 +1968,11 @@ def _(rid, params: dict) -> dict:
         # kitty is grid-safe in Ink — iTerm/sixel stay on the fallback.
         if params.get("graphics"):
             configured = str(pet_cfg.get("render_mode", "auto") or "auto").lower()
-            gmode = render.detect_terminal_graphics() if configured in ("", "auto") else configured
+            gmode = (
+                render.detect_terminal_graphics()
+                if configured in ("", "auto")
+                else configured
+            )
             if gmode == "kitty":
                 image_id = render.kitty_image_id(pet.slug)
                 # kitty sizes from scaled pixels (_cell_box), so unicode_cols is moot here.
@@ -1874,9 +2010,7 @@ def _(rid, params: dict) -> dict:
         frames = []
         for i in range(count):
             grid = renderer.cells(state, i, cols=cols)
-            frames.append(
-                [[[*top, *bottom] for (top, bottom) in row] for row in grid]
-            )
+            frames.append([[[*top, *bottom] for (top, bottom) in row] for row in grid])
 
         return _ok(
             rid,
@@ -1918,8 +2052,12 @@ def _(rid, params: dict) -> dict:
             from hermes_cli.config import load_config
 
             cfg = load_config()
-            display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
-            pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            display = (
+                cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
+            )
+            pet_cfg = (
+                display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
+            )
         except Exception:
             pet_cfg = {}
 
@@ -1937,34 +2075,31 @@ def _(rid, params: dict) -> dict:
 
             for entry in [] if local_only else fetch_manifest():
                 seen.add(entry.slug)
-                gallery.append(
-                    {
-                        "slug": entry.slug,
-                        "displayName": entry.display_name,
-                        "installed": entry.slug in installed,
-                        "spritesheetUrl": entry.spritesheet_url,
-                        # petdex exposes no popularity metric; "curated" (its
-                        # hand-picked/official set, identified by the asset path)
-                        # is the closest signal, so the picker can surface it first.
-                        "curated": "/curated/" in entry.spritesheet_url,
-                        "generated": entry.slug in installed and installed[entry.slug].generated,
-                    }
-                )
+                gallery.append({
+                    "slug": entry.slug,
+                    "displayName": entry.display_name,
+                    "installed": entry.slug in installed,
+                    "spritesheetUrl": entry.spritesheet_url,
+                    # petdex exposes no popularity metric; "curated" (its
+                    # hand-picked/official set, identified by the asset path)
+                    # is the closest signal, so the picker can surface it first.
+                    "curated": "/curated/" in entry.spritesheet_url,
+                    "generated": entry.slug in installed
+                    and installed[entry.slug].generated,
+                })
         except Exception as exc:  # noqa: BLE001 - offline: fall back to installed
             logger.debug("pet.gallery manifest fetch failed: %s", exc)
 
         # Always include locally-installed pets even if the gallery is unreachable.
         for slug, pet in installed.items():
             if slug not in seen:
-                gallery.append(
-                    {
-                        "slug": slug,
-                        "displayName": pet.display_name,
-                        "installed": True,
-                        "spritesheetUrl": "",
-                        "generated": pet.generated,
-                    }
-                )
+                gallery.append({
+                    "slug": slug,
+                    "displayName": pet.display_name,
+                    "installed": True,
+                    "spritesheetUrl": "",
+                    "generated": pet.generated,
+                })
 
         return _ok(
             rid,
@@ -2056,7 +2191,11 @@ def _(rid, params: dict) -> dict:
         filename, data = store.export_pet(slug)
         return _ok(
             rid,
-            {"ok": True, "filename": filename, "zipBase64": base64.standard_b64encode(data).decode("ascii")},
+            {
+                "ok": True,
+                "filename": filename,
+                "zipBase64": base64.standard_b64encode(data).decode("ascii"),
+            },
         )
     except Exception as exc:  # noqa: BLE001
         logger.debug("pet.export failed: %s", exc)
@@ -2128,7 +2267,8 @@ def _(rid, params: dict) -> dict:
             {
                 "ok": True,
                 "slug": slug,
-                "dataUri": "data:image/png;base64," + base64.standard_b64encode(data).decode("ascii"),
+                "dataUri": "data:image/png;base64,"
+                + base64.standard_b64encode(data).decode("ascii"),
             },
         )
     except Exception as exc:  # noqa: BLE001
@@ -2267,7 +2407,9 @@ def _(rid, params: dict) -> dict:
         sprite = None
         if provider_name:
             try:
-                sprite = resolve_provider(require_references=bool(reference_images), prefer=provider_name)
+                sprite = resolve_provider(
+                    require_references=bool(reference_images), prefer=provider_name
+                )
             except GenerationError as exc:
                 _pet_cancel_release(token)
                 return _err(rid, 5031, str(exc))
@@ -2297,7 +2439,12 @@ def _(rid, params: dict) -> dict:
                 _emit(
                     "pet.generate.progress",
                     "",
-                    {"token": token, "index": index, "dataUri": data_uri, "count": count},
+                    {
+                        "token": token,
+                        "index": index,
+                        "dataUri": data_uri,
+                        "count": count,
+                    },
                 )
             except Exception as exc:  # noqa: BLE001
                 logger.debug("pet.generate progress emit failed: %s", exc)
@@ -2441,7 +2588,10 @@ def _(rid, params: dict) -> dict:
         state = build_billing_state()
         return _ok(rid, _serialize_billing_state(state))
     except Exception:
-        return _ok(rid, {"ok": True, "logged_in": False, "error": "could not load billing state"})
+        return _ok(
+            rid,
+            {"ok": True, "logged_in": False, "error": "could not load billing state"},
+        )
 
 
 @method("usage.bars")
@@ -2472,7 +2622,14 @@ def _(rid, params: dict) -> dict:
         state = build_subscription_state()
         return _ok(rid, _serialize_subscription_state(state))
     except Exception:
-        return _ok(rid, {"ok": True, "logged_in": False, "error": "could not load subscription state"})
+        return _ok(
+            rid,
+            {
+                "ok": True,
+                "logged_in": False,
+                "error": "could not load subscription state",
+            },
+        )
 
 
 @method("subscription.preview")
@@ -2488,7 +2645,14 @@ def _(rid, params: dict) -> dict:
 
     tier_id = params.get("subscription_type_id")
     if not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id is required",
+            },
+        )
     try:
         preview = subscription_change_preview_from_payload(
             post_subscription_preview(subscription_type_id=tier_id)
@@ -2513,10 +2677,21 @@ def _(rid, params: dict) -> dict:
     cancel = bool(params.get("cancel"))
     tier_id = params.get("subscription_type_id")
     if not cancel and not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id or cancel is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id or cancel is required",
+            },
+        )
     try:
-        result = put_subscription_pending_change(subscription_type_id=tier_id, cancel=cancel)
-        return _ok(rid, {"ok": True, "message": result.get("message"), "payload": result})
+        result = put_subscription_pending_change(
+            subscription_type_id=tier_id, cancel=cancel
+        )
+        return _ok(
+            rid, {"ok": True, "message": result.get("message"), "payload": result}
+        )
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
     except Exception as exc:
@@ -2534,7 +2709,9 @@ def _(rid, params: dict) -> dict:
 
     try:
         result = delete_subscription_pending_change()
-        return _ok(rid, {"ok": True, "message": result.get("message"), "payload": result})
+        return _ok(
+            rid, {"ok": True, "message": result.get("message"), "payload": result}
+        )
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
     except Exception as exc:
@@ -2556,10 +2733,19 @@ def _(rid, params: dict) -> dict:
 
     tier_id = params.get("subscription_type_id")
     if not tier_id:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "subscription_type_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "subscription_type_id is required",
+            },
+        )
     key = params.get("idempotency_key") or new_idempotency_key()
     try:
-        result = post_subscription_upgrade(subscription_type_id=tier_id, idempotency_key=key)
+        result = post_subscription_upgrade(
+            subscription_type_id=tier_id, idempotency_key=key
+        )
         return _ok(
             rid,
             {
@@ -2576,7 +2762,15 @@ def _(rid, params: dict) -> dict:
         env["idempotency_key"] = key  # so the TUI can reuse on retry
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "idempotency_key": key})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "error",
+                "message": str(exc),
+                "idempotency_key": key,
+            },
+        )
 
 
 @method("billing.charge")
@@ -2592,17 +2786,35 @@ def _(rid, params: dict) -> dict:
 
     amount = params.get("amount_usd")
     if amount is None:
-        return _ok(rid, {"ok": False, "error": "invalid_request", "message": "amount_usd is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_request",
+                "message": "amount_usd is required",
+            },
+        )
     key = params.get("idempotency_key") or new_idempotency_key()
     try:
         result = post_charge(amount_usd=amount, idempotency_key=key)
-        return _ok(rid, {"ok": True, "charge_id": result.get("chargeId"), "idempotency_key": key})
+        return _ok(
+            rid,
+            {"ok": True, "charge_id": result.get("chargeId"), "idempotency_key": key},
+        )
     except BillingError as exc:
         env = _serialize_billing_error(exc)
         env["idempotency_key"] = key  # so the TUI can reuse on retry
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "idempotency_key": key})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "error",
+                "message": str(exc),
+                "idempotency_key": key,
+            },
+        )
 
 
 @method("billing.charge_status")
@@ -2615,7 +2827,14 @@ def _(rid, params: dict) -> dict:
 
     charge_id = params.get("charge_id")
     if not charge_id:
-        return _ok(rid, {"ok": False, "error": "invalid_charge_id", "message": "charge_id is required"})
+        return _ok(
+            rid,
+            {
+                "ok": False,
+                "error": "invalid_charge_id",
+                "message": "charge_id is required",
+            },
+        )
     try:
         result = get_charge_status(charge_id)
         return _ok(
@@ -2647,8 +2866,17 @@ def _(rid, params: dict) -> dict:
         threshold = params.get("threshold")
         top_up_amount = params.get("top_up_amount")
         if threshold is None or top_up_amount is None:
-            return _ok(rid, {"ok": False, "error": "invalid_request", "message": "threshold and top_up_amount are required"})
-        patch_auto_top_up(enabled=enabled, threshold=threshold, top_up_amount=top_up_amount)
+            return _ok(
+                rid,
+                {
+                    "ok": False,
+                    "error": "invalid_request",
+                    "message": "threshold and top_up_amount are required",
+                },
+            )
+        patch_auto_top_up(
+            enabled=enabled, threshold=threshold, top_up_amount=top_up_amount
+        )
         return _ok(rid, {"ok": True})
     except BillingError as exc:
         return _ok(rid, _serialize_billing_error(exc))
@@ -2694,7 +2922,9 @@ def _(rid, params: dict) -> dict:
         env["granted"] = False
         return _ok(rid, env)
     except Exception as exc:
-        return _ok(rid, {"ok": False, "error": "error", "message": str(exc), "granted": False})
+        return _ok(
+            rid, {"ok": False, "error": "error", "message": str(exc), "granted": False}
+        )
 
 
 @method("session.status")
@@ -2761,15 +2991,13 @@ def _(rid, params: dict) -> dict:
     title = (meta.get("title") or "").strip()
     if title:
         lines.append(f"Title: {title}")
-    lines.extend(
-        [
-            f"Model: {model} ({provider})",
-            f"Created: {created.strftime('%Y-%m-%d %H:%M')}",
-            f"Last Activity: {updated.strftime('%Y-%m-%d %H:%M')}",
-            f"Tokens: {int(usage.get('total') or 0):,}",
-            f"Agent Running: {'Yes' if session.get('running') else 'No'}",
-        ]
-    )
+    lines.extend([
+        f"Model: {model} ({provider})",
+        f"Created: {created.strftime('%Y-%m-%d %H:%M')}",
+        f"Last Activity: {updated.strftime('%Y-%m-%d %H:%M')}",
+        f"Tokens: {int(usage.get('total') or 0):,}",
+        f"Agent Running: {'Yes' if session.get('running') else 'No'}",
+    ])
     return _ok(rid, {"output": "\n".join(lines)})
 
 
@@ -2825,9 +3053,7 @@ def _(rid, params: dict) -> dict:
             return _err(
                 rid, 4009, "session busy — /interrupt the current turn before /undo"
             )
-        history = _history_without_ephemeral_scaffolding(
-            session.get("history", [])
-        )
+        history = _history_without_ephemeral_scaffolding(session.get("history", []))
         # Truncate from the last *real* user turn. Popping only trailing
         # assistant/tool then one user left timeline markers
         # (async_delegation_complete, model_switch, …) or compaction
@@ -2843,8 +3069,8 @@ def _(rid, params: dict) -> dict:
         ]
         if user_indices:
             try:
-                _installed, _live_view, rewound_count = (
-                    _rewind_active_session_history(session, len(user_indices) - 1)
+                _installed, _live_view, rewound_count = _rewind_active_session_history(
+                    session, len(user_indices) - 1
                 )
                 removed = rewound_count
             except Exception as exc:
@@ -2873,7 +3099,9 @@ def _(rid, params: dict) -> dict:
         except Exception as exc:
             return _err(rid, 5019, f"compute-host compress failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
-            return _err(rid, 4009, str(ack.get("message") or "compute-host compress failed"))
+            return _err(
+                rid, 4009, str(ack.get("message") or "compute-host compress failed")
+            )
         _apply_compute_host_metadata_mirror(session, ack)
         host_result = ack.get("result")
         if isinstance(host_result, dict):
@@ -2883,8 +3111,14 @@ def _(rid, params: dict) -> dict:
             # old text-only acknowledgement made Desktop show aborted work as a
             # success toast.
             return _ok(rid, {**host_result, "turn_isolation": True})
-        host_info = ack.get("session_info") if isinstance(ack.get("session_info"), dict) else {}
-        host_messages = _history_to_messages(ack.get("messages")) if isinstance(ack.get("messages"), list) else []
+        host_info = (
+            ack.get("session_info") if isinstance(ack.get("session_info"), dict) else {}
+        )
+        host_messages = (
+            _history_to_messages(ack.get("messages"))
+            if isinstance(ack.get("messages"), list)
+            else []
+        )
         # `messages` is returned at top level for the desktop transcript
         # replacement. Keep the host acknowledgement metadata, but do not send
         # the same (potentially large) transcript a second time inside it.
@@ -2897,7 +3131,9 @@ def _(rid, params: dict) -> dict:
                 "host_ack": host_ack,
                 "info": host_info,
                 "messages": host_messages,
-                "usage": host_info.get("usage") if isinstance(host_info.get("usage"), dict) else {},
+                "usage": host_info.get("usage")
+                if isinstance(host_info.get("usage"), dict)
+                else {},
             },
         )
     session, err = _sess(params, rid)
@@ -3011,11 +3247,15 @@ def _(rid, params: dict) -> dict:
         from agent.manual_compression_feedback import (
             describe_compression_lock_skip,
         )
-        return _ok(rid, {
-            "compressed": False,
-            "lock_held": True,
-            "message": describe_compression_lock_skip(e.holder),
-        })
+
+        return _ok(
+            rid,
+            {
+                "compressed": False,
+                "lock_held": True,
+                "message": describe_compression_lock_skip(e.holder),
+            },
+        )
     except Exception as e:
         finalize_context_engine_compression_notification(
             session["agent"],
@@ -3041,10 +3281,14 @@ def _(rid, params: dict) -> dict:
         except Exception as exc:
             return _err(rid, 5011, f"compute-host session save failed: {exc}")
         if ack.get("type") in {"control.error", "error"}:
-            return _err(rid, 5011, str(ack.get("message") or "compute-host session save failed"))
+            return _err(
+                rid, 5011, str(ack.get("message") or "compute-host session save failed")
+            )
         result = ack.get("result")
         if not isinstance(result, dict):
-            return _err(rid, 5011, "compute-host session save returned an invalid response")
+            return _err(
+                rid, 5011, "compute-host session save returned an invalid response"
+            )
         return _ok(rid, result)
 
     agent = session["agent"]
@@ -3122,14 +3366,18 @@ def _(rid, params: dict) -> dict:
         with session["history_lock"]:
             in_memory_history = [
                 dict(msg)
-                for msg in list(session.get("display_history_prefix") or []) + list(session.get("history", []))
+                for msg in list(session.get("display_history_prefix") or [])
+                + list(session.get("history", []))
                 if isinstance(msg, dict)
             ]
 
         def _visible_branch_history(messages):
             visible = []
             for message in messages or []:
-                if not isinstance(message, dict) or message.get("role") not in {"user", "assistant"}:
+                if not isinstance(message, dict) or message.get("role") not in {
+                    "user",
+                    "assistant",
+                }:
                     continue
                 if not _coerce_message_text(message.get("content")).strip():
                     continue
@@ -3149,7 +3397,9 @@ def _(rid, params: dict) -> dict:
         if callable(get_resume_conversations):
             try:
                 _, display_history = get_resume_conversations(old_key)
-                display_history = _reconcile_display_with_live(display_history, in_memory_history)
+                display_history = _reconcile_display_with_live(
+                    display_history, in_memory_history
+                )
                 history = _visible_branch_history(display_history)
             except Exception:
                 logger.debug("branch display projection read failed", exc_info=True)
@@ -3234,6 +3484,7 @@ def _(rid, params: dict) -> dict:
     # unbound, whatever raises inside.
     branch_db = None
     branch_owns_db = False
+    branch_runtime_owner_lease = None
     try:
         # Bind the branched AGENT to the parent's profile, mirroring
         # session.create/resume: home override so config/skills/memory resolve
@@ -3251,9 +3502,7 @@ def _(rid, params: dict) -> dict:
             # _init_session raising, both leave here without that transfer.
             branch_db = SessionDB(db_path=Path(parent_home) / "state.db")
             branch_owns_db = True
-        home_token = (
-            set_hermes_home_override(parent_home) if parent_home else None
-        )
+        home_token = set_hermes_home_override(parent_home) if parent_home else None
         # The home override alone only moves config/skills/memory; credentials
         # resolve through get_secret(), which without a scope falls through to
         # process os.environ — the LAUNCH profile's .env. Install the parent's
@@ -3263,6 +3512,9 @@ def _(rid, params: dict) -> dict:
             set_secret_scope(build_profile_secret_scope(Path(parent_home)))
             if parent_home
             else None
+        )
+        branch_runtime_owner_lease = _claim_local_runtime_owner(
+            new_key, Path(parent_home or _hermes_home)
         )
         try:
             tokens = _set_session_context(new_key)
@@ -3301,9 +3553,12 @@ def _(rid, params: dict) -> dict:
                 reset_hermes_home_override(home_token)
         if new_sid in _sessions:
             _sessions[new_sid]["active_session_lease"] = lease
+            _sessions[new_sid]["runtime_owner_lease"] = branch_runtime_owner_lease
     except Exception as e:
         if lease is not None:
             lease.release()
+        if branch_runtime_owner_lease is not None and new_sid not in _sessions:
+            branch_runtime_owner_lease.release()
         return _err(rid, 5000, f"agent init failed on branch: {e}")
     finally:
         if branch_owns_db and branch_db is not None:
@@ -3508,16 +3763,14 @@ def _(rid, params: dict) -> dict:
                 except Exception:
                     raw = {}
                 subagents = raw.get("subagents") or []
-                entries.append(
-                    {
-                        "path": str(p),
-                        "session_id": raw.get("session_id") or d.name,
-                        "finished_at": raw.get("finished_at") or stat.st_mtime,
-                        "started_at": raw.get("started_at"),
-                        "label": raw.get("label") or "",
-                        "count": len(subagents) if isinstance(subagents, list) else 0,
-                    }
-                )
+                entries.append({
+                    "path": str(p),
+                    "session_id": raw.get("session_id") or d.name,
+                    "finished_at": raw.get("finished_at") or stat.st_mtime,
+                    "started_at": raw.get("started_at"),
+                    "label": raw.get("label") or "",
+                    "count": len(subagents) if isinstance(subagents, list) else 0,
+                })
             except OSError:
                 continue
 
@@ -3602,7 +3855,14 @@ def _(rid, params: dict) -> dict:
     # model as the next turn, instead of a misleading 4010 the client silently
     # swallows into a lost follow-up.
     if agent is None and session.get("running"):
-        _enqueue_prompt(session, text, current_transport() or _stdio_transport)
+        queue_transport = current_transport() or _stdio_transport
+        _enqueue_prompt(
+            session,
+            text,
+            queue_transport,
+            origin_client_id=_legacy_client_id_for_transport(queue_transport),
+            request_id=str(rid),
+        )
         session["last_active"] = time.time()
         return _ok(rid, {"status": "queued", "text": text})
     if (
@@ -3637,6 +3897,156 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"cols": session["cols"]})
 
 
+@method("client.attach")
+def _(rid, params: dict) -> dict:
+    transport = current_transport() or _stdio_transport
+    protocol_version = params.get("protocol_version", 1)
+    if isinstance(protocol_version, bool) or protocol_version != 1:
+        return _err(rid, -32602, "unsupported protocol_version")
+    surface = params.get("surface", "legacy")
+    if not isinstance(surface, str) or not re.fullmatch(
+        r"[A-Za-z0-9][A-Za-z0-9._:-]{0,63}", surface
+    ):
+        return _err(rid, -32602, "surface must be 1-64 safe identifier characters")
+
+    supported = frozenset({"session.observe", "session.control", "session.replay"})
+    requested = params.get("capabilities")
+    if requested is None:
+        accepted = supported
+    elif (
+        not isinstance(requested, list)
+        or len(requested) > 32
+        or any(
+            not isinstance(item, str) or not item or len(item) > 64
+            for item in requested
+        )
+    ):
+        return _err(rid, -32602, "capabilities must be a list of up to 32 identifiers")
+    else:
+        accepted = supported.intersection(requested)
+
+    from tui_gateway.session_events import ATTACHMENT_MODES
+
+    attachment_capabilities = (
+        ATTACHMENT_MODES["control"]
+        if "session.control" in accepted
+        else ATTACHMENT_MODES["observe"].intersection(
+            {"observe"}
+            if accepted.intersection({"session.observe", "session.replay"})
+            else set()
+        )
+    )
+    negotiated = (1, surface, accepted)
+    existing_negotiated = getattr(transport, "client_negotiation", None)
+    if existing_negotiated is not None and existing_negotiated != negotiated:
+        return _err(rid, 4003, "connection negotiation is already bound")
+    try:
+        client_id, idempotent = _bind_client_identity(
+            transport, params.get("client_id")
+        )
+    except ValueError as exc:
+        return _err(rid, -32602, str(exc))
+    except PermissionError as exc:
+        return _err(rid, 4003, str(exc))
+    except RuntimeError as exc:
+        return _err(rid, 5030, str(exc))
+    transport.client_negotiation = negotiated
+    transport.negotiated_capabilities = frozenset(attachment_capabilities)
+    return _ok(
+        rid,
+        {
+            "protocol_version": 1,
+            "client_id": client_id,
+            "connection_id": str(getattr(transport, "connection_id", "")),
+            "surface": surface,
+            "capabilities": sorted(accepted),
+            "idempotent": idempotent,
+        },
+    )
+
+
+@method("session.attach")
+def _(rid, params: dict) -> dict:
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None:
+        return _err(rid, 4007, "session not live")
+    transport = current_transport() or _stdio_transport
+    client_id = getattr(transport, "client_id", None)
+    if not client_id:
+        return _err(rid, 4003, "client.attach required")
+    since = params.get("last_seen_seq", 0)
+    if isinstance(since, bool) or not isinstance(since, int) or since < 0:
+        return _err(rid, -32602, "last_seen_seq must be a non-negative integer")
+    try:
+        hub = _attach_current_transport(
+            sid, session, params.get("mode", "observe"), transport=transport
+        )
+    except ValueError as exc:
+        return _err(rid, -32602, str(exc))
+    snapshot = next(
+        item for item in hub.snapshots() if item["client_id"] == str(client_id)
+    )
+    from tui_gateway import event_replay
+
+    events = event_replay.events_since(sid, since)
+    truncated = event_replay.is_truncated(sid, since)
+    epoch = event_replay.replay_epoch()
+    return _ok(
+        rid,
+        {
+            **snapshot,
+            "session_id": sid,
+            "events": events,
+            "latest_seq": event_replay.latest_seq(sid),
+            "truncated": truncated,
+            "epoch": epoch,
+            "replay_epoch": epoch,
+            "replay": {"events": events, "truncated": truncated},
+        },
+    )
+
+
+@method("session.detach")
+def _(rid, params: dict) -> dict:
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None:
+        return _err(rid, 4007, "session not live")
+    transport = current_transport() or _stdio_transport
+    hub = session.get("event_hub")
+    try:
+        if hub is None:
+            raise PermissionError("transport is not attached")
+        hub.require(transport, "observe")
+    except PermissionError:
+        return _err(rid, 4003, "session observe permission required")
+    return _ok(
+        rid,
+        {
+            "session_id": sid,
+            "detached": _detach_transport_from_session(sid, session, transport),
+        },
+    )
+
+
+@method("session.attachments")
+def _(rid, params: dict) -> dict:
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None:
+        return _err(rid, 4007, "session not live")
+    transport = current_transport() or _stdio_transport
+    hub = session.get("event_hub")
+    try:
+        if hub is None:
+            raise PermissionError("transport is not attached")
+        hub.require(transport, "prompt.submit")
+    except PermissionError:
+        return _err(rid, 4003, "session control permission required")
+    return _ok(rid, {"session_id": sid, "attachments": hub.snapshots()})
+
+
 @method("session.events.since")
 def _(rid, params: dict) -> dict:
     """Replay recorded events for a session newer than the client's last-seen seq.
@@ -3648,24 +4058,43 @@ def _(rid, params: dict) -> dict:
     the client knows to refetch history instead of silently accepting a gap.
     """
     sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is None:
+        return _err(rid, 4007, "session not live")
+    hub = session.get("event_hub")
+    transport = current_transport() or _stdio_transport
     try:
-        last_seen = int(params.get("last_seen", 0))
+        if hub is None:
+            raise PermissionError("transport is not attached")
+        hub.require(transport, "observe")
+    except PermissionError:
+        # Do not reveal whether replay exists or any attachment metadata.
+        return _err(rid, 4003, "session observe permission required")
+    try:
+        last_seen = int(
+            params.get(
+                "last_seen", params.get("last_seen_seq", params.get("since_seq", 0))
+            )
+        )
     except (TypeError, ValueError):
         return _err(rid, -32602, "invalid params: last_seen must be an integer")
     from tui_gateway import event_replay
 
     frames = event_replay.events_since(sid, last_seen)
-    return _ok(rid, {
-        "events": frames,
-        "latest_seq": event_replay.latest_seq(sid),
-        "truncated": event_replay.is_truncated(sid, last_seen),
-        "count": len(frames),
-        # Restart detection: seq counters are in-process, so after a gateway
-        # restart a client's old high watermark would silently match nothing.
-        # Clients compare this against the epoch they learned at gateway.ready
-        # and reset watermarks on mismatch.
-        "epoch": event_replay.replay_epoch(),
-    })
+    return _ok(
+        rid,
+        {
+            "events": frames,
+            "latest_seq": event_replay.latest_seq(sid),
+            "truncated": event_replay.is_truncated(sid, last_seen),
+            "count": len(frames),
+            # Restart detection: seq counters are in-process, so after a gateway
+            # restart a client's old high watermark would silently match nothing.
+            # Clients compare this against the epoch they learned at gateway.ready
+            # and reset watermarks on mismatch.
+            "epoch": event_replay.replay_epoch(),
+        },
+    )
 
 
 @method("session.events.stats")

--- a/tui_gateway/runtime_proxy.py
+++ b/tui_gateway/runtime_proxy.py
@@ -1,0 +1,1019 @@
+"""Authenticated local wire primitives for canonical runtime proxying."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import queue
+import socket
+import stat
+import struct
+import threading
+import uuid
+from collections import OrderedDict
+from pathlib import Path
+from typing import Any, Callable
+
+from hermes_cli.live_runtime_owners import (
+    RuntimeOwner,
+    RuntimeOwnerLease,
+    assert_runtime_owner,
+    claim_runtime_owner,
+    lookup_runtime_owner,
+)
+from tui_gateway.session_events import SUPPORTED_CAPABILITIES
+
+RUNTIME_PROXY_PROTOCOL_VERSION = 1
+# Resume transcripts and tool results can legitimately exceed the old 512 KiB
+# ceiling. Keep the authenticated local transport bounded, but align it with a
+# practical websocket/message ceiling rather than rejecting normal sessions.
+MAX_FRAME_BYTES = 16 * 1024 * 1024
+DEFAULT_REQUEST_TIMEOUT_SECONDS = 30 * 60
+MAX_STABLE_RUNTIME_ROUTES = 4096
+
+
+def _profile_scoped_conversation_key(
+    conversation_key: str, profile_home: str | Path
+) -> str:
+    profile = str(Path(profile_home).expanduser().resolve())
+    material = f"{profile}\0{conversation_key}".encode("utf-8")
+    return f"v1:{hashlib.sha256(material).hexdigest()}"
+
+
+def _stable_route_identity(transport: Any) -> str:
+    client_id = str(
+        getattr(transport, "client_id", None)
+        or getattr(transport, "connection_id", id(transport))
+    )
+    auth_identity = getattr(transport, "auth_identity", None)
+    if auth_identity is None:
+        return f"{client_id}:legacy"
+    encoded = json.dumps(
+        auth_identity, ensure_ascii=False, sort_keys=True, separators=(",", ":")
+    ).encode("utf-8")
+    return f"{client_id}:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def proxy_scoped_client_id(transport: Any) -> str:
+    """Return an opaque owner-visible id scoped to the validated local principal."""
+    material = ("runtime-proxy-client-v1\0" + _stable_route_identity(transport)).encode(
+        "utf-8"
+    )
+    return f"proxy-v1:{hashlib.sha256(material).hexdigest()}"
+
+
+def _owner_unavailable_response(owner: RuntimeOwner, request_id: Any) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": request_id,
+        "error": {
+            "code": -32072,
+            "message": "canonical runtime owner unavailable",
+            "data": {
+                "outcome": "unknown",
+                "retryable": False,
+                "owner_id": owner.owner_id,
+                "generation": owner.generation,
+            },
+        },
+    }
+
+
+class RuntimeProxyProtocolError(RuntimeError):
+    """A local proxy peer violated identity or framing requirements."""
+
+
+def proxy_peer_auth_identity(*, peer_pid: int, peer_uid: int) -> dict[str, Any]:
+    """Build an owner-attested principal from kernel-reported peer credentials."""
+    if peer_pid <= 0 or peer_uid < 0:
+        raise RuntimeProxyProtocolError("invalid runtime proxy peer credentials")
+    return {
+        "provider": "runtime-proxy-peer",
+        "peer_pid": peer_pid,
+        "peer_uid": peer_uid,
+    }
+
+
+class ProxyTransport:
+    """Owner-side virtual transport for one authenticated remote client."""
+
+    def __init__(
+        self,
+        *,
+        client_id: str,
+        send: Callable[[dict[str, Any]], Any],
+        auth_identity: dict[str, Any] | None = None,
+        negotiated_capabilities: frozenset[str] | None = None,
+        outbound_queue_size: int = 256,
+    ) -> None:
+        if not isinstance(client_id, str) or not client_id.strip():
+            raise ValueError("client_id must be a non-empty string")
+        if outbound_queue_size < 1:
+            raise ValueError("outbound_queue_size must be positive")
+        self.connection_id = uuid.uuid4().hex
+        self.client_id = client_id
+        self.auth_identity = auth_identity
+        self.negotiated_capabilities = (
+            frozenset(negotiated_capabilities)
+            if negotiated_capabilities is not None
+            else None
+        )
+        self._send = send
+        self._outbound: queue.Queue[
+            tuple[dict[str, Any], threading.Event | None, list[bool]] | None
+        ] = queue.Queue(maxsize=outbound_queue_size)
+        self._closed = False
+        self._writer = threading.Thread(target=self._write_loop, daemon=True)
+        self._writer.start()
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def write(self, frame: dict[str, Any]) -> bool:
+        if self._closed:
+            return False
+        kind = "event" if frame.get("method") == "event" else "rpc.response"
+        try:
+            self._outbound.put_nowait(({"kind": kind, "frame": frame}, None, []))
+        except queue.Full:
+            self._closed = True
+            return False
+        return True
+
+    def write_and_wait(self, frame: dict[str, Any]) -> bool:
+        """Write a frame and wait until the proxy sender has completed it."""
+        if self._closed:
+            return False
+        kind = "event" if frame.get("method") == "event" else "rpc.response"
+        completed = threading.Event()
+        outcome: list[bool] = []
+        try:
+            self._outbound.put_nowait((
+                {"kind": kind, "frame": frame},
+                completed,
+                outcome,
+            ))
+        except queue.Full:
+            self._closed = True
+            return False
+        if not completed.wait(timeout=11.0):
+            self._closed = True
+            return False
+        return bool(outcome and outcome[0])
+
+    def _write_loop(self) -> None:
+        while True:
+            item = self._outbound.get()
+            if item is None:
+                return
+            envelope, completed, outcome = item
+            if self._closed:
+                if completed is not None:
+                    outcome.append(False)
+                    completed.set()
+                return
+            try:
+                result = self._send(envelope)
+            except Exception:
+                self._closed = True
+                if completed is not None:
+                    outcome.append(False)
+                    completed.set()
+                return
+            if result is False:
+                self._closed = True
+                if completed is not None:
+                    outcome.append(False)
+                    completed.set()
+                return
+            if completed is not None:
+                outcome.append(True)
+                completed.set()
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._outbound.put_nowait(None)
+        except queue.Full:
+            pass
+
+
+def handshake_frame(
+    owner: RuntimeOwner,
+    *,
+    client_id: str,
+    negotiated_capabilities: frozenset[str] | None = None,
+) -> dict[str, Any]:
+    if not isinstance(client_id, str) or not client_id.strip():
+        raise ValueError("client_id must be a non-empty string")
+    frame: dict[str, Any] = {
+        "kind": "hello",
+        "protocol": RUNTIME_PROXY_PROTOCOL_VERSION,
+        "conversation_key": owner.conversation_key,
+        "owner_id": owner.owner_id,
+        "generation": owner.generation,
+        "client_id": client_id,
+        "negotiated_capabilities": (
+            sorted(negotiated_capabilities)
+            if negotiated_capabilities is not None
+            else None
+        ),
+    }
+    return frame
+
+
+def validate_handshake(
+    frame: Any,
+    *,
+    expected_owner: RuntimeOwner,
+    current_owner: RuntimeOwner | None,
+) -> tuple[str, frozenset[str] | None]:
+    if not isinstance(frame, dict) or frame.get("kind") != "hello":
+        raise RuntimeProxyProtocolError("invalid runtime proxy handshake")
+    if frame.get("protocol") != RUNTIME_PROXY_PROTOCOL_VERSION:
+        raise RuntimeProxyProtocolError("unsupported runtime proxy protocol")
+    if "auth_identity" in frame:
+        raise RuntimeProxyProtocolError("unattested auth identity is forbidden")
+    claimed = (
+        frame.get("conversation_key"),
+        frame.get("owner_id"),
+        frame.get("generation"),
+    )
+    expected = (
+        expected_owner.conversation_key,
+        expected_owner.owner_id,
+        expected_owner.generation,
+    )
+    if claimed != expected:
+        raise RuntimeProxyProtocolError("runtime owner identity mismatch")
+    if current_owner != expected_owner:
+        raise RuntimeProxyProtocolError("runtime owner claim is no longer current")
+    client_id = frame.get("client_id")
+    if not isinstance(client_id, str) or not client_id.strip():
+        raise RuntimeProxyProtocolError("invalid runtime proxy client identity")
+    raw_capabilities = frame.get("negotiated_capabilities")
+    if raw_capabilities is None:
+        return client_id, None
+    if (
+        not isinstance(raw_capabilities, list)
+        or len(raw_capabilities) > len(SUPPORTED_CAPABILITIES)
+        or len(set(raw_capabilities)) != len(raw_capabilities)
+        or any(
+            not isinstance(capability, str) or capability not in SUPPORTED_CAPABILITIES
+            for capability in raw_capabilities
+        )
+    ):
+        raise RuntimeProxyProtocolError("invalid negotiated capabilities")
+    return client_id, frozenset(raw_capabilities)
+
+
+def encode_frame(frame: dict[str, Any]) -> bytes:
+    try:
+        encoded = json.dumps(frame, ensure_ascii=False, separators=(",", ":")).encode(
+            "utf-8"
+        )
+    except (TypeError, ValueError) as exc:
+        raise RuntimeProxyProtocolError(
+            "runtime proxy frame is not serializable"
+        ) from exc
+    if len(encoded) > MAX_FRAME_BYTES:
+        raise RuntimeProxyProtocolError("runtime proxy frame is too large")
+    return encoded + b"\n"
+
+
+def read_frame(stream: Any) -> dict[str, Any]:
+    raw = stream.readline(MAX_FRAME_BYTES + 2)
+    if not raw:
+        raise EOFError("runtime proxy peer closed")
+    if len(raw) > MAX_FRAME_BYTES + 1 or not raw.endswith(b"\n"):
+        raise RuntimeProxyProtocolError("runtime proxy frame is too large")
+    try:
+        frame = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeProxyProtocolError("runtime proxy frame is malformed") from exc
+    if not isinstance(frame, dict):
+        raise RuntimeProxyProtocolError("runtime proxy frame is malformed")
+    return frame
+
+
+class RuntimeProxyServer:
+    """Persistent authenticated Unix-socket owner endpoint."""
+
+    def __init__(
+        self,
+        *,
+        endpoint: str | Path,
+        owner_lookup: Callable[[str], RuntimeOwner | None],
+        dispatch: Callable[[dict[str, Any], ProxyTransport], dict[str, Any] | None],
+        detach: Callable[[ProxyTransport], None] | None = None,
+    ) -> None:
+        self.endpoint = Path(endpoint)
+        self._owner_lookup = owner_lookup
+        self._dispatch = dispatch
+        self._detach = detach
+        self._listener: socket.socket | None = None
+        self._stopping = threading.Event()
+        self._accept_thread: threading.Thread | None = None
+        self._connections_lock = threading.Lock()
+        self._connections: set[socket.socket] = set()
+
+    def start(self) -> bool:
+        if os.name == "nt":
+            raise RuntimeProxyProtocolError(
+                "Windows runtime proxy transport is not implemented"
+            )
+        self.endpoint.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self.endpoint.unlink(missing_ok=True)
+            listener = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            old_umask = os.umask(0o177)
+            try:
+                listener.bind(str(self.endpoint))
+            finally:
+                os.umask(old_umask)
+            os.chmod(self.endpoint, 0o600)
+            listener.listen()
+            listener.settimeout(0.2)
+        except OSError:
+            try:
+                listener.close()
+            except (NameError, OSError):
+                pass
+            return False
+        self._listener = listener
+        self._accept_thread = threading.Thread(target=self._accept_loop, daemon=True)
+        self._accept_thread.start()
+        return True
+
+    def stop(self) -> None:
+        self._stopping.set()
+        if self._listener is not None:
+            try:
+                self._listener.close()
+            except OSError:
+                pass
+            self._listener = None
+        with self._connections_lock:
+            connections = list(self._connections)
+        for connection in connections:
+            try:
+                connection.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                connection.close()
+            except OSError:
+                pass
+        if self._accept_thread is not None:
+            self._accept_thread.join(timeout=2)
+            self._accept_thread = None
+        try:
+            self.endpoint.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+    def _accept_loop(self) -> None:
+        while not self._stopping.is_set():
+            listener = self._listener
+            if listener is None:
+                return
+            try:
+                connection, _ = listener.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            with self._connections_lock:
+                self._connections.add(connection)
+            threading.Thread(
+                target=self._handle_connection, args=(connection,), daemon=True
+            ).start()
+
+    def _handle_connection(self, connection: socket.socket) -> None:
+        transport: ProxyTransport | None = None
+        stream = None
+        try:
+            peer_pid, peer_uid, _peer_gid = require_posix_peer_credentials(connection)
+            stream = connection.makefile("rwb", buffering=0)
+            hello = read_frame(stream)
+            key = hello.get("conversation_key")
+            current = self._owner_lookup(key) if isinstance(key, str) else None
+            if current is None:
+                raise RuntimeProxyProtocolError(
+                    "runtime owner claim is no longer current"
+                )
+            client_id, negotiated_capabilities = validate_handshake(
+                hello,
+                expected_owner=current,
+                current_owner=self._owner_lookup(current.conversation_key),
+            )
+
+            def send(envelope: dict[str, Any]) -> bool:
+                if self._owner_lookup(current.conversation_key) != current:
+                    try:
+                        connection.shutdown(socket.SHUT_RDWR)
+                    except OSError:
+                        pass
+                    raise RuntimeProxyProtocolError(
+                        "runtime owner claim is no longer current"
+                    )
+                connection.sendall(encode_frame(envelope))
+                return True
+
+            transport = ProxyTransport(
+                client_id=client_id,
+                send=send,
+                auth_identity=proxy_peer_auth_identity(
+                    peer_pid=peer_pid,
+                    peer_uid=peer_uid,
+                ),
+                negotiated_capabilities=negotiated_capabilities,
+            )
+            send({"kind": "hello.ok", "protocol": RUNTIME_PROXY_PROTOCOL_VERSION})
+            while not self._stopping.is_set():
+                envelope = read_frame(stream)
+                if envelope.get("kind") != "rpc.request" or not isinstance(
+                    envelope.get("frame"), dict
+                ):
+                    raise RuntimeProxyProtocolError(
+                        "invalid runtime proxy request envelope"
+                    )
+                if self._owner_lookup(current.conversation_key) != current:
+                    raise RuntimeProxyProtocolError(
+                        "runtime owner claim is no longer current"
+                    )
+                response = self._dispatch(envelope["frame"], transport)
+                if response is not None:
+                    transport.write(response)
+        except (EOFError, OSError, RuntimeProxyProtocolError):
+            pass
+        finally:
+            if transport is not None:
+                transport.close()
+                if self._detach is not None:
+                    self._detach(transport)
+            if stream is not None:
+                try:
+                    stream.close()
+                except OSError:
+                    pass
+            try:
+                connection.close()
+            except OSError:
+                pass
+            with self._connections_lock:
+                self._connections.discard(connection)
+
+
+class _TrackedRuntimeOwnerLease:
+    """Release a registry lease and remove its coordinator bookkeeping entry."""
+
+    def __init__(
+        self,
+        lease: RuntimeOwnerLease,
+        on_release: Callable[[Any], None],
+    ) -> None:
+        self._lease = lease
+        self._on_release = on_release
+        self._lock = threading.Lock()
+        self._released = False
+
+    @property
+    def owner(self) -> RuntimeOwner:
+        return self._lease.owner
+
+    @property
+    def released(self) -> bool:
+        return self._released or self._lease.released
+
+    def is_current(self) -> bool:
+        return not self.released and assert_runtime_owner(self._lease)
+
+    def release(self) -> bool:
+        with self._lock:
+            if self._released:
+                return False
+            self._released = True
+        try:
+            return self._lease.release()
+        finally:
+            self._on_release(self)
+
+
+class RuntimeProxyCoordinator:
+    """Own local leases and proxy remote frontend transports to canonical owners."""
+
+    def __init__(
+        self,
+        *,
+        registry_home: str | Path,
+        endpoint: str | Path,
+        owner_id: str,
+        surface: str,
+        dispatch: Callable[[dict[str, Any], ProxyTransport], dict[str, Any] | None],
+        detach: Callable[[ProxyTransport], None] | None = None,
+    ) -> None:
+        self.registry_home = Path(registry_home)
+        self.endpoint = Path(endpoint)
+        self.owner_id = owner_id
+        self.surface = surface
+        self._lock = threading.RLock()
+        self._claim_lock = threading.Lock()
+        self._stopped = False
+        self._local_leases: dict[str, _TrackedRuntimeOwnerLease] = {}
+        self._clients: dict[tuple[str, str, int], RuntimeProxyClient] = {}
+        self._routes: dict[tuple[str, str], tuple[str, str, int]] = {}
+        self._stable_routes: OrderedDict[tuple[str, str], RuntimeOwner] = OrderedDict()
+        self._server = RuntimeProxyServer(
+            endpoint=self.endpoint,
+            owner_lookup=lambda key: lookup_runtime_owner(
+                conversation_key=key,
+                registry_home=self.registry_home,
+            ),
+            dispatch=dispatch,
+            detach=detach,
+        )
+
+    def start(self) -> bool:
+        with self._claim_lock:
+            if self._stopped:
+                return False
+
+            return self._server.start()
+
+    def stop(self) -> None:
+        with self._claim_lock:
+            with self._lock:
+                self._stopped = True
+                clients = list(self._clients.values())
+                leases = list(self._local_leases.values())
+                self._clients.clear()
+                self._routes.clear()
+                self._stable_routes.clear()
+                self._local_leases.clear()
+        for client in clients:
+            client.close()
+        for lease in leases:
+            lease.release()
+        self._server.stop()
+
+    def claim_local(
+        self,
+        *,
+        conversation_key: str,
+        profile_home: str | Path,
+    ) -> _TrackedRuntimeOwnerLease:
+        """Claim a newly-created local runtime, failing closed on any collision."""
+        owner_key = _profile_scoped_conversation_key(conversation_key, profile_home)
+        with self._claim_lock:
+            if self._stopped:
+                raise RuntimeError("runtime proxy coordinator is stopped")
+
+            with self._lock:
+                existing = self._local_leases.get(owner_key)
+            if existing is not None and existing.is_current():
+                with self._lock:
+                    if (
+                        self._local_leases.get(owner_key) is existing
+                        and not existing.released
+                    ):
+                        return existing
+            claim = claim_runtime_owner(
+                conversation_key=owner_key,
+                owner_id=self.owner_id,
+                endpoint=str(self.endpoint),
+                surface=self.surface,
+                registry_home=self.registry_home,
+                profile_home=profile_home,
+            )
+            if claim.kind != "owned" or claim.lease is None:
+                raise RuntimeError(
+                    f"canonical runtime already owned by {claim.owner.owner_id}"
+                )
+            return self._track_local_lease(owner_key, claim.lease)
+
+    def _track_local_lease(
+        self, owner_key: str, lease: RuntimeOwnerLease
+    ) -> _TrackedRuntimeOwnerLease:
+        def remove(released: _TrackedRuntimeOwnerLease) -> None:
+            with self._lock:
+                if self._local_leases.get(owner_key) is released:
+                    self._local_leases.pop(owner_key, None)
+
+        tracked = _TrackedRuntimeOwnerLease(lease, remove)
+        with self._lock:
+            previous = self._local_leases.get(owner_key)
+            self._local_leases[owner_key] = tracked
+        if previous is not None:
+            previous.release()
+        return tracked
+
+    def _remember_stable_route(
+        self, route: tuple[str, str], owner: RuntimeOwner
+    ) -> None:
+        with self._lock:
+            self._stable_routes.pop(route, None)
+            self._stable_routes[route] = owner
+            while len(self._stable_routes) > MAX_STABLE_RUNTIME_ROUTES:
+                self._stable_routes.popitem(last=False)
+
+    def _stable_route_owner(self, route: tuple[str, str]) -> RuntimeOwner | None:
+        with self._lock:
+            owner = self._stable_routes.pop(route, None)
+            if owner is not None:
+                self._stable_routes[route] = owner
+            return owner
+
+    def _connect_remote_client(
+        self, owner: RuntimeOwner, transport: Any
+    ) -> tuple[tuple[str, str, int], "RuntimeProxyClient"] | None:
+        connection_id = str(getattr(transport, "connection_id", id(transport)))
+        client_key = (connection_id, owner.owner_id, owner.generation)
+        with self._lock:
+            client = self._clients.get(client_key)
+        if client is not None:
+            return client_key, client
+
+        client_id = proxy_scoped_client_id(transport)
+        raw_capabilities = getattr(transport, "negotiated_capabilities", None)
+        candidate = RuntimeProxyClient(
+            owner=owner,
+            client_id=client_id,
+            negotiated_capabilities=(
+                frozenset(raw_capabilities) if raw_capabilities is not None else None
+            ),
+            on_event=lambda frame: transport.write(frame),
+            on_disconnect=lambda: self._handle_remote_owner_loss(
+                client_key, candidate, transport, owner
+            ),
+        )
+        candidate.connect()
+        with self._lock:
+            client = self._clients.get(client_key)
+            if client is None and not candidate.closed:
+                self._clients[client_key] = candidate
+                client = candidate
+        if client is not candidate:
+            candidate.close()
+        return (client_key, client) if client is not None else None
+
+    def prepare_resume(
+        self,
+        *,
+        conversation_key: str,
+        request: dict[str, Any],
+        transport: Any,
+        profile_home: str | Path,
+    ) -> dict[str, Any] | None:
+        owner_key = _profile_scoped_conversation_key(conversation_key, profile_home)
+        with self._claim_lock:
+            if self._stopped:
+                raise RuntimeError("runtime proxy coordinator is stopped")
+
+            with self._lock:
+                existing = self._local_leases.get(owner_key)
+            if existing is not None and existing.is_current():
+                with self._lock:
+                    if (
+                        self._local_leases.get(owner_key) is existing
+                        and not existing.released
+                    ):
+                        return None
+            claim = claim_runtime_owner(
+                conversation_key=owner_key,
+                owner_id=self.owner_id,
+                endpoint=str(self.endpoint),
+                surface=self.surface,
+                registry_home=self.registry_home,
+                profile_home=profile_home,
+            )
+            if claim.kind == "owned":
+                if claim.lease is not None:
+                    self._track_local_lease(owner_key, claim.lease)
+                return None
+
+        connection_id = str(getattr(transport, "connection_id", id(transport)))
+        connected = self._connect_remote_client(claim.owner, transport)
+        if connected is None:
+            return _owner_unavailable_response(claim.owner, request.get("id"))
+        client_key, client = connected
+        response = client.request(request)
+        result = response.get("result")
+        if isinstance(result, dict):
+            live_session_id = result.get("session_id")
+            if isinstance(live_session_id, str) and live_session_id:
+                stable_identity = _stable_route_identity(transport)
+                with self._lock:
+                    self._routes[(connection_id, live_session_id)] = client_key
+                self._remember_stable_route(
+                    (stable_identity, live_session_id), claim.owner
+                )
+        return response
+
+    def _handle_remote_owner_loss(
+        self,
+        client_key: tuple[str, str, int],
+        client: "RuntimeProxyClient",
+        transport: Any,
+        owner: RuntimeOwner,
+    ) -> None:
+        with self._lock:
+            if self._clients.get(client_key) is not client:
+                return
+            self._clients.pop(client_key, None)
+            affected = sorted(
+                session_id
+                for (connection_id, session_id), route_key in self._routes.items()
+                if route_key == client_key
+            )
+            self._routes = {
+                route: route_key
+                for route, route_key in self._routes.items()
+                if route_key != client_key
+            }
+        current_owner = lookup_runtime_owner(
+            conversation_key=owner.conversation_key,
+            registry_home=self.registry_home,
+        )
+        if current_owner != owner:
+            with self._lock:
+                self._stable_routes = OrderedDict(
+                    (route, stable_owner)
+                    for route, stable_owner in self._stable_routes.items()
+                    if stable_owner != owner
+                )
+        if not affected:
+            return
+        try:
+            transport.write({
+                "jsonrpc": "2.0",
+                "method": "event",
+                "params": {
+                    "type": "session.runtime_owner_lost",
+                    "payload": {
+                        "session_ids": affected,
+                        "owner_id": owner.owner_id,
+                        "generation": owner.generation,
+                        "outcome": "unknown",
+                    },
+                },
+            })
+        except Exception:
+            pass
+
+    def has_remote_route(self, transport: Any, session_id: str) -> bool:
+        connection_id = str(getattr(transport, "connection_id", id(transport)))
+        stable_identity = _stable_route_identity(transport)
+        with self._lock:
+            if (connection_id, session_id) in self._routes:
+                return True
+        stable_owner = self._stable_route_owner((stable_identity, session_id))
+        if stable_owner is None:
+            return False
+        current_owner = lookup_runtime_owner(
+            conversation_key=stable_owner.conversation_key,
+            registry_home=self.registry_home,
+        )
+        if current_owner == stable_owner:
+            return True
+        with self._lock:
+            self._stable_routes.pop((stable_identity, session_id), None)
+        return False
+
+    def route_request(
+        self, request: dict[str, Any], transport: Any
+    ) -> dict[str, Any] | None:
+        params = request.get("params")
+        session_id = params.get("session_id") if isinstance(params, dict) else None
+        if not isinstance(session_id, str) or not session_id:
+            return None
+        connection_id = str(getattr(transport, "connection_id", id(transport)))
+        stable_identity = _stable_route_identity(transport)
+        with self._lock:
+            client_key = self._routes.get((connection_id, session_id))
+            client = self._clients.get(client_key) if client_key is not None else None
+        stable_owner = self._stable_route_owner((stable_identity, session_id))
+        if client is not None:
+            return client.request(request)
+        if stable_owner is None:
+            return None
+
+        current_owner = lookup_runtime_owner(
+            conversation_key=stable_owner.conversation_key,
+            registry_home=self.registry_home,
+        )
+        if current_owner != stable_owner:
+            with self._lock:
+                self._stable_routes.pop((stable_identity, session_id), None)
+            return _owner_unavailable_response(stable_owner, request.get("id"))
+        try:
+            connected = self._connect_remote_client(stable_owner, transport)
+        except (OSError, RuntimeProxyProtocolError):
+            return _owner_unavailable_response(stable_owner, request.get("id"))
+        if connected is None:
+            return _owner_unavailable_response(stable_owner, request.get("id"))
+        client_key, client = connected
+        with self._lock:
+            self._routes[(connection_id, session_id)] = client_key
+        return client.request(request)
+
+    def detach_transport(self, transport: Any) -> None:
+        connection_id = str(getattr(transport, "connection_id", id(transport)))
+        with self._lock:
+            keys = [key for key in self._clients if key[0] == connection_id]
+            clients = [self._clients.pop(key) for key in keys]
+            self._routes = {
+                route: key
+                for route, key in self._routes.items()
+                if route[0] != connection_id
+            }
+        for client in clients:
+            client.close()
+
+
+class RuntimeProxyClient:
+    """Remote-process client for one canonical owner connection."""
+
+    def __init__(
+        self,
+        *,
+        owner: RuntimeOwner,
+        client_id: str,
+        on_event: Callable[[dict[str, Any]], None],
+        negotiated_capabilities: frozenset[str] | None = None,
+        on_disconnect: Callable[[], None] | None = None,
+    ) -> None:
+        self.owner = owner
+        self.client_id = client_id
+        self.negotiated_capabilities = (
+            frozenset(negotiated_capabilities)
+            if negotiated_capabilities is not None
+            else None
+        )
+        self._on_event = on_event
+        self._on_disconnect = on_disconnect
+        self._socket: socket.socket | None = None
+        self._stream: Any = None
+        self._reader_thread: threading.Thread | None = None
+        self._write_lock = threading.Lock()
+        self._pending_lock = threading.Lock()
+        self._pending: dict[Any, tuple[threading.Event, list[dict[str, Any]]]] = {}
+        self._closed = False
+        self._disconnect_notify_lock = threading.Lock()
+        self._disconnect_notified = False
+
+    @property
+    def closed(self) -> bool:
+        return self._closed
+
+    def connect(self) -> None:
+        endpoint = Path(self.owner.endpoint)
+        metadata = endpoint.stat()
+        if metadata.st_uid != os.getuid() or stat.S_IMODE(metadata.st_mode) & 0o077:
+            raise RuntimeProxyProtocolError("runtime proxy socket ownership is unsafe")
+        connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        connection.connect(str(endpoint))
+        try:
+            require_posix_peer_uid(connection)
+            stream = connection.makefile("rwb", buffering=0)
+            connection.sendall(
+                encode_frame(
+                    handshake_frame(
+                        self.owner,
+                        client_id=self.client_id,
+                        negotiated_capabilities=self.negotiated_capabilities,
+                    )
+                )
+            )
+            acknowledgement = read_frame(stream)
+            if acknowledgement.get("kind") != "hello.ok":
+                raise RuntimeProxyProtocolError("runtime proxy handshake was rejected")
+        except Exception:
+            connection.close()
+            raise
+        self._socket = connection
+        self._stream = stream
+        self._reader_thread = threading.Thread(target=self._read_loop, daemon=True)
+        self._reader_thread.start()
+
+    def request(
+        self,
+        frame: dict[str, Any],
+        *,
+        timeout: float = DEFAULT_REQUEST_TIMEOUT_SECONDS,
+    ) -> dict[str, Any]:
+        if self._closed or self._socket is None:
+            raise RuntimeProxyProtocolError("runtime proxy is not connected")
+        request_id = frame.get("id")
+        if request_id is None:
+            raise ValueError("proxied JSON-RPC request requires an id")
+        waiter = threading.Event()
+        result: list[dict[str, Any]] = []
+        with self._pending_lock:
+            if request_id in self._pending:
+                raise ValueError("duplicate proxied JSON-RPC request id")
+            self._pending[request_id] = (waiter, result)
+        try:
+            with self._write_lock:
+                self._socket.sendall(
+                    encode_frame({"kind": "rpc.request", "frame": frame})
+                )
+            if not waiter.wait(timeout=timeout):
+                self.close()
+                self._notify_disconnect()
+                return _owner_unavailable_response(self.owner, request_id)
+            return result[0]
+        finally:
+            with self._pending_lock:
+                self._pending.pop(request_id, None)
+
+    def close(self) -> None:
+        self._closed = True
+        if self._socket is not None:
+            try:
+                self._socket.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            self._socket.close()
+            self._socket = None
+        if self._reader_thread is not None:
+            self._reader_thread.join(timeout=2)
+            self._reader_thread = None
+
+    def _read_loop(self) -> None:
+        try:
+            while not self._closed and self._stream is not None:
+                envelope = read_frame(self._stream)
+                frame = envelope.get("frame")
+                if not isinstance(frame, dict):
+                    raise RuntimeProxyProtocolError(
+                        "invalid runtime proxy response envelope"
+                    )
+                if envelope.get("kind") == "event":
+                    self._on_event(frame)
+                    continue
+                if envelope.get("kind") != "rpc.response":
+                    raise RuntimeProxyProtocolError(
+                        "invalid runtime proxy response envelope"
+                    )
+                request_id = frame.get("id")
+                with self._pending_lock:
+                    pending = self._pending.get(request_id)
+                if pending is not None:
+                    pending[1].append(frame)
+                    pending[0].set()
+        except (EOFError, OSError, RuntimeProxyProtocolError):
+            unexpected = not self._closed
+            self._closed = True
+            self._fail_pending()
+            if unexpected:
+                self._notify_disconnect()
+
+    def _notify_disconnect(self) -> None:
+        with self._disconnect_notify_lock:
+            if self._disconnect_notified:
+                return
+            self._disconnect_notified = True
+        if self._on_disconnect is not None:
+            self._on_disconnect()
+
+    def _fail_pending(self) -> None:
+        with self._pending_lock:
+            pending = list(self._pending.items())
+        for request_id, (waiter, result) in pending:
+            result.append(_owner_unavailable_response(self.owner, request_id))
+            waiter.set()
+
+
+def require_posix_peer_credentials(
+    sock: socket.socket, *, expected_uid: int | None = None
+) -> tuple[int, int, int]:
+    """Return kernel-attested credentials for an authorized Unix peer."""
+    if expected_uid is None:
+        expected_uid = os.getuid()
+    if not hasattr(socket, "SO_PEERCRED"):
+        raise RuntimeProxyProtocolError("peer credential verification is unavailable")
+    try:
+        credentials = sock.getsockopt(
+            socket.SOL_SOCKET, socket.SO_PEERCRED, struct.calcsize("3i")
+        )
+        pid, uid, gid = struct.unpack("3i", credentials)
+    except (OSError, struct.error) as exc:
+        raise RuntimeProxyProtocolError("peer credential verification failed") from exc
+    if uid != expected_uid:
+        raise RuntimeProxyProtocolError("runtime proxy peer uid mismatch")
+    if pid <= 0:
+        raise RuntimeProxyProtocolError("runtime proxy peer pid is invalid")
+    return pid, uid, gid
+
+
+def require_posix_peer_uid(
+    sock: socket.socket, *, expected_uid: int | None = None
+) -> int:
+    """Backward-compatible UID-only peer verifier."""
+    _pid, uid, _gid = require_posix_peer_credentials(sock, expected_uid=expected_uid)
+    return uid

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9,8 +9,11 @@ import json
 import logging
 import os
 import queue
+import re
+import socket
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 import uuid
@@ -146,6 +149,12 @@ _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
 _answers: dict[str, str] = {}
+_clarification_outcomes: dict[str, tuple[str, float]] = {}
+_CLARIFICATION_OUTCOMES_MAX = 1024
+_CLARIFICATION_OUTCOME_TTL_S = 300.0
+_approval_resolution_lock = threading.Lock()
+_approval_resolution_outcomes: dict[tuple[str, str], str] = {}
+_APPROVAL_RESOLUTION_OUTCOMES_MAX = 1024
 # Batch clarify accumulators: rid → {"qids": [...], "answers": {qid: answer}}.
 # Written by clarify.respond (per-question lock, update-in-place), read out by
 # _block on resolution/timeout so locked answers survive the deadline.
@@ -159,17 +168,52 @@ _cfg_lock = threading.Lock()
 # and multiple worker-pool RPCs.  Its compare/check/write transaction needs a
 # dedicated lock rather than the unrelated process-config cache lock.
 _profile_ui_meta_lock = threading.Lock()
-_sessions_lock = threading.RLock()  # reentrant: _close_session_by_id may run under callers that already hold it
+_sessions_lock = (
+    threading.RLock()
+)  # reentrant: _close_session_by_id may run under callers that already hold it
+_client_identity_lock = threading.Lock()
+_client_principals: dict[str, tuple[str, float]] = {}
+_CLIENT_IDENTITIES_MAX = 4096
 _prompt_lock = threading.Lock()
 _cfg_cache: dict | None = None
 _cfg_mtime: float | None = None
 _cfg_path = None
 _session_resume_lock = threading.Lock()
+_runtime_build_locks_guard = threading.Lock()
+_runtime_build_locks: dict[str, tuple[threading.Lock, int]] = {}
+
+
+@contextlib.contextmanager
+def _runtime_build_singleflight(key: str):
+    """Serialize construction/publication for one canonical conversation root."""
+
+    normalized = str(key).strip()
+    if not normalized:
+        raise ValueError("runtime build key must be non-empty")
+    with _runtime_build_locks_guard:
+        lock, users = _runtime_build_locks.get(normalized, (threading.Lock(), 0))
+        _runtime_build_locks[normalized] = (lock, users + 1)
+    lock.acquire()
+    try:
+        yield
+    finally:
+        lock.release()
+        with _runtime_build_locks_guard:
+            current = _runtime_build_locks.get(normalized)
+            if current is not None and current[0] is lock:
+                remaining = current[1] - 1
+                if remaining <= 0:
+                    _runtime_build_locks.pop(normalized, None)
+                else:
+                    _runtime_build_locks[normalized] = (lock, remaining)
+
+
 try:
     _slash_timeout = float(os.environ.get("HERMES_TUI_SLASH_TIMEOUT_S") or "45")
 except (ValueError, TypeError):
     _slash_timeout = 45.0
 _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
+
 
 # When a WebSocket client (the dashboard's embedded-chat tab / desktop app)
 # disconnects, ``tui_gateway.ws`` detaches the transport but intentionally
@@ -193,9 +237,7 @@ def _resolve_ws_orphan_reap_grace() -> float:
         try:
             from hermes_cli.config import load_config
 
-            raw = (load_config().get("dashboard") or {}).get(
-                "ws_orphan_reap_grace_s"
-            )
+            raw = (load_config().get("dashboard") or {}).get("ws_orphan_reap_grace_s")
         except Exception:
             raw = None
     try:
@@ -227,145 +269,143 @@ _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 # everything else stays on the main thread so ordering stays sane for the
 # fast path.  write_json is already _stdout_lock-guarded, so concurrent
 # response writes are safe.
-_LONG_HANDLERS = frozenset(
-    {
-        # Billing/usage reads each do a blocking portal HTTP fetch (state + usage
-        # is two serial round-trips); keep them off the main stdin loop so a slow
-        # portal can't stall approval.respond / session.interrupt / other RPCs.
-        "billing.state",
-        "subscription.state",
-        # Subscription change (V3): preview + the pending-change mutations + upgrade
-        # each do a blocking portal round-trip (preview + upgrade also hit Stripe,
-        # which can take seconds) — keep them off the main stdin loop.
-        "subscription.preview",
-        "subscription.change",
-        "subscription.resume",
-        "subscription.upgrade",
-        "usage.bars",
-        "session.usage",
-        "billing.step_up",
-        "browser.manage",
-        "cli.exec",
-        # Completion RPCs run inline on the reader thread by default, but both
-        # can block it for seconds: complete.path spawns `git ls-files` and
-        # fuzzy-ranks the whole repo (slow on large repos / WSL2 mounts), and
-        # complete.slash does first-call prompt_toolkit imports + a skill-dir
-        # scan. While either runs inline, prompt.submit / session.interrupt sit
-        # unread in the stdin pipe — the TUI appears frozen until the 120s RPC
-        # timeout fires (#21123). Routing them to the pool keeps the fast path
-        # responsive; completion is read-only and write_json is lock-guarded.
-        "complete.path",
-        "complete.slash",
-        "llm.oneshot",
-        # model.options builds the full picker payload — per-provider credential
-        # pool checks, pricing fetch, Nous tier check, optional custom-provider
-        # probe — measured seconds inline. While it runs on the reader thread,
-        # prompt.submit / session.interrupt sit unread (same class as #21123),
-        # and the Desktop model pill / picker block on it every open.
-        "model.options",
-        # Pet RPCs hit the network (manifest fetch / spritesheet download) or do
-        # per-frame PNG decode/encode (pet.cells): inline they serialize on the
-        # reader thread, so picker previews trickle in one at a time and the
-        # animation poll stutters. On the pool they run concurrently.
-        "pet.cells",
-        "pet.gallery",
-        # Generation is the heaviest pet path by far — multiple image-model
-        # round-trips per call — so it must never block the reader thread.
-        "pet.generate",
-        "pet.hatch",
-        "pet.info",
-        "pet.select",
-        "pet.thumb",
-        "learning.frames",
-        "plugins.manage",
-        # reload.mcp shuts down and rediscovers every MCP server — with a
-        # flapping server (retry loops, connect timeouts up to 120s) that can
-        # block for minutes. Inline it froze the reader thread: config.set,
-        # complete.slash, prompt.submit all sat unread and the TUI appeared
-        # dead after a few skin switches. The handler serializes concurrent
-        # reloads via _mcp_reload_lock.
-        "reload.mcp",
-        # MCP server test/OAuth RPCs block on network: a probe spawns a stdio
-        # server (cold `npx` cold start = many seconds) or connects to a remote
-        # endpoint; oauth.start blocks up to ~30s waiting for the provider to
-        # publish an authorization URL. Keep them off the reader thread.
-        "mcp.servers.test",
-        "mcp.servers.oauth.start",
-        "process.list",
-        # profiles.list runs list_profiles() (recursive skill-tree walk per
-        # profile) and opens each profile's state.db for the last-session
-        # preview; profiles.create copies skill bundles. Both are seconds-
-        # scale on cold disks — keep them off the WS reader thread.
-        "profiles.configure",
-        "profiles.create",
-        "profiles.describe",
-        "profiles.get_asset",
-        "profiles.list",
-        "profiles.set_asset",
-        # Bot-relay RPCs: roster.sync/outbox.drain/reply are cheap file I/O,
-        # but bot_relay.deliver runs a FULL one-turn agent conversation
-        # (subprocess, up to 600s) — all four stay off the WS reader thread
-        # so a slow relay delivery can never block prompt.submit.
-        "bot_relay.roster.sync",
-        "bot_relay.outbox.drain",
-        "bot_relay.deliver",
-        "bot_relay.reply",
-        # image.generate is a multi-second remote API round-trip.
-        "image.generate",
-        "projects.discover_repos",
-        "projects.record_repos",
-        "projects.for_cwd",
-        "projects.tree",
-        "projects.project_sessions",
-        # Setup readiness RPCs are polled by the Desktop frontend on connect
-        # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
-        # setup.runtime_check calls resolve_runtime_provider() which reads
-        # config, checks auth state, and may probe the provider endpoint;
-        # setup.status calls _has_any_provider_configured() which scans
-        # provider config + credential files. Under GIL pressure from
-        # concurrent agent turns, either can take seconds inline, blocking
-        # the WS read loop and causing false "needs setup" (#50005 family).
-        "setup.runtime_check",
-        "setup.status",
-        # Voice RPCs can trigger check_voice_requirements() → STT provider
-        # auto-detect → a SYNCHRONOUS faster-whisper lazy install (uv/pip
-        # subprocess with a 300s timeout). Inline they stall the WS reader
-        # loop (handle_ws awaits dispatch before reading the next frame), so
-        # prompt.submit / session.list queued behind a voice.toggle sit
-        # unread and the desktop "send message" appears dead for minutes
-        # (reproduced: voice.toggle → session.list 40s+ timeout). Route them
-        # to the pool so a slow lazy install can't block message handling.
-        "voice.toggle",
-        "voice.record",
-        "voice.tts",
-        # wake.start calls check_wake_word_requirements() → _stt_ready() →
-        # _get_provider() → _try_lazy_install_stt() → ensure("stt.faster_whisper")
-        # (same synchronous subprocess install chain as the voice RPCs above).
-        # It also calls start_listening() → _build_engine() whose constructors
-        # call lazy_deps.ensure("wake.openwakeword" / "wake.sherpa" / …).
-        # wake.status calls check_wake_word_requirements() too and is polled
-        # by the desktop on every gateway-ready, so it can re-trigger the
-        # same block on a fresh launch. Same bug class as #21123 / #50005.
-        "wake.start",
-        "wake.status",
-        # Desktop also polls the in-memory live-session registry every 15s.
-        # The handler is normally cheap, but under heavy agent GIL pressure it
-        # can still stall for tens of seconds. Keep it off the WS reader thread
-        # so a delayed status rehydrate cannot block runtime readiness, prompt
-        # submission, or interrupts queued behind it on the same socket.
-        "session.active_list",
-        "session.branch",
-        "session.compress",
-        "session.list",
-        "session.resume",
-        # Workspace re-home runs git branch/root subprocess probes against an
-        # arbitrary folder — inline they'd stall the reader on a slow mount.
-        "session.workspace.move",
-        "shell.exec",
-        "skills.manage",
-        "slash.exec",
-    }
-)
+_LONG_HANDLERS = frozenset({
+    # Billing/usage reads each do a blocking portal HTTP fetch (state + usage
+    # is two serial round-trips); keep them off the main stdin loop so a slow
+    # portal can't stall approval.respond / session.interrupt / other RPCs.
+    "billing.state",
+    "subscription.state",
+    # Subscription change (V3): preview + the pending-change mutations + upgrade
+    # each do a blocking portal round-trip (preview + upgrade also hit Stripe,
+    # which can take seconds) — keep them off the main stdin loop.
+    "subscription.preview",
+    "subscription.change",
+    "subscription.resume",
+    "subscription.upgrade",
+    "usage.bars",
+    "session.usage",
+    "billing.step_up",
+    "browser.manage",
+    "cli.exec",
+    # Completion RPCs run inline on the reader thread by default, but both
+    # can block it for seconds: complete.path spawns `git ls-files` and
+    # fuzzy-ranks the whole repo (slow on large repos / WSL2 mounts), and
+    # complete.slash does first-call prompt_toolkit imports + a skill-dir
+    # scan. While either runs inline, prompt.submit / session.interrupt sit
+    # unread in the stdin pipe — the TUI appears frozen until the 120s RPC
+    # timeout fires (#21123). Routing them to the pool keeps the fast path
+    # responsive; completion is read-only and write_json is lock-guarded.
+    "complete.path",
+    "complete.slash",
+    "llm.oneshot",
+    # model.options builds the full picker payload — per-provider credential
+    # pool checks, pricing fetch, Nous tier check, optional custom-provider
+    # probe — measured seconds inline. While it runs on the reader thread,
+    # prompt.submit / session.interrupt sit unread (same class as #21123),
+    # and the Desktop model pill / picker block on it every open.
+    "model.options",
+    # Pet RPCs hit the network (manifest fetch / spritesheet download) or do
+    # per-frame PNG decode/encode (pet.cells): inline they serialize on the
+    # reader thread, so picker previews trickle in one at a time and the
+    # animation poll stutters. On the pool they run concurrently.
+    "pet.cells",
+    "pet.gallery",
+    # Generation is the heaviest pet path by far — multiple image-model
+    # round-trips per call — so it must never block the reader thread.
+    "pet.generate",
+    "pet.hatch",
+    "pet.info",
+    "pet.select",
+    "pet.thumb",
+    "learning.frames",
+    "plugins.manage",
+    # reload.mcp shuts down and rediscovers every MCP server — with a
+    # flapping server (retry loops, connect timeouts up to 120s) that can
+    # block for minutes. Inline it froze the reader thread: config.set,
+    # complete.slash, prompt.submit all sat unread and the TUI appeared
+    # dead after a few skin switches. The handler serializes concurrent
+    # reloads via _mcp_reload_lock.
+    "reload.mcp",
+    # MCP server test/OAuth RPCs block on network: a probe spawns a stdio
+    # server (cold `npx` cold start = many seconds) or connects to a remote
+    # endpoint; oauth.start blocks up to ~30s waiting for the provider to
+    # publish an authorization URL. Keep them off the reader thread.
+    "mcp.servers.test",
+    "mcp.servers.oauth.start",
+    "process.list",
+    # profiles.list runs list_profiles() (recursive skill-tree walk per
+    # profile) and opens each profile's state.db for the last-session
+    # preview; profiles.create copies skill bundles. Both are seconds-
+    # scale on cold disks — keep them off the WS reader thread.
+    "profiles.configure",
+    "profiles.create",
+    "profiles.describe",
+    "profiles.get_asset",
+    "profiles.list",
+    "profiles.set_asset",
+    # Bot-relay RPCs: roster.sync/outbox.drain/reply are cheap file I/O,
+    # but bot_relay.deliver runs a FULL one-turn agent conversation
+    # (subprocess, up to 600s) — all four stay off the WS reader thread
+    # so a slow relay delivery can never block prompt.submit.
+    "bot_relay.roster.sync",
+    "bot_relay.outbox.drain",
+    "bot_relay.deliver",
+    "bot_relay.reply",
+    # image.generate is a multi-second remote API round-trip.
+    "image.generate",
+    "projects.discover_repos",
+    "projects.record_repos",
+    "projects.for_cwd",
+    "projects.tree",
+    "projects.project_sessions",
+    # Setup readiness RPCs are polled by the Desktop frontend on connect
+    # and periodically (use-status-snapshot → evaluateRuntimeReadiness).
+    # setup.runtime_check calls resolve_runtime_provider() which reads
+    # config, checks auth state, and may probe the provider endpoint;
+    # setup.status calls _has_any_provider_configured() which scans
+    # provider config + credential files. Under GIL pressure from
+    # concurrent agent turns, either can take seconds inline, blocking
+    # the WS read loop and causing false "needs setup" (#50005 family).
+    "setup.runtime_check",
+    "setup.status",
+    # Voice RPCs can trigger check_voice_requirements() → STT provider
+    # auto-detect → a SYNCHRONOUS faster-whisper lazy install (uv/pip
+    # subprocess with a 300s timeout). Inline they stall the WS reader
+    # loop (handle_ws awaits dispatch before reading the next frame), so
+    # prompt.submit / session.list queued behind a voice.toggle sit
+    # unread and the desktop "send message" appears dead for minutes
+    # (reproduced: voice.toggle → session.list 40s+ timeout). Route them
+    # to the pool so a slow lazy install can't block message handling.
+    "voice.toggle",
+    "voice.record",
+    "voice.tts",
+    # wake.start calls check_wake_word_requirements() → _stt_ready() →
+    # _get_provider() → _try_lazy_install_stt() → ensure("stt.faster_whisper")
+    # (same synchronous subprocess install chain as the voice RPCs above).
+    # It also calls start_listening() → _build_engine() whose constructors
+    # call lazy_deps.ensure("wake.openwakeword" / "wake.sherpa" / …).
+    # wake.status calls check_wake_word_requirements() too and is polled
+    # by the desktop on every gateway-ready, so it can re-trigger the
+    # same block on a fresh launch. Same bug class as #21123 / #50005.
+    "wake.start",
+    "wake.status",
+    # Desktop also polls the in-memory live-session registry every 15s.
+    # The handler is normally cheap, but under heavy agent GIL pressure it
+    # can still stall for tens of seconds. Keep it off the WS reader thread
+    # so a delayed status rehydrate cannot block runtime readiness, prompt
+    # submission, or interrupts queued behind it on the same socket.
+    "session.active_list",
+    "session.branch",
+    "session.compress",
+    "session.list",
+    "session.resume",
+    # Workspace re-home runs git branch/root subprocess probes against an
+    # arbitrary folder — inline they'd stall the reader on a slow mount.
+    "session.workspace.move",
+    "shell.exec",
+    "skills.manage",
+    "slash.exec",
+})
 
 try:
     _rpc_pool_workers = max(
@@ -437,7 +477,9 @@ def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
         managed_bin = str(Path(get_hermes_home()) / "bin")
     except Exception:
         pass
-    venv_bin = str(Path(sys.executable).parent)  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
+    venv_bin = str(
+        Path(sys.executable).parent
+    )  # <venv>/bin (POSIX) or <venv>/Scripts (Windows)
     user_bin = str(Path.home() / ".local" / "bin")
     existing = env.get("PATH") or ""
     env["PATH"] = os.pathsep.join(
@@ -477,6 +519,7 @@ class _SlashWorker:
         # build_subprocess_env factory's `extra` (applied last, always wins)
         # instead of a hand-rolled env["HERMES_HOME"] assignment.
         from tools.environments.local import build_subprocess_env
+
         env = build_subprocess_env(
             hermes_subprocess_env(inherit_credentials=True),
             scrub_secrets=False,
@@ -667,9 +710,7 @@ def _claim_active_session_slot(
     except Exception as exc:
         logger.warning("Failed to claim active session slot: %s", exc)
         return (
-            (None, _SESSION_OWNERSHIP_UNAVAILABLE)
-            if track_liveness
-            else (None, None)
+            (None, _SESSION_OWNERSHIP_UNAVAILABLE) if track_liveness else (None, None)
         )
 
 
@@ -829,7 +870,9 @@ def _transfer_active_session_slot(
             try:
                 old_lease.release()
             except Exception:
-                logger.debug("Failed to release stale active session slot", exc_info=True)
+                logger.debug(
+                    "Failed to release stale active session slot", exc_info=True
+                )
         session["active_session_lease"] = new_lease
         return True
     # Reserve failed — retain the existing lease rather than dropping it.
@@ -851,8 +894,20 @@ def _transfer_active_session_slot(
 # TUI backend itself creates ("tui", plus whatever a client passes as its
 # own ``source``) and the CLI's own sessions are NOT gateway-owned.
 _NON_GATEWAY_SOURCES = frozenset({
-    "", "tui", "cli", "webui", "desktop", "cron", "kanban", "subagent", "test",
-    "local", "acp", "webhook", "api_server", "msgraph_webhook",
+    "",
+    "tui",
+    "cli",
+    "webui",
+    "desktop",
+    "cron",
+    "kanban",
+    "subagent",
+    "test",
+    "local",
+    "acp",
+    "webhook",
+    "api_server",
+    "msgraph_webhook",
 })
 
 
@@ -965,7 +1020,9 @@ def _finalize_session(session: dict | None, end_reason: str = "tui_close") -> No
 
     session_key = session.get("session_key")
     session_id = getattr(agent, "session_id", None) or session_key
-    _notify_session_boundary("on_session_finalize", session_id, _session_source(session))
+    _notify_session_boundary(
+        "on_session_finalize", session_id, _session_source(session)
+    )
 
     # Mark session ended in DB so it doesn't linger as a ghost row in /resume.
     # Use session_id (from agent.session_id) not session_key — after compression,
@@ -1100,6 +1157,11 @@ def _teardown_session(session: dict | None, *, end_reason: str = "tui_close") ->
     _finalize_session(session, end_reason=end_reason)
     _announce_session_reclaimed(session, end_reason)
     try:
+        if hub := session.get("event_hub"):
+            hub.close()
+    except Exception:
+        logger.debug("session event hub close failed", exc_info=True)
+    try:
         from tools.approval import unregister_gateway_notify
 
         if key := session.get("session_key"):
@@ -1112,6 +1174,14 @@ def _teardown_session(session: dict | None, *, end_reason: str = "tui_close") ->
             agent.close()
     except Exception:
         pass
+    runtime_owner_lease = session.get("runtime_owner_lease")
+    if runtime_owner_lease is not None:
+        try:
+            released = runtime_owner_lease.release()
+            if released or getattr(runtime_owner_lease, "released", False):
+                session.pop("runtime_owner_lease", None)
+        except Exception:
+            logger.warning("Failed to release canonical runtime owner", exc_info=True)
     # NOTE: the slash-worker is closed inside _finalize_session (the single
     # _finalized-guarded chokepoint that main folded it into), exactly once.
     # We deliberately do NOT re-close it here — _teardown_session's job beyond
@@ -1214,12 +1284,13 @@ def _close_session_by_id(
 
 
 def _ws_session_is_detached(session: dict | None) -> bool:
-    """True if a live session is still bound to the disconnected-WS sentinel."""
-    return bool(
-        session
-        and not session.get("_finalized")
-        and session.get("transport") is _detached_ws_transport
-    )
+    """True when a live runtime has no attached clients."""
+    if not session or session.get("_finalized"):
+        return False
+    hub = session.get("event_hub")
+    if hub is not None:
+        return hub.count() == 0
+    return session.get("transport") is _detached_ws_transport
 
 
 def _ws_session_is_orphaned(session: dict | None) -> bool:
@@ -1261,9 +1332,9 @@ def _interrupt_session_turn(
         session["_turn_cancel_requested"] = True
         session["queued_prompt"] = None
         session.pop("queued_prompts", None)
-        session["_queued_prompt_generation"] = int(
-            session.get("_queued_prompt_generation", 0)
-        ) + 1
+        session["_queued_prompt_generation"] = (
+            int(session.get("_queued_prompt_generation", 0)) + 1
+        )
 
     if not use_compute_host:
         if should_interrupt:
@@ -1322,7 +1393,9 @@ def _session_async_delegation_selectors(
     agent = session.get("agent")
     session_key = str(session.get("session_key") or "")
     session_id = getattr(agent, "session_id", None) or session_key
-    owned_session_key = session_key if _session_owns_durable_lifecycle(session_id) else ""
+    owned_session_key = (
+        session_key if _session_owns_durable_lifecycle(session_id) else ""
+    )
     return own_sid, owned_session_key
 
 
@@ -1440,7 +1513,8 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                         "client_gone sid=%s: turn did not settle after %d "
                         "interrupt polls (%.0fs) — force-reaping detached "
                         "session",
-                        sid, polls - 1,
+                        sid,
+                        polls - 1,
                         (polls - 1) * _WS_ORPHAN_INTERRUPT_REAP_POLL_S,
                     )
                     session = _pop_session_by_id(sid)
@@ -1468,16 +1542,12 @@ def _schedule_ws_orphan_reap(sid: str, *, delay_s: float | None = None) -> None:
                 logger.exception("client_gone interrupt failed sid=%s", sid)
                 with _sessions_lock:
                     if _sessions.get(sid) is interrupt_session:
-                        interrupt_session.pop(
-                            "_client_gone_interrupt_requested", None
-                        )
+                        interrupt_session.pop("_client_gone_interrupt_requested", None)
 
         if reschedule_delay is not None:
             _schedule_ws_orphan_reap(sid, delay_s=reschedule_delay)
             return
-        if session is not None and session.get(
-            "_client_gone_interrupt_requested"
-        ):
+        if session is not None and session.get("_client_gone_interrupt_requested"):
             logger.info("client_gone sid=%s action=reap", sid)
         _teardown_popped_session(session, end_reason="ws_orphan_reap")
 
@@ -1513,12 +1583,53 @@ def _close_sessions_for_transport(
 
     Returns ``(reaped, detached)`` counts for disconnect-path observability."""
     with _sessions_lock:
-        owned = [(sid, s) for sid, s in _sessions.items() if s.get("transport") is transport]
+        owned = [
+            (sid, session)
+            for sid, session in _sessions.items()
+            if (
+                (
+                    session.get("event_hub") is not None
+                    and session["event_hub"].has_transport(transport)
+                )
+                or (
+                    session.get("event_hub") is None
+                    and session.get("transport") is transport
+                )
+            )
+        ]
     reaped = 0
     detached = 0
     for sid, session in owned:
         claimed_for_teardown = None
         should_schedule_reap = False
+        hub = session.get("event_hub")
+        if hub is not None:
+            # Never wait for a writer shutdown while holding lifecycle locks.
+            # Recheck the session generation before and after detach; reconnect
+            # may replace the attachment concurrently.
+            with _session_resume_lock:
+                with _sessions_lock:
+                    current = _sessions.get(sid)
+                    if current is not session or not hub.has_transport(transport):
+                        continue
+            try:
+                removed = _detach_transport_from_session(
+                    sid, session, transport, end_reason=end_reason
+                )
+            except RuntimeError:
+                logger.warning("session attachment detach timed out sid=%s", sid)
+                removed = not hub.has_transport(transport)
+            if not removed:
+                continue
+            if hub.count() > 0:
+                continue
+            with _sessions_lock:
+                current = _sessions.get(sid)
+                if current is None:
+                    reaped += 1
+                elif current is session and _ws_session_is_detached(current):
+                    detached += 1
+            continue
         # A session.resume fast-path rebinds its live session while holding
         # _session_resume_lock. Take that lock before re-checking the snapshot
         # so a reconnect cannot move the transport between this check and the
@@ -1797,7 +1908,11 @@ def _session_is_evictable(sid: str, session: dict, now: float) -> bool:
     # so their forever-unset agent_ready must not make them immortal.
     if ready is not None and not ready.is_set() and not session.get("lazy"):
         return False
-    if not _transport_is_dead(session.get("transport")):
+    hub = session.get("event_hub")
+    if hub is not None:
+        if hub.count() > 0:
+            return False
+    elif not _transport_is_dead(session.get("transport")):
         return False
     last_active = float(session.get("last_active") or 0.0)
     created_at = float(session.get("created_at") or 0.0)
@@ -1814,7 +1929,9 @@ def _reap_idle_sessions() -> None:
     except Exception:
         logger.debug("periodic incremental session flush failed", exc_info=True)
     with _sessions_lock:
-        victims = [sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)]
+        victims = [
+            sid for sid, s in _sessions.items() if _session_is_evictable(sid, s, now)
+        ]
     for sid in victims:
         _close_session_by_id(
             sid,
@@ -1837,9 +1954,7 @@ def _reap_idle_sessions() -> None:
     except Exception as exc:
         # debug, not warning — persistent failure would repeat every reaper
         # scan (300s) forever; sibling failure branches log at debug.
-        logger.debug(
-            "idle reaper memory trim failed: %s: %s", type(exc).__name__, exc
-        )
+        logger.debug("idle reaper memory trim failed: %s: %s", type(exc).__name__, exc)
 
 
 def _reclaim_orphaned_leases() -> None:
@@ -1895,6 +2010,9 @@ def _session_is_lru_evictable(sid: str, session: dict) -> bool:
     ready = session.get("agent_ready")
     if ready is not None and not ready.is_set() and not session.get("lazy"):
         return False
+    hub = session.get("event_hub")
+    if hub is not None:
+        return hub.count() == 0
     return _transport_is_dead(session.get("transport"))
 
 
@@ -1907,7 +2025,9 @@ def _enforce_session_cap() -> None:
         if total <= cap:
             return
         evictable = [
-            (sid, s) for sid, s in _sessions.items() if _session_is_lru_evictable(sid, s)
+            (sid, s)
+            for sid, s in _sessions.items()
+            if _session_is_lru_evictable(sid, s)
         ]
     # Oldest-touched first; only evict down to the cap (live/focused sessions on
     # a live transport are never eligible, so we may stop short of the cap).
@@ -2387,7 +2507,9 @@ def _profile_scoped(handler):
     """
 
     def wrapper(rid, params):
-        home = _profile_home(params.get("profile") if isinstance(params, dict) else None)
+        home = _profile_home(
+            params.get("profile") if isinstance(params, dict) else None
+        )
         if home is None:
             return handler(rid, params)
         token = set_hermes_home_override(home)
@@ -2481,7 +2603,163 @@ def _default_session_cwd() -> str:
     return _launch_configured_cwd() or os.getenv("TERMINAL_CWD") or os.getcwd()
 
 
-def write_json(obj: dict) -> bool:
+def _legacy_client_id_for_transport(transport: object) -> str:
+    """Return a deterministic attachment id until client negotiation exists."""
+    for attribute in ("client_id", "connection_id"):
+        value = getattr(transport, attribute, None)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return f"legacy-transport-{id(transport):x}"
+
+
+def _active_client_ids() -> set[str]:
+    """Snapshot stable client IDs currently attached to any live runtime."""
+    with _sessions_lock:
+        hubs = [
+            session.get("event_hub")
+            for session in _sessions.values()
+            if session.get("event_hub") is not None
+        ]
+    return {str(snapshot["client_id"]) for hub in hubs for snapshot in hub.snapshots()}
+
+
+def _bind_client_identity(transport: object, requested: object) -> tuple[str, bool]:
+    """Bind a validated stable client id to one authenticated connection."""
+    client_id = str(requested or "").strip()
+    if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._:-]{0,127}", client_id):
+        raise ValueError("client_id must be 1-128 safe identifier characters")
+    existing = getattr(transport, "client_id", None)
+    if existing is not None and str(existing) != client_id:
+        raise PermissionError("connection identity is already bound")
+
+    identity = getattr(transport, "auth_identity", None)
+    if isinstance(identity, dict) and identity:
+        encoded = json.dumps(
+            identity, sort_keys=True, separators=(",", ":"), default=str
+        )
+        principal = "auth:" + hashlib.sha256(encoded.encode("utf-8")).hexdigest()
+    else:
+        # Legacy local/token transports share the gateway owner's trust scope;
+        # the client id still never grants capabilities by itself.
+        principal = "gateway-owner"
+    active_client_ids = _active_client_ids()
+    with _client_identity_lock:
+        record = _client_principals.get(client_id)
+        bound_principal = record[0] if isinstance(record, tuple) else record
+        if bound_principal is not None and bound_principal != principal:
+            raise PermissionError("client_id belongs to another principal")
+        if bound_principal is None:
+            if len(_client_principals) >= _CLIENT_IDENTITIES_MAX:
+                for candidate in list(_client_principals):
+                    if candidate not in active_client_ids:
+                        _client_principals.pop(candidate, None)
+                        break
+            if len(_client_principals) >= _CLIENT_IDENTITIES_MAX:
+                raise RuntimeError("client identity registry is full")
+        else:
+            # Refresh insertion order so the dictionary itself is the LRU queue.
+            _client_principals.pop(client_id, None)
+        _client_principals[client_id] = (principal, time.monotonic())
+        setattr(transport, "client_id", client_id)
+    return client_id, existing == client_id
+
+
+def _ensure_session_event_hub(sid: str, session: dict):
+    """Return the one event hub owned by this live runtime record."""
+    from tui_gateway.session_events import SessionEventHub
+
+    with _sessions_lock:
+        hub = session.get("event_hub")
+        if hub is None:
+            hub = SessionEventHub(
+                on_detach=lambda _transport: _apply_zero_attachment_policy(
+                    sid, session, end_reason="attachment_failure"
+                )
+            )
+            session["event_hub"] = hub
+        return hub
+
+
+def _attach_current_transport(
+    sid: str,
+    session: dict,
+    mode="control",
+    *,
+    transport: Transport | None = None,
+):
+    """Attach the caller while retaining ``transport`` as a compatibility alias."""
+    from tui_gateway.session_events import AttachmentMode
+
+    target = transport or current_transport() or _stdio_transport
+    hub = _ensure_session_event_hub(sid, session)
+    hub.attach(
+        target,
+        client_id=_legacy_client_id_for_transport(target),
+        mode=AttachmentMode.parse(mode),
+        capabilities=getattr(target, "negotiated_capabilities", None),
+    )
+    with _sessions_lock:
+        # Compatibility only: event ownership and fan-out live in event_hub.
+        session["transport"] = target
+        session.pop("_zero_attachment_policy_applied", None)
+        session.setdefault("viewers", {})[target] = time.time()
+    if target is not _detached_ws_transport:
+        _cancel_ws_orphan_reap(sid)
+    return hub
+
+
+def _apply_zero_attachment_policy(
+    sid: str,
+    session: dict,
+    *,
+    end_reason: str,
+) -> None:
+    """Apply orphan/close policy once when a live runtime loses its final client."""
+    hub = session.get("event_hub")
+    claimed_for_teardown = None
+    should_schedule_reap = False
+    with _session_resume_lock:
+        with _sessions_lock:
+            current = _sessions.get(sid)
+            if (
+                current is not session
+                or hub is None
+                or hub.count() > 0
+                or current.get("_zero_attachment_policy_applied")
+            ):
+                return
+            current["_zero_attachment_policy_applied"] = True
+            if current.get("close_on_disconnect"):
+                claimed_for_teardown = _pop_session_by_id(sid)
+            else:
+                current["transport"] = _detached_ws_transport
+                current.pop("_client_gone_interrupt_requested", None)
+                current.pop("_client_gone_interrupt_polls", None)
+                should_schedule_reap = True
+    if claimed_for_teardown is not None:
+        _teardown_popped_session(claimed_for_teardown, end_reason=end_reason)
+    elif should_schedule_reap:
+        _schedule_ws_orphan_reap(sid)
+
+
+def _detach_transport_from_session(
+    sid: str,
+    session: dict,
+    transport: object,
+    *,
+    end_reason: str = "session_detach",
+) -> bool:
+    """Detach one client and apply lifetime policy on the zero-count transition."""
+    hub = session.get("event_hub")
+    if hub is None:
+        return False
+    removed = hub.detach(transport)
+    if removed:
+        _apply_zero_attachment_policy(sid, session, end_reason=end_reason)
+    return removed
+
+
+def write_json(obj: dict, *, wait_for_delivery: bool = False) -> bool:
     """Emit one JSON frame. Routes via the most-specific transport available.
 
     Precedence:
@@ -2508,7 +2786,11 @@ def write_json(obj: dict) -> bool:
 
             hub = session.get("event_hub")
             if hub is not None:
-                return hub.publish(obj, prepare=_stamp_event)
+                return hub.publish(
+                    obj,
+                    prepare=_stamp_event,
+                    wait_for_delivery=wait_for_delivery,
+                )
             if (t := session.get("transport")) is not None:
                 # Compatibility path for sessions not migrated to
                 # SessionEventHub yet. Keep replay sequence assignment and
@@ -2536,8 +2818,17 @@ def _event_frame(event: str, sid: str, payload: dict | None = None) -> dict:
     return {"jsonrpc": "2.0", "method": "event", "params": params}
 
 
-def _emit(event: str, sid: str, payload: dict | None = None):
-    write_json(_event_frame(event, sid, payload))
+def _emit(
+    event: str,
+    sid: str,
+    payload: dict | None = None,
+    *,
+    wait_for_delivery: bool = False,
+) -> bool:
+    return write_json(
+        _event_frame(event, sid, payload),
+        wait_for_delivery=wait_for_delivery,
+    )
 
 
 # Live client transports, one per connected WS peer (maintained by tui_gateway.ws).
@@ -2583,7 +2874,9 @@ def _broadcast_global_event(event: str, payload: dict | None = None) -> None:
         except Exception:
             # One wedged peer must not stall the rest; disconnect teardown
             # unregisters it.
-            logger.debug("global-event broadcast write failed type=%s", event, exc_info=True)
+            logger.debug(
+                "global-event broadcast write failed type=%s", event, exc_info=True
+            )
 
 
 _compute_host_supervisor = None
@@ -2621,7 +2914,9 @@ def _get_compute_host_supervisor(cfg: dict | None = None):
 
             _compute_host_supervisor = HostSupervisor(
                 rpc_sink=write_json,
-                heartbeat_secs=int(isolation_cfg.get("compute_host_heartbeat_secs") or 15),
+                heartbeat_secs=int(
+                    isolation_cfg.get("compute_host_heartbeat_secs") or 15
+                ),
                 respawn_max=int(isolation_cfg.get("compute_host_respawn_max") or 3),
             )
         return _compute_host_supervisor
@@ -2692,7 +2987,9 @@ def _apply_compute_host_metadata_mirror(session: dict, frame: dict | None) -> No
                 pass
         if frame.get("message_count") is not None:
             try:
-                session["_metadata_message_count"] = int(frame.get("message_count") or 0)
+                session["_metadata_message_count"] = int(
+                    frame.get("message_count") or 0
+                )
             except Exception:
                 pass
     info = frame.get("session_info")
@@ -2848,7 +3145,9 @@ def _pending_approval_request_payload(session_key: str) -> dict | None:
 
         approval = get_pending_gateway_approval(session_key)
     except Exception:
-        logger.debug("failed to read pending approval for %s", session_key, exc_info=True)
+        logger.debug(
+            "failed to read pending approval for %s", session_key, exc_info=True
+        )
         return None
     return _approval_request_payload(approval) if approval else None
 
@@ -2925,6 +3224,72 @@ def method(name: str):
     return dec
 
 
+_SESSION_RPC_CAPABILITIES = {
+    "prompt.submit": "prompt.submit",
+    "session.steer": "session.steer",
+    "session.redirect": "session.steer",
+    "session.interrupt": "session.interrupt",
+    "approval.respond": "approval.respond",
+    "clarify.respond": "clarify.respond",
+    "terminal.read.respond": "ui.respond",
+    "preview.read.respond": "ui.respond",
+    "preview.act.respond": "ui.respond",
+    "window.read.respond": "ui.respond",
+    "tour.respond": "ui.respond",
+    "mcp.setup.respond": "ui.respond",
+    "sudo.respond": "ui.respond",
+    "secret.respond": "ui.respond",
+}
+
+
+def _authorization_session(method_name: str, params: dict) -> dict | None:
+    """Resolve the live runtime whose capability protects one inbound RPC."""
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid) if sid else None
+    if session is not None:
+        return session
+
+    # Approval cards may outlive a reminted live sid. Preserve the existing
+    # durable-identity fallback, but authorize against the runtime it resolves.
+    if method_name == "approval.respond":
+        fallback = globals().get("_approval_respond_session_fallback")
+        if callable(fallback):
+            return fallback(params)
+
+    # Clarification/UI response authority is recoverable from the server-owned
+    # pending registry. request_id is merely a lookup hint, never the authority.
+    request_id = str(params.get("request_id") or "")
+    if request_id:
+        with _prompt_lock:
+            pending = _pending.get(request_id)
+        if pending is not None:
+            return _sessions.get(pending[0])
+    return None
+
+
+def _authorize_session_rpc(rid, method_name: str, params: dict) -> dict | None:
+    capability = _SESSION_RPC_CAPABILITIES.get(method_name)
+    if capability is None:
+        return None
+    session = _authorization_session(method_name, params)
+    if session is None:
+        # Let the handler preserve its established not-found/expired response.
+        return None
+    hub = session.get("event_hub")
+    transport = current_transport()
+    if hub is None and transport is None:
+        # Backward-compatible in-process invocation used by the stdio protocol
+        # harness and embedders. Network dispatch always binds a transport.
+        return None
+    if hub is None or transport is None:
+        return _err(rid, 4003, f"capability required: {capability}")
+    try:
+        hub.require(transport, capability)
+    except PermissionError:
+        return _err(rid, 4003, f"capability required: {capability}")
+    return None
+
+
 def _normalize_request(req: Any) -> tuple[Any, str, dict] | dict:
     """Validate a JSON-RPC request enough for safe local dispatch."""
     if not isinstance(req, dict):
@@ -2953,11 +3318,34 @@ def handle_request(req: dict) -> dict | None:
     fn = _methods.get(method)
     if not fn:
         return _err(rid, -32601, f"unknown method: {method}")
-    token = _current_rpc_method.set(method)
-    try:
-        return fn(rid, params)
-    finally:
-        _current_rpc_method.reset(token)
+
+    def invoke():
+        token = _current_rpc_method.set(method)
+        try:
+            return fn(rid, params)
+        finally:
+            _current_rpc_method.reset(token)
+
+    session = (
+        _authorization_session(method, params)
+        if method in _SESSION_RPC_CAPABILITIES
+        else None
+    )
+    if session is not None:
+        # The lock is part of the authoritative runtime record, so every
+        # attached transport converges on one control ingress order.
+        with _sessions_lock:
+            control_lock = session.setdefault("control_ingress_lock", threading.RLock())
+        with control_lock:
+            auth_error = _authorize_session_rpc(rid, method, params)
+            if auth_error is not None:
+                return auth_error
+            return invoke()
+
+    auth_error = _authorize_session_rpc(rid, method, params)
+    if auth_error is not None:
+        return auth_error
+    return invoke()
 
 
 def _current_session_steer_authority(
@@ -2976,13 +3364,153 @@ def _current_session_steer_authority(
     expected_session = _current_runtime_session_record.get()
     with _sessions_lock:
         session = _sessions.get(session_id)
-        if (
-            session is None
-            or (expected_session is not None and session is not expected_session)
-            or session.get("transport") is not transport
+        if session is None or (
+            expected_session is not None and session is not expected_session
         ):
             return None, None
+        hub = session.get("event_hub")
+        if hub is not None:
+            try:
+                hub.require(transport, "session.steer")
+            except PermissionError:
+                return None, None
+        elif session.get("transport") is not transport:
+            return None, None
         return transport, session
+
+
+_runtime_proxy_coordinator = None
+_runtime_proxy_coordinator_lock = threading.Lock()
+
+
+def _cross_process_runtime_proxy_supported() -> bool:
+    return (
+        os.name == "posix"
+        and hasattr(socket, "AF_UNIX")
+        and hasattr(socket, "SO_PEERCRED")
+    )
+
+
+def _runtime_proxy_endpoint(endpoint_name: str) -> Path:
+    """Return a Unix-socket path that fits the platform's ``sun_path`` limit."""
+    endpoint = Path(_hermes_home) / "runtime" / f"runtime-proxy-{endpoint_name}.sock"
+    # Linux sockaddr_un.sun_path is 108 bytes including the trailing NUL.
+    # Profile homes nested below long Desktop/E2E sandboxes can exceed it.
+    if len(os.fsencode(endpoint)) < 108:
+        return endpoint
+
+    runtime_root = Path(tempfile.gettempdir()) / f"hermes-runtime-{os.getuid()}"
+    runtime_root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    os.chmod(runtime_root, 0o700)
+    return runtime_root / f"runtime-proxy-{endpoint_name}.sock"
+
+
+def _get_runtime_proxy_coordinator():
+    """Start this process's authenticated canonical-runtime proxy endpoint lazily."""
+    global _runtime_proxy_coordinator
+    with _runtime_proxy_coordinator_lock:
+        if _runtime_proxy_coordinator is not None:
+            return _runtime_proxy_coordinator
+        from tui_gateway.runtime_proxy import RuntimeProxyCoordinator
+
+        endpoint_name = hashlib.sha256(
+            f"{Path(_hermes_home).resolve()}:{_backend_id_for_this_process()}".encode()
+        ).hexdigest()[:24]
+        coordinator = RuntimeProxyCoordinator(
+            registry_home=_hermes_home,
+            endpoint=_runtime_proxy_endpoint(endpoint_name),
+            owner_id=_backend_id_for_this_process(),
+            surface="tui_gateway",
+            dispatch=lambda request, transport: dispatch(request, transport),
+            detach=lambda transport: _close_sessions_for_transport(
+                transport, end_reason="runtime_proxy_disconnect"
+            ),
+        )
+        if not coordinator.start():
+            raise RuntimeError("canonical runtime proxy endpoint failed to start")
+        _runtime_proxy_coordinator = coordinator
+        atexit.register(coordinator.stop)
+        return coordinator
+
+
+def _profile_scoped_runtime_key(conversation_key: str, profile_home: str | Path) -> str:
+    profile = str(Path(profile_home).expanduser().resolve())
+    material = f"{profile}\0{conversation_key}".encode("utf-8")
+    return f"v1:{hashlib.sha256(material).hexdigest()}"
+
+
+def _claim_local_runtime_owner(conversation_key: str, profile_home: str | Path):
+    if _cross_process_runtime_proxy_supported():
+        return _get_runtime_proxy_coordinator().claim_local(
+            conversation_key=conversation_key,
+            profile_home=profile_home,
+        )
+
+    from hermes_cli.live_runtime_owners import claim_runtime_owner
+
+    owner_key = _profile_scoped_runtime_key(conversation_key, profile_home)
+    owner_id = _backend_id_for_this_process()
+    claim = claim_runtime_owner(
+        conversation_key=owner_key,
+        owner_id=owner_id,
+        endpoint=f"process-local:{owner_id}",
+        surface="tui_gateway_process_local",
+        registry_home=_hermes_home,
+        profile_home=profile_home,
+    )
+    if claim.kind != "owned" or claim.lease is None:
+        raise RuntimeError(
+            "canonical runtime is owned by another process; "
+            "authenticated cross-process proxying is unavailable on this platform"
+        )
+    return claim.lease
+
+
+def _prepare_runtime_resume_proxy(req: dict, transport: Transport) -> dict | None:
+    """Claim the compression-root runtime before the resume handler can build it."""
+    if not _cross_process_runtime_proxy_supported():
+        return None
+    params = req.get("params")
+    if not isinstance(params, dict):
+        return None
+    target = str(params.get("session_id") or "").strip()
+    if not target:
+        return None
+    profile = str(params.get("profile") or "").strip() or None
+    db, owns_db = _db_for_profile(profile)
+    if db is None:
+        return None
+    try:
+        found = db.get_session(target)
+        if not found:
+            found = db.get_session_by_title(target)
+            if found:
+                target = str(found["id"])
+        if not found:
+            return None
+        try:
+            target = db.resolve_resume_session_id(target) or target
+        except Exception:
+            pass
+        profile_home = _profile_home(profile) or Path(_hermes_home)
+        conversation_key = db.session_runtime_key(target)
+        return _get_runtime_proxy_coordinator().prepare_resume(
+            conversation_key=conversation_key,
+            request=req,
+            transport=transport,
+            profile_home=profile_home,
+        )
+    finally:
+        if owns_db:
+            with contextlib.suppress(Exception):
+                db.close()
+
+
+def detach_runtime_proxy_transport(transport: Transport) -> None:
+    """Drop remote-owner connections and route mappings for one frontend."""
+    coordinator = _runtime_proxy_coordinator
+    if coordinator is not None:
+        coordinator.detach_transport(transport)
 
 
 def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
@@ -3005,7 +3533,17 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
             return normalized
 
         _rid, method, _params = normalized
-        if method not in _LONG_HANDLERS:
+        remote_coordinator = _runtime_proxy_coordinator
+        remote_session_id = (
+            _params.get("session_id") if isinstance(_params, dict) else None
+        )
+        has_remote_route = bool(
+            remote_coordinator is not None
+            and isinstance(remote_session_id, str)
+            and remote_session_id
+            and remote_coordinator.has_remote_route(t, remote_session_id)
+        )
+        if method not in _LONG_HANDLERS and not has_remote_route:
             return handle_request(req)
 
         # Snapshot the context so the pool worker sees the bound transport.
@@ -3013,7 +3551,21 @@ def dispatch(req: dict, transport: Optional[Transport] = None) -> dict | None:
 
         def run():
             try:
-                resp = handle_request(req)
+                if has_remote_route:
+                    resp = remote_coordinator.route_request(req, t)
+                    if resp is None:
+                        resp = _err(
+                            req.get("id"),
+                            -32072,
+                            "canonical runtime owner unavailable",
+                            {"outcome": "unknown", "retryable": False},
+                        )
+                elif method == "session.resume":
+                    resp = _prepare_runtime_resume_proxy(req, t)
+                    if resp is None:
+                        resp = handle_request(req)
+                else:
+                    resp = handle_request(req)
             except Exception as exc:
                 resp = _err(req.get("id"), -32000, f"handler error: {exc}")
             if resp is not None:
@@ -3152,6 +3704,21 @@ def _wait_agent_for_prompt(session: dict, rid: str, sid: str) -> dict | None:
     return _err(rid, 5032, err) if err else None
 
 
+def _ensure_runtime_owner_for_session(session: dict) -> None:
+    """Fence agent construction behind the canonical compression-root lease."""
+    existing = session.get("runtime_owner_lease")
+    if existing is not None and not getattr(existing, "released", False):
+        return
+    session_key = str(session.get("session_key") or "").strip()
+    if not session_key:
+        raise RuntimeError("session has no canonical runtime key")
+    conversation_key = str(session.get("runtime_owner_key") or session_key)
+    profile_home = Path(session.get("profile_home") or _hermes_home)
+    session["runtime_owner_lease"] = _claim_local_runtime_owner(
+        conversation_key, profile_home
+    )
+
+
 def _start_agent_build(sid: str, session: dict) -> None:
     """Start building the real AIAgent for a TUI session, once.
 
@@ -3173,6 +3740,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
     # prompt/RPC builds the agent normally so the user can talk to the session.
     if session.get("lazy") and _child_run_active(str(session.get("session_key") or "")):
         return
+    _ensure_runtime_owner_for_session(session)
     lock = session.setdefault("agent_build_lock", threading.Lock())
     with lock:
         if ready.is_set() or session.get("agent_build_started"):
@@ -3214,9 +3782,14 @@ def _start_agent_build(sid: str, session: dict) -> None:
             if profile_home:
                 home_token = set_hermes_home_override(profile_home)
                 try:
-                    from agent.secret_scope import build_profile_secret_scope, set_secret_scope
+                    from agent.secret_scope import (
+                        build_profile_secret_scope,
+                        set_secret_scope,
+                    )
 
-                    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+                    secret_token = set_secret_scope(
+                        build_profile_secret_scope(Path(profile_home))
+                    )
                 except Exception:
                     pass
                 # DEDICATED handle — ours until _transfer_db_to_agent hands
@@ -3259,9 +3832,13 @@ def _start_agent_build(sid: str, session: dict) -> None:
                     # them directly (no global config, no build-then-switch).
                     if override := current.get("model_override"):
                         kw["model_override"] = override
-                    if (reasoning := current.get("create_reasoning_override")) is not None:
+                    if (
+                        reasoning := current.get("create_reasoning_override")
+                    ) is not None:
                         kw["reasoning_config_override"] = reasoning
-                    if (tier := current.get("create_service_tier_override")) is not None:
+                    if (
+                        tier := current.get("create_service_tier_override")
+                    ) is not None:
                         kw["service_tier_override"] = tier
                 agent = _make_agent(sid, key, **kw)
             finally:
@@ -3331,7 +3908,9 @@ def _start_agent_build(sid: str, session: dict) -> None:
                 pass
             with _sessions_lock:
                 if sid in _sessions:
-                    _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
+                    _sessions[sid]["_notif_stop"] = _start_notification_poller(
+                        sid, _sessions[sid]
+                    )
             _notify_session_boundary("on_session_reset", key, _session_source(current))
 
             info = _session_info(agent, current)
@@ -4068,10 +4647,11 @@ def _rewind_active_session_history(
             for part in content:
                 if isinstance(part, dict) and part.get("type") == "text":
                     text_parts.append(str(part.get("text", "")))
-                elif (
-                    isinstance(part, dict)
-                    and part.get("type") in {"image", "image_url", "input_image"}
-                ):
+                elif isinstance(part, dict) and part.get("type") in {
+                    "image",
+                    "image_url",
+                    "input_image",
+                }:
                     text_parts.append("[screenshot]")
             content = "\n".join(text_parts) if text_parts else None
         if message.get("role") in {"user", "assistant"} and isinstance(content, str):
@@ -4148,8 +4728,7 @@ def _rewind_active_session_history(
                 warm.get("role") == durable_message.get("role")
                 and bool(warm.get("display_kind"))
                 == bool(durable_message.get("display_kind"))
-                and _comparison_content(warm)
-                == _comparison_content(durable_message)
+                and _comparison_content(warm) == _comparison_content(durable_message)
                 for warm, durable_message in zip(installed, durable_prefix)
             ):
                 for warm, durable_message in zip(installed, durable_prefix):
@@ -4180,9 +4759,7 @@ def _history_without_ephemeral_scaffolding(history: list[dict]) -> list[dict]:
     from run_agent import _is_ephemeral_scaffolding
 
     return [
-        message.copy()
-        for message in history
-        if not _is_ephemeral_scaffolding(message)
+        message.copy() for message in history if not _is_ephemeral_scaffolding(message)
     ]
 
 
@@ -4210,7 +4787,10 @@ def _persist_session_git_meta(session: dict, cwd: str, generation: int) -> None:
         return
     # Snapshot the routing fields now; the live session dict may be gone by the
     # time the thread runs. `_session_db` reopens the profile-correct db inside.
-    db_session = {"session_key": session_key, "profile_home": session.get("profile_home")}
+    db_session = {
+        "session_key": session_key,
+        "profile_home": session.get("profile_home"),
+    }
 
     def _run() -> None:
         try:
@@ -4242,9 +4822,7 @@ def _persist_session_cwd_and_schedule_git_meta(
     """Claim a DB-backed probe generation, then start Git enrichment."""
     try:
         if db is not None:
-            generation = db.update_session_cwd(
-                session.get("session_key", ""), cwd
-            )
+            generation = db.update_session_cwd(session.get("session_key", ""), cwd)
         else:
             with _session_db(session) as owner_db:
                 if owner_db is None:
@@ -4364,6 +4942,7 @@ def _load_cfg_raw() -> dict:
                 return copy.deepcopy(_cfg_cache)
         if p.exists():
             from hermes_cli.config import read_user_config_raw
+
             data = read_user_config_raw(p)
         else:
             data = {}
@@ -4541,6 +5120,32 @@ def _enable_gateway_prompts() -> None:
 # ── Blocking prompt factory ──────────────────────────────────────────
 
 
+def _prune_clarification_outcomes_locked(now: float | None = None) -> None:
+    """Bound and expire clarification tombstones while holding _prompt_lock."""
+    current = time.monotonic() if now is None else now
+    expired = [
+        request_id
+        for request_id, (_status, recorded_at) in _clarification_outcomes.items()
+        if current - recorded_at > _CLARIFICATION_OUTCOME_TTL_S
+    ]
+    for request_id in expired:
+        _clarification_outcomes.pop(request_id, None)
+    while len(_clarification_outcomes) > _CLARIFICATION_OUTCOMES_MAX:
+        _clarification_outcomes.pop(next(iter(_clarification_outcomes)))
+
+
+def _remember_clarification_outcome_locked(request_id: str, status: str) -> None:
+    _clarification_outcomes.pop(request_id, None)
+    _clarification_outcomes[request_id] = (status, time.monotonic())
+    _prune_clarification_outcomes_locked()
+
+
+def _clarification_outcome_locked(request_id: str) -> str | None:
+    _prune_clarification_outcomes_locked()
+    outcome = _clarification_outcomes.get(request_id)
+    return outcome[0] if outcome is not None else None
+
+
 def _block(
     event: str,
     sid: str,
@@ -4578,6 +5183,19 @@ def _block(
             batch_state = _batch_clarify.pop(rid, None)
             if batch_state is not None:
                 batch_answers = dict(batch_state["answers"])
+            if event == "clarify.request":
+                batch_resolved = bool(
+                    batch_state is not None
+                    and all(
+                        qid in batch_state["answers"] for qid in batch_state["qids"]
+                    )
+                )
+                _remember_clarification_outcome_locked(
+                    rid,
+                    "already_resolved"
+                    if answer_present or batch_resolved
+                    else "expired",
+                )
 
     if batch_qids is not None:
         # Cancel-all (respond with no question_id) resolves via _answers with
@@ -4604,17 +5222,22 @@ def _block(
     # slow renderer (or a reconnect that dropped tool.complete) can still answer
     # afterward. Without this the late `*.respond` would hit the generic 4009
     # "no pending request" error and clients would surface a raw JSON-RPC string.
-    if not answered and not answer_present and event in {
-        "secret.request",
-        "sudo.request",
-        "clarify.request",
-        "terminal.read.request",
-        "preview.read.request",
-        "preview.act.request",
-        "window.read.request",
-        "mcp.setup.request",
-        "tour.request",
-    }:
+    if (
+        not answered
+        and not answer_present
+        and event
+        in {
+            "secret.request",
+            "sudo.request",
+            "clarify.request",
+            "terminal.read.request",
+            "preview.read.request",
+            "preview.act.request",
+            "window.read.request",
+            "mcp.setup.request",
+            "tour.request",
+        }
+    ):
         _emit(
             f"{event.removesuffix('.request')}.expire",
             sid,
@@ -4630,6 +5253,7 @@ def _clarify_timeout_seconds() -> float | None:
     means unlimited and is returned as ``None`` (never auto-skip)."""
     try:
         from tools.clarify_gateway import get_clarify_timeout
+
         timeout = get_clarify_timeout()
         return timeout if timeout > 0 else None
     except Exception:
@@ -4689,18 +5313,16 @@ _TOUR_TIMEOUT_S = 45
 # a working renderer cannot miss. See _tour_request.
 _TOUR_PROBE_TIMEOUT_S = 10
 
-_TOUR_BRIDGE_UNAVAILABLE = json.dumps(
-    {
-        "success": False,
-        "error": (
-            "No Hermes Desktop window answered the tour request. The tour is "
-            "driven by the desktop app's renderer, which updates separately "
-            "from this backend, so an app build older than the tour tool has "
-            "nothing listening. Update the Hermes Desktop app and start a new "
-            "session. Do not retry tour in this session."
-        ),
-    }
-)
+_TOUR_BRIDGE_UNAVAILABLE = json.dumps({
+    "success": False,
+    "error": (
+        "No Hermes Desktop window answered the tour request. The tour is "
+        "driven by the desktop app's renderer, which updates separately "
+        "from this backend, so an app build older than the tour tool has "
+        "nothing listening. Update the Hermes Desktop app and start a new "
+        "session. Do not retry tour in this session."
+    ),
+})
 
 
 def _tour_request(sid: str, payload: dict) -> str:
@@ -5286,9 +5908,7 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
                 base_url=base_url or None, model=model or None
             )
         except Exception:
-            logger.debug(
-                "custom provider identity recovery failed", exc_info=True
-            )
+            logger.debug("custom provider identity recovery failed", exc_info=True)
         provider = healed or ("" if not base_url else provider)
 
     if model:
@@ -5348,15 +5968,11 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
                 )
 
                 provider = (
-                    canonical_custom_identity(
-                        base_url=base_url, model=model or None
-                    )
+                    canonical_custom_identity(base_url=base_url, model=model or None)
                     or provider
                 )
             except Exception:
-                logger.debug(
-                    "custom provider identity lookup failed", exc_info=True
-                )
+                logger.debug("custom provider identity lookup failed", exc_info=True)
         config["provider"] = provider
     if base_url:
         config["base_url"] = base_url
@@ -5436,9 +6052,7 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     # override and the rebuilt prompt silently uses the root profile's
     # SOUL.md and skills.  See issue #50233.
     profile_home = session.get("profile_home")
-    home_token = (
-        set_hermes_home_override(profile_home) if profile_home else None
-    )
+    home_token = set_hermes_home_override(profile_home) if profile_home else None
     # Bind the session context too. This function runs on the RPC dispatcher
     # thread (model.switch, config.set model). On that thread the _SESSION_CWD
     # contextvar is not set, so resolve_agent_cwd() falls back to the process
@@ -5446,13 +6060,13 @@ def _persist_live_session_system_prompt(session: dict | None) -> None:
     # prompt then records the wrong working directory and persists it. Later
     # turns restore the stored bytes without change, because the turn
     # prologue rebuilds only when _cached_system_prompt is None.
-    session_tokens = _set_session_context(
-        session_key, cwd=_session_cwd(session)
-    )
+    session_tokens = _set_session_context(session_key, cwd=_session_cwd(session))
     try:
         prompt = agent._build_system_prompt(None)
         agent._cached_system_prompt = prompt
-        db.update_system_prompt(getattr(agent, "session_id", None) or session_key, prompt)
+        db.update_system_prompt(
+            getattr(agent, "session_id", None) or session_key, prompt
+        )
     except Exception:
         logger.warning(
             "failed to persist live session system prompt for session %s",
@@ -5494,7 +6108,9 @@ def _is_pivot_marker(entry: Any) -> bool:
     return isinstance(entry, dict) and entry.get("display_kind") == "personality_switch"
 
 
-def _append_model_switch_marker(session: dict | None, *, model: str, provider: str) -> None:
+def _append_model_switch_marker(
+    session: dict | None, *, model: str, provider: str
+) -> None:
     """Record a real system-history pivot after a live model switch.
 
     Only the most recent marker is kept: each new switch first strips any
@@ -5998,7 +6614,9 @@ def _restore_agent_model_runtime(agent, snapshot: dict | None) -> None:
             if agent._restore_primary_runtime():
                 return
         except Exception:
-            logger.debug("TUI one-turn model restore via primary runtime failed", exc_info=True)
+            logger.debug(
+                "TUI one-turn model restore via primary runtime failed", exc_info=True
+            )
     if hasattr(agent, "switch_model"):
         agent.switch_model(
             new_model=snapshot.get("model", ""),
@@ -6037,7 +6655,9 @@ def _apply_model_switch(
         is_session = parsed_flags.is_session
         one_turn = parsed_flags.is_once
     else:
-        model_input, explicit_provider, is_global_flag, _force_refresh, is_session = parsed_flags
+        model_input, explicit_provider, is_global_flag, _force_refresh, is_session = (
+            parsed_flags
+        )
         one_turn = False
     # Conflict validation delegates to the shared single-owner parser; the
     # TUI surfaces it as a raised ValueError (its historical behavior)
@@ -6113,11 +6733,15 @@ def _apply_model_switch(
     if not result.success:
         raise ValueError(result.error_message or "model switch failed")
 
-    restore_snapshot = _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
+    restore_snapshot = (
+        _snapshot_agent_model_runtime(agent) if (one_turn and agent) else None
+    )
 
     if agent:
         try:
-            from hermes_cli.context_switch_guard import merge_preflight_compression_warning
+            from hermes_cli.context_switch_guard import (
+                merge_preflight_compression_warning,
+            )
 
             _cfg_ctx = None
             if isinstance(cfg, dict):
@@ -6246,7 +6870,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
         if not title:
             db = getattr(agent, "_session_db", None)
             key = session.get("session_key") or ""
-            title = str((db.get_session_title(key) if (db and key) else None) or "").strip()
+            title = str(
+                (db.get_session_title(key) if (db and key) else None) or ""
+            ).strip()
         if title != "Bot Chat":
             return
         from tools.bot_mode_probe import capability_fingerprint
@@ -6282,7 +6908,9 @@ def _sync_bot_capabilities(sid: str, session: dict) -> None:
         _emit(
             "notice",
             sid,
-            {"message": "Capabilities updated — this bot's tools and prompt were refreshed."},
+            {
+                "message": "Capabilities updated — this bot's tools and prompt were refreshed."
+            },
         )
     except Exception as e:
         logger.warning("Bot capability sync failed for %s: %s", sid, e)
@@ -6377,7 +7005,11 @@ def _tui_compression_config_signature(cfg: dict | None) -> tuple:
         for key, value in keys.items()
         if key.startswith("compression.") or key == "model.context_length"
     }
-    compression = cfg.get("compression") if isinstance(cfg, dict) and isinstance(cfg.get("compression"), dict) else {}
+    compression = (
+        cfg.get("compression")
+        if isinstance(cfg, dict) and isinstance(cfg.get("compression"), dict)
+        else {}
+    )
     for extra in ("idle_compact_after_seconds", "tail_mode"):
         picked[f"compression.{extra}"] = compression.get(extra)
     return tuple(sorted(picked.items()))
@@ -6396,9 +7028,7 @@ def _compressor_ctor_default(name: str, fallback: Any) -> Any:
 
         from agent.context_compressor import ContextCompressor
 
-        default = inspect.signature(ContextCompressor.__init__).parameters[
-            name
-        ].default
+        default = inspect.signature(ContextCompressor.__init__).parameters[name].default
         if default is inspect.Parameter.empty:
             return fallback
         return default
@@ -6468,7 +7098,9 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
     acted only on PRESENT keys, leaving stale values active forever.
     """
     cfg = cfg if isinstance(cfg, dict) else {}
-    compression = cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+    compression = (
+        cfg.get("compression") if isinstance(cfg.get("compression"), dict) else {}
+    )
     model_cfg = cfg.get("model") if isinstance(cfg.get("model"), dict) else {}
 
     enabled_raw = compression.get("enabled", True)
@@ -6660,9 +7292,7 @@ def _sync_agent_compression_with_config(sid: str, session: dict) -> None:
     try:
         _apply_live_compression_config(agent, cfg)
     except Exception as e:
-        logger.warning(
-            "Could not apply live compression config for %s: %s", sid, e
-        )
+        logger.warning("Could not apply live compression config for %s: %s", sid, e)
 
 
 def _apply_pending_model_switch(sid: str, session: dict) -> None:
@@ -6693,7 +7323,11 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
             _emit(
                 "error",
                 sid,
-                {"message": result.get("confirm_message") or result.get("warning") or ""},
+                {
+                    "message": result.get("confirm_message")
+                    or result.get("warning")
+                    or ""
+                },
             )
     except Exception as e:
         _emit(
@@ -6706,6 +7340,7 @@ def _apply_pending_model_switch(sid: str, session: dict) -> None:
 class CompressionLockHeld(Exception):
     """Raised by _compress_session_history when compression skipped due
     to a concurrent lock on the session's compression_locks row."""
+
     def __init__(self, holder: str | None = None):
         self.holder = holder
         super().__init__(f"Compression lock held: {holder or 'unknown'}")
@@ -6925,9 +7560,9 @@ def _sync_session_key_after_compress(
     # claimed envelope is restored to the queue (see ``_drain_queued_prompt``)
     # so legitimate follow-ups still survive. Complements self-duplicate
     # scrubbing on redirect.
-    session["_queued_prompt_generation"] = int(
-        session.get("_queued_prompt_generation", 0)
-    ) + 1
+    session["_queued_prompt_generation"] = (
+        int(session.get("_queued_prompt_generation", 0)) + 1
+    )
 
     if clear_pending_title:
         session["pending_title"] = None
@@ -6976,13 +7611,16 @@ def _get_usage(agent) -> dict:
         if ctx_max and last_prompt:
             usage["context_used"] = last_prompt
             usage["context_max"] = ctx_max
-            usage["context_percent"] = max(0, min(100, round(last_prompt / ctx_max * 100)))
+            usage["context_percent"] = max(
+                0, min(100, round(last_prompt / ctx_max * 100))
+            )
         usage["compressions"] = getattr(comp, "compression_count", 0) or 0
     # Live count of background/async subagents still running (delegate_task
     # batches + background single delegations). Mirrors the classic CLI status
     # bar's ⛓ indicator; sourced from the same async_delegation registry.
     try:
         from tools.async_delegation import active_count as _async_active_count
+
         usage["active_subagents"] = _async_active_count()
     except Exception:
         pass
@@ -7122,7 +7760,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     session_key = str(
         (session or {}).get("session_key") or getattr(agent, "session_id", "") or ""
     )
-    cfg_personality = ((_load_cfg().get("display") or {}).get("personality") or "")
+    cfg_personality = (_load_cfg().get("display") or {}).get("personality") or ""
     personality = (session or {}).get("personality", cfg_personality)
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
@@ -7135,7 +7773,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
             reasoning_effort = "none"
         else:
             reasoning_effort = str(reasoning_config.get("effort", "") or "")
-    service_tier = getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    service_tier = (
+        getattr(agent, "service_tier", None) or mirror.get("service_tier") or ""
+    )
     # Effective approval-bypass state — the same three sources that
     # check_all_command_guards() ORs together: persistent config
     # (approvals.mode=off), the process-scoped --yolo env, and the
@@ -7181,8 +7821,12 @@ def _session_info(agent, session: dict | None = None) -> dict:
         "fast": service_tier == "priority",
         "yolo": yolo,
         "approval_mode": approval_mode,
-        "tools": dict(mirror.get("tools") or {}) if isinstance(mirror.get("tools"), dict) else {},
-        "skills": dict(mirror.get("skills") or {}) if isinstance(mirror.get("skills"), dict) else {},
+        "tools": dict(mirror.get("tools") or {})
+        if isinstance(mirror.get("tools"), dict)
+        else {},
+        "skills": dict(mirror.get("skills") or {})
+        if isinstance(mirror.get("skills"), dict)
+        else {},
         "cwd": cwd,
         "branch": _git_branch_for_cwd(cwd),
         "project": _project_info_for_cwd(cwd),
@@ -7220,9 +7864,9 @@ def _session_info(agent, session: dict | None = None) -> dict:
             info["tools"] = {}
             for t in getattr(agent, "tools", []) or []:
                 name = t["function"]["name"]
-                info["tools"].setdefault(get_toolset_for_tool(name) or "other", []).append(
-                    name
-                )
+                info["tools"].setdefault(
+                    get_toolset_for_tool(name) or "other", []
+                ).append(name)
         except Exception:
             pass
         try:
@@ -7503,7 +8147,11 @@ def _on_tool_complete(sid: str, tool_call_id: str, name: str, args: dict, result
             payload["inline_diff"] = "\n".join(rendered)
     except Exception:
         pass
-    if _tool_progress_enabled(sid) or payload.get("inline_diff") or _tool_lifecycle_required_for_ui(name):
+    if (
+        _tool_progress_enabled(sid)
+        or payload.get("inline_diff")
+        or _tool_lifecycle_required_for_ui(name)
+    ):
         _emit("tool.complete", sid, payload)
 
 
@@ -7710,7 +8358,9 @@ def _mirror_subagent_to_child(event_type: str, payload: dict) -> None:
         return
     csid = live[0]
     with _child_mirrors_lock:
-        st = _child_mirrors.setdefault(child_key, {"seq": 0, "open_tool": None, "started": False})
+        st = _child_mirrors.setdefault(
+            child_key, {"seq": 0, "open_tool": None, "started": False}
+        )
         if not st["started"]:
             st["started"] = True
             _emit("message.start", csid)
@@ -7757,11 +8407,13 @@ def _agent_cbs(sid: str) -> dict:
         "tool_complete_callback": lambda tc_id, name, args, result: _on_tool_complete(
             sid, tc_id, name, args, result
         ),
-        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: _on_tool_progress(
-            sid, event_type, name, preview, args, **kwargs
+        "tool_progress_callback": lambda event_type, name=None, preview=None, args=None, **kwargs: (
+            _on_tool_progress(sid, event_type, name, preview, args, **kwargs)
         ),
-        "tool_gen_callback": lambda name: _tool_progress_enabled(sid)
-        and _emit("tool.generating", sid, {"name": name}),
+        "tool_gen_callback": lambda name: (
+            _tool_progress_enabled(sid)
+            and _emit("tool.generating", sid, {"name": name})
+        ),
         "thinking_callback": lambda text: _emit("thinking.delta", sid, {"text": text}),
         # Affection reaction (ily / <3 / good bot) → hearts. Core-detected, so
         # the TUI heart and desktop floating hearts share one signal.
@@ -7891,7 +8543,10 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
             sid, session = key, _sessions[key]
         else:
             for cand_sid, cand in _sessions.items():
-                if cand.get("session_key") == key or getattr(cand.get("agent"), "session_id", None) == key:
+                if (
+                    cand.get("session_key") == key
+                    or getattr(cand.get("agent"), "session_id", None) == key
+                ):
                     sid, session = cand_sid, cand
                     break
 
@@ -7924,7 +8579,9 @@ def _apply_project_workspace(task_id: str, path: str, _name: str = "") -> None:
         )
         _emit("session.info", sid, info)
     except Exception:
-        logger.debug("failed to emit session.info after project workspace move", exc_info=True)
+        logger.debug(
+            "failed to emit session.info after project workspace move", exc_info=True
+        )
 
 
 def _wire_callbacks(sid: str):
@@ -8052,9 +8709,11 @@ def _apply_personality_to_session(
         # every later rewind resolves one turn too early and `replace_messages`
         # hard-deletes the difference (#82756).
         with session["history_lock"]:
-            session["history"].append(
-                {"role": "user", "content": marker, "display_kind": "personality_switch"}
-            )
+            session["history"].append({
+                "role": "user",
+                "content": marker,
+                "display_kind": "personality_switch",
+            })
             session["history_version"] = int(session.get("history_version", 0)) + 1
         info = _session_info(agent)
         _emit("session.info", sid, info)
@@ -8064,6 +8723,7 @@ def _apply_personality_to_session(
 
 def _cfg_max_turns(cfg: dict, default: int) -> int:
     from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+
     # Env var override (highest priority)
     env_val = os.environ.get("HERMES_TUI_MAX_TURNS")
     if env_val:
@@ -8144,7 +8804,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
             agent, "provider_require_parameters", False
         ),
         "provider_data_collection": getattr(agent, "provider_data_collection", None),
-        "openrouter_min_coding_score": getattr(agent, "openrouter_min_coding_score", None),
+        "openrouter_min_coding_score": getattr(
+            agent, "openrouter_min_coding_score", None
+        ),
         "session_id": task_id,
         "reasoning_config": getattr(agent, "reasoning_config", None)
         or _load_reasoning_config(str(getattr(agent, "model", "") or "")),
@@ -8158,17 +8820,17 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
 
 def _ephemeral_preview_agent_kwargs(agent, task_id: str) -> dict:
     kwargs = _background_agent_kwargs(agent, task_id)
-    kwargs.update(
-        {
-            "enabled_toolsets": ["terminal", "file"],
-            "session_db": None,
-            "skip_memory": True,
-        }
-    )
+    kwargs.update({
+        "enabled_toolsets": ["terminal", "file"],
+        "session_db": None,
+        "skip_memory": True,
+    })
     return kwargs
 
 
-def _preview_restart_history(session: dict, max_messages: int = 24, max_tool_chars: int = 1200) -> list[dict]:
+def _preview_restart_history(
+    session: dict, max_messages: int = 24, max_tool_chars: int = 1200
+) -> list[dict]:
     """Distill the parent session's recent history into a context the
     ephemeral preview-restart agent can actually use.
 
@@ -8255,7 +8917,11 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
     def progress(message: str, level: str = "info") -> None:
         text = str(message or "").strip()
         if text:
-            _emit("preview.restart.progress", parent, {"task_id": task_id, "level": level, "text": text})
+            _emit(
+                "preview.restart.progress",
+                parent,
+                {"task_id": task_id, "level": level, "text": text},
+            )
 
     def tool_start(tool_call_id: str, name: str, args: dict) -> None:
         started_at[tool_call_id] = time.time()
@@ -8264,11 +8930,16 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
 
     def tool_complete(tool_call_id: str, name: str, _args: dict, result: str) -> None:
         duration_s = time.time() - started_at.get(tool_call_id, time.time())
-        summary = _tool_summary(name, result, duration_s) or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
+        summary = (
+            _tool_summary(name, result, duration_s)
+            or f"Finished {name}{f' in {_fmt_tool_duration(duration_s)}' if duration_s else ''}"
+        )
         output = _preview_tool_result_preview(name, result)
         progress(summary + (f"\n{output}" if output else ""))
 
-    def tool_progress(event_type: str, name: str | None = None, preview: str | None = None, **_kwargs) -> None:
+    def tool_progress(
+        event_type: str, name: str | None = None, preview: str | None = None, **_kwargs
+    ) -> None:
         if preview:
             progress(str(preview))
         elif name:
@@ -8279,7 +8950,9 @@ def _preview_restart_callbacks(parent: str, task_id: str) -> dict:
         "tool_complete_callback": tool_complete,
         "tool_progress_callback": tool_progress,
         "tool_gen_callback": lambda name: progress(f"Preparing {name}"),
-        "status_callback": lambda kind, text=None: progress(text if text is not None else kind),
+        "status_callback": lambda kind, text=None: progress(
+            text if text is not None else kind
+        ),
     }
 
 
@@ -8310,7 +8983,9 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     session["attached_images"] = []
     session["queued_prompt"] = None
     session.pop("queued_prompts", None)
-    session["_queued_prompt_generation"] = int(session.get("_queued_prompt_generation", 0)) + 1
+    session["_queued_prompt_generation"] = (
+        int(session.get("_queued_prompt_generation", 0)) + 1
+    )
     session["edit_snapshots"] = {}
     session["image_counter"] = 0
     session["running"] = False
@@ -8393,6 +9068,7 @@ def _schedule_mcp_late_refresh(sid: str, agent) -> None:
             info = _session_info(agent, session)
         # Emit outside the lock — write_json must not block under _sessions_lock.
         _emit("session.info", sid, info)
+
     threading.Thread(
         target=_wait_then_refresh,
         name=f"tui-mcp-late-refresh-{sid}",
@@ -8627,7 +9303,9 @@ def _make_agent(
             if service_tier_override is not None
             else _load_service_tier()
         ),
-        enabled_toolsets=_load_enabled_toolsets(_resolve_agent_platform(platform_override)),
+        enabled_toolsets=_load_enabled_toolsets(
+            _resolve_agent_platform(platform_override)
+        ),
         # OpenRouter provider-routing prefs (config.yaml `provider_routing`).
         # Mirrors the messaging gateway + CLI so the desktop/TUI honors the same
         # routing instead of letting OpenRouter pick providers at random.
@@ -8693,8 +9371,10 @@ def _init_session(
             "model_override": None,
             # Pin async event emissions to whichever transport created the
             # session (stdio for Ink, JSON-RPC WS for the dashboard sidebar).
+            # Kept as a compatibility alias; event_hub owns delivery.
             "transport": current_transport() or _stdio_transport,
         }
+        _attach_current_transport(sid, _sessions[sid])
     _init_owns_db = False
     if session_db is not None:
         db = session_db
@@ -8732,9 +9412,7 @@ def _init_session(
                             _sessions[sid], _cwd, db=db
                         )
                 except Exception:
-                    logger.debug(
-                        "failed to persist resumed session cwd", exc_info=True
-                    )
+                    logger.debug("failed to persist resumed session cwd", exc_info=True)
     finally:
         if _init_owns_db and db is not None:
             try:
@@ -8773,8 +9451,12 @@ def _init_session(
     _wire_callbacks(sid)
     with _sessions_lock:
         if sid in _sessions:
-            _sessions[sid]["_notif_stop"] = _start_notification_poller(sid, _sessions[sid])
-    _notify_session_boundary("on_session_reset", key, _session_source(_sessions.get(sid, {})))
+            _sessions[sid]["_notif_stop"] = _start_notification_poller(
+                sid, _sessions[sid]
+            )
+    _notify_session_boundary(
+        "on_session_reset", key, _session_source(_sessions.get(sid, {}))
+    )
     _emit("session.info", sid, _session_info(agent, _sessions.get(sid, {})))
     _schedule_mcp_late_refresh(sid, agent)
 
@@ -8843,7 +9525,9 @@ def _build_image_ref_message(user_text: str, image_paths: list[str]) -> str:
     return text or "What do you see in this image?"
 
 
-def _build_persist_message_with_image_refs(user_text: str, image_paths: list[str]) -> str:
+def _build_persist_message_with_image_refs(
+    user_text: str, image_paths: list[str]
+) -> str:
     """Build the clean, UI-recognizable version of the user's message for
     persisting to session history. Uses ``@image:<path>`` directives — the
     format the desktop client (directive-text.tsx / HERMES_DIRECTIVE_RE)
@@ -8862,13 +9546,17 @@ def _build_persist_message_with_image_refs(user_text: str, image_paths: list[str
     from agent.context_references import format_reference_value
 
     text = user_text or ""
-    refs = "\n".join(f"@image:{format_reference_value(p)}" for p in image_paths if Path(p).exists())
+    refs = "\n".join(
+        f"@image:{format_reference_value(p)}" for p in image_paths if Path(p).exists()
+    )
     if not refs:
         return text
     return f"{text}\n{refs}" if text else refs
 
 
-def _build_persist_user_message(user_text: str, image_paths: list[str], run_message: Any) -> Any:
+def _build_persist_user_message(
+    user_text: str, image_paths: list[str], run_message: Any
+) -> Any:
     """Shape the persisted user turn to match what was sent to the model.
 
     Native-vision turns send ``content`` as a parts list, and
@@ -8882,7 +9570,9 @@ def _build_persist_user_message(user_text: str, image_paths: list[str], run_mess
     persist_text = _build_persist_message_with_image_refs(user_text, image_paths)
     if not isinstance(run_message, list):
         return persist_text
-    image_parts = [p for p in run_message if not (isinstance(p, dict) and p.get("type") == "text")]
+    image_parts = [
+        p for p in run_message if not (isinstance(p, dict) and p.get("type") == "text")
+    ]
     return [{"type": "text", "text": persist_text}, *image_parts]
 
 
@@ -9086,7 +9776,10 @@ def _expand_skill_invocation_for_replay(text: str, task_id: str) -> str:
         if cmd_key is None:
             return text
 
-        return build_skill_invocation_message(cmd_key, arg.strip(), task_id=task_id) or text
+        return (
+            build_skill_invocation_message(cmd_key, arg.strip(), task_id=task_id)
+            or text
+        )
     except Exception:
         # A skill that no longer resolves (renamed, disabled, external dir
         # gone) must not break the rewind — replay the text as typed.
@@ -9280,15 +9973,26 @@ def _inflight_text(value: Any) -> str:
     return _content_display_text(value).strip()
 
 
-def _start_inflight_turn(session: dict, text: Any) -> None:
+def _start_inflight_turn(
+    session: dict,
+    text: Any,
+    *,
+    origin_client_id: str | None = None,
+    request_id: str | None = None,
+) -> None:
     now = time.time()
-    session["inflight_turn"] = {
+    inflight = {
         "assistant": "",
         "started_at": now,
         "streaming": True,
         "updated_at": now,
         "user": _inflight_text(text),
     }
+    if origin_client_id is not None:
+        inflight["origin_client_id"] = origin_client_id
+    if request_id is not None:
+        inflight["request_id"] = request_id
+    session["inflight_turn"] = inflight
 
 
 def _append_inflight_delta(session: dict, delta: Any) -> None:
@@ -9354,7 +10058,11 @@ def _fail_inflight_turn(
 
     Caller must hold ``session["history_lock"]``.
     """
-    message = str(error) if not isinstance(error, BaseException) else (str(error) or type(error).__name__)
+    message = (
+        str(error)
+        if not isinstance(error, BaseException)
+        else (str(error) or type(error).__name__)
+    )
     now = time.time()
     turn = session.get("inflight_turn")
     if not isinstance(turn, dict):
@@ -9400,7 +10108,9 @@ def _auto_continue_config() -> tuple[bool, float, int]:
     if not isinstance(cfg, dict):
         cfg = {}
     try:
-        minutes = float(cfg.get("freshness_minutes", _AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT))
+        minutes = float(
+            cfg.get("freshness_minutes", _AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT)
+        )
     except (TypeError, ValueError):
         minutes = float(_AUTO_CONTINUE_FRESHNESS_MINUTES_DEFAULT)
     return (
@@ -9448,7 +10158,9 @@ def _auto_continue_note(prompt: str) -> str:
     )
 
 
-def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> dict | None:
+def _maybe_schedule_auto_continue(
+    sid: str, session: dict, session_key: str
+) -> dict | None:
     """Kick off a continuation turn for a crash-interrupted session.
 
     Called from session.resume's cold paths after the live record is
@@ -9481,14 +10193,20 @@ def _maybe_schedule_auto_continue(sid: str, session: dict, session_key: str) -> 
             _start_agent_build(sid, session)
             err = _wait_agent(session, rid, timeout=120.0)
         except Exception:
-            logger.warning("auto-continue agent build failed for %s", sid, exc_info=True)
+            logger.warning(
+                "auto-continue agent build failed for %s", sid, exc_info=True
+            )
             err = {"error": {"message": "agent build failed"}}
         if err:
             # Leave the marker: the next resume retries (bounded by attempts).
             session["_auto_continue_scheduled"] = False
             return
         with session["history_lock"]:
-            if session.get("running") or session.get("_turn_cancel_requested") or session.get("_finalized"):
+            if (
+                session.get("running")
+                or session.get("_turn_cancel_requested")
+                or session.get("_finalized")
+            ):
                 # A real user prompt beat us to it — their turn wins, and its
                 # own conclusion clears the marker.
                 session["_auto_continue_scheduled"] = False
@@ -9535,6 +10253,9 @@ def _enqueue_prompt(
     text: Any,
     transport: Any,
     image_paths: list[str] | None = None,
+    *,
+    origin_client_id: str | None = None,
+    request_id: str | None = None,
 ) -> None:
     """Stash a message to run as the very next turn once the live one ends.
 
@@ -9555,12 +10276,19 @@ def _enqueue_prompt(
     # the same user turn as a fresh agent invocation.
     if not image_paths and isinstance(text, str):
         turn = session.get("inflight_turn")
-        original = (
-            str(turn.get("user") or "").strip() if isinstance(turn, dict) else ""
-        )
+        original = str(turn.get("user") or "").strip() if isinstance(turn, dict) else ""
         if original and text.strip() == original:
             return
-    queued = {"text": text, "transport": transport}
+    legacy_envelope = origin_client_id is None and request_id is None
+    queued = {"text": text}
+    if legacy_envelope:
+        # Compatibility for internal/older call sites while RPC ingress is
+        # migrated. Multi-client envelopes carry origin, never a destination.
+        queued["transport"] = transport
+    else:
+        queued["origin_client_id"] = origin_client_id or "unknown"
+        if request_id is not None:
+            queued["request_id"] = request_id
     if image_paths:
         queued["image_paths"] = image_paths
     existing = session.get("queued_prompt")
@@ -9571,9 +10299,19 @@ def _enqueue_prompt(
         and not existing.get("image_paths")
         and not image_paths
         and not session.get("queued_prompts")
+        and (
+            legacy_envelope
+            or existing.get("origin_client_id") == queued.get("origin_client_id")
+        )
     ):
         prev = existing["text"]
         existing["text"] = f"{prev}\n\n{text}" if prev and text else (prev or text)
+        if request_id is not None:
+            request_ids = existing.setdefault(
+                "request_ids", [existing.get("request_id")]
+            )
+            if request_id not in request_ids:
+                request_ids.append(request_id)
         return
     if existing:
         session.setdefault("queued_prompts", []).append(queued)
@@ -9581,9 +10319,7 @@ def _enqueue_prompt(
     session["queued_prompt"] = queued
 
 
-def _sanitize_queued_entry_vs_inflight_user(
-    entry: Any, original: str
-) -> dict | None:
+def _sanitize_queued_entry_vs_inflight_user(entry: Any, original: str) -> dict | None:
     """Drop or rewrite a queue envelope that re-carries the live user text.
 
     Returns ``None`` to drop the envelope, or a (possibly rewritten) dict to
@@ -9689,11 +10425,20 @@ def _interrupt_busy_session(sid: str, session: dict, agent: Any) -> None:
             with session["history_lock"]:
                 session["_busy_interrupt_pending"] = False
 
-    threading.Thread(target=interrupt, daemon=True, name=f"busy-interrupt-{sid}").start()
+    threading.Thread(
+        target=interrupt, daemon=True, name=f"busy-interrupt-{sid}"
+    ).start()
 
 
 def _handle_busy_submit(
-    rid, sid: str, session: dict, text: Any, transport: Any, queued: bool = False
+    rid,
+    sid: str,
+    session: dict,
+    text: Any,
+    transport: Any,
+    queued: bool = False,
+    *,
+    origin_client_id: str | None = None,
 ) -> dict | None:
     """Apply the ``display.busy_input_mode`` policy to a prompt that lands while
     a turn is in flight, instead of rejecting it with ``session busy``.
@@ -9731,7 +10476,13 @@ def _handle_busy_submit(
             session["attached_images"] = []
     text_only = not image_paths and _is_text_only_busy_payload(text)
     plain_text = _coerce_message_text(text).strip() if text_only else ""
-    if mode == "steer" and text_only and plain_text and agent is not None and hasattr(agent, "steer"):
+    if (
+        mode == "steer"
+        and text_only
+        and plain_text
+        and agent is not None
+        and hasattr(agent, "steer")
+    ):
         try:
             if agent.steer(plain_text):
                 with session["history_lock"]:
@@ -9769,9 +10520,18 @@ def _handle_busy_submit(
     with session["history_lock"]:
         if not session.get("running"):
             if image_paths:
-                session["attached_images"] = image_paths + list(session.get("attached_images", []))
+                session["attached_images"] = image_paths + list(
+                    session.get("attached_images", [])
+                )
             return None
-        _enqueue_prompt(session, text, transport, image_paths=image_paths)
+        _enqueue_prompt(
+            session,
+            text,
+            transport,
+            image_paths=image_paths,
+            origin_client_id=origin_client_id,
+            request_id=str(rid) if origin_client_id is not None else None,
+        )
         session["last_active"] = time.time()
 
     # Attachments need a separate model invocation. Queue them without
@@ -9845,10 +10605,16 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                 )
             else:
                 resp = _submit_prompt_to_compute_host(
-                    rid, sid, session, queued["text"], queued_prompt_generation=queue_generation
+                    rid,
+                    sid,
+                    session,
+                    queued["text"],
+                    queued_prompt_generation=queue_generation,
                 )
             if resp.get("error"):
-                message = str(((resp.get("error") or {}).get("message")) or "queued prompt failed")
+                message = str(
+                    ((resp.get("error") or {}).get("message")) or "queued prompt failed"
+                )
                 with session["history_lock"]:
                     session["running"] = False
                     _clear_inflight_turn(session)
@@ -9863,6 +10629,8 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     queued["text"],
                     image_paths=queued["image_paths"],
                     queued_prompt_generation=queue_generation,
+                    origin_client_id=queued.get("origin_client_id"),
+                    request_id=queued.get("request_id"),
                 )
             else:
                 _run_prompt_submit(
@@ -9871,11 +10639,12 @@ def _drain_queued_prompt(rid, sid: str, session: dict) -> bool:
                     session,
                     queued["text"],
                     queued_prompt_generation=queue_generation,
+                    origin_client_id=queued.get("origin_client_id"),
+                    request_id=queued.get("request_id"),
                 )
     except Exception as exc:
         print(
-            f"[tui_gateway] queued prompt dispatch failed: "
-            f"{type(exc).__name__}: {exc}",
+            f"[tui_gateway] queued prompt dispatch failed: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         with session["history_lock"]:
@@ -9921,8 +10690,12 @@ def _inflight_snapshot(session: dict) -> dict | None:
         # Only sent when every correction has one, so clients can trust the
         # pairing; older in-memory turns without offsets omit the field and
         # clients fall back to placing corrections after the assistant dump.
-        if all(isinstance(offset, int) and offset >= 0 for _, offset in correction_pairs):
-            snapshot["correction_offsets"] = [int(offset) for _, offset in correction_pairs]  # type: ignore[arg-type]
+        if all(
+            isinstance(offset, int) and offset >= 0 for _, offset in correction_pairs
+        ):
+            snapshot["correction_offsets"] = [
+                int(offset) for _, offset in correction_pairs
+            ]  # type: ignore[arg-type]
     if error:
         # Retained failed turn (see _fail_inflight_turn): carry the error
         # semantics so a resuming client can rebuild the failed-turn bubble
@@ -10054,6 +10827,7 @@ def _lazy_resume_info(
 
 
 def _deferred_session_record(
+    sid: str,
     session_key: str,
     *,
     cols: int,
@@ -10067,11 +10841,13 @@ def _deferred_session_record(
     lazy: bool = False,
     model_override=None,
     resume_runtime_overrides: dict | None = None,
+    runtime_owner_key: str | None = None,
+    runtime_owner_lease=None,
 ) -> dict:
     """A live-session record whose AIAgent is built later (lazy watch / cold
     resume) — _init_session's shape minus the agent."""
     now = time.time()
-    return {
+    record = {
         "agent": None,
         "agent_error": None,
         "agent_ready": threading.Event(),
@@ -10097,6 +10873,8 @@ def _deferred_session_record(
         "resume_runtime_overrides": resume_runtime_overrides,
         "resume_session_id": session_key,
         "running": False,
+        "runtime_owner_key": runtime_owner_key or session_key,
+        "runtime_owner_lease": runtime_owner_lease,
         "session_key": session_key,
         "show_reasoning": _load_show_reasoning(),
         "slash_worker": None,
@@ -10105,6 +10883,8 @@ def _deferred_session_record(
         "tool_started_at": {},
         "transport": current_transport() or _stdio_transport,
     }
+    _attach_current_transport(sid, record)
+    return record
 
 
 def _claim_or_reuse_live(
@@ -10116,8 +10896,14 @@ def _claim_or_reuse_live(
     with _session_resume_lock:
         live = _find_live_session_by_key(session_key)
         if live is not None:
+            if runtime_owner_lease := record.get("runtime_owner_lease"):
+                live[1].setdefault("runtime_owner_lease", runtime_owner_lease)
             if lease is not None:
                 lease.release()
+            # The complete candidate runtime lost the claim race; retire its
+            # attachment worker before the caller attaches to the winner.
+            if hub := record.get("event_hub"):
+                hub.close()
             # The winner is being reattached by this resume: any pending
             # ws-orphan reap for it must not fire against the reclaimed
             # client (storm killer — see _cancel_ws_orphan_reap).
@@ -10159,7 +10945,7 @@ def _claim_parked_runtimes(
             if old_sid != keep_sid
             and not old.get("_finalized")
             and _session_lookup_key(old, fallback=old_sid) == session_key
-            and old.get("transport") is _detached_ws_transport
+            and _ws_session_is_detached(old)
         ]
     for old_sid, _old in candidates:
         _cancel_ws_orphan_reap(old_sid)
@@ -10183,9 +10969,7 @@ def _finalize_superseded_runtimes(stale: list[tuple[str, dict]]) -> None:
         try:
             _teardown_popped_session(popped, end_reason="superseded_by_resume")
         except Exception:
-            logger.exception(
-                "superseded runtime teardown failed sid=%s", old_sid
-            )
+            logger.exception("superseded runtime teardown failed sid=%s", old_sid)
 
 
 def _schedule_agent_build(sid: str, delay: float = 0.05) -> None:
@@ -10257,7 +11041,9 @@ def _schedule_resume_hydration(
             )
             _emit("error", sid, {"message": message})
             with _sessions_lock:
-                discarded = _sessions.pop(sid, None) if _sessions.get(sid) is session else None
+                discarded = (
+                    _sessions.pop(sid, None) if _sessions.get(sid) is session else None
+                )
             lease = (discarded or {}).get("active_session_lease")
             if lease is not None:
                 lease.release()
@@ -10330,7 +11116,9 @@ def _session_live_item(sid: str, session: dict, current_sid: str = "") -> dict:
     return {
         "current": sid == current_sid,
         "id": sid,
-        "last_active": float(session.get("last_active") or session.get("created_at") or now),
+        "last_active": float(
+            session.get("last_active") or session.get("created_at") or now
+        ),
         "message_count": len(history),
         "model": str(getattr(agent, "model", "") or _resolve_model()),
         "preview": preview,
@@ -10356,6 +11144,33 @@ def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
         if session.get("_finalized"):
             continue
         if _session_lookup_key(session, fallback=sid) == session_key:
+            return sid, session
+    return None
+
+
+def _find_live_session_by_runtime_key(
+    runtime_key: str, profile_home: Path | None = None
+) -> tuple[str, dict] | None:
+    expected_profile = (
+        str(Path(profile_home).expanduser().resolve())
+        if profile_home is not None
+        else None
+    )
+    for sid, session in list(_sessions.items()):
+        if session.get("_finalized"):
+            continue
+        session_profile = session.get("profile_home")
+        if expected_profile is not None:
+            if session_profile is None:
+                if expected_profile != str(Path(_hermes_home).expanduser().resolve()):
+                    continue
+            elif str(Path(session_profile).expanduser().resolve()) != expected_profile:
+                continue
+        session_runtime_key = str(
+            session.get("runtime_owner_key")
+            or _session_lookup_key(session, fallback=sid)
+        )
+        if session_runtime_key == runtime_key:
             return sid, session
     return None
 
@@ -10433,7 +11248,9 @@ def _reconcile_display_with_live(
     return list(db_display) + list(in_memory[last_shared + 1 :])
 
 
-def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> list[dict]:
+def _live_visible_history(
+    session: dict, db, in_memory_fallback: list[dict]
+) -> list[dict]:
     """Return the user-visible DISPLAY projection for a live/warm session.
 
     Serving the raw in-memory *model* history for the user-visible payload
@@ -10453,7 +11270,9 @@ def _live_visible_history(session: dict, db, in_memory_fallback: list[dict]) -> 
     key = session.get("session_key")
     if db is not None and key:
         try:
-            display = db.get_messages_as_conversation(key, include_ancestors=True, include_row_ids=True)
+            display = db.get_messages_as_conversation(
+                key, include_ancestors=True, include_row_ids=True
+            )
             return _reconcile_display_with_live(display, in_memory_fallback)
         except Exception:
             logger.debug("live display projection read failed", exc_info=True)
@@ -10467,24 +11286,20 @@ def _live_session_payload(
     cols: int | None = None,
     touch: bool = False,
     transport: Transport | None = None,
+    attachment_mode="control",
     omit_messages: bool = False,
 ) -> dict:
+    if transport is not None:
+        _attach_current_transport(
+            sid,
+            session,
+            attachment_mode,
+            transport=transport,
+        )
     with session["history_lock"]:
         if cols is not None:
             session["cols"] = cols
-        if transport is not None:
-            session["transport"] = transport
-            # Track every transport that has shown this session (multi-window:
-            # pop-out windows each resume the same sid). The last viewer
-            # becomes the transport on the disconnect path so closing a
-            # pop-out re-binds the session to a still-open window instead of
-            # stranding it on the drop sentinel (#83716).
-            viewers = session.setdefault("viewers", {})
-            viewers[transport] = time.time()
-            if transport is not _detached_ws_transport:
-                # A live transport rebind means the client is back — any
-                # pending ws-orphan reap must not fire (storm killer).
-                _cancel_ws_orphan_reap(sid)
+
         if touch:
             session["last_active"] = time.time()
         in_memory_history = list(session.get("display_history_prefix") or []) + list(
@@ -10528,7 +11343,9 @@ def _live_session_payload(
         payload["inflight"] = inflight
     if queued:
         payload["queued"] = queued
-    if approval := _pending_approval_request_payload(str(session.get("session_key") or "")):
+    if approval := _pending_approval_request_payload(
+        str(session.get("session_key") or "")
+    ):
         payload["pending_approval"] = approval
     if clarify := _pending_clarify_request_payload(sid):
         payload["pending_clarify"] = clarify
@@ -10627,7 +11444,12 @@ def _pet_row_frame_counts(spritesheet) -> dict:
             count = 0
             for col in range(cols):
                 left = col * constants.FRAME_W
-                frame = image.crop((left, top, left + constants.FRAME_W, top + constants.FRAME_H))
+                frame = image.crop((
+                    left,
+                    top,
+                    left + constants.FRAME_W,
+                    top + constants.FRAME_H,
+                ))
                 if render._frame_is_blank(frame):
                     break
                 count += 1
@@ -10647,7 +11469,9 @@ def _pet_config_scale() -> float:
         cfg = load_config()
         display = cfg.get("display", {}) if isinstance(cfg.get("display"), dict) else {}
         pet_cfg = display.get("pet", {}) if isinstance(display.get("pet"), dict) else {}
-        return float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
+        return float(
+            pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+        )
     except Exception:  # noqa: BLE001
         return constants.DEFAULT_SCALE
 
@@ -10711,7 +11535,9 @@ def _pet_active_selection():
     enabled = is_truthy_value(pet_cfg.get("enabled"), default=False)
     configured_slug = str(pet_cfg.get("slug", "") or "")
     pet = store.resolve_active_pet(configured_slug) if enabled else None
-    scale = float(pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE)
+    scale = float(
+        pet_cfg.get("scale", constants.DEFAULT_SCALE) or constants.DEFAULT_SCALE
+    )
     return enabled, pet, scale
 
 
@@ -10771,7 +11597,9 @@ def _pet_png_data_uri(path, *, max_px: int = 160) -> str:
     img.thumbnail((max_px, max_px), Image.LANCZOS)
     buf = io.BytesIO()
     img.save(buf, format="PNG")
-    return "data:image/png;base64," + base64.standard_b64encode(buf.getvalue()).decode("ascii")
+    return "data:image/png;base64," + base64.standard_b64encode(buf.getvalue()).decode(
+        "ascii"
+    )
 
 
 # Cooperative cancellation for the heavy pet generation paths. The client's Stop
@@ -10802,7 +11630,9 @@ def _pet_reference_images_from_data_url(ref_raw: str, stage) -> list:
     import binascii
     import re as _re
 
-    match = _re.match(r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", ref_raw, _re.DOTALL)
+    match = _re.match(
+        r"^data:image/([a-zA-Z0-9.+-]+);base64,(.*)$", ref_raw, _re.DOTALL
+    )
     if not match:
         raise ValueError("invalid reference image format")
 
@@ -11055,15 +11885,22 @@ def _serialize_usage_model(model) -> dict:
         "status": model.status,
         "plan_name": model.plan_name,
         "renews_at": model.renews_at,
-        "renews_display": getattr(model, "renews_display", None) or format_renews(model.renews_at),
+        "renews_display": getattr(model, "renews_display", None)
+        or format_renews(model.renews_at),
         "subscription_remaining_display": (
-            None if model.subscription_remaining_usd is None else _fmt_usd(model.subscription_remaining_usd)
+            None
+            if model.subscription_remaining_usd is None
+            else _fmt_usd(model.subscription_remaining_usd)
         ),
         "topup_remaining_display": (
-            None if model.topup_remaining_usd is None else _fmt_usd(model.topup_remaining_usd)
+            None
+            if model.topup_remaining_usd is None
+            else _fmt_usd(model.topup_remaining_usd)
         ),
         "total_spendable_display": (
-            None if model.total_spendable_usd is None else _fmt_usd(model.total_spendable_usd)
+            None
+            if model.total_spendable_usd is None
+            else _fmt_usd(model.total_spendable_usd)
         ),
         "has_topup": model.has_topup,
         "plan_bar": _serialize_usage_bar(model.plan_bar),
@@ -11093,7 +11930,9 @@ def _serialize_subscription_state(state) -> dict:
             "pending_downgrade_display": format_renews(c.pending_downgrade_at),
             "cancel_at_period_end": c.cancel_at_period_end,
             "cancellation_effective_at": c.cancellation_effective_at,
-            "cancellation_effective_display": format_renews(c.cancellation_effective_at),
+            "cancellation_effective_display": format_renews(
+                c.cancellation_effective_at
+            ),
         }
     # Selectable catalog for the in-terminal tier picker; price is pre-formatted
     # ($X / $X.YY) so the TUI renders it directly.
@@ -11236,7 +12075,9 @@ def _notification_event_belongs_elsewhere(sid: str, session: dict, evt: dict) ->
             return False
         try:
             with _sessions_lock:
-                owner_live = evt_ui_sid in _sessions and not _sessions[evt_ui_sid].get("_finalized")
+                owner_live = evt_ui_sid in _sessions and not _sessions[evt_ui_sid].get(
+                    "_finalized"
+                )
         except Exception:
             owner_live = False
         if owner_live:
@@ -11346,8 +12187,7 @@ def _session_owns_notification_event(sid: str, session: dict, evt: dict) -> bool
 def _notification_event_requires_owner(evt: dict) -> bool:
     """Whether ``evt`` must be positively claimed before TUI delivery."""
     return evt.get("type") == "async_delegation" or bool(
-        str(evt.get("origin_ui_session_id") or "")
-        or str(evt.get("session_key") or "")
+        str(evt.get("origin_ui_session_id") or "") or str(evt.get("session_key") or "")
     )
 
 
@@ -11392,8 +12232,14 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
 # the cursor advances past them and they can't wedge a later completed/blocked
 # event behind an unclaimed row.
 _KANBAN_NOTIFY_KINDS = (
-    "completed", "blocked", "gave_up", "crashed", "timed_out",
-    "status", "archived", "unblocked",
+    "completed",
+    "blocked",
+    "gave_up",
+    "crashed",
+    "timed_out",
+    "status",
+    "archived",
+    "unblocked",
 )
 _KANBAN_SILENT_KINDS = frozenset({"archived", "unblocked"})
 _KANBAN_POLL_SECONDS = 5.0
@@ -11476,14 +12322,15 @@ def _maybe_fire_tui_loop_tick(sid: str, session: dict) -> None:
                 pass
             decision = mgr.complete_tick("")
             if decision.get("message"):
-                _emit("status.update", sid, {"kind": "loop", "text": decision["message"]})
+                _emit(
+                    "status.update", sid, {"kind": "loop", "text": decision["message"]}
+                )
             return
         _emit("message.start", sid)
         _run_prompt_submit(rid, sid, session, wakeup)
     except Exception as exc:
         print(
-            f"[tui_gateway] loop wakeup dispatch failed: "
-            f"{type(exc).__name__}: {exc}",
+            f"[tui_gateway] loop wakeup dispatch failed: {type(exc).__name__}: {exc}",
             file=sys.stderr,
         )
         with session["history_lock"]:
@@ -11521,7 +12368,9 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
             handoff = f"\n{lines[0][:160]}" if lines else ""
         return f"✔ {board_tag}{tag}Kanban {task_id} done — {title}{handoff}"
     if kind == "blocked":
-        reason = f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+        reason = (
+            f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
+        )
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
         err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
@@ -11579,7 +12428,8 @@ def _collect_kanban_notifications(session: dict) -> list:
         try:
             resolved = (
                 str(Path(db_path).expanduser().resolve())
-                if db_path else str(_kb.kanban_db_path(slug).resolve())
+                if db_path
+                else str(_kb.kanban_db_path(slug).resolve())
             )
         except Exception:
             resolved = f"slug:{slug}"
@@ -11590,11 +12440,14 @@ def _collect_kanban_notifications(session: dict) -> list:
         # writable unless it has a subscription owned by this exact session;
         # subscriptions for gateways or other sessions are not actionable here.
         try:
-            if _kb.count_notify_subs(
-                board=slug,
-                platform="tui",
-                chat_id=session_key,
-            ) == 0:
+            if (
+                _kb.count_notify_subs(
+                    board=slug,
+                    platform="tui",
+                    chat_id=session_key,
+                )
+                == 0
+            ):
                 continue
         except Exception:
             # Preserve delivery if the read-only probe cannot inspect a
@@ -11764,7 +12617,9 @@ def _notification_poller_loop(
             continue
 
         _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        if evt.get("type") == "completion" and process_registry.is_completion_consumed(
+            _evt_sid
+        ):
             continue
 
         text = format_process_notification(evt)
@@ -11796,8 +12651,11 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            claim_event_delivery,
+            complete_event_delivery,
+            release_event_delivery,
         )
+
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
@@ -11855,7 +12713,9 @@ def _notification_poller_loop(
                 )
             continue
         _evt_sid = evt.get("session_id", "")
-        if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+        if evt.get("type") == "completion" and process_registry.is_completion_consumed(
+            _evt_sid
+        ):
             continue
         text = format_process_notification(evt)
         if not text:
@@ -11874,8 +12734,11 @@ def _notification_poller_loop(
 
         rid = f"__notif__{int(time.time() * 1000)}"
         from tools.async_delegation import (
-            claim_event_delivery, complete_event_delivery, release_event_delivery,
+            claim_event_delivery,
+            complete_event_delivery,
+            release_event_delivery,
         )
+
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
             continue
@@ -11911,17 +12774,17 @@ def _notification_poller_loop(
 def _async_delegation_display_metadata(evt: dict) -> dict:
     """Build display-only metadata before the completion event is formatted."""
     raw_results = evt.get("results")
-    results: list[dict] = [
-        result for result in raw_results if isinstance(result, dict)
-    ] if isinstance(raw_results, list) else []
+    results: list[dict] = (
+        [result for result in raw_results if isinstance(result, dict)]
+        if isinstance(raw_results, list)
+        else []
+    )
     task_count = len(results) or 1
     completed_count = sum(
-        1 for result in results
-        if result.get("status") in {"completed", "success"}
+        1 for result in results if result.get("status") in {"completed", "success"}
     )
     failed_count = sum(
-        1 for result in results
-        if result.get("status") in {"failed", "error"}
+        1 for result in results if result.get("status") in {"failed", "error"}
     )
     metadata = {
         "delegation_id": str(evt.get("delegation_id") or ""),
@@ -12229,6 +13092,8 @@ def _run_prompt_submit(
     display_metadata: dict | None = None,
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
+    origin_client_id: str | None = None,
+    request_id: str | None = None,
 ) -> bool:
     with session["history_lock"]:
         if session.get("_closing"):
@@ -12236,7 +13101,8 @@ def _run_prompt_submit(
             return False
         if (
             queued_prompt_generation is not None
-            and int(session.get("_queued_prompt_generation", 0)) != queued_prompt_generation
+            and int(session.get("_queued_prompt_generation", 0))
+            != queued_prompt_generation
         ):
             session["running"] = False
             return False
@@ -12249,7 +13115,12 @@ def _run_prompt_submit(
         # A retained failed turn (see _fail_inflight_turn) is a stale leftover
         # by the time a new turn starts — replace it, never append onto it.
         if not isinstance(inflight, dict) or inflight.get("status") == "error":
-            _start_inflight_turn(session, text)
+            _start_inflight_turn(
+                session,
+                text,
+                origin_client_id=origin_client_id,
+                request_id=request_id,
+            )
         agent = session["agent"]
         if hasattr(agent, "clear_interrupt"):
             try:
@@ -12311,7 +13182,9 @@ def _run_prompt_submit(
         marker_attempt = int(session.pop("_auto_continue_attempt", 0) or 0)
         marker_text = session.pop("_auto_continue_prompt", None) or text
         if isinstance(marker_text, str) and marker_text.strip():
-            record_turn_start(marker_home, marker_key, marker_text, attempts=marker_attempt)
+            record_turn_start(
+                marker_home, marker_key, marker_text, attempts=marker_attempt
+            )
         try:
             from tools.approval import (
                 reset_current_session_key,
@@ -12326,7 +13199,9 @@ def _run_prompt_submit(
             _profile_home_str = session.get("profile_home")
             if _profile_home_str:
                 home_token = set_hermes_home_override(_profile_home_str)
-                secret_token = set_secret_scope(build_profile_secret_scope(Path(_profile_home_str)))
+                secret_token = set_secret_scope(
+                    build_profile_secret_scope(Path(_profile_home_str))
+                )
             # The sudo password callback is thread-local (tools.terminal_tool
             # _callback_tls), so wiring it on the build thread doesn't reach this
             # turn thread — terminal sudo prompts would fall through to /dev/tty
@@ -12418,9 +13293,7 @@ def _run_prompt_submit(
                         _provider,
                         _model,
                         _cfg,
-                        requested_provider=getattr(
-                            agent, "requested_provider", ""
-                        ),
+                        requested_provider=getattr(agent, "requested_provider", ""),
                     )
                     if getattr(agent, "api_mode", "") == "codex_app_server":
                         _mode = "text"
@@ -12502,7 +13375,10 @@ def _run_prompt_submit(
             # Barged mid-speech? Tell the model (API-message note, same
             # enrichment channel as attached images) so it can react
             # ("rude!") instead of being oblivious to its own interruption.
-            from tools.tts_streaming import SPEECH_INTERRUPTED_NOTE, take_speech_interrupted
+            from tools.tts_streaming import (
+                SPEECH_INTERRUPTED_NOTE,
+                take_speech_interrupted,
+            )
 
             if take_speech_interrupted():
                 run_message = _prepend_note(run_message, SPEECH_INTERRUPTED_NOTE)
@@ -12530,11 +13406,18 @@ def _run_prompt_submit(
             # losing it when message.complete replaces the streaming buffer.
             # Gated on display.interim_assistant_messages (default true).
             if _load_interim_assistant_messages():
-                def _interim_assistant_cb(text: str, *, already_streamed: bool = False) -> None:
-                    _emit("message.interim", sid, {
-                        "text": text,
-                        "already_streamed": already_streamed,
-                    })
+
+                def _interim_assistant_cb(
+                    text: str, *, already_streamed: bool = False
+                ) -> None:
+                    _emit(
+                        "message.interim",
+                        sid,
+                        {
+                            "text": text,
+                            "already_streamed": already_streamed,
+                        },
+                    )
 
                 agent.interim_assistant_callback = _interim_assistant_cb
             else:
@@ -12544,7 +13427,9 @@ def _run_prompt_submit(
                 "conversation_history": list(history),
                 "stream_callback": _stream,
                 "persist_user_message": (
-                    _build_persist_user_message(prompt, images, run_message) if images else prompt
+                    _build_persist_user_message(prompt, images, run_message)
+                    if images
+                    else prompt
                 ),
             }
             # Type a synthesized turn at turn START so the crash persist writes
@@ -12587,7 +13472,9 @@ def _run_prompt_submit(
                 _usage_thread.join()
             if display_kind and isinstance(text, str):
                 db = getattr(agent, "_session_db", None)
-                current_session_id = getattr(agent, "session_id", None) or session.get("session_key")
+                current_session_id = getattr(agent, "session_id", None) or session.get(
+                    "session_key"
+                )
                 if db is not None:
                     try:
                         db.set_latest_matching_message_display_kind(
@@ -12598,10 +13485,17 @@ def _run_prompt_submit(
                             display_metadata=display_metadata,
                         )
                     except Exception:
-                        logger.debug("failed to stamp synthetic display kind", exc_info=True)
-                if isinstance(result, dict) and isinstance(result.get("messages"), list):
+                        logger.debug(
+                            "failed to stamp synthetic display kind", exc_info=True
+                        )
+                if isinstance(result, dict) and isinstance(
+                    result.get("messages"), list
+                ):
                     for message in reversed(result["messages"]):
-                        if message.get("role") == "user" and message.get("content") == text:
+                        if (
+                            message.get("role") == "user"
+                            and message.get("content") == text
+                        ):
                             message["display_kind"] = display_kind
                             if display_metadata:
                                 message["display_metadata"] = display_metadata
@@ -12682,10 +13576,7 @@ def _run_prompt_submit(
                             ]
                             pivot_only = (
                                 current_no_markers == history_no_markers
-                                and any(
-                                    _is_pivot_marker(e)
-                                    for e in current_history
-                                )
+                                and any(_is_pivot_marker(e) for e in current_history)
                             )
                             if pivot_only:
                                 # The agent's new messages start after the
@@ -12693,7 +13584,7 @@ def _run_prompt_submit(
                                 # auto-compression making result["messages"]
                                 # shorter than history (#77274 review).
                                 if len(result["messages"]) > len(history):
-                                    new_messages = result["messages"][len(history):]
+                                    new_messages = result["messages"][len(history) :]
                                 else:
                                     # Compression rebound the messages list —
                                     # use the full result as the base.
@@ -12724,14 +13615,19 @@ def _run_prompt_submit(
                 # worker-backed commands (/title etc.) target the live session.
                 # Fix for #20001.
                 _sync_session_key_after_compress(
-                    sid, session, clear_pending_title=False, restart_slash_worker=True,
+                    sid,
+                    session,
+                    clear_pending_title=False,
+                    restart_slash_worker=True,
                 )
 
                 raw = result.get("final_response", "")
                 status = (
                     "interrupted"
                     if result.get("interrupted")
-                    else "error" if result.get("error") else "complete"
+                    else "error"
+                    if result.get("error")
+                    else "complete"
                 )
                 # When the backend produced no visible response AND reported a
                 # real error (e.g. invalid model slug → provider 4xx), surface
@@ -12741,8 +13637,10 @@ def _run_prompt_submit(
                 # Leaves the None-with-no-error path untouched: an empty
                 # successful turn still renders as empty, and the existing
                 # "(empty)" sentinel handling stays in its own lane.
-                if (not raw) and result.get("error") and (
-                    result.get("failed") or result.get("partial")
+                if (
+                    (not raw)
+                    and result.get("error")
+                    and (result.get("failed") or result.get("partial"))
                 ):
                     raw = f"Error: {result.get('error')}"
                 # "Operation interrupted: waiting for model response (…)" is
@@ -12750,8 +13648,10 @@ def _run_prompt_submit(
                 # and the ACP adapter already suppress this sentinel; without
                 # this the desktop paints it as the agent's reply whenever a
                 # stop/steer lands mid-request (#7921).
-                if status == "interrupted" and isinstance(raw, str) and raw.strip().startswith(
-                    INTERRUPT_WAITING_FOR_MODEL_PREFIX
+                if (
+                    status == "interrupted"
+                    and isinstance(raw, str)
+                    and raw.strip().startswith(INTERRUPT_WAITING_FOR_MODEL_PREFIX)
                 ):
                     raw = ""
                 lr = result.get("last_reasoning")
@@ -12771,7 +13671,9 @@ def _run_prompt_submit(
             # Forward the structured billing-wall descriptor (provider,
             # billing_url, is_nous, message) so the TUI/desktop render a
             # billing-specific recovery surface instead of re-parsing text.
-            _billing_block = result.get("billing_block") if isinstance(result, dict) else None
+            _billing_block = (
+                result.get("billing_block") if isinstance(result, dict) else None
+            )
             if _billing_block:
                 payload["billing"] = _billing_block
                 payload["failure_reason"] = result.get("failure_reason")
@@ -12875,7 +13777,10 @@ def _run_prompt_submit(
                         )
                         if goal_mgr.is_active():
                             try:
-                                from hermes_cli.goals import gather_background_processes as _gather_bg
+                                from hermes_cli.goals import (
+                                    gather_background_processes as _gather_bg,
+                                )
+
                                 _bg_procs = _gather_bg()
                             except Exception:
                                 _bg_procs = None
@@ -12947,7 +13852,8 @@ def _run_prompt_submit(
                     session["pending_title"] = None
                     logger.info(
                         "Dropping pending title for session %s: %s",
-                        _session_key, exc,
+                        _session_key,
+                        exc,
                     )
                 except Exception:
                     # Transient DB failure — keep pending_title for retry.
@@ -13110,7 +14016,9 @@ def _run_prompt_submit(
         # so it isn't silently dropped — same rule as cli.py and gateway/run.py.
         # A real queued prompt still wins: the merge in _enqueue_prompt keeps
         # both texts.
-        _leftover_steer = result.get("pending_steer") if isinstance(result, dict) else None
+        _leftover_steer = (
+            result.get("pending_steer") if isinstance(result, dict) else None
+        )
         if isinstance(_leftover_steer, str) and _leftover_steer.strip():
             with session["history_lock"]:
                 _enqueue_prompt(session, _leftover_steer, session.get("transport"))
@@ -13171,8 +14079,11 @@ def _run_prompt_submit(
                         break
                     session["running"] = True
                 from tools.async_delegation import (
-                    claim_event_delivery, complete_event_delivery, release_event_delivery,
+                    claim_event_delivery,
+                    complete_event_delivery,
+                    release_event_delivery,
                 )
+
                 _claim = claim_event_delivery(_evt, "tui-post-turn")
                 if _claim is None:
                     continue
@@ -13199,9 +14110,8 @@ def _run_prompt_submit(
     run_thread = threading.Thread(target=run, daemon=True)
     with _sessions_lock:
         registered = _sessions.get(sid)
-        can_start = (
-            not session.get("_closing")
-            and (registered is None or registered is session)
+        can_start = not session.get("_closing") and (
+            registered is None or registered is session
         )
         if can_start:
             session["_run_thread"] = run_thread
@@ -13300,7 +14210,9 @@ def _session_images_dir(session: dict) -> Path:
     return base / "images"
 
 
-def _queue_attached_image(session: dict, img_bytes: bytes, ext: str, *, prefix: str) -> Path:
+def _queue_attached_image(
+    session: dict, img_bytes: bytes, ext: str, *, prefix: str
+) -> Path:
     """Write image bytes into the gateway's images dir and queue them.
 
     Mirrors what ``image.attach`` does for a local path: appends to
@@ -13426,7 +14338,9 @@ def _decode_attachment_data_url(data_url: str) -> bytes:
     import re as _re
 
     cleaned = (data_url or "").strip()
-    m = _re.match(r"^data:[^;,]*(?:;[^;,=]+=[^;,]+)*;base64,(.*)$", cleaned, _re.DOTALL | _re.I)
+    m = _re.match(
+        r"^data:[^;,]*(?:;[^;,=]+=[^;,]+)*;base64,(.*)$", cleaned, _re.DOTALL | _re.I
+    )
     if m:
         cleaned = m.group(1)
     cleaned = _re.sub(r"\s+", "", cleaned)
@@ -13484,31 +14398,53 @@ def _stage_session_file_attachment(
 def _respond(rid, params, key, *, allow_expired=False):
     r = params.get("request_id", "")
     question_id = str(params.get("question_id") or "")
+    resolution = None
+    response = None
     with _prompt_lock:
         entry = _pending.get(r)
         if not entry:
             if allow_expired and r:
-                return _ok(rid, {"status": "expired"})
+                outcome = _clarification_outcome_locked(r) if key == "answer" else None
+                return _ok(rid, {"status": outcome or "expired"})
             return _err(rid, 4009, f"no pending {key} request")
-        _, ev = entry
+        sid, ev = entry
         batch = _batch_clarify.get(r)
         if batch is not None and question_id:
-            # Per-question lock (multi-question clarify). Update-in-place is
-            # deliberate: a locked answer stays editable until the batch
-            # completes, and completion is exactly "every qid locked" — the
-            # final lock is the Confirm-and-continue click.
+            # Per-question lock (multi-question clarify). The prompt lock makes
+            # the first valid response authoritative even when two attached
+            # controllers answer concurrently.
             if question_id not in batch["qids"]:
                 return _err(rid, 4002, f"unknown question_id {question_id!r}")
+            if question_id in batch["answers"]:
+                return _ok(rid, {"status": "already_resolved"})
             batch["answers"][question_id] = params.get(key, "")
-            remaining = [
-                qid for qid in batch["qids"] if qid not in batch["answers"]
-            ]
+            remaining = [qid for qid in batch["qids"] if qid not in batch["answers"]]
             if not remaining:
                 ev.set()
-            return _ok(rid, {"status": "ok", "remaining": remaining})
-        _answers[r] = params.get(key, "")
-        ev.set()
-    return _ok(rid, {"status": "ok"})
+            response = {"status": "ok", "remaining": remaining}
+        else:
+            if r in _answers:
+                return _ok(rid, {"status": "already_resolved"})
+            _answers[r] = params.get(key, "")
+            ev.set()
+            response = {"status": "ok"}
+        if key == "answer":
+            resolution = (
+                sid,
+                {
+                    "request_id": r,
+                    "question_id": question_id or None,
+                    "status": "resolved",
+                },
+            )
+    if resolution is not None and not _emit(
+        "clarify.resolved",
+        resolution[0],
+        resolution[1],
+        wait_for_delivery=True,
+    ):
+        return _err(rid, 5004, "clarification resolved but event delivery failed")
+    return _ok(rid, response)
 
 
 # ── Methods: config ──────────────────────────────────────────────────
@@ -13656,7 +14592,10 @@ def _(rid, params: dict) -> dict:
         agent = session.get("agent") if session else None
         if agent is not None:
             current_fast = getattr(agent, "service_tier", None) == "priority"
-        elif session is not None and session.get("create_service_tier_override") is not None:
+        elif (
+            session is not None
+            and session.get("create_service_tier_override") is not None
+        ):
             # Pre-build session with a pinned tier (desktop draft pick or an
             # earlier session-scoped toggle) — report/toggle from the pin, not
             # the global default.
@@ -13718,9 +14657,7 @@ def _(rid, params: dict) -> dict:
             # build ("switch one session, switches everywhere"). Pin the
             # create override so lazily-built sessions and rebuilds (/new,
             # deferred resume) keep the choice; "" pins normal explicitly.
-            session["create_service_tier_override"] = (
-                "priority" if nv == "fast" else ""
-            )
+            session["create_service_tier_override"] = "priority" if nv == "fast" else ""
         else:
             _write_config_key("agent.service_tier", nv)
         if agent is not None:
@@ -14137,7 +15074,9 @@ def _(rid, params: dict) -> dict:
         # auto-detection (xterm.js hosts misreport OSC 11); 'auto' trusts it.
         raw = str(value or "").strip().lower()
         if raw not in {"auto", "light", "dark"}:
-            return _err(rid, 4002, f"unknown theme value: {value} (use auto|light|dark)")
+            return _err(
+                rid, 4002, f"unknown theme value: {value} (use auto|light|dark)"
+            )
         _write_config_key("display.tui_theme", raw)
         return _ok(rid, {"key": key, "value": raw})
 
@@ -14205,7 +15144,12 @@ def _(rid, params: dict) -> dict:
         os.environ["TERMINAL_CWD"] = cwd
         return _ok(
             rid,
-            {"key": "terminal.cwd", "value": cwd, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)},
+            {
+                "key": "terminal.cwd",
+                "value": cwd,
+                "cwd": cwd,
+                "branch": _git_branch_for_cwd(cwd),
+            },
         )
 
     if key in {"prompt", "personality", "skin"}:
@@ -14272,7 +15216,9 @@ def _projects_payload(conn) -> dict:
     from hermes_cli import projects_db as pdb
 
     return {
-        "projects": [p.to_dict() for p in pdb.list_projects(conn, include_archived=True)],
+        "projects": [
+            p.to_dict() for p in pdb.list_projects(conn, include_archived=True)
+        ],
         "active_id": pdb.get_active_id(conn),
     }
 
@@ -14388,7 +15334,9 @@ def _(rid, params, pdb, conn) -> dict:
 @_projects_method("projects.archive")
 def _(rid, params, pdb, conn) -> dict:
     proj = _require_project(pdb, conn, params)
-    (pdb.restore_project if params.get("restore") else pdb.archive_project)(conn, proj.id)
+    (pdb.restore_project if params.get("restore") else pdb.archive_project)(
+        conn, proj.id
+    )
     return _ok(rid, _projects_payload(conn))
 
 
@@ -14401,15 +15349,26 @@ def _(rid, params, pdb, conn) -> dict:
 
 @_projects_method("projects.set_active")
 def _(rid, params, pdb, conn) -> dict:
-    pdb.set_active(conn, _require_project(pdb, conn, params).id if params.get("id") else None)
+    pdb.set_active(
+        conn, _require_project(pdb, conn, params).id if params.get("id") else None
+    )
     return _ok(rid, {"active_id": pdb.get_active_id(conn)})
 
 
 @_projects_method("projects.for_cwd")
 def _(rid, params, pdb, conn) -> dict:
-    cwd = _completion_cwd({"cwd": str(params.get("cwd") or "").strip()} if params.get("cwd") else {})
+    cwd = _completion_cwd(
+        {"cwd": str(params.get("cwd") or "").strip()} if params.get("cwd") else {}
+    )
     proj = pdb.project_for_path(conn, cwd)
-    return _ok(rid, {"project": proj.to_dict() if proj else None, "cwd": cwd, "branch": _git_branch_for_cwd(cwd)})
+    return _ok(
+        rid,
+        {
+            "project": proj.to_dict() if proj else None,
+            "cwd": cwd,
+            "branch": _git_branch_for_cwd(cwd),
+        },
+    )
 
 
 def _non_workspace_dirs() -> set[str]:
@@ -14477,16 +15436,24 @@ def _repo_discovery_policy(raw: dict | None = None) -> dict:
     if not isinstance(source, dict):
         source = {}
 
-    enabled = source.get("enabled", source.get("repo_scan_enabled", defaults["repo_scan_enabled"]))
-    roots = source.get("roots", source.get("repo_scan_roots", defaults["repo_scan_roots"]))
+    enabled = source.get(
+        "enabled", source.get("repo_scan_enabled", defaults["repo_scan_enabled"])
+    )
+    roots = source.get(
+        "roots", source.get("repo_scan_roots", defaults["repo_scan_roots"])
+    )
     excludes = source.get(
         "exclude_paths",
         source.get("repo_scan_exclude_paths", defaults["repo_scan_exclude_paths"]),
     )
 
     return {
-        "enabled": enabled if isinstance(enabled, bool) else defaults["repo_scan_enabled"],
-        "roots": [value.strip() for value in roots if isinstance(value, str) and value.strip()]
+        "enabled": enabled
+        if isinstance(enabled, bool)
+        else defaults["repo_scan_enabled"],
+        "roots": [
+            value.strip() for value in roots if isinstance(value, str) and value.strip()
+        ]
         if isinstance(roots, list)
         else list(defaults["repo_scan_roots"]),
         "exclude_paths": [
@@ -14554,7 +15521,11 @@ def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
     authoritative = True
 
     def _is_excluded(path: str) -> bool:
-        return any(path == ex or path.startswith(ex.rstrip("/\\") + os.sep) for ex in excludes if ex)
+        return any(
+            path == ex or path.startswith(ex.rstrip("/\\") + os.sep)
+            for ex in excludes
+            if ex
+        )
 
     for root in roots:
         if not os.path.isdir(root):
@@ -14584,7 +15555,11 @@ def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
                     dirnames[:] = []
                 else:
                     # Not a repo: skip hidden dirs (e.g. .hermes) and node_modules.
-                    dirnames[:] = [d for d in dirnames if not d.startswith(".") and d not in ("node_modules",)]
+                    dirnames[:] = [
+                        d
+                        for d in dirnames
+                        if not d.startswith(".") and d not in ("node_modules",)
+                    ]
                 if len(pairs) >= 500:
                     break
         except Exception:
@@ -14601,7 +15576,10 @@ def _scan_discovered_repos_remote(conn, policy: dict) -> bool:
     if pairs:
         try:
             pdb.record_discovered_repos(
-                conn, pairs, replace=authoritative, policy_key=_repo_discovery_policy_key(policy)
+                conn,
+                pairs,
+                replace=authoritative,
+                policy_key=_repo_discovery_policy_key(policy),
             )
         except Exception:
             logger.debug("discover_repos cache write failed", exc_info=True)
@@ -14628,7 +15606,9 @@ def _discover_repos_payload(
     repos: dict[str, dict] = {}
 
     def _agg(root: str) -> dict:
-        return repos.setdefault(root, {"root": root, "label": "", "sessions": 0, "last_active": 0.0})
+        return repos.setdefault(
+            root, {"root": root, "label": "", "sessions": 0, "last_active": 0.0}
+        )
 
     # Session-derived roots (common repo root, folding worktrees; cached) +
     # backfill the column so persisted git_repo_root matches the tree grouping.
@@ -14695,7 +15675,9 @@ def _discover_repos_payload(
 
     out = sorted(repos.values(), key=lambda r: r["last_active"], reverse=True)
     for r in out:
-        r["label"] = r["label"] or os.path.basename(r["root"].rstrip("/\\")) or r["root"]
+        r["label"] = (
+            r["label"] or os.path.basename(r["root"].rstrip("/\\")) or r["root"]
+        )
     return out
 
 
@@ -14823,7 +15805,12 @@ def _dir_exists_cached(path: str) -> bool:
 
 
 def _build_project_tree(
-    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
+    db,
+    *,
+    preview_limit: int,
+    hydrate: bool,
+    session_limit: int,
+    include_discovered: bool,
 ) -> tuple[dict, str | None]:
     """Gather inputs and run the one authoritative builder. Returns (tree, active_id)."""
     from tui_gateway import project_tree
@@ -14909,7 +15896,11 @@ def _compute_mcp_rev() -> str:
         # /reload-mcp. `mcp` (settings) and `tools` (enable/disable) round
         # out the MCP-relevant surface.
         rev_src = json.dumps(
-            {"mcp": cfg.get("mcp"), "mcp_servers": cfg.get("mcp_servers"), "tools": cfg.get("tools")},
+            {
+                "mcp": cfg.get("mcp"),
+                "mcp_servers": cfg.get("mcp_servers"),
+                "tools": cfg.get("tools"),
+            },
             sort_keys=True,
             default=str,
         )
@@ -14936,15 +15927,13 @@ def _finish_reload(rid, params: dict, *, coalesced: bool) -> dict:
     return _ok(rid, payload)
 
 
-_TUI_HIDDEN: frozenset[str] = frozenset(
-    {
-        "sethome",
-        "set-home",
-        "commands",
-        "approve",
-        "deny",
-    }
-)
+_TUI_HIDDEN: frozenset[str] = frozenset({
+    "sethome",
+    "set-home",
+    "commands",
+    "approve",
+    "deny",
+})
 
 _TUI_EXTRA: list[tuple[str, str, str]] = [
     ("/density", "Toggle compact display mode", "TUI"),
@@ -14962,24 +15951,22 @@ _TUI_EXTRA: list[tuple[str, str, str]] = [
 # so slash.exec routes them to command.dispatch internally (which handles
 # them and returns a structured payload) instead of erroring out and
 # relying on a client-side fallback. See #48848.
-_PENDING_INPUT_COMMANDS: frozenset[str] = frozenset(
-    {
-        "retry",
-        "queue",
-        "q",
-        "steer",
-        "plan",
-        "goal",
-        "loop",
-        "proactive",
-        "moa",
-        "undo",
-        "learn",
-        "init",
-        "compress",
-        "compact",
-    }
-)
+_PENDING_INPUT_COMMANDS: frozenset[str] = frozenset({
+    "retry",
+    "queue",
+    "q",
+    "steer",
+    "plan",
+    "goal",
+    "loop",
+    "proactive",
+    "moa",
+    "undo",
+    "learn",
+    "init",
+    "compress",
+    "compact",
+})
 
 _WORKER_BLOCKED_COMMANDS: frozenset[str] = frozenset({"snapshot", "snap"})
 
@@ -15121,25 +16108,23 @@ _paste_counter = 0
 
 _FUZZY_CACHE_TTL_S = 5.0
 _FUZZY_CACHE_MAX_FILES = 20000
-_FUZZY_FALLBACK_EXCLUDES = frozenset(
-    {
-        ".git",
-        ".hg",
-        ".svn",
-        ".next",
-        ".cache",
-        ".venv",
-        "venv",
-        "node_modules",
-        "__pycache__",
-        "dist",
-        "build",
-        "target",
-        ".mypy_cache",
-        ".pytest_cache",
-        ".ruff_cache",
-    }
-)
+_FUZZY_FALLBACK_EXCLUDES = frozenset({
+    ".git",
+    ".hg",
+    ".svn",
+    ".next",
+    ".cache",
+    ".venv",
+    "venv",
+    "node_modules",
+    "__pycache__",
+    "dist",
+    "build",
+    "target",
+    ".mypy_cache",
+    ".pytest_cache",
+    ".ruff_cache",
+})
 _fuzzy_cache_lock = threading.Lock()
 _fuzzy_cache: dict[str, tuple[float, list[str]]] = {}
 
@@ -15376,7 +16361,9 @@ def _details_completions(text: str) -> list[dict] | None:
                 (
                     "section override"
                     if candidate in sections
-                    else "cycle global mode" if candidate == "cycle" else "global mode"
+                    else "cycle global mode"
+                    if candidate == "cycle"
+                    else "global mode"
                 ),
             )
             for candidate in candidates
@@ -15425,8 +16412,7 @@ def _model_picker_context(agent):
                 canonical_custom_identity(
                     base_url=base_url or None,
                     config_provider=ctx.current_provider,
-                    model=(getattr(agent, "model", "") if agent else "")
-                    or None,
+                    model=(getattr(agent, "model", "") if agent else "") or None,
                 )
                 or provider
             )
@@ -15447,20 +16433,18 @@ def _model_picker_context(agent):
 # ── Methods: slash.exec ──────────────────────────────────────────────
 
 
-_LIVE_SESSION_DIRECT_COMMANDS = frozenset(
-    {
-        "clear",
-        "compress",
-        "effort",
-        "history",
-        "models",
-        "prompt",
-        "rename",
-        "review",
-        "status",
-        "usage",
-    }
-)
+_LIVE_SESSION_DIRECT_COMMANDS = frozenset({
+    "clear",
+    "compress",
+    "effort",
+    "history",
+    "models",
+    "prompt",
+    "rename",
+    "review",
+    "status",
+    "usage",
+})
 
 _ISOLATED_SESSION_READ_COMMANDS = frozenset({"context", "tools", "help"})
 
@@ -15529,14 +16513,12 @@ def _format_live_usage_output(session: dict) -> str:
     reasoning = int(usage.get("reasoning") or 0)
     if reasoning:
         lines.append(f"Reasoning tokens:             {reasoning:,}")
-    lines.extend(
-        [
-            f"Prompt tokens:                {int(usage.get('prompt') or 0):,}",
-            f"Completion tokens:            {int(usage.get('completion') or 0):,}",
-            f"Total tokens:                 {int(usage.get('total') or 0):,}",
-            f"API calls:                    {int(usage.get('calls') or 0):,}",
-        ]
-    )
+    lines.extend([
+        f"Prompt tokens:                {int(usage.get('prompt') or 0):,}",
+        f"Completion tokens:            {int(usage.get('completion') or 0):,}",
+        f"Total tokens:                 {int(usage.get('total') or 0):,}",
+        f"API calls:                    {int(usage.get('calls') or 0):,}",
+    ])
     if usage.get("context_max"):
         lines.append(
             "Current context:              "
@@ -15544,12 +16526,10 @@ def _format_live_usage_output(session: dict) -> str:
             f"{int(usage.get('context_max') or 0):,} "
             f"({int(usage.get('context_percent') or 0)}%)"
         )
-    lines.extend(
-        [
-            f"Messages:                     {message_count:,}",
-            f"Compressions:                 {int(usage.get('compressions') or 0):,}",
-        ]
-    )
+    lines.extend([
+        f"Messages:                     {message_count:,}",
+        f"Compressions:                 {int(usage.get('compressions') or 0):,}",
+    ])
     return "\n".join(lines)
 
 
@@ -15573,7 +16553,13 @@ def _format_live_history_output(session: dict) -> str:
     lines = ["Conversation History", "────────────────────────────────────────"]
     for idx, message in enumerate(messages, start=1):
         role = str(message.get("role") or "unknown")
-        label = "You" if role == "user" else "Hermes" if role == "assistant" else role.title()
+        label = (
+            "You"
+            if role == "user"
+            else "Hermes"
+            if role == "assistant"
+            else role.title()
+        )
         text = str(message.get("text") or message.get("context") or "").strip()
         if len(text) > 400:
             text = f"{text[:400]}..."
@@ -15606,7 +16592,9 @@ def _format_live_context_output(session: dict) -> str:
             try:
                 messages = _history_to_messages(
                     db.get_messages_as_conversation(
-                        session["session_key"], include_ancestors=True, include_row_ids=True
+                        session["session_key"],
+                        include_ancestors=True,
+                        include_row_ids=True,
                     )
                 )
             except Exception:
@@ -15617,7 +16605,9 @@ def _format_live_context_output(session: dict) -> str:
     usage = _session_usage_snapshot(session)
     mirror = _metadata_mirror(session)
     lines = [
-        f"Conversation: {len(messages)} messages" if messages else "Conversation is empty (no messages yet)."
+        f"Conversation: {len(messages)} messages"
+        if messages
+        else "Conversation is empty (no messages yet)."
     ]
     roles: dict[str, int] = {}
     for msg in messages:
@@ -15689,7 +16679,9 @@ def _format_live_model_output(session: dict) -> str:
     return "Current model: (unknown)"
 
 
-def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg: str) -> Optional[str]:
+def _live_slash_command_output(
+    sid: str, session: Optional[dict], name: str, arg: str
+) -> Optional[str]:
     name = (name or "").lstrip("/").lower()
     arg = arg or ""
     if name == "model" and not arg.strip():
@@ -15748,7 +16740,6 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
     if name == "effort":
         return "Use /reasoning <effort> to change reasoning effort."
     return None
-
 
 
 def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
@@ -15850,12 +16841,15 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
                 from agent.manual_compression_feedback import (
                     describe_compression_lock_skip,
                 )
+
                 return describe_compression_lock_skip(e.holder)
             _sync_session_key_after_compress(sid, session)
 
             with session["history_lock"]:
                 _after_messages = list(session.get("history", []))
-            _sys_prompt_after = getattr(agent, "_cached_system_prompt", "") or _sys_prompt
+            _sys_prompt_after = (
+                getattr(agent, "_cached_system_prompt", "") or _sys_prompt
+            )
             _tools_after = getattr(agent, "tools", None) or _tools
             _after_tokens = (
                 estimate_request_tokens_rough(
@@ -16021,6 +17015,7 @@ def _tts_stream_stop(user_barge: bool = True) -> None:
         return
     if user_barge and not state["done"].is_set():
         import traceback as _tb
+
         logger.debug(
             "TTS CUT: _tts_stream_stop(user_barge=True) — new turn or "
             "interrupt cutting in-flight TTS\n%s",
@@ -16142,9 +17137,7 @@ def _full_duplex_listener() -> None:
             tripped.set()
             mark_speech_interrupted()
             if phase == "playback":
-                logger.debug(
-                    "TTS CUT: full-duplex listener tripped during playback"
-                )
+                logger.debug("TTS CUT: full-duplex listener tripped during playback")
                 _cut_all_tts()
             else:
                 logger.debug(
@@ -16157,9 +17150,7 @@ def _full_duplex_listener() -> None:
                 # process-global, and the same seam session.interrupt uses.
                 try:
                     with _sessions_lock:
-                        running = [
-                            s for s in _sessions.values() if s.get("running")
-                        ]
+                        running = [s for s in _sessions.values() if s.get("running")]
                     for s in running:
                         agent = s.get("agent")
                         if agent is not None and hasattr(agent, "interrupt"):
@@ -16182,13 +17173,18 @@ def _full_duplex_listener() -> None:
             return
         try:
             result = transcribe_recording(wav_path)
-            text = (result.get("transcript") or "").strip() if result.get("success") else ""
+            text = (
+                (result.get("transcript") or "").strip()
+                if result.get("success")
+                else ""
+            )
             if text:
                 # Stop-check must never break transcript delivery — if the
                 # helper is unavailable (stubbed voice_mode in tests, partial
                 # installs), treat as not-a-stop-phrase.
                 try:
                     from tools.voice_mode import is_voice_stop_phrase
+
                     _is_stop = is_voice_stop_phrase(text)
                 except Exception:
                     _is_stop = False
@@ -16319,8 +17315,9 @@ _wake_resume_retry_lock = threading.Lock()
 _wake_resume_retry_active = False
 
 
-def _wake_resume_if_owner(owner: "Transport", *, retry_seconds: float = 15.0,
-                          retry_interval: float = 1.0) -> bool:
+def _wake_resume_if_owner(
+    owner: "Transport", *, retry_seconds: float = 15.0, retry_interval: float = 1.0
+) -> bool:
     """Resume the wake detector for ``owner``; self-heal a busy microphone.
 
     Reopening the mic right after a voice turn can fail while the capture
@@ -16448,12 +17445,15 @@ def _(rid, params: dict) -> dict:
     reqs = check_wake_word_requirements(probe_cfg)
     if not reqs["available"]:
         logger.warning("wake.start(%s): not available — %s", surface, reqs.get("hint"))
-        return _ok(rid, {
-            "started": False,
-            "reason": "unavailable",
-            "hint": reqs.get("hint") or "",
-            "capture": capture_mode,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "unavailable",
+                "hint": reqs.get("hint") or "",
+                "capture": capture_mode,
+            },
+        )
     enabled_persisted = False
     if persist and not cfg.get("enabled"):
         enabled_persisted = _persist_wake_enabled(True)
@@ -16466,8 +17466,13 @@ def _(rid, params: dict) -> dict:
         # disabled_for_surface — respects an explicit wake_word.surface choice,
         # which persist does NOT override).
         reason = "disabled" if not cfg.get("enabled") else "disabled_for_surface"
-        logger.info("wake.start(%s): %s (enabled=%s, surface=%s)",
-                    surface, reason, cfg.get("enabled"), cfg.get("surface"))
+        logger.info(
+            "wake.start(%s): %s (enabled=%s, surface=%s)",
+            surface,
+            reason,
+            cfg.get("enabled"),
+            cfg.get("surface"),
+        )
         return _ok(rid, {"started": False, "reason": reason})
 
     existing_owner, existing_surface = _wake_owner_snapshot()
@@ -16478,11 +17483,14 @@ def _(rid, params: dict) -> dict:
         existing_owner = None
         existing_surface = ""
     if existing_owner is not None and existing_owner is not transport:
-        return _ok(rid, {
-            "started": False,
-            "reason": "owned",
-            "owner_surface": existing_surface,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "owned",
+                "owner_surface": existing_surface,
+            },
+        )
 
     sid = str(params.get("session_id") or "")
     phrase = wake_phrase(cfg)
@@ -16503,15 +17511,23 @@ def _(rid, params: dict) -> dict:
         # back to the owner's configured phrase / no profile for
         # single-phrase engines.
         matched_phrase, matched_profile = get_last_match() or (phrase, "")
-        logger.info("wake.detected: emitting to sid=%r (transport=%s, profile=%r)",
-                    sid, type(transport).__name__, matched_profile)
+        logger.info(
+            "wake.detected: emitting to sid=%r (transport=%s, profile=%r)",
+            sid,
+            type(transport).__name__,
+            matched_profile,
+        )
         token = bind_transport(transport)
         try:
-            _emit("wake.detected", sid, {
-                "phrase": matched_phrase or phrase,
-                "profile": matched_profile or None,
-                "start_new_session": new_session,
-            })
+            _emit(
+                "wake.detected",
+                sid,
+                {
+                    "phrase": matched_phrase or phrase,
+                    "profile": matched_profile or None,
+                    "start_new_session": new_session,
+                },
+            )
         finally:
             reset_transport(token)
 
@@ -16523,11 +17539,14 @@ def _(rid, params: dict) -> dict:
             external_audio=external_audio,
         )
     except WakeWordInUse:
-        return _ok(rid, {
-            "started": False,
-            "reason": "owned",
-            "owner_surface": existing_surface or None,
-        })
+        return _ok(
+            rid,
+            {
+                "started": False,
+                "reason": "owned",
+                "owner_surface": existing_surface or None,
+            },
+        )
     except Exception as e:
         logger.warning("wake.start(%s): failed to start listener: %s", surface, e)
         return _err(rid, 5026, str(e))
@@ -16538,18 +17557,25 @@ def _(rid, params: dict) -> dict:
     frame = detector_frame_info()
     logger.info(
         "wake.start(%s): listening for %r (%s) capture=%s frame=%s",
-        surface, reqs["phrase"], reqs["provider"], capture_mode, frame.get("frame_length"),
+        surface,
+        reqs["phrase"],
+        reqs["provider"],
+        capture_mode,
+        frame.get("frame_length"),
     )
-    return _ok(rid, {
-        "started": True,
-        "phrase": reqs["phrase"],
-        "provider": reqs["provider"],
-        "owner_surface": surface,
-        "enabled_persisted": enabled_persisted,
-        "capture": capture_mode,
-        "sample_rate": frame.get("sample_rate", 16000),
-        "frame_length": frame.get("frame_length", 1280),
-    })
+    return _ok(
+        rid,
+        {
+            "started": True,
+            "phrase": reqs["phrase"],
+            "provider": reqs["provider"],
+            "owner_surface": surface,
+            "enabled_persisted": enabled_persisted,
+            "capture": capture_mode,
+            "sample_rate": frame.get("sample_rate", 16000),
+            "frame_length": frame.get("frame_length", 1280),
+        },
+    )
 
 
 @method("wake.stop")
@@ -16572,11 +17598,14 @@ def _(rid, params: dict) -> dict:
             currently_enabled = True
         if currently_enabled:
             disabled_persisted = _persist_wake_enabled(False)
-    return _ok(rid, {
-        "stopped": stopped,
-        "reason": None if stopped else "not_owner",
-        "disabled_persisted": disabled_persisted,
-    })
+    return _ok(
+        rid,
+        {
+            "stopped": stopped,
+            "reason": None if stopped else "not_owner",
+            "disabled_persisted": disabled_persisted,
+        },
+    )
 
 
 @method("wake.pause")
@@ -16591,10 +17620,13 @@ def _(rid, params: dict) -> dict:
     except Exception as e:
         logger.debug("wake.pause failed: %s", e)
         paused = False
-    return _ok(rid, {
-        "paused": paused,
-        "reason": None if paused else "not_owner",
-    })
+    return _ok(
+        rid,
+        {
+            "paused": paused,
+            "reason": None if paused else "not_owner",
+        },
+    )
 
 
 @method("wake.resume")
@@ -16603,10 +17635,13 @@ def _(rid, params: dict) -> dict:
     transport = current_transport() or _stdio_transport
     resumed = _wake_resume_if_owner(transport)
     logger.info("wake.resume: detector resumed=%s", resumed)
-    return _ok(rid, {
-        "resumed": resumed,
-        "reason": None if resumed else "not_owner",
-    })
+    return _ok(
+        rid,
+        {
+            "resumed": resumed,
+            "reason": None if resumed else "not_owner",
+        },
+    )
 
 
 @method("wake.status")
@@ -16623,6 +17658,7 @@ def _(rid, params: dict) -> dict:
             resolve_capture_mode,
             silent_audio_hint,
         )
+
         cfg = load_wake_word_config()
         # Prefer client when the GUI asks (desktop remote re-arm / status).
         prefer_client = bool(params.get("client_capture")) or str(
@@ -16639,7 +17675,9 @@ def _(rid, params: dict) -> dict:
         input_device = get_input_device_status(cfg)
         hint = reqs.get("hint", "")
         if input_device.get("error") and not hint:
-            hint = f"Wake-word input device could not be resolved: {input_device['error']}"
+            hint = (
+                f"Wake-word input device could not be resolved: {input_device['error']}"
+            )
         if silent and not hint:
             hint = silent_audio_hint(input_device)
         # Effective capture: prefer the *armed* detector over config/auto.
@@ -16652,29 +17690,34 @@ def _(rid, params: dict) -> dict:
         elif owned_by_caller and listening:
             capture = "local"
         else:
-            capture = probe_cfg.get("capture") or reqs.get("capture") or str(
-                cfg.get("capture") or "auto"
+            capture = (
+                probe_cfg.get("capture")
+                or reqs.get("capture")
+                or str(cfg.get("capture") or "auto")
             )
-        return _ok(rid, {
-            "listening": listening,
-            "owned_by_caller": owned_by_caller,
-            "owner_surface": owner_surface if owner is not None else None,
-            "phrase": reqs["phrase"],
-            "provider": reqs["provider"],
-            "configured_surface": str(cfg.get("surface") or "auto"),
-            "input_device": input_device,
-            "available": reqs["available"],
-            "hint": hint,
-            # Config truth: clients use this to re-arm after a voice turn
-            # ("permanent on") without guessing from runtime listener state.
-            "enabled": bool(cfg.get("enabled")),
-            # Armed but deaf despite an open stream; see platform-specific hint.
-            "audio_silent": silent,
-            "capture": capture,
-            "local_input_available": bool(reqs.get("local_input_available")),
-            "sample_rate": frame.get("sample_rate", 16000),
-            "frame_length": frame.get("frame_length", 1280),
-        })
+        return _ok(
+            rid,
+            {
+                "listening": listening,
+                "owned_by_caller": owned_by_caller,
+                "owner_surface": owner_surface if owner is not None else None,
+                "phrase": reqs["phrase"],
+                "provider": reqs["provider"],
+                "configured_surface": str(cfg.get("surface") or "auto"),
+                "input_device": input_device,
+                "available": reqs["available"],
+                "hint": hint,
+                # Config truth: clients use this to re-arm after a voice turn
+                # ("permanent on") without guessing from runtime listener state.
+                "enabled": bool(cfg.get("enabled")),
+                # Armed but deaf despite an open stream; see platform-specific hint.
+                "audio_silent": silent,
+                "capture": capture,
+                "local_input_available": bool(reqs.get("local_input_available")),
+                "sample_rate": frame.get("sample_rate", 16000),
+                "frame_length": frame.get("frame_length", 1280),
+            },
+        )
     except Exception as e:
         return _err(rid, 5026, str(e))
 
@@ -16698,6 +17741,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4001, "wake.feed requires base64 pcm")
     try:
         import base64
+
         pcm = base64.b64decode(raw_b64, validate=False)
     except Exception as e:
         return _err(rid, 4001, f"invalid base64 pcm: {e}")
@@ -16711,6 +17755,7 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4001, "wake.feed only accepts 16 kHz PCM")
     try:
         from tools.wake_word import feed_audio
+
         ok = feed_audio(owner=transport, pcm_int16=pcm)
     except Exception as e:
         logger.debug("wake.feed failed: %s", e)
@@ -17100,7 +18145,10 @@ def _failure_messages(url: str, port: int, system: str) -> list[str]:
 
     command = manual_chrome_debug_command(port, system)
     hint = (
-        ["Start a Chromium-family browser with remote debugging, then retry /browser connect:", command]
+        [
+            "Start a Chromium-family browser with remote debugging, then retry /browser connect:",
+            command,
+        ]
         if command
         else [
             "No supported Chromium-family browser executable was found in this environment.",
@@ -17227,7 +18275,9 @@ def _browser_connect(rid, params: dict) -> dict:
                         rid, {"connected": False, "url": url, "messages": messages}
                     )
             else:
-                announce(f"Chromium-family browser is already listening at {discovered}")
+                announce(
+                    f"Chromium-family browser is already listening at {discovered}"
+                )
 
             # Adopt whatever loopback/port actually answered (may be
             # [::1] and/or an alternate port when 9222 was squatted).
@@ -17272,8 +18322,6 @@ def _browser_disconnect(rid) -> dict:
     os.environ.pop("BROWSER_CDP_URL", None)
     reap()
     return _ok(rid, {"connected": False})
-
-
 
 
 # Per-profile MCP lifecycle helpers (mcp.servers.* handlers). Defined on THIS

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13455,6 +13455,13 @@ def _run_prompt_submit(
             agent._on_session_title = lambda t, _src, _k=_title_key: _emit(
                 "session.title", sid, {"session_id": _k, "title": t}
             )
+            # The turn prologue calls this only after its inbound user row is
+            # durable. Fan the existing change signal through this session's
+            # ordered event hub so peer clients refresh before assistant output;
+            # the global state.db watcher remains the out-of-process fallback.
+            agent._on_user_message_persisted = lambda: _emit(
+                "sessions.changed", sid, {}
+            )
             _usage_stop, _usage_thread = _start_usage_ticker(sid, agent)
             try:
                 result = agent.run_conversation(run_message, **run_kwargs)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -153,6 +153,7 @@ _batch_clarify: dict[str, dict] = {}
 _db = None
 _db_error: str | None = None
 _stdout_lock = threading.Lock()
+_legacy_event_publish_lock = threading.RLock()
 _cfg_lock = threading.Lock()
 # Shared profile UI metadata can be updated concurrently by Desktop, mobile,
 # and multiple worker-pool RPCs.  Its compare/check/write transaction needs a
@@ -1174,7 +1175,12 @@ def _teardown_popped_session(
                 )
         except Exception:
             logger.debug("failed waiting for session turn thread", exc_info=True)
-    _teardown_session(session, end_reason=end_reason)
+    try:
+        _teardown_session(session, end_reason=end_reason)
+    finally:
+        from tui_gateway.event_replay import release_session
+
+        release_session(str(session.get("_sid") or ""))
     return True
 
 
@@ -2480,9 +2486,9 @@ def write_json(obj: dict) -> bool:
 
     Precedence:
 
-    1. Event frames with a session id → the transport stored on that session,
-       so async events land with the client that owns the session even if
-       the emitting thread has no contextvar binding.
+    1. Event frames with a session id → the session's event hub when present,
+       or its legacy single transport otherwise. The hub stamps and records the
+       event inside the same total-order publication boundary used for fan-out.
     2. Otherwise the transport bound on the current context (set by
        :func:`dispatch` for the lifetime of a request).
     3. Otherwise the module-level stdio transport, matching the historical
@@ -2496,15 +2502,30 @@ def write_json(obj: dict) -> bool:
     if obj.get("method") == "event":
         params = obj.get("params")
         sid = ((params or {}).get("session_id")) if isinstance(params, dict) else ""
-        if sid and (t := (_sessions.get(sid) or {}).get("transport")) is not None:
+        session = _sessions.get(sid) if sid else None
+        if session is not None:
+            from tui_gateway.event_replay import _stamp_event
+
+            hub = session.get("event_hub")
+            if hub is not None:
+                return hub.publish(obj, prepare=_stamp_event)
+            if (t := session.get("transport")) is not None:
+                # Compatibility path for sessions not migrated to
+                # SessionEventHub yet. Keep replay sequence assignment and
+                # transport delivery in one total order.
+                with _legacy_event_publish_lock:
+                    _stamp_event(obj)
+                    return t.write(obj)
+
+    if obj.get("method") == "event":
+        # Compatibility path for sessions not migrated to SessionEventHub yet.
+        # Keep replay sequence assignment and transport delivery in one total
+        # order so concurrent emitters cannot deliver seq=2 before seq=1.
+        with _legacy_event_publish_lock:
             from tui_gateway.event_replay import _stamp_event
 
             _stamp_event(obj)
-            return t.write(obj)
-
-    from tui_gateway.event_replay import _stamp_event
-
-    _stamp_event(obj)
+            return (current_transport() or _stdio_transport).write(obj)
     return (current_transport() or _stdio_transport).write(obj)
 
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2930,6 +2930,10 @@ def _compute_host_turn_frame(
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     display_kind: str | None = None,
+    client_message_id: str | None = None,
+    display_text: str | None = None,
+    submitted_at: float | None = None,
+    attachment_refs: list[str] | None = None,
 ) -> dict:
     with session["history_lock"]:
         history = list(session.get("history", []))
@@ -2946,6 +2950,18 @@ def _compute_host_turn_frame(
         "session_key": session.get("session_key") or sid,
         "text": text,
         **({"display_kind": display_kind} if display_kind else {}),
+        **(
+            {"client_message_id": client_message_id}
+            if client_message_id
+            else {}
+        ),
+        **({"display_text": display_text} if display_text is not None else {}),
+        **({"submitted_at": submitted_at} if submitted_at is not None else {}),
+        **(
+            {"attachment_refs": list(attachment_refs)}
+            if attachment_refs is not None
+            else {}
+        ),
         "history": history,
         "history_version": history_version,
         "cols": int(session.get("cols", 80) or 80),
@@ -3037,6 +3053,10 @@ def _submit_prompt_to_compute_host(
     image_paths: list[str] | None = None,
     queued_prompt_generation: int | None = None,
     display_kind: str | None = None,
+    client_message_id: str | None = None,
+    display_text: str | None = None,
+    submitted_at: float | None = None,
+    attachment_refs: list[str] | None = None,
 ) -> dict:
     cfg = _load_dashboard_process_isolation_config()
     frame = _compute_host_turn_frame(
@@ -3047,6 +3067,10 @@ def _submit_prompt_to_compute_host(
         image_paths=image_paths,
         queued_prompt_generation=queued_prompt_generation,
         display_kind=display_kind,
+        client_message_id=client_message_id,
+        display_text=display_text,
+        submitted_at=submitted_at,
+        attachment_refs=attachment_refs,
     )
 
     def _complete(done: dict) -> None:
@@ -13094,6 +13118,10 @@ def _run_prompt_submit(
     queued_prompt_generation: int | None = None,
     origin_client_id: str | None = None,
     request_id: str | None = None,
+    client_message_id: str | None = None,
+    display_text: str | None = None,
+    submitted_at: float | None = None,
+    attachment_refs: list[str] | None = None,
 ) -> bool:
     with session["history_lock"]:
         if session.get("_closing"):
@@ -13459,9 +13487,27 @@ def _run_prompt_submit(
             # durable. Fan the existing change signal through this session's
             # ordered event hub so peer clients refresh before assistant output;
             # the global state.db watcher remains the out-of-process fallback.
-            agent._on_user_message_persisted = lambda: _emit(
-                "sessions.changed", sid, {}
-            )
+            def _on_user_message_persisted() -> None:
+                # The DB watcher remains a coarse out-of-process fallback, but
+                # attached clients need the row itself on the ordered session
+                # stream. Otherwise assistant/tool frames outrun the async
+                # transcript reload by seconds. Only real client submissions
+                # carry a client_message_id; synthesized auto-continue/loop
+                # turns retain their existing typed timeline projections.
+                if client_message_id and display_kind != "hidden":
+                    payload = {
+                        "message_id": client_message_id,
+                        "text": display_text
+                        if display_text is not None
+                        else _content_display_text(text),
+                        "timestamp": submitted_at or time.time(),
+                    }
+                    if attachment_refs:
+                        payload["attachment_refs"] = list(attachment_refs)
+                    _emit("message.user", sid, payload)
+                _emit("sessions.changed", sid, {})
+
+            agent._on_user_message_persisted = _on_user_message_persisted
             _usage_stop, _usage_thread = _start_usage_ticker(sid, agent)
             try:
                 result = agent.run_conversation(run_message, **run_kwargs)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13974,9 +13974,10 @@ def _run_prompt_submit(
             _clear_session_context(session_tokens)
             _current_runtime_session_record.reset(runtime_session_token)
             reset_transport(transport_token)
-            # Clear the per-turn interim callback so a stale closure from
-            # this turn can't fire during a later turn on the same agent.
+            # Clear per-turn callbacks so stale closures from this turn cannot
+            # fire during a later turn on the same cached agent.
             agent.interim_assistant_callback = None
+            agent._on_user_message_persisted = None
             with session["history_lock"]:
                 session["running"] = False
                 session["last_active"] = time.time()

--- a/tui_gateway/session_events.py
+++ b/tui_gateway/session_events.py
@@ -16,19 +16,19 @@ _log = logging.getLogger(__name__)
 
 ATTACHMENT_QUEUE_MAX = 256
 _WORKER_JOIN_TIMEOUT_SECONDS = 11.0
+_DELIVERY_WAIT_TIMEOUT_SECONDS = 11.0
 
 _OBSERVE_CAPABILITIES = frozenset({"observe"})
-_CONTROL_CAPABILITIES = frozenset(
-    {
-        "observe",
-        "prompt.submit",
-        "session.steer",
-        "session.interrupt",
-        "approval.respond",
-        "clarify.respond",
-        "ui.respond",
-    }
-)
+_CONTROL_CAPABILITIES = frozenset({
+    "observe",
+    "prompt.submit",
+    "session.steer",
+    "session.interrupt",
+    "approval.respond",
+    "clarify.respond",
+    "ui.respond",
+})
+SUPPORTED_CAPABILITIES = _CONTROL_CAPABILITIES
 
 
 class AttachmentMode(str, Enum):
@@ -53,9 +53,9 @@ class AttachmentMode(str, Enum):
         return _OBSERVE_CAPABILITIES
 
 
-ATTACHMENT_MODES = MappingProxyType(
-    {mode.value: mode.capabilities for mode in AttachmentMode}
-)
+ATTACHMENT_MODES = MappingProxyType({
+    mode.value: mode.capabilities for mode in AttachmentMode
+})
 
 
 @dataclass(frozen=True)
@@ -71,10 +71,17 @@ class AttachmentSnapshot:
 
 
 @dataclass
+class _QueuedFrame:
+    frame: dict
+    delivered: Optional[threading.Event] = None
+    succeeded: bool = False
+
+
+@dataclass
 class _Attachment:
     transport: object
     snapshot: AttachmentSnapshot
-    events: queue.Queue[dict]
+    events: queue.Queue[_QueuedFrame]
     stopped: threading.Event
     worker: Optional[threading.Thread] = None
 
@@ -91,6 +98,7 @@ class SessionEventHub:
         self._registry_lock = threading.Lock()
         self._publication_lock = threading.Lock()
         self._attachments: dict[int, _Attachment] = {}
+        self._clients: dict[str, int] = {}
         self._retiring: dict[int, _Attachment] = {}
         self._closed = False
 
@@ -100,41 +108,66 @@ class SessionEventHub:
         *,
         client_id: str,
         mode: AttachmentMode,
+        capabilities: frozenset[str] | set[str] | None = None,
     ) -> AttachmentSnapshot:
-        """Attach once per transport, updating metadata on repeated calls."""
+        """Attach or reconnect one stable client to this live runtime."""
         parsed_mode = AttachmentMode.parse(mode)
+        granted = parsed_mode.capabilities
+        if capabilities is not None:
+            granted = granted.intersection(capabilities)
         snapshot = AttachmentSnapshot(
             client_id=str(client_id),
             mode=parsed_mode,
-            capabilities=parsed_mode.capabilities,
+            capabilities=granted,
         )
         key = id(transport)
+        replaced: _Attachment | None = None
         with self._publication_lock:
             with self._registry_lock:
                 if self._closed:
                     raise RuntimeError("session event hub is closed")
                 if key in self._retiring:
-                    raise RuntimeError("transport attachment cleanup is still in progress")
+                    raise RuntimeError(
+                        "transport attachment cleanup is still in progress"
+                    )
+
+                previous_key = self._clients.get(snapshot.client_id)
+                if previous_key is not None and previous_key != key:
+                    previous = self._attachments.pop(previous_key, None)
+                    if previous is not None:
+                        previous.stopped.set()
+                        self._retiring[previous_key] = previous
+                        replaced = previous
+
                 current = self._attachments.get(key)
                 if current is not None and current.transport is transport:
+                    previous_client_id = current.snapshot.client_id
+                    if self._clients.get(previous_client_id) == key:
+                        self._clients.pop(previous_client_id, None)
                     current.snapshot = snapshot
-                    return snapshot
+                    self._clients[snapshot.client_id] = key
+                else:
+                    attachment = _Attachment(
+                        transport=transport,
+                        snapshot=snapshot,
+                        events=queue.Queue(maxsize=ATTACHMENT_QUEUE_MAX),
+                        stopped=threading.Event(),
+                    )
+                    worker = threading.Thread(
+                        target=self._write_events,
+                        args=(attachment,),
+                        name=f"session-event-writer-{client_id}",
+                        daemon=True,
+                    )
+                    attachment.worker = worker
+                    self._attachments[key] = attachment
+                    self._clients[snapshot.client_id] = key
+                    worker.start()
 
-                attachment = _Attachment(
-                    transport=transport,
-                    snapshot=snapshot,
-                    events=queue.Queue(maxsize=ATTACHMENT_QUEUE_MAX),
-                    stopped=threading.Event(),
-                )
-                worker = threading.Thread(
-                    target=self._write_events,
-                    args=(attachment,),
-                    name=f"session-event-writer-{client_id}",
-                    daemon=True,
-                )
-                attachment.worker = worker
-                self._attachments[key] = attachment
-                worker.start()
+        if replaced is not None:
+            # Stable reconnect must not wait for a stale transport.write(). The
+            # retired writer owns generation-safe cleanup when it exits.
+            self._finish_detach(replaced, join=False)
         return snapshot
 
     def detach(self, transport: object) -> bool:
@@ -167,6 +200,7 @@ class SessionEventHub:
         frame: dict,
         *,
         prepare: Optional[Callable[[dict], None]] = None,
+        wait_for_delivery: bool = False,
     ) -> bool:
         """Prepare once, then enqueue private copies in one total order.
 
@@ -181,6 +215,7 @@ class SessionEventHub:
         # plain built-ins for the per-subscriber deepcopy below.
         normalized = json.loads(json.dumps(frame, ensure_ascii=False))
         overflowed: list[_Attachment] = []
+        queued: list[_QueuedFrame] = []
         enqueued = False
         with self._publication_lock:
             with self._registry_lock:
@@ -194,7 +229,12 @@ class SessionEventHub:
                 if attachment.stopped.is_set():
                     continue
                 try:
-                    attachment.events.put_nowait(copy.deepcopy(normalized))
+                    item = _QueuedFrame(
+                        frame=copy.deepcopy(normalized),
+                        delivered=threading.Event() if wait_for_delivery else None,
+                    )
+                    attachment.events.put_nowait(item)
+                    queued.append(item)
                     enqueued = True
                 except queue.Full:
                     removed = self._remove_registered(attachment.transport)
@@ -203,6 +243,14 @@ class SessionEventHub:
 
         for attachment in overflowed:
             self._finish_detach(attachment, join=False)
+        if wait_for_delivery:
+            for item in queued:
+                if item.delivered is None or not item.delivered.wait(
+                    timeout=_DELIVERY_WAIT_TIMEOUT_SECONDS
+                ):
+                    return False
+                if not item.succeeded:
+                    return False
         return enqueued
 
     def snapshots(self) -> list[dict]:
@@ -237,6 +285,7 @@ class SessionEventHub:
                     self._closed = True
                     attachments = list(self._attachments.values())
                     self._attachments.clear()
+                    self._clients.clear()
                     for attachment in attachments:
                         attachment.stopped.set()
                         self._retiring[id(attachment.transport)] = attachment
@@ -259,18 +308,31 @@ class SessionEventHub:
         try:
             while not attachment.stopped.is_set():
                 try:
-                    frame = attachment.events.get(timeout=0.05)
+                    item = attachment.events.get(timeout=0.05)
                 except queue.Empty:
                     continue
                 if attachment.stopped.is_set():
+                    if item.delivered is not None:
+                        item.delivered.set()
                     return
                 try:
-                    if attachment.transport.write(frame) is False:  # type: ignore[attr-defined]
+                    write_and_wait = getattr(
+                        attachment.transport, "write_and_wait", None
+                    )
+                    if item.delivered is not None and callable(write_and_wait):
+                        success = write_and_wait(item.frame)
+                    else:
+                        success = attachment.transport.write(item.frame)  # type: ignore[attr-defined]
+                    if success is False:
                         raise ConnectionError("transport write returned false")
+                    item.succeeded = True
                 except Exception as exc:
                     _log.debug("session attachment writer failed: %s", exc)
                     self._detach_failed_attachment(attachment)
                     return
+                finally:
+                    if item.delivered is not None:
+                        item.delivered.set()
         finally:
             # The writer itself owns deferred cleanup. This avoids creating a
             # second thread that waits forever when transport.write() is
@@ -293,6 +355,9 @@ class SessionEventHub:
             if attachment is None or attachment.transport is not transport:
                 return None
             del self._attachments[key]
+            client_id = attachment.snapshot.client_id
+            if self._clients.get(client_id) == key:
+                del self._clients[client_id]
             attachment.stopped.set()
             self._retiring[key] = attachment
             return attachment

--- a/tui_gateway/session_events.py
+++ b/tui_gateway/session_events.py
@@ -1,0 +1,333 @@
+"""Thread-isolated event fan-out for clients attached to one live session."""
+
+from __future__ import annotations
+
+import copy
+import json
+import logging
+import queue
+import threading
+from dataclasses import dataclass
+from enum import Enum
+from types import MappingProxyType
+from typing import Callable, Optional
+
+_log = logging.getLogger(__name__)
+
+ATTACHMENT_QUEUE_MAX = 256
+_WORKER_JOIN_TIMEOUT_SECONDS = 11.0
+
+_OBSERVE_CAPABILITIES = frozenset({"observe"})
+_CONTROL_CAPABILITIES = frozenset(
+    {
+        "observe",
+        "prompt.submit",
+        "session.steer",
+        "session.interrupt",
+        "approval.respond",
+        "clarify.respond",
+        "ui.respond",
+    }
+)
+
+
+class AttachmentMode(str, Enum):
+    """Authorization level granted to an attached client."""
+
+    OBSERVE = "observe"
+    CONTROL = "control"
+
+    @classmethod
+    def parse(cls, value: str | AttachmentMode) -> AttachmentMode:
+        if isinstance(value, cls):
+            return value
+        try:
+            return cls(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"invalid attachment mode: {value!r}") from exc
+
+    @property
+    def capabilities(self) -> frozenset[str]:
+        if self is AttachmentMode.CONTROL:
+            return _CONTROL_CAPABILITIES
+        return _OBSERVE_CAPABILITIES
+
+
+ATTACHMENT_MODES = MappingProxyType(
+    {mode.value: mode.capabilities for mode in AttachmentMode}
+)
+
+
+@dataclass(frozen=True)
+class AttachmentSnapshot:
+    """Immutable, transport-free attachment metadata."""
+
+    client_id: str
+    mode: AttachmentMode
+    capabilities: frozenset[str]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "capabilities", frozenset(self.capabilities))
+
+
+@dataclass
+class _Attachment:
+    transport: object
+    snapshot: AttachmentSnapshot
+    events: queue.Queue[dict]
+    stopped: threading.Event
+    worker: Optional[threading.Thread] = None
+
+
+class SessionEventHub:
+    """Publish ordered event copies to independently drained transports."""
+
+    def __init__(
+        self,
+        *,
+        on_detach: Optional[Callable[[object], None]] = None,
+    ) -> None:
+        self._on_detach = on_detach
+        self._registry_lock = threading.Lock()
+        self._publication_lock = threading.Lock()
+        self._attachments: dict[int, _Attachment] = {}
+        self._retiring: dict[int, _Attachment] = {}
+        self._closed = False
+
+    def attach(
+        self,
+        transport: object,
+        *,
+        client_id: str,
+        mode: AttachmentMode,
+    ) -> AttachmentSnapshot:
+        """Attach once per transport, updating metadata on repeated calls."""
+        parsed_mode = AttachmentMode.parse(mode)
+        snapshot = AttachmentSnapshot(
+            client_id=str(client_id),
+            mode=parsed_mode,
+            capabilities=parsed_mode.capabilities,
+        )
+        key = id(transport)
+        with self._publication_lock:
+            with self._registry_lock:
+                if self._closed:
+                    raise RuntimeError("session event hub is closed")
+                if key in self._retiring:
+                    raise RuntimeError("transport attachment cleanup is still in progress")
+                current = self._attachments.get(key)
+                if current is not None and current.transport is transport:
+                    current.snapshot = snapshot
+                    return snapshot
+
+                attachment = _Attachment(
+                    transport=transport,
+                    snapshot=snapshot,
+                    events=queue.Queue(maxsize=ATTACHMENT_QUEUE_MAX),
+                    stopped=threading.Event(),
+                )
+                worker = threading.Thread(
+                    target=self._write_events,
+                    args=(attachment,),
+                    name=f"session-event-writer-{client_id}",
+                    daemon=True,
+                )
+                attachment.worker = worker
+                self._attachments[key] = attachment
+                worker.start()
+        return snapshot
+
+    def detach(self, transport: object) -> bool:
+        """Remove one transport and stop its writer worker."""
+        with self._publication_lock:
+            attachment = self._remove_registered(transport)
+        if attachment is None:
+            return False
+        if not self._finish_detach(attachment, join=True):
+            raise RuntimeError("session attachment writer did not stop")
+        return True
+
+    def has_transport(self, transport: object) -> bool:
+        with self._registry_lock:
+            attachment = self._attachments.get(id(transport))
+            return attachment is not None and attachment.transport is transport
+
+    def require(self, transport: object, capability: str) -> None:
+        """Raise when *transport* is detached or lacks *capability*."""
+        with self._registry_lock:
+            attachment = self._attachments.get(id(transport))
+            if attachment is None or attachment.transport is not transport:
+                raise PermissionError("transport is not attached")
+            capabilities = attachment.snapshot.capabilities
+        if capability not in capabilities:
+            raise PermissionError(f"attachment requires capability: {capability}")
+
+    def publish(
+        self,
+        frame: dict,
+        *,
+        prepare: Optional[Callable[[dict], None]] = None,
+    ) -> bool:
+        """Prepare once, then enqueue private copies in one total order.
+
+        ``prepare`` runs while the publication lock is held, before subscriber
+        snapshots are cloned.  Callers use it for sequence allocation and replay
+        recording so the stamped order and every subscriber's delivery order
+        cannot diverge under concurrent emitters.
+        """
+        # Normalize before taking the publication lock. Besides proving the
+        # protocol frame is JSON-safe before any subscriber sees it, this keeps
+        # custom mapping/value hooks outside the hub's lock and leaves only
+        # plain built-ins for the per-subscriber deepcopy below.
+        normalized = json.loads(json.dumps(frame, ensure_ascii=False))
+        overflowed: list[_Attachment] = []
+        enqueued = False
+        with self._publication_lock:
+            with self._registry_lock:
+                if self._closed:
+                    return False
+                attachments = list(self._attachments.values())
+            if prepare is not None:
+                prepare(normalized)
+
+            for attachment in attachments:
+                if attachment.stopped.is_set():
+                    continue
+                try:
+                    attachment.events.put_nowait(copy.deepcopy(normalized))
+                    enqueued = True
+                except queue.Full:
+                    removed = self._remove_registered(attachment.transport)
+                    if removed is not None:
+                        overflowed.append(removed)
+
+        for attachment in overflowed:
+            self._finish_detach(attachment, join=False)
+        return enqueued
+
+    def snapshots(self) -> list[dict]:
+        """Return sanitized attachment metadata with no transport internals."""
+        with self._registry_lock:
+            snapshots = [item.snapshot for item in self._attachments.values()]
+        return [
+            {
+                "client_id": snapshot.client_id,
+                "mode": snapshot.mode.value,
+                "capabilities": sorted(snapshot.capabilities),
+            }
+            for snapshot in snapshots
+        ]
+
+    def count(self) -> int:
+        with self._registry_lock:
+            return len(self._attachments)
+
+    def close(self) -> None:
+        """Idempotently detach all clients and join all writer workers.
+
+        Raises ``RuntimeError`` rather than silently claiming success when a
+        transport write exceeds the bounded shutdown interval. Cleanup for that
+        attachment remains deferred until its writer actually exits.
+        """
+        with self._publication_lock:
+            with self._registry_lock:
+                if self._closed:
+                    attachments = []
+                else:
+                    self._closed = True
+                    attachments = list(self._attachments.values())
+                    self._attachments.clear()
+                    for attachment in attachments:
+                        attachment.stopped.set()
+                        self._retiring[id(attachment.transport)] = attachment
+
+                # A prior close may have timed out while a transport.write()
+                # was still in flight. Keep those workers discoverable so a
+                # repeated close can re-check them without spawning an
+                # unbounded cleanup waiter.
+                for attachment in self._retiring.values():
+                    if attachment not in attachments:
+                        attachments.append(attachment)
+
+        failed = False
+        for attachment in attachments:
+            failed = not self._finish_detach(attachment, join=True) or failed
+        if failed:
+            raise RuntimeError("one or more session attachment writers did not stop")
+
+    def _write_events(self, attachment: _Attachment) -> None:
+        try:
+            while not attachment.stopped.is_set():
+                try:
+                    frame = attachment.events.get(timeout=0.05)
+                except queue.Empty:
+                    continue
+                if attachment.stopped.is_set():
+                    return
+                try:
+                    if attachment.transport.write(frame) is False:  # type: ignore[attr-defined]
+                        raise ConnectionError("transport write returned false")
+                except Exception as exc:
+                    _log.debug("session attachment writer failed: %s", exc)
+                    self._detach_failed_attachment(attachment)
+                    return
+        finally:
+            # The writer itself owns deferred cleanup. This avoids creating a
+            # second thread that waits forever when transport.write() is
+            # permanently blocked. _complete_cleanup atomically claims the
+            # retiring generation, so a concurrent detach/close can also call
+            # it without invoking the callback twice.
+            self._complete_cleanup(attachment.transport)
+
+    def _detach_failed_attachment(self, attachment: _Attachment) -> None:
+        with self._publication_lock:
+            removed = self._remove_registered(attachment.transport)
+        if removed is not None:
+            self._finish_detach(removed, join=False)
+
+    def _remove_registered(self, transport: object) -> Optional[_Attachment]:
+        """Remove under the registry lock; caller serializes publications."""
+        with self._registry_lock:
+            key = id(transport)
+            attachment = self._attachments.get(key)
+            if attachment is None or attachment.transport is not transport:
+                return None
+            del self._attachments[key]
+            attachment.stopped.set()
+            self._retiring[key] = attachment
+            return attachment
+
+    def _finish_detach(self, attachment: _Attachment, *, join: bool) -> bool:
+        worker = attachment.worker
+        if worker is None or worker is threading.current_thread():
+            self._complete_cleanup(attachment.transport)
+            return True
+        if not join:
+            return True
+        worker.join(timeout=_WORKER_JOIN_TIMEOUT_SECONDS)
+        if worker.is_alive():
+            return False
+        self._complete_cleanup(attachment.transport)
+        return True
+
+    def _complete_cleanup(self, transport: object) -> None:
+        with self._registry_lock:
+            key = id(transport)
+            attachment = self._retiring.get(key)
+            if attachment is None or attachment.transport is not transport:
+                return
+            del self._retiring[key]
+        try:
+            self._run_cleanup(transport)
+        except Exception:
+            # _run_cleanup already logs user callback failures. The retiring
+            # generation is still complete and must not block reattachment.
+            pass
+
+    def _run_cleanup(self, transport: object) -> None:
+        if self._on_detach is None:
+            return
+        try:
+            self._on_detach(transport)
+        except Exception:
+            _log.exception("session attachment cleanup failed")

--- a/tui_gateway/transport.py
+++ b/tui_gateway/transport.py
@@ -33,14 +33,17 @@ from typing import Any, Callable, Optional, Protocol, runtime_checkable
 # Errno values that mean "the peer is gone" rather than "the host has a
 # real I/O problem".  Anything outside this set re-raises so it surfaces
 # in the crash log instead of looking like a clean disconnect.
-_PEER_GONE_ERRNOS = frozenset({
-    errno.EPIPE,        # write to closed pipe (POSIX)
-    errno.ECONNRESET,   # peer reset the connection
-    errno.EBADF,        # fd closed under us
-    errno.ESHUTDOWN,    # transport endpoint shut down
-    getattr(errno, "WSAECONNRESET", -1),  # win32 mapping (no-op on POSIX)
-    getattr(errno, "WSAESHUTDOWN", -1),
-} - {-1})
+_PEER_GONE_ERRNOS = frozenset(
+    {
+        errno.EPIPE,  # write to closed pipe (POSIX)
+        errno.ECONNRESET,  # peer reset the connection
+        errno.EBADF,  # fd closed under us
+        errno.ESHUTDOWN,  # transport endpoint shut down
+        getattr(errno, "WSAECONNRESET", -1),  # win32 mapping (no-op on POSIX)
+        getattr(errno, "WSAESHUTDOWN", -1),
+    }
+    - {-1}
+)
 
 logger = logging.getLogger(__name__)
 
@@ -55,7 +58,9 @@ logger = logging.getLogger(__name__)
 # those, JSON-RPC frames will accumulate in the buffer and the TUI
 # will hang waiting for ``gateway.ready``.  Default stays off so the
 # existing flush-after-write behaviour is unchanged.
-_DISABLE_FLUSH = (os.environ.get("HERMES_TUI_GATEWAY_NO_FLUSH", "") or "").strip().lower() in {
+_DISABLE_FLUSH = (
+    os.environ.get("HERMES_TUI_GATEWAY_NO_FLUSH", "") or ""
+).strip().lower() in {
     "1",
     "true",
     "yes",
@@ -66,6 +71,9 @@ _DISABLE_FLUSH = (os.environ.get("HERMES_TUI_GATEWAY_NO_FLUSH", "") or "").strip
 @runtime_checkable
 class Transport(Protocol):
     """Minimal interface every transport implements."""
+
+    connection_id: str
+    client_id: Optional[str]
 
     def write(self, obj: dict) -> bool:
         """Emit one JSON frame. Return ``False`` when the peer is gone."""
@@ -105,11 +113,13 @@ class StdioTransport:
     existing test suite relies on (``monkeypatch.setattr(server, "_real_stdout", ...)``).
     """
 
-    __slots__ = ("_stream_getter", "_lock")
+    __slots__ = ("_stream_getter", "_lock", "connection_id", "client_id")
 
     def __init__(self, stream_getter: Callable[[], Any], lock: threading.Lock) -> None:
         self._stream_getter = stream_getter
         self._lock = lock
+        self.connection_id = "stdio"
+        self.client_id = "stdio"
 
     def write(self, obj: dict) -> bool:
         """Return ``True`` on success, ``False`` ONLY when the peer is gone.
@@ -207,6 +217,14 @@ class TeeTransport:
             except Exception:
                 pass
         return ok
+
+    @property
+    def connection_id(self) -> str:
+        return self._primary.connection_id
+
+    @property
+    def client_id(self) -> Optional[str]:
+        return self._primary.client_id
 
     def close(self) -> None:
         try:

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -30,6 +30,7 @@ import logging
 import socket
 import threading
 import time
+import uuid
 from typing import Any
 
 from tui_gateway import server
@@ -96,6 +97,10 @@ class WSTransport:
         self._ws = ws
         self._loop = loop
         self._peer = peer
+        # Server-minted connection identity is authorization metadata, not a
+        # value supplied by RPC params, network address, or user-agent.
+        self.connection_id = uuid.uuid4().hex
+        self.client_id: str | None = None
         #: Server-verified identity carried from the WS-upgrade credential
         #: (dashboard ticket / internal credential) — stamped by
         #: ``hermes_cli.web_server._ws_auth_reason`` onto the WS object and
@@ -170,6 +175,7 @@ class WSTransport:
         # scheduled INSIDE the lock so the on-the-wire order matches the buffer
         # order even if the coalesce timer fires on the loop at the same moment.
         from agent.async_utils import safe_schedule_threadsafe
+
         with self._token_lock:
             self._pending_tokens.append(line)
             batch = self._pending_tokens
@@ -178,9 +184,7 @@ class WSTransport:
                 # Fire-and-forget — don't block the loop waiting on itself.
                 self._loop.create_task(self._safe_send_many(batch))
                 return True
-            fut = safe_schedule_threadsafe(
-                self._safe_send_many(batch), self._loop
-            )
+            fut = safe_schedule_threadsafe(self._safe_send_many(batch), self._loop)
             if fut is None:
                 self._closed = True
                 return False
@@ -198,14 +202,17 @@ class WSTransport:
             # latches on a real socket error when the frame actually fails.
             _log.warning(
                 "ws write slow (loop stalled >%ss) peer=%s — frame left in flight",
-                _WS_WRITE_TIMEOUT_S, self._peer,
+                _WS_WRITE_TIMEOUT_S,
+                self._peer,
             )
             return not self._closed
         except Exception as exc:
             self._closed = True
             _log.warning(
                 "ws write failed peer=%s error_type=%s error=%s",
-                self._peer, type(exc).__name__, exc,
+                self._peer,
+                type(exc).__name__,
+                exc,
             )
             return False
 
@@ -265,7 +272,9 @@ class WSTransport:
                 self._closed = True
                 _log.warning(
                     "ws send failed peer=%s error_type=%s error=%s",
-                    self._peer, type(exc).__name__, exc,
+                    self._peer,
+                    type(exc).__name__,
+                    exc,
                 )
 
     def close(self) -> None:
@@ -298,7 +307,9 @@ def _disable_nagle(ws: Any) -> None:
     """
     try:
         scope = getattr(ws, "scope", None) or {}
-        transport = (scope.get("extensions") or {}).get("transport") or getattr(ws, "transport", None)
+        transport = (scope.get("extensions") or {}).get("transport") or getattr(
+            ws, "transport", None
+        )
         sock = transport.get_extra_info("socket") if transport is not None else None
         if sock is not None:
             sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
@@ -366,27 +377,45 @@ async def handle_ws(
         # (#60800). The skin payload is small (a dict of strings/arrays),
         # so the to_thread overhead is negligible.
         skin_payload = await asyncio.to_thread(server.resolve_skin)
-        ready_ok = await transport.write_async(
-            {
-                "jsonrpc": "2.0",
-                "method": "event",
-                "params": {
-                    "type": "gateway.ready",
-                    # change_events: this backend broadcasts pet.changed /
-                    # cron.changed / sessions.changed, so clients can demote
-                    # their legacy polls to slow backstops.
-                    "payload": {
-                        "skin": skin_payload,
-                        "change_events": True,
-                        "heartbeat": True,
-                        # Replay-contract process identity: lets reconnecting
-                        # clients detect a backend restart and reset their
-                        # per-session seq watermarks (see event_replay).
-                        "replay_epoch": replay_epoch(),
+        ready_ok = await transport.write_async({
+            "jsonrpc": "2.0",
+            "method": "event",
+            "params": {
+                "type": "gateway.ready",
+                # change_events: this backend broadcasts pet.changed /
+                # cron.changed / sessions.changed, so clients can demote
+                # their legacy polls to slow backstops.
+                "payload": {
+                    "skin": skin_payload,
+                    "change_events": True,
+                    "heartbeat": True,
+                    # Replay-contract process identity: lets reconnecting
+                    # clients detect a backend restart and reset their
+                    # per-session seq watermarks (see event_replay).
+                    "replay_epoch": replay_epoch(),
+                    "connection_id": transport.connection_id,
+                    "runtime_host_id": server._backend_id_for_this_process(),
+                    "multi_client_sessions": 1,
+                    "capabilities": [
+                        "client.attach",
+                        "session.attach",
+                        "session.detach",
+                        "session.attachments",
+                    ],
+                    "multi_client": {
+                        "protocol_version": 1,
+                        "attachment_modes": ["observe", "control"],
+                        "methods": [
+                            "client.attach",
+                            "session.attach",
+                            "session.detach",
+                            "session.attachments",
+                            "session.events.since",
+                        ],
                     },
                 },
-            }
-        )
+            },
+        })
         if ready_ok:
             # Live-apply skins Hermes activates mid-conversation.
             server._ensure_skin_watcher()
@@ -449,13 +478,11 @@ async def handle_ws(
                     exc,
                     line[:_WS_LOG_PAYLOAD_PREVIEW],
                 )
-                ok = await transport.write_async(
-                    {
-                        "jsonrpc": "2.0",
-                        "error": {"code": -32700, "message": "parse error"},
-                        "id": None,
-                    }
-                )
+                ok = await transport.write_async({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32700, "message": "parse error"},
+                    "id": None,
+                })
                 if not ok:
                     disconnect_reason = "send_failed_after_parse_error"
                     send_failures += 1
@@ -472,17 +499,17 @@ async def handle_ws(
             req_method = req.get("method") if isinstance(req, dict) else None
 
             if req_method == "gateway.ping":
-                ok = await transport.write_async(
-                    {
-                        "jsonrpc": "2.0",
-                        "result": {"ok": True},
-                        "id": req_id,
-                    }
-                )
+                ok = await transport.write_async({
+                    "jsonrpc": "2.0",
+                    "result": {"ok": True},
+                    "id": req_id,
+                })
                 if not ok:
                     disconnect_reason = "send_failed_after_heartbeat"
                     send_failures += 1
-                    _log.warning("ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
+                    _log.warning(
+                        "ws heartbeat reply send failed peer=%s id=%s", peer, req_id
+                    )
                     break
                 continue
 
@@ -496,13 +523,11 @@ async def handle_ws(
                     req_id,
                     req_method,
                 )
-                ok = await transport.write_async(
-                    {
-                        "jsonrpc": "2.0",
-                        "error": {"code": -32603, "message": "internal error"},
-                        "id": req_id if req_id is not None else None,
-                    }
-                )
+                ok = await transport.write_async({
+                    "jsonrpc": "2.0",
+                    "error": {"code": -32603, "message": "internal error"},
+                    "id": req_id if req_id is not None else None,
+                })
                 if not ok:
                     disconnect_reason = "send_failed_after_dispatch_crash"
                     send_failures += 1
@@ -529,6 +554,12 @@ async def handle_ws(
         detached_sessions = 0
         if transport is not None:
             server.unregister_live_transport(transport)
+            try:
+                await asyncio.to_thread(
+                    server.detach_runtime_proxy_transport, transport
+                )
+            except Exception:
+                _log.exception("ws runtime-proxy detach failed peer=%s", peer)
 
             # Owner-safely park browser controllers this transport registered.
             # A reconnect with the same stable identity may deliver a terminal

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1515,6 +1515,27 @@ describe('createGatewayEventHandler', () => {
     ).toBe(false)
   })
 
+  it('rehydrates the active TUI session from durable identity after runtime owner loss', () => {
+    const appended: Msg[] = []
+    const ctx = buildCtx(appended)
+    const resumeById = vi.fn()
+    ctx.session.resumeById = resumeById
+    const onEvent = createGatewayEventHandler(ctx)
+
+    patchUiState({ sid: 'live-session' })
+    onEvent({
+      payload: {
+        durable_session_ids: ['stored-session'],
+        session_ids: ['live-session']
+      },
+      type: 'session.runtime_owner_lost'
+    } as any)
+
+    expect(resumeById).toHaveBeenCalledOnce()
+    expect(resumeById).toHaveBeenCalledWith('stored-session')
+    expect(getUiState().status).toBe('recovering session…')
+  })
+
   it('persists an abandoned (timed-out) clarify into the transcript when the clarify tool completes', () => {
     const appended: Msg[] = []
     const onEvent = createGatewayEventHandler(buildCtx(appended))

--- a/ui-tui/src/__tests__/gatewayClient.test.ts
+++ b/ui-tui/src/__tests__/gatewayClient.test.ts
@@ -160,6 +160,241 @@ describe('GatewayClient websocket attach mode', () => {
     gw.kill()
   })
 
+  it('maps owner loss to the durable id from a production session resume', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: any[] = []
+
+    gw.on('event', event => events.push(event))
+    gw.start()
+    gw.drain()
+    await Promise.resolve()
+    const socket = FakeWebSocket.instances[0]!
+    socket.open()
+
+    const resume = gw.request('session.resume', { session_id: 'stored-session' })
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1))
+    const request = JSON.parse(socket.sent[0] ?? '{}') as { id: string }
+    socket.message(JSON.stringify({
+      id: request.id,
+      jsonrpc: '2.0',
+      result: { session_id: 'live-session', session_key: 'stored-session', resumed: 'stored-session' }
+    }))
+    await resume
+
+    socket.message(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['live-session'] }
+      }
+    }))
+
+    await vi.waitFor(() => expect(events.at(-1)?.payload).toEqual({
+      durable_session_ids: ['stored-session'],
+      session_ids: ['live-session']
+    }))
+    gw.kill()
+  })
+
+  it('maps owner loss to stored_session_id from a production session create', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: any[] = []
+
+    gw.on('event', event => events.push(event))
+    gw.start()
+    gw.drain()
+    await Promise.resolve()
+    const socket = FakeWebSocket.instances[0]!
+    socket.open()
+
+    const create = gw.request('session.create', {})
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1))
+    const request = JSON.parse(socket.sent[0] ?? '{}') as { id: string }
+    socket.message(JSON.stringify({
+      id: request.id,
+      jsonrpc: '2.0',
+      result: { session_id: 'live-created', stored_session_id: 'durable-created' }
+    }))
+    await create
+
+    socket.message(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'session.runtime_owner_lost',
+        payload: { session_ids: ['live-created'] }
+      }
+    }))
+
+    await vi.waitFor(() => expect(events.at(-1)?.payload).toEqual({
+      durable_session_ids: ['durable-created'],
+      session_ids: ['live-created']
+    }))
+    gw.kill()
+  })
+
+  it('reconstructs durable sessions before readiness after runtime host takeover', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: any[] = []
+
+    gw.on('event', event => events.push(event))
+    gw.start()
+    gw.drain()
+    await Promise.resolve()
+    const first = FakeWebSocket.instances[0]!
+    first.open()
+
+    first.message(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          capabilities: ['client.attach'],
+          connection_id: 'connection-1',
+          replay_epoch: 'epoch-1',
+          runtime_host_id: 'host-1'
+        }
+      }
+    }))
+    await vi.waitFor(() => expect(first.sent).toHaveLength(1))
+    const firstAttach = JSON.parse(first.sent[0] ?? '{}') as { id: string }
+    first.message(JSON.stringify({ id: firstAttach.id, jsonrpc: '2.0', result: { ok: true } }))
+    await vi.waitFor(() => expect(events.filter(event => event.type === 'gateway.ready')).toHaveLength(1))
+
+    const create = gw.request('session.create', {})
+    await vi.waitFor(() => expect(first.sent).toHaveLength(2))
+    const createFrame = JSON.parse(first.sent[1] ?? '{}') as { id: string }
+    first.message(JSON.stringify({
+      id: createFrame.id,
+      jsonrpc: '2.0',
+      result: { session_id: 'live-old', stored_session_id: 'durable-session' }
+    }))
+    await create
+
+    gw.start()
+    gw.drain()
+    await Promise.resolve()
+    const second = FakeWebSocket.instances[1]!
+    second.open()
+    second.message(JSON.stringify({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: {
+        type: 'gateway.ready',
+        payload: {
+          capabilities: ['client.attach'],
+          connection_id: 'connection-2',
+          replay_epoch: 'epoch-2',
+          runtime_host_id: 'host-2'
+        }
+      }
+    }))
+    await vi.waitFor(() => expect(second.sent).toHaveLength(1))
+    const secondAttach = JSON.parse(second.sent[0] ?? '{}') as { id: string }
+    second.message(JSON.stringify({ id: secondAttach.id, jsonrpc: '2.0', result: { ok: true } }))
+
+    await vi.waitFor(() => expect(second.sent).toHaveLength(2))
+
+    const resumeFrame = JSON.parse(second.sent[1] ?? '{}') as {
+      id: string
+      method: string
+      params: { session_id: string }
+    }
+
+    expect(resumeFrame).toMatchObject({
+      method: 'session.resume',
+      params: { session_id: 'durable-session' }
+    })
+    expect(events.filter(event => event.type === 'gateway.ready')).toHaveLength(1)
+
+    second.message(JSON.stringify({
+      id: resumeFrame.id,
+      jsonrpc: '2.0',
+      result: {
+        session_id: 'live-new',
+        session_key: 'durable-session',
+        resumed: 'durable-session'
+      }
+    }))
+
+    await vi.waitFor(() => expect(events.map(event => event.type).slice(-2)).toEqual([
+      'session.runtime_owner_lost',
+      'gateway.ready'
+    ]))
+    expect(events.at(-2)?.payload).toEqual({
+      durable_session_ids: ['durable-session'],
+      recovered_session_ids: ['live-new'],
+      session_ids: ['live-old']
+    })
+    gw.kill()
+  })
+
+  it('negotiates a stable TUI identity before publishing gateway readiness', async () => {
+    process.env.HERMES_TUI_GATEWAY_URL = 'ws://gateway.test/api/ws?token=abc'
+    const gw = new GatewayClient()
+    const events: string[] = []
+
+    gw.on('event', event => events.push(event.type))
+    gw.start()
+    gw.drain()
+    await Promise.resolve()
+    const gatewaySocket = FakeWebSocket.instances[0]!
+
+    gatewaySocket.open()
+    gatewaySocket.message(
+      JSON.stringify({
+        jsonrpc: '2.0',
+        method: 'event',
+        params: {
+          type: 'gateway.ready',
+          payload: {
+            capabilities: ['client.attach'],
+            connection_id: 'connection-1',
+            replay_epoch: 'epoch-1'
+          }
+        }
+      })
+    )
+
+    await vi.waitFor(() => expect(gatewaySocket.sent).toHaveLength(1))
+    expect(events).not.toContain('gateway.ready')
+
+    const attach = JSON.parse(gatewaySocket.sent[0] ?? '{}') as {
+      id: string
+      method: string
+      params: { client_id: string; protocol_version: number; surface: string }
+    }
+
+    expect(attach.method).toBe('client.attach')
+    expect(attach.params).toMatchObject({
+      client_id: expect.stringMatching(/^tui:/),
+      protocol_version: 1,
+      surface: 'tui'
+    })
+    gatewaySocket.message(
+      JSON.stringify({
+        id: attach.id,
+        jsonrpc: '2.0',
+        result: {
+          capabilities: ['session.observe', 'session.control', 'session.replay'],
+          client_id: attach.params.client_id,
+          connection_id: 'connection-1',
+          idempotent: false,
+          protocol_version: 1,
+          surface: 'tui'
+        }
+      })
+    )
+
+    await vi.waitFor(() => expect(events).toContain('gateway.ready'))
+    gw.kill()
+  })
+
   it('drains buffered events on a later microtask, not synchronously inside drain()', async () => {
     // Regression for #36658: in attach mode the already-running gateway
     // replays `gateway.ready` the instant the socket connects, so it lands in

--- a/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
+++ b/ui-tui/src/__tests__/virtualHistoryOffsetCache.test.ts
@@ -539,10 +539,11 @@ describe('useVirtualHistory offset cache reuse', () => {
 
       staleHeights.set(items[0]!.key, 1)
       instance.rerender(React.createElement(Harness, { expose, initialHeights: staleHeights, items }))
-      await delay(40)
+      await vi.waitFor(() => {
+        expect(adjustScrollTop).toHaveBeenCalledOnce()
+        expect(adjustScrollTop).toHaveBeenCalledWith(1)
+      })
 
-      expect(adjustScrollTop).toHaveBeenCalledOnce()
-      expect(adjustScrollTop).toHaveBeenCalledWith(1)
       expect(scroll.getScrollTop()).toBe(6)
       expect(scroll.isSticky()).toBe(false)
       expect(expose.current!.virtualHistory.start).toBeGreaterThan(0)

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -762,6 +762,23 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         handleReady(ev.payload?.skin)
 
         return
+      case 'session.runtime_owner_lost': {
+        const sessionIds = Array.isArray(ev.payload?.session_ids) ? ev.payload.session_ids : []
+
+        const durableSessionIds = Array.isArray(ev.payload?.durable_session_ids)
+          ? ev.payload.durable_session_ids
+          : []
+
+        const index = sessionIds.findIndex((sessionId: unknown) => sessionId === sid)
+        const durableSessionId = index >= 0 ? durableSessionIds[index] : undefined
+
+        if (typeof durableSessionId === 'string' && durableSessionId) {
+          resumeById(durableSessionId)
+          patchUiState({ status: 'recovering session…' })
+        }
+
+        return
+      }
 
       case 'skin.changed':
         if (ev.payload) {

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1,4 +1,5 @@
 import { type ChildProcess, spawn } from 'node:child_process'
+import { randomUUID } from 'node:crypto'
 import { EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
 import { delimiter, resolve } from 'node:path'
@@ -138,8 +139,10 @@ const redactUrl = (raw: string): string => {
 interface Pending {
   id: string
   method: string
+  params: Record<string, unknown>
   reject: (e: Error) => void
   resolve: (v: unknown) => void
+  trackSessionResult: boolean
   timeout: ReturnType<typeof setTimeout>
 }
 
@@ -153,6 +156,8 @@ export class GatewayClient extends EventEmitter {
   private reqId = 0
   private logs = new CircularBuffer<string>(MAX_GATEWAY_LOG_LINES)
   private pending = new Map<string, Pending>()
+  private durableSessionIds = new Map<string, string>()
+  private runtimeHostId: string | null = null
   private bufferedEvents = new CircularBuffer<GatewayEvent>(MAX_BUFFERED_EVENTS)
   private pendingExit: number | null | undefined
   private ready = false
@@ -168,6 +173,7 @@ export class GatewayClient extends EventEmitter {
   private heartbeatSeq = 0
   private heartbeatPendingId: string | null = null
   private heartbeatSentAt = 0
+  private readonly clientId = `tui:${randomUUID()}`
   // Set on kill() so we never auto-reconnect after an intentional shutdown.
   private disposed = false
 
@@ -686,6 +692,125 @@ export class GatewayClient extends EventEmitter {
     this.startSpawnedGateway(root)
   }
 
+  private async reconstructSessionsAfterHostTakeover() {
+    const tracked = [...this.durableSessionIds.entries()]
+    const oldSessionIds: string[] = []
+    const recoveredSessionIds: string[] = []
+    const durableSessionIds: string[] = []
+
+    for (const [oldSessionId, durableSessionId] of tracked) {
+      const result = await this.request<{
+        session_id?: unknown
+      }>('session.resume', { session_id: durableSessionId }, false)
+
+      const recoveredSessionId = typeof result?.session_id === 'string'
+        ? result.session_id
+        : ''
+
+      if (!recoveredSessionId) {
+        throw new Error(`session recovery returned no live id for ${durableSessionId}`)
+      }
+
+      oldSessionIds.push(oldSessionId)
+      recoveredSessionIds.push(recoveredSessionId)
+      durableSessionIds.push(durableSessionId)
+    }
+
+    for (const oldSessionId of oldSessionIds) {
+      this.durableSessionIds.delete(oldSessionId)
+    }
+
+    recoveredSessionIds.forEach((sessionId, index) => {
+      this.durableSessionIds.set(sessionId, durableSessionIds[index]!)
+    })
+
+    if (oldSessionIds.length > 0) {
+      this.publish({
+        type: 'session.runtime_owner_lost',
+        payload: {
+          durable_session_ids: durableSessionIds,
+          recovered_session_ids: recoveredSessionIds,
+          session_ids: oldSessionIds
+        }
+      })
+    }
+  }
+
+  private publishReadyAfterAttachment(ev: GatewayEvent) {
+    const payload = ev.payload as
+      | {
+          capabilities?: unknown
+          multi_client?: { methods?: unknown }
+          runtime_host_id?: unknown
+        }
+      | undefined
+
+    const capabilities = Array.isArray(payload?.capabilities) ? payload.capabilities : []
+    const methods = Array.isArray(payload?.multi_client?.methods) ? payload.multi_client.methods : []
+
+    const nextRuntimeHostId = typeof payload?.runtime_host_id === 'string' && payload.runtime_host_id
+      ? payload.runtime_host_id
+      : null
+
+    const runtimeHostChanged = this.runtimeHostId !== null &&
+      nextRuntimeHostId !== null &&
+      this.runtimeHostId !== nextRuntimeHostId
+
+    if (!capabilities.includes('client.attach') && !methods.includes('client.attach')) {
+      if (nextRuntimeHostId !== null) {
+        this.runtimeHostId = nextRuntimeHostId
+      }
+
+      this.publish(ev)
+
+      return
+    }
+
+    const generation = this.drainGeneration
+
+    const fail = (err: unknown) => {
+      if (this.drainGeneration !== generation || this.disposed) {
+        return
+      }
+
+      const message = err instanceof Error ? err.message : String(err)
+
+      this.pushLog(`[protocol] client attachment/recovery failed: ${message}`)
+      this.publish({ type: 'gateway.protocol_error', payload: { preview: message.slice(0, MAX_LOG_PREVIEW) } })
+
+      if (this.ws) {
+        try {
+          this.ws.close()
+        } catch {
+          // best effort; the close handler owns reconnect.
+        }
+      } else {
+        this.proc?.kill()
+      }
+    }
+
+    void this.request('client.attach', {
+      client_id: this.clientId,
+      protocol_version: 1,
+      surface: 'tui'
+    }).then(async () => {
+      if (runtimeHostChanged) {
+        await this.reconstructSessionsAfterHostTakeover()
+      }
+    }).then(
+      () => {
+        if (this.drainGeneration === generation && !this.disposed) {
+          if (nextRuntimeHostId !== null) {
+            this.runtimeHostId = nextRuntimeHostId
+          }
+
+          this.publish(ev)
+        }
+      },
+      fail
+    )
+  }
+
   private dispatch(msg: Record<string, unknown>) {
     const id = msg.id as string | undefined
 
@@ -708,7 +833,25 @@ export class GatewayClient extends EventEmitter {
       const ev = asGatewayEvent(msg.params)
 
       if (ev) {
-        this.publish(ev)
+        if (ev.type === 'gateway.ready') {
+          this.publishReadyAfterAttachment(ev)
+        } else if (ev.type === 'session.runtime_owner_lost') {
+          const payload = (ev.payload ?? {}) as { session_ids?: unknown }
+
+          const sessionIds = Array.isArray(payload.session_ids)
+            ? payload.session_ids.filter((value): value is string => typeof value === 'string')
+            : []
+
+          this.publish({
+            ...ev,
+            payload: {
+              durable_session_ids: sessionIds.map(sessionId => this.durableSessionIds.get(sessionId) ?? ''),
+              session_ids: sessionIds
+            }
+          })
+        } else {
+          this.publish(ev)
+        }
       }
     }
   }
@@ -726,8 +869,52 @@ export class GatewayClient extends EventEmitter {
     if (err) {
       p.reject(err)
     } else {
+      if (p.trackSessionResult) {
+        this.trackSessionResult(p.method, p.params, result)
+      }
+
       p.resolve(result)
     }
+  }
+
+  private trackSessionResult(method: string, params: Record<string, unknown>, result: unknown) {
+    if (method !== 'session.create' && method !== 'session.resume') {
+      return
+    }
+
+    const value = result as {
+      session_id?: unknown
+      stored_session_id?: unknown
+      session_key?: unknown
+      resumed?: unknown
+    } | null
+
+    const liveSessionId = typeof value?.session_id === 'string' ? value.session_id : ''
+
+    if (!liveSessionId) {
+      return
+    }
+
+    const requested = typeof params.session_id === 'string' ? params.session_id : ''
+
+    const storedSessionId = typeof value?.stored_session_id === 'string'
+      ? value.stored_session_id
+      : ''
+
+    const sessionKey = typeof value?.session_key === 'string' ? value.session_key : ''
+    const resumed = typeof value?.resumed === 'string' ? value.resumed : ''
+
+    const durableSessionId = method === 'session.resume'
+      ? (requested || resumed || sessionKey || liveSessionId)
+      : (storedSessionId || sessionKey || liveSessionId)
+
+    for (const [sessionId, durableId] of this.durableSessionIds) {
+      if (durableId === durableSessionId) {
+        this.durableSessionIds.delete(sessionId)
+      }
+    }
+
+    this.durableSessionIds.set(liveSessionId, durableSessionId)
   }
 
   private pushLog(line: string) {
@@ -836,7 +1023,11 @@ export class GatewayClient extends EventEmitter {
     return this.ws
   }
 
-  private requestOverWebSocket<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  private requestOverWebSocket<T = unknown>(
+    method: string,
+    params: Record<string, unknown> = {},
+    trackSessionResult = true
+  ): Promise<T> {
     return this.ensureAttachedWebSocket(method).then(
       ws =>
         new Promise<T>((resolve, reject) => {
@@ -847,8 +1038,10 @@ export class GatewayClient extends EventEmitter {
           this.pending.set(id, {
             id,
             method,
+            params,
             reject,
             resolve: v => resolve(v as T),
+            trackSessionResult,
             timeout
           })
 
@@ -868,7 +1061,11 @@ export class GatewayClient extends EventEmitter {
     )
   }
 
-  request<T = unknown>(method: string, params: Record<string, unknown> = {}): Promise<T> {
+  request<T = unknown>(
+    method: string,
+    params: Record<string, unknown> = {},
+    trackSessionResult = true
+  ): Promise<T> {
     const attachUrl = resolveGatewayAttachUrl()
 
     if (attachUrl) {
@@ -881,7 +1078,7 @@ export class GatewayClient extends EventEmitter {
         this.start()
       }
 
-      return this.requestOverWebSocket<T>(method, params)
+      return this.requestOverWebSocket<T>(method, params, trackSessionResult)
     }
 
     if (!this.proc?.stdin || this.proc.killed || this.proc.exitCode !== null) {
@@ -902,8 +1099,10 @@ export class GatewayClient extends EventEmitter {
       this.pending.set(id, {
         id,
         method,
+        params,
         reject,
         resolve: v => resolve(v as T),
+        trackSessionResult,
         timeout
       })
 

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -756,4 +756,13 @@ export type GatewayEvent =
       type: 'message.complete'
     }
   | { payload?: { usage?: Usage }; session_id?: string; type: 'session.usage' }
+  | {
+      payload?: {
+        durable_session_ids?: string[]
+        recovered_session_ids?: string[]
+        session_ids?: string[]
+      }
+      session_id?: string
+      type: 'session.runtime_owner_lost'
+    }
   | { payload?: { message?: string }; session_id?: string; type: 'error' }

--- a/web/src/lib/gatewayClient.test.ts
+++ b/web/src/lib/gatewayClient.test.ts
@@ -18,6 +18,7 @@ class FakeWebSocket {
 
   listeners = new Map<string, Array<(event: EventLike) => void>>();
   readyState = 0;
+  sent: string[] = [];
   url: string;
 
   constructor(url: string) {
@@ -47,17 +48,21 @@ class FakeWebSocket {
     );
   }
 
-  send() {}
+  send(frame: string) {
+    this.sent.push(frame);
+  }
 }
 
 type EventLike = {
   code?: number;
+  data?: string;
 };
 
 beforeEach(() => {
   FakeWebSocket.instances = [];
   reloadMocks.maybeReloadForLoopbackWsAuthFailure.mockClear();
   vi.stubGlobal("WebSocket", FakeWebSocket);
+  sessionStorage.clear();
   Object.defineProperty(window, "__HERMES_SESSION_TOKEN__", {
     configurable: true,
     value: "stale-token",
@@ -84,6 +89,46 @@ describe("GatewayClient", () => {
     const socket = FakeWebSocket.instances[0];
     socket.readyState = 1;
     socket.emit("open", {});
+    socket.emit("message", {
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "event",
+        params: {
+          type: "gateway.ready",
+          payload: {
+            connection_id: "connection-1",
+            replay_epoch: "epoch-1",
+            multi_client: {
+              protocol_version: 1,
+              attachment_modes: ["observe", "control"],
+              methods: ["client.attach", "session.attach", "session.events.since"],
+            },
+          },
+        },
+      }),
+    });
+    await vi.waitFor(() => expect(socket.sent).toHaveLength(1));
+    const attach = JSON.parse(socket.sent[0]);
+    expect(attach.method).toBe("client.attach");
+    expect(attach.params).toMatchObject({
+      client_id: expect.stringMatching(/^web:/),
+      protocol_version: 1,
+      surface: "web",
+    });
+    socket.emit("message", {
+      data: JSON.stringify({
+        jsonrpc: "2.0",
+        id: attach.id,
+        result: {
+          capabilities: ["session.observe", "session.control", "session.replay"],
+          client_id: attach.params.client_id,
+          connection_id: "connection-1",
+          idempotent: false,
+          protocol_version: 1,
+          surface: "web",
+        },
+      }),
+    });
     await connectPromise;
 
     socket.emit("close", { code: 4401 });

--- a/web/src/lib/gatewayClient.ts
+++ b/web/src/lib/gatewayClient.ts
@@ -16,6 +16,7 @@
 import {
   JsonRpcGatewayClient,
   buildHermesWebSocketUrl,
+  getOrCreateGatewayClientId,
   type ConnectionState,
   type GatewayEvent,
   type GatewayEventName,
@@ -26,9 +27,22 @@ import { maybeReloadForLoopbackWsAuthFailure } from "@/lib/dashboard-auth-reload
 
 export type { ConnectionState, GatewayEvent, GatewayEventName };
 
+function webClientId(): string {
+  try {
+    return getOrCreateGatewayClientId("web", globalThis.sessionStorage);
+  } catch {
+    return getOrCreateGatewayClientId("web", null);
+  }
+}
+
 export class GatewayClient extends JsonRpcGatewayClient {
   constructor() {
     super({
+      clientAttachment: {
+        client_id: webClientId(),
+        protocol_version: 1,
+        surface: "web",
+      },
       closedErrorMessage: "WebSocket closed",
       connectErrorMessage: "WebSocket connection failed",
       notConnectedErrorMessage: "gateway not connected",


### PR DESCRIPTION
## Summary
- publish durable submitted user messages on the ordered session event stream
- render peer-submitted user messages immediately without waiting for transcript polling
- preserve metadata through isolated compute-host turns
- deduplicate the submitting client’s optimistic message

## Validation
- 65 surrounding gateway/compute-host tests passed
- targeted canonical pytest: 4 passed
- Desktop Vitest regression: 1 passed
- Desktop build and typecheck passed
- Ruff, Python compilation, and diff checks passed
- live two-PC Hermes Desktop validation passed: submitted user message appears on PC2 before assistant output

Draft typing intentionally remains local and is not streamed.