### PR TITLE
fix(telegram): allow duplicate visible topic titles

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23577,10 +23577,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         source: SessionSource,
         session_id: str,
         title: str,
-    ) -> None:
+    ) -> Optional[bool]:
         """Best-effort rename of a Telegram DM topic when Hermes auto-titles a session."""
-        if not await asyncio.to_thread(self._is_telegram_topic_lane, source) or not source.chat_id or not source.thread_id:
+        if not await asyncio.to_thread(self._is_telegram_topic_lane, source):
             return
+        if not source.chat_id or not source.thread_id:
+            return False
 
         # Operator can fully disable per-topic auto-rename via
         # extra.disable_topic_auto_rename. Useful when topics are managed
@@ -23618,13 +23620,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=str(source.thread_id),
                 )
                 if binding and str(binding.get("session_id") or "") != str(session_id):
-                    return
+                    return False
             except Exception:
                 logger.debug("Failed to verify Telegram topic binding before rename", exc_info=True)
-                return
+                return False
 
         if adapter is None:
-            return
+            return False
         topic_name = self._sanitize_telegram_topic_title(title)
         try:
             rename_topic = getattr(adapter, "rename_dm_topic", None)
@@ -23634,14 +23636,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     thread_id=str(source.thread_id),
                     name=topic_name,
                 )
-                return
+                return True
 
             bot = getattr(adapter, "_bot", None)
             edit_forum_topic = getattr(bot, "edit_forum_topic", None) if bot is not None else None
             if edit_forum_topic is None:
                 edit_forum_topic = getattr(bot, "editForumTopic", None) if bot is not None else None
             if edit_forum_topic is None:
-                return
+                return False
             try:
                 await edit_forum_topic(
                     chat_id=int(source.chat_id),
@@ -23654,8 +23656,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     message_thread_id=source.thread_id,
                     name=topic_name,
                 )
+            return True
         except Exception:
             logger.debug("Failed to rename Telegram topic for auto-generated title", exc_info=True)
+            return False
 
     def _telegram_topic_auto_rename_disabled(self, source: SessionSource) -> bool:
         """Return True when operator disabled per-topic auto-rename for this Telegram chat.

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4863,26 +4863,63 @@ class GatewaySlashCommandsMixin:
                 return t("gateway.shared.warn_passthrough", error=e)
             if not sanitized:
                 return t("gateway.title.empty_after_clean")
-            # Set the title
+            # Telegram topic labels are display names and may legitimately be
+            # duplicated. Keep the resumable session alias unique by reserving
+            # a lineage title atomically, while every other lane retains the
+            # strict duplicate-title error.
+            telegram_topic_lane = self._is_telegram_topic_lane(source)
             try:
-                if await self._session_db.set_session_title(session_id, sanitized):
+                if telegram_topic_lane:
+                    persisted_title = await self._session_db.set_session_title_in_lineage(
+                        session_id, sanitized
+                    )
+                    title_was_set = persisted_title is not None
+                else:
+                    title_was_set = await self._session_db.set_session_title(
+                        session_id, sanitized
+                    )
+                    persisted_title = sanitized if title_was_set else None
+                if title_was_set:
                     # Propagate the user-chosen title to the visible Telegram
                     # forum topic name too. Auto-generated titles already rename
                     # the topic; without this, /title only updated the DB title
                     # and the topic kept its auto-assigned name. No-ops off
                     # Telegram topic lanes and when auto-rename is disabled.
+                    if telegram_topic_lane:
+                        rename_topic = getattr(
+                            self, "_rename_telegram_topic_for_session_title", None
+                        )
+                        rename_succeeded = (
+                            await rename_topic(source, session_id, sanitized)
+                            if callable(rename_topic)
+                            else None
+                        )
+                        response = t("gateway.title.set_to", title=persisted_title)
+                        if rename_succeeded is False:
+                            warning = t(
+                                "gateway.shared.warn_passthrough",
+                                error=(
+                                    "Telegram topic rename failed; the session title "
+                                    f"was saved as '{persisted_title}'."
+                                ),
+                            )
+                            return f"{response}\n{warning}"
+                        return response
+
                     schedule_rename = getattr(
                         self, "_schedule_telegram_topic_title_rename", None
                     )
                     if callable(schedule_rename):
                         try:
-                            await asyncio.to_thread(schedule_rename, source, session_id, sanitized)
+                            await asyncio.to_thread(
+                                schedule_rename, source, session_id, sanitized
+                            )
                         except Exception:
                             logger.debug(
                                 "Failed to rename Telegram topic from /title",
                                 exc_info=True,
                             )
-                    return t("gateway.title.set_to", title=sanitized)
+                    return t("gateway.title.set_to", title=persisted_title)
                 else:
                     return t("gateway.title.not_found")
             except ValueError as e:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9202,13 +9202,14 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         ).fetchone()
         return row is not None
 
-    def _set_session_title(
+    def _write_session_title(
         self,
         session_id: str,
         title: str,
         *,
         source: str,
-    ) -> bool:
+        lineage_fallback: bool = False,
+    ) -> Tuple[bool, Optional[str]]:
         """Write a title, enforcing provenance precedence.
 
         ``source`` is one of ``TITLE_SOURCE_{DERIVED,LLM,USER}``. A ``user``
