### PR TITLE
fix(config): preserve .env ownership across rewrites

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -9,10 +9,8 @@ import os
 import platform
 import re
 import shutil
-import stat
 import subprocess
 import sys
-import tempfile
 import threading
 import time
 import unicodedata
@@ -30,7 +28,7 @@ from hermes_cli.default_soul import DEFAULT_SOUL_MD, is_legacy_template_soul
 from hermes_cli.secret_prompt import masked_secret_prompt
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F401
-from utils import atomic_replace, atomic_yaml_write, fast_safe_load
+from utils import atomic_write_text, atomic_yaml_write, fast_safe_load
 
 logger = logging.getLogger(__name__)
 
@@ -2441,34 +2439,19 @@ def _read_env_lines(env_path: Path) -> list:
 
 
 def _write_env_lines(env_path: Path, lines: list, *, preserve_mode: bool) -> None:
-    """Atomically replace ``.env`` (tmp file + fsync + rename).
-    ``preserve_mode`` keeps the original file mode (e.g. 0640 for Docker volume mounts) instead of
-    letting ``_secure_file`` tighten to 0600; a new file is always secured."""
-    original_mode = None
-    try:
-        original_mode = stat.S_IMODE(env_path.stat().st_mode) if preserve_mode else None
-    except OSError:
-        pass
-    fd, tmp_path = tempfile.mkstemp(dir=str(env_path.parent), suffix=".tmp", prefix=".env_")
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as f:
-            f.writelines(lines)
-            f.flush()
-            os.fsync(f.fileno())
-        atomic_replace(tmp_path, env_path)
-    except BaseException:
-        try:
-            os.unlink(tmp_path)
-        except OSError:
-            pass
-        raise
-    if original_mode is not None:
-        try:
-            os.chmod(env_path, original_mode)
-        except OSError:
-            pass
-    else:
-        _secure_file(env_path)
+    """Atomically replace ``.env`` without changing an existing file's owner.
+
+    ``preserve_mode=False`` still preserves ownership during the swap, then
+    tightens permissions to 0600.  New files are always secured.
+    """
+    existed = env_path.exists()
+    atomic_write_text(
+        env_path,
+        "".join(lines),
+        preserve_mode=preserve_mode and existed,
+        preserve_owner=existed,
+        create_mode=0o600,
+    )
 
 
 def _check_non_ascii_credential(key: str, value: str) -> str:

--- a/tests/hermes_cli/test_env_write_metadata.py
+++ b/tests/hermes_cli/test_env_write_metadata.py
@@ -1,0 +1,36 @@
+import os
+from pathlib import Path
+
+from hermes_cli import config
+import utils
+
+
+def test_env_rewrite_publishes_secure_mode_and_preserves_owner(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("OLD=1\n", encoding="utf-8")
+    os.chmod(env_path, 0o644)
+    original = env_path.stat()
+    chowns = []
+    real_fchown = os.fchown
+    monkeypatch.setattr(
+        utils.os, "fchown",
+        lambda fd, uid, gid: (chowns.append((uid, gid)), real_fchown(fd, uid, gid))[1],
+    )
+
+    config._write_env_lines(env_path, ["NEW=2\n"], preserve_mode=False)
+
+    rewritten = env_path.stat()
+    assert env_path.read_text(encoding="utf-8") == "NEW=2\n"
+    assert rewritten.st_mode & 0o777 == 0o600
+    assert (rewritten.st_uid, rewritten.st_gid) == (original.st_uid, original.st_gid)
+    assert chowns == [(original.st_uid, original.st_gid)]
+
+    os.chmod(env_path, 0o640)
+    config._write_env_lines(env_path, ["NEW=3\n"], preserve_mode=True)
+    assert env_path.stat().st_mode & 0o777 == 0o640
+
+    new_path = tmp_path / "new.env"
+    config._write_env_lines(new_path, ["TOKEN=x\n"], preserve_mode=True)
+    assert new_path.stat().st_mode & 0o777 == 0o600

--- a/utils.py
+++ b/utils.py
@@ -175,24 +175,40 @@ def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
 
 
 def _atomic_write(path: Path, write, *, prefix: str, encoding: str = "utf-8", mode: "int | None" = None, preserve_owner: bool = True) -> None:
-    """Temp file + fsync + :func:`atomic_replace`, then re-apply owner/mode.
+    """Temp file + fsync + :func:`atomic_replace`, preserving metadata atomically.
 
-    *write(f)* emits the payload into the open text handle. *mode* is fchmod'd onto the temp fd
-    BEFORE the replace so the target never transits through mkstemp's 0600 (fchmod is Unix-only;
-    the post-replace chmod is the sole path on Windows). The temp file is removed on any failure —
-    ``BaseException`` on purpose, so KeyboardInterrupt / SystemExit still clean up.
+    The temp stays at ``mkstemp``'s owner-only mode while content is incomplete.
+    Owner and mode are applied to its open descriptor after the payload is
+    complete but before fsync + replace; unsupported platforms fall back to
+    post-replace metadata restoration.
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     original_owner = _preserve_file_owner(path) if preserve_owner else None
     fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), prefix=prefix, suffix=".tmp")
