### PR TITLE
fix(cron): keep bot-chat output when a live session owns the chat

### DIFF
--- a/cron/bot_chat_delivery.py
+++ b/cron/bot_chat_delivery.py
@@ -1,0 +1,347 @@
+"""Durable cron delivery into canonical Bot Chat sessions.
+
+Bot Chat turns cannot start a second process while CLI/TUI/Desktop owns the
+same session: the active-session lease correctly rejects stale transcript
+writers. This module durably admits each completed cron output, attempts the
+canonical one-shot chat lane immediately when unowned, and retries retained
+records on later scheduler ticks.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        msvcrt = None
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.config import load_config
+
+logger = logging.getLogger(__name__)
+
+QUEUE_DIR_NAME = "bot_chat_delivery_queue"
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+
+
+@contextlib.contextmanager
+def _file_lock(queue_dir: Path, name: str):
+    """Take one blocking cross-process lock inside *queue_dir*."""
+    _ensure_private_dir(queue_dir)
+    fh = open(queue_dir / name, "a+b")
+    try:
+        if os.name == "nt" and msvcrt:
+            fh.seek(0, os.SEEK_END)
+            if fh.tell() == 0:
+                fh.write(b"\0")
+                fh.flush()
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+        elif fcntl:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt" and msvcrt:
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+            elif fcntl:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _queue_dir(source_home: Path) -> Path:
+    return Path(source_home) / "cron" / QUEUE_DIR_NAME
+
+
+def _queue_delivery(job: dict, message: str, profile: str, source_home: Path) -> str:
+    """Atomically persist one turn before the scheduler acknowledges it."""
+    delivery_id = uuid.uuid4().hex
+    record = {
+        "id": delivery_id,
+        "job_id": str(job.get("id") or "?"),
+        "job_name": str(job.get("name") or job.get("id") or "?"),
+        "profile": str(profile or ""),
+        "message": message,
+        "created_at": time.time(),
+    }
+    queue_dir = _queue_dir(source_home)
+    with _file_lock(queue_dir, ".queue.lock"):
+        path = queue_dir / f"{time.time_ns():020d}-{delivery_id}.json"
+        tmp = path.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(record, fh, ensure_ascii=False, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+            if os.name != "nt":
+                dir_fd = os.open(queue_dir, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+    return delivery_id
+
+
+def _target_home(profile: str, source_home: Path) -> Path:
+    if not profile:
+        return Path(source_home)
+    from hermes_cli.profiles import get_profile_dir
+
+    return get_profile_dir(profile)
+
+
+def _target_has_live_owner(profile: str, source_home: Path) -> Optional[bool]:
+    """Return whether the target Bot Chat is leased, or None if unknown."""
+    try:
+        target_home = _target_home(profile, source_home)
+        db_path = target_home / "state.db"
+        if not db_path.exists():
+            return False
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=db_path, read_only=True)
+        try:
+            row = db.get_session_by_title("Bot Chat")
+            if not row:
+                return False
+            session_id = str(row.get("id") or "")
+            try:
+                session_id = str(db.get_compression_tip(session_id) or session_id)
+            except Exception:
+                pass
+        finally:
+            db.close()
+
+        from hermes_cli.active_sessions import active_session_registry_snapshot
+
+        return any(
+            str(entry.get("session_id") or "") == session_id
+            for entry in active_session_registry_snapshot(registry_home=target_home)
+        )
+    except Exception:
+        logger.warning(
+            "Could not prove Bot Chat ownership for profile '%s'; retaining queued delivery",
+            profile or "(own)",
+            exc_info=True,
+        )
+        return None
+
+
+def _delivery_timeout() -> int:
+    try:
+        cfg = load_config()
+        value = int(cfg.get("cron", {}).get("bot_chat_delivery_timeout_seconds", 600))
+        return value if value > 0 else 600
+    except Exception:
+        return 600
+
+
+def _run_delivery(record: dict) -> Optional[str]:
+    """Run one already-durable record through the canonical one-shot CLI lane."""
+    profile = str(record.get("profile") or "")
+    job_id = str(record.get("job_id") or "?")
+    message = str(record.get("message") or "")
+
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        argv = [hermes_bin]
+    else:
+        try:
+            import importlib.util
+
+            if importlib.util.find_spec("hermes_cli") is not None:
+                argv = [sys.executable, "-m", "hermes_cli.main"]
+            else:
+                return "bot-chat delivery failed: hermes CLI not resolvable"
+        except Exception:
+            return "bot-chat delivery failed: hermes CLI not resolvable"
+
+    env = os.environ.copy()
+    if profile:
+        argv += ["-p", profile]
+        env.pop("HERMES_HOME", None)
+
+    query_file = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".txt",
+            prefix="hermes-cron-botchat-",
+            delete=False,
+        ) as fh:
+            fh.write(message)
+            query_file = fh.name
+
+        argv += [
+            "chat",
+            "--in",
+            "~",
+            "-c",
+            "Bot Chat",
+            "--create-if-missing",
+            "-Q",
+            "--query-file",
+            query_file,
+        ]
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_delivery_timeout(),
+            env=env,
+            creationflags=windows_hide_flags(),
+        )
+        if result.returncode != 0:
+            tail = (result.stderr or result.stdout or "").strip()[-500:]
+            msg = (
+                f"bot-chat delivery to profile '{profile or '(own)'}' failed "
+                f"(exit {result.returncode})" + (f": {tail}" if tail else "")
+            )
+            logger.warning("Job '%s': %s", job_id, msg)
+            return msg
+        logger.info(
+            "Job '%s': delivered to Bot Chat of profile '%s'",
+            job_id,
+            profile or "(own)",
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        msg = (
+            f"bot-chat delivery to profile '{profile or '(own)'}' timed out "
+            f"after {_delivery_timeout()}s (the bot's turn may still complete; "
+            "the durable record is retained for retry)"
+        )
+        logger.warning("Job '%s': %s", job_id, msg)
+        return msg
+    except Exception as exc:
+        msg = f"bot-chat delivery failed: {str(exc) or type(exc).__name__}"
+        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
+        return msg
+    finally:
+        if query_file:
+            try:
+                os.unlink(query_file)
+            except OSError:
+                pass
+
+
+def drain_queue(source_home: Path) -> tuple[int, Optional[str]]:
+    """Retry retained turns in order per target profile.
+
+    One blocked profile does not head-of-line block independent profiles. The
+    dedicated drain lock serializes subprocess attempts without preventing new
+    cron workers from durably appending records through ``.queue.lock``.
+    """
+    delivered = 0
+    first_error: Optional[str] = None
+    blocked_profiles: set[str] = set()
+    queue_dir = _queue_dir(source_home)
+    # Keep the scheduler's common idle tick read-only and allocation-free.
+    # A concurrent writer that creates the directory after this check is picked
+    # up immediately by its own drain attempt or by the next 60-second tick.
+    if not queue_dir.exists():
+        return 0, None
+    with _file_lock(queue_dir, ".drain.lock"):
+        for path in sorted(queue_dir.glob("*.json")):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(record, dict) or not record.get("message"):
+                    raise ValueError("invalid queued bot-chat delivery")
+            except Exception as exc:
+                msg = f"bot-chat delivery queue record unreadable: {path.name}: {exc}"
+                logger.error(msg)
+                first_error = first_error or msg
+                continue
+
+            profile = str(record.get("profile") or "")
+            if profile in blocked_profiles:
+                continue
+            owner = _target_has_live_owner(profile, source_home)
+            if owner is not False:
+                reason = (
+                    "target session has a live owner"
+                    if owner
+                    else "target ownership is unknown"
+                )
+                first_error = first_error or reason
+                blocked_profiles.add(profile)
+                continue
+
+            error = _run_delivery(record)
+            if error:
+                first_error = first_error or error
+                blocked_profiles.add(profile)
+                continue
+            try:
+                path.unlink()
+            except OSError as exc:
+                msg = f"delivered bot-chat queue record could not be acknowledged: {exc}"
+                logger.warning(msg)
+                first_error = first_error or msg
+                blocked_profiles.add(profile)
+                continue
+            delivered += 1
+    return delivered, first_error
+
+
+def deliver(job: dict, content: str, profile: str, source_home: Path) -> Optional[str]:
+    """Durably admit one cron output and attempt immediate ordered delivery."""
+    job_id = job.get("id", "?")
+    job_name = job.get("name", job_id)
+    message = (
+        f'[Cronjob "{job_name}" output — scheduled job, not the user. '
+        f"Review it, act on anything that needs action, and summarize "
+        f"for the chat.]\n\n{content}"
+    )
+    try:
+        delivery_id = _queue_delivery(job, message, profile, Path(source_home))
+    except Exception as exc:
+        msg = f"bot-chat delivery could not be durably queued: {str(exc) or type(exc).__name__}"
+        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
+        return msg
+
+    delivered, deferred_reason = drain_queue(Path(source_home))
+    if deferred_reason:
+        logger.info(
+            "Job '%s': Bot Chat delivery %s admitted; queue remains pending (%s)",
+            job_id,
+            delivery_id,
+            deferred_reason,
+        )
+    elif delivered:
+        logger.info("Job '%s': durably queued Bot Chat delivery completed", job_id)
+    return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2611,124 +2611,18 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     }
 
 
-def _get_bot_chat_delivery_timeout() -> int:
-    """Timeout for one bot-chat delivery turn (the target bot runs a full
-    agent turn on the injected output, so this is minutes, not seconds).
-
-    ``cron.bot_chat_delivery_timeout_seconds`` in config.yaml; default 600.
-    """
-    try:
-        cfg = load_config()
-        value = int(cfg.get("cron", {}).get("bot_chat_delivery_timeout_seconds", 600))
-        return value if value > 0 else 600
-    except Exception:
-        return 600
-
-
 def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]:
-    """Deliver job output into a profile's canonical Bot Chat as an inbound turn.
+    """Durably admit a cron output for delivery to a canonical Bot Chat."""
+    from cron.bot_chat_delivery import deliver
 
