### PR TITLE
fix(gateway): accept is_voice kwarg in Mattermost and LINE send_voice

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1463,7 +1463,11 @@ class LineAdapter(BasePlatformAdapter):
         audio_path: str,
         duration_ms: int = 1000,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False,
     ) -> SendResult:
+        # ``is_voice`` is accepted for signature compatibility with the
+        # gateway media router (BasePlatformAdapter.send_voice kwarg set)
+        # and has no effect on LINE delivery.
         path = Path(audio_path)
         if not path.exists() or not path.is_file():
             return SendResult(success=False, error=f"audio file not found: {audio_path}")

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -498,8 +498,15 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False,
     ) -> SendResult:
-        """Upload an audio file."""
+        """Upload an audio file.
+
+        ``is_voice`` mirrors the shared ``BasePlatformAdapter.send_voice``
+        keyword set (the gateway media router passes it for MEDIA: audio);
+        Mattermost uploads are generic attachments, so the flag is accepted
+        for signature compatibility and ignored.
+        """
         return await self._send_local_file(
             chat_id, audio_path, caption, reply_to, metadata=metadata
         )

--- a/tests/gateway/test_send_voice_is_voice_kwarg.py
+++ b/tests/gateway/test_send_voice_is_voice_kwarg.py
@@ -1,0 +1,85 @@
+"""Regression tests: send_voice must accept the gateway router's is_voice kwarg.
+
+The gateway media dispatch loop (gateway/platforms/base.py) calls
+``self.send_voice(chat_id=..., audio_path=..., metadata=..., is_voice=...)``
+whenever ``should_send_media_as_audio`` routes an audio MEDIA: attachment to
+the voice sender. Adapters whose ``send_voice`` lacks ``is_voice`` (and any
+``**kwargs``) raise ``TypeError`` at argument-binding time, and the dispatch
+loop swallows it, so the attachment silently never arrives.
+
+Matrix was fixed for this in #99712; these tests pin the same contract for
+the Mattermost and LINE adapters.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+mattermost_adapter = load_plugin_adapter("mattermost")
+line_adapter = load_plugin_adapter("line")
+
+
+def _send_voice_params(module, class_name):
+    adapter_cls = getattr(module, class_name)
+    return inspect.signature(adapter_cls.send_voice).parameters
+
+
+class TestMattermostSendVoiceSignature:
+    def test_accepts_is_voice_kwarg(self):
+        params = _send_voice_params(mattermost_adapter, "MattermostAdapter")
+        assert "is_voice" in params, (
+            "gateway media router calls send_voice(is_voice=...); "
+            "MattermostAdapter must accept it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_router_kwarg_set_binds(self):
+        """The exact kwarg set from the base.py dispatch loop must bind."""
+        adapter_cls = mattermost_adapter.MattermostAdapter
+        instance = adapter_cls.__new__(adapter_cls)
+
+        # No connection/file: the adapter either returns a controlled SendResult
+        # or skips the missing local file — anything except a TypeError from
+        # argument binding.
+        adapter_cls = mattermost_adapter.MattermostAdapter
+        instance = adapter_cls.__new__(adapter_cls)
+        try:
+            await adapter_cls.send_voice(
+                instance,
+                chat_id="C1",
+                audio_path="/tmp/does-not-exist.ogg",
+                metadata=None,
+                is_voice=True,
+            )
+        except TypeError as e:
+            pytest.fail(f"send_voice rejected the router's is_voice kwarg: {e}")
+
+
+class TestLineSendVoiceSignature:
+    def test_accepts_is_voice_kwarg(self):
+        params = _send_voice_params(line_adapter, "LineAdapter")
+        assert "is_voice" in params, (
+            "gateway media router calls send_voice(is_voice=...); "
+            "LineAdapter must accept it"
+        )
+
+    @pytest.mark.asyncio
+    async def test_router_kwarg_set_binds(self):
+        """The exact kwarg set from the base.py dispatch loop must bind."""
+        adapter_cls = line_adapter.LineAdapter
+        instance = adapter_cls.__new__(adapter_cls)
+
+        result = await adapter_cls.send_voice(
+            instance,
+            chat_id="C1",
+            audio_path="/tmp/does-not-exist.ogg",
+            metadata=None,
+            is_voice=True,
+        )
+        # Missing file returns a controlled failure, proving binding worked.
+        assert result.success is False
+        assert "not found" in result.error


### PR DESCRIPTION
## What does this PR do?

Fixes a silent audio-attachment failure on Mattermost and LINE.

The gateway media dispatch loop (`gateway/platforms/base.py:6956`) passes `is_voice=is_voice` when routing an audio `MEDIA:` attachment to the adapter's `send_voice`. `MattermostAdapter.send_voice` and `LineAdapter.send_voice` don't accept that kwarg (no `is_voice` param, no `**kwargs`), so the call raises `TypeError` at binding time. The dispatch loop's `except Exception` swallows it, the attachment never uploads, and because `_notify_media_delivery_failure` only fires on `success=False` inside the try, the user gets no notice at all.

This adds `is_voice: bool = False` to both signatures. It's accepted and ignored: Mattermost uploads are generic attachments and LINE sends audio messages without a voice/audio distinction, so `False` is the right default (a regular audio file should not be marked as a voice bubble on platforms that can't express it).

Sibling of #99712, which fixes the same router kwarg for the matrix adapter. Of the 16 adapters, these were the only two left without the kwarg after that PR.

## Related Issue

Fixes #100018

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — `send_voice`: add `is_voice: bool = False` param, docstring notes it's accepted for signature compatibility with the router and ignored.
- `plugins/platforms/line/adapter.py` — `send_voice`: same, one-line comment. `duration_ms` and all other existing behavior untouched.
- `tests/gateway/test_send_voice_is_voice_kwarg.py` — new: signature contract + exact router-kwarg-set binding test per adapter, using the existing `tests/gateway/_plugin_adapter_loader.py` isolation convention.

No core files touched. No behavior change beyond letting the router's call bind.

## How to Test

On the repo's documented test runner:

```bash
uv run --python 3.11 --with pytest --with pytest-asyncio --with pyyaml \
  --with python-dotenv --with httpx --with pillow --with requests \
  --with rich --with prompt_toolkit --with aiohttp \
  python -m pytest -q -o 'addopts=' tests/gateway/test_send_voice_is_voice_kwarg.py
```

Observed on this branch: `4 passed in 0.27s`.
On unmodified `origin/main` @ `21b2095d00`: `4 failed` — the two binding tests fail with `TypeError: ... unexpected keyword argument 'is_voice'`, the two signature tests fail on the missing param. Confirms the tests pin exactly this gap.

Baseline (unchanged by this PR): `tests/gateway/test_mattermost.py`, `test_mattermost_plugin_setup.py`, `test_line_plugin.py`, `test_voice_transcode.py` — `61 passed`.

The live-repro script for the pre-fix failure (clean worktree, no credentials needed) is in the linked issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13, Python 3.11.15, origin/main @ 21b2095d00

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (in-code comment documents the shape contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
