### PR TITLE
fix(terminal): run background commands in their requested workdir

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -773,6 +773,27 @@ class TestSpawnEnvSanitization:
         # A failed launch must not be exposed as a running/tracked session.
         assert session.id not in registry._running
 
+    def test_spawn_via_env_executes_wrapper_in_requested_cwd(self, registry):
+        class FakeEnv:
+            def __init__(self):
+                self.commands = []
+
+            def execute(self, command, **kwargs):
+                self.commands.append((command, kwargs))
+                return {"output": "launch failed", "returncode": 2}
+
+        env = FakeEnv()
+
+        with patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(
+                env,
+                "./gradlew test",
+                cwd="/workspace/project",
+            )
+
+        assert env.commands[0][1]["cwd"] == "/workspace/project"
+        assert session.cwd == "/workspace/project"
+
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1335,6 +1335,7 @@ class ProcessRegistry:
         try:
             result = env.execute(
                 bg_command,
+                cwd=cwd,
                 timeout=timeout,
                 rewrite_compound_background=False,
             )


### PR DESCRIPTION
## What does this PR do?

Background terminal commands on non-local backends now run in the requested `workdir` instead of the backend default directory. This keeps relative build and test commands usable with `background=true` and forwards the already-resolved cwd through the existing environment execution interface.

### Symptom

A command such as `./gradlew test` succeeds with `background=false` and an explicit workdir, but the background form starts from the backend default cwd and fails because the relative executable is not present there.

### Impact

Users running long builds or tests through Docker and other non-local terminal backends cannot rely on `workdir` for background execution. The failure appears as a missing file in an otherwise valid checkout.

### Bug Cause

**Trigger:** `tools/process_registry.py:1285` / `ProcessRegistry.spawn_via_env()` when a non-local background command has an explicit or resolved cwd.

**Causal chain:**
1. `terminal_tool()` resolves the requested workdir and passes it to `spawn_via_env()`.
2. `spawn_via_env()` stores the cwd on the process session but calls `env.execute()` without it.
3. The backend wraps and launches the command from its default cwd, so relative paths resolve against the wrong directory.

**Why it is wrong:** The execution argument is dropped between the process registry and the environment backend even though every supported environment execution interface accepts `cwd`.

**Working sibling / contrast:** Foreground execution passes the resolved cwd directly to `env.execute()`, and local background execution passes it to `spawn_local()`.

**Ruled out:** Workdir resolution is not the failure. The terminal call site already passes the resolved value to the process registry, and the regression test demonstrates that the value is present on the session while absent from the backend execution call.

### Fix

Pass `cwd` to the existing `env.execute()` call that launches the non-local background wrapper. Add a regression test that verifies the requested cwd reaches that execution boundary and remains recorded on the process session.

## Related Issue

Closes #100020

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py` - forward the background session cwd to non-local environment execution.
- `tests/tools/test_process_registry.py` - cover cwd propagation at the backend launch boundary.

## How to Test

1. Run the process-registry regression subset.
2. Run the terminal task-cwd suite.

```bash
scripts/run_tests.sh tests/tools/test_process_registry.py -k 'spawn_via_env' -q
scripts/run_tests.sh tests/tools/test_terminal_task_cwd.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - behavior is covered at the non-local environment execution boundary.
