### PR TITLE
fix(slack): enforce machine thread affinity

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3199,6 +3199,25 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.append(bot_chat_error)
             continue
 
+        from gateway.platforms.base import (
+            strict_machine_thread_affinity_error,
+            strict_machine_thread_metadata,
+        )
+
+        affinity_metadata = strict_machine_thread_metadata(
+            {"thread_id": str(thread_id)} if thread_id else None
+        )
+        affinity_error = strict_machine_thread_affinity_error(
+            platform_name,
+            affinity_metadata,
+            str(thread_id) if thread_id else None,
+        )
+        if affinity_error:
+            msg = f"delivery to {platform_name}:{chat_id} suppressed: {affinity_error}"
+            logger.warning("Job '%s': %s", job["id"], msg)
+            delivery_errors.append(msg)
+            continue
+
         # Diagnostic: log thread_id for topic-aware delivery debugging
         origin = _resolve_origin(job) or {}
         origin_thread = origin.get("thread_id")
@@ -3342,6 +3361,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         # consumer; "first consumer ≠ definition").
         surface_mode = _resolve_cron_surface_mode(pconfig, platform_name)
         in_channel_surface = surface_mode == "in_channel"
+        if platform == Platform.SLACK and in_channel_surface:
+            # Cron output is machine-generated and therefore cannot use Slack's
+            # channel-root continuation surface.  Keep an explicit thread
+            # anchor intact; unanchored targets were suppressed above.
+            in_channel_surface = False
         if in_channel_surface and runtime_adapter is not None:
             # Per-platform capability first: one RelayAdapter fronts N
             # platforms and the connector advertises the bit per platform at
@@ -3522,6 +3546,10 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata.setdefault("scope_id", str(origin["scope_id"]))
                 media_metadata = dict(media_metadata or {})
                 media_metadata.setdefault("scope_id", str(origin["scope_id"]))
+
+            if platform == Platform.SLACK:
+                route_metadata = strict_machine_thread_metadata(route_metadata)
+                media_metadata = strict_machine_thread_metadata(media_metadata)
 
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -705,6 +705,10 @@ class GatewayKanbanWatchersMixin:
 
                         if sub.get("thread_id") and not metadata.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
+                        if str(sub.get("platform") or "").lower() == "slack":
+                            from gateway.platforms.base import strict_machine_thread_metadata
+
+                            metadata = strict_machine_thread_metadata(metadata)
                         # Adapters with no push channel (the API server —
                         # ``supports_async_delivery = False``) can NEVER
                         # satisfy a text-send: ``send()`` always reports
@@ -998,6 +1002,9 @@ class GatewayKanbanWatchersMixin:
                                 user_id_alt=sub.get("user_id_alt"),
                                 profile=sub_profile or None,
                                 scope_id=_wake_scope_id(adapter, sub),
+                                strict_machine_thread_affinity=(
+                                    getattr(plat, "value", plat) == "slack"
+                                ),
                             )
                             # deliver_wake preserves the synthetic
                             # MessageEvent/handle_message path for

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -121,6 +121,39 @@ def _platform_name(platform) -> str:
     return str(value or "").lower()
 
 
+_STRICT_MACHINE_THREAD_AFFINITY_KEY = "_strict_machine_thread_affinity"
+_STRICT_MACHINE_THREAD_AFFINITY_ERROR = (
+    "strict machine Slack delivery requires an exact thread anchor"
+)
+
+
+def strict_machine_thread_metadata(metadata: dict | None = None) -> dict:
+    """Mark a machine-generated send as fail-closed for Slack threads."""
+    strict_metadata = dict(metadata) if metadata else {}
+    strict_metadata[_STRICT_MACHINE_THREAD_AFFINITY_KEY] = True
+    return strict_metadata
+
+
+def is_strict_machine_thread_delivery(metadata: dict | None) -> bool:
+    """Return whether *metadata* carries the strict machine-delivery policy."""
+    return bool((metadata or {}).get(_STRICT_MACHINE_THREAD_AFFINITY_KEY))
+
+
+def strict_machine_thread_affinity_error(
+    platform,
+    metadata: dict | None,
+    thread_anchor: object | None,
+) -> str | None:
+    """Return an explicit suppression error for an unanchored strict send."""
+    if not is_strict_machine_thread_delivery(metadata):
+        return None
+    if _platform_name(platform) != "slack":
+        return None
+    if str(thread_anchor or "").strip():
+        return None
+    return _STRICT_MACHINE_THREAD_AFFINITY_ERROR
+
+
 def _float_env(name: str, default: float) -> float:
     raw = os.environ.get(name, "").strip()
     if not raw:
@@ -143,6 +176,8 @@ def _thread_metadata_for_source(source, reply_to_message_id: str | None = None) 
     """
     thread_id = getattr(source, "thread_id", None)
     metadata = {"thread_id": thread_id} if thread_id is not None else {}
+    if getattr(source, "strict_machine_thread_affinity", False):
+        metadata = strict_machine_thread_metadata(metadata)
     # Slack workspace identity is durable routing state, not ephemeral event
     # metadata. Carry it on every outbound path (including unthreaded sends)
     # so a multi-workspace Socket Mode gateway never falls back to its primary

--- a/gateway/relay/adapter.py
+++ b/gateway/relay/adapter.py
@@ -27,7 +27,13 @@ from collections import OrderedDict
 from typing import Any, Callable, Dict, Optional, Tuple, cast
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    SendResult,
+    is_strict_machine_thread_delivery,
+    strict_machine_thread_affinity_error,
+)
 from gateway.relay.descriptor import CapabilityDescriptor
 from gateway.relay.media import RelayMediaClient
 from gateway.relay.transport import RelayTransport
@@ -560,6 +566,17 @@ class RelayAdapter(BasePlatformAdapter):
         content: str,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
+        draft_platform = self._platform_by_chat.get(str(chat_id)) or getattr(
+            self.descriptor, "platform", None
+        )
+        affinity_error = strict_machine_thread_affinity_error(
+            draft_platform,
+            metadata,
+            (metadata or {}).get("thread_id") or (metadata or {}).get("thread_ts"),
+        )
+        if affinity_error:
+            logger.warning("Relay draft suppressed: %s (chat=%s)", affinity_error, chat_id)
+            return SendResult(success=False, error=affinity_error)
         if not self.supports_draft_streaming(chat_id=str(chat_id)):
             raise NotImplementedError(
                 "connector does not advertise the 'draft' relay op"
@@ -1818,6 +1835,28 @@ class RelayAdapter(BasePlatformAdapter):
                 error=f"relay does not front platform {platform_value}",
             )
         _sfp_metadata = dict(metadata or {})
+        if (
+            is_strict_machine_thread_delivery(_sfp_metadata)
+            and platform_value == Platform.SLACK.value
+            and reply_to
+            and not (_sfp_metadata.get("thread_id") or _sfp_metadata.get("thread_ts"))
+        ):
+            _sfp_metadata["thread_id"] = str(reply_to)
+        affinity_error = strict_machine_thread_affinity_error(
+            platform_value,
+            _sfp_metadata,
+            _sfp_metadata.get("thread_id")
+            or _sfp_metadata.get("thread_ts")
+            or reply_to,
+        )
+        if affinity_error:
+            logger.warning(
+                "Relay send suppressed: %s (platform=%s chat=%s)",
+                affinity_error,
+                platform_value,
+                chat_id,
+            )
+            return SendResult(success=False, error=affinity_error)
         # Gateway-internal interim marker (see send()): strip before the
         # wire; an interim send through this door also skips interception.
         _interim = bool(_sfp_metadata.pop("_interim_send", False))
@@ -1978,6 +2017,31 @@ class RelayAdapter(BasePlatformAdapter):
     ) -> SendResult:
         send_metadata = dict(metadata or {})
         explicit_platform = send_metadata.pop("_relay_logical_platform", None)
+        logical_platform = (
+            explicit_platform
+            or self._platform_by_chat.get(str(chat_id))
+            or getattr(self.descriptor, "platform", None)
+        )
+        if (
+            is_strict_machine_thread_delivery(send_metadata)
+            and str(getattr(logical_platform, "value", logical_platform)).lower()
+            == Platform.SLACK.value
+            and reply_to
+            and not (send_metadata.get("thread_id") or send_metadata.get("thread_ts"))
+        ):
+            # Machine replies retain the exact originating parent regardless of
+            # the operator's ordinary DM reply_in_thread preference.
+            send_metadata["thread_id"] = str(reply_to)
+        affinity_error = strict_machine_thread_affinity_error(
+            logical_platform,
+            send_metadata,
+            send_metadata.get("thread_id")
+            or send_metadata.get("thread_ts")
+            or reply_to,
+        )
+        if affinity_error:
+            logger.warning("Relay send suppressed: %s (chat=%s)", affinity_error, chat_id)
+            return SendResult(success=False, error=affinity_error)
         # Consumer-declared interim send (commentary, tail flush): NOT the
         # turn-final, so it must never trigger seal-interception — sealing
         # the live stream with interim text orphans the true final into a
@@ -2219,6 +2283,18 @@ class RelayAdapter(BasePlatformAdapter):
         returned. Non-Slack and non-DM chats are untouched by (1), and (3) is
         Slack-only, so other fronted platforms keep their existing behaviour.
         """
