### PR TITLE
fix(browser): pick the navigated page, not Chrome New Tab, for supervisor eval

### DIFF
--- a/tests/tools/test_browser_eval_supervisor_path.py
+++ b/tests/tools/test_browser_eval_supervisor_path.py
@@ -303,3 +303,86 @@ class TestEvaluateRuntimeDomNodeCrashRetry:
             assert calls == [True]
         finally:
             _stop_supervisor(sup)
+
+
+# ---------------------------------------------------------------------------
+# Initial page-target selection: tools.browser_supervisor._select_initial_page_target
+# ---------------------------------------------------------------------------
+
+
+class TestSelectInitialPageTarget:
+    """The supervisor must not attach to Chrome's New Tab when a real page exists.
+
+    Regression for the multi-tab wedge: ``_attach_initial_page`` used to grab
+    the first ``type == "page"`` entry from ``Target.getTargets``, which can
+    be the browser's own New Tab, so every supervisor-backed eval landed on
+    ``chrome://new-tab-page`` instead of the page Hermes navigated to.
+    """
+
+    @staticmethod
+    def _target(tid: str, url: str) -> dict:
+        return {"targetId": tid, "type": "page", "url": url}
+
+    def test_prefers_real_page_over_new_tab(self):
+        from tools.browser_supervisor import _select_initial_page_target
+
+        targets = [
+            self._target("t-newtab", "chrome://new-tab-page/"),
+            self._target("t-wiki", "https://en.wikipedia.org/wiki/Hermes_Agent"),
+        ]
+        picked = _select_initial_page_target(targets)
+        assert picked is not None
+        assert picked["targetId"] == "t-wiki"
+
+    def test_prefers_last_real_page_when_multiple(self):
+        from tools.browser_supervisor import _select_initial_page_target
+
+        targets = [
+            self._target("t-newtab", "chrome://new-tab-page/"),
+            self._target("t-old", "https://old.example.com/"),
+            self._target("t-latest", "https://latest.example.com/"),
+        ]
+        picked = _select_initial_page_target(targets)
+        assert picked is not None
+        assert picked["targetId"] == "t-latest"
+
+    def test_falls_back_to_internal_page_when_only_option(self):
+        from tools.browser_supervisor import _select_initial_page_target
+
+        targets = [
+            {"targetId": "t-bw", "type": "browser", "url": ""},
+            self._target("t-newtab", "chrome://new-tab-page/"),
+        ]
+        picked = _select_initial_page_target(targets)
+        assert picked is not None
+        assert picked["targetId"] == "t-newtab"
+
+    def test_falls_back_to_about_blank(self):
+        from tools.browser_supervisor import _select_initial_page_target
+
+        targets = [self._target("t-blank", "about:blank")]
+        picked = _select_initial_page_target(targets)
+        assert picked is not None
+        assert picked["targetId"] == "t-blank"
+
+    def test_returns_none_when_no_page_targets(self):
+        from tools.browser_supervisor import _select_initial_page_target
+
+        targets = [{"targetId": "t-bw", "type": "browser", "url": ""}]
+        picked = _select_initial_page_target(targets)
+        assert picked is None
+
+    def test_devtools_and_edge_prefixes_are_internal(self):
+        from tools.browser_supervisor import _is_internal_page_url
+
+        for url in (
+            "chrome://new-tab-page/",
+            "chrome-error://chromewebdata/",
+            "devtools://devtools/bundled/inspector.html",
+            "edge://newtab/",
+            "about:blank",
+        ):
+            assert _is_internal_page_url(url), url
+        assert not _is_internal_page_url("https://example.com/")
+        assert not _is_internal_page_url("")
+        assert not _is_internal_page_url(None)

