### PR TITLE
fix(cron): classify delivery failures on the error's first line only

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -302,6 +302,19 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     text = (error or "unknown error").strip()
     lower = text.lower()
 
+    # The provider branches below classify on the error's FIRST line only.
+    # Provider errors arrive as single-line ``str(exc)`` ("Error code: 401 -
+    # ...", "httpx.ReadTimeout: ..."), so the signature lives on line one.
+    # Later lines are embedded content — an OSError filename carries a whole
+    # script's source (newlines included), subprocess output gets captured
+    # into exception text, tool payloads land in tracebacks — and reading
+    # them as an error signature blames a provider that was never called
+    # (#99988: a "File name too long" crash whose embedded script contained
+    # the word "Authorization" was delivered as "provider authentication
+    # error"). ``text[:2000]`` bounds length, not position.
+    first_line = text.splitlines()[0] if text else ""
+    first_lower = first_line.lower()
+
     if "skipped to prevent unintended spend: global inference config drifted" in lower:
         if "finite one-shot job is consumed" in lower:
             remediation = (
@@ -356,14 +369,17 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Provider/API failures are the common noisy path. Keep these short.
     # Match 429 as a whole token (#83188 @cation98): bare substring matching
     # let identifiers containing those digits (job ids, ports, hashes) trip
-    # a false "provider rate limit" alert.
+    # a false "provider rate limit" alert. First-line-only for the same
+    # reason as the timeout/auth branches below (#99988).
     if provider_reachable and (
-        re.search(r"\b429\b", text) or "rate limit" in lower or "usage limit" in lower
+        re.search(r"\b429\b", first_line)
+        or "rate limit" in first_lower
+        or "usage limit" in first_lower
     ):
         reason = "rate limit"
-        if "weekly usage limit" in lower:
+        if "weekly usage limit" in first_lower:
             reason = "weekly usage limit"
-        elif "quota" in lower:
+        elif "quota" in first_lower:
             reason = "quota limit"
         return (
             f"⚠️ Cron '{job_name}' failed: provider {reason}. "
@@ -396,7 +412,9 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
         )
 
     if provider_reachable and (
-        "readtimeout" in lower or "timed out" in lower or "timeout" in lower
+        "readtimeout" in first_lower
+        or "timed out" in first_lower
+        or "timeout" in first_lower
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider timeout. "
@@ -406,9 +424,12 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
 
     # Match authentication/authorization wording at a word boundary and the
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
-    # not trip a misleading auth message.
+    # not trip a misleading auth message. First line only: an embedded
+    # payload word like a curl "Authorization" header inside a long OSError
+    # filename is script content, not a provider signature (#99988).
     if provider_reachable and (
-        re.search(r"authenticat|authoriz", lower) or re.search(r"\b(401|403)\b", text)
+        re.search(r"authenticat|authoriz", first_lower)
+        or re.search(r"\b(401|403)\b", first_line)
     ):
         return (
             f"⚠️ Cron '{job_name}' failed: provider authentication error. "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -315,6 +315,20 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     first_line = text.splitlines()[0] if text else ""
     first_lower = first_line.lower()
 
+    # An OSError's ``str()`` embeds the filename repr with newlines escaped
+    # to a literal ``\n``, so the whole payload rides on a SINGLE line and
+    # the first-line bound above cannot keep it out of the scan: the
+    # agent-path capture is ``f"{type(e).__name__}: {str(e)}"`` and
+    # ``str(OSError(63, "File name too long", script_source))`` is one line
+    # carrying every word of the embedded script, "Authorization" included
+    # (#99988 review). Provider errors come from the HTTP stack
+    # (``httpx.ReadTimeout: ...``, ``Error code: 401 - ...``), never as
+    # ``[Errno N]``, so an OSError signature line is system-level by
+    # construction — the provider branches below must not scan it.
+    oserror_signature = re.match(
+        r"^(?:[A-Za-z_][\w.]*: )?\[Errno \d+\]", first_line
+    )
+
     if "skipped to prevent unintended spend: global inference config drifted" in lower:
         if "finite one-shot job is consumed" in lower:
             remediation = (
@@ -370,8 +384,11 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # Match 429 as a whole token (#83188 @cation98): bare substring matching
     # let identifiers containing those digits (job ids, ports, hashes) trip
     # a false "provider rate limit" alert. First-line-only for the same
-    # reason as the timeout/auth branches below (#99988).
-    if provider_reachable and (
+    # reason as the timeout/auth branches below (#99988). Skipped for
+    # OSError signature lines: their single-line filename repr IS the
+    # payload, and a bare "\n429\n" inside a script's embedded source is
+    # content, not a provider status.
+    if provider_reachable and not oserror_signature and (
         re.search(r"\b429\b", first_line)
         or "rate limit" in first_lower
         or "usage limit" in first_lower
@@ -411,7 +428,11 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
             "quiet. Full details saved in cron output."
         )
 
-    if provider_reachable and (
+    # OSError signature lines are exempt even here: an OS-level connect
+    # timeout ("[Errno 110] Connection timed out") names the socket layer,
+    # not a provider response, so it falls through to the verbatim cleaner
+    # instead of claiming a fallback chain was exhausted.
+    if provider_reachable and not oserror_signature and (
         "readtimeout" in first_lower
         or "timed out" in first_lower
         or "timeout" in first_lower
@@ -426,8 +447,10 @@ def _summarize_cron_failure_for_delivery(job: dict, error: str | None) -> str:
     # 401/403 status codes as whole tokens, so "oauth", "4015" and similar do
     # not trip a misleading auth message. First line only: an embedded
     # payload word like a curl "Authorization" header inside a long OSError
-    # filename is script content, not a provider signature (#99988).
-    if provider_reachable and (
+    # filename is script content, not a provider signature (#99988) — and
+    # because OSError's filename repr keeps everything on one line, OSError
+    # signature lines are exempt from the scan entirely.
+    if provider_reachable and not oserror_signature and (
         re.search(r"authenticat|authoriz", first_lower)
         or re.search(r"\b(401|403)\b", first_line)
     ):

--- a/tests/cron/test_cron_failure_summarizer_embedded_payload.py
+++ b/tests/cron/test_cron_failure_summarizer_embedded_payload.py
@@ -1,0 +1,91 @@
+"""_summarize_cron_failure_for_delivery must classify on the error's first
+line (the exception line), never on substrings embedded in later payload
+lines.
+
+Field-reported (#99988): a monitor-job creation bug stored the whole script
+SOURCE in ``monitor_script`` (which must hold a filename), so every run died
+with ``[Errno 63] File name too long: '/home/user/.hermes/scripts/#!/bin/bash
+... Authorization: Bearer $TOKEN ...'`` — OSError embeds the whole too-long
+"filename", newlines included, and the embedded curl header's word
+"Authorization" tripped the auth substring match. The operator was delivered
+"provider authentication error" for a crash that never opened a provider
+socket and was told to debug the wrong subsystem. Replacing the single word
+"Authorization" with "Xuthorization" flipped the label — the classifier was
+reading the crashed script's own source code as an error signature.
+
+The no-agent script path already guards this class via its mode gate
+(test_no_agent_failure_never_blamed_on_a_provider); an agent-mode job's error
+text can embed the same attacker-content-shaped strings (OSError filenames,
+captured subprocess output, tool payloads in tracebacks), so the provider
+branches match the FIRST line only: provider errors arrive as single-line
+``str(exc)`` ("Error code: 401 - ...", "httpx.ReadTimeout: ..."), while
+anything on later lines is payload, not signature.
+"""
+
+from cron.scheduler import _summarize_cron_failure_for_delivery
+
+
+def _agent_job():
+    return {"name": "watch-manifest", "id": "m111", "no_agent": False}
+
+
+def test_file_name_too_long_embedding_auth_wording_not_provider_auth():
+    """#99988 replay: an OSError whose embedded filename is a whole script
+    whose source contains "Authorization" must not be labeled a provider
+    authentication error."""
+    error = (
+        "[Errno 63] File name too long: '/home/user/.hermes/scripts/#!/bin/bash\n"
+        "# watch the deployment manifest\n"
+        'TOKEN=$(curl -s "https://auth.example/token")\n'
+        'MANIFEST=$(curl -s -H "Authorization: Bearer $TOKEN" '
+        "https://registry.example/manifests/latest)"
+    )
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider authentication error" not in msg
+    assert "provider" not in msg.lower()
+    # The generic cleaner names what actually failed.
+    assert "File name too long" in msg
+
+
+def test_embedded_timeout_wording_in_payload_not_provider_timeout():
+    """A crash whose payload lines merely mention "timeout" must not be
+    rewritten into "provider timeout / fallback chain" prose."""
+    error = (
+        "OSError: [Errno 5] Input/output error: '/var/lib/hermes/state.db'\n"
+        "# retry loop: sleep 30 then retry on timeout after 30s"
+    )
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider timeout" not in msg
+    assert "fallback chain" not in msg.lower()
+    assert "Input/output error" in msg
+
+
+def test_embedded_rate_limit_wording_in_payload_not_rate_limit():
+    """A script's captured log line "HTTP 429" on a later line is payload,
+    not the crash's signature."""
+    error = (
+        "RuntimeError: script produced invalid JSON for manifest\n"
+        "upstream log: HTTP 429 Too Many Requests (backoff applied)"
+    )
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider rate limit" not in msg
+    assert "provider" not in msg.lower()
+    assert "invalid JSON" in msg
+
+
+def test_first_line_signature_in_a_multiline_error_still_classifies():
+    """Genuine provider errors can carry payload on later lines; the
+    signature on the FIRST line must still classify."""
+    error = (
+        "Error code: 429 - {'error': {'message': 'rate limit exceeded'}}\n"
+        "request-id: req_abc123\n"
+        "retry-after: 60"
+    )
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider rate limit" in msg
+
+
+def test_first_line_401_still_classifies_as_provider_auth():
+    error = "Error code: 401 - {'error': {'message': 'Invalid API key'}}"
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider authentication error" in msg

--- a/tests/cron/test_cron_failure_summarizer_embedded_payload.py
+++ b/tests/cron/test_cron_failure_summarizer_embedded_payload.py
@@ -20,6 +20,17 @@ captured subprocess output, tool payloads in tracebacks), so the provider
 branches match the FIRST line only: provider errors arrive as single-line
 ``str(exc)`` ("Error code: 401 - ...", "httpx.ReadTimeout: ..."), while
 anything on later lines is payload, not signature.
+
+One escape hatch remains for a first-line bound: ``str(OSError)`` embeds the
+filename repr with newlines escaped to a literal ``\\n``, so the ENTIRE
+payload stays on one line — ``str(OSError(63, "File name too long",
+script_source))`` is a single line carrying every word of the embedded
+script. The scheduler's capture is ``f"{type(e).__name__}: {str(e)}"``, so
+the delivered error text is that single line. OSError signature lines
+(``[Errno N]``, with or without a type-name prefix) are therefore exempt
+from the provider scan altogether: provider errors come from the HTTP
+stack and never carry ``[Errno N]``, while an OSError names the
+system/IO layer by construction (#99988 review).
 """
 
 from cron.scheduler import _summarize_cron_failure_for_delivery
@@ -89,3 +100,53 @@ def test_first_line_401_still_classifies_as_provider_auth():
     error = "Error code: 401 - {'error': {'message': 'Invalid API key'}}"
     msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
     assert "provider authentication error" in msg
+
+
+def _script_source():
+    return (
+        "#!/bin/bash\n"
+        'TOKEN=$(curl -s "https://auth.example/token")\n'
+        'MANIFEST=$(curl -s -H "Authorization: Bearer $TOKEN" '
+        "https://registry.example/manifests/latest)"
+    )
+
+
+def test_oserror_str_repr_single_line_not_provider_auth():
+    """Real ``str(OSError)`` replay: the filename repr keeps newlines
+    escaped on ONE line, so the first-line bound alone cannot keep the
+    embedded "Authorization" out of the scan — OSError signature lines are
+    exempt from the provider branches (#99988 review)."""
+    # Built from a real OSError, not hand-typed text: str(OSError) embeds
+    # the filename repr, which escapes newlines to a literal "\n".
+    error = f"OSError: {OSError(63, 'File name too long', _script_source())}"
+    # Pin the premise: this is the single-line repr form. If this ever
+    # becomes a multi-line string, the fixture stopped reproducing the
+    # reported shape and the regression it guards is gone.
+    assert len(error.splitlines()) == 1
+    assert "Authorization" in error
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider authentication error" not in msg
+    assert "provider" not in msg.lower()
+    assert "File name too long" in msg
+
+
+def test_oserror_str_without_type_prefix_same_treatment():
+    """A caller storing bare ``str(e)`` (no type-name prefix) gets the same
+    exemption: the signature is the leading ``[Errno N]`` token."""
+    error = str(OSError(63, "File name too long", _script_source()))
+    assert len(error.splitlines()) == 1
+    assert "Authorization" in error
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider" not in msg.lower()
+    assert "File name too long" in msg
+
+
+def test_oserror_connect_timeout_verbatim_not_provider_timeout():
+    """An OS-level connect timeout names the socket layer, not a provider
+    response: no "provider timeout / fallback chain exhausted" claim, the
+    verbatim error text carries the signal instead."""
+    error = "TimeoutError: [Errno 110] Connection timed out"
+    msg = _summarize_cron_failure_for_delivery(_agent_job(), error)
+    assert "provider timeout" not in msg
+    assert "fallback chain" not in msg.lower()
+    assert "Connection timed out" in msg


### PR DESCRIPTION
## What does this PR do?

`_summarize_cron_failure_for_delivery` matched its provider signatures (auth/timeout/rate-limit) against the **full** error text, so any failure whose payload embeds those words on later lines was classified by the payload instead of the cause. In #99988 a monitor job crashed with `[Errno 63] File name too long: '<whole bash script>'` — OSError embeds the entire too-long "filename", and the script's own curl header (`Authorization: Bearer $TOKEN`) tripped the auth regex, delivering **"provider authentication error"** for a crash that never touched a provider. Replacing that single word flipped the label.

The no-agent script path already guards this class via its mode gate (`test_no_agent_failure_never_blamed_on_a_provider`); this fix closes the equivalent hole for agent-mode jobs, whose error text can embed the same content-shaped strings (OSError filenames, captured subprocess output, tool payloads in tracebacks).

Provider errors arrive as single-line `str(exc)` (`"Error code: 401 - ..."`, `"httpx.ReadTimeout: ..."`), so the fix matches the provider branches' regexes/substrings against the error's **first line** (the exception line) only. Embedded content now falls through to the generic cleaner, which delivers the verbatim cleaned error — naming what actually broke. `text[:2000]` bounded length, not position; this bounds position.

## Related Issue

Fixes #99988

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cron/scheduler.py` — `_summarize_cron_failure_for_delivery`: derive `first_line`/`first_lower` and match the rate-limit, provider-timeout, and auth branches' signatures against the first line instead of the full text. The drift-skip, script-timeout (`startswith` contract), inactivity-watchdog (shape regex), and import-skew (append-only hint, guarded by a live skew probe) branches are untouched.
- `tests/cron/test_cron_failure_summarizer_embedded_payload.py` — new: #99988 replay (embedded `Authorization` in an OSError filename), embedded timeout/rate-limit wording, plus regression guards that a first-line signature in a multi-line error still classifies.

## How to Test

1. `python -m pytest tests/cron/test_cron_failure_summarizer_embedded_payload.py -q` — Observed result: 5 passed (before the fix, the three embedded-payload cases fail with "provider authentication error"/"provider timeout"/"provider rate limit" delivered).
2. `python -m pytest tests/cron/ -q` — Observed result: 1086 passed, 1 skipped (existing mode-gate, inactivity, provider-pin, and skew-hint suites unchanged).
3. `python scripts/check-windows-footguns.py --all` — should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