+        if (
+            is_strict_machine_thread_delivery(metadata)
+            and (
+                self._platform_by_chat.get(str(chat_id))
+                or str(getattr(self.descriptor.platform, "value", self.descriptor.platform))
+            )
+            == Platform.SLACK.value
+            and reply_to is not None
+        ):
+            metadata.setdefault("thread_id", str(reply_to))
+            return reply_to
+
         effective_reply_to = self._resolve_reply_to_for_send(
             chat_id, reply_to, metadata
         )
@@ -2552,6 +2628,24 @@ class RelayAdapter(BasePlatformAdapter):
         """
         if self._transport is None or not self.descriptor.supports_op("send_media"):
             return None
+        media_metadata: Dict[str, Any] = dict(metadata or {})
+        effective_reply_to = self._apply_slack_thread_anchor(
+            chat_id, reply_to, media_metadata
+        )
+        media_platform = self._platform_by_chat.get(str(chat_id)) or getattr(
+            self.descriptor, "platform", None
+        )
+        affinity_error = strict_machine_thread_affinity_error(
+            media_platform,
+            media_metadata,
+            media_metadata.get("thread_id")
+            or media_metadata.get("thread_ts")
+            or effective_reply_to,
+        )
+        if affinity_error:
+            logger.warning("Relay media suppressed: %s (chat=%s)", affinity_error, chat_id)
+            return SendResult(success=False, error=affinity_error)
+
         source_url = source
         if source_is_path:
             client = self._get_media_client()
@@ -2566,10 +2660,6 @@ class RelayAdapter(BasePlatformAdapter):
         # unresolved anchor threads an image under the user's DM message in
         # flat mode, and loses the per-message thread entirely in thread mode
         # (threadTs() reads metadata only). Route through the shared helper.
-        media_metadata: Dict[str, Any] = dict(metadata or {})
-        effective_reply_to = self._apply_slack_thread_anchor(
-            chat_id, reply_to, media_metadata
-        )
         _media_unfurl = self._slack_unfurl_hints(
             self._platform_by_chat.get(str(chat_id))
             or getattr(self.descriptor, "platform", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -534,12 +534,14 @@ def _non_conversational_metadata(
     *,
     platform: Any = None,
 ) -> Optional[Dict[str, Any]]:
-    """Mark Discord lifecycle/status sends without changing other platforms."""
-    if _gateway_platform_value(platform) != "discord":
-        return metadata
+    """Mark machine lifecycle/status sends and enforce Slack thread affinity."""
+    platform_value = _gateway_platform_value(platform)
     merged = dict(metadata or {})
-    merged["non_conversational"] = True
-    return merged
+    if platform_value == "slack":
+        merged = strict_machine_thread_metadata(merged)
+    if platform_value == "discord":
+        merged["non_conversational"] = True
+    return merged or None
 
 
 def _interim_metadata(
@@ -2774,6 +2776,7 @@ from gateway.platforms.base import (
     _reply_anchor_for_event,
     build_auto_tts_output_path,
     merge_pending_message_event,
+    strict_machine_thread_metadata,
     utf16_len,
 )
 from gateway.shutdown_watchdog import (
@@ -24772,6 +24775,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             chat_type=getattr(source, "chat_type", None),
             reply_to_message_id=reply_to_message_id or getattr(source, "message_id", None),
         )
+        if getattr(source, "strict_machine_thread_affinity", False):
+            metadata = strict_machine_thread_metadata(metadata)
         if getattr(source, "platform", None) == Platform.SLACK:
             # Per-turn egress identity (R3-5, connector PR gateway-gateway#210).
             # Slack's chat.startStream requires recipient_user_id (+
@@ -26034,9 +26039,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Falling back to the currently active foreground event is what causes
         cross-topic bleed, so don't do that.
         """
+        from dataclasses import replace
+
         from gateway.session import SessionSource
 
         session_key = str(evt.get("session_key") or "").strip()
+        origin_source = None
         derived_platform = ""
         derived_chat_type = ""
         derived_chat_id = ""
@@ -26046,7 +26054,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 self.session_store._ensure_loaded()
                 entry = self.session_store._entries.get(session_key)
                 if entry and getattr(entry, "origin", None):
-                    return entry.origin
+                    origin_source = entry.origin
             except Exception as exc:
                 logger.debug(
                     "Synthetic process-event session-store lookup failed for %s: %s",
@@ -26054,15 +26062,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     exc,
                 )
 
-            cached_source = self._get_cached_session_source(session_key)
-            if cached_source is not None:
-                return cached_source
+            if origin_source is None:
+                origin_source = self._get_cached_session_source(session_key)
 
-            _parsed = _parse_session_key(session_key)
-            if _parsed:
-                derived_platform = _parsed["platform"]
-                derived_chat_type = _parsed["chat_type"]
-                derived_chat_id = _parsed["chat_id"]
+            if origin_source is not None:
+                derived_platform = str(
+                    getattr(origin_source.platform, "value", origin_source.platform)
+                    or ""
+                ).lower()
+                derived_chat_type = str(origin_source.chat_type or "")
+                derived_chat_id = str(origin_source.chat_id or "")
+            else:
+                _parsed = _parse_session_key(session_key)
+                if _parsed:
+                    derived_platform = _parsed["platform"]
+                    derived_chat_type = _parsed["chat_type"]
+                    derived_chat_id = _parsed["chat_id"]
 
         platform_name = str(evt.get("platform") or derived_platform or "").strip().lower()
         chat_type = str(evt.get("chat_type") or derived_chat_type or "").strip().lower()
@@ -26096,7 +26111,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             return None
 
-        scope_id = str(evt.get("scope_id") or "").strip() or None
+        thread_id = (
+            str(
+                evt.get("thread_id")
+                or getattr(origin_source, "thread_id", None)
+                or ""
+            ).strip()
+            or None
+        )
+        message_id = (
+            str(
+                evt.get("message_id")
+                or getattr(origin_source, "message_id", None)
+                or ""
+            ).strip()
+            or None
+        )
+        scope_id = (
+            str(
+                evt.get("scope_id")
+                or getattr(origin_source, "scope_id", None)
+                or ""
+            ).strip()
+            or None
+        )
         if scope_id is None and chat_type not in ("dm", "thread"):
             # Reconstructed (non-persisted) source for a scoped chat with no
             # scope discriminator: on a relay-fronted deployment the
@@ -26111,15 +26149,32 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 "the connector's tenant guard (user_id fallback only).",
                 platform_name, chat_id, chat_type,
             )