-    Runs ``hermes [-p <profile>] chat --in ~ -c "Bot Chat" --create-if-missing
-    -Q --query-file <tmp>`` — the exact lane Bot Mode agent-to-agent messages
-    use, so the adopt-before-mint canonical-session rules apply and the target
-    bot receives the output as a real user-role message it can act on.
-    Alternation-safe by construction: this is an inbound turn on the chat
-    command lane, not a transcript splice.
+    return deliver(job, content, profile, _get_hermes_home())
 
-    ``profile`` is ``""`` for the job's own profile (subprocess inherits this
-    scheduler's HERMES_HOME) or a validated local profile name.  Returns None
-    on success or an error string for ``last_delivery_error``.
-    """
-    import shutil as _shutil
-    import tempfile
 
-    job_id = job.get("id", "?")
-    job_name = job.get("name", job_id)
+def _drain_bot_chat_delivery_queue() -> tuple[int, Optional[str]]:
+    """Retry bot-chat turns retained by earlier deliveries."""
+    from cron.bot_chat_delivery import drain_queue
 
-    hermes_bin = _shutil.which("hermes")
-    if hermes_bin:
-        argv = [hermes_bin]
-    else:
-        try:
-            import importlib.util as _ilu
-
-            if _ilu.find_spec("hermes_cli") is not None:
-                argv = [sys.executable, "-m", "hermes_cli.main"]
-            else:
-                return "bot-chat delivery failed: hermes CLI not resolvable"
-        except Exception:
-            return "bot-chat delivery failed: hermes CLI not resolvable"
-
-    env = os.environ.copy()
-    if profile:
-        argv += ["-p", profile]
-        # -p owns profile resolution in the child; a leftover HERMES_HOME
-        # from THIS scheduler's profile must not shadow it.
-        env.pop("HERMES_HOME", None)
-
-    # The prefix tells the receiving bot this is scheduled output, not the
-    # human typing — mirrors the Bot Mode sender-attribution convention.
-    message = (
-        f'[Cronjob "{job_name}" output — scheduled job, not the user. '
-        f"Review it, act on anything that needs action, and summarize "
-        f"for the chat.]\n\n{content}"
-    )
-
-    query_file = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", suffix=".txt", prefix="hermes-cron-botchat-",
-            delete=False,
-        ) as fh:
-            fh.write(message)
-            query_file = fh.name
-
-        argv += [
-            "chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing",
-            "-Q", "--query-file", query_file,
-        ]
-
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=_get_bot_chat_delivery_timeout(),
-            env=env,
-            creationflags=windows_hide_flags(),
-        )
-        if result.returncode != 0:
-            tail = (result.stderr or result.stdout or "").strip()[-500:]
-            msg = (
-                f"bot-chat delivery to profile "
-                f"'{profile or '(own)'}' failed (exit {result.returncode})"
-                + (f": {tail}" if tail else "")
-            )
-            logger.warning("Job '%s': %s", job_id, msg)
-            return msg
-        logger.info(
-            "Job '%s': delivered to Bot Chat of profile '%s'",
-            job_id, profile or "(own)",
-        )
-        return None
-    except subprocess.TimeoutExpired:
-        msg = (
-            f"bot-chat delivery to profile '{profile or '(own)'}' timed out "
-            f"after {_get_bot_chat_delivery_timeout()}s (the bot's turn may "
-            "still complete; raise cron.bot_chat_delivery_timeout_seconds if "
-            "this recurs)"
-        )
-        logger.warning("Job '%s': %s", job_id, msg)
-        return msg
-    except Exception as e:
-        msg = f"bot-chat delivery failed: {str(e) or type(e).__name__}"
-        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
-        return msg
-    finally:
-        if query_file:
-            try:
-                os.unlink(query_file)
-            except OSError:
-                pass
+    return drain_queue(_get_hermes_home())
 
 
 def _normalize_deliver_value(deliver) -> str:
@@ -7966,6 +7860,18 @@ def tick(
             _maybe_run_worktree_maintenance()
         except Exception as _wt_exc:
             logger.debug("Worktree maintenance dispatch failed: %s", _wt_exc)
+
+        # Bot Chat output is admitted durably before a job is marked delivered.
+        # Retry the oldest retained turn on idle ticks too: a CLI/TUI/Desktop
+        # owner may release the canonical session when no cron job is due.
+        try:
+            _retried, _retry_error = _drain_bot_chat_delivery_queue()
+            if _retried:
+                logger.info("Delivered %d queued Bot Chat cron turn(s)", _retried)
+            if _retry_error:
+                logger.debug("Bot Chat delivery queue remains pending: %s", _retry_error)
+        except Exception:
+            logger.warning("Bot Chat delivery queue retry failed", exc_info=True)
 
         due_jobs = get_due_jobs()
 

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -6,11 +6,13 @@ preflight exemption, create-time validation, the subprocess delivery lane,
 and the delivery-targets listing used by UI pickers.
 """
 
