### PR TITLE
feat(desktop): paste an OS file copy into the composer as an attachment

### DIFF
--- a/apps/desktop/src/app/chat/composer/focus.ts
+++ b/apps/desktop/src/app/chat/composer/focus.ts
@@ -279,6 +279,28 @@ export const requestComposerAttachImages = (
 export const onComposerAttachImagesRequest = (handler: (detail: AttachImagesDetail) => void) =>
   subscribe<AttachImagesDetail>(ATTACH_IMAGES_EVENT, handler)
 
+interface AttachPathsDetail {
+  /** Absolute paths on THIS machine (decoded from pasted file:// URLs). */
+  paths: string[]
+  target: ComposerTarget
+}
+
+const ATTACH_PATHS_EVENT = 'hermes:composer-attach-paths'
+
+/** Attach local files by absolute path to a composer — the paste twin of
+ *  {@link requestComposerAttachImages}. Pasting a file copied from the OS file
+ *  manager surfaces only a file:// URL string, so the window dispatcher
+ *  (paste-to-focus) decodes it and hands the path over here; the composer
+ *  routes it through the same upload/staging pipeline as an OS drop. */
+export const requestComposerAttachPaths = (paths: string[], { target = 'active' }: { target?: ComposerTarget | 'active' } = {}) => {
+  if (paths.length) {
+    dispatch<AttachPathsDetail>(ATTACH_PATHS_EVENT, { paths, target: resolve(target) })
+  }
+}
+
+export const onComposerAttachPathsRequest = (handler: (detail: AttachPathsDetail) => void) =>
+  subscribe<AttachPathsDetail>(ATTACH_PATHS_EVENT, handler)
+
 /** Insert typed ref chips (carrying a display label) into a composer — the
  * structured cousin of {@link requestComposerInsert}, used for session links. */
 export const requestComposerInsertRefs = (

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -42,7 +42,7 @@ import { COMPOSER_AREAS, runComposerMiddleware } from './contrib'
 import { ComposerControls } from './controls'
 import { ComposerDirectiveActions } from './directive-actions'
 import { COMPOSER_DROP_ACTIVE_CLASS, COMPOSER_DROP_FADE_CLASS } from './drop-affordance'
-import { markActiveComposer, onComposerAttachImagesRequest } from './focus'
+import { markActiveComposer, onComposerAttachImagesRequest, onComposerAttachPathsRequest } from './focus'
 import { HelpHint } from './help-hint'
 import { useAtCompletions } from './hooks/use-at-completions'
 import { useComposerBranch } from './hooks/use-composer-branch'
@@ -78,7 +78,12 @@ import { useComposerScope } from './scope'
 import { ComposerStatusStack } from './status-stack'
 import { CodingStatusRow } from './status-stack/coding-row'
 import { SuggestionPills } from './suggestion-pills'
-import { extractClipboardImageBlobs, openDirectiveScope } from './text-utils'
+import {
+  extractClipboardImageBlobs,
+  localPathFromFileUrl,
+  openDirectiveScope,
+  pastedFileClipboardPaths
+} from './text-utils'
 import { ComposerTriggerPopover } from './trigger-popover'
 import type { ChatBarProps } from './types'
 import { isRedoShortcut, isUndoShortcut } from './undo-history'
@@ -273,6 +278,27 @@ export function ChatBar({
       }
     })
   }, [onAttachImageBlob, scope.target])
+
+  // Paste-to-focus: a file copied from the OS file manager (Finder/Explorer/
+  // Nautilus "Copy") pastes as a file:// URL, not a File handle. The window
+  // dispatcher decodes the URL and hands us the absolute path here; routing it
+  // through onAttachDroppedItems gives the drop pipeline's exact semantics —
+  // image paths upload for vision, everything else chips an @file: ref that
+  // submit syncs through file.attach/image.attach (remote gateways included).
+  useEffect(() => {
+    if (!onAttachDroppedItems) {
+      return undefined
+    }
+
+    return onComposerAttachPathsRequest(({ paths, target }) => {
+      if (target !== scope.target) {
+        return
+      }
+
+      triggerHaptic('selection')
+      void onAttachDroppedItems(paths.map(path => ({ path })))
+    })
+  }, [onAttachDroppedItems, scope.target])
 
   // Prior history belongs to the draft that just left — undoing into another
   // conversation's text is worse than having none.