-        return SessionSource(
-            platform=platform,
-            chat_id=chat_id,
-            chat_type=chat_type,
-            thread_id=str(evt.get("thread_id") or "").strip() or None,
-            user_id=str(evt.get("user_id") or "").strip() or None,
-            user_name=str(evt.get("user_name") or "").strip() or None,
-            scope_id=scope_id,
-        )
+        source_updates = {
+            "platform": platform,
+            "chat_id": chat_id,
+            "chat_type": chat_type,
+            "thread_id": thread_id,
+            "message_id": message_id,
+            "user_id": (
+                str(evt.get("user_id") or getattr(origin_source, "user_id", None) or "").strip()
+                or None
+            ),
+            "user_name": (
+                str(
+                    evt.get("user_name")
+                    or getattr(origin_source, "user_name", None)
+                    or ""
+                ).strip()
+                or None
+            ),
+            "scope_id": scope_id,
+            "strict_machine_thread_affinity": platform == Platform.SLACK,
+        }
+        if origin_source is not None:
+            # Clone rather than mutate the canonical session origin: strict
+            # affinity belongs only to this synthetic machine turn.
+            return replace(origin_source, **source_updates)
+        return SessionSource(**source_updates)
 
     async def _drain_watch_notifications(self, completion_queue) -> None:
         """Consume queued watch events and inject them when notifications are enabled.

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -185,6 +185,14 @@ class SessionSource:
     # Transport-local fail-closed signal for an explicit profile route whose
     # target is not served. Excluded from repr/equality and wire serialization.
     profile_route_rejected: bool = field(default=False, repr=False, compare=False)
+    # Internal, wire-invisible policy for synthetic machine updates. When set,
+    # Slack egress must have an exact parent-thread anchor or suppress the send.
+    # Direct human events never set this flag and retain ordinary root delivery.
+    strict_machine_thread_affinity: bool = field(
+        default=False,
+        repr=False,
+        compare=False,
+    )
 
     # Discord auto-thread metadata.  Newly auto-created Discord threads start
     # with a fast placeholder title from the raw message, then the gateway can

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -57,6 +57,8 @@ from gateway.platforms.base import (
     _ssrf_redirect_guard,
     cache_document_from_bytes,
     cache_video_from_bytes,
+    is_strict_machine_thread_delivery,
+    strict_machine_thread_affinity_error,
 )
 
 try:  # sibling module; support both package and flat plugin-dir import
@@ -1274,8 +1276,11 @@ class SlackAdapter(BasePlatformAdapter):
         # Each value: {"response_url": str, "ts": float}
         self._slash_command_contexts: Dict[Tuple[str, ...], Dict[str, Any]] = {}
         # Native streaming (chat.startStream/appendStream/stopStream) state.
-        # One active stream per chat, keyed by chat_id. Each value:
-        # {"ts": str, "draft_id": int, "sent": str, "started": float}
+        # One active stream per chat, keyed by chat_id. Each value includes
+        # the parent ``thread_ts`` so strict machine finals cannot seal a
+        # stream from another Slack thread.
+        # {"ts": str, "thread_ts": str, "draft_id": int, "sent": str,
+        #  "started": float}
         # ``sent`` is the raw (pre-mrkdwn) text streamed so far — deltas are
         # computed against it because the streaming API is append-only.
         self._active_streams: Dict[str, Dict[str, Any]] = {}
@@ -2932,6 +2937,16 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        affinity_thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK,
+            metadata,
+            affinity_thread_ts,
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed outbound machine send: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
+
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
@@ -2991,7 +3006,12 @@ class SlackAdapter(BasePlatformAdapter):
             # chat.startStream stream and this send carries its final
             # content, seal the stream instead of posting a duplicate
             # message (the streamed message IS the final message).
-            stream_result = await self._try_finalize_stream(chat_id, content)
+            stream_result = await self._try_finalize_stream(
+                chat_id,
+                content,
+                expected_thread_ts=affinity_thread_ts,
+                strict_machine=is_strict_machine_thread_delivery(metadata),
+            )
             if stream_result is not None:
                 return stream_result
 
@@ -3397,9 +3417,34 @@ class SlackAdapter(BasePlatformAdapter):
         if self._native_stream_unsupported:
             return SendResult(success=False, error="native streaming unsupported")
 
+        thread_ts = self._resolve_thread_ts(None, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK,
+            metadata,
+            thread_ts,
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed outbound machine stream: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
+
         text = self._strip_stream_cursor(content)
         client = self._get_client(chat_id)
         stream = self._active_streams.get(chat_id)
+
+        if (
+            is_strict_machine_thread_delivery(metadata)
+            and stream is not None
+            and str(stream.get("thread_ts") or "") != str(thread_ts or "")
+        ):
+            logger.warning(
+                "[Slack] Suppressed machine stream frame for %s: active stream "
+                "belongs to a different thread",
+                chat_id,
+            )
+            return SendResult(
+                success=False,
+                error="strict machine Slack stream belongs to a different thread",
+            )
 
         try:
             if stream is not None and stream.get("draft_id") != draft_id:
@@ -3409,7 +3454,6 @@ class SlackAdapter(BasePlatformAdapter):
                 stream = None
 
             if stream is None:
-                thread_ts = self._resolve_thread_ts(None, metadata)
                 if not thread_ts:
                     # Streamed messages must anchor to a thread_ts. The
                     # gateway sets metadata.thread_id even for top-level
@@ -3438,6 +3482,7 @@ class SlackAdapter(BasePlatformAdapter):
                     raise RuntimeError("chat.startStream returned no ts")
                 self._active_streams[chat_id] = {
                     "ts": str(ts),
+                    "thread_ts": str(thread_ts),
                     "draft_id": draft_id,
                     "sent": text,
                     "started": time.time(),
@@ -3533,6 +3578,9 @@ class SlackAdapter(BasePlatformAdapter):
         self,
         chat_id: str,
         content: str,
+        *,
+        expected_thread_ts: Optional[str] = None,
+        strict_machine: bool = False,
     ) -> Optional[SendResult]:
         """Finalize an active native stream with the turn-final content.
 
@@ -3544,6 +3592,12 @@ class SlackAdapter(BasePlatformAdapter):
         """
         stream = self._active_streams.get(chat_id)
         if stream is None:
+            return None
+        if strict_machine and str(stream.get("thread_ts") or "") != str(
+            expected_thread_ts or ""
+        ):
+            # A synthetic machine final may share a channel with an active
+            # stream from another thread. Let send() use its exact anchor.
             return None
         sent = stream.get("sent", "")
         text = self._strip_stream_cursor(content)
@@ -3870,6 +3924,10 @@ class SlackAdapter(BasePlatformAdapter):
         thread replies.  Messages that originate inside an existing thread are
         always replied to in-thread to preserve conversation context.
         """
+        if is_strict_machine_thread_delivery(metadata):
+            md = metadata or {}
+            return md.get("thread_id") or md.get("thread_ts") or reply_to
+
         # When reply_in_thread is disabled (default: True for backward compat),
         # only thread messages that are already part of an existing thread.
         # For top-level channel messages, the inbound handler sets
@@ -3914,10 +3972,17 @@ class SlackAdapter(BasePlatformAdapter):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File not found: {file_path}")
 
+        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK, metadata, thread_ts
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed machine file upload: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
+
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
-        thread_ts = self._resolve_thread_ts(reply_to, metadata)
         last_exc = None
         for attempt in range(3):
             try:
@@ -3973,6 +4038,14 @@ class SlackAdapter(BasePlatformAdapter):
         if not images:
             return
 
+        thread_ts = self._resolve_thread_ts(None, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK, metadata, thread_ts
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed machine image batch: %s", affinity_error)
+            return
+
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
@@ -3986,8 +4059,6 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception:
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
             return
-
-        thread_ts = self._resolve_thread_ts(None, metadata)
 
         CHUNK = 10
         chunks = [images[i : i + CHUNK] for i in range(0, len(images), CHUNK)]
@@ -4793,6 +4864,14 @@ class SlackAdapter(BasePlatformAdapter):
         if not self._app:
             return SendResult(success=False, error="Not connected")
 
+        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK, metadata, thread_ts
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed machine image upload: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
+
         from tools.url_safety import create_ssrf_safe_async_client, is_safe_url
 
         if not is_safe_url(image_url):
@@ -4818,7 +4897,6 @@ class SlackAdapter(BasePlatformAdapter):
                 response = await client.get(image_url)
                 response.raise_for_status()
 
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             chat_id = await self._ensure_dm_conversation(
                 chat_id, team_id=self._metadata_team_id(metadata)
             )
@@ -4895,11 +4973,18 @@ class SlackAdapter(BasePlatformAdapter):
                 success=False, error=f"Video file not found: {video_path}"
             )
 
+        thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK, metadata, thread_ts
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed machine video upload: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
+
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )
         try:
-            thread_ts = self._resolve_thread_ts(reply_to, metadata)
             last_exc = None
             for attempt in range(3):
                 try:
@@ -4960,6 +5045,12 @@ class SlackAdapter(BasePlatformAdapter):
 
         display_name = file_name or os.path.basename(file_path)
         thread_ts = self._resolve_thread_ts(reply_to, metadata)
+        affinity_error = strict_machine_thread_affinity_error(
+            Platform.SLACK, metadata, thread_ts
+        )
+        if affinity_error:
+            logger.warning("[Slack] Suppressed machine document upload: %s", affinity_error)
+            return SendResult(success=False, error=affinity_error)
         chat_id = await self._ensure_dm_conversation(
             chat_id, team_id=self._metadata_team_id(metadata)
         )

--- a/tests/cron/test_cron_relay_delivery_guards.py
+++ b/tests/cron/test_cron_relay_delivery_guards.py
@@ -16,16 +16,19 @@ Two related defects on relay-fronted Slack deployments:
    would have delivered it. Preflight must consult the relay's fronted set.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
 from cron import scheduler as sched
 from cron.scheduler import (
+    _deliver_result,
     _preflight_check_delivery,
     _resolve_single_delivery_target,
     cron_delivery_targets,
 )
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from plugins.platforms.slack.adapter import SlackAdapter
 
 
 def _slack_home(monkeypatch, chat_id="D0BJTDCSR7C", thread_id=None):
@@ -124,6 +127,123 @@ class TestPreflightRelayFronted:
             reason = _preflight_check_delivery({"deliver": "discord:12345"})
             assert reason is not None
             assert "discord" in reason
