### PR TITLE
fix(cli): serialize the direct-alias cache refresh against its readers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -24,6 +24,7 @@ import http.client
 import logging
 import os
 import re
+import threading
 import time
 from dataclasses import dataclass
 from typing import Any, List, NamedTuple, Optional
@@ -536,6 +537,16 @@ _BUILTIN_DIRECT_ALIASES: dict[str, DirectAlias] = {}
 # Merged dict (builtins + user config); populated by _load_direct_aliases()
 DIRECT_ALIASES: dict[str, DirectAlias] = {}
 
+# Serializes the cache's clear()+update() republish against readers. The
+# refresh cannot rebind the module attribute — callers hold this exact dict
+# (#16767) — so it empties and refills it, and a reader iterating .items()
+# across that window raises "dictionary changed size during iteration" or,
+# worse, silently observes the empty half and reports a live alias as missing.
+# Reachable from the gateway, which resolves models off the event loop via
+# asyncio.to_thread: two sessions running /model land on two threadpool
+# workers while any config write reloads the cache underneath them.
+_DIRECT_ALIAS_LOCK = threading.RLock()
+
 
 def _load_direct_aliases() -> dict[str, DirectAlias]:
     """Load direct aliases from config.yaml ``model_aliases:`` section.
@@ -660,23 +671,42 @@ def _ensure_direct_aliases() -> None:
     the module attribute. This keeps `from hermes_cli.model_switch import
     DIRECT_ALIASES` references valid in callers — rebinding would leave them
     pointing at a stale empty dict.
+
+    Held under `_DIRECT_ALIAS_LOCK` for its whole body, so a reader taking a
+    snapshot never observes the dict between the clear() and the update().
+    The config load runs inside the lock too: it is a cached read, and letting
+    two threads publish interleaved generations would defeat the point.
     """
     global _DIRECT_ALIAS_IDENTITY, _DIRECT_ALIAS_LOADED
-    identity = _direct_alias_source_identity()
-    if DIRECT_ALIASES and (
-        # Contents are not what we loaded — seeded or edited by a caller.
-        # Not ours to discard.
-        DIRECT_ALIASES != _DIRECT_ALIAS_LOADED
-        # Ours, and still the same config file at the same signature.
-        or (identity is not None and identity == _DIRECT_ALIAS_IDENTITY)
-    ):
-        return
-    loaded = _load_direct_aliases()
-    # clear()+update() rather than a rebind: callers hold this exact dict.
-    DIRECT_ALIASES.clear()
-    DIRECT_ALIASES.update(loaded)
-    _DIRECT_ALIAS_IDENTITY = identity
-    _DIRECT_ALIAS_LOADED = dict(loaded)
+    with _DIRECT_ALIAS_LOCK:
+        identity = _direct_alias_source_identity()
+        if DIRECT_ALIASES and (
+            # Contents are not what we loaded — seeded or edited by a caller.
+            # Not ours to discard.
+            DIRECT_ALIASES != _DIRECT_ALIAS_LOADED
+            # Ours, and still the same config file at the same signature.
+            or (identity is not None and identity == _DIRECT_ALIAS_IDENTITY)
+        ):
+            return
+        loaded = _load_direct_aliases()
+        # clear()+update() rather than a rebind: callers hold this exact dict.
+        DIRECT_ALIASES.clear()
+        DIRECT_ALIASES.update(loaded)
+        _DIRECT_ALIAS_IDENTITY = identity
+        _DIRECT_ALIAS_LOADED = dict(loaded)
+
+
+def _direct_alias_snapshot() -> dict[str, DirectAlias]:
+    """Refresh the cache, then return a stable copy of one whole generation.
+
+    Readers must not scan DIRECT_ALIASES directly: a refresh on another thread
+    mutates it in place, and iterating across that raises. Copying under the
+    lock gives the caller a dict nobody else writes to, so its own lookups stay
+    consistent for as long as it holds it.
+    """
+    with _DIRECT_ALIAS_LOCK:
+        _ensure_direct_aliases()
+        return dict(DIRECT_ALIASES)
 
 
 def direct_alias_api_key(alias: DirectAlias) -> str:
