### PR TITLE
feat(desktop): DOM navigation tracer to diagnose the 5s flash/reset symptom

### DIFF
--- a/apps/desktop/electron/dom-navigation-tracer.test.ts
+++ b/apps/desktop/electron/dom-navigation-tracer.test.ts
@@ -1,0 +1,137 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { formatDomNavigationLine, traceWindowDomNavigation } from './dom-navigation-tracer'
+
+// Fake Electron surface — real listener wiring, no Electron import. Mirrors
+// how the rest of electron/*.test.ts exercises Electron-free modules.
+function makeFakeWindow(overrides: { destroyed?: boolean } = {}) {
+  const listeners = new Map<string, ((...args: any[]) => void)[]>()
+  let destroyed = overrides.destroyed ?? false
+
+  const win = {
+    isDestroyed: () => destroyed,
+    setDestroyed: (value: boolean) => {
+      destroyed = value
+    },
+    webContents: {
+      on: (event: string, listener: (...args: any[]) => void) => {
+        const list = listeners.get(event) ?? []
+
+        list.push(listener)
+        listeners.set(event, list)
+      },
+      removeListener: (event: string, listener: (...args: any[]) => void) => {
+        listeners.set(
+          event,
+          (listeners.get(event) ?? []).filter(candidate => candidate !== listener)
+        )
+      },
+      emit: (event: string, ...args: unknown[]) => {
+        for (const listener of listeners.get(event) ?? []) {
+          listener(...args)
+        }
+      },
+      listenerCount: (event: string) => (listeners.get(event) ?? []).length
+    }
+  }
+
+  return win
+}
+
+function makeTracer(win: ReturnType<typeof makeFakeWindow>, label = 'main') {
+  const logs: string[] = []
+
+  const dispose = traceWindowDomNavigation(win as never, label, {
+    log: (line: string) => {
+      logs.push(line)
+    }
+  })
+
+  return { logs, dispose }
+}
+
+test('logs a did-start-navigation line with url, main-frame and in-place fields', () => {
+  const win = makeFakeWindow()
+  const { logs } = makeTracer(win)
+
+  win.webContents.emit('did-start-navigation', {}, 'file:///app/index.html', false, true)
+
+  assert.deepEqual(logs, ['[domnav:main] did-start-navigation url=file:///app/index.html main=true inPlace=false'])
+})
+
+test('logs did-navigate, in-page navigation and did-finish-load lines', () => {
+  const win = makeFakeWindow()
+  const { logs } = makeTracer(win, 'session-window')
+
+  win.webContents.emit('did-navigate', {}, 'file:///app/index.html')
+  win.webContents.emit('did-navigate-in-page', {}, 'file:///app/index.html#/chat', true)
+  win.webContents.emit('did-finish-load', {})
+
+  assert.deepEqual(logs, [
+    '[domnav:session-window] did-navigate url=file:///app/index.html',
+    '[domnav:session-window] did-navigate-in-page url=file:///app/index.html#/chat main=true',
+    '[domnav:session-window] did-finish-load'
+  ])
+})
+
+test('formats did-fail-load with code, description, url and main-frame', () => {
+  const win = makeFakeWindow()
+  const { logs } = makeTracer(win)
+
+  win.webContents.emit('did-fail-load', {}, -3, 'ERR_ABORTED', 'file:///app/index.html', true)
+
+  assert.deepEqual(logs, ['[domnav:main] did-fail-load code=-3 desc=ERR_ABORTED url=file:///app/index.html main=true'])
+})
+
+test('renders missing did-fail-load fields as ? instead of undefined', () => {
+  assert.equal(
+    formatDomNavigationLine('hud', 'did-fail-load', ['code=?', 'desc=?', 'url=?', 'main=?']),
+    '[domnav:hud] did-fail-load code=? desc=? url=? main=?'
+  )
+})
+
+test('logs render-process-gone with reason and exit code', () => {
+  const win = makeFakeWindow()
+  const { logs } = makeTracer(win)
+
+  win.webContents.emit('render-process-gone', {}, { reason: 'crashed', exitCode: 1 })
+
+  assert.deepEqual(logs, ['[domnav:main] render-process-gone reason=crashed exitCode=1'])
+})
+
+test('emits nothing while the window is destroyed (teardown noise stays out of the log)', () => {
+  const win = makeFakeWindow({ destroyed: true })
+  const { logs } = makeTracer(win)
+
+  win.webContents.emit('did-start-navigation', {}, 'file:///app/index.html', false, true)
+  win.webContents.emit('did-finish-load', {})
+  win.webContents.emit('render-process-gone', {}, { reason: 'killed', exitCode: 0 })
+
+  assert.deepEqual(logs, [])
+})
+
+test('dispose removes every listener so window recreation cannot stack handlers', () => {
+  const win = makeFakeWindow()
+  const { dispose } = makeTracer(win)
+
+  const events = [
+    'did-start-navigation',
+    'did-navigate',
+    'did-navigate-in-page',
+    'did-finish-load',
+    'did-fail-load',
+    'render-process-gone'
+  ]
+
+  for (const event of events) {
+    assert.equal(win.webContents.listenerCount(event), 1)
+  }
+
+  dispose()
+
+  for (const event of events) {
+    assert.equal(win.webContents.listenerCount(event), 0)
+  }
+})