+
+
+class TestStrictSlackMachineDelivery:
+    @staticmethod
+    def _config():
+        return GatewayConfig(
+            platforms={Platform.SLACK: PlatformConfig(enabled=True)}
+        )
+
+    @pytest.mark.parametrize(
+        "job",
+        [
+            {
+                "id": "bare-origin",
+                "deliver": "origin",
+                "origin": {"platform": "slack", "chat_id": "C0BTQQX0SLC"},
+            },
+            {"id": "bare-explicit", "deliver": "slack:C0BTQQX0SLC"},
+        ],
+    )
+    def test_unanchored_slack_cron_delivery_is_suppressed(self, job):
+        standalone_send = AsyncMock(return_value={"success": True})
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._config()),
+            patch(
+                "cron.scheduler.load_config",
+                return_value={"cron": {"wrap_response": False}},
+            ),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(job, "scheduled result")
+
+        assert result is not None
+        assert "strict machine Slack delivery requires an exact thread anchor" in result
+        standalone_send.assert_not_awaited()
+
+    def test_exact_slack_cron_thread_is_preserved(self):
+        standalone_send = AsyncMock(return_value={"success": True})
+        job = {
+            "id": "thread-origin",
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0BTQQX0SLC",
+                "chat_type": "thread",
+                "thread_id": "1788217797.757469",
+            },
+        }
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._config()),
+            patch(
+                "cron.scheduler.load_config",
+                return_value={"cron": {"wrap_response": False}},
+            ),
+            patch("tools.send_message_tool._send_to_platform", new=standalone_send),
+        ):
+            result = _deliver_result(job, "scheduled result")
+
+        assert result is None
+        standalone_send.assert_awaited_once()
+        assert standalone_send.await_args.kwargs["thread_id"] == "1788217797.757469"
+
+    def test_live_slack_cron_delivery_posts_to_the_exact_thread(self):
+        import asyncio
+        from concurrent.futures import Future
+
+        adapter = SlackAdapter(PlatformConfig(enabled=True))
+        adapter._app = MagicMock()
+        client = MagicMock()
+        client.chat_postMessage = AsyncMock(
+            return_value={"ok": True, "ts": "1788217798.000001"}
+        )
+        adapter._get_client = MagicMock(return_value=client)
+        loop = MagicMock()
+        loop.is_running.return_value = True
+        job = {
+            "id": "live-thread-origin",
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "C0BTQQX0SLC",
+                "chat_type": "thread",
+                "thread_id": "1788217797.757469",
+            },
+        }
+
+        def run_on_loop(coro, _loop):
+            future = Future()
+            try:
+                future.set_result(asyncio.run(coro))
+            except BaseException as exc:  # noqa: BLE001
+                future.set_exception(exc)
+            return future
+
+        with (
+            patch("gateway.config.load_gateway_config", return_value=self._config()),
+            patch(
+                "cron.scheduler.load_config",
+                return_value={"cron": {"wrap_response": False}},
+            ),
+            patch("asyncio.run_coroutine_threadsafe", side_effect=run_on_loop),
+        ):
+            result = _deliver_result(
+                job,
+                "scheduled result",
+                adapters={Platform.SLACK: adapter},
+                loop=loop,
+            )
+
+        assert result is None
+        client.chat_postMessage.assert_awaited_once()
+        assert (
+            client.chat_postMessage.await_args.kwargs["thread_ts"]
+            == "1788217797.757469"
+        )
 
     def test_native_strictness_without_relay(self, monkeypatch):
         """No relay configured: the native credential check is unchanged."""

--- a/tests/cron/test_media_delivery_parity.py
+++ b/tests/cron/test_media_delivery_parity.py
@@ -45,8 +45,12 @@ def slack_job():
     return {
         "id": "job-media-1",
         "name": "media-parity",
-        "deliver": "slack:D0123456789",
-        "origin": {"platform": "slack", "chat_id": "D0123456789"},
+        "deliver": "origin",
+        "origin": {
+            "platform": "slack",
+            "chat_id": "D0123456789",
+            "thread_id": "1788217797.757469",
+        },
     }
 
 
@@ -319,8 +323,12 @@ class TestMediaPolicyEnvBridge:
         job = {
             "id": "job-media-3",
             "name": "bridge",
-            "deliver": "slack:D0123456789",
-            "origin": {"platform": "slack", "chat_id": "D0123456789"},
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "D0123456789",
+                "thread_id": "1788217797.757469",
+            },
         }
         _deliver_result(job, f"Report.\n\nMEDIA:{media_file}", adapters=None, loop=None)
         sent_media = [m for c in calls for m in c["media_files"]]

--- a/tests/cron/test_mirror_origin_fallback.py
+++ b/tests/cron/test_mirror_origin_fallback.py
@@ -174,30 +174,33 @@ class TestFallbackMirrorEndToEnd:
         return {"send": send_calls, "mirror": mirror_calls}
 
     def test_origin_fallback_job_mirrors_brief(self, slack_env):
-        """The field repro: managed cron, deliver=origin, no origin captured.
-        The brief must be mirrored into the home-channel session."""
+        """A bare home-channel fallback is suppressed rather than root-posted."""
         job = {"id": "j1", "name": "brief", "deliver": "origin", "origin": None}
         err = _deliver_result(job, "Risk-off close brief", adapters=None, loop=None)
-        assert err is None
-        assert len(slack_env["send"]) == 1
-        assert len(slack_env["mirror"]) == 1, (
-            "origin-fallback delivery must mirror the brief into the "
-            "home-channel session (the reply-continuity bug)"
-        )
-        assert slack_env["mirror"][0]["chat_id"] == "D0HOME"
-        assert slack_env["mirror"][0]["role"] == "user"
+        assert err is not None
+        assert "exact thread anchor" in err
+        assert slack_env["send"] == []
+        assert slack_env["mirror"] == []
 
     def test_all_broadcast_does_not_mirror(self, slack_env):
         job = {"id": "j2", "name": "cast", "deliver": "all", "origin": None}
         err = _deliver_result(job, "broadcast text", adapters=None, loop=None)
-        assert err is None
-        assert len(slack_env["send"]) == 1
-        assert len(slack_env["mirror"]) == 0
+        assert err is not None
+        assert "exact thread anchor" in err
+        assert slack_env["send"] == []
+        assert slack_env["mirror"] == []
 
-    def test_explicit_target_with_attach_mirrors(self, slack_env):
+    def test_exact_origin_with_attach_mirrors(self, slack_env):
         job = {
-            "id": "j3", "name": "managed-dm", "deliver": "slack:D0USER7",
-            "origin": None, "attach_to_session": True,
+            "id": "j3", "name": "managed-dm",
+            "deliver": "origin",
+            "origin": {
+                "platform": "slack",
+                "chat_id": "D0USER7",
+                "chat_type": "dm",
+                "thread_id": "1788217797.757469",
+            },
+            "attach_to_session": True,
         }
         err = _deliver_result(job, "managed brief", adapters=None, loop=None)
         assert err is None
@@ -206,18 +209,26 @@ class TestFallbackMirrorEndToEnd:
 
     def test_explicit_target_without_attach_does_not_mirror(self, slack_env):
         job = {
-            "id": "j4", "name": "plain-explicit", "deliver": "slack:D0USER8",
+            "id": "j4", "name": "plain-explicit",
+            "deliver": "slack:D0USER8",
             "origin": None,
         }
         err = _deliver_result(job, "plain text", adapters=None, loop=None)
-        assert err is None
-        assert len(slack_env["mirror"]) == 0
+        assert err is not None
+        assert "exact thread anchor" in err
+        assert slack_env["send"] == []
+        assert slack_env["mirror"] == []
 
     def test_origin_job_still_mirrors_unchanged(self, slack_env):
         """Regression control: the June origin-scoped behavior is untouched."""
         job = {
             "id": "j5", "name": "origin-job", "deliver": "origin",
-            "origin": {"platform": "slack", "chat_id": "D0AAA", "chat_type": "dm"},
+            "origin": {
+                "platform": "slack",
+                "chat_id": "D0AAA",
+                "chat_type": "dm",
+                "thread_id": "1788217797.757469",
+            },
         }
         err = _deliver_result(job, "origin brief", adapters=None, loop=None)
         assert err is None

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -445,15 +445,10 @@ class TestDeliverResultWrapping:
                 loop=loop,
             )
 
-        assert result is None
-        relay.send_for_platform.assert_awaited_once()
-        args = relay.send_for_platform.await_args.args
-        assert args[:3] == (Platform.SLACK, "D123", "scheduled result")
-        assert relay.send_for_platform.await_args.kwargs["metadata"]["user_id"] == "U123"
-        relay.send_voice.assert_awaited_once()
-        media_metadata = relay.send_voice.await_args.kwargs["metadata"]
-        assert media_metadata["_relay_logical_platform"] == "slack"
-        assert media_metadata["user_id"] == "U123"
+        assert result is not None
+        assert "strict machine Slack delivery requires an exact thread anchor" in result
+        relay.send_for_platform.assert_not_awaited()
+        relay.send_voice.assert_not_awaited()
         standalone_send.assert_not_awaited()
 
 