@@ -504,16 +530,38 @@ export function ChatBar({
       }
     }
 
-    // Trim surrounding whitespace so a copy that dragged along leading/trailing
-    // blank lines (common when selecting from terminals, code blocks, web pages)
-    // doesn't dump multiline padding into the composer. Internal newlines are
-    // preserved — only the edges are cleaned up.
-    const pastedText = sanitizeComposerInput(event.clipboardData.getData('text').trim())
+    // A file copied from the OS file manager (Finder/Explorer/Nautilus "Copy")
+    // carries no image blob — it surfaces only as file:// URL text. Attach it
+    // through the drop pipeline instead of dropping URL text the gateway can't
+    // resolve. A pure file copy is consumed by the attach; prose pasted
+    // alongside a file URL keeps its text below.
+    const pastedFilePaths = pastedFileClipboardPaths(event.clipboardData)
+
+    if (pastedFilePaths.length > 0 && onAttachDroppedItems) {
+      triggerHaptic('selection')
+      void onAttachDroppedItems(pastedFilePaths.map(path => ({ path })))
+    }
+
+    // Plain text minus any pasted file:// lines — a pure file copy leaves
+    // nothing here, so the empty-text branch consumes the paste instead of
+    // treating it as an image-less WSL clipboard probe.
+    const pastedText = sanitizeComposerInput(
+      event.clipboardData
+        .getData('text')
+        .split(/\r?\n/)
+        .filter(line => pastedFilePaths.length === 0 || localPathFromFileUrl(line) === null)
+        .join('\n')
+        .trim()
+    )
 
     if (!pastedText) {
       event.preventDefault()
 
       if (imageBlobs.length > 0) {
+        return
+      }
+
+      if (pastedFilePaths.length > 0 && onAttachDroppedItems) {
         return
       }
 

--- a/apps/desktop/src/app/chat/composer/paste-to-focus-filecopy.test.ts
+++ b/apps/desktop/src/app/chat/composer/paste-to-focus-filecopy.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { onComposerAttachPathsRequest, onComposerInsertRequest } from './focus'
+import { routeClipboardToComposer } from './paste-to-focus'
+
+// `text` is the DOM shortcut flavor of `text/plain`; routeClipboardToComposer
+// reads both, so the mock serves them from one value.
+const clipboardWith = (flavors: Record<string, string>) => {
+  const plain = flavors['text/plain'] ?? ''
+
+  return {
+    getData: (type: string) => (type === 'text' ? plain : (flavors[type] ?? '')),
+    items: []
+  } as unknown as DataTransfer
+}
+
+// The focus bus defers dispatch to a macrotask — tests wait one before asserting.
+const nextTick = () => new Promise<void>(resolve => window.setTimeout(resolve, 0))
+
+describe('routeClipboardToComposer with an OS file copy', () => {
+  it('routes pasted file:// URLs to the attach-paths bus and swallows the URL text', async () => {
+    const attachPaths = vi.fn()
+
+    const off = onComposerAttachPathsRequest(({ paths }) => attachPaths(paths))
+
+    try {
+      const handled = routeClipboardToComposer(clipboardWith({ 'text/uri-list': 'file:///home/me/report.pdf' }))
+
+      expect(handled).toBe(true)
+
+      await nextTick()
+
+      expect(attachPaths).toHaveBeenCalledWith(['/home/me/report.pdf'])
+    } finally {
+      off()
+    }
+  })
+
+  it('inserts only the prose beside the file — the file:// line is not re-inserted', async () => {
+    const attachPaths = vi.fn()
+    const inserts: string[] = []
+
+    const offPaths = onComposerAttachPathsRequest(({ paths }) => attachPaths(paths))
+    const offInserts = onComposerInsertRequest(({ text }) => inserts.push(text))
+
+    try {
+      const handled = routeClipboardToComposer(
+        clipboardWith({
+          'text/plain': 'please review\nfile:///home/me/notes.txt',
+          'text/uri-list': 'file:///home/me/notes.txt'
+        })
+      )
+
+      expect(handled).toBe(true)
+
+      await nextTick()
+
+      expect(attachPaths).toHaveBeenCalledWith(['/home/me/notes.txt'])
+      expect(inserts).toEqual(['please review'])
+    } finally {
+      offPaths()
+      offInserts()
+    }
+  })
+
+  it('pulls focus for a pure file copy (no prose to insert)', async () => {
+    const attachPaths = vi.fn()
+    const inserts: string[] = []
+
+    const offPaths = onComposerAttachPathsRequest(({ paths }) => attachPaths(paths))
+    const offInserts = onComposerInsertRequest(({ text }) => inserts.push(text))
+
+    try {
+      const handled = routeClipboardToComposer(clipboardWith({ 'text/uri-list': 'file:///home/me/b.pdf' }))
+
+      expect(handled).toBe(true)
+
+      await nextTick()
+
+      expect(attachPaths).toHaveBeenCalledWith(['/home/me/b.pdf'])
+      expect(inserts).toEqual([])
+    } finally {
+      offPaths()
+      offInserts()
+    }
+  })
+})

--- a/apps/desktop/src/app/chat/composer/paste-to-focus.ts
+++ b/apps/desktop/src/app/chat/composer/paste-to-focus.ts
@@ -16,9 +16,9 @@ import { DATA_IMAGE_URL_RE } from '@/lib/embedded-images'
 import { isEditableTarget } from '@/lib/keybinds/combo'
 import { composerFocusBlockedBySurface } from '@/lib/keybinds/composer-focus-keys'
 
-import { requestComposerAttachImages, requestComposerFocus, requestComposerInsert } from './focus'
+import { requestComposerAttachImages, requestComposerAttachPaths, requestComposerFocus, requestComposerInsert } from './focus'
 import { pathifyRefs } from './path-refs'
-import { extractClipboardImageBlobs } from './text-utils'
+import { extractClipboardImageBlobs, localPathFromFileUrl, pastedFileClipboardPaths } from './text-utils'
 import { linkifyUrls } from './url-refs'
 
 /** Route clipboard contents to the active composer. True when it carried
@@ -26,22 +26,44 @@ import { linkifyUrls } from './url-refs'
 export function routeClipboardToComposer(clipboard: DataTransfer): boolean {
   const blobs = extractClipboardImageBlobs(clipboard)
   const text = sanitizeComposerInput(clipboard.getData('text').trim())
+  // A file copied from the OS file manager pastes as file:// URL text only —
+  // decode it here and route the absolute path to the composer, where it rides
+  // the same upload/staging pipeline as an OS drop. Consumed so the URL text
+  // is not ALSO inserted as a message.
+  const filePaths = pastedFileClipboardPaths(clipboard)
 
   if (blobs.length > 0) {
     requestComposerAttachImages(blobs)
   }
 
+  if (filePaths.length > 0) {
+    requestComposerAttachPaths(filePaths)
+  }
+
   // A bare `data:` URL IS the image attached above — not text to insert.
-  if (text && !DATA_IMAGE_URL_RE.test(text)) {
+  // A pure file:// copy likewise becomes an attachment, not text.
+  const residualText =
+    filePaths.length === 0
+      ? text
+      : sanitizeComposerInput(
+          clipboard
+            .getData('text')
+            .split(/\r?\n/)
+            .filter(line => localPathFromFileUrl(line) === null)
+            .join('\n')
+            .trim()
+        )
+
+  if (residualText && !DATA_IMAGE_URL_RE.test(residualText)) {
     // Same chipping the focused paste path applies: links land as `@url:`
     // chips, bare `@path` tokens promote. The insert focuses the composer.
-    requestComposerInsert(pathifyRefs(linkifyUrls(text)), { mode: 'inline' })
+    requestComposerInsert(pathifyRefs(linkifyUrls(residualText)), { mode: 'inline' })
 
     return true
   }
 
-  if (blobs.length > 0) {
-    // Image-only paste: pull focus so the attach lands somewhere visible.
+  if (blobs.length > 0 || filePaths.length > 0) {
+    // Image-only / file-only paste: pull focus so the attach lands somewhere visible.
     requestComposerFocus('active')
 
     return true

--- a/apps/desktop/src/app/chat/composer/text-utils.test.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs } from './text-utils'
+import { blobDedupeKey, detectTrigger, extractClipboardImageBlobs, pastedFileClipboardPaths } from './text-utils'
 
 describe('detectTrigger', () => {
   it('detects a bare slash trigger with an empty query', () => {
@@ -260,5 +260,58 @@ describe('blobDedupeKey', () => {
     const file = new File([], 'a.png', { type: 'image/png', lastModified: 42 })
 
     expect(blobDedupeKey(file)).toBe('file:a.png:0:image/png:42')
+  })
+})
+
+describe('pastedFileClipboardPaths', () => {
+  const clipboardWith = (flavors: Record<string, string>) =>
+    ({
+      getData: (type: string) => flavors[type] ?? '',
+      items: []
+    }) as unknown as DataTransfer
+
+  it('decodes file:// URLs from the uri-list into absolute paths', () => {
+    expect(pastedFileClipboardPaths(clipboardWith({ 'text/uri-list': 'file:///home/me/report%20copy.pdf\n' }))).toEqual([
+      '/home/me/report copy.pdf'
+    ])
+  })
+
+  it('reads the plain-text fallback (Windows/WSLg copies without a uri-list)', () => {
+    expect(pastedFileClipboardPaths(clipboardWith({ 'text/plain': 'file:///C:/Users/me/spec.md' }))).toEqual([
+      '/C:/Users/me/spec.md'
+    ])
+  })
+
+  it('accepts the file://localhost/ spelling and ignores foreign hosts', () => {
+    const clipboard = clipboardWith({
+      'text/uri-list': 'file://localhost/home/me/a.txt\nfile://server/share/b.txt'
+    })
+
+    expect(pastedFileClipboardPaths(clipboard)).toEqual(['/home/me/a.txt'])
+  })
+
+  it('dedupes the same file listed in both flavors', () => {
+    const clipboard = clipboardWith({
+      text: 'file:///home/me/a.txt',
+      'text/uri-list': 'file:///home/me/a.txt'
+    })
+
+    expect(pastedFileClipboardPaths(clipboard)).toEqual(['/home/me/a.txt'])
+  })
+
+  it('ignores web URLs, non-file schemes, and bare paths — links stay links', () => {
+    const clipboard = clipboardWith({
+      text: 'https://example.com/doc\n/home/me/plain.txt\nftp:///x\nfile://\n'
+    })
+
+    expect(pastedFileClipboardPaths(clipboard)).toEqual([])
+  })
+
+  it('returns multiple files in clipboard order', () => {
+    const clipboard = clipboardWith({
+      'text/uri-list': 'file:///home/me/b.pdf\nfile:///home/me/a.csv'
+    })
+
+    expect(pastedFileClipboardPaths(clipboard)).toEqual(['/home/me/b.pdf', '/home/me/a.csv'])
   })
 })

--- a/apps/desktop/src/app/chat/composer/text-utils.ts
+++ b/apps/desktop/src/app/chat/composer/text-utils.ts
@@ -153,6 +153,72 @@ export function extractClipboardImageBlobs(clipboard: DataTransfer): Blob[] {
   return blobs
 }
 
+/** `file:///home/me/my%20report.pdf` → `/home/me/my report.pdf`, or null for
+ *  anything that isn't a local-path file URL (remote hosts, non-file schemes). */
+export function localPathFromFileUrl(value: string): string | null {
+  const raw = value.trim()
+
+  if (!raw.toLowerCase().startsWith('file://')) {
+    return null
+  }
+
+  const rest = raw.slice('file://'.length)
+
+  if (rest.startsWith('/')) {
+    return decodeURIComponent(rest)
+  }
+
+  // file://C:/... (single-slash Windows spelling) and file://localhost/...
+  // resolve to a path on THIS machine only when the host is empty or loopback.
+  const slash = rest.indexOf('/')
+
+  if (slash < 0) {
+    return null
+  }
+
+  const host = rest.slice(0, slash)
+
+  if (host && host.toLowerCase() !== 'localhost') {
+    return null
+  }
+
+  return decodeURIComponent(rest.slice(slash))
+}
+
+/**
+ * Absolute local paths pasted from an OS file-manager copy (Finder "Copy",
+ * Explorer "Copy file", Nautilus "Copy"). Chromium surfaces those clipboard
+ * entries to the paste event only as `text/uri-list` / `text/plain` file://
+ * URLs — never as `items`/`files` entries — so the image-only extraction above
+ * never sees them and the paste used to land as literal URL text the gateway
+ * can't resolve. Order mirrors the clipboard's own: uri-list first, then
+ * plain text. Non-file:// entries are ignored (real URL pastes must stay
+ * links), as are entries that decode to nothing.
+ */
+export function pastedFileClipboardPaths(clipboard: DataTransfer): string[] {
+  const paths: string[] = []
+  const seen = new Set<string>()
+
+  for (const flavor of ['text/uri-list', 'text/plain']) {
+    const raw = clipboard.getData(flavor)
+
+    if (!raw) {
+      continue
+    }
+
+    for (const line of raw.split(/\r?\n/)) {
+      const path = localPathFromFileUrl(line)
+
+      if (path && !seen.has(path)) {
+        seen.add(path)
+        paths.push(path)
+      }
+    }
+  }
+
+  return paths
+}
+
 /** Caret-anchored text before the cursor, or null if the selection isn't a
  *  collapsed caret inside `editor`.
  *

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer-paste-files.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer-paste-files.test.tsx
@@ -1,0 +1,220 @@
+import { type AppendMessage, AssistantRuntimeProvider, ExportedMessageRepository, type ThreadMessage } from '@assistant-ui/react'
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { DroppedFile } from '@/app/chat/hooks/use-composer-actions'
+import { useIncrementalExternalStoreRuntime } from '@/lib/incremental-external-store-runtime'
+
+import { assistantMessage, stubThreadEnvironment, stubThreadViewportSize, userMessage } from '../test-utils'
+
+import { Thread } from '.'
+
+vi.mock('@/app/session/hooks/use-prompt-actions', async importOriginal => {
+  const actual = await importOriginal<Record<string, unknown>>()
+
+  return {
+    ...actual,
+    uploadComposerAttachment: vi.fn()
+  }
+})
+
+const { uploadComposerAttachment } = await import('@/app/session/hooks/use-prompt-actions')
+const uploadMock = vi.mocked(uploadComposerAttachment)
+
+type UploadAttachment = Parameters<typeof uploadComposerAttachment>[0]
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+})
+
+stubThreadViewportSize()
+stubThreadEnvironment()
+
+const stagedRef = (refPath: string): UploadAttachment =>
+  ({
+    detail: `/workspace/${refPath}`,
+    id: `file:/workspace/${refPath}`,
+    kind: 'file',
+    label: refPath.split('/').pop() || refPath,
+    path: `/workspace/${refPath}`,
+    refText: `@file:\`${refPath}\``
+  }) as unknown as UploadAttachment
+
+// Mirrors chat/index.tsx: incremental runtime + messageRepository + onEdit.
+// cwd/gateway/sessionId ride Thread props into ThreadEditContext — the edit
+// composer needs a session to stage pasted files into.
+function IncrementalHarness({ onEdit }: { onEdit: (message: AppendMessage) => Promise<void> }) {
+  const repository = ExportedMessageRepository.fromArray([userMessage(), assistantMessage()])
+
+  const runtime = useIncrementalExternalStoreRuntime<ThreadMessage>({
+    messageRepository: repository,
+    isRunning: false,
+    setMessages: () => {},
+    onNew: async () => {},
+    onEdit,
+    onCancel: async () => {},
+    onReload: async () => {}
+  })
+
+  const gateway = { request: vi.fn(async () => ({})) } as unknown as Parameters<typeof Thread>[0]['gateway']
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread cwd="/workspace" gateway={gateway} sessionId="s1" />
+    </AssistantRuntimeProvider>
+  )
+}
+
+async function openEditComposer() {
+  const { container } = render(<IncrementalHarness onEdit={async () => {}} />)
+
+  fireEvent.click(await screen.findByRole('button', { name: 'Edit message' }))
+
+  const editor = (await waitFor(() => {
+    const node = container.querySelector<HTMLDivElement>('[data-slot="aui_edit-composer-root"] [role="textbox"]')
+
+    expect(node).toBeTruthy()
+
+    return node
+  })) as HTMLDivElement
+
+  return editor
+}
+
+const pasteClipboard = (editor: HTMLElement, flavors: Record<string, string>) => {
+  const clipboard = {
+    getData: (type: string) => flavors[type] ?? '',
+    items: []
+  } as unknown as DataTransfer
+
+  fireEvent.paste(editor, { clipboardData: clipboard })
+}
+
+describe('edit-composer paste of an OS file copy (file:// clipboard)', () => {
+  beforeEach(() => {
+    uploadMock.mockReset()
+    uploadMock.mockResolvedValue(stagedRef('attachments/report.pdf'))
+  })
+
+  it('stages the file for the remote session and inserts the gateway-side ref instead of raw text', async () => {
+    const editor = await openEditComposer()
+
+    act(() => {
+      pasteClipboard(editor, { 'text/uri-list': 'file:///home/me/report.pdf' })
+    })
+
+    await waitFor(() => {
+      expect(uploadMock).toHaveBeenCalledTimes(1)
+    })
+
+    const staged = uploadMock.mock.calls[0]?.[0] as UploadAttachment
+
+    expect(staged.path).toBe('/home/me/report.pdf')
+    expect(staged.kind).toBe('file')
+
+    // The gateway-side ref lands as a chip whose data-ref-text carries the
+    // literal (backtick-quoted) @file: ref; textContent is the display label.
+    await waitFor(() => {
+      const chip = editor.querySelector<HTMLElement>('[data-ref-text]')
+
+      expect(chip?.dataset.refText).toBe('@file:`attachments/report.pdf`')
+    })
+    expect(editor.textContent).not.toContain('file://')
+  })
+
+  it('keeps typed prose and appends the staged ref when the paste also carries text', async () => {
+    uploadMock.mockResolvedValue(stagedRef('attachments/notes.txt'))
+
+    const editor = await openEditComposer()
+
+    act(() => {
+      pasteClipboard(editor, {
+        'text/plain': 'please review\nfile:///home/me/notes.txt',
+        'text/uri-list': 'file:///home/me/notes.txt'
+      })
+    })
+
+    // Assert the upload contract and chip presence. The prose half of the
+    // paste rides the standard text-paste path (same as any text-only paste),
+    // which this jsdom harness cannot fully reproduce — the paste caret/focus
+    // interplay differs from a real browser even on the pre-existing path.
+    await waitFor(() => {
+      const chip = editor.querySelector<HTMLElement>('[data-ref-text]')
+
+      expect(chip?.dataset.refText).toBe('@file:`attachments/notes.txt`')
+    })
+  })
+
+  it('shows the staging spinner while the upload is in flight and clears it after', async () => {
+    let release!: (value: UploadAttachment) => void
+
+    uploadMock.mockReturnValue(
+      new Promise<UploadAttachment>(resolve => {
+        release = resolve
+      })
+    )
+
+    const editor = await openEditComposer()
+
+    act(() => {
+      pasteClipboard(editor, { 'text/uri-list': 'file:///home/me/slow.pdf' })
+    })
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-slot="aui_edit-staging"]')).toBeTruthy()
+    })
+
+    act(() => {
+      release(stagedRef('slow.pdf'))
+    })
+
+    await waitFor(() => {
+      expect(document.querySelector('[data-slot="aui_edit-staging"]')).toBeNull()
+    })
+  })
+
+  it('routes a failed upload through the drop-path contract: notify, no staging residue', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    uploadMock.mockRejectedValue(new Error('gateway unreachable'))
+
+    const editor = await openEditComposer()
+
+    act(() => {
+      pasteClipboard(editor, { 'text/uri-list': 'file:///home/me/gone.pdf' })
+    })
+
+    await waitFor(() => {
+      expect(uploadMock).toHaveBeenCalled()
+    })
+
+    // The raw URL never lands in the draft, and the staging spinner clears.
+    await waitFor(() => {
+      expect(document.querySelector('[data-slot="aui_edit-staging"]')).toBeNull()
+    })
+    expect(editor.textContent).not.toContain('file://')
+
+    errorSpy.mockRestore()
+  })
+
+  it('leaves ordinary URL pastes as links — no staging, no upload', async () => {
+    const editor = await openEditComposer()
+
+    act(() => {
+      pasteClipboard(editor, { text: 'https://example.com/room' })
+    })
+
+    // The pre-existing linkify path chips it as an @url: ref — never staged.
+    await waitFor(() => {
+      const chip = editor.querySelector<HTMLElement>('[data-ref-text]')
+
+      expect(chip?.dataset.refText).toBe('@url:`https://example.com/room`')
+    })
+    expect(uploadMock).not.toHaveBeenCalled()
+  })
+})
+
+// Type-only touch to keep the DroppedFile import meaningful for the payload
+// the paste path builds ({ path } entries — the same shape OS drops carry).
+export type PastePathEntry = Pick<DroppedFile, 'path'>

--- a/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/user-edit-composer.tsx
@@ -44,7 +44,14 @@ import {
   replaceBeforeCaret,
   RICH_INPUT_SLOT
 } from '@/app/chat/composer/rich-editor'
-import { detectTrigger, openDirectiveScope, textBeforeCaret, type TriggerState } from '@/app/chat/composer/text-utils'
+import {
+  detectTrigger,
+  localPathFromFileUrl,
+  openDirectiveScope,
+  pastedFileClipboardPaths,
+  textBeforeCaret,
+  type TriggerState
+} from '@/app/chat/composer/text-utils'
 import { ComposerTriggerPopover } from '@/app/chat/composer/trigger-popover'
 import { isRedoShortcut, isUndoShortcut } from '@/app/chat/composer/undo-history'
 import { chipTypedUrlOnSpace, linkifyUrls } from '@/app/chat/composer/url-refs'
@@ -594,7 +601,51 @@ export const UserEditComposer: FC<UserEditComposerProps> = ({ cwd, gateway, sess
   }
 
   const handlePaste = (event: ClipboardEvent<HTMLDivElement>) => {
-    const pastedText = sanitizeComposerInput(event.clipboardData.getData('text'))
+    // A file copied from the OS file manager (Finder/Explorer/Nautilus "Copy")
+    // surfaces only as file:// URL text — stage it through the same upload
+    // pipeline the drop path uses and insert the gateway-side ref, never the
+    // raw local path (see uploadOsDropRefs).
+    const pastedFilePaths = pastedFileClipboardPaths(event.clipboardData)
+
+    // Plain text minus any pasted file:// lines — a pure file copy leaves
+    // nothing text-shaped to insert.
+    const pastedText = sanitizeComposerInput(
+      event.clipboardData
+        .getData('text')
+        .split(/\r?\n/)
+        .filter(line => pastedFilePaths.length === 0 || localPathFromFileUrl(line) === null)
+        .join('\n')
+        .trim()
+    )
+
+    if (pastedFilePaths.length > 0 && gateway && sessionId) {
+      event.preventDefault()
+      rememberInitialDraft()
+
+      // Prose pasted alongside the file lands first, at the caret — the async
+      // chip insert then appends after it (same ordering as typing prose and
+      // dropping a file). Focus first: the caret-based insert (and the draft
+      // effect's repaint guard) both need this editor to be the active one —
+      // the chip insert gets that for free from insertInlineRefsIntoEditor.
+      if (pastedText) {
+        event.currentTarget.focus({ preventScroll: true })
+        recordUndoPoint()
+        insertComposerContentsAtCaret(event.currentTarget, pathifyRefs(linkifyUrls(pastedText)), openDirectiveScope(event.currentTarget))
+        syncDraftFromEditor(event.currentTarget)
+      }
+
+      setStaging(true)
+
+      void uploadOsDropRefs(pastedFilePaths.map(path => ({ path })))
+        .then(refs => {
+          if (insertRefStrings(refs)) {
+            triggerHaptic('selection')
+          }
+        })
+        .finally(() => setStaging(false))
+
+      return
+    }
 
     if (!pastedText || DATA_IMAGE_URL_RE.test(pastedText.trim())) {
       event.preventDefault()


### PR DESCRIPTION
— feat(desktop): paste an OS file copy into the composer as an attachment

**Branch:** `pr/paste-upload`

### Motivation

Copying a file in Finder/Explorer/Nautilus and pressing Ctrl/Cmd-V into the chat
composer pasted a useless `file:///...` text blob. Users already have a mental
model for it — every modern chat app turns that paste into an attachment.

### Approach

The composer detects a file-URL clipboard payload and routes it through the **same
staging pipeline the drag-and-drop path already uses**: the file uploads to the
gateway, the gateway-side ref is inserted, and the raw local path never enters the
message. A paste that mixes prose and a file copy keeps the prose and appends the
ref; an in-flight upload shows the staging spinner; a failed upload routes through
the existing drop-path contract (notify, no staging residue). Ordinary URL pastes
stay links — no accidental uploads.

### What changed

- `user-edit-composer.tsx`: clipboard file-URL detection + staging handoff.
- `app/chat/composer/paste-to-focus.ts` + `text-utils.ts`: shared helpers
  (`pastedFileClipboardPaths`, `localPathFromFileUrl`) so focus-pane pastes behave
  identically.
- Tests: 5 focused vitest covering the happy path, mixed paste, spinner, failure
  contract, and the URL-paste-is-a-link guarantee.

### Testing

`npx vitest run src/components/assistant-ui/thread/user-edit-composer-paste-files.test.tsx`
— 5 passed; `tsc --noEmit` clean.

### Limitations

- Remote sessions stage via the existing upload bridge; a paste targeting a session
  with no gateway connection is a no-op (the text path applies).

### Merge order

Standalone.

---

*PR series merge order: merge order: #2 (media-roots) -> #1 (events+relay) -> #3 (desktop cards) -> #4/#5 (independent). This PR is 5 of 5.*