@@ -1258,16 +1288,21 @@ def resolve_alias(
     """
     key = raw_input.strip().lower()
 
+    # One snapshot for both lookups below: a refresh on another thread
+    # republishes DIRECT_ALIASES in place, so re-reading it between the exact
+    # match and the reverse scan can straddle two generations — and iterating
+    # it live raises "dictionary changed size during iteration".
+    direct_aliases = _direct_alias_snapshot()
+
     # Check direct aliases first (exact model+provider+base_url mappings)
-    _ensure_direct_aliases()
-    direct = DIRECT_ALIASES.get(key)
+    direct = direct_aliases.get(key)
     if direct is not None:
         return (direct.provider, direct.model, key)
 
     # Reverse lookup: match by model ID so full names (e.g. "kimi-k2.5",
     # "glm-4.7") route through direct aliases instead of falling through
     # to the catalog/OpenRouter.
-    for alias_name, da in DIRECT_ALIASES.items():
+    for alias_name, da in direct_aliases.items():
         if da.model.lower() == key:
             return (da.provider, da.model, alias_name)
 
@@ -2121,8 +2156,7 @@ def switch_model(
 
     # --- Direct alias override: use exact base_url from the alias if set ---
     if resolved_alias:
-        _ensure_direct_aliases()
-        _da = DIRECT_ALIASES.get(resolved_alias)
+        _da = _direct_alias_snapshot().get(resolved_alias)
         if _da is not None and _da.base_url:
             # Credentials above were resolved against the DEFAULT provider.
             # Carrying that key onto the alias's endpoint both 401s and ships

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -411,8 +411,9 @@ def _run_agent(
             # endpoints not in any catalog (local servers, custom proxies, etc.).
             try:
                 from hermes_cli import model_switch as _ms
-                _ms._ensure_direct_aliases()
-                direct = _ms.DIRECT_ALIASES.get(explicit_model.strip().lower())
+                direct = _ms._direct_alias_snapshot().get(
+                    explicit_model.strip().lower()
+                )
             except Exception:
                 direct = None
             if direct is not None:

--- a/tests/hermes_cli/test_direct_alias_concurrency.py
+++ b/tests/hermes_cli/test_direct_alias_concurrency.py
@@ -1,0 +1,162 @@
+"""``DIRECT_ALIASES`` is refreshed in place while readers scan it.
+
+``_ensure_direct_aliases`` republishes the cache with ``clear()`` + ``update()``
+whenever the config identity moves, and ``resolve_alias`` iterates the same dict
+(``for alias_name, da in DIRECT_ALIASES.items()``) on every alias miss. Nothing
+serialized the two, so a concurrent refresh could:
+
+* raise ``RuntimeError: dictionary changed size during iteration`` out of the
+  reverse-model scan, and
+* answer ``None`` for an alias that exists in *every* generation, because a
+  reader can land in the window between ``clear()`` and ``update()`` — the
+  silent half, which no exception ever reports and which a ``try/except``
+  around the scan would leave fully intact.
+
+Both are reachable from the gateway, which resolves models off the event loop
+(``asyncio.to_thread``), so ``/model`` on two sessions runs the reader on two
+threadpool workers while any config write reloads the cache underneath them.
+
+Republishing by rebinding the module attribute would be atomic and need no
+lock, but callers hold this exact dict (#16767) — so the refresh has to empty
+and refill it, and the two steps have to be serialized against readers instead.
+"""
+
+import threading
+
+import pytest
+
+import hermes_cli.model_switch as ms
+from hermes_cli.model_switch import DirectAlias
+
+
+# A key that is in DIRECT_ALIASES for every generation the refresher publishes.
+STABLE_ALIAS = "zz-stable-alias"
+# A key in neither DIRECT_ALIASES nor MODEL_ALIASES: forces resolve_alias all
+# the way through the reverse-model scan, then straight out. A HIT would return
+# from the .get() fast path and never reach the iteration under test.
+MISSING_ALIAS = "zz-deliberate-miss"
+
+# The two generations differ in SIZE, not just contents: a same-size rewrite
+# often skips the resize that makes the iteration raise.
+SMALL, LARGE = 400, 900
+
+# Enough of each to interleave; one-vs-one frequently does not.
+READERS = REFRESHERS = 3
+RUN_SECONDS = 3.0
+
+
+def _generation(count: int) -> dict:
+    aliases = {
+        f"zz-alias-{i}": DirectAlias(f"zz-model-{i}", "custom", "")
+        for i in range(count)
+    }
+    aliases[STABLE_ALIAS] = DirectAlias("zz-stable-model", "custom", "")
+    return aliases
+
+
+@pytest.fixture
+def contended_alias_cache(monkeypatch):
+    """Point the loader at two alternating generations, reloading every call.
+
+    ``_direct_alias_source_identity`` returning ``None`` means "source unknown,
+    do not reuse the cache" — exactly the refresh-on-every-call shape the race
+    needs, without depending on a real config file's mtime granularity.
+    """
+    monkeypatch.setattr(ms, "DIRECT_ALIASES", {})
+    monkeypatch.setattr(ms, "_DIRECT_ALIAS_IDENTITY", None)
+    monkeypatch.setattr(ms, "_DIRECT_ALIAS_LOADED", None)
+    monkeypatch.setattr(ms, "_direct_alias_source_identity", lambda: None)
+
+    generations = (_generation(SMALL), _generation(LARGE))
+    counter = [0]
+
+    def _alternating_load():
+        counter[0] += 1
+        return dict(generations[counter[0] % 2])
+
+    monkeypatch.setattr(ms, "_load_direct_aliases", _alternating_load)
+    ms._ensure_direct_aliases()
+    return generations
+
+
+def _run_contended(reader):
+    """Drive *reader* on several threads against a refresher storm.
+
+    Returns whatever the reader threads raised. Exceptions are collected and
+    re-asserted on the main thread: one raised inside a ``Thread`` target is
+    otherwise just printed, and the test passes green.
+    """
+    errors = []
+    stop = threading.Event()
+
+    def _guard(fn):
+        def _loop():
+            try:
+                while not stop.is_set():
+                    fn()
+            except BaseException as exc:  # noqa: BLE001 - re-raised from main
+                errors.append(exc)
+                stop.set()
+
+        return _loop
+
+    threads = [
+        threading.Thread(target=_guard(reader), daemon=True)
+        for _ in range(READERS)
+    ]
+    threads += [
+        threading.Thread(target=_guard(ms._ensure_direct_aliases), daemon=True)
+        for _ in range(REFRESHERS)
+    ]
+    for thread in threads:
+        thread.start()
+    # `stop` doubles as the early exit: the first failure ends the run.
+    stop.wait(RUN_SECONDS)
+    stop.set()
+    for thread in threads:
+        thread.join(timeout=10)
+    return errors
+
+
+def test_reader_survives_a_concurrent_refresh(contended_alias_cache):
+    """The reverse-model scan must not raise while the cache is republished."""
+    errors = _run_contended(lambda: ms.resolve_alias(MISSING_ALIAS, "custom"))
+
+    assert not errors, f"{type(errors[0]).__name__}: {errors[0]}"
+
+
+def test_reader_never_sees_a_half_published_cache(contended_alias_cache):
+    """An alias present in every generation must never resolve to None.
+
+    The silent half of the race: no exception, the caller is just told the
+    alias does not exist and falls through to the default provider.
+    """
+
+    def _resolve_stable():
+        if ms.resolve_alias(STABLE_ALIAS, "custom") is None:
+            raise AssertionError(
+                f"{STABLE_ALIAS!r} resolved to None during a refresh: the "
+                "reader observed the cache between clear() and update()"
+            )
+
+    errors = _run_contended(_resolve_stable)
+
+    assert not errors, f"{type(errors[0]).__name__}: {errors[0]}"
+
+
+def test_snapshot_holds_one_whole_generation(contended_alias_cache):
+    """Each snapshot is one published generation, never a mix of two."""
+    small, large = contended_alias_cache
+    valid = ({*small}, {*large})
+
+    def _snapshot():
+        keys = {*ms._direct_alias_snapshot()}
+        if keys not in valid:
+            raise AssertionError(
+                f"snapshot held {len(keys)} keys, matching neither the "
+                f"{len(small)}-entry nor the {len(large)}-entry generation"
+            )
+
+    errors = _run_contended(_snapshot)
+
+    assert not errors, f"{type(errors[0]).__name__}: {errors[0]}"


### PR DESCRIPTION
## The bug

`hermes_cli/model_switch.py` refreshes the process-global `DIRECT_ALIASES` cache in place, and `resolve_alias` iterates that same dict on every alias miss. Nothing serializes the two.

The writer, `_ensure_direct_aliases` (`model_switch.py:656`), republishes whenever the config's identity moves:

```python
loaded = _load_direct_aliases()
# clear()+update() rather than a rebind: callers hold this exact dict.
DIRECT_ALIASES.clear()
DIRECT_ALIASES.update(loaded)
```

The reader, `resolve_alias` (`model_switch.py:1270`), scans it:

```python
for alias_name, da in DIRECT_ALIASES.items():
    if da.model.lower() == key:
```

Two distinct defects fall out of that window:

1. **The loud one** — a refresh landing mid-scan raises `RuntimeError: dictionary changed size during iteration` out of `/model`.
2. **The silent one** — a reader arriving between the `clear()` and the `update()` observes an empty cache and reports a live alias as **missing**. Nothing raises and nothing logs; the caller just falls through to the default provider, which for a URL-bearing alias means the request goes somewhere the user did not ask for. A `try/except RuntimeError` around the scan would leave this half completely intact.

It is reachable in the gateway, which resolves models off the event loop via `asyncio.to_thread` — two sessions running `/model` execute the reader on two threadpool workers, while any config write reloads the cache underneath them.

## RED proof

The new test reproduces defect 1 on the unfixed tree:

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_direct_alias_concurrency.py::test_reader_survives_a_concurrent_refresh -q -o addopts=""
E       AssertionError: RuntimeError: dictionary changed size during iteration
E       assert not [RuntimeError('dictionary changed size during iteration')]
1 failed in 0.31s
```

The reproduction needs three things, all of which the test does deliberately: look up a key that **misses** (a hit returns from the `.get()` fast path and never reaches the iteration), alternate two generations of **different size** (a same-size rewrite often skips the resize that raises), and run several threads per side (one-vs-one rarely interleaves).

## The fix

Rebinding the module attribute would publish atomically and need no lock at all, but callers hold this exact dict — that is what `#16767` is about, and two existing tests pin it (`test_ensure_direct_aliases_mutates_in_place`, `test_cache_is_still_mutated_in_place`). So the refresh has to keep emptying and refilling the dict, and the two steps get serialized against readers instead:

- `_DIRECT_ALIAS_LOCK` (an `RLock`, since the snapshot helper calls the loader while holding it) wraps the whole `_ensure_direct_aliases` body, so the clear/update window is never observable.
- `_direct_alias_snapshot()` refreshes and returns a copy under that lock — a dict nobody else writes to.
- The three readers take one snapshot rather than touching the live dict: `resolve_alias`, the alias override in `switch_model`, and the `model_aliases` lookup in `hermes_cli/oneshot.py`.

`resolve_alias` needs the snapshot for a reason beyond the exception: its exact-match `.get()` and its reverse scan would otherwise be two separate reads that can straddle two generations.

## Discriminating RED — each half gates a distinct defect

Reverting only the lock (leaving the snapshot helper and the reader rewrites in place) still fails, on the silent half:

```
E  AssertionError: 'zz-stable-alias' resolved to None during a refresh:
   the reader observed the cache between clear() and update()
1 failed, 2 passed
```

Reverting only the reader rewrite (leaving the lock in place) fails both:

```
E  AssertionError: RuntimeError: dictionary changed size during iteration
E  AssertionError: 'zz-stable-alias' resolved to None during a refresh: ...
2 failed, 1 passed
```

So neither half is decoration, and the tests are gating the actual change rather than an incidental timing shift.

## Verification

Hermetic env via `uv sync --extra all --extra dev` in a clean worktree off `main` (`21b2095d00`).

New tests, with the fix:

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_direct_alias_concurrency.py -q -o addopts=""
3 passed in 15.67s
```

The suites that own this code:

```
$ .venv/bin/python -m pytest tests/hermes_cli/test_direct_alias_concurrency.py \
    tests/hermes_cli/test_model_alias_credentials_83612.py \
    tests/hermes_cli/test_ollama_cloud_auth.py \
    tests/hermes_cli/test_regression_16767.py \
    tests/hermes_cli/test_models.py -q -o addopts=""
164 passed in 29.10s
```

The whole of `tests/hermes_cli` (758 files, run per-file with a 180s cap because `test_cmd_update.py` hangs), against **the same run on a pristine `main` worktree** as the control:

```
non-zero on branch:   12
non-zero on baseline: 12
REGRESSIONS (fail on branch, pass on pristine main): 0
```

All 12 are inherited and identical on both trees (`test_approval_transport`, `test_auth_commands`, `test_cmd_update` timeout, `test_relaunch`, `test_relay_shared_metrics_runtime`, `test_runtime_provider_resolution`, `test_subparser_routing_fallback`, and five `test_update_*`), with matching pass/fail counts file for file.

Cross-package consumers of these readers — `tests/test_tui_gateway_server.py`, `tests/tools/test_delegate.py`, `tests/tools/test_oneshot_completion_linger.py`: `1 failed, 724 passed`. That one failure (`test_model_options_preserves_canonical_custom_row_after_agent_init`) reproduces identically on pristine `main`, so it is inherited too.

`ruff check` passes on all three files. `ty check` reports the same 32 diagnostics on the two touched production files before and after; the new test file adds none.
