### PR TITLE
fix(desktop): write pre-save gateway sign-in sessions to the connection's own jar

### DIFF
--- a/apps/desktop/electron/connection-registry.test.ts
+++ b/apps/desktop/electron/connection-registry.test.ts
@@ -17,6 +17,7 @@ import {
   buildAgentRoster,
   connectionDialFieldsChanged,
   connectionIdForLabel,
+  connectionIdForPendingLogin,
   labelKey,
   labelSlug,
   LOCAL_CONNECTION_ID,
@@ -606,6 +607,62 @@ test('connectionIdForLabel suffixes on collision and never mints "local"', () =>
   assert.equal(connectionIdForLabel('Homelab', ['homelab']), 'homelab-2')
   assert.equal(connectionIdForLabel('Homelab', ['homelab', 'homelab-2']), 'homelab-3')
   assert.equal(connectionIdForLabel('Local', []), 'local-2')
+})
+
+// A registry-editor sign-in can run before the draft is saved: the id settled
+// here names the cookie partition the login writes, so it MUST equal the id
+// normalizeConnectionInput mints when the draft is saved.
+test('connectionIdForPendingLogin: an explicit draft id wins (trimmed)', () => {
+  const registry = emptyRegistry()
+
+  assert.equal(connectionIdForPendingLogin({ connectionId: 'homelab', registry }), 'homelab')
+  assert.equal(connectionIdForPendingLogin({ connectionId: '  homelab  ', registry }), 'homelab')
+})
+
+test('connectionIdForPendingLogin: mints the save-time id for an unpersisted draft', () => {
+  let registry = emptyRegistry()
+  const entry = normalizeConnectionInput({ kind: 'remote', label: 'Homelab', url: 'http://10.0.0.5:9119' }, registry)
+  registry = upsertConnection(registry, entry)
+
+  // Label-derived and collision-suffixed exactly like normalizeConnectionInput.
+  assert.equal(connectionIdForPendingLogin({ label: 'Mac mini', registry }), 'mac-mini')
+  assert.equal(connectionIdForPendingLogin({ label: 'Homelab', registry }), 'homelab-2')
+
+  // The save must land on the same id the login used.
+  const saved = normalizeConnectionInput(
+    {
+      kind: 'remote',
+      id: connectionIdForPendingLogin({ label: 'Mac mini', registry }),
+      label: 'Mac mini',
+      url: 'http://10.0.0.6:9119'
+    },
+    registry
+  )
+
+  assert.equal(saved.id, 'mac-mini')
+})
+
+test('connectionIdForPendingLogin: an unnamed draft still gets a stable unique id', () => {
+  let registry = emptyRegistry()
+  registry = upsertConnection(registry, {
+    id: 'connection',
+    kind: 'remote',
+    label: 'Taken',
+    url: 'http://10.0.0.7:9119',
+    authMode: 'oauth'
+  })
+
+  // labelSlug('') is 'connection'; the collision suffixes just like a label.
+  assert.equal(connectionIdForPendingLogin({ label: '', registry }), 'connection-2')
+  assert.equal(connectionIdForPendingLogin({ registry }), 'connection-2')
+})
+
+test('connectionIdForPendingLogin: blank or non-string ids fall back to minting', () => {
+  const registry = emptyRegistry()
+
+  for (const junk of ['', '   ', 42, null, undefined]) {
+    assert.equal(connectionIdForPendingLogin({ connectionId: junk, label: 'Homelab', registry }), 'homelab')
+  }
 })
 
 test('uniqueLabel counts up (never "X 2 2") and clamps long candidates', () => {

--- a/apps/desktop/electron/connection-registry.ts
+++ b/apps/desktop/electron/connection-registry.ts
@@ -801,6 +801,34 @@ export function connectionIdForLabel(label: string, taken: Iterable<string>): st
   }
 }
 
