### PR TITLE
fix(title): bound auto-title generation and avoid timeout amplification

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4595,6 +4595,11 @@ def _is_connection_error(exc: Exception) -> bool:
     return False
 
 
+def _title_timeout_should_stop(task: Optional[str], exc: Exception) -> bool:
+    """Title generation is cosmetic; a timeout should not amplify load."""
+    return task == "title_generation" and _is_timeout_error(exc)
+
+
 def _is_transient_transport_error(exc: Exception) -> bool:
     """Return True for a one-off transport blip worth retrying ON the
     same provider before any provider/model fallback.
@@ -9116,6 +9121,7 @@ def _build_call_kwargs(
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
         _is_moa = bool(task) and str(task) == "moa_reference"
+        _is_title_generation = bool(task) and str(task) == "title_generation"
         # Gemini's native generateContent maps max_tokens → maxOutputTokens and,
         # when it is omitted, applies a fixed 65,535-token ceiling rather than
         # "the model's full budget" (see gemini_native_adapter.build_gemini_request).
@@ -9151,6 +9157,7 @@ def _build_call_kwargs(
             or _nous_on_messages
             or _is_nvidia_nim
             or _is_moa
+            or _is_title_generation
             or _is_gemini_native
             or _is_openrouter
         ):
@@ -10296,6 +10303,13 @@ def _call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
+            if task == "title_generation" and _is_timeout_error(transient_err):
+                logger.info(
+                    "Auxiliary title_generation: timeout; skipping same-provider "
+                    "retry and fallback: %s",
+                    transient_err,
+                )
+                raise
             # Compression is on the critical preflight path: a user cannot
             # continue or resume an oversized session until it compacts. A
             # same-provider retry on a timeout means another full ``timeout``-
@@ -10355,6 +10369,16 @@ def _call_llm_impl(
             # Retries exhausted — fall through to first_err fallback handling.
             raise _last_transient
     except Exception as first_err:
+        if _title_timeout_should_stop(task, first_err):
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary title_generation: cache eviction after timeout failed",
+                        exc_info=True,
+                    )
+            raise
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)
@@ -11130,6 +11154,13 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
+            if task == "title_generation" and _is_timeout_error(transient_err):
+                logger.info(
+                    "Auxiliary title_generation (async): timeout; skipping "
+                    "same-provider retry and fallback: %s",
+                    transient_err,
+                )
+                raise
             # See call_llm(): compression is on the critical preflight path,
             # so skip the same-provider retry on a full-budget timeout and
             # fall straight through to fallback (issue #54465).
@@ -11155,6 +11186,16 @@ async def _async_call_llm_impl(
                 ),
                 task)
     except Exception as first_err:
+        if _title_timeout_should_stop(task, first_err):
+            if _is_connection_error(first_err):
+                try:
+                    _evict_cached_client_instance(client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary title_generation (async): cache eviction after timeout failed",
+                        exc_info=True,
+                    )
+            raise
         if "temperature" in kwargs and _is_unsupported_temperature_error(first_err):
             retry_kwargs = dict(kwargs)
             retry_kwargs.pop("temperature", None)

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1113,7 +1113,8 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 # the user's main chat model. The opt-in lives in
 # ``auxiliary.<task>.prefer_fast_model`` so the default ``auto = main model``
 # contract remains true on every settings surface.
-_FAST_MODEL_TASKS: frozenset = frozenset({"title_generation"})
+_TITLE_GENERATION_TASK = "title_generation"
+_FAST_MODEL_TASKS: frozenset = frozenset({_TITLE_GENERATION_TASK})
 
 
 def _task_prefers_fast_model(task: Optional[str]) -> bool:
@@ -4597,7 +4598,7 @@ def _is_connection_error(exc: Exception) -> bool:
 
 def _title_timeout_should_stop(task: Optional[str], exc: Exception) -> bool:
     """Title generation is cosmetic; a timeout should not amplify load."""
-    return task == "title_generation" and _is_timeout_error(exc)
+    return task == _TITLE_GENERATION_TASK and _is_timeout_error(exc)
 
 
 def _is_transient_transport_error(exc: Exception) -> bool:
@@ -9121,7 +9122,7 @@ def _build_call_kwargs(
             or base_url_host_matches(_effective_base, "integrate.api.nvidia.com")
         )
         _is_moa = bool(task) and str(task) == "moa_reference"
-        _is_title_generation = bool(task) and str(task) == "title_generation"
+        _is_title_generation = bool(task) and str(task) == _TITLE_GENERATION_TASK
         # Gemini's native generateContent maps max_tokens → maxOutputTokens and,
         # when it is omitted, applies a fixed 65,535-token ceiling rather than
         # "the model's full budget" (see gemini_native_adapter.build_gemini_request).
@@ -10303,7 +10304,7 @@ def _call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            if task == "title_generation" and _is_timeout_error(transient_err):
+            if task == _TITLE_GENERATION_TASK and _is_timeout_error(transient_err):
                 logger.info(
                     "Auxiliary title_generation: timeout; skipping same-provider "
                     "retry and fallback: %s",
@@ -11154,7 +11155,7 @@ async def _async_call_llm_impl(
         except Exception as transient_err:
             if not _is_transient_transport_error(transient_err):
                 raise
-            if task == "title_generation" and _is_timeout_error(transient_err):
+            if task == _TITLE_GENERATION_TASK and _is_timeout_error(transient_err):
                 logger.info(
                     "Auxiliary title_generation (async): timeout; skipping "
                     "same-provider retry and fallback: %s",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1257,7 +1257,8 @@ DEFAULT_CONFIG = {
             "prefer_fast_model": False,  # opt in to provider fast tier; auto otherwise uses the main model
             "base_url": "",
             "api_key": "",
-            "timeout": 30,
+            "timeout": 10,
+            "max_concurrency": 1,
             "extra_body": {},
             "reasoning_effort": "",  # per-task thinking level: none|minimal|low|medium|high|xhigh|max|ultra (empty = provider default)
             "language": "",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1257,6 +1257,7 @@ DEFAULT_CONFIG = {
             "prefer_fast_model": False,  # opt in to provider fast tier; auto otherwise uses the main model
             "base_url": "",
             "api_key": "",
+            # Title generation is cosmetic; keep provider stalls bounded.
             "timeout": 10,
             "max_concurrency": 1,
             "extra_body": {},

--- a/tests/agent/test_auxiliary_transient_retry.py
+++ b/tests/agent/test_auxiliary_transient_retry.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import os
 import types
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -58,5 +58,94 @@ def test_model_participates_in_client_cache_key():
         api_key="K", model="anthropic/claude-opus-4.8",
     )
     assert k_opus == k_opus2
+
+
+def test_title_generation_timeout_does_not_retry_or_fallback(monkeypatch):
+    """A cosmetic title timeout should keep the derived title, not add load."""
+    from agent.auxiliary_client import call_llm
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create.side_effect = TimeoutError("request timed out")
+
+    monkeypatch.setattr("agent.auxiliary_client._TRANSIENT_RETRY_BACKOFF_BASE", 0)
+
+    with (
+        patch("agent.auxiliary_client._resolve_task_provider_model",
+              return_value=("custom", "tiny-title-model", None, None, None)),
+        patch("agent.auxiliary_client._get_cached_client",
+              return_value=(client, "tiny-title-model")),
+        patch("agent.auxiliary_client._get_auxiliary_task_config",
+              return_value={"timeout": 1}),
+        patch("agent.auxiliary_client._try_configured_fallback_chain") as configured,
+        patch("agent.auxiliary_client._try_main_agent_model_fallback") as main_fallback,
+        patch("agent.auxiliary_client._try_payment_fallback") as payment_fallback,
+        pytest.raises(TimeoutError, match="request timed out"),
+    ):
+        call_llm(task="title_generation", messages=[{"role": "user", "content": "title"}])
+
+    assert client.chat.completions.create.call_count == 1
+    configured.assert_not_called()
+    main_fallback.assert_not_called()
+    payment_fallback.assert_not_called()
+
+
+def test_async_title_generation_timeout_does_not_retry_or_fallback():
+    """The async title path must have the same terminal-timeout behavior."""
+    import asyncio
+
+    from agent import auxiliary_client as ac
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create = AsyncMock(side_effect=TimeoutError("request timed out"))
+
+    async def run():
+        with (
+            patch.object(ac, "_resolve_task_provider_model",
+                         return_value=("custom", "tiny-title-model", None, None, None)),
+            patch.object(ac, "_get_cached_client",
+                         return_value=(client, "tiny-title-model")),
+            patch.object(ac, "_get_auxiliary_task_config", return_value={"timeout": 1}),
+            patch.object(ac, "_try_configured_fallback_chain") as configured,
+            patch.object(ac, "_try_main_agent_model_fallback") as main_fallback,
+            patch.object(ac, "_try_payment_fallback") as payment_fallback,
+            pytest.raises(TimeoutError, match="request timed out"),
+        ):
+            await ac.async_call_llm(
+                task="title_generation",
+                messages=[{"role": "user", "content": "title"}],
+            )
+        configured.assert_not_called()
+        main_fallback.assert_not_called()
+        payment_fallback.assert_not_called()
+
+    asyncio.run(run())
+    assert client.chat.completions.create.call_count == 1
+
+
+def test_title_generation_forwards_output_cap():
+    """OpenAI-compatible title requests preserve the 64-token cap."""
+    from agent.auxiliary_client import call_llm
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create.return_value = MagicMock()
+
+    with (
+        patch("agent.auxiliary_client._resolve_task_provider_model",
+              return_value=("custom", "tiny-title-model", None, None, None)),
+        patch("agent.auxiliary_client._get_cached_client",
+              return_value=(client, "tiny-title-model")),
+        patch("agent.auxiliary_client._validate_llm_response",
+              side_effect=lambda response, _task, **_kwargs: response),
+    ):
+        call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "title"}],
+            max_tokens=64,
+        )
+
+    assert client.chat.completions.create.call_args.kwargs["max_tokens"] == 64
 
 

--- a/tests/agent/test_auxiliary_transient_retry.py
+++ b/tests/agent/test_auxiliary_transient_retry.py
@@ -149,3 +149,28 @@ def test_title_generation_forwards_output_cap():
     assert client.chat.completions.create.call_args.kwargs["max_tokens"] == 64
 
 
+def test_title_generation_without_output_cap_does_not_inject_one():
+    """Omitting a title cap must not silently request a provider default cap."""
+    from agent.auxiliary_client import call_llm
+
+    client = MagicMock()
+    client.base_url = "http://localhost:13305/v1"
+    client.chat.completions.create.return_value = MagicMock()
+
+    with (
+        patch("agent.auxiliary_client._resolve_task_provider_model",
+              return_value=("custom", "tiny-title-model", None, None, None)),
+        patch("agent.auxiliary_client._get_cached_client",
+              return_value=(client, "tiny-title-model")),
+        patch("agent.auxiliary_client._validate_llm_response",
+              side_effect=lambda response, _task, **_kwargs: response),
+    ):
+        call_llm(
+            task="title_generation",
+            messages=[{"role": "user", "content": "title"}],
+        )
+
+    call_kwargs = client.chat.completions.create.call_args.kwargs
+    assert "max_tokens" not in call_kwargs
+    assert "max_completion_tokens" not in call_kwargs
+

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -42,7 +42,8 @@ def test_title_generation_present_in_default_config():
     assert tg["provider"] == "auto"
     assert tg["model"] == ""
     assert tg["prefer_fast_model"] is False
-    assert tg["timeout"] > 0
+    assert tg["timeout"] == 10
+    assert tg["max_concurrency"] == 1
     assert tg["extra_body"] == {}
 
 


### PR DESCRIPTION
## What does this PR do?

Supersedes #88177, which could not be reopened after its source branch was recreated.

Auto-title generation is cosmetic, but its retry and fallback path could hold the user-facing flow for over a minute and then attempt a paid fallback after the auxiliary provider was unavailable. A real Family Manager run against Bubbles took about 94 seconds: three 30-second title requests, followed by the fallback attempt.

This change makes a failed title-generation request terminal, keeps the user’s configured timeout as the total bound for that operation, forwards the title's 64-token limit to custom/OpenAI-compatible clients, and makes the default title timeout/concurrency conservative.

## Related Issue

Supersedes #88177. No separate issue is known.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/auxiliary_client.py`: do not retry or fall back from title-generation timeouts; forward `max_tokens=64` to custom and OpenAI-compatible routes.
- `hermes_cli/config_defaults.py`: set title generation defaults to a 10-second timeout and concurrency of 1.
- `tests/agent/test_auxiliary_transient_retry.py`: cover synchronous and asynchronous title timeout behavior and max-token forwarding.
- `tests/hermes_cli/test_aux_config.py`: cover the revised defaults.

## How to Test

1. Configure an auxiliary title-generation provider that exceeds the configured timeout.
2. Generate a session title and verify that the operation logs one terminal timeout, with no retry and no fallback request.
3. Run `pytest tests/agent/test_auxiliary_transient_retry.py tests/hermes_cli/test_aux_config.py -q`.

Focused validation on the Linux staging worktree: **12 passed in 2.39s**. The full `pytest tests/ -q` suite has not been run for this revision.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux staging worktree (focused pytest only)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

No screenshots. The observed production-like failure mode was: three 30-second Bubbles title attempts, then an attempted fallback; this patch bounds that path and prevents fallback for title timeouts.