@@ -2392,10 +2387,14 @@ class TestCronContinuableSurfaceInChannel:
             "id": "brief-job",
             "name": "Daily Brief",
             "deliver": "origin",
-            # Channel origin: no thread_id (flat channel message scheduled it).
-            # Carries the scheduling user's id — the in_channel seed must key
-            # the flat channel session to THIS user (see build_session_key).
-            "origin": origin or {"platform": "slack", "chat_id": "C123", "user_id": "U_HUMAN"},
+            # Slack machine output must remain on this exact parent thread even
+            # when the legacy in_channel surface is configured.
+            "origin": origin or {
+                "platform": "slack",
+                "chat_id": "C123",
+                "user_id": "U_HUMAN",
+                "thread_id": "1787188000.000100",
+            },
             # Opt into the continuable mirror (parameterized: the seed must
             # NOT depend on this — see the no-attach regression test).
             "attach_to_session": attach_to_session,
@@ -2480,17 +2479,8 @@ class TestCronContinuableSurfaceInChannel:
         assert mirror_mock.call_args.kwargs.get("thread_id") is None
         assert mirror_mock.call_args.kwargs.get("user_id") == "U_HUMAN"
 
-    def test_in_channel_seed_fires_without_attach_to_session(self):
-        """REGRESSION (live, Alice 2026-08-19): the in_channel seed was gated on
-        mirror_this_target (mirror_enabled AND origin match), so a continuable
-        in_channel cron created WITHOUT attach_to_session (and with the
-        cron.mirror_delivery global at its default False) delivered the brief
-        flat but never seeded the flat session — the next plain reply hit a
-        blank session and the agent had no idea about its own delivery message.
-
-        in_channel IS the continuation surface: the seed must fire on origin
-        match alone. attach_to_session stays the opt-in for the SEPARATE
-        default-surface mirror behavior; it must not be required here."""
+    def test_slack_machine_delivery_does_not_seed_flat_session(self):
+        """Strict Slack machine output cannot create a channel-root surface."""
         from cron.scheduler import _deliver_result  # noqa: F401 (driven via helper)
 
         adapter = self._slack_adapter(supports_inchannel=True)
@@ -2499,20 +2489,10 @@ class TestCronContinuableSurfaceInChannel:
                 {"slack": {"cron_continuable_surface": "in_channel"}}, adapter,
                 attach_to_session=False,
             )
-        seed_mock.assert_called_once()
-        # user_id must ride along even without the mirror opt-in — the flat
-        # session key includes it on per-user-isolated chats.
-        assert seed_mock.call_args.kwargs.get("user_id") == "U_HUMAN"
+        seed_mock.assert_not_called()
 
-    def test_in_channel_flattens_thread_without_attach_to_session(self):
-        """REGRESSION: the thread-id-clearing gate was `mirror_this_target`
-        while the seed below had been decoupled to origin-match alone. With
-        the default knobs off (attach_to_session=False, cron.mirror_delivery
-        unset) and an origin carrying a REAL thread_id, the brief still
-        delivered INTO the origin thread while the flat (thread_id=None)
-        session got seeded — brief and continuation surface in different
-        places. The flatten must use the same gate as the seed: origin_target.
-        Asserts on the routed DeliveryTarget, not just that the seed ran."""
+    def test_in_channel_setting_preserves_exact_slack_thread(self):
+        """The legacy flat setting cannot erase a machine delivery anchor."""
         captured = {}
 
         class _SpyRouter:
@@ -2535,12 +2515,8 @@ class TestCronContinuableSurfaceInChannel:
                 {"slack": {"cron_continuable_surface": "in_channel"}}, adapter,
                 attach_to_session=False, origin=origin_with_thread,
             )
-        seed_mock.assert_called_once()
-        assert captured["target"].thread_id is None, (
-            "in_channel delivery routed into the origin thread "
-            f"({captured['target'].thread_id}) — the flat seeded session "
-            "does not match where the brief actually landed"
-        )
+        seed_mock.assert_not_called()
+        assert captured["target"].thread_id == "1787188000.000100"
 
     def test_origin_scope_id_rides_delivery_metadata(self):
         """REGRESSION (restart-shaped): the connector's fail-closed tenant
@@ -2568,6 +2544,7 @@ class TestCronContinuableSurfaceInChannel:
             # Persisted workspace scope (captured at job creation). C123 is
             # not any configured home channel in this harness.
             "scope_id": "T0AAAA111",
+            "thread_id": "1787188000.000100",
         }
         with patch("gateway.delivery.DeliveryRouter", _SpyRouter), \
              patch("cron.scheduler._seed_cron_channel_session", return_value=True):
@@ -2667,12 +2644,8 @@ class TestCronContinuableSurfaceInChannel:
         # heuristics (and their populated-chat bail-out) are out of the path.
         assert mirror_mock.call_args.kwargs.get("session_id") == "sess-flat-exact"
 
-    def test_in_channel_also_seeds_thread_surface_of_delivered_brief(self):
-        """REGRESSION (live, Alice 2026-08-19 19:19): the user replied IN THE
-        BRIEF'S THREAD (Slack's natural affordance on a flat message). That
-        reply keys to (chat, thread=<brief ts>) — a session in_channel mode
-        never seeded, so the agent had no idea about its own brief. The flat
-        delivery's message_id must anchor a companion thread-surface seed."""
+    def test_exact_slack_thread_needs_no_flat_companion_seed(self):
+        """An exact thread delivery must not create a root-derived thread."""
         adapter = self._slack_adapter(supports_inchannel=True)
         with patch("cron.scheduler._seed_cron_channel_session", return_value=True), \
              patch("cron.scheduler._seed_cron_thread_session") as thread_seed_mock:
@@ -2680,9 +2653,7 @@ class TestCronContinuableSurfaceInChannel:
                 {"slack": {"cron_continuable_surface": "in_channel"}}, adapter,
                 attach_to_session=False,
             )
-        thread_seed_mock.assert_called_once()
-        # Anchored on the delivered message id (the router's SendResult).
-        assert thread_seed_mock.call_args.args[4] == "msg_1"
+        thread_seed_mock.assert_not_called()
 
 
 class TestMultiTargetDeliveryContinuesOnFailure:

--- a/tests/gateway/relay/test_relay_slack_dm_streaming.py
+++ b/tests/gateway/relay/test_relay_slack_dm_streaming.py
@@ -24,7 +24,11 @@ from __future__ import annotations
 import pytest
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import MessageEvent, MessageType
+from gateway.platforms.base import (
+    MessageEvent,
+    MessageType,
+    strict_machine_thread_metadata,
+)
 from gateway.relay.adapter import RelayAdapter
 from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
 from gateway.session import SessionSource