+/**
+ * Settle the connection id a pre-save OAuth login must write its session for.
+ * The registry editor can open the sign-in window BEFORE the draft is saved,
+ * and the login window's cookie partition is derived from this id
+ * (oauth-partition.ts) — so it must equal the id the eventual save uses. An
+ * explicit draft id wins; otherwise mint from the label exactly like
+ * normalizeConnectionInput will (labelSlug maps an empty label to
+ * 'connection', so even an unnamed draft gets a stable, unique id). The
+ * editor's save path never promotes a fresh entry to primary, so a pending
+ * draft always ends up on its own partition.
+ */
+export function connectionIdForPendingLogin(opts: {
+  connectionId?: unknown
+  label?: unknown
+  registry: ConnectionRegistry
+}): string {
+  if (typeof opts.connectionId === 'string' && opts.connectionId.trim()) {
+    return opts.connectionId.trim()
+  }
+
+  const label = typeof opts.label === 'string' ? opts.label : ''
+
+  return connectionIdForLabel(
+    label,
+    opts.registry.connections.map(c => c.id)
+  )
+}
+
 // ── Validation ──────────────────────────────────────────────────────────────
 
 export interface ConnectionInput {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -130,6 +130,7 @@ import {
   backendScopePrefix,
   buildAgentRoster,
   connectionDialFieldsChanged,
+  connectionIdForPendingLogin,
   mergeConnectionInput,
   migrateV1ToRegistry,
   normalizeConnectionInput,
@@ -6999,9 +7000,10 @@ function getOauthSession() {
 // shared partition; see oauth-partition.ts for the full rules.
 const oauthSessionsByPartition = new Map()
 
-function resolveOauthPartitionForUrl(url) {
+function resolveOauthPartitionForUrl(url, { connectionId = '' } = {}) {
   try {
     return resolveOauthPartition(url, {
+      connectionId,
       registry: readDesktopConnectionsRegistry(),
       v1RemoteUrl: readDesktopConnectionConfig()?.remote?.url
     })
@@ -7011,8 +7013,8 @@ function resolveOauthPartitionForUrl(url) {
   }
 }
 
-function getOauthSessionForUrl(url) {
-  const partition = resolveOauthPartitionForUrl(url)
+function getOauthSessionForUrl(url, { connectionId = '' } = {}) {
+  const partition = resolveOauthPartitionForUrl(url, { connectionId })
 
   if (partition === OAUTH_SESSION_PARTITION) {
     return getOauthSession()
@@ -7086,8 +7088,8 @@ function warmOauthCookieStore(url?) {
 // connection-config.ts (cookiesHaveSession / cookiesHaveLiveSession). See
 // that module for details.
 
-async function hasOauthSessionCookie(baseUrl) {
-  const sess = getOauthSessionForUrl(baseUrl)
+async function hasOauthSessionCookie(baseUrl, { connectionId = '' } = {}) {
+  const sess = getOauthSessionForUrl(baseUrl, { connectionId })
 
   if (!sess) {
     return false
@@ -7209,7 +7211,7 @@ async function clearOauthSession(baseUrl) {
 //     ``/auth/login`` → portal ``/oauth/authorize`` (auto-approves org members)
 //     → ``/auth/callback``, which sets the gateway cookie with NO interactive
 //     prompt. This is the per-agent cloud cascade (decisions.md Q5).
-function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
+function openOauthLoginWindow(baseUrl, { silent = false, connectionId = '' } = {}) {
   return new Promise((resolve, reject) => {
     if (!app.isReady()) {
       reject(new Error('Desktop is not ready to start an OAuth login.'))
@@ -7217,7 +7219,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
       return
     }
 
-    const sess = getOauthSessionForUrl(baseUrl)
+    const sess = getOauthSessionForUrl(baseUrl, { connectionId })
 
     if (!sess) {
       reject(new Error('OAuth session partition is unavailable.'))
@@ -7265,7 +7267,7 @@ function openOauthLoginWindow(baseUrl, { silent = false } = {}) {
         return
       }
 
-      if (await hasOauthSessionCookie(baseUrl)) {
+      if (await hasOauthSessionCookie(baseUrl, { connectionId })) {
         finish(null)
       }
     }
@@ -15327,7 +15329,7 @@ async function fetchJsonForBackend(
 }
 
 ipcMain.handle('hermes:connection-config:probe', async (_event, rawUrl) => probeRemoteAuthMode(rawUrl))
-ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) => {
+ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl, rawOpts) => {
   // Capability-gated login (RFC 8252). Probe the gateway's public /api/status
   // for supported auth_flows and /api/auth/providers for provider capabilities:
   //   - all providers support password → always use the embedded login window
@@ -15340,6 +15342,25 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
   //   - a failed native login reports the error rather than auto-falling back
   //     to the embedded flow — one sign-in action opens at most one window.
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)
+
+  // A registry-editor sign-in can run BEFORE the draft connection is saved:
+  // settle the id the save will reuse (returned so the renderer pins it into
+  // the draft) so the login window writes its session cookies into the
+  // per-connection jar the saved connection will actually read — not the
+  // legacy shared jar an unmatched URL would fall back to, where the session
+  // is both unreadable by the new connection and able to evict a same-host
+  // primary's cookie (#92183 isolation hole). '' → URL-matched behavior.
+  let loginConnectionId = ''
+
+  try {
+    loginConnectionId = connectionIdForPendingLogin({
+      connectionId: rawOpts?.connectionId,
+      label: rawOpts?.label,
+      registry: readDesktopConnectionsRegistry()
+    })
+  } catch {
+    loginConnectionId = ''
+  }
 
   let statusBody: any = null
 
@@ -15368,18 +15389,23 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
       // startHermes() re-dials instead of replaying the stale rejection.
       remoteReauthFailure = null
 
-      return { ok: true, baseUrl, connected: true }
+      return { ok: true, baseUrl, connected: true, connectionId: loginConnectionId || undefined }
     } catch (error) {
       rememberLog(`[native-oauth] native login failed (${error instanceof Error ? error.message : String(error)})`)
 
-      return { ok: false, error: error instanceof Error ? error.message : String(error), connected: false }
+      return {
+        ok: false,
+        error: error instanceof Error ? error.message : String(error),
+        connected: false,
+        connectionId: loginConnectionId || undefined
+      }
     }
   }
 
   // Legacy embedded-webview cookie flow.
-  await openOauthLoginWindow(baseUrl)
+  await openOauthLoginWindow(baseUrl, { connectionId: loginConnectionId })
 
-  const connected = await hasOauthSessionCookie(baseUrl)
+  const connected = await hasOauthSessionCookie(baseUrl, { connectionId: loginConnectionId })
 
   // Only a CONFIRMED sign-in releases the latch. A cancelled/closed login
   // window must leave it set, or the overlay's "Sign in" button starts
@@ -15388,7 +15414,7 @@ ipcMain.handle('hermes:connection-config:oauth-login', async (_event, rawUrl) =>
     remoteReauthFailure = null
   }
 
-  return { ok: true, baseUrl, connected }
+  return { ok: true, baseUrl, connected, connectionId: loginConnectionId || undefined }
 })
 ipcMain.handle('hermes:connection-config:oauth-logout', async (_event, rawUrl) => {
   const baseUrl = normalizeRemoteBaseUrl(rawUrl)

--- a/apps/desktop/electron/oauth-partition.test.ts
+++ b/apps/desktop/electron/oauth-partition.test.ts
@@ -142,3 +142,93 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
     expect(got).toContain('alpha')
   })
 })
+
+// The registry editor can sign a draft in BEFORE it is saved. The login window
+// must then write to the jar the saved entry will read — an unsaved draft has
+// no on-disk entry to URL-match, so identity (connectionId) decides instead.
+describe('resolveOauthPartition with connectionId (pre-save sign-in identity)', () => {
+  it('sends a pending (unsaved) draft sign-in to its own jar, not the legacy shared one', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }])
+
+    const got = resolveOauthPartition('https://macmini.lan:9119', { registry: reg, connectionId: 'macmini' })
+
+    expect(got).not.toBe(LEGACY_OAUTH_PARTITION)
+    expect(got).toContain('conn:macmini')
+    // Deterministic across calls — the saved entry must read the jar the login wrote.
+    expect(resolveOauthPartition('https://macmini.lan:9119', { registry: reg, connectionId: 'macmini' })).toBe(got)
+  })
+
+  it('keeps a pending same-host sign-in out of an existing gateway’s jar (no #92183 eviction)', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }, remote('conn-a', 'https://10.27.27.7:9119')])
+
+    const pending = resolveOauthPartition('https://10.27.27.7:9220', { registry: reg, connectionId: 'conn-b' })
+    const existing = resolveOauthPartition('https://10.27.27.7:9119', { registry: reg })
+
+    expect(pending).not.toBe(LEGACY_OAUTH_PARTITION)
+    expect(pending).not.toBe(existing)
+    expect(existing).toContain('conn-a')
+    expect(pending).toContain('conn-b')
+  })
+
+  it('resolves an existing entry by identity even when the URL was edited but not yet saved', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }, remote('conn-a', 'https://old.example.com')])
+
+    const got = resolveOauthPartition('https://new.example.com', { registry: reg, connectionId: 'conn-a' })
+
+    expect(got).toContain('conn-a')
+    expect(got).not.toBe(LEGACY_OAUTH_PARTITION)
+  })
+
+  it('keeps the primary, the local entry, cloud, and token-auth identities on the legacy jar', () => {
+    const reg = registry('conn-a', [
+      { id: 'local', kind: 'local' },
+      remote('conn-a', 'https://gw-a.example.com'),
+      remote('tok-1', 'https://gw-t.example.com', { authMode: 'token' }),
+      { id: 'cloud-1', kind: 'cloud', url: 'https://agent.nousresearch.com', authMode: 'oauth' }
+    ])
+
+    expect(resolveOauthPartition('https://gw-a.example.com', { registry: reg, connectionId: 'conn-a' })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://gw-a.example.com', { registry: reg, connectionId: 'local' })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://gw-t.example.com', { registry: reg, connectionId: 'tok-1' })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://agent.nousresearch.com', { registry: reg, connectionId: 'cloud-1' })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('keeps a v1-migrated entry on the legacy jar even when named by id', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }, remote('mig-1', 'https://gw-a.example.com')])
+
+    expect(
+      resolveOauthPartition('https://gw-a.example.com', {
+        registry: reg,
+        connectionId: 'mig-1',
+        v1RemoteUrl: 'https://gw-a.example.com'
+      })
+    ).toBe(LEGACY_OAUTH_PARTITION)
+  })
+
+  it('ignores blank or non-string connectionIds and falls back to URL matching', () => {
+    const reg = registry('local', [remote('conn-a', 'https://gw-a.example.com')])
+
+    for (const junk of ['', '   ', 42, null, undefined]) {
+      expect(resolveOauthPartition('https://gw-a.example.com', { registry: reg, connectionId: junk })).toContain(
+        'conn-a'
+      )
+    }
+  })
+
+  it('sanitizes hostile pending ids into partition-safe names', () => {
+    const reg = registry('local', [{ id: 'local', kind: 'local' }])
+
+    const got = resolveOauthPartition('https://gw.example.com', { registry: reg, connectionId: 'we ird/id:€' })
+
+    expect(got.startsWith('persist:')).toBe(true)
+    expect(got).not.toMatch(/[\s/€]/)
+  })
+})

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -29,6 +29,13 @@
  *     cascade deliberately shares one jar with the Nous Portal session.
  *   - Token-auth remotes, portal URLs, and anything unmatched or malformed
  *     fall back to the legacy partition (cookie-free flows are unaffected).
