### PR TITLE
fix(gateway): document hermes gateway run instead of python cli.py --gateway

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8,9 +8,9 @@ This module provides:
 Usage:
     # Start the gateway
     python -m gateway.run
-    
+
     # Or from CLI
-    python cli.py --gateway
+    hermes gateway run
 """
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio

--- a/tests/gateway/test_run_module_docstring.py
+++ b/tests/gateway/test_run_module_docstring.py
@@ -1,0 +1,11 @@
+"""Docstring for gateway.run should advertise the supported CLI start command."""
+
+from pathlib import Path
+
+
+def test_gateway_run_docstring_uses_hermes_gateway_run():
+    source = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    text = source.read_text(encoding="utf-8")
+    docstring = text.split('"""', 2)[1]
+    assert "hermes gateway run" in docstring
+    assert "python cli.py --gateway" not in docstring


### PR DESCRIPTION
## Summary
`gateway/run.py` still told users to start the gateway with `python cli.py --gateway`, which fails for a normal install (no local `cli.py`). The supported command is `hermes gateway run`.

#98840 already updated the `/gateway` status text in `cli.py`. This PR covers the remaining docstring seam.

## Test
`python3 -m pytest tests/gateway/test_run_module_docstring.py -q`

Related to #98819.