--- a/tools/browser_supervisor.py
+++ b/tools/browser_supervisor.py
@@ -38,6 +38,46 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+# Browser-built-in placeholder pages a fresh Chrome opens on its own (the
+# New Tab the user left open, DevTools frontends). CDP target ordering does
+# not promise the Hermes-navigated page comes first, so picking the first
+# ``type == "page"`` entry can wedge every supervisor-backed eval onto
+# ``chrome://new-tab-page`` while the real page sits later in the list.
+_INTERNAL_PAGE_URL_PREFIXES = (
+    "about:",
+    "chrome://",
+    "chrome-error://",
+    "devtools://",
+    "edge://",
+    "view-source:about:",
+)
+
+
+def _is_internal_page_url(url: object) -> bool:
+    url = str(url or "")
+    return any(url.startswith(prefix) for prefix in _INTERNAL_PAGE_URL_PREFIXES)
+
+
+def _select_initial_page_target(
+    targets: List[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    """Pick the page target the supervisor should attach to.
+
+    Deterministic preference order:
+      1. The last real (non-internal) page target — with a New Tab lingering
+         from startup plus pages Hermes navigated afterwards, the real page
+         is the freshest entry; targetInfo ordering puts newer targets last.
+      2. The last internal page target (fresh browser, only a New Tab open) —
+         still a usable page session; navigation later replaces its content.
+      3. ``None`` — no page targets at all; the caller creates one.
+    """
+    pages = [t for t in targets if t.get("type") == "page"]
+    real_pages = [t for t in pages if not _is_internal_page_url(t.get("url"))]
+    if real_pages:
+        return real_pages[-1]
+    return pages[-1] if pages else None
+
+
 def _redact_cdp_error_text(exc: object) -> str:
     """Redact any CDP endpoint credentials from an error's string form.
 
@@ -742,7 +782,7 @@ class CDPSupervisor:
         """Find a page target, attach flattened session, enable domains, install dialog bridge."""
         resp = await self._cdp("Target.getTargets")
         targets = resp.get("result", {}).get("targetInfos", [])
-        page_target = next((t for t in targets if t.get("type") == "page"), None)
+        page_target = _select_initial_page_target(targets)
         if page_target is None:
             created = await self._cdp("Target.createTarget", {"url": "about:blank"})
             target_id = created["result"]["targetId"]


### PR DESCRIPTION
## Problem

`browser_console(expression=...)` evaluated in Chrome's New Tab instead of the page Hermes just navigated whenever multiple `page` targets existed (#99962).

## Root cause

`CDPSupervisor._attach_initial_page()` in `tools/browser_supervisor.py` attached to the first `type == "page"` entry from `Target.getTargets`. CDP target ordering carries no promise that this is the active or Hermes-navigated page — with a lingering New Tab it wins, and every supervisor-backed eval (`evaluate_runtime`, i.e. `browser_console` / `browser_eval`) then lands on `chrome://new-tab-page/`.

## Fix

Extract selection into a deterministic helper:

- prefer the **last non-internal page target** (`about:`, `chrome://`, `chrome-error://`, `devtools://`, `edge://`, `view-source:about:` are treated as browser-built-in placeholders) — newer targets sort later, so the page Hermes navigated last wins over the startup New Tab;
- fall back to the **last page target** when only internal pages exist (fresh browser, single New Tab — still a usable session, navigation later replaces its content);
- `None` when there are no page targets at all → the caller's existing `Target.createTarget("about:blank")` path is unchanged.

One-page fallback, no-page behavior, dialog bridge, OOPIF auto-attach, and the non-CDP subprocess path are untouched.

## Tests

New unit class `TestSelectInitialPageTarget` in `tests/tools/test_browser_eval_supervisor_path.py` (6 tests): prefers a real page over New Tab, prefers the latest real page, falls back to internal-only, falls back to `about:blank`, returns `None` with no pages, and covers the internal-prefix classifier.

Local run (venv of this repo):

```
tests/tools/test_browser_eval_supervisor_path.py  14 passed
+ test_browser_console / test_browser_supervisor_healthcheck / test_browser_cdp_override / test_browser_secret_exfil → 70 passed
ruff check on both files → clean
```

A real-CDP regression test with a New Tab + navigated page is gated behind `HERMES_E2E_BROWSER=1` territory (existing integration suite) — happy to extend that suite on request; the deterministic unit coverage pins the selection logic itself.

Fixes #99962