+ *   - Login flows may name the connection explicitly (`connectionId`): the
+ *     registry editor can sign a draft in BEFORE it is persisted, and the
+ *     login window must write to the jar the saved entry will read from.
+ *     Identity then decides — a known entry follows the rules above; an
+ *     unknown id is a pending non-primary oauth remote (the editor's save
+ *     path never promotes a fresh entry to primary) and gets its own
+ *     partition up front.
  *
  * Kept free of `electron` imports so it unit-tests in the electron vitest
  * project; main.ts owns session.fromPartition() and injects nothing here.
@@ -47,6 +54,12 @@ export interface ResolveOauthPartitionOptions {
   registry?: PartitionRegistrySnapshot | null
   /** v1 single-connection remote URL (connection.json `remote.url`), when set. */
   v1RemoteUrl?: unknown
+  /**
+   * Connection id for login flows that run before the draft is persisted.
+   * When set, identity decides the jar (module header); URL matching below
+   * is skipped entirely.
+   */
+  connectionId?: unknown
 }
 
 /**
@@ -88,6 +101,15 @@ function sanitizePartitionComponent(id: string): string {
   return encodeURIComponent(id).replace(/%/g, '_')
 }
 
+/** Read one property off an untrusted registry entry (parsed JSON) without a cast. */
+function entryField(entry: unknown, key: string): unknown {
+  if (!entry || typeof entry !== 'object' || !(key in entry)) {
+    return undefined
+  }
+
+  return Object.getOwnPropertyDescriptor(entry, key)?.value
+}
+
 /**
  * Decide the Electron session partition a cookie-authenticated request against
  * `requestUrl` must ride. See the module header for the rules.
@@ -107,6 +129,35 @@ export function resolveOauthPartition(requestUrl: unknown, opts: ResolveOauthPar
 
   const primaryId = typeof registry.primary === 'string' ? registry.primary : ''
   const v1Norm = normalizeForMatch(opts.v1RemoteUrl)
+
+  // Identity-keyed resolution for pre-save logins. A pending draft has no
+  // persisted entry to URL-match against; without this branch its sign-in
+  // would fall through to the legacy shared jar — where the session is both
+  // unreadable by the saved connection AND able to evict a same-host primary's
+  // cookie (the #92183 leak the per-connection jars exist to stop).
+  const wantedId = typeof opts.connectionId === 'string' ? opts.connectionId.trim() : ''
+
+  if (wantedId) {
+    const own = (registry.connections as unknown[]).find(c => entryField(c, 'id') === wantedId)
+
+    if (!own) {
+      return `${CONNECTION_PARTITION_PREFIX}${sanitizePartitionComponent(wantedId)}`
+    }
+
+    const ownBaseNorm = normalizeForMatch(entryField(own, 'url'))
+
+    if (
+      wantedId !== primaryId &&
+      entryField(own, 'kind') === 'remote' &&
+      entryField(own, 'authMode') === 'oauth' &&
+      ownBaseNorm &&
+      !(v1Norm && ownBaseNorm === v1Norm)
+    ) {
+      return `${CONNECTION_PARTITION_PREFIX}${sanitizePartitionComponent(wantedId)}`
+    }
+
+    return LEGACY_OAUTH_PARTITION
+  }
 
   let best: { baseNorm: string; id: string } | null = null
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -205,7 +205,12 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   sshConfigHosts: () => ipcRenderer.invoke('hermes:ssh-config:hosts'),
   sshResolveHost: host => ipcRenderer.invoke('hermes:ssh-config:resolve', host),
   probeConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:probe', remoteUrl),
-  oauthLoginConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-login', remoteUrl),
+  // `options` lets a registry-editor draft sign in BEFORE it is saved: the
+  // main process settles the draft's connection id up front so the login
+  // window writes into the per-connection cookie jar the saved entry will
+  // read (not the legacy shared jar an unsaved URL would fall back to).
+  oauthLoginConnectionConfig: (remoteUrl, options) =>
+    ipcRenderer.invoke('hermes:connection-config:oauth-login', remoteUrl, options),
   oauthLogoutConnectionConfig: remoteUrl => ipcRenderer.invoke('hermes:connection-config:oauth-logout', remoteUrl),
   // Hermes Cloud: one portal login powers discovery + silent per-agent sign-in
   // (cloud-auto-discovery Phase 3).

--- a/apps/desktop/src/app/settings/connections-registry.tsx
+++ b/apps/desktop/src/app/settings/connections-registry.tsx
@@ -325,6 +325,13 @@ export function ConnectionsRegistrySection() {
   // it mints (native PKCE bearer tokens, or the legacy session cookies). This
   // is the same IPC the first-run form and the gateway panel use — the
   // registry editor simply had no affordance to reach it.
+  //
+  // The draft's identity rides along because this sign-in can run BEFORE the
+  // connection is saved: the main process settles the id the save will reuse
+  // and writes the session into that connection's own cookie jar. An unsaved
+  // draft has no on-disk entry to URL-match, so without the identity the
+  // session would land in the legacy shared jar the saved connection never
+  // reads. Pin the settled id into the draft so Save reuses it.
   const signInOauth = useCallback(async () => {
     if (!editorUrl) {
       notify({ kind: 'warning', title: t.settings.gateway.authTitle, message: t.settings.gateway.enterUrlFirst })
@@ -335,7 +342,16 @@ export function ConnectionsRegistrySection() {
     setSigningIn(true)
 
     try {
-      const result = await window.hermesDesktop.oauthLoginConnectionConfig(editorUrl)
+      const result = await window.hermesDesktop.oauthLoginConnectionConfig(editorUrl, {
+        connectionId: editor?.id ?? null,
+        label: editor?.label ?? ''
+      })
+
+      if (result.connectionId) {
+        const settledId = result.connectionId
+
+        setEditor(prev => (prev && !prev.id ? { ...prev, id: settledId } : prev))
+      }
 
       setOauthConnected(Boolean(result.connected))
 
@@ -356,7 +372,7 @@ export function ConnectionsRegistrySection() {
     } finally {
       setSigningIn(false)
     }
-  }, [authProviderShape.providerLabel, editorUrl, t])
+  }, [authProviderShape.providerLabel, editor?.id, editor?.label, editorUrl, t])
 
   const load = useCallback(async () => {
     if (!bridge) {

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -193,7 +193,10 @@ declare global {
       sshConfigHosts: () => Promise<DesktopSshHostsResult>
       sshResolveHost: (host: string) => Promise<DesktopSshResolveResult>
       probeConnectionConfig: (remoteUrl: string) => Promise<DesktopConnectionProbeResult>
-      oauthLoginConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLoginResult>
+      oauthLoginConnectionConfig: (
+        remoteUrl: string,
+        options?: DesktopOauthLoginOptions
+      ) => Promise<DesktopOauthLoginResult>
       oauthLogoutConnectionConfig: (remoteUrl: string) => Promise<DesktopOauthLogoutResult>
       // Hermes Cloud: one portal login powers discovery + silent per-agent
       // sign-in (cloud-auto-discovery Phase 3).
@@ -1030,10 +1033,27 @@ export interface DesktopConnectionProbeResult {
   error: string | null
 }
 
+export interface DesktopOauthLoginOptions {
+  /**
+   * Registry-draft identity for a sign-in that runs before the draft is
+   * saved. The main process derives the login window's cookie partition from
+   * the settled connection id; without it an unsaved draft's session lands in
+   * the legacy shared jar the saved connection never reads.
+   */
+  connectionId?: null | string
+  /** Draft label — used to mint the id when `connectionId` is absent. */
+  label?: string
+}
+
 export interface DesktopOauthLoginResult {
   ok: boolean
   baseUrl: string
   connected: boolean
+  /**
+   * The connection id the session was written for. A pre-save sign-in should
+   * pin this into the draft so the later save reuses the same id (and jar).
+   */
+  connectionId?: string
 }
 
 export interface DesktopOauthLogoutResult {


### PR DESCRIPTION
## What does this PR do?

Settings → Connections lets a draft remote gateway be signed in **before** it is saved ("Add gateway" → URL → **Sign in** → **Save**). The login IPC carried only the URL, so `resolveOauthPartition()` matched against the **on-disk** registry, found no entry for the unsaved draft, and fell back to the legacy shared partition `persist:hermes-remote-oauth`. The session cookies were written there — but after Save, the new non-primary oauth remote reads its own per-connection jar `persist:hermes-remote-oauth:conn:<id>` (#92183), which stayed empty. Net effect: every pre-save sign-in was lost on connect.

Worse, in the #92183 same-host setup (one box, two dashboards), the pre-save login also **evicted the other gateway's session cookie in the shared legacy jar** — the exact cross-connection eviction the per-connection jars were built to stop.

The fix settles the connection id at sign-in time and threads it through the partition resolution:

- The login IPC (`hermes:connection-config:oauth-login`) accepts `{ connectionId?, label? }` and returns the settled `connectionId`.
- New `connectionIdForPendingLogin()` (connection-registry.ts): an explicit draft id wins; otherwise the id is minted from the label exactly like `normalizeConnectionInput` will at save time (a still-unnamed draft gets labelSlug's `connection` fallback, suffix-uniqued).
- `resolveOauthPartition()` resolves a named connection by **identity**: a known entry follows the existing rules (primary / v1 / cloud / token → legacy); an unknown id is a pending non-primary oauth remote — the editor's save path never promotes a fresh entry to primary — and gets its own partition up front.
- The editor pins the returned id into the draft, so **Save reuses the same id** and the connection reads the jar the login wrote.

Request-time resolution (no `connectionId`) is byte-for-byte unchanged. Other sign-in callers (first-run form, gateway panel, boot-failure reauth) pass no options and behave exactly as before — their flows land on the legacy jar by design (apply→primary / already-persisted entries).

Known edge, self-healing: sign in → save → immediately "Set as primary" moves the entry to the legacy jar, so one re-login is needed there (the existing reauth UX catches it). Before this fix, the mirror flow (non-primary, the common one) was broken 100% of the time.

## Related Issue

Fixes #99989

Related: #92183 (per-connection jars feature), #94856 (partition-wide logout on reauth — adjacent, untouched here)

**Overlap note — #91530** addresses the same root problem (pre-save sign-in writing into the wrong jar) with a much larger mechanism: a new `registry-auth.ts` scope system (`draft-<uuid>` scopes promoted at save time), a separate partition family (`persist:hermes-registry-auth-<scope>`), and a new `hermes:connections:auth:login` IPC. This PR instead stays inside the existing #92183 scheme: it reuses the current `conn:<id>` partitions and the `connection-config:oauth-login` seam, changing 8 files / +311 lines with no new IPC surface. The two patches conflict textually (both touch `main.ts`, `connections-registry.tsx`, `preload.ts`, `global.d.ts`) and should be treated as alternatives — merging either closes the bug.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/oauth-partition.ts` — `ResolveOauthPartitionOptions.connectionId`; identity-keyed resolution branch for logins; docs
- `apps/desktop/electron/connection-registry.ts` — new `connectionIdForPendingLogin()` export
- `apps/desktop/electron/main.ts` — login handler settles/threads/returns the connection id; `resolveOauthPartitionForUrl` / `getOauthSessionForUrl` / `hasOauthSessionCookie` / `openOauthLoginWindow` accept an optional connection id
- `apps/desktop/electron/preload.ts` — `oauthLoginConnectionConfig(url, options?)` passthrough
- `apps/desktop/src/global.d.ts` — `DesktopOauthLoginOptions`; `DesktopOauthLoginResult.connectionId`
- `apps/desktop/src/app/settings/connections-registry.tsx` — sign-in passes the draft identity; pins the settled id into the draft
- Tests: `oauth-partition.test.ts` (+7), `connection-registry.test.ts` (+4)

## How to Test

1. Settings → Connections → Add gateway; enter a cookie-auth gateway URL; click **Sign in** (before Save); complete login.
2. Click **Save**, then open a session on the new connection.
3. The connection uses the session from step 1 — no re-auth prompt. (Before: empty jar → immediate re-auth.)

Automated: `npx vitest run electron/oauth-partition.test.ts electron/connection-registry.test.ts` — 113 passed, covering pending-id resolution, same-host jar isolation during pre-save login, identity resolution after a pre-save URL edit, primary/cloud/token/v1 exemptions, garbage-id fallback, and save-time id equality.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] Desktop test suite: `npx vitest run` — 8893 passed; the single failure (`managed-ssh-update.test.ts › POSIX managed launcher…`) reproduces identically on a clean `main` checkout on this machine, pre-existing and unrelated
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon)

### Documentation & Housekeeping

- [x] Documentation — N/A (module header + JSDoc updated in place)
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — partition naming/sanitization unchanged and platform-independent; Electron session partitions behave the same on Windows/macOS/Linux
- [x] Tool descriptions/schemas — N/A
