### PR TITLE
Fix Docker config propagation for file-tool-first sessions

### DIFF
--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -30,7 +30,7 @@ def test_sibling_container_config_sites_carry_docker_network():
     import tools.code_execution_tool as code_execution_tool
     import tools.file_tools as file_tools
 
-    for module in (terminal_tool, file_tools, code_execution_tool):
+    for module in (terminal_tool, code_execution_tool):
         tree = ast.parse(inspect.getsource(module))
         sites = 0
         for node in ast.walk(tree):
@@ -45,6 +45,10 @@ def test_sibling_container_config_sites_carry_docker_network():
                     f"(line {node.lineno})"
                 )
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
+
+    # File tools delegate construction to the terminal's canonical builder,
+    # which covers docker_network alongside every other Docker setting.
+    assert "_container_config_from_config(config)" in inspect.getsource(file_tools)
 
 
 def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):

--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -7,10 +7,12 @@ import tools.file_tools as file_tools
 def _make_env_config(**overrides):
     base = {
         "env_type": "docker",
+        "modal_mode": "direct",
         "docker_image": "test-image:latest",
         "singularity_image": "docker://test",
         "modal_image": "test",
         "daytona_image": "test",
+        "vercel_runtime": "python3.13",
         "cwd": "/workspace",
         "host_cwd": None,
         "timeout": 180,
@@ -21,6 +23,14 @@ def _make_env_config(**overrides):
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {"HERMES_TEST_ENV": "file-tool-first"},
+        "docker_run_as_host_user": True,
+        "docker_extra_args": ["--cap-drop=ALL"],
+        "docker_shm_size": "2g",
+        "docker_network": False,
+        "docker_persist_across_processes": False,
+        "docker_shared_container_key": "test-profile",
+        "docker_orphan_reaper": False,
     }
     base.update(overrides)
     return base
@@ -53,6 +63,15 @@ class TestFileToolsContainerConfig:
         """docker_mount_cwd_to_workspace is forwarded to container_config."""
         cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t1").get("container_config", {})
         assert cc.get("docker_mount_cwd_to_workspace") is True
+
+    def test_container_config_matches_terminal_builder(self):
+        """File-first creation forwards the same config as terminal-first."""
+        from tools.terminal_tool import _container_config_from_config
+
+        env_config = _make_env_config()
+        captured = self._run(env_config, "config-parity")
+
+        assert captured["container_config"] == _container_config_from_config(env_config)
 
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1416,6 +1416,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_container_task_id,
         _resolve_task_host_cwd,
         _is_unusable_container_cwd,
+        _container_config_from_config,
         _CONTAINER_BACKENDS,
     )
     import time
@@ -1524,18 +1525,7 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             from tools.terminal_tool import _is_container_backend as _is_container
 
             if _is_container(env_type):
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "vercel_runtime": config.get("vercel_runtime", ""),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
+                container_config = _container_config_from_config(config)
 
             ssh_config = None
             if env_type == "ssh":


### PR DESCRIPTION
When a file tool created a Docker environment before the terminal tool ran, it built a smaller container configuration and dropped settings such as `docker_env`.

File-tool-created environments now use the terminal path's existing configuration builder. The regression test compares both paths, and the Docker-network test recognizes the shared builder.

Tests:
- `scripts/run_tests.sh tests/tools/test_file_tools_container_config.py tests/tools/test_terminal_config_env_sync.py tests/tools/test_docker_session_isolation.py tests/tools/test_docker_network_config.py tests/tools/test_managed_browserbase_and_modal.py tests/tools/test_modal_sandbox_fixes.py -q` (82 passed)
- `ruff check tools/file_tools.py tests/tools/test_file_tools_container_config.py tests/tools/test_docker_network_config.py`
- `git diff --check`
- Isolated Docker smoke: file-tool-first and terminal-first both received the same harmless configured value.