+import json
 import subprocess
 from unittest import mock
 
 import pytest
 
+from cron import bot_chat_delivery as bot_delivery
 from cron import scheduler as sched
 from cron.scheduler import (
     BOT_CHAT_PLATFORM,
@@ -127,8 +129,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the output", "")
 
     assert err is None
@@ -152,9 +154,9 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
-         mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.dict(bot_delivery.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
 
     assert err is None
@@ -164,23 +166,75 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
     assert "HERMES_HOME" not in calls["kwargs"]["env"]
 
 
-def test_deliver_failure_returns_error_string():
+def test_deliver_failure_is_durably_queued_for_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
     with mock.patch.object(
-        sched.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+        bot_delivery.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
-    assert err is not None
-    assert "boom" in err
+    assert err is None
+    queued = list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))
+    assert len(queued) == 1
 
-
-def test_deliver_timeout_returns_error_string():
     with mock.patch.object(
-        sched.subprocess, "run",
+        bot_delivery.subprocess, "run", return_value=_completed()
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        delivered, retry_error = bot_delivery.drain_queue(tmp_path)
+    assert delivered == 1
+    assert retry_error is None
+    assert list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json")) == []
+
+
+def test_deliver_timeout_is_durably_queued_for_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
+    with mock.patch.object(
+        bot_delivery.subprocess, "run",
         side_effect=subprocess.TimeoutExpired(cmd="hermes", timeout=600),
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
-    assert err is not None
-    assert "timed out" in err
+    assert err is None
+    assert len(list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))) == 1
+
+
+def test_live_owner_defers_without_starting_second_session(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
+    with mock.patch.object(bot_delivery, "_target_has_live_owner", return_value=True), \
+         mock.patch.object(bot_delivery.subprocess, "run") as run:
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is None
+    run.assert_not_called()
+    queued = list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))
+    assert len(queued) == 1
+    record = json.loads(queued[0].read_text(encoding="utf-8"))
+    assert record["profile"] == ""
+    assert record["message"].endswith("out")
+
+
+def test_live_owner_probe_resolves_exact_canonical_session(tmp_path):
+    from hermes_cli.active_sessions import try_acquire_active_session
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bot-session", source="cli")
+        db.set_session_title("bot-session", "Bot Chat")
+    finally:
+        db.close()
+
+    lease, refusal = try_acquire_active_session(
+        session_id="bot-session",
+        surface="cli",
+        config={},
+        metadata={"live_session_id": "bot-session"},
+        registry_home=tmp_path,
+    )
+    assert lease is not None and refusal is None
+    try:
+        assert bot_delivery._target_has_live_owner("", tmp_path) is True
+    finally:
+        lease.release()
+    assert bot_delivery._target_has_live_owner("", tmp_path) is False
 
 
 def test_deliver_message_carries_cron_attribution(tmp_path):
