### PR TITLE
feat(cron): per-job api_max_retries override, wired end to end

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2122,6 +2122,49 @@ def _normalize_reasoning_effort(value: Any) -> Optional[str]:
     return text
 
 
+def _normalize_api_max_retries(value: Any) -> Optional[int]:
+    """Validate a per-job API retry budget at the storage choke point.
+
+    Semantics deliberately match the ``agent.api_max_retries`` config sibling
+    (``agent/agent_init.py``): an integer count of attempts per model API call,
+    clamped to ``>= 1`` (1 = a single attempt, no retry). The clamp is applied
+    here rather than at fire time so the stored record reads exactly as it
+    behaves.
+
+    Where this is STRICTER than config is the failure mode, and for the same
+    reason the reasoning-effort pin is: config falls back to the default 3 on
+    a garbage value because a human is watching the session start, while a
+    cron job is fire-and-forget — a typo that silently degraded to the default
+    at 3am would look like the pin never worked. So a non-integer raises here
+    and nothing invalid ever persists. Booleans are rejected rather than
+    coerced (``int(True) == 1``) so a YAML ``true`` cannot become a retry
+    budget.
+
+    Returns None for unset (None / empty string), which clears the pin and
+    keeps the job following ``agent.api_max_retries``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise ValueError(
+            f"Invalid api_max_retries {value!r}. Expected an integer >= 1 "
+            "(empty string clears the override)."
+        )
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return None
+        value = text
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Invalid api_max_retries {value!r}. Expected an integer >= 1 "
+            "(empty string clears the override)."
+        ) from None
+    return max(parsed, 1)
+
+
 def _compute_provider_model_snapshots(
     *,
     provider: Any,
@@ -2225,6 +2268,7 @@ def create_job(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    api_max_retries: Optional[Union[int, str]] = None,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -2292,6 +2336,17 @@ def create_job(
                 exactly like config-set effort. Inert with ``no_agent=True``
                 (no LLM call to configure). None/empty = unset (job follows
                 config resolution, pre-existing behavior).
+        api_max_retries: Optional per-job API retry budget. Overrides the
+                global ``agent.api_max_retries`` (config.yaml, default 3) for
+                this job's runs only — the number of attempts each model API
+                call gets on transient errors before the fallback-provider
+                chain engages. Clamped to ``>= 1`` (1 = single attempt, no
+                retry). Useful for a job pinned to a flaky endpoint: more
+                attempts keep it on its requested model through a transient
+                stretch instead of swapping models, without slowing failure
+                handling for every other agent and job. Inert with
+                ``no_agent=True`` (no API call to retry). None/empty = unset
+                (job follows config, pre-existing behavior).
 
     Returns:
         The created job dict
@@ -2327,6 +2382,7 @@ def create_job(
     normalized_no_agent = bool(no_agent)
     normalized_attach = attach_to_session if isinstance(attach_to_session, bool) else None
     normalized_reasoning_effort = _normalize_reasoning_effort(reasoning_effort)
+    normalized_api_max_retries = _normalize_api_max_retries(api_max_retries)
     normalized_monitor_script = str(monitor_script).strip() if isinstance(monitor_script, str) else None
     normalized_monitor_script = normalized_monitor_script or None
     normalized_monitor_url = str(monitor_url).strip() if isinstance(monitor_url, str) else None
@@ -2443,6 +2499,10 @@ def create_job(
     # absent key = job follows config resolution (pre-feature behavior).
     if normalized_reasoning_effort is not None:
         job["reasoning_effort"] = normalized_reasoning_effort
+    # Same conditional-persist rule for the per-job API retry budget: absent
+    # key = job follows agent.api_max_retries (pre-feature behavior).
+    if normalized_api_max_retries is not None:
+        job["api_max_retries"] = normalized_api_max_retries
 
     with _jobs_lock():
         jobs = load_jobs()
@@ -2556,6 +2616,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             if "reasoning_effort" in updates:
                 updates["reasoning_effort"] = _normalize_reasoning_effort(
                     updates["reasoning_effort"]
+                )
+
+            # Same choke point for the per-job API retry budget: integer >= 1,
+            # empty string (or None) clears. Invalid values raise BEFORE the
+            # merge so the stored value stays untouched.
+            if "api_max_retries" in updates:
+                updates["api_max_retries"] = _normalize_api_max_retries(
+                    updates["api_max_retries"]
                 )
 
             # Normalize repeat the same way create_job does. Callers pass

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2138,7 +2138,8 @@ def _normalize_api_max_retries(value: Any) -> Optional[int]:
     at 3am would look like the pin never worked. So a non-integer raises here
     and nothing invalid ever persists. Booleans are rejected rather than
     coerced (``int(True) == 1``) so a YAML ``true`` cannot become a retry
-    budget.
+    budget, and floats likewise (``int(3.5) == 3``) so a pin can never persist
+    a quietly different budget than the caller asked for.
 
     Returns None for unset (None / empty string), which clears the pin and
     keeps the job following ``agent.api_max_retries``.
@@ -2146,6 +2147,18 @@ def _normalize_api_max_retries(value: Any) -> Optional[int]:
     if value is None:
         return None
     if isinstance(value, bool):
+        raise ValueError(
+            f"Invalid api_max_retries {value!r}. Expected an integer >= 1 "
+            "(empty string clears the override)."
+        )
+    # Floats are rejected rather than truncated (``int(3.5) == 3``): a pin
+    # that silently persists a DIFFERENT budget than the caller asked for is
+    # the same silent degradation this normalizer exists to prevent, and the
+    # string form ("3.5") already raises. Rejecting the whole type — not just
+    # non-integral values — keeps 1.0 from passing and leaving the contract
+    # half-enforced. Only reachable via direct Python calls; the CLI hands
+    # over strings.
+    if isinstance(value, float):
         raise ValueError(
             f"Invalid api_max_retries {value!r}. Expected an integer >= 1 "
             "(empty string clears the override)."

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -672,6 +672,49 @@ def _resolve_job_reasoning_config(job: dict, cfg: dict, model: str) -> dict | No
     return resolve_reasoning_config(cfg if isinstance(cfg, dict) else {}, str(model))
 
 
+def _apply_job_api_max_retries(agent: Any, job: dict) -> None:
+    """Apply the per-job API retry budget to an already-constructed agent.
+
+    Precedence mirrors the reasoning pin above: a per-job ``api_max_retries``
+    (validated at the store choke point,
+    ``cron/jobs.py::_normalize_api_max_retries``) wins over the global
+    ``agent.api_max_retries`` that ``agent/agent_init.py`` resolved from
+    config. It is applied here, after construction, because the budget is read
+    per API call (``agent/conversation_loop.py`` reads ``_api_max_retries``),
+    so a plain attribute set is the whole wiring.
+
+    A value that no longer parses (hand-edited jobs.json) logs a warning and
+    leaves the agent default in place — a bad pin must degrade the run's retry
+    budget, never kill the tick. Absent pin is a no-op, so an unpinned job is
+    byte-identical to pre-feature behavior.
+    """
+    pinned = job.get("api_max_retries")
+    if pinned is None:
+        return
+    try:
+        if isinstance(pinned, bool):
+            raise ValueError(pinned)
+        retries = max(int(pinned), 1)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Job '%s': invalid stored api_max_retries %r — ignoring the pin "
+            "and keeping the agent default. Fix with `hermes cron edit %s "
+            "--api-max-retries <n>` (integer >= 1).",
+            job.get("id", "?"),
+            pinned,
+            job.get("id", "?"),
+        )
+        return
+    previous = getattr(agent, "_api_max_retries", None)
+    agent._api_max_retries = retries
+    logger.info(
+        "Job '%s': using per-job api_max_retries %d (agent default was %s)",
+        job.get("id", "?"),
+        retries,
+        previous,
+    )
+
+
 # Valid delivery platforms — used to validate user-supplied platform names
 # in cron delivery targets, preventing env var enumeration via crafted names.
 _KNOWN_DELIVERY_PLATFORMS = frozenset({
@@ -6463,7 +6506,11 @@ def run_job(
             session_id=_cron_session_id,
             session_db=_session_db,
         )
-        
+
+        # Per-job API retry budget: overrides agent.api_max_retries for this
+        # job's runs only. No-op when the job carries no pin.
+        _apply_job_api_max_retries(agent, job)
+
         # Run the agent with an *inactivity*-based timeout: the job can run
         # for hours if it's actively calling tools / receiving stream tokens,
         # but a hung API call or stuck tool with no activity for the configured

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -685,14 +685,16 @@ def _apply_job_api_max_retries(agent: Any, job: dict) -> None:
 
     A value that no longer parses (hand-edited jobs.json) logs a warning and
     leaves the agent default in place — a bad pin must degrade the run's retry
-    budget, never kill the tick. Absent pin is a no-op, so an unpinned job is
-    byte-identical to pre-feature behavior.
+    budget, never kill the tick. Floats are rejected here as well as at the
+    store: JSON draws no int/float distinction, so a hand-edited ``3.5`` would
+    otherwise truncate to a budget the operator never wrote. Absent pin is a
+    no-op, so an unpinned job is byte-identical to pre-feature behavior.
     """
     pinned = job.get("api_max_retries")
     if pinned is None:
         return
     try:
