### PR TITLE
fix(slack): use display names in approval labels

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7733,6 +7733,17 @@ class SlackAdapter(BasePlatformAdapter):
             )
             count = 0
 
+        # Interactive payloads expose Slack's legacy username (``user.name``),
+        # which may differ from the member's current profile display name.
+        # Resolve the approval first so a users.info lookup cannot delay or
+        # time out the command; preserve the payload name if lookup fails.
+        if count:
+            resolved_user_name = await self._resolve_user_name(
+                user_id, chat_id=channel_id, team_id=team_id
+            )
+            if resolved_user_name and resolved_user_name != user_id:
+                user_name = resolved_user_name
+
         # Update the message to show the decision and remove buttons
         label_map = {
             "once": f"✅ Approved once by {user_name}",

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -180,6 +180,84 @@ class TestSlackApprovalAction:
         assert len(section_text) <= 3000
 
     @pytest.mark.asyncio
+    async def test_uses_slack_display_name_in_resolved_label(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+        adapter._user_name_cache[("T1", "U_MASUMI")] = "geeknees"
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {
+                "ts": "1234.5678",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Run command?"},
+                    },
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "mgka", "id": "U_MASUMI"},
+        }
+        action = {
+            "action_id": "hermes_approve_always",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1):
+            await adapter._handle_approval_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        decision_text = update_kwargs["blocks"][1]["elements"][0]["text"]
+        assert decision_text == "✅ Approved permanently by geeknees"
+
+    @pytest.mark.asyncio
+    async def test_resolves_approval_before_display_name_lookup(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["1234.5678"] = False
+
+        ack = AsyncMock()
+        body = {
+            "team": {"id": "T1"},
+            "message": {
+                "ts": "1234.5678",
+                "blocks": [
+                    {
+                        "type": "section",
+                        "text": {"type": "mrkdwn", "text": "Run command?"},
+                    },
+                ],
+            },
+            "channel": {"id": "C1"},
+            "user": {"name": "mgka", "id": "U_MASUMI"},
+        }
+        action = {
+            "action_id": "hermes_approve_always",
+            "value": "agent:main:slack:group:C1:1111",
+        }
+
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as resolve:
+            async def resolve_display_name(*_args, **_kwargs):
+                assert resolve.called
+                return "geeknees"
+
+            adapter._resolve_user_name = resolve_display_name
+            await adapter._handle_approval_action(ack, body, action)
+
+        update_kwargs = mock_client.chat_update.call_args[1]
+        decision_text = update_kwargs["blocks"][1]["elements"][0]["text"]
+        assert decision_text == "✅ Approved permanently by geeknees"
+
+    @pytest.mark.asyncio
     async def test_global_allowlist_blocks_unauthorized_click(self, monkeypatch):
         adapter = _make_adapter()
         adapter._approval_resolved["1234.5678"] = False


### PR DESCRIPTION
## What does this PR do?

Slack approval buttons currently render the interactive payload's legacy `user.name` value in audit labels such as `Approved permanently by …`. That value can differ from the member's current Slack profile display name.

This change resolves the approving user's ID through the adapter's existing `users.info`-backed `_resolve_user_name()` path before rendering the audit label. If resolution fails and returns the raw user ID, the handler preserves the legacy payload name as its fallback.

## Related Issue

N/A — no matching issue or pull request was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Resolve Slack approval actors to their current profile display name in `plugins/platforms/slack/adapter.py`.
- Preserve the legacy payload name when `users.info` cannot resolve a profile name.
- Resolve the approval before the profile lookup so Slack API latency cannot delay command execution.
- Add regression coverage for both display-name rendering and approval-before-lookup ordering.

## How to Test

1. Run `python -m pytest tests/gateway/test_slack_approval_buttons.py -q`.
2. Verify the regression fixture sends `user.name = mgka` while the existing profile-name cache resolves the user to `geeknees`.
3. Verify the updated approval label is `✅ Approved permanently by geeknees`.

Local verification:

- `22 passed` in `tests/gateway/test_slack_approval_buttons.py`
- `442 passed, 1 skipped` across `tests/gateway/test_slack*.py` (8 pre-existing async-mock `RuntimeWarning`s)
- `ruff check plugins/platforms/slack/adapter.py tests/gateway/test_slack_approval_buttons.py` → `All checks passed!`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Docker), focused Slack adapter tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is covered by the Slack Block Kit regression test above.
