### PR TITLE
feat(web): unified media-roots policy for dashboard media endpoints

### DIFF
--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -191,9 +191,11 @@ export function isRemoteGateway(): boolean {
 }
 
 // Fetch gateway-local media as a data URL via the authenticated desktop FS
-// bridge. Remote Desktop artifacts can live anywhere the gateway can read
-// (workspace, skills, ~/.hermes/cache, etc.); /api/media is intentionally
-// narrower and rejects non-images plus images outside its media roots.
+// bridge. All gateway media-serving endpoints (/api/media, /api/files/stream,
+// the audio/video download branch, and /api/fs/read-data-url for media
+// extensions) enforce the same server-side media-roots policy (config.yaml
+// `media.roots`); anything outside a root arrives here as a denial and renders
+// as a fallback card with Save-as.
 export async function gatewayMediaDataUrl(path: string): Promise<string> {
   return readDesktopFileDataUrl(filePathFromMediaPath(path))
 }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1829,6 +1829,27 @@ display:
 #   redact_pii: false
 
 # =============================================================================
+# Media-serving roots
+# =============================================================================
+# The dashboard endpoints that serve media inline — GET /api/media (images),
+# GET /api/files/stream (audio/video), the audio/video branch of
+# GET /api/files/download, and GET /api/fs/read-data-url for media-extension
+# files — only serve files under one of these directories. Unset/empty means
+# the safe default: the gateway workspace plus ~/.hermes/{images,screenshots,
+# cache} (generated images, browser screenshots, cached platform/relay media).
+#
+# Add a directory (absolute path, ~ expanded) to also serve agent-written
+# media from elsewhere, e.g. a shared project tree:
+#
+# media:
+#   roots:
+#     - /srv/shared-media
+#     - ~/gallery
+#
+# Non-media files (text previews, document downloads, explicit Save-as) are
+# not restricted by this key; the dashboard Files tab has its own policy.
+
+# =============================================================================
 # Shell-script hooks
 # =============================================================================
 # Register shell scripts as plugin-hook callbacks.  Each entry is executed as

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1837,6 +1837,18 @@ DEFAULT_CONFIG = {
         "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
     },
 
+    # Media-serving roots (hermes_cli/media_roots.py). The dashboard endpoints
+    # that serve media inline — GET /api/media, GET /api/files/stream, the
+    # media branch of GET /api/files/download, and GET /api/fs/read-data-url
+    # for media-extension files — only serve files under one of these
+    # directories. Unset/empty = the safe default: the gateway workspace plus
+    # ~/.hermes/{images,screenshots,cache} (generated images, screenshots,
+    # cached platform/relay media). Add a directory to serve agent-written
+    # media from elsewhere; entries are ~-expanded absolute paths.
+    "media": {
+        "roots": [],
+    },
+
     # Text-to-speech configuration
     # Each provider supports an optional `max_text_length:` override for the
     # per-request input-character cap. Omit it to use the provider's documented

