### PR TITLE
fix(kanban): do not auto-decompose a triage card that already has runs

### DIFF
--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -289,6 +289,24 @@ def decompose_task(
         return DecomposeOutcome(
             task_id, False, f"task is not in triage (status={task.status!r})"
         )
+    # A task that has ALREADY been worked is not fresh triage. `started_at` is
+    # set on first claim and never cleared, so it survives every later
+    # transition (review -> changes_requested -> blocked -> triage). Without
+    # this guard, parking an in-flight card in triage as a deliberate
+    # human-decision hold makes the auto-decomposer treat it as a brand-new
+    # request: it re-specifies work that already exists, links the synthetic
+    # children as PARENTS of the original card (inverting the graph), and the
+    # dispatcher then spawns a worker into the same workspace as the real
+    # card. Observed on t_3a7e66e3 (choker-os): 19 runs of finished work,
+    # parked in triage pending an owner decision, fanned out into 3 duplicate
+    # children with one already running against the live artifact.
+    # Rework is routed by the review lifecycle (request-changes / reopen-review),
+    # never by decomposition.
+    if task.started_at is not None:
+        return DecomposeOutcome(
+            task_id, False,
+            "task has prior runs (started_at set); triage is a hold, not fresh intake",
+        )
 
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)

--- a/tests/hermes_cli/test_kanban_decompose.py
+++ b/tests/hermes_cli/test_kanban_decompose.py
@@ -161,3 +161,66 @@ def test_decompose_returns_false_when_task_not_triage(kanban_home):
     assert "not in triage" in outcome.reason
 
 
+def test_decompose_skips_task_that_already_ran(kanban_home):
+    """A card sent BACK to triage after real work is a hold, not fresh intake.
+
+    `started_at` is set on first claim and never cleared, so it survives
+    review -> changes_requested -> blocked -> triage. Without this guard the
+    decomposer re-specifies work that already exists and the dispatcher
+    spawns a duplicate worker into the same workspace as the live card.
+    """
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already worked", triage=True)
+        # Simulate a prior run, then a human parking it back in triage.
+        conn.execute(
+            "UPDATE tasks SET started_at = ? WHERE id = ?", (1_700_000_000, tid)
+        )
+        conn.commit()
+        assert kb.get_task(conn, tid).status == "triage"
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        # No aux client patch: the guard must return BEFORE any LLM call.
+        outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is False
+    assert "prior runs" in outcome.reason
+    assert outcome.child_ids in (None, [])
+
+    with kb.connect() as conn:
+        assert kb.get_task(conn, tid).status == "triage"
+        assert kb.list_tasks(conn, limit=100) and len(kb.list_tasks(conn, limit=100)) == 1
+
+
+def test_decompose_still_runs_for_fresh_triage_task(kanban_home):
+    """Guard must not block genuine intake: started_at is None before any run."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fresh intake", triage=True)
+        assert kb.get_task(conn, tid).started_at is None
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Specified title",
+        "body": "Specified body.",
+        "assignee": "orchestrator",
+    })
+
+    patches = _patch_list_profiles(["orchestrator"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload), _patch_extra_body():
+            outcome = decomp.decompose_task(tid, author="me")
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert outcome.ok is True, outcome.reason
+
+


### PR DESCRIPTION
## Problem

`decompose_task()` gates only on `status == "triage"`. But triage is not only the intake column — it is also where an operator parks an **in-flight** card as a deliberate hold: after a review round, after `changes_requested`, after a run ends `blocked` pending a human decision.

To the auto-decomposer that card is indistinguishable from brand-new intake, so it re-specifies work that already exists.

The duplicate card is the smaller half of the problem. The synthetic children are linked as **parents** of the original card, inverting the graph; `auto_promote_children` then makes one of them `ready`; and the dispatcher spawns a worker into **the same workspace as the live card** — a second writer against an artifact that is under review.

Observed on a real card with 19 runs of completed work. It was parked in triage awaiting an owner decision on how to proceed, and within one dispatcher tick it had fanned out into 3 children, one already running against the live artifact.

## Fix

Return early when `task.started_at is not None`.

```python
if task.started_at is not None:
    return DecomposeOutcome(
        task_id, False,
        "task has prior runs (started_at set); triage is a hold, not fresh intake",
    )
```

**Why `started_at` and not a status allowlist.** `started_at` is set on first claim and never cleared, so it survives every later transition — `review`, `changes_requested`, `blocked`, back to `triage`. A status-based guard would have to enumerate the paths that lead back into triage and would need updating whenever a new one is added; this one does not. Rework already has a route: the review lifecycle (`request-changes` / `reopen-review`). Decomposition is for intake.

Fresh intake is untouched: a newly created triage card has `started_at is None`.

## Verification

RED → GREEN against the real DB helper, no network (`call_llm` mocked, as in the existing tests in this file):

- **Without** the guard, `test_decompose_skips_task_that_already_ran` fails, and the log shows the decomposer proceeding all the way to the auxiliary LLM call.
- **With** the guard, `decompose_task` returns early, the card stays in `triage`, no children are created, and no LLM call is made.
- `test_decompose_still_runs_for_fresh_triage_task` pins the other side, so the guard cannot regress genuine intake.

```
tests/hermes_cli/test_kanban_decompose.py — 5 passed
```

Note for anyone running the neighbouring suite on Windows: `tests/hermes_cli/test_doctor_journal_modes.py` fails at collection with `AttributeError: module 'os' has no attribute 'geteuid'`. That is pre-existing on `main` and unrelated to this change — verified by reproducing it with the change stashed.

## Scope

Two files, +81 lines, no deletions. No config surface, no new env var, no new core tool, no schema change. Behaviour change is limited to one early return in the auto-decompose path.
