### PR TITLE
fix(search): handle unprefixed ripgrep I/O diagnostics

### DIFF
--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -95,6 +95,33 @@ class TestSearchErrorGuard:
         assert res.error is None
         assert res.total_count >= 4
 
+    def test_context_line_ending_in_os_error_survives(self, method, tmp_path):
+        # A file whose CONTEXT line legitimately ends in "(os error N)". rg
+        # emits it as "<path>-1-context (os error 13)"; a suffix heuristic
+        # that ignores the exit code silently drops it from a *successful*
+        # search.
+        (tmp_path / "a.txt").write_text("context (os error 13)\nneedle\n")
+        res = _search(_ops(tmp_path), method, "needle", tmp_path, context=1)
+        assert res.error is None
+        contents = [m.content for m in res.matches]
+        assert "context (os error 13)" in contents, (
+            f"context line was dropped as a diagnostic: {contents!r}"
+        )
+        assert "needle" in contents
+
+    def test_files_only_path_ending_in_os_error_survives(self, method, tmp_path):
+        # A successful files-only result whose PATH ends in "(os error N)".
+        # It has no line number to exempt it from a blanket suffix rule.
+        sub = tmp_path / "dir-2"
+        sub.mkdir()
+        (sub / "good (os error 13)").write_text("needle\n")
+        res = _search(_ops(tmp_path), method, "needle", tmp_path,
+                      output_mode="files_only")
+        assert res.error is None
+        assert any("good (os error 13)" in f for f in res.files), (
+            f"files-only payload was dropped as a diagnostic: {res.files!r}"
+        )
+
 
 class TestSearchContentNewlineWarning:
     def test_odd_backslash_n_is_detected_as_regex_newline(self):
@@ -119,14 +146,14 @@ class TestSplitToolDiagnostics:
 
     def test_pure_error_has_empty_payload(self):
         out = "rg: regex parse error:\n    (?:[)\n       ^\nerror: unclosed character class\n"
-        diagnostics, payload = _split_tool_diagnostics(out)
+        diagnostics, payload = _split_tool_diagnostics(out, exit_code=2)
         assert payload.strip() == ""
         assert "regex parse error" in diagnostics
 
 
     def test_context_lines_and_separator_are_payload(self):
         out = "a.py:5:hit\na.py-6-after\n--\nb.py:9:hit\n"
-        diagnostics, payload = _split_tool_diagnostics(out)
+        diagnostics, payload = _split_tool_diagnostics(out, exit_code=0)
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
@@ -141,7 +168,7 @@ class TestSplitToolDiagnostics:
         "/var/db-2/x: Operation not permitted (os error 1)",
     ])
     def test_unprefixed_old_ripgrep_os_error_is_a_diagnostic(self, line):
-        diagnostics, payload = _split_tool_diagnostics(line + "\n")
+        diagnostics, payload = _split_tool_diagnostics(line + "\n", exit_code=2)
         assert payload.strip() == "", (
             f"old-ripgrep diagnostic leaked into the payload: {payload!r}"
         )
@@ -155,10 +182,66 @@ class TestSplitToolDiagnostics:
         "a.py:1:needle (os error 13)",
         "src/io-3/mod.rs:42:    warn!(\"open failed (os error 2)\");",
         "C:/proj/app.py:7:raise OSError(\"boom (os error 5)\")",
+        # ...including one whose content itself contains a ": " separator,
+        # which is the only structural tell the unprefixed diagnostic has.
+        "a.py:1:open: failed (os error 13)",
     ])
     def test_real_match_ending_in_os_error_is_kept(self, line):