@@ -118,6 +122,129 @@ async def test_slack_dm_reply_with_real_thread_keeps_anchor():
     frame = stub.sent[0]
     assert frame["reply_to"] == "1700.0002"
     assert frame["metadata"]["thread_id"] == "1699.9000"
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_send_without_anchor_is_suppressed():
+    adapter, stub = _wire("D1", "dm")
+
+    result = await adapter.send(
+        "D1", "machine update", metadata=strict_machine_thread_metadata()
+    )
+
+    assert result.success is False
+    assert "exact thread anchor" in (result.error or "")
+    assert stub.sent == []
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_send_keeps_reply_anchor_in_flat_mode():
+    adapter, stub = _wire("D1", "dm")
+    adapter.config.extra = {"reply_in_thread": False}
+
+    result = await adapter.send(
+        "D1",
+        "machine update",
+        reply_to="1700.0001",
+        metadata=strict_machine_thread_metadata(),
+    )
+
+    assert result.success is True
+    assert stub.sent[0]["reply_to"] == "1700.0001"
+    assert stub.sent[0]["metadata"]["thread_id"] == "1700.0001"
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_explicit_send_without_anchor_is_suppressed():
+    adapter, stub = _wire("D1", "dm")
+
+    result = await adapter.send_for_platform(
+        Platform.SLACK,
+        "D1",
+        "machine update",
+        metadata=strict_machine_thread_metadata(),
+    )
+
+    assert result.success is False
+    assert "exact thread anchor" in (result.error or "")
+    assert stub.sent == []
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_send_for_platform_promotes_reply_anchor():
+    adapter, stub = _wire("D123", "dm")
+
+    result = await adapter.send_for_platform(
+        Platform.SLACK,
+        "D123",
+        "machine",
+        reply_to="1788217797.757469",
+        metadata=strict_machine_thread_metadata(),
+    )
+
+    assert result.success is True
+    assert stub.sent[-1]["metadata"]["thread_id"] == "1788217797.757469"
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_draft_without_anchor_is_suppressed():
+    desc = _slack_desc(
+        supports_draft_streaming=True,
+        supported_ops=("send", "edit", "typing", "draft"),
+    )
+    stub = StubConnector(desc)
+    adapter = RelayAdapter(PlatformConfig(), desc, transport=stub)
+    adapter._capture_scope(
+        MessageEvent(
+            text="hi",
+            source=SessionSource(
+                platform=Platform.SLACK,
+                chat_id="D1",
+                chat_type="dm",
+                user_id="U1",
+            ),
+            message_type=MessageType.TEXT,
+        )
+    )
+
+    result = await adapter.send_draft(
+        "D1", 1, "machine update", metadata=strict_machine_thread_metadata()
+    )
+
+    assert result.success is False
+    assert "exact thread anchor" in (result.error or "")
+    assert stub.sent == []
+
+
+@pytest.mark.asyncio
+async def test_strict_machine_slack_media_without_anchor_is_suppressed():
+    desc = _slack_desc(supported_ops=("send", "edit", "typing", "send_media"))
+    stub = StubConnector(desc)
+    adapter = RelayAdapter(
+        PlatformConfig(), desc, transport=stub  # type: ignore[arg-type]
+    )
+    adapter._capture_scope(
+        MessageEvent(
+            text="hi",
+            source=SessionSource(
+                platform=Platform.SLACK,
+                chat_id="D1",
+                chat_type="dm",
+                user_id="U1",
+            ),
+            message_type=MessageType.TEXT,
+        )
+    )
+
+    result = await adapter.send_image(
+        "D1",
+        "https://example.com/image.png",
+        metadata=strict_machine_thread_metadata(),
+    )
+
+    assert result.success is False
+    assert "exact thread anchor" in (result.error or "")
+    assert stub.sent == []
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_async_delegation_session_binding.py
+++ b/tests/gateway/test_async_delegation_session_binding.py
@@ -8,6 +8,8 @@ Three invariants on the messaging-gateway surface, mirroring the TUI rules:
 3. /new interrupts the old conversation's in-flight async delegations.
 """
 
+import queue
+import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -33,6 +35,140 @@ def _seed_record(delegation_id, session_key="", parent_session_id="", status="ru
             "interrupt_fn": fn,
         }
     return fn
+
+
+SLACK_ROUTE = {
+    "platform": "slack",
+    "chat_id": "C0BTQQX0SLC",
+    "chat_type": "thread",
+    "thread_id": "1788217797.757469",
+    "message_id": "1788217900.000001",
+}
+
+
+def test_capture_routing_origin_includes_exact_slack_parent(monkeypatch):
+    env = {
+        "HERMES_SESSION_PLATFORM": "slack",
+        "HERMES_SESSION_CHAT_ID": "C0BTQQX0SLC",
+        "HERMES_SESSION_CHAT_TYPE": "thread",
+        "HERMES_SESSION_THREAD_ID": "1788217797.757469",
+        "HERMES_SESSION_MESSAGE_ID": "1788217900.000001",
+    }
+    monkeypatch.setattr(
+        "gateway.session_context.get_session_env",
+        lambda name, default="": env.get(name, default),
+    )
+
+    assert ad._capture_routing_origin() == SLACK_ROUTE
+
+
+@pytest.mark.parametrize("is_batch", [False, True], ids=["single", "batch"])
+def test_completion_and_restart_replay_preserve_exact_slack_thread(
+    monkeypatch, is_batch,
+):
+    from tools.process_registry import process_registry
+
+    now = time.time()
+    record = {
+        "delegation_id": f"d-{'batch' if is_batch else 'single'}",
+        "goal": "check routing",
+        "goals": ["check routing"] if is_batch else None,
+        "context": None,
+        "toolsets": None,
+        "role": "researcher",
+        "model": "test-model",
+        "is_batch": is_batch,
+        "session_key": "agent:main:slack:thread:C0BTQQX0SLC:1788217797.757469",
+        "origin_ui_session_id": "",
+        "origin_session_id": "origin-session",
+        "parent_session_id": "parent-session",
+        "status": "running",
+        "dispatched_at": now,
+        "completed_at": now,
+        **SLACK_ROUTE,
+    }
+    ad._persist_dispatch(record)
+    live_queue = queue.Queue()
+    monkeypatch.setattr(process_registry, "completion_queue", live_queue)
+
+    if is_batch:
+        ad._push_batch_completion_event(
+            record,
+            {"results": [{"status": "completed", "summary": "done"}]},
+            "completed",
+        )
+    else:
+        ad._push_completion_event(
+            record,
+            {"status": "completed", "summary": "done"},
+            "completed",
+        )
+
+    live_event = live_queue.get_nowait()
+    assert {key: live_event.get(key) for key in SLACK_ROUTE} == SLACK_ROUTE
+
+    restarted_queue = queue.Queue()
+    assert ad.restore_undelivered_completions(restarted_queue) == 1
+    restored_event = restarted_queue.get_nowait()
+    assert restored_event["restored"] is True
+    assert {key: restored_event.get(key) for key in SLACK_ROUTE} == SLACK_ROUTE
+
+
+def _source_runner(session_key, origin=None):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = MagicMock()
+    runner.session_store._entries = (
+        {session_key: MagicMock(origin=origin)} if origin is not None else {}
+    )
+    runner._get_cached_session_source = MagicMock(return_value=None)
+    return runner
+
+
+def test_persisted_async_route_overrides_stale_session_origin():
+    from gateway.config import Platform
+    from gateway.session import SessionSource
+
+    session_key = "agent:main:slack:thread:C0BTQQX0SLC:stale"
+    stale_origin = SessionSource(
+        platform=Platform.SLACK,
+        chat_id="C0BTQQX0SLC",
+        chat_type="channel",
+        thread_id=None,
+    )
+    source = _source_runner(session_key, stale_origin)._build_process_event_source(
+        {"session_key": session_key, **SLACK_ROUTE}
+    )
+
+    assert source is not None
+    assert source is not stale_origin
+    assert source.chat_type == "thread"
+    assert source.thread_id == "1788217797.757469"
+    assert source.message_id == "1788217900.000001"
+    assert source.strict_machine_thread_affinity is True
+
+
+def test_unanchored_async_route_is_still_marked_fail_closed():
+    from gateway.config import Platform
+    from gateway.platforms.base import strict_machine_thread_affinity_error
+
+    source = _source_runner("")._build_process_event_source(
+        {
+            "platform": "slack",
+            "chat_id": "C0BTQQX0SLC",
+            "chat_type": "channel",
+        }
+    )
+
+    assert source is not None
+    assert source.thread_id is None
+    assert source.message_id is None
+    assert source.strict_machine_thread_affinity is True
+    metadata = _source_runner("")._thread_metadata_for_source(source)
+    assert strict_machine_thread_affinity_error(
+        Platform.SLACK, metadata, None
+    ) is not None
 
 
 class TestInterruptForSessionByParentId:

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -11,12 +11,14 @@ import asyncio
 import queue
 import threading
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from gateway.config import GatewayConfig, Platform
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import _thread_metadata_for_source
 from gateway.run import GatewayRunner, _parse_session_key
+from plugins.platforms.slack.adapter import SlackAdapter
 
 
 # ---------------------------------------------------------------------------
@@ -77,6 +79,51 @@ def _watch_event(session_id="proc_watch", thread_id="42"):
         "command": "build",
         "output": "READY\n",
     }
+
+
+class _ImmediateSlackAdapter(SlackAdapter):
+    """Real Slack egress with synchronous synthetic completion handling."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="xoxb-fake"))
+        self._app = MagicMock()
+        self.client = AsyncMock()
+        self.client.chat_postMessage = AsyncMock(return_value={"ts": "999.111"})
+        self._get_client = MagicMock(return_value=self.client)
+        self.stop_typing = AsyncMock()
+        self.handled = []
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+        reply_to = event.reply_to_message_id or event.message_id
+        await self.send(
+            event.source.chat_id,
+            "Synthetic completion final",
+            reply_to=reply_to,
+            metadata=_thread_metadata_for_source(event.source, reply_to),
+        )
+
+
+def _slack_runner(monkeypatch, tmp_path, mode):
+    runner = _build_runner(monkeypatch, tmp_path, mode)
+    adapter = _ImmediateSlackAdapter()
+    runner.adapters = {Platform.SLACK: adapter}
+    return runner, adapter
+
+
+def _slack_watcher(*, thread_id=None, notify_on_complete=False):
+    watcher = {
+        "session_id": "proc_slack",
+        "check_interval": 0,
+        "session_key": "agent:main:slack:thread:C0BTQQX0SLC",
+        "platform": "slack",
+        "chat_id": "C0BTQQX0SLC",
+        "chat_type": "thread" if thread_id else "channel",
+        "notify_on_complete": notify_on_complete,
+    }
+    if thread_id:
+        watcher["thread_id"] = thread_id
+    return watcher
 
 
 # ---------------------------------------------------------------------------