@@ -9233,7 +9234,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 (session_id,),
             ).fetchone()
             if current is None:
-                return 0
+                return False, None
             # The canonical Bot Chat's NAME is its identity: Bot Mode resolves
             # the forever-chat by exact-title lookup on every open, so renaming
             # the row orphans the entire conversation — the next click mints an
@@ -9256,8 +9257,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 )
             if not is_user and current["title"] is not None:
                 if self._title_rank(current["title_source"]) >= new_rank:
-                    return 0
+                    return False, current["title"]
 
+            persisted_title = title
             if title:
                 # Check uniqueness (allow the same session to keep its own title)
                 cursor = conn.execute(
@@ -9285,6 +9287,31 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             "UPDATE sessions SET title = NULL WHERE id = ?",
                             (conflict_id,),
                         )
+                    elif lineage_fallback:
+                        match = re.match(r"^(.*?) #(\d+)$", title)
+                        base = match.group(1) if match else title
+                        escaped = _escape_like(base)
+                        rows = conn.execute(
+                            "SELECT title FROM sessions "
+                            "WHERE title = ? OR title LIKE ? ESCAPE '\\'",
+                            (base, f"{escaped} #%"),
+                        ).fetchall()
+                        max_num = 1
+                        for row in rows:
+                            numbered = re.match(r"^.* #(\d+)$", row["title"])
+                            if numbered:
+                                max_num = max(max_num, int(numbered.group(1)))
+                        while True:
+                            max_num += 1
+                            suffix = f" #{max_num}"
+                            candidate = f"{base[:self.MAX_TITLE_LENGTH - len(suffix)]}{suffix}"
+                            occupied = conn.execute(
+                                "SELECT 1 FROM sessions WHERE title = ? AND id != ?",
+                                (candidate, session_id),
+                            ).fetchone()
+                            if occupied is None:
+                                persisted_title = candidate
+                                break
                     else:
                         raise ValueError(
                             f"Title '{title}' is already in use by session {conflict_id}"
@@ -9296,17 +9323,30 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 "UPDATE sessions SET title = ?, title_source = ? "
                 "WHERE id = ? AND title IS ? AND title_source IS ?",
                 (
-                    title,
+                    persisted_title,
                     source if title else None,
                     session_id,
                     current["title"],
                     current["title_source"],
                 ),
             )
-            return cursor.rowcount
+            return cursor.rowcount > 0, persisted_title
 
-        rowcount = self._execute_write(_do)
-        return rowcount > 0
+        return self._execute_write(_do)
+
+    def _set_session_title(
+        self,
+        session_id: str,
+        title: str,
+        *,
+        source: str,
+    ) -> bool:
+        written, _ = self._write_session_title(
+            session_id,
+            title,
+            source=source,
+        )
+        return written
 
     def set_session_title(self, session_id: str, title: str) -> bool:
         """Set or update a session's title on the user's behalf.
@@ -9322,6 +9362,25 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         return self._set_session_title(
             session_id, title, source=self.TITLE_SOURCE_USER
         )
+
+    def set_session_title_in_lineage(
+        self, session_id: str, title: str
+    ) -> Optional[str]:
+        """Atomically persist a unique user title from the requested lineage.
+
+        The exact sanitized title is preferred. If another session owns it,
+        the next `` #N`` alias is selected and written in the same
+        ``BEGIN IMMEDIATE`` transaction, so concurrent callers cannot reserve
+        the same alias. Returns the persisted title, or ``None`` when the
+        session was not found.
+        """
+        written, persisted_title = self._write_session_title(
+            session_id,
+            title,
+            source=self.TITLE_SOURCE_USER,
+            lineage_fallback=True,
+        )
+        return persisted_title if written else None
 
     def set_auto_title(self, session_id: str, title: str, *, source: str) -> bool:
         """Set an automatically generated title, honoring provenance precedence.