--- a/apps/desktop/electron/dom-navigation-tracer.ts
+++ b/apps/desktop/electron/dom-navigation-tracer.ts
@@ -1,0 +1,179 @@
+// DOM navigation tracer for the five-second flash/reset symptom (no issue #).
+//
+// The reported symptom is a visible ~5s flash/reset of the desktop UI while
+// every existing diagnostic is quiet: desktop.log carries zero
+// render-process-gone / did-fail-load / reload lines across days (verified
+// 2026-08-31 over desktop.log + desktop.log.1), the renderer console hook
+// logs only error-level messages, and the backend logs show nothing while the
+// flash persists. A stable renderer PID does NOT rule out webContents.reload()
+// — a reload re-navigates the SAME webContents and renderer process — and no
+// instrument today would ever log one.
+//
+// This tracer closes that gap. It attaches ONE cheap, navigation-scoped
+// listener set to a webContents and writes a single desktop.log line per
+// navigation lifecycle event. These events are silent in steady state (they
+// only fire on actual navigation/load), so the log cost is zero while nothing
+// happens and complete (with exact timestamps) when the symptom fires:
+//
+//   [domnav:main] did-start-navigation url=... main=true inPlace=false
+//   [domnav:main] did-navigate url=...
+//   [domnav:main] did-finish-load url=...
+//   [domnav:main] did-fail-load code=-3 desc=... url=... main=true
+//   [domnav:main] render-process-gone reason=crashed exitCode=1
+//
+// What each outcome will mean for the diagnosis:
+// - a `did-start-navigation` burst with ~5s cadence and a stable renderer PID
+//   proves a programmatic reload loop (webContents.reload / location.reload)
+//   — next step is finding the caller, no more guessing;
+// - navigation events ABSENT while the flash is still seen rules the whole
+//   document-reload class out and points at compositor-level repaint
+//   (GPU/theme/translucency) or a renderer-internal remount;
+// - a render-process-gone line here but nowhere else means the lifecycle
+//   wiring missed this window (the tracer must be attached everywhere this
+//   helper is, so absence is meaningful).
+//
+// Deliberately duplicate-free of policy: the lifecycle helper owns reload
+// decisions (window-renderer-lifecycle.ts); this module only OBSERVES, so its
+// did-fail-load lines intentionally coexist with the lifecycle's own log line.
+
+export interface DomNavigationTracerWindowLike {
+  isDestroyed: () => boolean
+  webContents: {
+    on: (event: string, listener: (...args: unknown[]) => void) => unknown
+    removeListener?: (event: string, listener: (...args: unknown[]) => void) => unknown
+  }
+}
+
+interface NavigationDetails {
+  url?: unknown
+  isInPlace?: unknown
+  isMainFrame?: unknown
+}
+
+interface FailedLoadDetails {
+  errorCode?: unknown
+  errorDescription?: unknown
+  validatedURL?: unknown
+  isMainFrame?: unknown
+}
+
+interface RenderGoneDetails {
+  reason?: unknown
+  exitCode?: unknown
+}
+
+/** One line per event, e.g.
+ *  `[domnav:main] did-fail-load code=-3 desc=ERR_ABORTED url=... main=true`.
+ *  Unknown values render as `?` so a support bundle reads as a story, not
+ *  `undefined undefined undefined`. Exported for tests. */
+export function formatDomNavigationLine(label: string, event: string, parts: string[]): string {
+  const body = parts.length > 0 ? ` ${parts.join(' ')}` : ''
+
+  return `[domnav:${String(label || '?')}] ${event}${body}`
+}
+
+function field(name: string, value: unknown): string {
+  return `${name}=${value === undefined || value === null || value === '' ? '?' : String(value)}`
+}
+
+export interface DomNavigationTracerOptions {
+  log: (line: string) => void
+}
+
+/**
+ * Attach navigation/telemetry listeners to a renderer-content window. Returns
+ * a dispose() that removes every listener (window recreation must not stack
+ * handlers). Attach alongside attachRendererConsoleCapture — the SAME window
+ * set, so "no domnav lines" is itself evidence.
+ */
+export function traceWindowDomNavigation(
+  win: DomNavigationTracerWindowLike,
+  label: string,
+  options: DomNavigationTracerOptions
+): () => void {
+  const { log } = options
+  const contents = win.webContents
+  const bound: [string, (...args: unknown[]) => void][] = []
+
+  const listen = (event: string, handler: (...args: unknown[]) => void) => {
+    contents.on(event, handler)
+    bound.push([event, handler])
+  }
+
+  listen('did-start-navigation', (_event, url?: unknown, isInPlace?: unknown, isMainFrame?: unknown) => {
+    if (win.isDestroyed()) {
+      return
+    }
+
+    log(
+      formatDomNavigationLine(label, 'did-start-navigation', [
+        field('url', url),
+        field('main', isMainFrame),
+        field('inPlace', isInPlace)
+      ])
+    )
+  })
+
+  listen('did-navigate', (_event, url?: unknown) => {
+    if (win.isDestroyed()) {
+      return
+    }
+
+    log(formatDomNavigationLine(label, 'did-navigate', [field('url', url)]))
+  })
+
+  listen('did-navigate-in-page', (_event, url?: unknown, isMainFrame?: unknown) => {
+    if (win.isDestroyed()) {
+      return
+    }
+
+    log(formatDomNavigationLine(label, 'did-navigate-in-page', [field('url', url), field('main', isMainFrame)]))
+  })
+
+  listen('did-finish-load', () => {
+    if (win.isDestroyed()) {
+      return
+    }
+
+    log(formatDomNavigationLine(label, 'did-finish-load', []))
+  })
+
+  listen(
+    'did-fail-load',
+    (_event, errorCode?: unknown, errorDescription?: unknown, validatedURL?: unknown, isMainFrame?: unknown) => {
+      if (win.isDestroyed()) {
+        return
+      }
+
+      log(
+        formatDomNavigationLine(label, 'did-fail-load', [
+          field('code', errorCode),
+          field('desc', errorDescription),
+          field('url', validatedURL),
+          field('main', isMainFrame)
+        ])
+      )
+    }
+  )
+
+  listen('render-process-gone', (_event, details?: RenderGoneDetails) => {
+    if (win.isDestroyed()) {
+      return
+    }
+
+    log(
+      formatDomNavigationLine(label, 'render-process-gone', [
+        field('reason', details?.reason),
+        field('exitCode', details?.exitCode)
+      ])
+    )
+  })
+
+  return () => {
+    for (const [event, handler] of bound) {
+      contents.removeListener?.(event, handler)
+    }
+
+    bound.length = 0
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -167,6 +167,7 @@ import {
   uninstallArgsForMode
 } from './desktop-uninstall'
 import { describeDevCdpDecision, resolveDevCdpPort } from './dev-cdp'
+import { traceWindowDomNavigation } from './dom-navigation-tracer'
 import { installEmbedReferer } from './embed-referer'
 import { createEventDeduper } from './event-dedupe'
 import {
@@ -12835,6 +12836,7 @@ function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?
   streamThrottle.register(win)
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
   attachRendererConsoleCapture(win, 'session-window', rememberLog)
+  traceWindowDomNavigation(win, 'session-window', { log: rememberLog })
 
   // Renderer lifecycle diagnostics + recovery (#81290): a dead session-window
   // renderer used to log nothing and stay black; now it logs with its window
@@ -12920,6 +12922,7 @@ function spawnBrowserWindow(tabId) {
   streamThrottle.register(win)
   wireCommonWindowHandlers(win, zoomWiringForWindowKind('chat'))
   attachRendererConsoleCapture(win, 'browser-window', rememberLog)
+  traceWindowDomNavigation(win, 'browser-window', { log: rememberLog })
 
   installWindowRendererLifecycle(win, {
     kind: 'browser',
@@ -13038,6 +13041,7 @@ function createInstanceWindow() {
   })
 
   attachRendererConsoleCapture(win, 'instance', rememberLog)
+  traceWindowDomNavigation(win, 'instance', { log: rememberLog })
   loadWindowUrl(
     win,
     buildInstanceWindowUrl({
@@ -13170,6 +13174,7 @@ function spawnPetOverlayWindow(bounds) {
   })
 
   attachRendererConsoleCapture(win, 'pet-overlay', rememberLog)
+  traceWindowDomNavigation(win, 'pet-overlay', { log: rememberLog })
   loadWindowUrl(win, petOverlayUrl(), 'Pet overlay')
 
   return win
@@ -13627,6 +13632,7 @@ function spawnHudWindow(sessionId, profile) {
   })
 
   attachRendererConsoleCapture(win, 'hud', rememberLog)
+  traceWindowDomNavigation(win, 'hud', { log: rememberLog })
   // Log-only lifecycle (#81290): the HUD is a compact auxiliary surface the
   // user can re-toggle; a dead renderer should be diagnosable, not resurrected.
   installWindowRendererLifecycle(win, { kind: 'hud', callbacks: { log: rememberLog } })
@@ -13840,6 +13846,7 @@ function spawnQuickEntryWindow() {
   })
 
   attachRendererConsoleCapture(win, 'quick-entry', rememberLog)
+  traceWindowDomNavigation(win, 'quick-entry', { log: rememberLog })
   loadWindowUrl(win, quickEntryUrl(), 'Quick entry')
 
   return win
@@ -14135,6 +14142,7 @@ function createWindow() {
   // every renderer-content window shares (#79428: crashes in secondary/HUD/
   // quick-entry windows used to vanish without a trace).
   attachRendererConsoleCapture(mainWindow, 'main', rememberLog)
+  traceWindowDomNavigation(mainWindow, 'main', { log: rememberLog })
 
   // #95575: a torn renderer bundle (update replaced the app while its files
   // were locked) loads fine and then dies on the first lazy import — a white

--- a/apps/desktop/electron/wake-indicator-window.ts
+++ b/apps/desktop/electron/wake-indicator-window.ts
@@ -2,6 +2,7 @@ import { pathToFileURL } from 'node:url'
 
 import { BrowserWindow, screen } from 'electron'
 
+import { traceWindowDomNavigation } from './dom-navigation-tracer'
 import { attachRendererConsoleCapture } from './renderer-log'
 import {
   normalizeWakeIndicatorState,
@@ -110,6 +111,9 @@ export function createWakeIndicatorWindowController({
     // Console errors go through the shared capture (renderer-log.ts owns
     // console-message; the lifecycle helper deliberately does not).
     attachRendererConsoleCapture(next, 'wake', log)
+    // Navigation telemetry for the flash/reset diagnosis rides the same
+    // window set (dom-navigation-tracer.ts header explains why).
+    traceWindowDomNavigation(next, 'wake', { log })
 
     next.webContents.on('did-finish-load', sendState)
     next.once('ready-to-show', () => {


### PR DESCRIPTION
## Summary

Instrumentation-only PR to diagnose the reported **five-second desktop flash/reset** symptom. The symptom was **not reproduced** in this session, so per the task guardrail **no speculative fix is included — the five-second elapsed timer is untouched**. What this adds is the missing observation point for the entire class of causes that are invisible today.

## The diagnosis gap

Evidence from this machine (packaged app 0.17.0, logs archived 2026-08-31):

- `desktop.log` + `desktop.log.1` (multi-day): **zero** `render-process-gone`, **zero** `did-fail-load`, **zero** reload/lifecycle events. Both bounded auto-reload paths (`window-renderer-lifecycle.ts`) have never fired here.
- The renderer console hook records **error-level only**, so a quiet log does not mean a quiet renderer.
- A stable renderer PID does **not** rule out `webContents.reload()`: a reload re-navigates the *same* webContents. No instrument observes navigation today, so a programmatic reload loop would leave exactly zero evidence — matching what we see.
- WebSocket correlation: `sessions.changed` events fire in bursts (~2s cadence, ~1000/hr during heavy agent activity) — a plausible renderer-churn trigger, recorded as correlated-but-unproven.

## What this PR adds

`traceWindowDomNavigation()` (`electron/dom-navigation-tracer.ts`): an observation-only per-window tracer logging one `[domnav:<kind>]` desktop.log line per navigation lifecycle event — `did-start-navigation`, `did-navigate`, `did-navigate-in-page`, `did-finish-load`, `did-fail-load`, `render-process-gone`.

- **Zero log cost in steady state** — these events fire only on actual navigation/load.
- Attached at **every** `attachRendererConsoleCapture` site (main, session-window, browser-window, instance, pet-overlay, hud, quick-entry, wake), so the invariant "same window set as console capture" holds and *absence* of `domnav` lines is itself evidence.
- **No policy**: the lifecycle helper keeps owning reload decisions; this only observes.

### Reading the results once the next flash occurs

| Observation | Conclusion |
|---|---|
| `domnav` navigation burst at ~5s cadence | Programmatic reload loop confirmed; caller hunt trivial from timestamps |
| Flash visible, **no** `domnav` lines | Document-reload class fully ruled out → investigate WebSocket-driven remount (`sessions.changed`) or compositor repaint |
| `render-process-gone` only in `domnav` lines | A window was missing lifecycle wiring |

## Testing

- New `dom-navigation-tracer.test.ts`: 7 vitest cases (event formatting, destroy-gating, dispose removing all listeners) — all pass.
- `tsc -p tsconfig.electron.json --noEmit`: clean. ESLint on touched files: clean.
- Full desktop suite: 8333 passed / 557 failed in this branch; the failing-file set is **byte-identical to pristine `main`** (verified by comm-diff; pre-existing environment-dependent failures, no regression).
- `npm run build` and `npm run pack` produce a working artifact in a worktree.

## Not done / open

- Live visual before/after verification (≥30s) was **blocked**: the running app's main window is staged/offscreen (Stage Manager; capture of `app=Hermes` returns 0x0) and disturbing the user's active window was out of scope. The built artifact has not been visually exercised yet.
- Full diagnostic report preserved at `~/.hermes/audit/desktop-5s-flash/diagnostic-report.md`.
