### PR TITLE
feat(plugins): add generic gateway message policy contracts

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3808,6 +3808,35 @@ class BasePlatformAdapter(ABC):
                     self.name, plugin_name, exc, exc_info=True,
                 )
 
+    def _plugin_marks_control_message(self, event: MessageEvent) -> bool:
+        """Classify a plugin-owned event before any text coalescing."""
+
+        cached = getattr(event, "_hermes_plugin_control_message", None)
+        if isinstance(cached, bool):
+            return cached
+        source = getattr(event, "source", None)
+        platform = (
+            getattr(source, "platform", None)
+            or getattr(self, "platform", None)
+            or getattr(self, "_platform", None)
+        )
+        try:
+            from hermes_cli.plugins import is_gateway_control_message
+
+            claimed = is_gateway_control_message(
+                platform=_platform_name(platform),
+                event=event,
+            )
+        except Exception:
+            logger.warning(
+                "[%s] Plugin control-message classification failed",
+                self.name,
+                exc_info=True,
+            )
+            claimed = False
+        setattr(event, "_hermes_plugin_control_message", bool(claimed))
+        return bool(claimed)
+
     @property
     def name(self) -> str:
         """Human-readable name for this adapter."""
@@ -6294,6 +6323,45 @@ class BasePlatformAdapter(ABC):
 
         # Check if there's already an active handler for this session
         if session_key in self._active_sessions:
+            # A plugin control message must reach pre_gateway_dispatch as one
+            # intact event. Dispatch it inline without merging it into ordinary
+            # pending text; the claiming plugin is responsible for returning a
+            # skip directive before any agent work starts.
+            if self._plugin_marks_control_message(event):
+                self._discard_text_debounce(session_key)
+                logger.debug(
+                    "[%s] Plugin control message bypassing active-session queue for %s",
+                    self.name,
+                    session_key,
+                )
+                try:
+                    response = await self._message_handler(event)
+                    text, ephemeral_ttl = self._unwrap_ephemeral(response)
+                    if text:
+                        thread_meta = _thread_metadata_for_source(
+                            event.source, _reply_anchor_for_event(event)
+                        )
+                        result = await self._send_with_retry(
+                            chat_id=event.source.chat_id,
+                            content=text,
+                            reply_to=_reply_anchor_for_event(event),
+                            metadata=_mark_notify_metadata(thread_meta),
+                        )
+                        if ephemeral_ttl > 0 and result.success and result.message_id:
+                            self._schedule_ephemeral_delete(
+                                chat_id=event.source.chat_id,
+                                message_id=result.message_id,
+                                ttl_seconds=ephemeral_ttl,
+                            )
+                except Exception as exc:
+                    logger.error(
+                        "[%s] Plugin control-message dispatch failed: %s",
+                        self.name,
+                        exc,
+                        exc_info=True,
+                    )
+                return
+
             # Certain commands must bypass the active-session guard and be
             # dispatched directly to the gateway runner.  Without this, they
             # are queued as pending messages and either:

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -235,7 +235,7 @@ class ThreadParticipationTracker:
 
     _MAX_TRACKED = 500
 
-    def __init__(self, platform_name: str, max_tracked: int = 500):
+    def __init__(self, platform_name: str, max_tracked: int | None = 500):
         self._platform = platform_name
         self._max_tracked = max_tracked
         self._threads: dict[str, None] = {
@@ -260,7 +260,7 @@ class ThreadParticipationTracker:
     def _save(self) -> None:
         path = self._state_path()
         thread_list = list(self._threads)
-        if len(thread_list) > self._max_tracked:
+        if self._max_tracked and len(thread_list) > self._max_tracked:
             thread_list = thread_list[-self._max_tracked:]
             self._threads = dict.fromkeys(thread_list)
         atomic_json_write(path, thread_list, indent=None)
@@ -270,6 +270,11 @@ class ThreadParticipationTracker:
         if thread_id not in self._threads:
             self._threads[thread_id] = None
             self._save()
+
+    def ids(self) -> tuple[str, ...]:
+        """Return a stable snapshot of all persistently tracked IDs."""
+
+        return tuple(self._threads)
 
     def __contains__(self, thread_id: str) -> bool:
         return thread_id in self._threads

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18156,12 +18156,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not is_internal:
             self._scale_to_zero_note_real_inbound()
 
+        # Compute the ordinary authorization result once. The hook receives the
+        # immutable decision before enforcement, so an ingest plugin may still
+        # deliberately consume unauthorized input without duplicating private
+        # allowlist logic or triggering the pairing flow.
+        is_authorized = (
+            True
+            if is_internal
+            else self._is_user_authorized_for_source(source)
+        )
+
         # Fire pre_gateway_dispatch plugin hook for user-originated messages.
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
         #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
+        # Hook runs before auth enforcement so plugins can inspect the cached
+        # authorization decision without causing a second policy lookup.
         # (e.g. customer handover ingest) without triggering the pairing flow.
         if not is_internal:
             try:
@@ -18174,6 +18185,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # object.__new__ without __init__ (pitfall #17), and the
                     # hook must not fail dispatch over a missing attribute.
                     session_store=getattr(self, "session_store", None),
+                    adapter=self._adapter_for_source(source),
+                    is_authorized=is_authorized,
                 )
             except Exception as _hook_exc:
                 logger.warning("pre_gateway_dispatch invocation failed: %s", _hook_exc)
@@ -18209,10 +18222,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # chat-scoped allowlist (e.g. TELEGRAM_GROUP_ALLOWED_CHATS
             # authorizes every member of the listed chat regardless of
             # sender). Defer to _is_user_authorized so that path runs.
-            if not self._is_user_authorized_for_source(source):
+            if not is_authorized:
                 logger.debug("Ignoring message with no user_id from %s", source.platform.value)
                 return None