+    owner_applied = mode_applied = False
     try:
         with os.fdopen(fd, "w", encoding=encoding) as f:
-            if mode is not None and hasattr(os, "fchmod"):
-                os.fchmod(f.fileno(), mode)
             write(f)
             f.flush()
+            if original_owner is not None and hasattr(os, "fchown"):
+                try:
+                    os.fchown(f.fileno(), original_owner[0], original_owner[1])
+                    owner_applied = True
+                except (OSError, NotImplementedError):
+                    pass
+            if mode is not None and hasattr(os, "fchmod"):
+                try:
+                    os.fchmod(f.fileno(), mode)
+                    mode_applied = True
+                except (OSError, NotImplementedError):
+                    pass
             os.fsync(f.fileno())
-        _restore_file_metadata(Path(atomic_replace(tmp_path, path)), original_owner, mode)  # symlink-preserving
+        real_path = Path(atomic_replace(tmp_path, path))
+        _restore_file_metadata(
+            real_path,
+            None if owner_applied else original_owner,
+            None if mode_applied else mode,
+        )
     except BaseException:
         with suppress(OSError):
             os.unlink(tmp_path)
@@ -206,15 +222,18 @@ def _mode_for_write(path: Path, create_mode: "int | None", preserve: bool = True
 
 
 def atomic_write_text(path: Union[str, Path], content: str, *, encoding: str = "utf-8", tmp_prefix: str = ".tmp_",
-                      preserve_mode: bool = False, create_mode: "int | None" = None) -> None:
+                      preserve_mode: bool = False, create_mode: "int | None" = None,
+                      preserve_owner: "bool | None" = None) -> None:
     """Write *content* to *path* via temp file + fsync + atomic rename.
 
     The target is never left partially written on crash/interrupt. Shared by every destructive
     file rewrite (memory store, skill manager, agent importer, ...).
     """
     path = Path(path)
+    if preserve_owner is None:
+        preserve_owner = preserve_mode
     _atomic_write(path, lambda f: f.write(content), prefix=tmp_prefix, encoding=encoding,
-                  mode=_mode_for_write(path, create_mode, preserve=preserve_mode), preserve_owner=preserve_mode)
+                  mode=_mode_for_write(path, create_mode, preserve=preserve_mode), preserve_owner=preserve_owner)
 
 
 def atomic_json_write(path: Union[str, Path], data: Any, *, indent: int = 2, mode: int | None = None, **dump_kwargs: Any) -> None:


### PR DESCRIPTION
## Summary

- Route the shared `_write_env_lines()` helper in `hermes_cli/config.py` through `atomic_write_text()` instead of its bespoke temporary-file replacement code.
- Preserve an existing `.env` owner's UID/GID independently of mode preservation using explicit `preserve_owner=existed`.
- Preserve the existing mode when requested; otherwise publish owner-only mode (`0600`). New files use `0600`.
- Extend `atomic_write_text()` with an optional `preserve_owner` argument. Omitting it retains the existing behavior tied to `preserve_mode`.
- Keep temporary files owner-only while content is incomplete. Apply ownership and mode after flushing the complete payload, before fsync and replacement where supported; retain best-effort post-replace fallbacks.
- Add `tests/hermes_cli/test_env_write_metadata.py` for ownership, secure-mode publication, and keeping incomplete temporary content private.

## Problem

An elevated rewrite can replace a service-owned `.env` with a file owned by the writing process, preventing the service from reading its credentials. This change addresses the shared config-writing helper and preserves ownership without forcing preservation of a less restrictive existing mode.

## Review follow-up

Static inspection of the current `hermes_cli/config.py` found no remaining name references to the removed `stat`, `tempfile`, or `atomic_replace` imports. The earlier automated review described the pre-refactor implementation; the current change targets `_write_env_lines()` rather than three separate writer implementations.

## Validation for the current revision

Current head: `0bc6d33f695ce0e504afc87310d62ff382ead1a8`.

The commands below have been updated to paths present at this head. They are **commands to run, not new passing results**. Tests, lint, and compilation were not rerun as part of this description-only update. Previously reported pass counts and root E2E results belong to earlier validation and must not be treated as evidence for this head.

```bash
scripts/run_tests.sh tests/hermes_cli/test_env_write_metadata.py tests/hermes_cli/test_config.py tests/test_atomic_write_text_metadata.py tests/test_atomic_replace_symlinks.py
ruff check hermes_cli/config.py tests/hermes_cli/test_env_write_metadata.py utils.py
python -m py_compile hermes_cli/config.py tests/hermes_cli/test_env_write_metadata.py utils.py
git diff --check
```

At the latest status check, this head had no check runs or commit-status results. The repository requires `All required checks pass`, which is not yet satisfied; absence of results is not a confirmed test failure. Full-suite success is not claimed. Earlier local full-suite collection was blocked by the optional ACP dependency.

## Related work

PR #17221 addressed the broader class by proposing parent-owner propagation in every atomic replacement and was closed after official Docker entrypoints began dropping privileges before writes. This change is narrower: it preserves the owner of an existing `.env` for the canonical config writers, including elevated invocations outside that official container path, using the metadata-preservation primitive already present on current `main`.