@@ -366,6 +413,121 @@ async def test_inject_watch_notification_ignores_foreground_event_source(monkeyp
     # Must route to thread 42 (process origin), NOT some other thread
     assert synth_event.source.thread_id == "42"
     assert synth_event.source.user_id == "proc_owner"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("notify_on_complete", [False, True], ids=["direct", "agent"])
+async def test_process_completion_uses_exact_slack_thread(
+    monkeypatch, tmp_path, notify_on_complete,
+):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        command="echo done",
+        started_at=None,
+    )
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry([session], consumed=False),
+    )
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner, adapter = _slack_runner(monkeypatch, tmp_path, "concise")
+
+    await runner._run_process_watcher(
+        _slack_watcher(
+            thread_id="1788217797.757469",
+            notify_on_complete=notify_on_complete,
+        )
+    )
+
+    adapter.client.chat_postMessage.assert_awaited_once()
+    assert adapter.client.chat_postMessage.await_args.kwargs["thread_ts"] == (
+        "1788217797.757469"
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_mode_interim_and_final_use_exact_slack_thread(
+    monkeypatch, tmp_path,
+):
+    import tools.process_registry as pr_module
+
+    running = SimpleNamespace(
+        output_buffer="still running\n",
+        exited=False,
+        exit_code=None,
+        command="make build",
+        started_at=None,
+    )
+    done = SimpleNamespace(
+        output_buffer="still running\ndone\n",
+        exited=True,
+        exit_code=0,
+        command="make build",
+        started_at=None,
+    )
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry([running, done], consumed=False),
+    )
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner, adapter = _slack_runner(monkeypatch, tmp_path, "all")
+
+    await runner._run_process_watcher(
+        _slack_watcher(thread_id="1788217797.757469")
+    )
+
+    assert adapter.client.chat_postMessage.await_count == 2
+    assert {
+        call.kwargs["thread_ts"]
+        for call in adapter.client.chat_postMessage.await_args_list
+    } == {"1788217797.757469"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("notify_on_complete", [False, True], ids=["direct", "agent"])
+async def test_unanchored_process_completion_never_posts_slack_root(
+    monkeypatch, tmp_path, notify_on_complete,
+):
+    import tools.process_registry as pr_module
+
+    session = SimpleNamespace(
+        output_buffer="done\n",
+        exited=True,
+        exit_code=0,
+        command="echo done",
+        started_at=None,
+    )
+    monkeypatch.setattr(
+        pr_module,
+        "process_registry",
+        _FakeRegistry([session], consumed=False),
+    )
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+    runner, adapter = _slack_runner(monkeypatch, tmp_path, "concise")
+
+    await runner._run_process_watcher(
+        _slack_watcher(notify_on_complete=notify_on_complete)
+    )
+
+    adapter.client.chat_postMessage.assert_not_awaited()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -1,15 +1,18 @@
 import asyncio
 import sqlite3
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 
-from gateway.config import Platform
+from gateway.config import Platform, PlatformConfig
 from gateway.kanban_watchers import (
     _acquire_singleton_lock,
     _release_singleton_lock,
 )
+from gateway.platforms.base import _thread_metadata_for_source
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
+from plugins.platforms.slack.adapter import SlackAdapter
 
 
 class RecordingAdapter:
@@ -44,15 +47,112 @@ async def _run_one_notifier_tick(monkeypatch, runner):
     await runner._kanban_notifier_watcher(interval=1)
 
 
-def _make_runner(adapter):
+def _make_runner(adapter, platform=Platform.TELEGRAM):
     runner = GatewayRunner.__new__(GatewayRunner)
     runner._running = True
-    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner.adapters = {platform: adapter}
     runner._kanban_sub_fail_counts = {}
     # Most tests model the default gateway after its dispatcher acquired the
     # singleton lock. Tests for startup or non-owner gateways clear this.
     runner._kanban_dispatcher_lock_handle = object()
     return runner
+
+
+class ImmediateSlackAdapter(SlackAdapter):
+    """Real Slack egress with synchronous synthetic-wake completion for tests."""
+
+    def __init__(self):
+        super().__init__(PlatformConfig(enabled=True, token="xoxb-fake"))
+        self._app = MagicMock()
+        self.client = AsyncMock()
+        self.client.chat_postMessage = AsyncMock(return_value={"ts": "999.111"})
+        self._get_client = MagicMock(return_value=self.client)
+        self.stop_typing = AsyncMock()
+        self.handled = []
+        self.wake_result = None
+
+    async def handle_message(self, event):
+        self.handled.append(event)
+        reply_to = event.reply_to_message_id or event.message_id
+        self.wake_result = await self.send(
+            event.source.chat_id,
+            "Wake final",
+            reply_to=reply_to,
+            metadata=_thread_metadata_for_source(event.source, reply_to),
+        )
+
+
+def _create_completed_slack_subscription(db_path, *, thread_id):
+    kb.init_db(db_path)
+    conn = kb.connect(db_path)
+    try:
+        task_id = kb.create_task(
+            conn,
+            title="strict Slack delivery",
+            assignee="worker",
+            session_id="agent:main:slack:thread:C0BTQQX0SLC",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="slack",
+            chat_id="C0BTQQX0SLC",
+            thread_id=thread_id,
+            chat_type="thread",
+            delivery_mode="notify+wake",
+        )
+        kb.complete_task(conn, task_id, summary="done")
+        return task_id
+    finally:
+        conn.close()
+
+
+def test_slack_notifier_passive_and_wake_final_use_exact_thread(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "strict-slack-thread.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    _create_completed_slack_subscription(
+        db_path,
+        thread_id="1788217797.757469",
+    )
+    adapter = ImmediateSlackAdapter()
+
+    asyncio.run(
+        _run_one_notifier_tick(
+            monkeypatch,
+            _make_runner(adapter, Platform.SLACK),
+        )
+    )
+
+    assert len(adapter.handled) == 1
+    assert adapter.handled[0].source.chat_type == "thread"
+    assert adapter.handled[0].source.thread_id == "1788217797.757469"
+    assert adapter.handled[0].source.strict_machine_thread_affinity is True
+    assert adapter.client.chat_postMessage.await_count == 2
+    assert {
+        call.kwargs["thread_ts"]
+        for call in adapter.client.chat_postMessage.await_args_list
+    } == {"1788217797.757469"}
+
+
+def test_slack_notifier_without_anchor_suppresses_passive_and_wake(
+    tmp_path, monkeypatch,
+):
+    db_path = tmp_path / "strict-slack-unanchored.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    _create_completed_slack_subscription(db_path, thread_id=None)
+    adapter = ImmediateSlackAdapter()
+
+    asyncio.run(
+        _run_one_notifier_tick(
+            monkeypatch,
+            _make_runner(adapter, Platform.SLACK),
+        )
+    )
+
+    adapter.client.chat_postMessage.assert_not_awaited()
+    assert adapter.handled == []
 
 
 def _create_completed_subscription(summary="done once"):

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -526,12 +526,14 @@ async def test_run_agent_progress_uses_event_message_id_for_slack_dm(monkeypatch
 
     assert result["final_response"] == "done"
     assert adapter.sent
-    expected_metadata = {
-        "thread_id": "1234567890.000001",
-        "message_id": "1234567890.000001",
-    }
-    assert adapter.sent[0]["metadata"] == expected_metadata
-    assert all(call["metadata"] == expected_metadata for call in adapter.typing)
+    sent_metadata = adapter.sent[0]["metadata"]
+    assert sent_metadata["thread_id"] == "1234567890.000001"
+    assert sent_metadata["message_id"] == "1234567890.000001"
+    assert all(
+        call["metadata"]["thread_id"] == "1234567890.000001"
+        and call["metadata"]["message_id"] == "1234567890.000001"
+        for call in adapter.typing
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_slack_native_streaming.py
+++ b/tests/gateway/test_slack_native_streaming.py
@@ -23,6 +23,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 from gateway.config import PlatformConfig
+from gateway.platforms.base import strict_machine_thread_metadata
 from plugins.platforms.slack.adapter import SlackAdapter
 
 
@@ -43,6 +44,119 @@ def _make_adapter(extra=None):
 
 
 META = {"thread_id": "111.000", "user_id": "U123"}
+
+
+class TestStrictMachineThreadAffinity:
+    @pytest.mark.asyncio
+    async def test_exact_thread_is_used_for_machine_post(self):
+        adapter, client = _make_adapter()
+
+        result = await adapter.send(
+            "C0BTQQX0SLC",
+            "Machine update",
+            metadata=strict_machine_thread_metadata(
+                {"thread_id": "1788217797.757469"}
+            ),
+        )
+
+        assert result.success
+        assert client.chat_postMessage.await_args.kwargs["thread_ts"] == (
+            "1788217797.757469"
+        )
+
+    @pytest.mark.asyncio
+    async def test_unanchored_machine_post_is_suppressed(self):
+        adapter, client = _make_adapter()
+
+        result = await adapter.send(
+            "C0BTQQX0SLC",
+            "Machine update",
+            metadata=strict_machine_thread_metadata(),
+        )
+
+        assert not result.success
+        assert "thread anchor" in (result.error or "")
+        client.chat_postMessage.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unanchored_machine_stream_is_suppressed(self):
+        adapter, client = _make_adapter()
+
+        result = await adapter.send_draft(
+            "C0BTQQX0SLC",
+            7,
+            "Machine update",
+            metadata=strict_machine_thread_metadata(),
+        )
+
+        assert not result.success
+        assert "thread anchor" in (result.error or "")
+        client.chat_startStream.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_unanchored_machine_file_upload_is_suppressed(self, tmp_path):
+        adapter, client = _make_adapter()
+        file_path = tmp_path / "status.txt"
+        file_path.write_text("machine status")
+
+        result = await adapter._upload_file(
+            "C0BTQQX0SLC",
+            str(file_path),
+            metadata=strict_machine_thread_metadata(),
+        )
+
+        assert not result.success
+        assert "thread anchor" in (result.error or "")
+        client.files_upload_v2.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_direct_human_root_send_remains_allowed(self):
+        adapter, client = _make_adapter()
+
+        result = await adapter.send("C0BTQQX0SLC", "Human-authored root send")
+
+        assert result.success
+        assert "thread_ts" not in client.chat_postMessage.await_args.kwargs
+
+    @pytest.mark.asyncio
+    async def test_machine_reply_anchor_ignores_flat_reply_preference(self):
+        adapter, client = _make_adapter({"reply_in_thread": False})
+
+        result = await adapter.send(
+            "D1",
+            "Machine update",
+            reply_to="1788217797.757469",
+            metadata=strict_machine_thread_metadata(),
+        )
+
+        assert result.success
+        assert (
+            client.chat_postMessage.await_args.kwargs["thread_ts"]
+            == "1788217797.757469"
+        )
+
+    @pytest.mark.asyncio
+    async def test_machine_final_does_not_seal_stream_in_a_different_thread(self):
+        adapter, client = _make_adapter()
+        origin_thread = "1788217797.757469"
+        final_thread = "1788217999.000001"
+
+        await adapter.send_draft(
+            "C0BTQQX0SLC",
+            7,
+            "Machine update",
+            metadata=strict_machine_thread_metadata({"thread_id": origin_thread}),
+        )
+
+        result = await adapter.send(
+            "C0BTQQX0SLC",
+            "Machine update final",
+            metadata=strict_machine_thread_metadata({"thread_id": final_thread}),
+        )
+
+        assert result.success
+        client.chat_stopStream.assert_not_awaited()
+        assert client.chat_postMessage.await_args.kwargs["thread_ts"] == final_thread
 
 
 class TestSupportsDraftStreaming:

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -90,6 +90,18 @@ _MAX_DELIVERY_ATTEMPTS = 8
 _MAX_COMPLETION_REPLAY_AGE_S = 48 * 3600.0
 _DB_LOCK = threading.Lock()
 
+_ROUTING_ORIGIN_ENV = (
+    ("platform", "HERMES_SESSION_PLATFORM"),
+    ("chat_id", "HERMES_SESSION_CHAT_ID"),
+    ("chat_type", "HERMES_SESSION_CHAT_TYPE"),
+    ("thread_id", "HERMES_SESSION_THREAD_ID"),
+    ("message_id", "HERMES_SESSION_MESSAGE_ID"),
+    ("scope_id", "HERMES_SESSION_SCOPE_ID"),
+    ("user_id", "HERMES_SESSION_USER_ID"),
+    ("user_name", "HERMES_SESSION_USER_NAME"),
+)
+_ROUTING_ORIGIN_FIELDS = tuple(key for key, _env_name in _ROUTING_ORIGIN_ENV)
+
 # ---------------------------------------------------------------------------
 # Stale-delegation detection (progress-based, on by default)
 # ---------------------------------------------------------------------------
@@ -228,11 +240,7 @@ def _capture_routing_origin() -> Dict[str, Any]:
     try:
         from gateway.session_context import get_session_env
 
-        for evt_key, env_name in (
-            ("scope_id", "HERMES_SESSION_SCOPE_ID"),
-            ("user_id", "HERMES_SESSION_USER_ID"),
-            ("user_name", "HERMES_SESSION_USER_NAME"),
-        ):
+        for evt_key, env_name in _ROUTING_ORIGIN_ENV:
             value = get_session_env(env_name, "")
             if value:
                 origin[evt_key] = value
@@ -252,10 +260,9 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
         key: record.get(key)
         for key in (
             "goal", "goals", "context", "toolsets", "role", "model", "is_batch",
-            # Routing origin (scope_id/user_id/user_name): persisted so a
-            # restart-recovered completion can reconstruct a full
-            # SessionSource — see _capture_routing_origin.
-            "scope_id", "user_id", "user_name",
+            # Exact routing origin: persisted so restart-recovered completions
+            # reconstruct the same parent thread and workspace identity.
+            *_ROUTING_ORIGIN_FIELDS,
         )
         if key in record
     }
@@ -380,10 +387,8 @@ def recover_abandoned_delegations() -> int:
                 "error": "Delegation owner exited before recording a terminal result; outcome unknown.",
                 "dispatched_at": dispatched_at, "completed_at": now,
             }
-            # Routing origin persisted at dispatch (see _capture_routing_origin):
-            # restores scope_id/user_id for the reconstructed SessionSource so
-            # relay egress priming works after a restart.
-            for _k in ("scope_id", "user_id", "user_name"):
+            # Routing origin persisted at dispatch (see _capture_routing_origin).
+            for _k in _ROUTING_ORIGIN_FIELDS:
                 if task.get(_k):
                     event[_k] = task[_k]
             result = {"status": "unknown", "summary": None, "error": event["error"]}
@@ -993,10 +998,8 @@ def _push_completion_event(
         "completed_at": completed_at,
         "exit_reason": result.get("exit_reason"),
     }
-    # Routing origin captured at dispatch (see _capture_routing_origin):
-    # additive, lets the gateway reconstruct a full SessionSource (incl.
-    # scope_id for relay tenant egress) when its own caches are cold.
-    for _k in ("scope_id", "user_id", "user_name"):
+    # Exact routing origin captured at dispatch (see _capture_routing_origin).
+    for _k in _ROUTING_ORIGIN_FIELDS:
         if record.get(_k):
             evt[_k] = record[_k]
     # Structured stall metadata (#51690) — additive, present only on
@@ -1209,8 +1212,8 @@ def _push_batch_completion_event(
         "dispatched_at": dispatched_at,
         "completed_at": completed_at,
     }
-    # Routing origin captured at dispatch (see _capture_routing_origin).
-    for _k in ("scope_id", "user_id", "user_name"):
+    # Exact routing origin captured at dispatch (see _capture_routing_origin).
+    for _k in _ROUTING_ORIGIN_FIELDS:
         if event_record.get(_k):
             evt[_k] = event_record[_k]
     # Structured stall metadata (#51690) — additive, present only on


### PR DESCRIPTION
## Summary

- add one explicit strict-machine thread-affinity marker for Slack automation
- preserve the exact originating Slack parent through Kanban notify/wake, async delegation replay, background-process notifications, cron delivery, native Slack, and Relay
- fail closed when strict machine output has no thread anchor instead of falling back to a channel-root post
- preserve direct human root and threaded behavior
- prevent strict machine finals from sealing a native Slack stream belonging to a different thread

## Why

Machine-generated events could retain a source thread during injection but lose the effective reply anchor before Slack egress. When that happened, normal Slack fallback behavior created unwanted channel-root posts. This makes machine thread affinity an enforced delivery contract rather than an advisory preference.

## Verification

Independently rerun and approved by a separate reviewer:

- required gateway set: 52 passed
- required cron set: 121 passed
- added/affected set: 110 passed
- full Relay suite: 298 passed
- full cron suite: 1,037 passed; 1 Windows-only skip on macOS
- `git diff --check` passed

The full cron run observed one pre-existing timing flake in `test_script_claim_heartbeat.py`; it passed on retry and is outside this diff.

## Safety boundaries

- no deployment or service restart
- no Slack credential or configuration change
- unanchored strict Slack automation is suppressed with an explicit error
- explicit human-authored root sends remain unchanged
