### PR TITLE
fix(cli): pass resolved max_iterations to AIAgent in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -354,6 +354,23 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _resolve_oneshot_max_iterations(cfg: dict) -> int:
+    """Resolve the -z turn limit with the interactive CLI's precedence.
+
+    ``agent.max_turns`` from config (the legacy root-level spelling is already
+    folded in by ``load_config``), then ``HERMES_MAX_ITERATIONS``, else the
+    unlimited default — the tail of cli.py's HermesCLI chain minus the CLI
+    arg.  Until #99957 this value was resolved and then discarded on every
+    -z run: AIAgent fell back to its constructor default.
+    """
+    from hermes_cli.config import resolve_turn_limit
+
+    raw = (cfg.get("agent") or {}).get("max_turns")
+    if raw is None:
+        raw = os.getenv("HERMES_MAX_ITERATIONS")
+    return resolve_turn_limit(raw)
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -499,6 +516,7 @@ def _run_agent(
             enabled_toolsets=toolsets_list,
             quiet_mode=True,
             platform="cli",
+            max_iterations=_resolve_oneshot_max_iterations(cfg),
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=_fb or None,

--- a/tests/hermes_cli/test_oneshot_max_iterations.py
+++ b/tests/hermes_cli/test_oneshot_max_iterations.py
@@ -1,0 +1,128 @@
+"""Regression tests: -z (oneshot) must honour the same turn-limit resolution
+chain as the interactive CLI (#99957).
+
+``hermes_cli/oneshot.py:_run_agent`` used to build AIAgent without ever
+passing ``max_iterations``, so ``agent.max_turns`` / the legacy root-level
+``max_turns`` / ``HERMES_MAX_ITERATIONS`` were all silently discarded for
+every ``-z`` run and the agent fell back to its constructor default
+(unbounded iterations on current main).
+"""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock
+
+from hermes_cli.oneshot import _resolve_oneshot_max_iterations, _run_agent
+
+
+class TestResolveOneshotMaxIterations:
+    def test_config_agent_max_turns_wins_over_env(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "4")
+        assert _resolve_oneshot_max_iterations({"agent": {"max_turns": 150}}) == 150
+
+    def test_env_used_when_config_missing(self, monkeypatch):
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "4")
+        assert _resolve_oneshot_max_iterations({}) == 4
+
+    def test_env_used_when_config_explicitly_none(self, monkeypatch):
+        # cli.py's chain skips a config value of None the same way — env is
+        # the next stop, not the unlimited default.
+        monkeypatch.setenv("HERMES_MAX_ITERATIONS", "4")
+        assert _resolve_oneshot_max_iterations({"agent": {"max_turns": None}}) == 4
+
+    def test_unlimited_when_nothing_set(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        assert _resolve_oneshot_max_iterations({}) == sys.maxsize
+
+    def test_unlimited_spellings_normalise(self, monkeypatch):
+        # resolve_turn_limit is the single normalization point: "none" etc.
+        # are first-class spellings of unlimited, not parse errors.
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        assert _resolve_oneshot_max_iterations({"agent": {"max_turns": "none"}}) == sys.maxsize
+
+    def test_numeric_string_config(self, monkeypatch):
+        monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+        assert _resolve_oneshot_max_iterations({"agent": {"max_turns": "150"}}) == 150
+
+
+def test_run_agent_passes_resolved_max_iterations(monkeypatch):
+    """_run_agent must forward the resolved turn limit into AIAgent (#99957)."""
+    captured: dict = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = None
+
+        def run_conversation(self, prompt):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.delenv("HERMES_MAX_ITERATIONS", raising=False)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config", lambda: {"agent": {"max_turns": 150}}
+    )
+    monkeypatch.setattr("hermes_cli.oneshot.get_fallback_chain", lambda cfg: [])
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: {}
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._create_session_db_for_oneshot", lambda: MagicMock()
+    )
+    monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+
+    text, result = _run_agent("hi", toolsets=["standard"])
+
+    assert captured["max_iterations"] == 150
+    assert text == "ok"
+
+
+def test_run_agent_env_only_feeds_through(monkeypatch):
+    """No config value: the env var must still reach AIAgent — the issue's
+    exact reproduction (HERMES_MAX_ITERATIONS=4 hermes -z ...)."""
+    captured: dict = {}
+
+    class _FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self._session_messages = None
+
+        def run_conversation(self, prompt):
+            return {"final_response": "ok"}
+
+        def shutdown_memory_provider(self, *args, **kwargs):
+            pass
+
+        def close(self):
+            pass
+
+    monkeypatch.delenv("HERMES_INFERENCE_MODEL", raising=False)
+    monkeypatch.setenv("HERMES_MAX_ITERATIONS", "4")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.oneshot.get_fallback_chain", lambda cfg: [])
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider", lambda **kw: {}
+    )
+    monkeypatch.setattr(
+        "hermes_cli.mcp_startup.ensure_mcp_discovery_before_agent_build",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.oneshot._create_session_db_for_oneshot", lambda: MagicMock()
+    )
+    monkeypatch.setattr("run_agent.AIAgent", _FakeAgent)
+
+    text, result = _run_agent("hi", toolsets=["standard"])
+
+    assert captured["max_iterations"] == 4

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -181,7 +181,13 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {"model": {"default": "m"}},
+            # None (no agent.max_turns, no HERMES_MAX_ITERATIONS) resolves
+            # to TURN_LIMIT_UNLIMITED == sys.maxsize in the real helper.
+            resolve_turn_limit=lambda _raw: sys.maxsize,
+        ),
     )
     monkeypatch.setitem(
         sys.modules,


### PR DESCRIPTION
## What does this PR do?

`hermes -z` (oneshot) builds `AIAgent` directly in `hermes_cli/oneshot.py:_run_agent` and never passes `max_iterations`, so the turn limit the CLI resolves — `agent.max_turns` from config.yaml (with the legacy root-level `max_turns` folded in by `load_config`), then `HERMES_MAX_ITERATIONS` — was silently discarded on every `-z` run. The agent fell back to the constructor default, which on current main is `sys.maxsize` (unbounded iterations), turning "wrong limit" into "no limit".

This PR resolves the limit in `_run_agent` with the same precedence tail as the interactive CLI chain in `cli.py` (`agent.max_turns` → env → unlimited default) and forwards it into the `AIAgent` constructor — exactly what the interactive path already does at `cli_agent_setup_mixin.py` (`max_iterations=self.max_turns`). Normalization goes through the single existing `hermes_cli.config.resolve_turn_limit` point, so string spellings (`"150"`, `"none"`, `"unlimited"`, …) behave identically on both paths. When nothing is configured the resolved value is `TURN_LIMIT_UNLIMITED` (`sys.maxsize`), identical to the constructor default, so default behaviour is unchanged.

## Related Issue

Fixes #99957

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/oneshot.py` — added `_resolve_oneshot_max_iterations(cfg)`: resolves `agent.max_turns` (root-level spelling already folded by `load_config`), falling back to `HERMES_MAX_ITERATIONS`, then to the unlimited default via `resolve_turn_limit`; `_run_agent`'s `AIAgent(...)` call now passes `max_iterations=`.
- `tests/hermes_cli/test_oneshot_max_iterations.py` — new regression tests: precedence matrix for the helper (config over env, env when config missing/explicitly-None, unlimited when unset, `"none"`/numeric-string normalization) plus two end-to-end `_run_agent` runs with a fake `AIAgent` asserting the resolved value reaches the constructor (config=150 and env=4 — the issue's exact reproduction).

## How to Test

1. `python -m pytest tests/hermes_cli/test_oneshot_max_iterations.py -q` — Observed result: **8 passed** (the file fails to even import before the fix: `_resolve_oneshot_max_iterations` does not exist, and pre-fix the end-to-end assertion `captured["max_iterations"]` has nothing to capture).
2. `python -m pytest tests/hermes_cli/test_oneshot_surrogate.py tests/hermes_cli/test_oneshot_skills.py tests/hermes_cli/test_oneshot_usage_file.py tests/agent/test_oneshot.py tests/hermes_cli/test_mcp_discovery_timing.py -q` — Observed result: **30 passed** (surrounding oneshot coverage, including the `_run_agent` ordering assertions from #38448).
3. Manual reproduction from the issue: set `agent.max_turns: 150` in config.yaml, run `HERMES_MAX_ITERATIONS=4 hermes -z "Reply with the single word OK and nothing else."`, then check `sqlite3 state.db "SELECT json_extract(model_config,'$.max_iterations') FROM sessions ORDER BY started_at DESC LIMIT 1;"` — should record 4 while the env var is set (and 150 without it); pre-fix it always recorded the constructor default (90 on v0.20.1).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (focused oneshot/cli suites listed above all green)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper docstring documents the precedence)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no new keys; existing ones now honoured)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure config plumbing; `scripts/check-windows-footguns.py` clean on touched files)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
