### PR TITLE
fix(contributors): remove case-colliding email file; normalize filenames to lowercase

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -57,6 +57,12 @@ def _legacy_login(email: str) -> str | None:
 
 def add_contributor(email: str, login: str, comment: str = "") -> int:
     email = email.strip()
+    # Filenames are case-insensitive on Windows/NTFS and macOS/APFS: two
+    # emails differing only in letter case map to ONE file on disk while git
+    # tracks two paths — every checkout flaps the content and every rebase
+    # onto the branch fails with unstaged changes (#99966). Normalize the
+    # FILENAME to lowercase so one email = one path on every filesystem.
+    path = EMAILS_DIR / email.lower()
     login = login.strip().lstrip("@")
 
     if not _EMAIL_RE.match(email):
@@ -66,7 +72,6 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         print(f"error: {login!r} is not a valid GitHub login", file=sys.stderr)
         return 2
 
-    path = EMAILS_DIR / email
     existing = read_mapping_file(path) if path.is_file() else None
     if existing is None:
         existing = _legacy_login(email)
@@ -86,7 +91,7 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
     if comment:
         body += f"# {comment}\n"
     path.write_text(body, encoding="utf-8")
-    print(f"added: contributors/emails/{email} -> {login}")
+    print(f"added: contributors/emails/{email.lower()} -> {login}")
     return 0
 
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -2089,6 +2089,12 @@ def _load_contributor_dir(directory: "Path | None" = None) -> dict:
     Filename = commit-author email, first non-comment line = GitHub login.
     Additions never merge-conflict (each mapping is a distinct file), which
     is why new entries go here instead of the frozen LEGACY_AUTHOR_MAP.
+
+    Keys are LOWERCASED: email hosts case-flap in the wild
+    (agents-Mac-mini.local vs Agents-Mac-mini.local, #99966), and a
+    case-insensitive filesystem maps both filenames to one file while git
+    tracks two — the release lookup must see one canonical key regardless
+    of which spelling a commit carries.
     """
     directory = directory or CONTRIBUTORS_EMAILS_DIR
     mapping = {}
@@ -2101,7 +2107,7 @@ def _load_contributor_dir(directory: "Path | None" = None) -> dict:
             for line in path.read_text(encoding="utf-8").splitlines():
                 line = line.strip()
                 if line and not line.startswith("#"):
-                    mapping[path.name] = line.lstrip("@")
+                    mapping[path.name.lower()] = line.lstrip("@")
                     break
         except OSError:
             continue

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -116,3 +116,43 @@ def test_cli_entrypoint_end_to_end(tmp_path):
     assert proc.returncode == 0, proc.stderr
     out = (tmp_path / "contributors" / "emails" / "cli@example.com").read_text(encoding="utf-8")
     assert out.splitlines()[0] == "cliperson"
+
+
+# ── case-collision normalization (#99966) ─────────────────────────────
+
+
+def test_add_normalizes_email_filename_to_lowercase(emails_dir):
+    """Windows/NTFS and macOS/APFS are case-insensitive: two filenames
+    differing only in letter case map to ONE file while git tracks two
+    paths, permanently flapping checkout state and failing every rebase
+    (#99966). The writer must canonicalize to lowercase."""
+    assert add_contributor("agent@Agents-Mac-mini.local", "momomojo") == 0
+    # The canonical (lowercase) path exists...
+    assert (emails_dir / "agent@agents-mac-mini.local").is_file()
+    # ...and it is the ONLY file the write created. On case-INSENSITIVE
+    # hosts (NTFS/APFS) a case-variant path stat resolves to the same file,
+    # so the meaningful check is the directory listing: exactly one entry,
+    # spelled lowercase.
+    entries = [p.name for p in emails_dir.iterdir()]
+    assert entries == ["agent@agents-mac-mini.local"]
+
+    # Re-adding the same mapping through the OTHER case spelling is
+    # idempotent — it hits the same canonical file.
+    assert add_contributor("agent@agents-Mac-mini.local", "momomojo") == 0
+
+
+def test_loader_lowercases_keys_for_release_lookup(tmp_path):
+    """Email hosts case-flap in commit metadata; the release-time lookup
+    must resolve any spelling to one canonical entry."""
+    d = tmp_path / "emails"
+    d.mkdir()
+    (d / "jane@example.com").write_text("janedoe\n")
+    mapping = release._load_contributor_dir(d)
+    assert mapping == {"jane@example.com": "janedoe"}
+
+    # A mixed-case filename in the store still loads as lowercase, so a
+    # commit carrying the uppercase spelling resolves at release time.
+    (d / "Agent@Example.COM").write_text("someone\n")
+    mapping2 = release._load_contributor_dir(d)
+    assert "agent@example.com" in mapping2
+    assert "Agent@Example.COM" not in mapping2


### PR DESCRIPTION
Fixes #99966

## Problem

`main` carries **two tracked paths differing only in letter case**:

- `contributors/emails/agent@agents-Mac-mini.local` (content `momomojo`, added in `bb06a8d41`)
- `contributors/emails/agent@Agents-Mac-mini.local` (content `skip-agent`, added in `29112bef0`, v0.21.0)

On case-insensitive filesystems (Windows NTFS default, macOS APFS default) both map to **one file on disk**, so:

- `git status` permanently shows `modified: agent@agents-Mac-mini.local` with the content flapping `momomojo` ↔ `skip-agent` on every checkout
- **every `git rebase` / `git pull --rebase` onto current `main` fails** with `error: cannot rebase: You have unstaged changes` — including half-started rebases that wedge the repo in `rebase-merge` state; `--autostash` doesn't help because the file re-dirties during the rebase's own checkout

This bites anyone on Windows/macOS tracking `main` from source, including `hermes update` flows that rebase local branches (live-install evidence in the issue).

**Verified on this Windows checkout:** removing the uppercase twin via `git rm` simultaneously dirtied the lowercase twin's status — the exact single-inode behavior reported.

## Fix (three parts)

1. **Data**: delete the uppercase twin — the lowercase mapping predates it and `skip-agent` is a superseded duplicate of the same contributor identity (host case-flapping)
2. **Writer**: `add_contributor.py` lowercases the filename — one email = one path on every filesystem, so this class of collision can't be created again
3. **Reader**: `release.py::_load_contributor_dir` lowercases map keys, so a commit carrying either spelling of the host resolves to one canonical entry at release-attribution time

## Verification

`tests/scripts/test_contributor_map.py`: **9/9 pass**, including two new regression tests:

- writer: mixed-case email produces exactly one directory entry, spelled lowercase; re-adding via the other spelling is idempotent (assertion is directory-listing-based — the case-variant path-stat is meaningless on NTFS/APFS, which is the bug itself)
- loader: mixed-case filename in the store loads as a lowercase key