--- a/tests/gateway/test_telegram_topic_mode.py
+++ b/tests/gateway/test_telegram_topic_mode.py
@@ -689,6 +689,33 @@ async def test_auto_generated_title_renames_bound_telegram_topic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_telegram_topic_rename_failure_is_reported_to_caller(tmp_path):
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.apply_telegram_topic_migration()
+    db.create_session("sess-topic", source="telegram", user_id="208214988")
+    db.bind_telegram_topic(
+        chat_id="208214988",
+        thread_id="42",
+        user_id="208214988",
+        session_key="agent:main:telegram:dm:208214988:42",
+        session_id="sess-topic",
+    )
+    runner = _make_runner(session_db=db)
+    runner._telegram_topic_mode_enabled = lambda _source: True
+    runner.adapters[Platform.TELEGRAM].rename_dm_topic.side_effect = RuntimeError(
+        "Telegram unavailable"
+    )
+
+    renamed = await runner._rename_telegram_topic_for_session_title(
+        _make_source(thread_id="42"),
+        "sess-topic",
+        "Build Telegram Topic UX",
+    )
+
+    assert renamed is False
+
+
+@pytest.mark.asyncio
 async def test_topic_refuses_unauthorized_user(tmp_path, monkeypatch):
     """Unauthorized DMs cannot flip multi-session mode on."""
     import gateway.run as gateway_run

--- a/tests/gateway/test_title_command.py
+++ b/tests/gateway/test_title_command.py
@@ -15,12 +15,14 @@ from gateway.session import SessionSource
 
 
 def _make_event(text="/title", platform=Platform.TELEGRAM,
-                user_id="12345", chat_id="67890"):
+                user_id="12345", chat_id="67890", thread_id=None):
     """Build a MessageEvent for testing."""
     source = SessionSource(
         platform=platform,
         user_id=user_id,
         chat_id=chat_id,
+        chat_type="dm",
+        thread_id=thread_id,
         user_name="testuser",
     )
     return MessageEvent(text=text, source=source)
@@ -68,7 +70,7 @@ class TestHandleTitleCommand:
         db.create_session("test_session_123", "telegram")
 
         runner = _make_runner(session_db=db)
-        event = _make_event(text="/title Taken Title")
+        event = _make_event(text="/title Taken Title", platform=Platform.DISCORD)
         result = await runner._handle_title_command(event)
         assert "already in use" in result
         assert "⚠️" in result
@@ -107,6 +109,58 @@ class TestHandleTitleCommand:
         runner._schedule_telegram_topic_title_rename.assert_called_once_with(
             event.source, "test_session_123", "My Topic Name"
         )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_duplicate_topic_label_uses_internal_lineage_alias(self, tmp_path):
