### PR TITLE
feat(image_gen): Meta Muse Image joins the FAL catalog at $0.01/image

### DIFF
--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -167,6 +167,39 @@ class TestAugust2026Catalog:
         assert p["image_size"] == "landscape_16_9"
 
 
+class TestMetaMuseImage:
+    """Meta Muse Image (meta/muse-image/*) — Aug 2026 addition."""
+
+    MODEL = "meta/muse-image/text-to-image"
+
+    def test_in_catalog_with_edit_pair(self, image_tool):
+        meta = image_tool.FAL_MODELS[self.MODEL]
+        assert meta["size_style"] == "aspect_ratio"
+        assert meta["edit_endpoint"] == "meta/muse-image/edit"
+        # FAL schema: edit takes 1-10 reference image_urls.
+        assert meta["max_reference_images"] == 10
+
+    def test_text_payload_matches_vendor_schema(self, image_tool):
+        """Muse's schema exposes only prompt/aspect_ratio/num_images/
+        output_format/sync_mode — no seed, no resolution/quality knobs."""
+        p = image_tool._build_fal_payload(self.MODEL, "hello", "landscape", seed=42)
+        assert p["aspect_ratio"] == "16:9"
+        assert p["num_images"] == 1
+        assert p["output_format"] == "png"
+        for absent in ("seed", "image_size", "resolution", "quality"):
+            assert absent not in p
+
+    def test_edit_payload_omits_aspect_ratio(self, image_tool):
+        """On edits Muse follows the input image's framing; we deliberately
+        keep aspect_ratio off the edit whitelist."""
+        p = image_tool._build_fal_edit_payload(
+            self.MODEL, "swap the sky", ["https://x/a.png"], "portrait"
+        )
+        assert p["image_urls"] == ["https://x/a.png"]
+        assert "aspect_ratio" not in p
+        assert "seed" not in p
+
+
 # ---------------------------------------------------------------------------
 # Payload building — three size families
 # ---------------------------------------------------------------------------

--- a/tools/image_generation_catalog.py
+++ b/tools/image_generation_catalog.py
@@ -347,6 +347,18 @@ FAL_MODELS: Dict[str, Dict[str, Any]] = {
         },
         max_reference_images=3,
     ),
+    "meta/muse-image/text-to-image": _model(
+        "Meta Muse Image", "~5s", "Meta. Realism + typography at commodity price", "$0.01/image",
+        style="aspect_ratio",
+        # Muse accepts 21:9…9:21; aspect_ratio is always sent on text-to-image for deterministic
+        # framing and omitted on edits so Muse follows the input image. No seed in the vendor
+        # schema (like Grok Imagine 2.0) — the supports whitelist filters it.
+        defaults={"num_images": 1, "output_format": "png"},
+        supports={"prompt", "aspect_ratio", "num_images", "output_format", "sync_mode"},
+        edit_endpoint="meta/muse-image/edit",
+        edit_supports={"prompt", "image_urls", "num_images", "output_format", "sync_mode"},
+        max_reference_images=10,
+    ),
 }
 
 


### PR DESCRIPTION
## Summary
`image_generate` gains **Meta Muse Image** (`meta/muse-image/text-to-image` + paired `/edit`) — Meta's image model, now on FAL at **$0.01/image**, the cheapest edit-capable entry in the catalog.

## Changes
- `tools/image_generation_tool.py`: FAL_MODELS entry — aspect_ratio family (16:9/1:1/9:16), edit endpoint with 1-10 reference `image_urls`, no seed (absent from the vendor schema; whitelist filters it), aspect_ratio omitted on edits so Muse follows the input image's framing.
- `tests/tools/test_image_generation.py`: `TestMetaMuseImage` — catalog/edit contract, t2i payload matches vendor schema (seed/resolution/quality stripped), edit payload omits aspect_ratio.

## Validation
| Check | Result |
|---|---|
| FAL OpenAPI schema (both endpoints) | fetched + keys verified: prompt, aspect_ratio (21:9..9:21 enum), num_images, output_format, sync_mode; edit adds image_urls maxItems=10 |
| Targeted tests (4 image test files) | 77 passed, 29 subtests |
| Live E2E | **blocked** — FAL account 403 `Exhausted balance` (recurring); schema-verified only |

## Cost / trust notes
- $0.01/image (price confirmed in FAL model page payload) — vs Seedream Lite $0.035, Grok Imagine $0.06. Tags: realism, typography, editing.
- No new deps, no new config keys; default model unchanged (`fal-ai/flux-2/klein/9b`).
- Distinct from PR #97283 (@mreso), which adds the **Meta Model API** (`api.meta.ai`) provider plugin with `MODEL_API_KEY` auth — this entry rides the existing FAL credential/managed gateway instead. Complementary, not competing.

## Infographic

![Meta Muse Image on FAL](https://v3b.fal.media/files/b/0aa8a319/bHgx_xv5lGOyg5vLzIrfm_ctbbxxLy.png)