@@ -193,8 +247,8 @@ def test_deliver_message_carries_cron_attribution(tmp_path):
             captured["message"] = fh.read()
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the payload", "")
 
     assert 'Cronjob "Daily digest" output' in captured["message"]


### PR DESCRIPTION
## What does this PR do?

Cron output targeting `bot-chat[:profile]` is no longer permanently discarded when CLI, TUI, or Desktop owns the canonical Bot Chat session. The scheduler now persists the completed output before reporting delivery success, preserves single-owner session exclusivity, and retries the oldest retained turn after the owner releases the session.

### Symptom

A completed cron run invokes a second `hermes chat` process. If the canonical Bot Chat is open on another surface, the child exits with `Session already has a live owner`, and the completed output is lost.

### Impact

Users with a long-lived CLI, TUI, or Desktop Bot Chat can lose scheduled results even though the cron run itself completed successfully. This affects both the job's own profile and explicit `bot-chat:<profile>` targets.

### Bug Cause

**Trigger:** `cron/scheduler.py:_deliver_to_bot_chat` invokes the one-shot Bot Chat subprocess while the target session has an active lease.

**Causal chain:**
1. A cron job completes and resolves a Bot Chat delivery target.
2. The scheduler starts an independent `hermes chat` process against the canonical session.
3. `hermes_cli.active_sessions.try_acquire_active_session` correctly refuses the second writer, but the scheduler has no durable handoff or retry record.
4. The cron execution finishes with a delivery error and the output is permanently discarded.