+        """Telegram topics keep the requested label while sessions stay unique."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("other_session", "telegram")
+        db.set_session_title("other_session", "Consolidate Skills")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        runner._telegram_topic_mode_enabled = lambda _source: True
+        runner._rename_telegram_topic_for_session_title = AsyncMock(return_value=True)
+        event = _make_event(
+            text="/title Consolidate Skills",
+            thread_id="42",
+        )
+
+        result = await runner._handle_title_command(event)
+
+        assert "Consolidate Skills #2" in result
+        assert db.get_session_title("test_session_123") == "Consolidate Skills #2"
+        runner._rename_telegram_topic_for_session_title.assert_awaited_once_with(
+            event.source, "test_session_123", "Consolidate Skills"
+        )
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_topic_rename_failure_reports_partial_success(self, tmp_path):
+        """A persisted alias is not presented as a fully successful topic rename."""
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("other_session", "telegram")
+        db.set_session_title("other_session", "Consolidate Skills")
+        db.create_session("test_session_123", "telegram")
+
+        runner = _make_runner(session_db=db)
+        runner._telegram_topic_mode_enabled = lambda _source: True
+        runner._rename_telegram_topic_for_session_title = AsyncMock(return_value=False)
+        event = _make_event(
+            text="/title Consolidate Skills",
+            thread_id="42",
+        )
+
+        result = await runner._handle_title_command(event)
+
+        assert "Consolidate Skills #2" in result
+        assert "topic rename failed" in result.lower()
+        assert db.get_session_title("test_session_123") == "Consolidate Skills #2"
         db.close()
 
     @pytest.mark.asyncio

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -4,6 +4,7 @@ import sqlite3
 import time
 import json
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from unittest import mock
 
@@ -2228,6 +2229,33 @@ class TestTitleLineage:
     def test_next_title_no_existing(self, db):
         """With no existing sessions, base title is returned as-is."""
         assert db.get_next_title_in_lineage("my project") == "my project"
+
+    def test_concurrent_lineage_title_reservations_are_distinct(self, tmp_path):
+        """Lineage allocation and title persistence share one write transaction."""
+        db_path = tmp_path / "state.db"
+        setup = SessionDB(db_path=db_path)
+        setup.create_session("original", "telegram")
+        setup.create_session("topic-a", "telegram")
+        setup.create_session("topic-b", "telegram")
+        setup.set_session_title("original", "Consolidate Skills")
+        setup.close()
+
+        barrier = threading.Barrier(2)
+
+        def reserve(session_id):
+            worker = SessionDB(db_path=db_path)
+            try:
+                barrier.wait()
+                return worker.set_session_title_in_lineage(
+                    session_id, "Consolidate Skills"
+                )
+            finally:
+                worker.close()
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            aliases = set(pool.map(reserve, ("topic-a", "topic-b")))
+
+        assert aliases == {"Consolidate Skills #2", "Consolidate Skills #3"}
 
 
 


### PR DESCRIPTION
## What does this PR do?

Telegram forum topics can now share the same visible label without colliding on Hermes' unique, resumable session titles. Topic lanes atomically reserve lineage aliases such as `Consolidate Skills #2`, while Telegram receives the requested visible label `Consolidate Skills`; non-topic title collisions remain errors.

### Symptom

Running `/title Consolidate Skills` in a second Telegram topic returned `Title 'Consolidate Skills' is already in use by session ...`, so the session title and topic label were not updated.

### Impact

Users could not use valid duplicate Telegram topic labels even though routing already uses chat and thread IDs. A Telegram API rename failure was also hidden after the session title write.

### Bug Cause

**Trigger:** `gateway/slash_commands.py` in `_handle_title_command` when a Telegram topic requests a title already owned by another session.

**Causal chain:**
1. `/title` sent the requested visible topic label directly to `SessionDB.set_session_title`.
2. `SessionDB._set_session_title` correctly enforced the unique `sessions.title` alias constraint and rejected the second topic.
3. The handler returned before scheduling the Telegram topic rename.

**Why it is wrong:** Telegram topic labels are display names and may be duplicated, while Hermes session titles are unique aliases. Treating both values as one identity imposed the session constraint on Telegram's UI. Separately reading `get_next_title_in_lineage` and then writing would introduce a concurrent allocation race.

**Working sibling / contrast:** Non-topic messaging and CLI sessions intentionally keep strict duplicate-title rejection because their title is the resumable alias, not a platform display label.

**Ruled out:** The unique title index is not the defect and remains intact; removing it would make title-based resume ambiguous.

### Fix

- Add one `BEGIN IMMEDIATE` transaction that selects and persists the next free lineage alias, including concurrent writers.
- Use that allocator only for Telegram topic lanes and rename the topic with the original requested label.
- Return the persisted internal alias to the user and append a partial-success warning when the Telegram rename attempt fails.
- Preserve strict duplicate-title behavior outside Telegram topic lanes.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` - atomically reserve and persist unique lineage aliases.
- `gateway/slash_commands.py` - separate Telegram topic labels from internal session aliases and report partial success.
- `gateway/run.py` - return the outcome of Telegram topic rename attempts.
- `tests/test_hermes_state.py` - cover concurrent lineage reservations across SQLite connections.
- `tests/gateway/test_title_command.py` - cover duplicate topic labels, partial success, and unchanged non-Telegram collisions.
- `tests/gateway/test_telegram_topic_mode.py` - cover surfaced adapter rename failures.

## How to Test

1. Create two Telegram topics backed by different Hermes sessions.
2. Run `/title Consolidate Skills` in both topics.
3. Verify both topics display `Consolidate Skills`, while `/title` reports distinct internal aliases.
4. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/test_hermes_state.py
scripts/run_tests.sh tests/gateway/test_title_command.py tests/gateway/test_telegram_topic_mode.py
```

Results: 244 passed and 2 skipped in the state suite; 29 passed in the gateway suites.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; behavior is covered by command responses and docstrings
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated tests cover the persistence, concurrency, and gateway response contracts.