--- a/hermes_cli/media_roots.py
+++ b/hermes_cli/media_roots.py
@@ -1,0 +1,177 @@
+"""Unified server-side media-roots policy (one source of truth for every
+media-serving dashboard endpoint).
+
+Historically the three media fetch surfaces enforced *different* root
+restrictions (see the ``lib/media.ts`` comment this module retires):
+
+* ``GET /api/media`` — image-extension allowlist + a private root list
+  (``~/.hermes/{images,screenshots,cache}``).
+* ``GET /api/files/stream`` / the audio-video branch of ``GET /api/files/download``
+  — streamable-extension allowlist, no root confinement at all.
+* ``GET /api/fs/read-data-url`` — any path on disk (16 MB cap), no confinement.
+
+That divergence is the "finicky" class: a file the gateway happily serves as an
+inline attachment is refused by the data-URL preview (or vice versa) depending
+on which endpoint the desktop picked for its extension, and the rules are not
+written down anywhere a user can adjust.
+
+This module defines ONE policy:
+
+* The allowed roots come from ``media.roots`` in config.yaml. Each entry is a
+  ``~``-expanded absolute directory; the safe default (``None`` / unset /
+  empty) is the gateway's workspace plus the Hermes-managed media subtrees —
+  ``images/``, ``screenshots/``, and ``cache/`` (where generated images,
+  browser screenshots, inbound platform media, and relay-staged media all
+  live).
+* ``media_roots()`` resolves those to symlink-safe absolute paths at request
+  time (config changes apply without a restart).
+* ``path_in_media_roots()`` is the single containment test every media-serving
+  endpoint consults. Symlinks are resolved before the check, so a link escaping
+  a root is judged by its target.
+
+Scope: media-serving fetch surfaces only. The dashboard Files tab
+(``/api/files`` list/read/upload under :class:`ManagedFilesPolicy`) keeps its
+own operator-facing contract — a root-level filesystem browser and a media
+player are different surfaces with different threat models. Explicit Save-as
+via ``GET /api/fs/download`` stays ungated for the same reason: it is the
+desktop's fallback path when an inline fetch is denied (never-silent cards),
+and it already enforces the sensitive-file denylist.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def _load_config() -> Dict[str, Any]:
+    """Best-effort config load; policy must survive a broken config.yaml."""
+    try:
+        from hermes_cli.config import load_config
+
+        return load_config() or {}
+    except Exception:  # noqa: BLE001 - policy falls back to safe defaults
+        return {}
+
+
+def default_media_roots() -> List[Path]:
+    """The safe default roots, as *unresolved* paths.
+
+    Workspace (the gateway process's cwd — agent-produced artifacts land here
+    by default) plus the Hermes-managed media subtrees under
+    :func:`hermes_constants.get_hermes_home` (generated images, screenshots,
+    cached platform/relay media). Resolved per-request by :func:`media_roots`
+    so profile HERMES_HOME overrides are honored at call time.
+    """
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home()
+    return [
+        Path.cwd(),
+        home / "images",
+        home / "screenshots",
+        home / "cache",
+    ]
+
+
+def configured_roots(config: Optional[Dict[str, Any]] = None) -> Optional[List[Path]]:
+    """Raw ``media.roots`` entries from config.yaml, or None for the default.
+
+    Returns None (meaning "use :func:`default_media_roots`") when the key is
+    absent, empty, or malformed — an operator clearing the list gets the safe
+    default rather than a policy that serves nothing. Invalid entries are
+    skipped individually so one bad path can't disable the whole policy.
+    """
+    if config is None:
+        config = _load_config()
+    media_cfg = config.get("media")
+    if not isinstance(media_cfg, dict):
+        return None
+    raw = media_cfg.get("roots")
+    if not isinstance(raw, (list, tuple)) or not raw:
+        return None
+
+    out: List[Path] = []
+    for entry in raw:
+        if not isinstance(entry, str) or not entry.strip():
+            continue
+        candidate = Path(entry).expanduser()
+        if not candidate.is_absolute():
+            logger.warning("media.roots entry %r is not absolute; ignoring", entry)
+            continue
+        out.append(candidate)
+    return out or None
+
+
+def media_roots(config: Optional[Dict[str, Any]] = None) -> List[Path]:
+    """Resolved, symlink-safe media roots. Never raises; never empty.
+
+    Resolution failures (unresolvable symlink loops, permission errors) drop
+    the offending root rather than failing the request — a partially
+    restrictive policy is the graceful degradation, matching how
+    ``/api/media``'s private root builder behaved. Drops of *default* roots
+    (e.g. ``~/.hermes/images`` before the first generated image creates it)
+    are silent — no file can live under a not-yet-existing directory, so the
+    policy outcome is identical — while drops of *configured* entries are
+    logged so an operator typo can't become silent 403s.
+    """
+    raw_roots = configured_roots(config)
+    explicit = raw_roots is not None
+    if raw_roots is None:
+        raw_roots = default_media_roots()
+
+    out: List[Path] = []
+    for root in raw_roots:
+        try:
+            resolved = root.resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            if explicit:
+                logger.warning("media.roots entry %r could not be resolved; ignoring", root)
+            continue
+        if resolved.is_dir():
+            out.append(resolved)
+        elif explicit:
+            logger.warning(
+                "media.roots entry %r is not an existing directory; media under it "
+                "will be denied until it exists",
+                root,
+            )
+    return out
+
+
+def path_in_media_roots(
+    path: Path,
+    config: Optional[Dict[str, Any]] = None,
+    extra_roots: Optional[List[Path]] = None,
+) -> bool:
+    """True when *path* (resolved, symlink-safe) is under an allowed root.
+
+    The single containment test for every media-serving endpoint. ``extra_roots``
+    lets a caller extend the policy with a root it already trusts for full read
+    access — the dashboard's operator-locked managed files root
+    (``ManagedFilesPolicy.locked_root``): when an operator pins the Files tab to
+    a root, every file under it is already downloadable, so media playback from
+    the same tree must not be denied by the media policy. A root itself counts
+    as inside (a root directory is not readable as media — the callers check
+    ``is_file`` — but containment-wise ``target == root`` keeps the predicate
+    total).
+    """
+    try:
+        resolved = path.resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    roots = media_roots(config)
+    for extra in extra_roots or ():
+        try:
+            extra_resolved = Path(extra).expanduser().resolve(strict=False)
+        except (OSError, RuntimeError, ValueError):
+            continue
+        if extra_resolved.is_dir():
+            roots.append(extra_resolved)
+    for root in roots:
+        if resolved == root or root in resolved.parents:
+            return True
+    return False

--- a/hermes_cli/media_roots.py
+++ b/hermes_cli/media_roots.py
@@ -117,6 +117,13 @@ def media_roots(config: Optional[Dict[str, Any]] = None) -> List[Path]:
     are silent — no file can live under a not-yet-existing directory, so the
     policy outcome is identical — while drops of *configured* entries are
     logged so an operator typo can't become silent 403s.
+
+    Concurrency note: the policy is re-read and re-resolved on every request,
+    so a config edit can flip a root set between two requests. Each request
+    is judged against one internally-consistent snapshot (this function's
+    return value), which is the guarantee callers need; there is no
+    cross-request atomicity, by design — the config file is not a transaction
+    surface.
     """
     raw_roots = configured_roots(config)
     explicit = raw_roots is not None

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1461,6 +1461,9 @@ _CATEGORY_MERGE: Dict[str, str] = {
     # bot_mode holds a couple of relay tuning knobs — keep it folded into the
     # agent tab rather than spawning a tiny standalone category.
     "bot_mode": "agent",
+    # `media.roots` is the only schema-surfaced media field — fold it into the
+    # security tab next to the other what-can-be-read knobs.
+    "media": "security",
     "goals": "agent",
     "updates": "general",
     # `onboarding.profile_build` is the only schema-surfaced onboarding field
@@ -2484,21 +2487,16 @@ def _fs_git_branch(cwd: str) -> str:
 def _media_serve_roots() -> list[Path]:
     """Directories ``GET /api/media`` is allowed to read from.
 
-    Confined to where the agent and attach pipeline actually write media on the
-    gateway host — its images dir and cache subtree. This stops an authenticated
-    client from reading image-extension files anywhere on disk (e.g. a renamed
-    key or a screenshot outside the cache) merely because the suffix passes the
+    Delegates to the unified media-roots policy (``hermes_cli.media_roots``):
+    ``media.roots`` from config.yaml, defaulting to the gateway workspace plus
+    the Hermes-managed media subtrees. This stops an authenticated client from
+    reading image-extension files anywhere on disk (e.g. a renamed key or a
+    screenshot outside the cache) merely because the suffix passes the
     allowlist.
     """
-    home = get_hermes_home()
-    roots = [home / "images", home / "screenshots", home / "cache"]
-    out: list[Path] = []
-    for root in roots:
-        try:
-            out.append(root.resolve())
-        except (OSError, RuntimeError):
-            continue
-    return out
+    from hermes_cli.media_roots import media_roots
+
+    return media_roots()
 
 
 @app.get("/api/media")
@@ -2895,6 +2893,28 @@ async def read_managed_file(request: Request, path: str):
     }
 
 