-        elif not self._is_user_authorized_for_source(source):
+        elif not is_authorized:
             logger.warning("Unauthorized user: %s (%s) on %s", source.user_id, source.user_name, source.platform.value)
             # In DMs: offer pairing code. In groups: silently ignore.
             if (

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -226,13 +226,29 @@ VALID_HOOKS: Set[str] = {
     "subagent_start",
     "subagent_stop",
     # Gateway pre-dispatch hook. Fired once per incoming MessageEvent
-    # after the internal-event guard but BEFORE auth/pairing and agent
-    # dispatch. Plugins may return a dict to influence flow:
+    # after the internal-event guard and the core authorization decision, but
+    # BEFORE auth enforcement/pairing and agent dispatch. Plugins may return a
+    # dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
     #   {"action": "allow"}  /  None             -> normal dispatch
-    # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
+    # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store,
+    # adapter: BasePlatformAdapter, is_authorized: bool.
     "pre_gateway_dispatch",
+    # Synchronous gateway message policy boundaries. These callbacks must stay
+    # fast and must not return awaitables: adapters call them before message
+    # coalescing and while reconstructing conversational history.
+    #
+    # gateway_control_message receives ``platform`` and ``event``. Returning
+    # True (or {"control": True}) keeps the event intact and lets it bypass an
+    # active session's pending-message merge. A claiming plugin must consume
+    # the event from pre_gateway_dispatch.
+    "gateway_control_message",
+    # gateway_history_message receives normalized platform/message/source
+    # metadata. Returning True (or {"exclude": True}) omits that message from
+    # reconstructed agent context. Callback errors fail closed for the one
+    # message so a known control record cannot leak into the LLM prompt.
+    "gateway_history_message",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.
@@ -396,6 +412,8 @@ VALID_HOOKS: Set[str] = {
 # Support for a shell response shape can lift an event out of this set.
 SHELL_UNSUPPORTED_HOOKS: Set[str] = {
     "transform_api_error_classification",
+    "gateway_control_message",
+    "gateway_history_message",
 }
 
 # Timeout coverage is an allowlist for the agent-turn hot path, not every
@@ -414,6 +432,10 @@ SHELL_UNSUPPORTED_HOOKS: Set[str] = {
 #   - pre_gateway_dispatch — policy gate (skip/rewrite/allow). Abandoning is
 #     unsafe either way (fail-open skips auth-like checks; fail-closed can
 #     drop legitimate messages). Prefer finish-or-exception fallthrough.
+#   - gateway_control_message / gateway_history_message — caller-thread,
+#     synchronous adapter policy. Async returns are rejected explicitly;
+#     callbacks must remain cheap because these run before coalescing and while
+#     reconstructing history.
 #   - pre_approval_request / post_approval_response — observers only (cannot
 #     veto); the approval UX already has its own timeout; not on the tool
 #     loop hot path.
@@ -1486,6 +1508,16 @@ class PluginContext:
             if key == plugin_id or loaded.manifest.name == plugin_id:
                 return True
         return False
+
+    def supports_hook(self, hook_name: str) -> bool:
+        """Return whether this host implements an official hook contract.
+
+        Unknown hooks remain registerable for forward compatibility, so
+        plugins that require a real fire site should probe with this method
+        before activating functionality that must fail closed.
+        """
+
+        return isinstance(hook_name, str) and hook_name in VALID_HOOKS
 
     # -- namespaced config and durable state --------------------------------
 
@@ -5899,6 +5931,59 @@ class PluginManager:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
 
+    def should_exclude_gateway_history_message(self, **kwargs: Any) -> bool:
+        """Apply synchronous history filters, failing closed per message."""
+
+        payload = dict(kwargs)
+        payload.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        for callback in self._hooks.get("gateway_history_message", []):
+            try:
+                result = self._invoke_hook_callback(callback, payload)
+                if inspect.isawaitable(result):
+                    if inspect.iscoroutine(result):
+                        result.close()
+                    raise TypeError(
+                        "gateway_history_message callbacks must be synchronous"
+                    )
+                if result is True or (
+                    isinstance(result, Mapping) and result.get("exclude") is True
+                ):
+                    return True
+            except Exception as exc:
+                logger.warning(
+                    "History filter callback %s raised; excluding message: %s",
+                    getattr(callback, "__name__", repr(callback)),
+                    exc,
+                )
+                return True
+        return False
+
+    def is_gateway_control_message(self, **kwargs: Any) -> bool:
+        """Return whether a plugin claims an intact pre-dispatch event."""
+
+        payload = dict(kwargs)
+        payload.setdefault("telemetry_schema_version", OBSERVER_SCHEMA_VERSION)
+        for callback in self._hooks.get("gateway_control_message", []):
+            try:
+                result = self._invoke_hook_callback(callback, payload)
+                if inspect.isawaitable(result):
+                    if inspect.iscoroutine(result):
+                        result.close()
+                    raise TypeError(
+                        "gateway_control_message callbacks must be synchronous"
+                    )
+                if result is True or (
+                    isinstance(result, Mapping) and result.get("control") is True
+                ):
+                    return True
+            except Exception as exc:
+                logger.warning(
+                    "Gateway control-message callback %s raised: %s",
+                    getattr(callback, "__name__", repr(callback)),
+                    exc,
+                )
+        return False
+
     def iter_hook_callbacks(self, hook_name: str) -> tuple[Callable, ...]:
         """Return a stable snapshot of callbacks registered for a hook."""
         return tuple(self._hooks.get(hook_name, ()))
@@ -6513,6 +6598,18 @@ def has_hook(hook_name: str) -> bool:
     :func:`has_middleware` (tracking #64178).
     """
     return _delivery_manager().has_hook(hook_name)
+
+
+def should_exclude_gateway_history_message(**kwargs: Any) -> bool:
+    """Return whether plugin policy excludes one reconstructed message."""
+
+    return _delivery_manager().should_exclude_gateway_history_message(**kwargs)
+
+
+def is_gateway_control_message(**kwargs: Any) -> bool:
+    """Return whether a plugin owns one intact pre-dispatch event."""
+
+    return _delivery_manager().is_gateway_control_message(**kwargs)
 
 
 def iter_hook_callbacks(hook_name: str) -> tuple[Callable, ...]:

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1116,7 +1116,10 @@ class DiscordAdapter(BasePlatformAdapter):
         # Track threads where the bot has participated so follow-up messages
         # in those threads don't require @mention.  Persisted to disk so the
         # set survives gateway restarts.
-        self._threads = ThreadParticipationTracker("discord")
+        # Keep the complete durable Discord participation inventory. Plugins
+        # can process it in bounded batches, but a fixed recent-N cache would
+        # make older still-relevant threads undiscoverable after installation.
+        self._threads = ThreadParticipationTracker("discord", max_tracked=None)
         # Persistent typing indicator loops per channel (DMs don't reliably
         # show the standard typing gateway event for bots)
         self._typing_tasks: Dict[str, asyncio.Task] = {}
@@ -1179,6 +1182,136 @@ class DiscordAdapter(BasePlatformAdapter):
         # Mirrors the Telegram #58563 fix. Entries are dropped on finalize.
         self._last_overflow_preview: Dict[tuple, str] = {}
         self._warned_fail_closed_default = False
+
+    # ------------------------------------------------------------------
+    # Public plugin integration surface
+    # ------------------------------------------------------------------
+
+    def participating_thread_ids(self) -> tuple[str, ...]:
+        """Return the durable Discord participation snapshot."""
+
+        return self._threads.ids()
+
+    async def validate_delivery_target(self, channel_id: str) -> Dict[str, Any]:
+        """Validate that this bot can view and send to one Discord target."""
+
+        client = getattr(self, "_client", None)
+        if client is None or getattr(client, "user", None) is None:
+            return {"ok": False, "error": "Discord client is not connected"}
+        try:
+            target = client.get_channel(int(channel_id))
+            if target is None:
+                fetch_channel = getattr(client, "fetch_channel", None)
+                if callable(fetch_channel):
+                    target = await fetch_channel(int(channel_id))
+            if target is None:
+                return {"ok": False, "error": "Discord channel not found"}
+
+            guild = getattr(target, "guild", None)
+            member = getattr(guild, "me", None) or client.user
+            permissions_for = getattr(target, "permissions_for", None)
+            if callable(permissions_for):
+                permissions = permissions_for(member)
+                can_view = bool(
+                    getattr(permissions, "view_channel", False)
+                    or getattr(permissions, "read_messages", False)
+                )
+                can_send = bool(getattr(permissions, "send_messages", False))
+                if self._get_parent_channel_id(target) is not None:
+                    can_send = can_send or bool(
+                        getattr(permissions, "send_messages_in_threads", False)
+                    )
+                if not can_view or not can_send:
+                    return {
+                        "ok": False,
+                        "error": "Discord bot lacks view/send permission",
+                    }
+            if not callable(getattr(target, "send", None)):
+                return {"ok": False, "error": "Discord target cannot receive messages"}
+            return {
+                "ok": True,
+                "channel_id": str(getattr(target, "id", channel_id)),
+            }
+        except Exception as exc:
+            return {"ok": False, "error": type(exc).__name__}
+
+    async def resolve_thread_metadata(
+        self,
+        thread_id: str,
+        *,
+        include_activity_history: bool = True,
+    ) -> Dict[str, Any]:
+        """Resolve one Discord thread without returning message content."""
+
+        client = getattr(self, "_client", None)
+        if client is None:
+            return {"accessible": False, "thread_id": str(thread_id)}
+        try:
+            channel = client.get_channel(int(thread_id))
+            if channel is None:
+                fetch_channel = getattr(client, "fetch_channel", None)
+                if callable(fetch_channel):
+                    channel = await fetch_channel(int(thread_id))
+            parent_id = self._get_parent_channel_id(channel) if channel is not None else None
+            if channel is None or parent_id is None:
+                return {"accessible": False, "thread_id": str(thread_id)}
+
+            guild = getattr(channel, "guild", None)
+            auto_archive_minutes = getattr(channel, "auto_archive_duration", None)
+            created_at = getattr(channel, "created_at", None)
+            last_discord_activity_at = None
+            last_message_id = getattr(channel, "last_message_id", None)
+            if last_message_id:
+                try:
+                    candidate = discord.utils.snowflake_time(int(last_message_id))
+                    if isinstance(candidate, dt.datetime):
+                        last_discord_activity_at = candidate
+                except Exception:
+                    pass
+            if last_discord_activity_at is None:
+                last_discord_activity_at = created_at
+
+            # Inspect only author IDs and timestamps. The bounded scan never
+            # exposes or returns message content.
+            last_hermes_activity_at = None
+            history = getattr(channel, "history", None)
+            if include_activity_history and callable(history):
+                try:
+                    bot_id = getattr(getattr(client, "user", None), "id", None)
+                    async for message in history(limit=100, oldest_first=False):
+                        if getattr(getattr(message, "author", None), "id", None) == bot_id:
+                            last_hermes_activity_at = getattr(message, "created_at", None)
+                            break
+                except Exception:
+                    last_hermes_activity_at = None
+            if last_hermes_activity_at is None:
+                # Durable participation proves Hermes engaged at some point;
+                # created_at is a conservative lower bound when that message is
+                # outside the bounded scan.
+                last_hermes_activity_at = created_at
+
+            archive_at = None
+            if isinstance(last_discord_activity_at, dt.datetime) and auto_archive_minutes:
+                archive_at = last_discord_activity_at + dt.timedelta(
+                    minutes=int(auto_archive_minutes)
+                )
+            if getattr(channel, "archived", False):
+                archive_at = getattr(channel, "archive_timestamp", None) or archive_at
+
+            return {
+                "accessible": True,
+                "thread_id": str(getattr(channel, "id", thread_id)),
+                "scope_id": str(getattr(guild, "id", "") or "") or None,
+                "parent_channel_id": str(parent_id),
+                "thread_name": str(getattr(channel, "name", "") or "") or None,
+                "last_discord_activity_at": last_discord_activity_at,
+                "last_hermes_activity_at": last_hermes_activity_at,
+                "archived": bool(getattr(channel, "archived", False)),
+                "auto_archive_minutes": auto_archive_minutes,
+                "archive_at": archive_at,
+            }
+        except Exception:
+            return {"accessible": False, "thread_id": str(thread_id)}
 
     def _config_value(
         self, key: str, default: Any, *, env_key: Optional[str] = None
@@ -2617,6 +2750,11 @@ class DiscordAdapter(BasePlatformAdapter):
                 scanned += 1
                 message_id = str(getattr(message, "id", ""))
                 self._record_discord_message_seen(message, status="discovered")
+                if self._plugin_excludes_history_message(message):
+                    self._record_discord_message_seen(message, status="excluded")
+                    channel_id, _thread_id, _parent_id = self._message_channel_ids(message)
+                    self._advance_discord_recovery_cursor(channel_id, message_id)
+                    continue
                 # A live gateway event may race this REST scan. Check without
                 # claiming the ID; the shared ingress helper owns the dedup
                 # write immediately before normal auth/filter dispatch.
@@ -2846,6 +2984,8 @@ class DiscordAdapter(BasePlatformAdapter):
     async def _should_backfill_discord_message(self, message: Any) -> bool:
         """Return True when a recent Discord message still needs Hermes work."""
         if not self._client or not getattr(self._client, "user", None):
+            return False
+        if self._plugin_excludes_history_message(message):
             return False
         if getattr(getattr(message, "author", None), "id", None) == getattr(self._client.user, "id", None):
             return False
@@ -3357,7 +3497,12 @@ class DiscordAdapter(BasePlatformAdapter):
         """Add an in-progress reaction and record durable handling state."""
         message = event.raw_message
         acked = False
-        if self._reactions_enabled() and hasattr(message, "add_reaction"):
+        plugin_managed = self._plugin_marks_control_message(event)
+        if (
+            not plugin_managed
+            and self._reactions_enabled()
+            and hasattr(message, "add_reaction")
+        ):
             acked = await self._add_reaction(message, "👀")
         await asyncio.to_thread(
             self._record_discord_processing_start,
@@ -3372,6 +3517,8 @@ class DiscordAdapter(BasePlatformAdapter):
             event,
             outcome,
         )
+        if self._plugin_marks_control_message(event):
+            return
         if not self._reactions_enabled():
             return
         message = event.raw_message
@@ -6912,6 +7059,63 @@ class DiscordAdapter(BasePlatformAdapter):
         except (ValueError, TypeError):
             return 50
 
+    def _plugin_excludes_history_message(self, message: Any) -> bool:
+        """Apply generic plugin policy to one Discord history message."""
+
+        channel = getattr(message, "channel", None)
+        channel_id = str(getattr(channel, "id", "") or "")
+        parent_id = self._get_parent_channel_id(channel)
+        is_thread = parent_id is not None
+        guild = getattr(message, "guild", None) or getattr(channel, "guild", None)
+        author = getattr(message, "author", None)
+        author_id = str(getattr(author, "id", "") or "")
+        client = getattr(self, "_client", None)
+        self_user = getattr(client, "user", None) if client is not None else None
+        author_is_self = bool(
+            self_user is not None
+            and getattr(author, "id", None) == getattr(self_user, "id", None)
+        )
+        author_is_bot = bool(getattr(author, "bot", False))
+        author_is_authorized = None
+        if author_id and not author_is_bot:
+            try:
+                author_is_authorized = self._is_sender_authorized(
+                    author_id,
+                    chat_type="dm" if guild is None else ("thread" if is_thread else "group"),
+                    chat_id=channel_id,
+                )
+            except Exception:
+                author_is_authorized = None
+        try:
+            from hermes_cli.plugins import should_exclude_gateway_history_message
+
+            return should_exclude_gateway_history_message(
+                platform="discord",
+                message_id=str(getattr(message, "id", "") or ""),
+                content=(
+                    getattr(message, "clean_content", None)
+                    or getattr(message, "content", "")
+                    or ""
+                ),
+                chat_type="dm" if guild is None else ("thread" if is_thread else "group"),
+                chat_id=channel_id,
+                thread_id=channel_id if is_thread else None,
+                parent_chat_id=parent_id,
+                scope_id=str(getattr(guild, "id", "") or "") or None,
+                author_id=author_id or None,
+                author_is_bot=author_is_bot,
+                author_is_self=author_is_self,
+                author_is_authorized=author_is_authorized,
+            )
+        except Exception:
+            logger.warning(
+                "[%s] Plugin history boundary failed; excluding Discord message %s",
+                self.name,
+                getattr(message, "id", "unknown"),
+                exc_info=True,
+            )
+            return True
+
     async def _fetch_channel_context(
         self,
         channel: Any,
@@ -6982,6 +7186,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 if (
                     str(getattr(msg, "id", "")) in self._nonconversational_messages
                     or _looks_like_nonconversational_history_message(content)
+                    or self._plugin_excludes_history_message(msg)
                 ):
                     return None
                 # Respect DISCORD_ALLOW_BOTS for other bots.  For history
@@ -7048,6 +7253,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 if (
                     str(getattr(msg, "id", "")) in self._nonconversational_messages
                     or _looks_like_nonconversational_history_message(_content)
+                    or self._plugin_excludes_history_message(msg)
                 ):
                     continue
                 # Stop at our own (conversational) message — this is the
@@ -8550,7 +8756,9 @@ class DiscordAdapter(BasePlatformAdapter):
         if message.reference:
             reply_to_id = str(message.reference.message_id)
             if message.reference.resolved:
-                reply_to_text = getattr(message.reference.resolved, "content", None) or None
+                resolved_reply = message.reference.resolved
+                if not self._plugin_excludes_history_message(resolved_reply):
+                    reply_to_text = getattr(resolved_reply, "content", None) or None
 
         event = MessageEvent(
             text=event_text,
@@ -8580,6 +8788,7 @@ class DiscordAdapter(BasePlatformAdapter):
             not recovered
             and msg_type == MessageType.TEXT
             and self._text_batch_delay_seconds > 0
+            and not self._plugin_marks_control_message(event)
         ):
             self._enqueue_text_event(event)
         else:

--- a/tests/gateway/test_base_topic_sessions.py
+++ b/tests/gateway/test_base_topic_sessions.py
@@ -70,6 +70,26 @@ def _make_event(chat_id: str, thread_id: str, message_id: str = "1") -> MessageE
 class TestBasePlatformTopicSessions:
 
     @pytest.mark.asyncio
+    async def test_plugin_control_message_bypasses_busy_session_without_merging(self):
+        adapter = DummyTelegramAdapter()
+        handler = AsyncMock(return_value=None)
+        adapter.set_message_handler(handler)
+        event = _make_event("-1001", "17585", message_id="control")
+        session_key = build_session_key(event.source)
+        active_guard = asyncio.Event()
+        adapter._active_sessions[session_key] = active_guard
+
+        with patch(
+            "hermes_cli.plugins.is_gateway_control_message",
+            return_value=True,
+        ):
+            await adapter.handle_message(event)
+
+        handler.assert_awaited_once_with(event)
+        assert adapter._pending_messages == {}
+        assert adapter._active_sessions[session_key] is active_guard
+
+    @pytest.mark.asyncio
     async def test_handle_message_interrupts_same_topic(self, monkeypatch):
         adapter = DummyTelegramAdapter()
         adapter.set_message_handler(lambda event: asyncio.sleep(0, result=None))
@@ -198,4 +218,3 @@ class TestTelegramAutoTtsCaptionDelivery:
                 "metadata": {"thread_id": "17585", "notify": True},
             }
         ]
-

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -8,6 +8,7 @@ import sys
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import ProcessingOutcome
 
 
 def _ensure_discord_mock():
@@ -333,6 +334,54 @@ async def test_fetch_channel_context_stops_at_self_message_and_reverses_to_chron
         "[Gemini [bot]] latest bot note\n"
         "[Alice] latest human note"
     )
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_applies_plugin_history_exclusion(adapter, monkeypatch):
+    adapter.config.extra["history_backfill_limit"] = 10
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    channel = FakeHistoryChannel(
+        [
+            make_history_message(author=human, content="keep me", msg_id=4),
+            make_history_message(author=human, content="!c", msg_id=3),
+        ],
+        channel_id=123,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.plugins.should_exclude_gateway_history_message",
+        lambda **kwargs: kwargs["message_id"] == "3",
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger")
+    )
+
+    assert "keep me" in result
+    assert "!c" not in result
+
+
+@pytest.mark.asyncio
+async def test_fetch_channel_context_fails_closed_when_plugin_boundary_breaks(adapter, monkeypatch):
+    adapter.config.extra["history_backfill_limit"] = 10
+    human = SimpleNamespace(id=56, display_name="Alice", name="Alice", bot=False)
+    channel = FakeHistoryChannel(
+        [make_history_message(author=human, content="candidate", msg_id=3)],
+        channel_id=123,
+    )
+
+    def broken(**_kwargs):
+        raise RuntimeError("plugin manager unavailable")
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.should_exclude_gateway_history_message",
+        broken,
+    )
+
+    result = await adapter._fetch_channel_context(
+        channel, before=make_message(channel=channel, content="trigger")
+    )
+
+    assert result == ""
 
 
 @pytest.mark.asyncio
@@ -827,3 +876,29 @@ async def test_discord_reply_in_free_channel_triggers_backfill(adapter, monkeypa
     )
 
 
+@pytest.mark.asyncio
+async def test_plugin_control_message_owns_discord_reaction_lifecycle(adapter):
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(),
+        remove_reaction=AsyncMock(),
+    )
+    event = SimpleNamespace(raw_message=raw_message)
+    adapter._plugin_marks_control_message = MagicMock(return_value=True)
+    adapter._record_discord_processing_start = MagicMock()
+    adapter._record_discord_processing_complete = MagicMock()
+    adapter._add_reaction = AsyncMock(return_value=True)
+    adapter._remove_reaction = AsyncMock(return_value=True)
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    adapter._record_discord_processing_start.assert_called_once_with(
+        event,
+        emoji_ack=False,
+    )
+    adapter._record_discord_processing_complete.assert_called_once_with(
+        event,
+        ProcessingOutcome.FAILURE,
+    )
+    adapter._add_reaction.assert_not_awaited()
+    adapter._remove_reaction.assert_not_awaited()

--- a/tests/gateway/test_discord_missed_message_backfill.py
+++ b/tests/gateway/test_discord_missed_message_backfill.py
@@ -140,6 +140,17 @@ async def test_configured_bot_sender_is_left_for_shared_ingress_policy(adapter, 
 
 
 @pytest.mark.asyncio
+async def test_plugin_excluded_message_never_enters_recovery_dispatch(adapter, monkeypatch):
+    message = make_message(message_id=73, content="!c")
+    monkeypatch.setattr(
+        "hermes_cli.plugins.should_exclude_gateway_history_message",
+        lambda **kwargs: kwargs["message_id"] == "73",
+    )
+
+    assert await adapter._should_backfill_discord_message(message) is False
+
+
+@pytest.mark.asyncio
 async def test_should_not_backfill_message_with_non_down_bot_response(adapter):
     bot_reply = SimpleNamespace(
         id=2,
@@ -456,5 +467,4 @@ async def test_iter_candidates_keeps_latest_messages_when_window_exceeds_limit(a
         got.append(msg.id)
 
     assert got == [2, 3, 4]
-
 

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -244,6 +244,27 @@ class TestReplyToText:
         assert event.reply_to_message_id is None
         assert event.reply_to_text is None
 
+    @pytest.mark.asyncio
+    async def test_plugin_excluded_reference_keeps_id_but_drops_reply_text(
+        self, reply_text_adapter, monkeypatch
+    ):
+        resolved_msg = SimpleNamespace(
+            id=555,
+            content="✅ 종료됨\n명령: control list",
+        )
+        ref = SimpleNamespace(message_id=555, resolved=resolved_msg)
+        message = _make_message(reference=ref)
+        monkeypatch.setattr(
+            "hermes_cli.plugins.should_exclude_gateway_history_message",
+            lambda **kwargs: kwargs["message_id"] == "555",
+        )
+
+        await reply_text_adapter._handle_message(message)
+
+        event = reply_text_adapter.handle_message.await_args.args[0]
+        assert event.reply_to_message_id == "555"
+        assert event.reply_to_text is None
+
 
     @pytest.mark.asyncio
     async def test_reference_with_empty_resolved_content(self, reply_text_adapter):

--- a/tests/gateway/test_discord_thread_persistence.py
+++ b/tests/gateway/test_discord_thread_persistence.py
@@ -6,7 +6,11 @@ being persisted to ~/.hermes/discord_threads.json.
 
 import json
 import os
-from unittest.mock import patch
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
 
 
 class TestDiscordThreadPersistence:
@@ -47,4 +51,82 @@ class TestDiscordThreadPersistence:
         assert "aaa" in adapter2._threads
         assert "bbb" in adapter2._threads
 
+    def test_public_snapshot_is_unbounded_for_discord(self, tmp_path):
+        adapter = self._make_adapter(tmp_path)
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            adapter._threads.mark("111")
+            adapter._threads.mark("222")
+
+        assert adapter._threads._max_tracked is None
+        assert adapter.participating_thread_ids() == ("111", "222")
+
+    @pytest.mark.asyncio
+    async def test_lightweight_metadata_refresh_skips_message_history(self):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        created_at = datetime(2026, 8, 1, tzinfo=timezone.utc)
+
+        class FakeThread:
+            id = 123
+            parent_id = 456
+            guild = SimpleNamespace(id=789)
+            name = "Tracked"
+            last_message_id = None
+            auto_archive_duration = 10080
+            archived = False
+
+            def __init__(self):
+                self.created_at = created_at
+                self.history_calls = 0
+
+            def history(self, **_kwargs):
+                self.history_calls += 1
+
+                async def messages():
+                    if False:
+                        yield None
+
+                return messages()
+
+        channel = FakeThread()
+        adapter = object.__new__(DiscordAdapter)
+        adapter._client = SimpleNamespace(
+            user=SimpleNamespace(id=1),
+            get_channel=lambda _thread_id: channel,
+        )
+
+        metadata = await adapter.resolve_thread_metadata(
+            "123", include_activity_history=False
+        )
+
+        assert metadata["accessible"] is True
+        assert metadata["parent_channel_id"] == "456"
+        assert metadata["last_hermes_activity_at"] == created_at
+        assert channel.history_calls == 0
+
+    @pytest.mark.asyncio
+    async def test_delivery_target_validation_checks_permissions_and_send(self):
+        from plugins.platforms.discord.adapter import DiscordAdapter
+
+        target = SimpleNamespace(
+            id=999,
+            guild=SimpleNamespace(me=SimpleNamespace(id=1)),
+            parent_id=None,
+            send=AsyncMock(),
+            permissions_for=lambda _member: SimpleNamespace(
+                view_channel=True,
+                read_messages=True,
+                send_messages=True,
+            ),
+        )
+        adapter = object.__new__(DiscordAdapter)
+        adapter._client = SimpleNamespace(
+            user=SimpleNamespace(id=1),
+            get_channel=lambda _channel_id: target,
+        )
+
+        assert await adapter.validate_delivery_target("999") == {
+            "ok": True,
+            "channel_id": "999",
+        }
 

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -118,3 +118,24 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
     adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_hook_receives_cached_authorization_decision_and_public_adapter(monkeypatch):
+    observed = {}
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            observed.update(kwargs)
+            return [{"action": "skip", "reason": "probe"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner._is_user_authorized_for_source = MagicMock(return_value=True)
+
+    await runner._handle_message(_make_event("hi"))
+
+    assert observed["is_authorized"] is True
+    assert observed["adapter"] is adapter
+    runner._is_user_authorized_for_source.assert_called_once()

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -9,7 +9,7 @@ Telegram and Feishu.
 """
 
 import asyncio
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -58,6 +58,18 @@ def _make_discord_adapter():
 
 
 class TestDiscordTextBatching:
+    def test_plugin_policy_can_keep_control_event_out_of_batch(self):
+        adapter = _make_discord_adapter()
+        event = _make_event("!c", Platform.DISCORD)
+
+        with patch(
+            "hermes_cli.plugins.is_gateway_control_message",
+            return_value=True,
+        ) as boundary:
+            assert adapter._plugin_marks_control_message(event) is True
+
+        boundary.assert_called_once_with(platform="discord", event=event)
+
     @pytest.mark.asyncio
     async def test_single_message_dispatched_after_delay(self):
         adapter = _make_discord_adapter()
@@ -272,5 +284,4 @@ class TestFeishuAdaptiveDelay:
 
         await asyncio.sleep(0.15)
         adapter._handle_message_with_guards.assert_called_once()
-
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1585,6 +1585,17 @@ class TestThreadToolWhitelist:
 class TestPluginContext:
     """Tests for the PluginContext facade."""
 
+    def test_supports_hook_distinguishes_real_host_contracts(self):
+        manager = PluginManager()
+        context = PluginContext(
+            PluginManifest(name="probe", source="user"),
+            manager,
+        )
+
+        assert context.supports_hook("pre_gateway_dispatch") is True
+        assert context.supports_hook("gateway_control_message") is True
+        assert context.supports_hook("future_unimplemented_hook") is False
+
 
 
 
@@ -2324,3 +2335,59 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestGatewayMessagePolicyHooks:
+    def test_history_filter_excludes_explicit_result_and_fails_closed(self, caplog):
+        manager = PluginManager()
+        manager._hooks["gateway_history_message"] = [
+            lambda message_id: {"exclude": message_id == "1"}
+        ]
+
+        assert manager.should_exclude_gateway_history_message(message_id="1") is True
+        assert manager.should_exclude_gateway_history_message(message_id="2") is False
+
+        def broken(**_kwargs):
+            raise RuntimeError("ledger unavailable")
+
+        manager._hooks["gateway_history_message"] = [broken]
+        with caplog.at_level(logging.WARNING):
+            assert manager.should_exclude_gateway_history_message(message_id="3") is True
+        assert "excluding message" in caplog.text
+
+    def test_async_history_filter_is_rejected_fail_closed(self, caplog):
+        manager = PluginManager()
+
+        async def invalid_filter(**_kwargs):
+            return False
+
+        manager._hooks["gateway_history_message"] = [invalid_filter]
+        with caplog.at_level(logging.WARNING):
+            assert manager.should_exclude_gateway_history_message(message_id="1") is True
+        assert "must be synchronous" in caplog.text
+
+    def test_control_classifier_claims_only_explicit_result_and_fails_open(self, caplog):
+        manager = PluginManager()
+        manager._hooks["gateway_control_message"] = [
+            lambda **_kwargs: {"control": True}
+        ]
+        assert manager.is_gateway_control_message(message_id="1") is True
+
+        def broken(**_kwargs):
+            raise RuntimeError("parser unavailable")
+
+        manager._hooks["gateway_control_message"] = [broken]
+        with caplog.at_level(logging.WARNING):
+            assert manager.is_gateway_control_message(message_id="2") is False
+        assert "control-message callback" in caplog.text
+
+    def test_async_control_classifier_is_rejected_without_claiming(self, caplog):
+        manager = PluginManager()
+
+        async def invalid_classifier(**_kwargs):
+            return True
+
+        manager._hooks["gateway_control_message"] = [invalid_classifier]
+        with caplog.at_level(logging.WARNING):
+            assert manager.is_gateway_control_message(message_id="1") is False
+        assert "must be synchronous" in caplog.text

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -910,6 +910,22 @@ override check).
 
 ### Register multiple hooks
 
+Plugins that require a particular host fire site can probe it before
+activating fail-closed functionality:
+
+```python
+def register(ctx):
+    required = ("pre_gateway_dispatch", "gateway_control_message")
+    missing = [name for name in required if not ctx.supports_hook(name)]
+    if missing:
+        raise RuntimeError(f"Hermes host is missing hooks: {', '.join(missing)}")
+```
+
+`ctx.supports_hook(name)` reports official hooks implemented by the running
+host. This is intentionally different from `register_hook()`, which continues
+to accept unknown names so a plugin can be installed on an older host without
+failing during discovery.
+
 ```python
 def register(ctx):
     ctx.register_hook("pre_tool_call", before_any_tool)
@@ -936,6 +952,9 @@ Each hook is documented in full on the **[Event Hooks reference](/user-guide/fea
 | [`on_session_end`](/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit | `session_id: str, completed: bool, interrupted: bool, model: str, platform: str` | ignored |
 | [`on_session_finalize`](/user-guide/features/hooks#on_session_finalize) | CLI/gateway tears down an active session | `session_id: str \| None, platform: str` | ignored |
 | [`on_session_reset`](/user-guide/features/hooks#on_session_reset) | Gateway swaps in a new session key (`/new`, `/reset`) | `session_id: str, platform: str` | ignored |
+| [`pre_gateway_dispatch`](/user-guide/features/hooks#pre_gateway_dispatch) | After the gateway computes authorization but before it enforces auth/pairing or starts an agent | `event, gateway, session_store, adapter, is_authorized: bool` | optional `skip` / `rewrite` / `allow` directive |
+| [`gateway_control_message`](/user-guide/features/hooks#gateway_control_message) | Before adapter text batching or busy-session merging | `platform: str, event: MessageEvent` | synchronous `True` / `{"control": true}` claims the intact event |
+| [`gateway_history_message`](/user-guide/features/hooks#gateway_history_message) | Before a platform history message enters reconstructed agent context | normalized message, author, chat, and authorization fields | synchronous `True` / `{"exclude": true}` omits the message |
 | [`gateway_platform_event`](/user-guide/features/hooks#gateway_platform_event) | An authorized platform-native event is normalized at the gateway boundary (Telegram reactions currently) | `platform: str, event_type: str, payload: dict` | ignored |
 | `kanban_task_claimed` | A kanban task is claimed (dispatcher process, before the worker spawns) | `task_id: str, board: str \| None, assignee: str \| None, run_id: int \| None, profile_name: str` | ignored |
 | `kanban_task_completed` | A kanban task completes (worker process) | `task_id, board, assignee, run_id, profile_name, summary: str \| None` | ignored |
@@ -1358,6 +1377,21 @@ def register(ctx):
 
     ctx.register_platform_handler("discord", _wire)
 ```
+
+#### Discord thread inventory and delivery helpers
+
+The Discord adapter passed to a native handler exposes these stable helpers for
+plugins that maintain thread inventories or deliver scheduled summaries:
+
+| Method | Contract |
+|--------|----------|
+| `participating_thread_ids()` | Stable tuple containing the complete durable set of Discord thread IDs Hermes has participated in. New Discord tracking is not truncated to a recent-N cache. |
+| `resolve_thread_metadata(thread_id, include_activity_history=True)` | Async metadata lookup returning accessibility, guild/parent/name, archive policy/state, and Discord/Hermes activity timestamps. It never returns message content. Set `include_activity_history=False` for a lightweight refresh. |
+| `validate_delivery_target(channel_id)` | Async existence and view/send-permission check returning `{"ok": true, ...}` or `{"ok": false, "error": ...}`. |
+
+Use the adapter's existing async `send(...)` method after validation. These
+methods return structured failure results instead of requiring plugins to
+reach into private Discord adapter fields.
 
 :::tip
 This guide covers **general plugins** (tools, hooks, slash commands, CLI commands). The sections below sketch the authoring pattern for each specialized plugin type; each links to its full guide for field reference and examples.

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -462,7 +462,9 @@ Payload fields below are the exact event-specific fields supplied by each call s
 | `on_skill_lifecycle` | Observer | After an authoritative skill-usage state change; return ignored. | `action`, `skill_name`, `provenance`, `task_id`, `session_id`, `use_count`, `reused`, `reuse_after_patch` | Exposes the local skill name and provenance. |
 | `subagent_start` | Observer | Child constructed and about to run; return ignored. | `parent_session_id`, `parent_turn_id`, `parent_subagent_id`, `child_session_id`, `child_subagent_id`, `child_role`, `child_goal` | Child goal may contain user/project content. |
 | `subagent_stop` | Observer | Child exit; return ignored. | `parent_session_id`, `parent_turn_id`, `child_session_id`, `child_role`, `child_summary`, `child_status`, `tool_call_history`, `duration_ms` | Summary and redacted tool-history metadata may reveal project structure. |
-| `pre_gateway_dispatch` | Directive/control | Incoming non-internal message before auth/pairing/dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
+| `pre_gateway_dispatch` | Directive/control | Incoming non-internal message after authorization is computed but before auth/pairing enforcement or agent dispatch; first valid `skip`, `rewrite`, or `allow` controls flow. | `event`, `gateway`, `session_store`, `adapter`, `is_authorized` | Extremely privileged in-process objects expose inbound user/routing data and host handles. |
+| `gateway_control_message` | Directive/control | Synchronous classification before adapter text batching and busy-session merging; any explicit claim keeps the event intact for `pre_gateway_dispatch`. | `platform`, `event` | Raw normalized event and platform SDK payload may contain user content. |
+| `gateway_history_message` | Filter | Synchronous filter before a platform history message enters reconstructed agent context; any explicit exclusion wins and callback errors exclude that one message. | `platform`, message/chat/author IDs and flags, `content`, `author_is_authorized` | Full historical message content and identity metadata. |
 | `gateway_platform_event` | Observer | After the gateway's profile-scoped authorization succeeds, when a supported platform-native event is normalized at the gateway boundary (Telegram: reactions, message edits; Discord: message edits/deletes, thread created/renamed); return ignored. | `platform`, `event_type`, `payload` (event-type-specific dict — see the per-event contracts below) | Normalized plain-dict envelope only; raw SDK objects, adapter handles, and bot clients are never exposed. |
 | `pre_command` | Observer | Recognized slash command about to be dispatched, before the handler runs, on CLI and gateway cold-path dispatch; return ignored in v1 (directive-shaped dicts are logged at debug). Gateway running-agent intercept commands (`/stop`, `/approve` during an active run) are deliberately excluded — control-plane escape hatches must stay outside plugin reach. | `surface` (`"cli"` \| `"gateway"`), `command` (canonical name), `alias_used`, `args_raw`, `session_key`, `platform` | `args_raw` may contain user content or secrets typed after the command. |
 | `pre_approval_request` | Observer | Before prompted or smart approval; return ignored. | `command`, `description`, `pattern_key`, `pattern_keys`, `session_key`, `surface`, `turn_id`, `tool_call_id` | Command may contain secrets; smart observer preparation force-redacts, but surfaces do not all have identical redaction. |
@@ -1167,12 +1169,12 @@ With heavy delegation (e.g. orchestrator roles × 5 leaves × nested depth), `su
 
 ### `pre_gateway_dispatch`
 
-Fires **once per incoming `MessageEvent`** in the gateway, after the internal-event guard but **before** auth/pairing and agent dispatch. This is the interception point for gateway-level message-flow policies (listen-only windows, human handover, per-chat routing, etc.) that don't fit cleanly into any single platform adapter.
+Fires **once per incoming `MessageEvent`** in the gateway, after the internal-event guard and after Hermes computes the ordinary authorization decision, but **before** auth/pairing enforcement and agent dispatch. This is the interception point for gateway-level message-flow policies (listen-only windows, human handover, per-chat routing, etc.) that don't fit cleanly into any single platform adapter.
 
 **Callback signature:**
 
 ```python
-def my_callback(event, gateway, session_store, **kwargs):
+def my_callback(event, gateway, session_store, adapter, is_authorized, **kwargs):
 ```
 
 | Parameter | Type | Description |
@@ -1180,8 +1182,10 @@ def my_callback(event, gateway, session_store, **kwargs):
 | `event` | `MessageEvent` | The normalized inbound message (has `.text`, `.source`, `.message_id`, `.internal`, etc.). |
 | `gateway` | `GatewayRunner` | The active gateway runner, so plugins can call `gateway.adapters[platform].send(...)` for side-channel replies (owner notifications, etc.). |
 | `session_store` | `SessionStore` | For silent transcript ingestion via `session_store.append_to_transcript(...)`. |
+| `adapter` | `BasePlatformAdapter` | The public adapter for this message's source platform. |
+| `is_authorized` | `bool` | Hermes' immutable authorization decision for this event. Plugins should not duplicate private allowlist logic. |
 
-**Fires:** In `gateway/run.py`, inside `GatewayRunner._handle_message()`, immediately after `is_internal` is computed. **Internal events skip the hook entirely** (they are system-generated — background-process completions, etc. — and must not be gate-kept by user-facing policy).
+**Fires:** In `gateway/run.py`, inside `GatewayRunner._handle_message()`, before the authorization decision is enforced. **Internal events skip the hook entirely** (they are system-generated — background-process completions, etc. — and must not be gate-kept by user-facing policy).
 
 **Return value:** `None` or a dict. The first recognized action dict wins; remaining plugin results are ignored. Exceptions in plugin callbacks are caught and logged; the gateway always falls through to normal dispatch on error.
 
@@ -1196,9 +1200,9 @@ def my_callback(event, gateway, session_store, **kwargs):
 **Example — drop unauthorized DMs silently without triggering the pairing code:**
 
 ```python
-def deny_unauthorized_dms(event, **kwargs):
+def deny_unauthorized_dms(event, is_authorized, **kwargs):
     src = event.source
-    if src.chat_type == "dm" and not _is_approved_user(src.user_id):
+    if src.chat_type == "dm" and not is_authorized:
         return {"action": "skip", "reason": "unauthorized-dm"}
     return None
 
@@ -1223,6 +1227,58 @@ def buffer_or_rewrite(event, **kwargs):
 
 def register(ctx):
     ctx.register_hook("pre_gateway_dispatch", buffer_or_rewrite)
+```
+
+---
+
+### `gateway_control_message`
+
+Classifies plugin-owned control messages **synchronously**, before Discord
+split-message batching and before any platform's busy-session pending-message
+merge. A callback receives `platform` and the normalized `event`; return
+`True` or `{"control": True}` to claim it.
+
+A claimed event is delivered intact to `pre_gateway_dispatch`, even while an
+agent turn is active. The same plugin must consume it there with an
+`{"action": "skip", ...}` result. Classifier exceptions fail open (the message
+follows the ordinary path), and async callbacks are rejected. Keep this
+callback limited to cheap parsing—no network or database work.
+
+```python
+def is_my_control(platform, event, **kwargs):
+    return platform == "discord" and event.text.startswith("!mine")
+
+def consume_my_control(event, **kwargs):
+    if event.text.startswith("!mine"):
+        update_local_state(event)
+        return {"action": "skip", "reason": "my-control"}
+
+def register(ctx):
+    ctx.register_hook("gateway_control_message", is_my_control)
+    ctx.register_hook("pre_gateway_dispatch", consume_my_control)
+```
+
+---
+
+### `gateway_history_message`
+
+Filters individual platform-history messages before Hermes uses them to
+reconstruct conversational context. Discord currently invokes it for missed
+message recovery, recent/reply context windows, and resolved reply text.
+
+Callbacks are synchronous and receive normalized fields: `platform`,
+`message_id`, `content`, `chat_type`, `chat_id`, `thread_id`,
+`parent_chat_id`, `scope_id`, `author_id`, `author_is_bot`, `author_is_self`,
+and `author_is_authorized`. Return `True` or `{"exclude": True}` to omit the
+message. If a registered callback raises or returns an awaitable, Hermes fails
+closed for that one message so a known control record cannot become LLM input.
+
+```python
+def exclude_receipts(platform, message_id, **kwargs):
+    return platform == "discord" and message_id in committed_receipt_ids
+
+def register(ctx):
+    ctx.register_hook("gateway_history_message", exclude_receipts)
 ```
 
 ---


### PR DESCRIPTION
## What does this PR do?

Standalone gateway plugins sometimes own lightweight control records that must be handled without an agent turn. Today `pre_gateway_dispatch` can consume a message, but adapters may already have batched it with neighboring text or merged it into an active session, and later Discord history reconstruction can put that control record back into LLM context.

This PR widens the generic plugin surface so those records can stay intact and remain out of reconstructed history. It contains no consumer-specific command grammar, configuration, or persistence logic. The motivating external consumer is [`discord-related-threads`](https://github.com/chriskimjj/agent-extensions/tree/main/plugins/hermes/discord-related-threads).

The new contracts are:

- `PluginContext.supports_hook(name)` for fail-closed compatibility checks.
- Synchronous `gateway_control_message`, called before text coalescing and active-session merging. A positive result preserves one intact event; the claiming plugin must consume it through `pre_gateway_dispatch`. Callback failures fail open.
- Synchronous `gateway_history_message`, applied to Discord recovery, backfill, recent context, and resolved replies. Exclusion or callback failure omits only that message (fail closed).
- `pre_gateway_dispatch` receives the already-computed `is_authorized` decision and the public platform `adapter`; authorization is evaluated once before enforcement.
- The Discord adapter exposes a durable participation-ID snapshot, content-free thread metadata resolution, and delivery-target validation.

Claimed Discord control events also opt out of core reaction ownership, leaving the claiming plugin responsible for its own acknowledgement.

## Related Issue

No issue. This is a generic host-contract request backed by the external consumer above.

Related open work was checked before submission. In particular, #97707 covers registered native plugin commands during active turns, while #16489 and #78016 cover general `pre_gateway_dispatch` parity on the busy path. This PR's classifier is earlier and narrower: it preserves non-slash plugin-owned records before adapter batching/merging, then routes them through the existing pre-dispatch hook exactly once.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py` — define and enforce the two synchronous policy hooks and add `supports_hook()`.
- `gateway/platforms/base.py` — classify/cache control records before batching or active-session merging.
- `gateway/run.py` — expose the cached authorization decision and active adapter to pre-dispatch plugins.
- `plugins/platforms/discord/adapter.py` — apply history exclusion at every reconstruction path, suppress core reactions for claimed records, and expose thread inventory/metadata/target-validation methods.
- `gateway/platforms/helpers.py` — allow an unbounded durable tracker where a platform needs a complete inventory.
- `tests/` and `website/docs/` — behavior coverage and public contract documentation.

## How to Test

1. Run the focused behavior suite:

   ```bash
   scripts/run_tests.sh -j 4 \
     tests/hermes_cli/test_plugins.py \
     tests/gateway/test_base_topic_sessions.py \
     tests/gateway/test_discord_free_response.py \
     tests/gateway/test_discord_missed_message_backfill.py \
     tests/gateway/test_discord_reply_mode.py \
     tests/gateway/test_discord_thread_persistence.py \
     tests/gateway/test_pre_gateway_dispatch.py \
     tests/gateway/test_text_batching.py -q
   ```

2. Install the linked external plugin into a temporary `HERMES_HOME`; verify its required-hook probe passes, `!ㅊ` is classified before batching, `pre_gateway_dispatch` returns `skip`, and the same message ID is excluded from history without an LLM call.
3. Run Ruff on the changed Python files and `git diff --check`.

Focused result: **155 passed, 0 failed**. External plugin registration and enabled control/history integration smokes passed.

Broader result: `scripts/run_tests.sh -j 8 tests/gateway/ tests/hermes_cli/test_plugins.py -q` completed with **7,430 passed, 8 failed, 40 skipped** on macOS. An isolated worktree at the exact base commit (`21b2095d00`) reproduces the same eight failures: macOS path/socket constraints, readiness fixture state, shutdown diagnostic spawning, and unavailable optional WeCom XML support. None of those files are changed here.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run the full local test area with no failures — eight exact-base macOS/environment failures are documented above; focused tests are green
- [x] I've added tests for my changes
- [x] I've tested on macOS 26.4.1 with Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant plugin and hook documentation
- [x] `cli-config.yaml.example` — N/A; no config keys added
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; contributor workflow unchanged
- [x] I've considered cross-platform impact; new production paths use Python/adapter abstractions only
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

N/A; this is a host API and gateway behavior change.
