### PR TITLE
fix(tui_gateway): skip hidden dirs when enumerating local profiles

### DIFF
--- a/tests/tui_gateway/test_hosted_room_service.py
+++ b/tests/tui_gateway/test_hosted_room_service.py
@@ -315,6 +315,30 @@ def _wait_for(predicate, timeout=2.0):
     raise AssertionError("condition was not reached")
 
 
+def test_local_profiles_hides_tombstone_so_roster_validation_survives(tmp_path):
+    """A deleted profile must not brick roster validation install-wide.
+
+    ``hermes profile delete`` leaves a hidden ``.deleted`` tombstone directory
+    under ``profiles/``. Profile identifiers must start alphanumeric, so
+    listing the tombstone would make roster validation reject its own
+    known-profile set with "invalid local profile" before even looking at the
+    requested members.
+    """
+    (tmp_path / "profiles" / "ops").mkdir(parents=True)
+    (tmp_path / "profiles" / ".deleted" / "ops").mkdir(parents=True)
+    service = HostedRoomService(_server(), db_path=tmp_path / "state.db")
+
+    assert service.local_profiles() == ("default", "ops")
+    members = discussion.validate_roster(
+        [
+            {"member_id": "m1", "profile": "default", "handle": "alice"},
+            {"member_id": "m2", "profile": "ops", "handle": "bob"},
+        ],
+        local_profiles=service.local_profiles(),
+    )
+    assert [member.profile for member in members] == ["default", "ops"]
+
+
 def test_stop_room_snapshots_tasks_before_status_transitions(monkeypatch, tmp_path):
     """One running task must not be counted again after it becomes stopping."""
 

--- a/tui_gateway/hosted_room_service.py
+++ b/tui_gateway/hosted_room_service.py
@@ -152,8 +152,14 @@ class HostedRoomService:
         profiles = {"default"}
         profiles_dir = self.root / "profiles"
         if profiles_dir.is_dir():
+            # Hidden directories (e.g. the `.deleted` tombstone created by
+            # `hermes profile delete`) are not addressable profiles: profile
+            # identifiers must start alphanumeric, so listing them would make
+            # every roster validation fail with "invalid local profile".
             profiles.update(
-                path.name for path in profiles_dir.iterdir() if path.is_dir()
+                path.name
+                for path in profiles_dir.iterdir()
+                if path.is_dir() and not path.name.startswith(".")
             )
         return tuple(sorted(profiles))
 


### PR DESCRIPTION
## What does this PR do?

Fixes an install-wide breakage of hosted rooms (`groups.create` over `/api/ws`): once any profile has been deleted with `hermes profile delete`, every roster validation fails with error 5111 `invalid local profile`, regardless of the members requested.

Root cause: `hermes profile delete` leaves a hidden tombstone directory `profiles/.deleted/` (see `_DELETED_PROFILES_DIR` in `hermes_constants.py`). `HostedRoomService.local_profiles()` listed every directory under `profiles/`, including that tombstone. `validate_roster` then builds its `known_profiles` set by passing each enumerated name through `_identifier(...)`, whose regex `^[A-Za-z0-9][A-Za-z0-9._:-]*$` rejects leading dots — so the exception fired while building the known set, before the requested roster was even looked at.

The fix skips all hidden directories (not just `.deleted`) when enumerating local profiles. This matches the identifier contract: a profile must start alphanumeric, so no hidden directory can ever be a valid roster entry, and any future hidden directory created under `profiles/` stays harmless.

## Related Issue

Fixes #100001

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/hosted_room_service.py`: `local_profiles()` now skips directory names starting with `.` when enumerating `profiles/` (with a comment explaining why hidden dirs are not addressable profiles).
- `tests/tui_gateway/test_hosted_room_service.py`: added `test_local_profiles_hides_tombstone_so_roster_validation_survives` — builds a `profiles/` tree containing a real profile dir plus a `.deleted` tombstone, asserts `local_profiles()` excludes the tombstone, and feeds the result through `discussion.validate_roster` to lock the end-to-end behavior (2-6 member roster validates instead of raising `invalid local profile`).

## How to Test

1. `pytest tests/tui_gateway/test_hosted_room_service.py::test_local_profiles_hides_tombstone_so_roster_validation_survives -q` — should pass.
2. Observed result: with the fix reverted, the same test fails at `assert service.local_profiles() == ("default", "ops")` with `AssertionError: assert ('.deleted', 'default', 'ops') == ('default', 'ops')` (red→green verified locally).
3. Full affected surface passes: `pytest tests/tui_gateway/test_hosted_room_service.py tests/gateway/test_hosted_room_discussion.py tests/tui_gateway/test_hosted_room_two_gateway_scoped.py tests/gateway/test_hosted_room_gateway_lifecycle.py tests/cron/test_cron_bot_chat_delivery.py -q` — Observed result: 107 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (directory-name filtering is platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

N/A