+def _ensure_media_roots_allowed(target: Path, *, media_only: bool, extra_roots=None) -> None:
+    """Deny media-serving fetches outside the unified media-roots policy.
+
+    The one shared gate for ``/api/media``, ``/api/files/stream``, the
+    media-subresource branch of ``/api/files/download``, and
+    ``/api/fs/read-data-url`` for media-extension files (see
+    ``hermes_cli.media_roots``). Non-media branches (documents, the FS text
+    preview) are NOT gated here — a chart PDF or a text file the agent wrote
+    into an arbitrary workspace is a legitimate managed-file read, and the
+    Save-as fallback (``/api/fs/download``) remains available for anything the
+    inline policy denies. ``extra_roots`` extends the policy with roots the
+    caller already trusts for full read access (the operator-locked managed
+    files root) — see ``hermes_cli.media_roots.path_in_media_roots``.
+    """
+    if not media_only:
+        return
+    from hermes_cli.media_roots import path_in_media_roots
+
+    if not path_in_media_roots(target, extra_roots=extra_roots):
+        raise HTTPException(status_code=403, detail="Path outside media roots")
+
+
 def _managed_file_response(
     request: Request,
     path: str,
@@ -2912,6 +2932,9 @@ def _managed_file_response(
         raise HTTPException(status_code=403, detail="Access to sensitive files is not allowed")
     if media_only and target.suffix.lower() not in _STREAMABLE_MEDIA_EXTENSIONS:
         raise HTTPException(status_code=415, detail="Unsupported media type")
+    _ensure_media_roots_allowed(
+        target, media_only=media_only, extra_roots=[policy.locked_root] if policy.locked_root else None
+    )
 
     try:
         size = target.stat().st_size
@@ -3222,6 +3245,12 @@ async def fs_read_data_url(path: str):
     target, st = _fs_regular_file(_fs_path(path))
     if st.st_size > _FS_DATA_URL_MAX_BYTES:
         raise HTTPException(status_code=413, detail="File too large")
+    # Unified media-roots policy: media-extension files (the desktop's inline
+    # preview class) must live under a media root, same as /api/media and the
+    # streaming endpoints. Non-media files (text, PDF, ...) keep the historical
+    # unconfined preview so the FS browser/editor still works anywhere.
+    if target.suffix.lower() in _MEDIA_CONTENT_TYPES or target.suffix.lower() in _FS_MIME_TYPES:
+        _ensure_media_roots_allowed(target, media_only=True)
     try:
         encoded = base64.b64encode(target.read_bytes()).decode("ascii")
     except PermissionError:

--- a/tests/hermes_cli/test_web_server_files.py
+++ b/tests/hermes_cli/test_web_server_files.py
@@ -264,6 +264,20 @@ def test_stream_upload_cleans_temp_on_cancellation(forced_files_client):
     assert leftovers == [], f"temp upload files leaked on cancellation: {leftovers}"
 
 
+def test_locked_managed_files_root_allows_media_playback(forced_files_client):
+    """An operator-locked Files root is already fully trusted for reads, so
+    media playback through /api/files/stream must not require it to ALSO be a
+    configured media root (the overlap between the managed-files policy and
+    the unified media-roots policy)."""
+    client, root = forced_files_client
+    file_path = _seed_file(client, root, name="out/demo.mp4")
+
+    response = client.get("/api/files/stream", params={"path": str(file_path)})
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+
+
 def test_sensitive_env_files_hidden_from_listing(forced_files_client):
     """Regression test for #57505: .env files must not appear in directory listings."""
     client, root = forced_files_client

--- a/tests/hermes_cli/test_web_server_media_roots.py
+++ b/tests/hermes_cli/test_web_server_media_roots.py
@@ -1,0 +1,305 @@
+"""Unified media-roots policy (M3 / D3): allow/deny contract tests.
+
+Every media-serving dashboard endpoint must enforce ONE policy —
+``media.roots`` from config.yaml (hermes_cli/media_roots.py), defaulting to the
+gateway workspace plus ~/.hermes/{images,screenshots,cache}:
+
+* ``GET /api/media``                    (images)
+* ``GET /api/files/stream``             (audio/video)
+* ``GET /api/files/download`` media branch (Sec-Fetch-Dest: audio|video)
+* ``GET /api/fs/read-data-url``         (media-extension files)
+
+Behavior contract, not change-detectors: a media file inside a root is served;
+the same file outside every root gets 403 ``Path outside media roots``; a
+configured extra root serves files under it; a non-media file (or a non-media
+download/preview branch) is NOT gated by this policy.
+"""
+
+from pathlib import Path
+
+import pytest
+from starlette.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli import media_roots as media_roots_mod
+
+
+pytest.importorskip("starlette.testclient")
+
+
+@pytest.fixture
+def client():
+    previous_auth_required = getattr(web_server.app.state, "auth_required", None)
+    web_server.app.state.auth_required = False
+    test_client = TestClient(web_server.app)
+    test_client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    try:
+        yield test_client
+    finally:
+        if previous_auth_required is None:
+            try:
+                delattr(web_server.app.state, "auth_required")
+            except AttributeError:
+                pass
+        else:
+            web_server.app.state.auth_required = previous_auth_required
+
+
+@pytest.fixture
+def roots_config(monkeypatch):
+    """Point the policy at an explicit config dict and return a setter.
+
+    ``load_config()`` is cached on the real config file's mtime, so tests
+    override the module-level loader seam instead of writing config.yaml.
+    Passing None as the value restores the default policy (unconfigured).
+    """
+    state = {"media_roots": None}
+
+    def _fake_load_config():
+        if state["media_roots"] is None:
+            return {}
+        return {"media": {"roots": state["media_roots"]}}
+
+    monkeypatch.setattr(media_roots_mod, "_load_config", _fake_load_config)
+    return state.__setitem__
+
+
+@pytest.fixture
+def media_tree(tmp_path):
+    """A served tree (workspace root) and an unserved outside tree."""
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    for d in (workspace, outside):
+        d.mkdir()
+    return workspace, outside
+
+
+# ── Policy module unit contract ─────────────────────────────────────────────
+
+
+def test_default_roots_cover_workspace_and_hermes_media_dirs(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    for sub in ("images", "screenshots", "cache"):
+        (tmp_path / "home" / sub).mkdir(parents=True)
+
+    monkeypatch.chdir(workspace)
+
+    resolved = media_roots_mod.media_roots({})
+
+    names = {p.name for p in resolved}
+    assert workspace in resolved
+    assert {"images", "screenshots", "cache"} <= names
+
+
+def test_configured_roots_replace_and_expand_tilde(monkeypatch, tmp_path):
+    srv = tmp_path / "srv"
+    srv.mkdir()
+    gallery = tmp_path / "gallery"
+    gallery.mkdir()
+    monkeypatch.setenv("HOME", str(tmp_path))
+    fake_config = {"media": {"roots": [str(srv), "~/gallery"]}}
+
+    resolved = media_roots_mod.media_roots(fake_config)
+
+    assert resolved == [srv, gallery]
+
+
+def test_relative_or_junk_roots_are_dropped(tmp_path):
+    ok = tmp_path / "ok"
+    ok.mkdir()
+    fake_config = {"media": {"roots": ["relative/path", 17, "", str(ok)]}}
+
+    assert media_roots_mod.media_roots(fake_config) == [ok]
+
+
+def test_nonexistent_configured_root_is_dropped(tmp_path):
+    ok = tmp_path / "ok"
+    ok.mkdir()
+
+    fake_config = {"media": {"roots": [str(tmp_path / "missing"), str(ok)]}}
+
+    assert media_roots_mod.media_roots(fake_config) == [ok]
+
+
+def test_empty_roots_list_falls_back_to_default(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    monkeypatch.chdir(workspace)
+
+    assert media_roots_mod.media_roots({"media": {"roots": []}}) == (
+        media_roots_mod.media_roots({})
+    )
+
+
+def test_containment_rejects_sibling_prefix_paths(tmp_path):
+    root = tmp_path / "media"
+    root.mkdir()
+    (root / "a.png").write_bytes(b"x")
+    sibling = tmp_path / "media-evil"
+    sibling.mkdir()
+    evil = sibling / "a.png"
+    evil.write_bytes(b"x")
+    config = {"media": {"roots": [str(root)]}}
+
+    assert media_roots_mod.path_in_media_roots(root / "a.png", config) is True
+    assert media_roots_mod.path_in_media_roots(evil, config) is False
+
+
+def test_symlink_escaping_root_is_denied(tmp_path):
+    root = tmp_path / "media"
+    root.mkdir()
+    secret = tmp_path / "secret.png"
+    secret.write_bytes(b"x")
+    link = root / "escape.png"
+    link.symlink_to(secret)
+
+    assert media_roots_mod.path_in_media_roots(link) is False
+
+
+# ── Endpoint allow/deny (the three formerly-diverging surfaces) ─────────────
+
+
+def test_api_media_serves_inside_and_denies_outside(client, roots_config, media_tree):
+    workspace, outside = media_tree
+    inside = workspace / "chart.png"
+    inside.write_bytes(b"png-inside")
+    denied = outside / "secret.png"
+    denied.write_bytes(b"png-outside")
+    roots_config("media_roots", [str(workspace)])
+
+    ok = client.get("/api/media", params={"path": str(inside)})
+    assert ok.status_code == 200
+    assert "data:image/png;base64," in ok.json()["data_url"]
+
+    no = client.get("/api/media", params={"path": str(denied)})
+    assert no.status_code == 403
+    assert no.json()["detail"] == "Path outside media roots"
+
+
+def test_api_media_configured_extra_root_allows_outside_default_tree(
+    client, roots_config, tmp_path
+):
+    # A file under neither the workspace nor ~/.hermes, but under an
+    # operator-configured root, is served — that is the point of the key.
+    extra = tmp_path / "exports"
+    extra.mkdir()
+    media = extra / "render.png"
+    media.write_bytes(b"png")
+    roots_config("media_roots", [str(extra)])
+
+    assert client.get("/api/media", params={"path": str(media)}).status_code == 200
+
+
+def test_api_media_default_denies_arbitrary_disk_image(client, roots_config, tmp_path):
+    # Default policy (no configured roots): workspace + ~/.hermes media dirs
+    # only. /tmp is not a media root — regression for the old unconfined
+    # surfaces.
+    stray = tmp_path / "stray.png"
+    stray.write_bytes(b"png")
+    roots_config("media_roots", None)
+
+    assert client.get("/api/media", params={"path": str(stray)}).status_code == 403
+
+
+def test_files_stream_serves_inside_and_denies_outside(client, roots_config, media_tree):
+    workspace, outside = media_tree
+    inside = workspace / "demo.mp4"
+    inside.write_bytes(b"aaaaa")
+    denied = outside / "demo.mp4"
+    denied.write_bytes(b"aaaaa")
+    roots_config("media_roots", [str(workspace)])
+
+    ok = client.get("/api/files/stream", params={"path": str(inside)})
+    assert ok.status_code == 200
+    assert ok.headers["content-type"] == "video/mp4"
+
+    no = client.get("/api/files/stream", params={"path": str(denied)})
+    assert no.status_code == 403
+    assert no.json()["detail"] == "Path outside media roots"
+
+
+def test_files_download_media_subresource_is_gated_plain_download_is_not(
+    client, roots_config, media_tree
+):
+    workspace, outside = media_tree
+    denied = outside / "clip.mp4"
+    denied.write_bytes(b"aaaaa")
+    roots_config("media_roots", [str(workspace)])
+
+    media_branch = client.get(
+        "/api/files/download",
+        params={"path": str(denied)},
+        headers={"Sec-Fetch-Dest": "video"},
+    )
+    assert media_branch.status_code == 403
+
+    save_as = client.get("/api/files/download", params={"path": str(denied)})
+    assert save_as.status_code == 200
+    assert save_as.headers["content-disposition"].startswith("attachment;")
+
+
+def test_read_data_url_gates_media_ext_allows_text_ext(client, roots_config, media_tree):
+    workspace, outside = media_tree
+    denied_image = outside / "pic.png"
+    denied_image.write_bytes(b"png")
+    denied_av = outside / "song.ogg"
+    denied_av.write_bytes(b"ogg")
+    text_outside = outside / "notes.txt"
+    text_outside.write_text("hello")
+    roots_config("media_roots", [str(workspace)])
+
+    for denied in (denied_image, denied_av):
+        no = client.get("/api/fs/read-data-url", params={"path": str(denied)})
+        assert no.status_code == 403, denied
+        assert no.json()["detail"] == "Path outside media roots"
+
+    # Non-media previews stay ungated (FS browser/editor behavior unchanged).
+    ok_text = client.get("/api/fs/read-data-url", params={"path": str(text_outside)})
+    assert ok_text.status_code == 200
+    assert "data:text/plain;base64," in ok_text.json()["dataUrl"]
+
+
+def test_read_data_url_serves_media_inside_roots(client, roots_config, media_tree):
+    workspace, _outside = media_tree
+    inside_image = workspace / "pic.png"
+    inside_image.write_bytes(b"png")
+    roots_config("media_roots", [str(workspace)])
+
+    ok = client.get("/api/fs/read-data-url", params={"path": str(inside_image)})
+    assert ok.status_code == 200
+    assert "data:image/png;base64," in ok.json()["dataUrl"]
+
+
+def test_all_three_surfaces_share_one_configured_root_set(
+    client, roots_config, media_tree, tmp_path
+):
+    """One config change moves all three formerly-diverging policies together."""
+    workspace, _outside = media_tree
+    extra = tmp_path / "shared-root"
+    extra.mkdir()
+    shared = extra / "clip.webm"
+    shared.write_bytes(b"webm")
+    shared_img = extra / "shot.png"
+    shared_img.write_bytes(b"png")
+    roots_config("media_roots", [str(extra)])
+
+    assert client.get("/api/files/stream", params={"path": str(shared)}).status_code == 200
+    assert client.get("/api/media", params={"path": str(shared_img)}).status_code == 200
+    assert (
+        client.get("/api/fs/read-data-url", params={"path": str(shared_img)}).status_code == 200
+    )
+    # And the workspace-only file is now denied on all three — one policy.
+    stray = workspace / "now-outside.png"
+    stray.write_bytes(b"png")
+    workspace_av = workspace / "v.mp4"
+    workspace_av.write_bytes(b"mp4")
+    assert client.get("/api/media", params={"path": str(stray)}).status_code == 403
+    assert (
+        client.get("/api/files/stream", params={"path": str(workspace_av)}).status_code == 403
+    )
+    assert (
+        client.get("/api/fs/read-data-url", params={"path": str(stray)}).status_code == 403
+    )

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -733,6 +733,30 @@ memory:
 
 With `memory.write_approval: true`, memory writes need your approval before they land: interactive CLI turns prompt inline; messaging sessions and the background self-improvement review stage the write for `/memory pending` → `/memory approve <id>` / `/memory reject <id>` review. Toggle at runtime with `/memory approval on|off`. See [Controlling memory writes](/user-guide/features/memory#controlling-memory-writes-write_approval).
 
+## Media Serving Roots
+
+When Hermes Desktop talks to a gateway over the network, media the agent wrote on the gateway host is fetched through authenticated dashboard endpoints: `GET /api/media` (images), `GET /api/files/stream` (audio/video playback), the audio/video branch of `GET /api/files/download`, and `GET /api/fs/read-data-url` for media-extension files. All four enforce **one** shared policy: the file must live under a **media root**.
+
+```yaml
+media:
+  roots: []   # default — workspace + ~/.hermes/{images, screenshots, cache}
+```
+
+The safe default covers where Hermes itself writes media: the gateway's workspace (agent-produced artifacts) and the Hermes home's `images/`, `screenshots/`, and `cache/` directories (generated images, browser screenshots, cached platform and relay media). Files inside those trees render inline; anything else gets a visible fallback card with a Save-as option instead of a silent failure.
+
+To serve media the agent writes elsewhere (a shared project tree, an export directory), add absolute paths (`~` is expanded):
+
+```yaml
+media:
+  roots:
+    - /srv/shared-media
+    - ~/gallery
+```
+
+Configuring `media.roots` replaces the default set, so include the directories you still want covered. Entries must be existing directories; a typo is logged as a warning rather than silently ignored. The policy is re-read per request — edits apply without restarting the gateway.
+
+Not restricted by this key: non-media file reads (text previews, documents) in the dashboard Files tab, and explicit Save-as downloads, which keep their own credential-file denylist.
+
 ## Context File Truncation
 
 Controls how much content Hermes loads from each automatic context file before applying head/tail truncation. This applies to files injected into the system prompt such as `SOUL.md`, `.hermes.md`, `AGENTS.md`, `CLAUDE.md`, and `.cursorrules`. It does **not** affect the `read_file` tool.


### PR DESCRIPTION
— feat(gateway): structured media-deliverable events

**Branch:** `pr/media-events-relay`

### Motivation

When an agent produces media (a chart, a render, an exported file), desktop clients
currently learn about it by scraping the literal `MEDIA:` tags out of the reply text.
That scrape is fragile in exactly the ways you'd expect: markdown transformations can
mangle the tag, a relayed turn can lose it, and a client that reconnects mid-turn never
sees it at all. Meanwhile the gateway *already knows* precisely which files it is about
to deliver — the delivery pipeline validates and filters them.

### Approach

Emit one structured `media.deliverable` event per deliverable, through the existing
tui-gateway event transport — the same frames, seq-stamping, and bounded replay ring
that tool/reasoning/status events already use. A reconnecting desktop recovers missed
events via `session.events.since` exactly like any other event.

Payload contract: `{path, kind, mime, size, session_id, origin}`.

Three emission sites, each mirroring files the delivery pipeline has *already accepted*:

- turn-level auto-append in `gateway/run.py` (`origin: "gateway"`),
- post-stream explicit rescan in `gateway/run.py` (`origin: "gateway"`),
- serve/desktop turn completion in `tui_gateway/server.py` (`origin: "serve"`).

Extraction reuses `BasePlatformAdapter.extract_media` +
`filter_media_delivery_paths`, so the event set can never exceed what platform
delivery would accept — the events are a mirror, not a parallel path.

### What changed

- **New** `gateway/media_events.py`: describe/extract/payload/emit helpers. Emission
  is best-effort and silent when no desktop client is listening on the session —
  there is deliberately **no stdio fallback**, so a messaging gateway's stdout stays
  byte-identical whether or not it imported tui_gateway.
- `gateway/run.py`: two emission hooks in the delivery paths (52 lines).
- `tui_gateway/server.py`: emission at serve-turn completion + a public
  `session_transport()` accessor so out-of-module emitters don't reach into the
  `_sessions` dict (lock discipline stays owned by the module).
- `tools/bot_relay.py` + `tui_gateway/methods_bot_relay.py`: relay envelopes can now
  carry validated `media[]` rows (path/kind/mime/size, length- and control-char-capped,
  relative paths rejected) with inline payload staging under an 8 MB cap, so
  cross-connection DMs deliver media as structured data instead of bare paths.
- `tui_gateway/server.py` public accessor `session_transport()`.
- Tests: 835 lines across 4 files, including real turn integration (no mocks on the
  emit path), the no-transport no-op contract, and relay staging round-trips.

### Testing

`pytest tests/tui_gateway/test_media_deliverable_events.py
tests/tools/test_bot_relay_media.py tests/gateway/test_media_deliverable_events.py
tests/tui_gateway/test_bot_relay_media_methods.py` — 31 passed.

### Limitations

- Events describe files; they don't deliver them. Platform delivery remains the sole
  owner of actual delivery — events are additive, never a replacement.
- Emission is silent (debug-logged) when no client listens; operators debugging a
  "missing card" should check the client was connected to that session id.

### Merge order

Standalone. PR3 (desktop cards) consumes these events but compiles without them.

---

---

*PR series merge order: merge order: #2 (media-roots) -> #1 (events+relay) -> #3 (desktop cards) -> #4/#5 (independent). This PR is 1 of 5.*