-        if isinstance(pinned, bool):
+        if isinstance(pinned, (bool, float)):
             raise ValueError(pinned)
         retries = max(int(pinned), 1)
     except (TypeError, ValueError):

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -702,6 +702,7 @@ def cron_create(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        api_max_retries=getattr(args, "api_max_retries", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -777,6 +778,7 @@ def cron_edit(args):
         monitor_url=getattr(args, "monitor_url", None),
         continuity=getattr(args, "continuity", None),
         reasoning_effort=getattr(args, "reasoning_effort", None),
+        api_max_retries=getattr(args, "api_max_retries", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))

--- a/hermes_cli/subcommands/cron.py
+++ b/hermes_cli/subcommands/cron.py
@@ -120,6 +120,18 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
         ),
     )
     cron_create.add_argument(
+        "--api-max-retries",
+        dest="api_max_retries",
+        help=(
+            "Pin this job's API retry budget: how many attempts each model "
+            "API call gets on transient errors before the fallback chain "
+            "engages. Integer >= 1 (1 = single attempt). Overrides "
+            "agent.api_max_retries for this job only — raise it for a job "
+            "pinned to a flaky endpoint so it stays on its requested model "
+            "instead of swapping. Omit to follow config."
+        ),
+    )
+    cron_create.add_argument(
         "--continuity",
         dest="continuity",
         action="store_const",
@@ -252,6 +264,15 @@ def build_cron_parser(subparsers, *, cmd_cron: Callable) -> None:
             "Pin this job's reasoning (thinking) effort: none, minimal, low, "
             "medium, high, xhigh, max, or ultra. Pass empty string to clear "
             "the pin and follow config resolution."
+        ),
+    )
+    cron_edit.add_argument(
+        "--api-max-retries",
+        dest="api_max_retries",
+        help=(
+            "Pin this job's API retry budget (integer >= 1). Overrides "
+            "agent.api_max_retries for this job only. Pass empty string to "
+            "clear the pin and follow config."
         ),
     )
 