-        diagnostics, payload = _split_tool_diagnostics(line + "\n")
-        assert line in payload, (
-            f"legitimate match was discarded as a diagnostic: {diagnostics!r}"
-        )
+        for exit_code in (0, 2):
+            diagnostics, payload = _split_tool_diagnostics(
+                line + "\n", exit_code=exit_code
+            )
+            assert line in payload, (
+                f"legitimate match was discarded as a diagnostic "
+                f"(exit {exit_code}): {diagnostics!r}"
+            )
+            assert diagnostics.strip() == ""
+
+
+    @pytest.mark.parametrize("line", [
+        # A real `path-line-context` line whose CONTENT ends in the suffix.
+        # rg/grep emit context as "<path>-<line>-<content>"; scoping the
+        # suffix heuristic by exit code alone still has to keep these.
+        "a.txt-1-context (os error 13)",
+        "/tmp/pytest-686/a.txt-1-context (os error 13)",
+        # ...including content carrying its own ": " separator.
+        "a.txt-1-open: failed (os error 13)",
+    ])
+    def test_context_line_ending_in_os_error_is_kept(self, line):
+        for exit_code in (0, 2):
+            diagnostics, payload = _split_tool_diagnostics(
+                line + "\n", exit_code=exit_code
+            )
+            assert line in payload, (
+                f"legitimate context line was discarded as a diagnostic "
+                f"(exit {exit_code}): {diagnostics!r}"
+            )
+            assert diagnostics.strip() == ""
+
+
+    @pytest.mark.parametrize("line", [
+        # A successful files-only result whose PATH ends in the suffix. There
+        # is no line number to exempt it, so a blanket suffix rule eats it.
+        "dir-2/good (os error 13)",
+        "/tmp/pytest-686/dir-2/good (os error 13)",
+    ])
+    def test_files_only_path_ending_in_os_error_is_kept(self, line):
+        for exit_code in (0, 2):
+            diagnostics, payload = _split_tool_diagnostics(
+                line + "\n", exit_code=exit_code
+            )
+            assert line in payload, (
+                f"legitimate files-only path was discarded as a diagnostic "
+                f"(exit {exit_code}): {diagnostics!r}"
+            )
+            assert diagnostics.strip() == ""
+
+
+    def test_os_error_heuristic_does_not_run_on_a_successful_exit(self):
+        # rg/grep only emit per-file I/O diagnostics on an error exit (2), so
+        # on a successful search the heuristic can only produce false
+        # positives. Keep it scoped to the exit codes that can carry one.
+        line = "/tmp/pytest-686/locked.txt: Permission denied (os error 13)"
+        diagnostics, payload = _split_tool_diagnostics(line + "\n", exit_code=0)
+        assert line in payload
         assert diagnostics.strip() == ""

--- a/tests/tools/test_search_error_guard.py
+++ b/tests/tools/test_search_error_guard.py
@@ -130,3 +130,35 @@ class TestSplitToolDiagnostics:
         assert diagnostics == ""
         assert "--" in payload
         assert "a.py-6-after" in payload
+
+
+    @pytest.mark.parametrize("line", [
+        # Older ripgrep (0.10) omits the "rg: " prefix on per-file I/O errors.
+        # The path contains "-<digit>", which the generic shape regex reads as
+        # a context line -- so without the os-error heuristic this diagnostic
+        # is mis-classified as a match.
+        "/tmp/pytest-686/locked.txt: Permission denied (os error 13)",
+        "/var/db-2/x: Operation not permitted (os error 1)",
+    ])
+    def test_unprefixed_old_ripgrep_os_error_is_a_diagnostic(self, line):
+        diagnostics, payload = _split_tool_diagnostics(line + "\n")
+        assert payload.strip() == "", (
+            f"old-ripgrep diagnostic leaked into the payload: {payload!r}"
+        )
+        assert line in diagnostics
+
+
+    @pytest.mark.parametrize("line", [
+        # A REAL match whose matched content happens to end in "(os error N)".
+        # A blanket "endswith (os error N) => diagnostic" rule silently drops
+        # these; the guard must only fire on non-line-numbered lines.
+        "a.py:1:needle (os error 13)",
+        "src/io-3/mod.rs:42:    warn!(\"open failed (os error 2)\");",
+        "C:/proj/app.py:7:raise OSError(\"boom (os error 5)\")",
+    ])
+    def test_real_match_ending_in_os_error_is_kept(self, line):
+        diagnostics, payload = _split_tool_diagnostics(line + "\n")
+        assert line in payload, (
+            f"legitimate match was discarded as a diagnostic: {diagnostics!r}"
+        )
+        assert diagnostics.strip() == ""

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -411,13 +411,18 @@ def _search_stdout_and_limit(result: ExecuteResult) -> tuple[str, Optional[str]]
     return result.stdout, None
 
 