**Why it is wrong:** session exclusivity is a correctness boundary, but a transient ownership refusal must not become permanent data loss.

**Working sibling / contrast:** normal platform deliveries can use a live gateway adapter. Bot Chat is a local pseudo-platform and bypasses that transport, so it needs its own durable admission boundary.

**Ruled out:** the secondary multiplexed-profile `cron status` report is a separate gateway service-detection problem and is not changed here.

### Fix

- Move Bot Chat subprocess delivery into a focused `cron.bot_chat_delivery` module.
- Atomically persist each completed output in an owner-only, source-profile queue before acknowledging delivery.
- Resolve the exact canonical Bot Chat, including its compression tip, and defer without starting a competing process while that session has a live owner.
- Retry retained turns on every healthy scheduler tick, including idle ticks, and delete a record only after the canonical subprocess succeeds.
- Preserve FIFO order per target profile without allowing one busy profile to block independent targets.
- Keep queue writers independent from the potentially long-running drain lock, and retain records across failures, timeouts, or process restarts.

## Related Issue
N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/bot_chat_delivery.py` - durable queue, exact-owner probe, canonical subprocess delivery, and ordered retry.
- `cron/scheduler.py` - route Bot Chat delivery through durable admission and retry retained turns on idle and active ticks.
- `tests/cron/test_cron_bot_chat_delivery.py` - cover live-owner deferral, durable failure/timeout retention, exact canonical owner resolution, and successful retry cleanup.

## How to Test

1. Open the target profile's canonical Bot Chat in CLI, TUI, or Desktop.
2. Fire a cron job with `deliver: bot-chat` or `deliver: bot-chat:<profile>` and confirm the output is durably queued without starting a competing chat process.
3. Release the live owner and run the next scheduler tick; confirm the retained turn is delivered and removed from the queue.
4. Run the focused automated suites:

```bash
scripts/run_tests.sh tests/cron/test_cron_bot_chat_delivery.py tests/cron/test_idle_tick_config_skip.py tests/hermes_cli/test_active_sessions.py -q
```

Local result: 37 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant module and function docstrings describe the durable delivery contract
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because the existing scheduler and session ownership contracts are preserved
- [x] Cross-platform impact was considered; locking uses `fcntl` on Unix and `msvcrt` on Windows, matching the scheduler's existing lock strategy
- [x] Tool descriptions and schemas are N/A
