### PR TITLE
fix(terminal): include Linuxbrew in fallback PATH

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -1547,7 +1547,7 @@ class TestBlocklistCoverage:
 
 
 class TestSanePathIncludesHomebrew:
-    """Verify _SANE_PATH includes macOS Homebrew directories."""
+    """Verify _SANE_PATH includes macOS Homebrew and Linuxbrew directories."""
 
     @pytest.fixture(autouse=True)
     def _disable_hermes_bin_injection(self):
@@ -1564,6 +1564,8 @@ class TestSanePathIncludesHomebrew:
     def test_sane_path_includes_homebrew_bin(self):
         from tools.environments.local import _SANE_PATH
         assert "/opt/homebrew/bin" in _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/bin" in _SANE_PATH
+        assert "/home/linuxbrew/.linuxbrew/sbin" in _SANE_PATH
 
 
     def test_make_run_env_appends_homebrew_on_minimal_path(self, monkeypatch):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -1317,6 +1317,7 @@ def _find_shell() -> str:
 # Standard PATH entries for environments with minimal PATH.
 _SANE_PATH = (
     "/opt/homebrew/bin:/opt/homebrew/sbin:"
+    "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin:"
     "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 )
 


### PR DESCRIPTION
## Summary
- add canonical Linuxbrew `bin` and `sbin` directories to the local terminal fallback PATH
- cover both directories with the existing PATH regression test

## Test plan
- `python -m pytest tests/tools/test_local_env_blocklist.py -q` (87 passed, 3 skipped)

Closes #69625