-def _split_tool_diagnostics(output: str) -> tuple[str, str]:
+def _split_tool_diagnostics(output: str, exit_code: int) -> tuple[str, str]:
     """Separate rg/grep diagnostic lines from real match output.
 
     ``_exec`` runs commands with ``stderr=subprocess.STDOUT``, so error and
     warning text from ``rg``/``grep`` is interleaved with match lines in a
     single stream. Diagnostics must not be parsed as matches, and on a hard
     failure they are the error message to surface.
+
+    ``exit_code`` is the search process' status. It scopes the unprefixed
+    old-ripgrep heuristic below to runs that can actually carry a per-file
+    I/O diagnostic: a clean exit (0) means every file was read successfully,
+    so any ``(os error N)`` text in that output is content, not a diagnostic.
 
     Returns ``(diagnostics, payload)`` where ``payload`` contains only lines
     that look like real search output — a match line (``file:line:content``),
@@ -451,12 +456,19 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         # shape regex below already rejects most of those, but it mis-reads the
         # ones whose path contains "-<digit>" (e.g. "/tmp/pytest-686/x: ...
         # (os error 13)"), classifying the diagnostic as a match. Catch that
-        # narrow gap here -- but ONLY for lines that are not a real,
-        # line-numbered search hit, so a legitimate match whose *content* ends
-        # in "(os error N)" (e.g. "a.py:1:needle (os error 13)") is kept.
+        # narrow gap here, guarded so it can only ever fire on a genuine
+        # diagnostic:
+        #   * only on an error exit -- a successful search never emitted one;
+        #   * only on the "<path>: <message>" shape, since real output always
+        #     separates the path from a line number with ":<n>:" or "-<n>-",
+        #     never with a colon-SPACE;
+        #   * and never on a line-numbered match or a numbered context line,
+        #     whose *content* may legitimately end in "(os error N)".
         if (
-            _OS_ERROR_DIAGNOSTIC_RE.search(line)
+            exit_code != 0
+            and _OS_ERROR_DIAGNOSTIC_RE.search(line)
             and not _SEARCH_LINE_NUMBERED_RE.match(line)
+            and not _SEARCH_CONTEXT_NUMBERED_RE.match(line)
         ):
             diagnostics.append(line)
             continue
@@ -476,13 +488,27 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
 
 # Matches an rg/grep per-file I/O diagnostic that some rg versions emit
 # WITHOUT a "rg: " prefix, e.g. "<path>: Permission denied (os error 13)".
-_OS_ERROR_DIAGNOSTIC_RE = re.compile(r"\(os error \d+\)\s*$")
+# The ": " separator is part of the shape on purpose: real search output
+# separates a path from a line number with ":<n>:" (match) or "-<n>-"
+# (context) and emits a files-only path bare, so a colon-SPACE is the
+# structural tell of the unprefixed diagnostic form. Without it a successful
+# files-only result whose path ends in "(os error N)" would be discarded.
+_OS_ERROR_DIAGNOSTIC_RE = re.compile(r"^.*?: .*\(os error \d+\)\s*$")
 
 # Matches a REAL, line-numbered search hit: "<path>:<line>:<content>" (rg is
 # always invoked with --line-number/--with-filename for content mode). Used to
 # exempt genuine matches from the unprefixed-diagnostic heuristic above, so a
 # match whose content happens to end in "(os error N)" is never discarded.
 _SEARCH_LINE_NUMBERED_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?:\d+:')
+
+# Matches a REAL, numbered CONTEXT line: "<path>-<line>-<content>". Same
+# exemption as above for -A/-B/-C output, whose content may also legitimately
+# end in "(os error N)". A path that itself contains "-<digits>-" makes a
+# single line inherently ambiguous (the same ambiguity
+# ``_parse_search_context_line`` documents); this resolves it toward keeping
+# user-visible results, since a leaked diagnostic is noise while a dropped
+# context line is silent data loss.
+_SEARCH_CONTEXT_NUMBERED_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?-\d+-')
 
 
 # A real rg/grep output line starts with a path token and is followed by a
@@ -3308,7 +3334,7 @@ class ShellFileOperations(FileOperations):
         # diagnostic lines ("rg: <file>: <error>", "rg: regex parse error:")
         # are interleaved with match output. Split them out: diagnostics must
         # not be parsed as matches, and on a hard error they ARE the message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, result.exit_code)
 
         # rg exit codes: 0=matches found, 1=no matches, 2=error. rg returns 2
         # even on partial errors (e.g. one unreadable file in a tree that
@@ -3523,7 +3549,7 @@ class ShellFileOperations(FileOperations):
         # ("grep: <file>: <error>") are interleaved with matches. Split them
         # out so they're never parsed as matches and so a hard error has a
         # clean message.
-        diagnostics, payload = _split_tool_diagnostics(stdout)
+        diagnostics, payload = _split_tool_diagnostics(stdout, result.exit_code)
 
         # grep exit codes: 0=matches found, 1=no matches, 2=error. grep
         # returns 2 on partial errors (e.g. an unreadable file) even when

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -446,6 +446,20 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         if stripped.startswith("rg: ") or stripped.startswith("grep: "):
             diagnostics.append(line)
             continue
+        # Older ripgrep (e.g. 0.10) emits per-file I/O errors WITHOUT the
+        # "rg: " prefix, e.g. "<path>: Permission denied (os error 13)". The
+        # shape regex below already rejects most of those, but it mis-reads the
+        # ones whose path contains "-<digit>" (e.g. "/tmp/pytest-686/x: ...
+        # (os error 13)"), classifying the diagnostic as a match. Catch that
+        # narrow gap here -- but ONLY for lines that are not a real,
+        # line-numbered search hit, so a legitimate match whose *content* ends
+        # in "(os error N)" (e.g. "a.py:1:needle (os error 13)") is kept.
+        if (
+            _OS_ERROR_DIAGNOSTIC_RE.search(line)
+            and not _SEARCH_LINE_NUMBERED_RE.match(line)
+        ):
+            diagnostics.append(line)
+            continue
         # Otherwise classify by output shape. rg's regex-parse-error block
         # also emits an indented caret line and a trailing "error: ..." line
         # with no tool prefix; neither matches a search-output shape, so they
@@ -458,6 +472,17 @@ def _split_tool_diagnostics(output: str) -> tuple[str, str]:
         else:
             diagnostics.append(line)
     return '\n'.join(diagnostics), '\n'.join(payload)
+
+
+# Matches an rg/grep per-file I/O diagnostic that some rg versions emit
+# WITHOUT a "rg: " prefix, e.g. "<path>: Permission denied (os error 13)".
+_OS_ERROR_DIAGNOSTIC_RE = re.compile(r"\(os error \d+\)\s*$")
+
+# Matches a REAL, line-numbered search hit: "<path>:<line>:<content>" (rg is
+# always invoked with --line-number/--with-filename for content mode). Used to
+# exempt genuine matches from the unprefixed-diagnostic heuristic above, so a
+# match whose content happens to end in "(os error N)" is never discarded.
+_SEARCH_LINE_NUMBERED_RE = re.compile(r'^([A-Za-z]:)?[^\s:][^\n]*?:\d+:')
 
 
 # A real rg/grep output line starts with a path token and is followed by a


### PR DESCRIPTION
## Evidence

On current `main` (`21b2095d00`), ripgrep 0.10.0 emits per-file I/O errors without an `rg:` prefix:

```console
$ rg --line-number --no-heading --with-filename needle /tmp/pytest-686
/tmp/pytest-686/locked.txt: Permission denied (os error 13)
```

`_split_tool_diagnostics()` mistakes that line for payload whenever the path contains `-<digit>`. The two old-rg cases were RED before the production change: each leaked the entire diagnostic into `payload`.

The inverse edge matters too, and it is wider than a single shape. Three kinds of *legitimate* output can end in the same suffix:

```text
/tmp/pytest-686/good.txt:1:needle (os error 13)      # line-numbered match
/tmp/pytest-686/a.txt-1-context (os error 13)        # numbered context line
/tmp/pytest-686/dir-2/good (os error 13)             # files-only path
```

A suffix filter that runs on every line, regardless of exit code, silently discards the last two. Reproduced with real ripgrep against the first revision of this branch:

- Searching `needle` with `context=1` in a file containing `context (os error 13)\nneedle\n` returned only `[(2, "needle")]`; `21b2095d00` returns both the line-1 context and the line-2 match.
- A files-only search matching `dir-2/good (os error 13)` returned no files at all — and on a partial error (one unreadable sibling, exit 2) the dropped payload additionally turned a successful search into `Search failed`.

## Fix

Scope the unprefixed-diagnostic heuristic three ways so it can only fire on a genuine diagnostic:

- **Only on an error exit.** `_split_tool_diagnostics()` now takes the search process' exit code. A clean exit means every file was read successfully, so `(os error N)` text in that output is content.
- **Only on the `<path>: <message>` shape.** Real output separates a path from a line number with `:<n>:` or `-<n>-`, or emits a files-only path bare — so the colon-space is the structural tell of the unprefixed diagnostic form.
- **Never on numbered match or context lines**, whose content may legitimately end in the suffix.

This is the still-live diagnostic subset of #65334. The snapshot-temp portion was independently fixed by `911d380296`; the old newline-error path was superseded by automatic ripgrep multiline mode in `1cefabc8af`.

## Verification

- `uv sync --extra all --extra dev`
- RED before the fix, against the previous head of this branch: 16 failing cases — including 4 end-to-end ones that failed *behaviourally*, not on the new signature (`AssertionError: context line was dropped as a diagnostic: ['needle']` and `files-only payload was dropped as a diagnostic: []`), for both the `rg` and `grep` backends.
- Both regressions confirmed fixed against real ripgrep at exit 0 **and** at exit 2 (partial error): the context search now returns `[(1, 'context (os error 13)'), (2, 'needle')]`, matching base `21b2095d00`, and the files-only path is preserved.
- Retained coverage: unprefixed old-rg `path: Permission denied (os error 13)` on exit 2 is still classified as a diagnostic, and colon-form matches ending in the suffix (POSIX, Windows-shaped, and one whose content carries its own `": "`) remain payload.
- `scripts/run_tests.sh tests/tools/test_search_error_guard.py tests/tools/test_search_zero_match_and_multipath.py tests/tools/test_search_hidden_dirs.py tests/tools/test_search_budget_truncation.py tests/tools/test_search_auto_multiline.py tests/tools/test_macos_protected_search.py -q` — **74 passed**, 0 failed.
- Blast radius: `tests/tools/test_file_operations.py`, `test_file_operations_edge_cases.py`, `test_file_ops_cwd_tracking.py`, `test_tool_search.py`, `test_tool_search_context_provider.py`, `test_tool_search_multiquery.py` — 155 passed, 0 failed.
- `ruff check tools/file_operations.py tests/tools/test_search_error_guard.py` — passed.
