### PR TITLE
fix(video-gen): expose one-sided duration bounds

### DIFF
--- a/tests/tools/test_video_generate_schema.py
+++ b/tests/tools/test_video_generate_schema.py
@@ -220,6 +220,30 @@ class TestDynamicParamGating(unittest.TestCase):
             self.assertNotIn(p, props, p)
         self.assertIn("text-to-video only", schema["description"])
 
+    def test_duration_bounds_are_emitted_independently(self):
+        """A declared one-sided duration limit remains visible in the schema."""
+        shared_caps = {
+            "modalities": ["text"],
+            "supports_audio": False, "supports_negative_prompt": False,
+            "supports_seed": False, "supports_upscale": False,
+            "max_reference_images": 0,
+        }
+        cases = (
+            ({"max_duration": 8}, {"maximum": 8}),
+            ({"min_duration": 2}, {"minimum": 2}),
+            ({"min_duration": 2, "max_duration": 8},
+             {"minimum": 2, "maximum": 8}),
+            ({}, {}),
+        )
+        for caps, expected in cases:
+            with self.subTest(caps=caps):
+                schema = self._schema_with({**shared_caps, **caps})
+                duration = schema["parameters"]["properties"]["duration"]
+                self.assertEqual(
+                    {key: duration[key] for key in ("minimum", "maximum") if key in duration},
+                    expected,
+                )
+
     def test_i2v_only_model_overrides_backend_union(self):
         # gemini-omni-flash case: dual-modality backend, i2v-only model.
         schema = self._schema_with(

--- a/tools/video_generation_tool.py
+++ b/tools/video_generation_tool.py
@@ -532,11 +532,23 @@ def _build_dynamic_video_schema() -> Dict[str, Any]:
     min_duration = model_meta.get("min_duration", caps.get("min_duration"))
     max_duration = model_meta.get("max_duration", caps.get("max_duration"))
     duration_param = dict(static_props["duration"])
-    if min_duration and max_duration:
+    if min_duration is not None:
         duration_param["minimum"] = int(min_duration)
+    if max_duration is not None:
         duration_param["maximum"] = int(max_duration)
+    if min_duration is not None and max_duration is not None:
         duration_param["description"] = (
             f"Video duration in seconds ({min_duration}-{max_duration}). "
+            "Omit for the provider default."
+        )
+    elif min_duration is not None:
+        duration_param["description"] = (
+            f"Video duration in seconds (at least {min_duration}). "
+            "Omit for the provider default."
+        )
+    elif max_duration is not None:
+        duration_param["description"] = (
+            f"Video duration in seconds (up to {max_duration}). "
             "Omit for the provider default."
         )
     properties["duration"] = duration_param


### PR DESCRIPTION
## Summary
- Advertise declared `min_duration` and `max_duration` independently in the dynamic `video_generate` JSON Schema.
- Keep the existing two-sided range wording and use accurate one-sided range descriptions.
- Add regression coverage for min-only, max-only, two-sided, and absent duration capabilities.

## Verification
- `scripts/run_tests.sh tests/tools/test_video_generate_schema.py -q`
- `git diff --check HEAD^ HEAD`