--- a/tests/cron/test_cron_api_max_retries.py
+++ b/tests/cron/test_cron_api_max_retries.py
@@ -1,0 +1,430 @@
+"""Per-job api_max_retries override: producer, store contract, and the E2E
+path from a created job to the constructed agent.
+
+A cron job may pin its own API retry budget — how many attempts each model
+API call gets on transient errors before the fallback-provider chain engages
+— independent of the global ``agent.api_max_retries``. Contract under test:
+
+- Producer (``tools/cronjob_tools.py::cronjob`` create/update, reached from
+  ``hermes cron create/edit --api-max-retries``): the value is accepted,
+  validated and persisted. The model-facing surface deliberately does NOT
+  expose it (same standing policy as model/provider/reasoning_effort — models
+  do not make unattended-spend decisions), so the tool schema omits it and
+  the registry dispatch drops a hallucinated argument.
+- Job store (``cron/jobs.py``): validated at the storage choke point
+  (``_normalize_api_max_retries``) — integers clamp to >= 1, garbage raises
+  so nothing invalid ever persists for a fire-and-forget job, and an absent
+  field keeps the record byte-identical to pre-feature behavior.
+- Scheduler consumption (``cron/scheduler.py::_apply_job_api_max_retries``):
+  a pinned budget overrides the agent's config-resolved ``_api_max_retries``;
+  an absent pin is a no-op; a garbage value in a hand-edited store warns and
+  keeps the agent default instead of killing the tick.
+- End to end: a job created through the supported ``cronjob(action='create')``
+  producer, reloaded from the store, reaches the constructed agent with the
+  pinned budget on it — the wiring a raw-dict scheduler test cannot see.
+"""
+
+import json
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure project root is importable (mirrors tests/cron/test_cron_provider_pin.py).
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from cron.jobs import create_job, get_job, load_jobs, update_job
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate the cron store (same pattern as tests/cron/test_jobs.py)."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path / "cron"
+
+
+def _create(**kw):
+    kw.setdefault("prompt", "say hi")
+    kw.setdefault("schedule", "every 1h")
+    return create_job(**kw)
+
+
+class TestJobStoreApiMaxRetries:
+    def test_absent_field_not_persisted(self, tmp_cron_dir):
+        """No api_max_retries arg => the key is absent, so an existing job's
+        record shape is unchanged and the job follows agent.api_max_retries."""
+        job = _create()
+        assert "api_max_retries" not in job
+        assert load_jobs()[0].get("api_max_retries") is None
+
+    @pytest.mark.parametrize("value", [1, 2, 6, 25])
+    def test_valid_counts_stored(self, tmp_cron_dir, value):
+        job = _create(api_max_retries=value)
+        assert job["api_max_retries"] == value
+        # And it round-trips through the store.
+        assert load_jobs()[0]["api_max_retries"] == value
+
+    @pytest.mark.parametrize("raw,expected", [("6", 6), (" 4 ", 4)])
+    def test_numeric_strings_coerced(self, tmp_cron_dir, raw, expected):
+        """argparse hands the CLI a string; the store owns the coercion."""
+        assert _create(api_max_retries=raw)["api_max_retries"] == expected
+
+    @pytest.mark.parametrize("value", [0, -3])
+    def test_below_floor_clamps_to_one(self, tmp_cron_dir, value):
+        """Clamped at the store, not at fire time, so the persisted record
+        reads exactly as it behaves (1 = single attempt, no retry)."""
+        assert _create(api_max_retries=value)["api_max_retries"] == 1
+
+    @pytest.mark.parametrize("garbage", ["six", "3.5", [4], {"n": 4}])
+    def test_garbage_rejected_at_create(self, tmp_cron_dir, garbage):
+        """A fire-and-forget job must never persist a pin that silently
+        degrades to the default at 3am."""
+        with pytest.raises(ValueError):
+            _create(api_max_retries=garbage)
+        assert load_jobs() == []
+
+    @pytest.mark.parametrize("flag", [True, False])
+    def test_booleans_rejected_not_coerced(self, tmp_cron_dir, flag):
+        """int(True) == 1 would silently turn a YAML `true` into a retry
+        budget of 1 — i.e. disable retries. Reject instead."""
+        with pytest.raises(ValueError):
+            _create(api_max_retries=flag)
+
+    def test_empty_string_is_unset(self, tmp_cron_dir):
+        assert "api_max_retries" not in _create(api_max_retries="")
+
+    def test_update_sets_field(self, tmp_cron_dir):
+        job = _create()
+        updated = update_job(job["id"], {"api_max_retries": 8})
+        assert updated["api_max_retries"] == 8
+        assert load_jobs()[0]["api_max_retries"] == 8
+
+    def test_update_empty_string_clears(self, tmp_cron_dir):
+        job = _create(api_max_retries=6)
+        assert update_job(job["id"], {"api_max_retries": ""})["api_max_retries"] is None
+
+    def test_update_garbage_rejected_stored_value_untouched(self, tmp_cron_dir):
+        job = _create(api_max_retries=6)
+        with pytest.raises(ValueError):
+            update_job(job["id"], {"api_max_retries": "lots"})
+        assert load_jobs()[0]["api_max_retries"] == 6
+
+    def test_update_clamps_below_floor(self, tmp_cron_dir):
+        job = _create(api_max_retries=6)
+        assert update_job(job["id"], {"api_max_retries": 0})["api_max_retries"] == 1
+
+    def test_retries_change_does_not_trigger_snapshot_recompute(self, tmp_cron_dir):
+        """The retry budget is NOT a drift-guard axis (#44585 guard
+        unchanged): updating it alone must not touch the snapshots."""
+        job = _create()
+        before = (job.get("provider_snapshot"), job.get("model_snapshot"))
+        updated = update_job(job["id"], {"api_max_retries": 6})
+        assert (updated.get("provider_snapshot"), updated.get("model_snapshot")) == before
+
+
+class TestSchedulerAppliesJobApiMaxRetries:
+    """Contract for cron/scheduler.py::_apply_job_api_max_retries."""
+
+    def _agent(self, default=3):
+        agent = MagicMock()
+        agent._api_max_retries = default
+        return agent
+
+    def test_pin_overrides_agent_default(self):
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=3)
+        _apply_job_api_max_retries(agent, {"id": "j1", "api_max_retries": 6})
+        assert agent._api_max_retries == 6
+
+    def test_absent_pin_is_a_noop(self):
+        """An unpinned job must be byte-identical to pre-feature behavior."""
+        from cron.scheduler import _apply_job_api_max_retries
+
+        for job in ({}, {"api_max_retries": None}):
+            agent = self._agent(default=3)
+            _apply_job_api_max_retries(agent, job)
+            assert agent._api_max_retries == 3
+
+    def test_pin_can_lower_the_budget(self):
+        """A job on a hopeless endpoint can fail over faster than global."""
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=5)
+        _apply_job_api_max_retries(agent, {"id": "j2", "api_max_retries": 1})
+        assert agent._api_max_retries == 1
+
+    def test_hand_edited_garbage_warns_and_keeps_default(self, caplog):
+        """A bad pin in a hand-edited jobs.json must degrade the retry
+        budget, never kill the tick."""
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=3)
+        job = {"id": "abc123", "api_max_retries": "loads"}
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            _apply_job_api_max_retries(agent, job)
+        assert agent._api_max_retries == 3
+        assert any("loads" in r.message for r in caplog.records)
+
+    def test_hand_edited_boolean_warns_and_keeps_default(self, caplog):
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=3)
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            _apply_job_api_max_retries(agent, {"id": "b", "api_max_retries": True})
+        assert agent._api_max_retries == 3
+
+    def test_hand_edited_below_floor_clamps(self):
+        """The store clamps, but a hand-edited 0 must not disable the loop."""
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=3)
+        _apply_job_api_max_retries(agent, {"id": "z", "api_max_retries": 0})
+        assert agent._api_max_retries == 1
+
+
+def _run_persisted_job(job_id, tmp_path):
+    """Drive the real run_job path with the job as it was PERSISTED.
+
+    Returns (success, error, effective_api_max_retries) where the third value
+    is read off the agent the scheduler actually constructed — the wiring a
+    raw-dict scheduler test cannot see.
+    """
+    from cron.scheduler import run_job
+
+    job = get_job(job_id)
+    assert job is not None, "job was not persisted"
+
+    fake_db = MagicMock()
+    seen = {}
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        agent = MagicMock()
+        # The agent resolves the global default from config at construction
+        # (agent/agent_init.py); the scheduler override lands on top of it.
+        agent._api_max_retries = 3
+        agent.run_conversation.side_effect = lambda *a, **kw: (
+            seen.update(api_max_retries=agent._api_max_retries),
+            {"final_response": "ok"},
+        )[1]
+        mock_agent_cls.return_value = agent
+
+        success, _output, _final, error = run_job(job)
+
+    return success, error, seen.get("api_max_retries")
+
+
+class TestCronjobProducerEndToEnd:
+    """The reviewer-visible contract: a job created through the supported
+    producer reaches the constructed agent with its pinned retry budget."""
+
+    def test_created_job_budget_reaches_the_agent(self, tmp_cron_dir, tmp_path):
+        from tools.cronjob_tools import cronjob
+
+        out = json.loads(
+            cronjob(
+                action="create",
+                prompt="morning digest",
+                schedule="every 1h",
+                model="gpt-5-codex",
+                provider="openrouter",
+                api_max_retries=6,
+            )
+        )
+        assert out["success"] is True
+        assert out["job"]["api_max_retries"] == 6
+
+        success, error, effective = _run_persisted_job(out["job_id"], tmp_path)
+        assert success is True, error
+        assert effective == 6
+
+    def test_unpinned_created_job_keeps_agent_default(self, tmp_cron_dir, tmp_path):
+        """No pin => the agent's config-resolved budget is untouched."""
+        from tools.cronjob_tools import cronjob
+
+        out = json.loads(
+            cronjob(
+                action="create",
+                prompt="morning digest",
+                schedule="every 1h",
+                model="gpt-5-codex",
+                provider="openrouter",
+            )
+        )
+        assert out["success"] is True
+        assert "api_max_retries" not in out["job"]
+
+        success, error, effective = _run_persisted_job(out["job_id"], tmp_path)
+        assert success is True, error
+        assert effective == 3
+
+    def test_updated_job_budget_reaches_the_agent(self, tmp_cron_dir, tmp_path):
+        from tools.cronjob_tools import cronjob
+
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="morning digest",
+                schedule="every 1h",
+                model="gpt-5-codex",
+                provider="openrouter",
+            )
+        )
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                api_max_retries=9,
+            )
+        )
+        assert updated["success"] is True
+
+        success, error, effective = _run_persisted_job(created["job_id"], tmp_path)
+        assert success is True, error
+        assert effective == 9
+
+    def test_producer_rejects_garbage_and_persists_nothing(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        out = json.loads(
+            cronjob(
+                action="create",
+                prompt="morning digest",
+                schedule="every 1h",
+                api_max_retries="six",
+            )
+        )
+        assert out.get("success") is False
+        assert "api_max_retries" in out.get("error", "")
+        assert load_jobs() == []
+
+
+class TestCronjobToolApiMaxRetriesPolicy:
+    """The model tool READS the field (list surfacing) but must never WRITE
+    it: models do not make unattended-spend decisions (same standing policy
+    as model/provider/base_url/reasoning_effort). The pin is set via
+    `hermes cron create/edit --api-max-retries` only."""
+
+    def _tool_handler(self):
+        import tools.cronjob_tools as mod
+
+        return mod.registry._tools["cronjob"].handler
+
+    def test_format_job_surfaces_pin_when_set(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        _create(api_max_retries=6)
+        assert json.loads(cronjob(action="list"))["jobs"][0]["api_max_retries"] == 6
+
+    def test_format_job_surfaces_floor_pin(self, tmp_cron_dir):
+        """1 is falsy-adjacent in the sense that reviewers reach for
+        `if job.get(...)`; it must still surface."""
+        _create(api_max_retries=1)
+
+        from tools.cronjob_tools import cronjob
+
+        assert json.loads(cronjob(action="list"))["jobs"][0]["api_max_retries"] == 1
+
+    def test_format_job_omits_field_when_unset(self, tmp_cron_dir):
+        from tools.cronjob_tools import cronjob
+
+        _create()
+        assert "api_max_retries" not in json.loads(cronjob(action="list"))["jobs"][0]
+
+    def test_schema_does_not_expose_api_max_retries(self):
+        from tools.cronjob_tools import CRONJOB_SCHEMA
+
+        assert "api_max_retries" not in CRONJOB_SCHEMA["parameters"]["properties"]
+
+    def test_tool_dispatch_drops_api_max_retries_arg(self, tmp_cron_dir):
+        """Even if a model hallucinates the argument, dispatch ignores it:
+        the created job must carry NO pin."""
+        out = json.loads(
+            self._tool_handler()(
+                {
+                    "action": "create",
+                    "prompt": "daily digest",
+                    "schedule": "every 1h",
+                    "api_max_retries": 50,
+                }
+            )
+        )
+        assert out["success"] is True
+        assert load_jobs()[0].get("api_max_retries") is None
+
+    def test_tool_dispatch_cannot_raise_an_existing_pin(self, tmp_cron_dir):
+        """The update door is closed to the model too: the argument is
+        dropped before it becomes an update, so the pin is untouched."""
+        job = _create(api_max_retries=2)
+        out = json.loads(
+            self._tool_handler()(
+                {"action": "update", "job_id": job["id"], "api_max_retries": 99}
+            )
+        )
+        # Nothing the tool accepts was supplied, so there is no update to make.
+        assert out["success"] is False
+        assert load_jobs()[0]["api_max_retries"] == 2
+
+
+class TestCliProducerWiring:
+    """`hermes cron create/edit --api-max-retries` is the supported producer:
+    the flag must parse and reach cronjob()."""
+
+    def _parse(self, argv):
+        import argparse
+
+        from hermes_cli.subcommands.cron import build_cron_parser
+
+        parser = argparse.ArgumentParser()
+        sub = parser.add_subparsers(dest="command")
+        build_cron_parser(sub, cmd_cron=lambda args: 0)
+        return parser.parse_args(argv)
+
+    def test_create_flag_parses(self):
+        args = self._parse(["cron", "create", "every 1h", "ping", "--api-max-retries", "6"])
+        assert args.api_max_retries == "6"
+
+    def test_edit_flag_parses(self):
+        args = self._parse(["cron", "edit", "abc123", "--api-max-retries", "6"])
+        assert args.api_max_retries == "6"
+
+    def test_create_forwards_to_cronjob(self, tmp_cron_dir):
+        from hermes_cli.cron import cron_create
+
+        args = self._parse(["cron", "create", "every 1h", "ping", "--api-max-retries", "6"])
+        assert cron_create(args) == 0
+        assert load_jobs()[0]["api_max_retries"] == 6
+
+    def test_edit_forwards_to_cronjob(self, tmp_cron_dir):
+        from hermes_cli.cron import cron_edit
+
+        job = _create()
+        args = self._parse(["cron", "edit", job["id"], "--api-max-retries", "6"])
+        assert cron_edit(args) == 0
+        assert load_jobs()[0]["api_max_retries"] == 6
+
+    def test_edit_empty_string_clears(self, tmp_cron_dir):
+        from hermes_cli.cron import cron_edit
+
+        job = _create(api_max_retries=6)
+        args = self._parse(["cron", "edit", job["id"], "--api-max-retries", ""])
+        assert cron_edit(args) == 0
+        assert load_jobs()[0].get("api_max_retries") is None

--- a/tests/cron/test_cron_api_max_retries.py
+++ b/tests/cron/test_cron_api_max_retries.py
@@ -87,6 +87,31 @@ class TestJobStoreApiMaxRetries:
             _create(api_max_retries=garbage)
         assert load_jobs() == []
 
+    @pytest.mark.parametrize("value", [3.5, 2.999, 1.0])
+    def test_floats_rejected_not_truncated(self, tmp_cron_dir, value):
+        """A float must raise, not silently truncate.
+
+        ``int(3.5)`` is ``3``, so without an explicit guard a float pin
+        persists a DIFFERENT budget than the caller asked for — the exact
+        silent-degradation failure this normalizer exists to prevent, and
+        which the string form ``"3.5"`` is already rejected for. Reported by
+        @Enough1122: the garbage parametrization above covers only the string.
+
+        ``1.0`` is included deliberately: it round-trips through ``int()``
+        without changing value, so a truncation-only check would let it pass
+        and leave the type contract half-enforced.
+        """
+        with pytest.raises(ValueError):
+            _create(api_max_retries=value)
+        assert load_jobs() == []
+
+    def test_floats_rejected_at_update(self, tmp_cron_dir):
+        """Same guard on the update path — the stored pin stays untouched."""
+        job = _create(api_max_retries=6)
+        with pytest.raises(ValueError):
+            update_job(job["id"], {"api_max_retries": 3.5})
+        assert load_jobs()[0]["api_max_retries"] == 6
+
     @pytest.mark.parametrize("flag", [True, False])
     def test_booleans_rejected_not_coerced(self, tmp_cron_dir, flag):
         """int(True) == 1 would silently turn a YAML `true` into a retry
@@ -177,6 +202,21 @@ class TestSchedulerAppliesJobApiMaxRetries:
         with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
             _apply_job_api_max_retries(agent, {"id": "b", "api_max_retries": True})
         assert agent._api_max_retries == 3
+
+    def test_hand_edited_float_warns_and_keeps_default(self, caplog):
+        """JSON has no integer type distinction, so a hand-edited jobs.json
+        can legally carry ``3.5``. The store choke point rejects floats, but
+        this consumer reads the file directly and must not silently truncate
+        to a budget the operator never wrote — degrade to the agent default
+        and say so, matching the boolean/garbage paths.
+        """
+        from cron.scheduler import _apply_job_api_max_retries
+
+        agent = self._agent(default=3)
+        with caplog.at_level(logging.WARNING, logger="cron.scheduler"):
+            _apply_job_api_max_retries(agent, {"id": "f", "api_max_retries": 3.5})
+        assert agent._api_max_retries == 3
+        assert any("3.5" in (r.getMessage()) for r in caplog.records)
 
     def test_hand_edited_below_floor_clamps(self):
         """The store clamps, but a hand-edited 0 must not disable the loop."""

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -781,6 +781,8 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("reasoning_effort"):
         result["reasoning_effort"] = job["reasoning_effort"]
+    if job.get("api_max_retries") is not None:
+        result["api_max_retries"] = job["api_max_retries"]
     if job.get("monitor_script"):
         result["monitor_script"] = job["monitor_script"]
     if job.get("monitor_url"):
@@ -1482,6 +1484,7 @@ def cronjob(
     monitor_script: Optional[str] = None,
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
+    api_max_retries: Optional[Union[int, str]] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1592,12 +1595,14 @@ def cronjob(
                     attach_to_session=attach_to_session,
                     monitor_script=_normalize_optional_job_value(monitor_script),
                     monitor_url=_normalize_optional_job_value(monitor_url),
-                    # reasoning_effort reaches here from the CLI
-                    # (hermes cron create --reasoning-effort) ONLY — it is
-                    # deliberately absent from CRONJOB_SCHEMA and the model
-                    # dispatch below: models do not make model-config
-                    # decisions (standing policy).
+                    # reasoning_effort / api_max_retries reach here from the
+                    # CLI (hermes cron create --reasoning-effort /
+                    # --api-max-retries) ONLY — both are deliberately absent
+                    # from CRONJOB_SCHEMA and the model dispatch below: models
+                    # do not make model-config or unattended-spend decisions
+                    # (standing policy).
                     reasoning_effort=reasoning_effort,
+                    api_max_retries=api_max_retries,
                 )
             except CronSchedulerRegistrationError as exc:
                 _partial = exc.to_dict()
@@ -1814,6 +1819,10 @@ def cronjob(
                 # CLI-only lane (see create above): update_job validates
                 # against the canonical grammar; empty string clears the pin.
                 updates["reasoning_effort"] = reasoning_effort
+            if api_max_retries is not None:
+                # CLI-only lane (see create above): update_job validates the
+                # integer and clamps to >= 1; empty string clears the pin.
+                updates["api_max_retries"] = api_max_retries
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -37,6 +37,10 @@ Whichever provider a job resolves to, its provider-specific request settings (e.
 **Per-job reasoning effort.** A job can pin its own thinking level, independent of the model pin: one of `none`, `minimal`, `low`, `medium`, `high`, `xhigh`, `max`, `ultra`. When set, it overrides both the global `agent.reasoning_effort` and per-model `agent.reasoning_overrides` for that job's runs (`none` disables thinking). Set it via `hermes cron create/edit --reasoning-effort high`; pass an empty string on edit to clear the pin and follow config again. (It is deliberately not exposed on the agent's `cronjob` tool — model configuration stays a user decision.) Levels a model doesn't support are clamped or omitted by the provider at request time — pinning `xhigh` on a model that caps at `high` runs at `high`. The pin has no effect on `no_agent` jobs (there is no LLM call to tune). Use it to run heavy scheduled analyses at `high` while cheap recurring jobs run at `minimal`, without touching your global default.
 :::
 
+:::tip
+**Per-job API retry budget.** A job can pin how many attempts each model API call gets on transient errors (rate limits, connection drops, 5xx) before the [fallback-provider](/user-guide/features/fallback-providers) chain engages, overriding the global `agent.api_max_retries` for that job's runs only. Set it via `hermes cron create/edit --api-max-retries 6`; pass an empty string on edit to clear the pin and follow config again. (Like the reasoning pin, it is deliberately not exposed on the agent's `cronjob` tool — unattended spend stays a user decision.) Integers below `1` clamp to `1` (a single attempt, no retry). The pin has no effect on `no_agent` jobs (there is no API call to retry). Use it when one job is pinned to a flaky endpoint: more attempts keep that job on its requested model through a transient stretch instead of swapping models, without slowing failure handling for every other agent and job.
+:::
+
 :::warning
 Cron-run sessions cannot recursively create more cron jobs. Hermes disables cron management tools inside cron executions to prevent runaway scheduling loops.
 :::


### PR DESCRIPTION
## Problem

A cron job's API retry budget is governed solely by the global `agent.api_max_retries` (config.yaml, default 3) — the count of attempts each model API call gets on transient errors (rate limits, connection drops, 5xx) before the fallback-provider chain engages. There is no way to give a single job a different budget without changing it for **every** agent and job in the deployment.

This matters for a job pinned to a flaky endpoint. With only 3 attempts, a transient stretch of backend wedging exhausts the budget and the fallback-model chain silently swaps the job onto a different model — a scheduled digest quietly stops running on the model it was pinned to. Raising the global count to compensate slows failure handling for every other agent and job.

Verified absent on current `main`: `git grep api_max_retries origin/main -- cron/` returns nothing. `agent/agent_init.py:2092-2099` resolves `agent._api_max_retries` from config only, and `agent/conversation_loop.py:3093` reads it per API call.

## Fix

Add an optional per-job `api_max_retries` pin, plumbed through every layer the existing per-job `reasoning_effort` pin uses — so the field has a real **producer**, not just a scheduler reader.

```bash
hermes cron create "every 1h" "morning digest" --model gpt-5-codex --api-max-retries 6
hermes cron edit <job_id> --api-max-retries ""    # clear the pin, follow config again
```

- **`cron/jobs.py`** — `_normalize_api_max_retries` validates at the storage choke point: integers clamp to `>= 1` (1 = single attempt, no retry), numeric strings coerce (argparse hands the CLI a string), garbage raises. Booleans are rejected rather than coerced, since `int(True) == 1` would silently turn a YAML `true` into "no retries". `create_job` / `update_job` accept and persist it **conditionally**, so an unpinned job's record is byte-identical to before.

  The validator is deliberately stricter than the config sibling, for the same reason the reasoning pin is: config falls back to the default on a bad value because a human is watching the session start, while a cron job is fire-and-forget — a typo that silently degraded to the default at 3am would look like the pin never worked.

- **`cron/scheduler.py`** — `_apply_job_api_max_retries` applies the pin to the constructed agent, landed beside its structural sibling `_resolve_job_reasoning_config`. A value that no longer parses (hand-edited `jobs.json`) warns and keeps the agent default — a bad pin must degrade the run's retry budget, never kill the tick. An absent pin is a no-op.

- **`tools/cronjob_tools.py`** — `cronjob()` accepts it on create and update; `_format_job` surfaces it on list. It is **deliberately absent** from `CRONJOB_SCHEMA` and the registry dispatch, matching the standing policy already applied to `model` / `provider` / `base_url` / `reasoning_effort` (`tools/cronjob_tools.py:2085-2089`): models do not make unattended-spend decisions. A hallucinated argument is dropped.

- **`hermes_cli/`** — `hermes cron create/edit --api-max-retries` is the supported producer; empty string on edit clears the pin.

- **docs** — `website/docs/user-guide/features/cron.md`, beside the reasoning-effort tip.

## Tests

`tests/cron/test_cron_api_max_retries.py` — **42 tests, all pass.**

```
$ uv run pytest tests/cron/test_cron_api_max_retries.py -q
..........................................                               [100%]
42 passed in 46.65s
```

Coverage: the store contract (clamping, string coercion, boolean rejection, garbage rejection at create and through the update door, clear-on-empty, and that the pin is not a drift-guard axis so it never triggers a snapshot recompute), scheduler application (override, no-op when absent, lowering the budget, hand-edited garbage/boolean/below-floor), the model-facing policy pin, CLI flag parsing and forwarding, and an **E2E path** that creates a job through `cronjob(action='create')`, reloads it from the store with `get_job`, drives the real `run_job`, and asserts the budget on the agent the scheduler actually constructed.

That E2E test is the point: a scheduler test driving `run_job` with a raw dict cannot detect a missing producer, because the dict never goes through create/update persistence.

### RED proof

Two scoped mutations, helpers and imports left intact so nothing fails on `ImportError`:

**1. Remove only the scheduler hook** (`_apply_job_api_max_retries(agent, job)`):

```
FAILED tests/cron/test_cron_api_max_retries.py::TestCronjobProducerEndToEnd::test_created_job_budget_reaches_the_agent
FAILED tests/cron/test_cron_api_max_retries.py::TestCronjobProducerEndToEnd::test_updated_job_budget_reaches_the_agent
2 failed, 40 passed in 3.16s
```

**2. Restore the hook, remove only the producer forwards** in `cronjob()`:

```
FAILED tests/cron/test_cron_api_max_retries.py::TestCronjobProducerEndToEnd::test_created_job_budget_reaches_the_agent
FAILED tests/cron/test_cron_api_max_retries.py::TestCronjobProducerEndToEnd::test_updated_job_budget_reaches_the_agent
FAILED tests/cron/test_cron_api_max_retries.py::TestCronjobProducerEndToEnd::test_producer_rejects_garbage_and_persists_nothing
FAILED tests/cron/test_cron_api_max_retries.py::TestCliProducerWiring::test_create_forwards_to_cronjob
FAILED tests/cron/test_cron_api_max_retries.py::TestCliProducerWiring::test_edit_forwards_to_cronjob
FAILED tests/cron/test_cron_api_max_retries.py::TestCliProducerWiring::test_edit_empty_string_clears
6 failed, 36 passed in 3.05s
```

Each mutation fails a surgical, expected subset — proving the E2E tests are wired to real code on both ends, and that the store/policy tests aren't passing for the wrong reason.

### Blast radius, A/B'd against clean `main`

Both runs on a fresh worktree, `uv sync --extra all --extra dev`.

`tests/cron/`: **1121 passed, 2 failed.** Both failures (`test_scheduler_cron_session_isolation.py::test_run_job_cron_execute_code_deny_does_not_pollute_later_gateway_execute_code`, `test_script_claim_heartbeat.py::test_repeated_heartbeat_errors_cancel_after_bounded_grace`) reproduce identically on clean `origin/main` — pre-existing, unrelated to this diff.

`tests/cron` subset + all of `tests/tools/`: **281 failed, 8040 passed, 112 skipped** on this branch — and **281 failed, 8040 passed, 112 skipped** on clean `origin/main` at the same commit. Sorted failure lists diffed byte-identical (`diff` output empty). **This diff adds zero failures.**

## Notes for review

- Supersedes #39587, which added the scheduler-side read only. The review on that PR was correct: without a producer the field was reachable only by hand-editing a job record, which is the "dead code wired in without E2E proof" rejection class in AGENTS.md. This PR is a fresh, self-contained implementation of the whole path rather than a rebase, and #39587 can be closed in its favour.
- The one judgment call worth a second opinion: keeping this **off** the model-facing `cronjob` schema. I followed the existing precedent for `reasoning_effort` and the inference pins — a model raising its own retry budget on an unattended job is a spend decision. If you'd rather have it exposed to the agent, it's a schema property plus one dispatch line, and I'm happy to add it.
