### PR TITLE
fix(acp): propagate configured reasoning effort

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -8,7 +8,7 @@ history.
 """
 from __future__ import annotations
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, resolve_reasoning_config
 
 import copy
 import json
@@ -632,6 +632,7 @@ class SessionManager:
             if not isinstance(cfg, dict) or cfg.get("enabled", True) is not False
         ]
 
+        effective_model = model or default_model
         kwargs = {
             "platform": "acp",
             "enabled_toolsets": _expand_acp_enabled_toolsets(
@@ -641,7 +642,8 @@ class SessionManager:
             "quiet_mode": True,
             "session_id": session_id,
             "session_db": self._get_db(),
-            "model": model or default_model,
+            "model": effective_model,
+            "reasoning_config": resolve_reasoning_config(config, effective_model),
         }
 
         try:

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -73,8 +73,8 @@ def make_agent_and_state():
     return acp_agent, state, fake, conn
 
 
-def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
-    """ACP sessions persist to SessionDB; recall must receive the same DB handle."""
+def test_acp_real_agent_gets_session_db_and_reasoning_config(monkeypatch):
+    """ACP agent construction propagates shared session state and model config."""
     captured = {}
     sentinel_db = NoopDb()
 
@@ -93,7 +93,16 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     monkeypatch.setitem(
         sys.modules,
         "hermes_cli.config",
-        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m", "provider": "p"}}),
+        mod(
+            "hermes_cli.config",
+            load_config=lambda: {
+                "model": {"default": "default-model", "provider": "p"},
+                "agent": {
+                    "reasoning_effort": "high",
+                    "reasoning_overrides": {"openai/gpt-5.2-codex": "low"},
+                },
+            },
+        ),
     )
     monkeypatch.setitem(
         sys.modules,
@@ -112,12 +121,17 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     )
 
     manager = SessionManager(db=sentinel_db)
-    agent = manager._make_agent(session_id="acp-session", cwd=".")
+    agent = manager._make_agent(
+        session_id="acp-session",
+        cwd=".",
+        model="openai/gpt-5.2-codex",
+    )
 
     assert isinstance(agent, CapturingAgent)
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "low"}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## summary

- resolve ACP reasoning configuration through the shared `resolve_reasoning_config` helper
- pass the effective model's global/per-model effort into `AIAgent`
- cover per-model override precedence in ACP construction

## problem

ACP sessions constructed `AIAgent` without `reasoning_config`. Provider transports therefore used their own fallback effort instead of `agent.reasoning_effort` or `agent.reasoning_overrides` from config. For the OpenAI Codex transport, that silently meant `medium` even when a profile configured `high`.

## verification

- red before fix: focused test failed with missing `reasoning_config`
- `uv run --with pytest --with pytest-asyncio --with ruff --with agent-client-protocol==0.9.0 pytest tests/acp_adapter/ -q -o 'addopts='` -> `15 passed`
- `ruff check acp_adapter/session.py tests/acp_adapter/test_acp_commands.py` -> passed
- live fresh ACP construction with `gpt-5.6-terra` and `agent.reasoning_effort: high` -> `{'enabled': True, 'effort': 'high'}`

The unrelated contributor-email working-tree modification is not included.