### PR TITLE
feat(cli): support interactive bang shell

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12381,13 +12381,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         through to normal routing.
         """
         from hermes_cli.bang_shell import (
-            USAGE_HINT,
             bang_shell_enabled,
             check_bang_approval,
             is_bang_command,
             parse_bang_command,
             resolve_bang_cwd,
             run_bang_command,
+            run_bang_command_interactive,
         )
 
         if not is_bang_command(text):
@@ -12399,10 +12399,45 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             return False
 
         command = parse_bang_command(text)
+        cwd = resolve_bang_cwd(getattr(self, "session_id", None))
+        app = getattr(self, "_app", None)
+        on_event_loop = False
+        if app is not None and getattr(app, "is_running", False):
+            import asyncio
+
+            try:
+                asyncio.get_running_loop()
+            except RuntimeError:
+                pass
+            else:
+                on_event_loop = True
+
+        if on_event_loop:
+            async def _run_interactive():
+                if command:
+
+                    approval = await asyncio.to_thread(check_bang_approval, command)
+                    if not approval.get("approved"):
+                        message = approval.get("message") or (
+                            f"Command denied: {approval.get('description', 'flagged as dangerous')}"
+                        )
+                        self._console_print(f"[bold red]{_escape(str(message))}[/]")
+                        return
+
+                exit_code = await run_bang_command_interactive(
+                    app,
+                    command or None,
+                    cwd=cwd,
+                )
+                if exit_code:
+                    self._console_print(f"[dim]! exited {exit_code}[/]")
+
+            app.create_background_task(_run_interactive())
+            return True
+
         if not command:
-            # Bare `!` — show what the feature does instead of running an
-            # empty shell or sending "!" to the model.
-            self._console_print(f"[dim]{USAGE_HINT}[/]")
+            # A real interactive application launches the user's shell for a
+            # bare `!`. Headless callers have no terminal to hand over.
             return True
 
         approval = check_bang_approval(command)
@@ -12413,7 +12448,6 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             self._console_print(f"[bold red]{_escape(str(message))}[/]")
             return True
 
-        cwd = resolve_bang_cwd(getattr(self, "session_id", None))
         exit_code = run_bang_command(
             command,
             cwd=cwd,
@@ -18615,19 +18649,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     event.app.invalidate()
                     return
 
+                # Shell escapes need prompt_toolkit to hand its real terminal
+                # to the child. Dispatch on the UI thread instead of queuing
+                # through process_loop, which cannot safely transfer the TTY.
+                if text.startswith("!") and self.handle_bang_shell(text):
+                    event.app.current_buffer.reset(append_to_history=True)
+                    event.app.invalidate()
+                    return
+
                 # Snapshot and clear attached images
                 images = list(self._attached_images)
                 self._attached_images.clear()
                 event.app.invalidate()
                 # Bundle text + images as a tuple when images are present
                 payload = (text, images) if images else text
-                # A bang command is treated like a slash command while the
-                # agent is busy: it must never be routed into steer/redirect
-                # (which would inject `!git status` into the model's context as
-                # a prompt). It queues and runs locally once the loop drains.
-                _is_local_dispatch = bool(text) and (
-                    _looks_like_slash_command(text) or text.strip().startswith("!")
-                )
+                _is_local_dispatch = bool(text) and _looks_like_slash_command(text)
                 if self._agent_running and not _is_local_dispatch:
                     _effective_mode = self.busy_input_mode
                     redirected = False

--- a/hermes_cli/bang_shell.py
+++ b/hermes_cli/bang_shell.py
@@ -1,15 +1,15 @@
-"""``!<command>`` shell mode for the interactive CLI.
+"""Direct shell escapes for the interactive CLI.
 
-Typing ``!git status`` at the composer runs the command directly in the
-session's working directory. The model is never invoked: no user message, no
-assistant message, no tool result enters the conversation history, so a bang
-command costs zero tokens and cannot perturb role alternation or the prompt
-cache.
+Typing ``!git status`` runs one command in the session's working directory;
+typing a bare ``!`` hands the terminal to the user's shell until that shell
+exits. Both paths inherit the real terminal, so OAuth logins, pagers, REPLs,
+and other TTY-dependent programs work normally.
 
-A user-typed command still goes through the SAME dangerous-pattern approval
-gate the terminal tool uses (``tools.approval.check_all_command_guards``),
-reached here through ``tools.terminal_tool._check_all_guards`` so the CLI
-approval callback and Docker host-access handling behave identically.
+The model is never invoked: no user message, assistant message, or tool result
+enters conversation history. One-shot commands still pass through the terminal
+tool's dangerous-pattern approval gate. A bare ``!`` is an explicit escape
+into the user's own shell, so commands entered there are not mediated by
+Hermes.
 
 CLI-only by design: gateway/API/cron sessions have their own shells and no
 composer, so :func:`bang_shell_enabled` gates the feature off there.
@@ -21,7 +21,6 @@ import os
 import subprocess
 from typing import Optional
 
-USAGE_HINT = "Usage: !<command> — run a shell command without spending a model turn (e.g. !git status)"
 
 # Bang commands are interactive convenience, not agent work. Keep the ceiling
 # well under the terminal tool's foreground cap: a user watching output can
@@ -139,6 +138,67 @@ def _bang_env() -> dict:
         return _sanitize_subprocess_env(os.environ.copy())
     except Exception:
         return os.environ.copy()
+
+
+def resolve_interactive_shell() -> list[str]:
+    """Return the user's interactive shell without involving ``shell=True``."""
+    if os.name == "nt":
+        return [os.environ.get("COMSPEC") or "cmd.exe"]
+    return [os.environ.get("SHELL") or "/bin/sh"]
+
+
+async def run_bang_command_interactive(
+    app,
+    command: Optional[str],
+    *,
+    cwd: Optional[str] = None,
+) -> int:
+    """Run a command, or the user's shell, on prompt_toolkit's real terminal."""
+    import sys
+
+    from prompt_toolkit.application import in_terminal
+    from prompt_toolkit.eventloop import run_in_executor_with_context
+
+    run_cwd = cwd if (cwd and os.path.isdir(os.path.expanduser(cwd))) else None
+    if run_cwd:
+        run_cwd = os.path.expanduser(run_cwd)
+
+    try:
+        input_fd = app.input.fileno()
+    except (AttributeError, OSError):
+        input_fd = sys.stdin.fileno()
+    try:
+        output_fd = app.output.fileno()
+    except (AttributeError, OSError):
+        output_fd = sys.stdout.fileno()
+
+    def run() -> int:
+        try:
+            if command is None:
+                proc = subprocess.Popen(
+                    resolve_interactive_shell(),
+                    stdin=input_fd,
+                    stdout=output_fd,
+                    stderr=output_fd,
+                    cwd=run_cwd,
+                    env=_bang_env(),
+                )
+            else:
+                proc = subprocess.Popen(
+                    command,
+                    shell=True,
+                    stdin=input_fd,
+                    stdout=output_fd,
+                    stderr=output_fd,
+                    cwd=run_cwd,
+                    env=_bang_env(),
+                )
+            return int(proc.wait() or 0)
+        except OSError:
+            return 127
+
+    async with in_terminal():
+        return await run_in_executor_with_context(run)
 
 
 def run_bang_command(

--- a/tests/cli/test_bang_shell_mode.py
+++ b/tests/cli/test_bang_shell_mode.py
@@ -8,16 +8,17 @@ byte-identical because it never becomes a turn.
 import copy
 import json
 import os
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from hermes_cli.bang_shell import (
-    USAGE_HINT,
     bang_shell_enabled,
     is_bang_command,
     parse_bang_command,
+    resolve_interactive_shell,
     run_bang_command,
+    run_bang_command_interactive,
 )
 
 
@@ -121,8 +122,81 @@ class TestBangExecution:
         assert code == 0
         assert "ok" in lines
 
+class _TerminalHandoff:
+    async def __aenter__(self):
+        return None
 
-# ── CLI handler: approval gate, usage hint, exit codes ─────────────────────
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+async def _run_inline(callback):
+    return callback()
+
+
+class TestInteractiveBangExecution:
+    @pytest.mark.asyncio
+    async def test_command_inherits_prompt_toolkit_terminal(self):
+        app = MagicMock()
+        app.input.fileno.return_value = 11
+        app.output.fileno.return_value = 12
+        proc = MagicMock()
+        proc.wait.return_value = 0
+
+        with patch(
+            "prompt_toolkit.application.in_terminal",
+            return_value=_TerminalHandoff(),
+        ), patch(
+            "prompt_toolkit.eventloop.run_in_executor_with_context",
+            side_effect=_run_inline,
+        ), patch("subprocess.Popen", return_value=proc) as popen:
+            code = await run_bang_command_interactive(app, "oauth-login")
+
+        assert code == 0
+        popen.assert_called_once()
+        assert popen.call_args.args == ("oauth-login",)
+        assert popen.call_args.kwargs["shell"] is True
+        assert popen.call_args.kwargs["stdin"] == 11
+        assert popen.call_args.kwargs["stdout"] == 12
+        assert popen.call_args.kwargs["stderr"] == 12
+        assert popen.call_args.kwargs["cwd"] is None
+
+    @pytest.mark.asyncio
+    async def test_bare_bang_runs_configured_shell_directly(self, monkeypatch):
+        monkeypatch.setenv("SHELL", "/bin/test-shell")
+        app = MagicMock()
+        app.input.fileno.return_value = 21
+        app.output.fileno.return_value = 22
+        proc = MagicMock()
+        proc.wait.return_value = 0
+
+        with patch(
+            "prompt_toolkit.application.in_terminal",
+            return_value=_TerminalHandoff(),
+        ), patch(
+            "prompt_toolkit.eventloop.run_in_executor_with_context",
+            side_effect=_run_inline,
+        ), patch("subprocess.Popen", return_value=proc) as popen:
+            code = await run_bang_command_interactive(app, None)
+
+        assert code == 0
+        assert popen.call_args.args == (["/bin/test-shell"],)
+        assert "shell" not in popen.call_args.kwargs
+        assert popen.call_args.kwargs["stdin"] == 21
+        assert popen.call_args.kwargs["stdout"] == 22
+        assert popen.call_args.kwargs["stderr"] == 22
+
+    def test_windows_shell_uses_comspec(self):
+        with patch("hermes_cli.bang_shell.os.name", "nt"), patch.dict(
+            os.environ,
+            {"COMSPEC": r"C:\Windows\System32\cmd.exe"},
+        ):
+            assert resolve_interactive_shell() == [
+                r"C:\Windows\System32\cmd.exe"
+            ]
+
+
+# ── CLI handler: approval gate, terminal handoff, exit codes ───────────────
 
 def _make_cli(history=None):
     """Build a HermesCLI shell with only what handle_bang_shell touches."""
@@ -155,12 +229,25 @@ class TestBangHandlerDispatch:
         assert cli.handle_bang_shell("please fix this bug!") is False
         assert cli.handle_bang_shell("/help") is False
 
-    def test_bare_bang_prints_usage_and_runs_nothing(self):
+    @pytest.mark.asyncio
+    async def test_bare_bang_launches_interactive_shell(self):
         cli = _make_cli()
-        with patch("hermes_cli.bang_shell.run_bang_command") as runner:
+        app = MagicMock()
+        app.is_running = True
+        scheduled = []
+        app.create_background_task.side_effect = scheduled.append
+        cli._app = app
+
+        with patch(
+            "hermes_cli.bang_shell.run_bang_command_interactive",
+            new=AsyncMock(return_value=0),
+        ) as runner:
             assert cli.handle_bang_shell("!") is True
-        runner.assert_not_called()
-        assert any(USAGE_HINT in line for line in _printed(cli))
+            assert len(scheduled) == 1
+            await scheduled[0]
+
+        runner.assert_awaited_once()
+        assert runner.await_args.args == (app, None)
 
     def test_command_output_is_printed(self):
         cli = _make_cli()
@@ -220,6 +307,30 @@ class TestBangApprovalGate:
         runner.assert_not_called()
         assert any("denied" in line.lower() for line in _printed(cli))
 
+    @pytest.mark.asyncio
+    async def test_denied_interactive_command_is_not_executed(self):
+        cli = _make_cli()
+        app = MagicMock()
+        app.is_running = True
+        scheduled = []
+        app.create_background_task.side_effect = scheduled.append
+        cli._app = app
+        cli._console_print = MagicMock()
+        gate = MagicMock(return_value={
+            "approved": False,
+            "message": "Command denied: recursive delete",
+        })
+
+        with patch("tools.terminal_tool._check_all_guards", gate), patch(
+            "hermes_cli.bang_shell.run_bang_command_interactive",
+            new=AsyncMock(return_value=0),
+        ) as runner:
+            assert cli.handle_bang_shell("!rm -rf /important") is True
+            await scheduled[0]
+
+        runner.assert_not_awaited()
+        assert "denied" in cli._console_print.call_args.args[0].lower()
+
     def test_real_gate_blocks_a_hardline_command(self):
         """End-to-end through the real approval module — no execution."""
         cli = _make_cli()
@@ -259,7 +370,7 @@ class TestBangLeavesHistoryByteIdentical:
     @pytest.mark.parametrize("submission", [
         "!echo history-check",     # succeeds
         "!exit 7",                 # non-zero exit
-        "!",                       # bare bang / usage hint
+        "!",                       # bare bang / interactive shell
         "!definitely-not-a-real-binary-xyz",  # command not found
     ])
     def test_history_is_byte_identical_before_and_after(self, submission):

--- a/website/docs/user-guide/cli.md
+++ b/website/docs/user-guide/cli.md
@@ -187,7 +187,7 @@ When resuming a previous session (`hermes -c` or `hermes --resume <id>`), a "Pre
 | `Ctrl+D` | Exit |
 | `Ctrl+Z` | Suspend Hermes to background (Unix only). Run `fg` in the shell to resume. |
 | `Tab` | Accept auto-suggestion (ghost text) or autocomplete slash commands |
-| `!<command>` | **Shell mode** — run a shell command yourself without spending a model turn (e.g. `!git status`, `!pytest -x`). See below. |
+| `!<command>` / `!` | **Shell mode** — run one command, or open your interactive shell, without spending a model turn. See below. |
 
 **Multiline paste preview.** When you paste a multi-line block, the CLI echoes a compact single-line preview (`[pasted: 47 lines, 1,842 chars — press Enter to send]`) instead of dumping the whole payload into the scrollback. The full content is still what gets sent; this is just display polish.
 
@@ -197,16 +197,20 @@ Start a line with `!` to run it as a shell command instead of sending it to the 
 
 ```
 > !git status
-> !ls -la
-> !pytest -x tests/cli
+> !hermes mcp login github
+> !
 ```
+
+One-shot commands and a shell opened by bare `!` inherit your real terminal.
+Interactive login flows, password prompts, pagers, and REPLs therefore work as
+they do outside Hermes. Type `exit` or press `Ctrl+D` to leave a shell opened
+by bare `!` and return to the Hermes composer.
 
 - **Zero cost.** The model is never invoked — no API call, no tokens, no latency.
 - **Nothing enters the conversation.** The command and its output are not added to history, so your context stays clean and the prompt cache is untouched.
 - **Runs where the agent's `terminal` tool runs.** Uses the session working directory, so `!pwd` matches what the agent would see.
-- **Approvals still apply.** A dangerous command (`rm -rf`, writes to `~/.hermes/config.yaml`, etc.) goes through the same approval prompt the agent's `terminal` tool uses. `!` is a cost/latency shortcut, not a security bypass.
-- **Non-zero exits are shown.** A failing command prints `! exited <code>` after its output.
-- `!` on its own prints a one-line usage reminder.
+- **One-shot approvals still apply.** `!<command>` goes through the same approval prompt as the agent's `terminal` tool. Bare `!` explicitly enters your own shell; commands entered there are not mediated by Hermes.
+- **Non-zero exits are shown.** A failing command or shell prints `! exited <code>` after it returns.
 
 Shell mode is CLI-only. Gateway platforms (Discord, Telegram, Slack) and cron runs ignore it — those users already have their own shells.
 


### PR DESCRIPTION
## Summary

- hand prompt_toolkit's real terminal to `!command` subprocesses so OAuth logins, prompts, pagers, and REPLs work
- make bare `!` open the user's configured shell until `exit`/Ctrl+D
- preserve the existing approval gate for one-shot commands and keep all shell activity out of model history
- keep the feature scoped to the classic interactive CLI; gateway, cron, and messaging contexts remain disabled

## Security boundary

`!command` still goes through the terminal tool's approval gate. Bare `!` is an explicit escape into the user's own shell, so commands entered after that handoff are intentionally not mediated by Hermes. Both paths retain the existing sanitized subprocess environment.

## Verification

- `54 passed` — `tests/cli/test_bang_shell_mode.py`
- `ruff check cli.py hermes_cli/bang_shell.py tests/cli/test_bang_shell_mode.py`
- real PTY smoke: an interactive Python child read an OAuth-style code from inherited stdin and returned control to Hermes
- real PTY smoke: bare `!` opened a persistent shell, executed a command, and returned to Hermes after `exit`
- Windows shell selection test covers `%COMSPEC%`

Fixes #99789