### PR TITLE
feat(session-search): add optional NL expansion fallback

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,16 @@ jobs:
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
 
+      - name: Run NL search evaluation gate
+        run: |
+          source .venv/bin/activate
+          # "all" resolves against the packs actually present in this branch:
+          # core validates default, Latin validates default+Latin, and the
+          # final stacked branch validates the full registry.
+          python scripts/nl_search_eval.py --packs all \
+            --min-nl-recall 0.95 --min-nl-precision 0.80 \
+            --min-absent-accuracy 1.00
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/nl-search-language-packs.md
+++ b/docs/nl-search-language-packs.md
@@ -1,0 +1,60 @@
+# Natural-language session-search language packs
+
+Language packs are data-only registry entries in `hermes_state_nl_expansion.py`.
+They must not change the session-search pipeline.
+
+## Required evidence for a new pack
+
+A contribution must include all of the following:
+
+1. **Schema data**: `stopwords`, `affinity_stopwords`, morphology settings and
+   a conservative `min_stem` precision floor.
+2. **Routing coverage**: at least one query with a language-specific affinity
+   marker, plus an ambiguity case for every script/lexical neighbour that could
+   otherwise win detection.
+3. **Search coverage**: at least three privacy-safe synthetic cases spanning
+   stopword removal, inflection and an ordinary query. Add the pack name to
+   each case's `packs` field in `nl_search_eval_v1.json`.
+4. **Adversarial coverage**: add a lexical-near-miss or cross-language cognate
+   case when the new language shares vocabulary with an existing pack.
+5. **Human validation**: a fluent speaker or a documented authoritative grammar
+   source must review stopwords, affinity markers and morphology assumptions.
+   Record the source/reviewer in the PR body; do not add personal identifiers
+   to the repository.
+
+## Evaluation protocol
+
+Run the pack-aware harness against only the packs present on the branch:
+
+```bash
+PYTHONPATH=. python scripts/nl_search_eval.py --packs default,new-pack
+```
+
+The runner creates one temporary SQLite database per case. It reports
+`hit@1`, `recall@5`, `precision@5`, MRR, absent-query accuracy, and p50/p95
+latency. It is a controlled mechanism regression suite, not a claim about
+population-level relevance.
+
+## Review boundaries
+
+- `SessionDB.search_messages()` remains strict by default.
+- Only conversational callers opt into `natural_language=True`.
+- Explicit FTS5 syntax is never expanded.
+- New packs may not add runtime dependencies or database schema changes.
+- Keep broad OR recovery behind the explicit conversational path and include
+  a relevance counterexample whenever its vocabulary is widened.
+
+## Controlled rollout
+
+`HERMES_SEARCH_NL_ROUTE_LOG=1` emits only successful NL fallback events:
+route, selected language, elapsed time, result count and query length. Query
+text stays out of logs. Use this in a bounded rollout to determine whether a
+pack is selected and useful before proposing it as a default behavior change.
+
+For temporary text-level diagnostics only:
+
+```bash
+HERMES_SEARCH_LOG_QUERY=1
+```
+
+Do not enable that setting as a normal production default.

--- a/hermes_state_nl_expansion.py
+++ b/hermes_state_nl_expansion.py
@@ -1,0 +1,256 @@
+# Natural-language query expansion for FTS5 session search.
+#
+# This module implements language-agnostic NL expansion: stopword removal,
+# light suffix stripping, and prefix wildcards for inflectional languages.
+# Language data lives in ``_NL_LANG_PACKS`` as pure dictionaries — adding a
+# language is just adding a new entry, no mechanism changes required.
+#
+# Usage in hermes_state_search.py:
+#   try:
+#       from . import hermes_state_nl_expansion as _nle
+#   except ImportError:
+#       _nle = None  # optional feature, don't break core search
+#   ...
+#   nl_support = _nle.NLSupport() if _nle else None
+#   ...
+#   expanded = nl_support.expand_nl_query(query) if nl_support else None
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Any, Collection, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Pack schema (all fields documented inline above each pack below)
+# ---------------------------------------------------------------------------
+#   stopwords           frozenset[str]   words dropped from the query
+#   affinity_stopwords  frozenset[str]   small function-word set used ONLY
+#                                        for language detection scoring
+#   suffixes            tuple[str, ...]  light suffixes stripped first
+#   endings             frozenset[str]   2-char flexion endings → drop 2
+#   vowels              str              vowel set for trailing-vowel drop
+#   trailing_vowel_drop bool             tail vowel counts as flexion
+#   min_stem            int              shortest prefix kept (precision)
+#   fallback            str              "keep" (stem already) | "drop1"
+
+
+# ===========================================================================
+# LANGUAGE PACKS — pure data, no logic
+# ===========================================================================
+_NL_LANG_PACKS: Dict[str, Dict[str, Any]] = {
+    "default": {
+        # English + conservative universal layer. Latin terms are usually
+        # already stems after suffix strip; keep them whole with *.
+        "stopwords": frozenset(
+            """
+            a an and are as at be but by for if in into is it no not of on or
+            s such t that the their then there these they this to was we will
+            with you your do does did how what why when where which who whom
+            whose can could should would may might must shall please help show
+            find tell explain check make give get
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(),  # default is fallback, no score
+        "suffixes": ("ing", "ed", "es", "'s", "s"),
+        "endings": frozenset(),
+        "vowels": "",
+        "trailing_vowel_drop": False,
+        "min_stem": 4,
+        "fallback": "keep",
+    },
+}
+
+
+# ===========================================================================
+# DETECTION
+# ===========================================================================
+def detect_lang(query: str) -> str:
+    """Pick a language pack for the raw query (two-stage detection).
+
+    Stage 1 — script: non-Latin scripts are unambiguous. Cyrillic anywhere
+    in the query narrows candidates to ru/be/uk. Everything else falls
+    through to stage 2.
+
+    Stage 2 — affinity: each pack's ``affinity_stopwords`` (small function-
+    word set) is scored against query tokens; the best-scoring pack wins.
+    Ties and zero scores degrade to ``default``.
+    """
+    if re.search(r"[а-яё]", query, re.IGNORECASE):
+        # Among Cyrillic packs, choose the best-affinity one
+        tokens = set(re.findall(r"[^\W_]+", query.lower()))
+        best_score, best_lang = 0, "ru"  # ru is the largest Cyrillic pack
+        for lang, pack in _NL_LANG_PACKS.items():
+            if lang == "default":
+                continue
+            aff = pack.get("affinity_stopwords")
+            if not aff:
+                continue
+            score = len(tokens & aff)
+            if score > best_score:
+                best_score = score
+                best_lang = lang
+        return best_lang
+
+    # Latin-script or digits-only: score all packs
+    tokens = set(re.findall(r"[^\W_]+", query.lower()))
+    best_lang, best_score = "default", 0
+    for lang, pack in _NL_LANG_PACKS.items():
+        aff = pack.get("affinity_stopwords")
+        if not aff:
+            continue  # default has no affinity set
+        score = len(tokens & aff)
+        if score > best_score:
+            best_lang, best_score = lang, score
+    return best_lang
+
+
+# ===========================================================================
+# MORPHOLOGY + EXPANSION
+# ===========================================================================
+def morph_prefix(
+    tok: str,
+    *,
+    suffixes: Tuple[str, ...] = (),
+    endings: Collection[str] = frozenset(),
+    vowels: str = "",
+    min_stem: int = 4,
+    trailing_vowel_drop: bool = True,
+    fallback: str = "drop1",
+) -> str:
+    """Prefix wildcard for one term; heuristics guided by pack data.
+
+    Inflection lives in the suffix for most natural languages. The heuristic
+    is recall-oriented and needs no morphology library:
+
+      - explicit light ``suffixes`` (s/es/ed/ing/'s …) stripped first
+        when enough stem remains;
+      - trailing vowel → drop that one char, when the pack says the tail
+        is flexion ("servers"→"server*");
+      - 2-char flexion ``endings`` → drop 2;
+      - otherwise the pack ``fallback`` decides: ``keep`` (Latin stems
+        are usually already the stem: "config"→"config*") or
+        ``drop1`` (agglutinative tails carry flexion).
+
+    Tokens shorter than ``min_stem`` are returned unchanged.
+    """
+    if len(tok) < min_stem:
+        return tok
+    low = tok.lower()
+    # 1. Explicit suffix strip (highest priority)
+    for suf in suffixes:
+        if suf and low.endswith(suf) and len(tok) - len(suf) >= min_stem:
+            return f"{tok[: len(tok) - len(suf)]}*"
+    # 2. Trailing vowel drop
+    if trailing_vowel_drop and vowels and low[-1] in vowels:
+        return f"{tok[:-1]}*"
+    # 3. 2-char endings table
+    if len(tok) >= min_stem + 2 and tok[-2:].lower() in endings:
+        return f"{tok[:-2]}*"
+    # 4. Default fallback
+    if fallback == "keep":
+        return f"{tok}*"
+    if len(tok) == min_stem:
+        return f"{tok}*"
+    return f"{tok[:-1]}*"
+
+
+class NLSupport:
+    """Build bounded FTS5 expansions for plain conversational text."""
+
+    _CACHE_MAXSIZE = 256
+    # Expansion adds up to two FTS5 retries. Bound it independently of the
+    # caller so a long conversational prompt cannot amplify search work.
+    _MAX_QUERY_CHARS = 512
+    _MAX_MEANINGFUL_TERMS = 8
+
+    def __init__(self) -> None:
+        # Queries originate with users; do not retain an unbounded input log.
+        self._cache: OrderedDict[str, Optional[Dict[str, str]]] = OrderedDict()
+
+    def expand_nl_query(self, query: str) -> Optional[Dict[str, str]]:
+        """Expand a natural-language query into FTS5-friendly variants.
+
+        Returns ``None`` when the query has fewer than two meaningful terms
+        (nothing to gain from expansion) or is entirely stopwords.
+        """
+        # Do not cache or expand unusually long user input. Search still
+        # continues through the existing bounded fallback chain unchanged.
+        if len(query) > self._MAX_QUERY_CHARS:
+            return None
+
+        # Check cache first
+        cache_key = query
+        if cache_key in self._cache:
+            self._cache.move_to_end(cache_key)
+            return self._cache[cache_key]
+
+        lang = detect_lang(query)
+        pack = _NL_LANG_PACKS.get(lang, _NL_LANG_PACKS["default"])
+        stopwords = pack["stopwords"]
+        suffixes = tuple(pack.get("suffixes", ()))
+        endings = pack.get("endings", frozenset())
+        vowels = pack.get("vowels", "")
+        min_stem = pack.get("min_stem", 4)
+        vowel_drop = bool(pack.get("trailing_vowel_drop", True))
+        fallback = pack.get("fallback", "drop1")
+
+        meaningful: List[str] = []
+        and_parts: List[str] = []
+        or_parts: List[str] = []
+
+        def _add_subtoken(sub: str) -> None:
+            if not sub or not re.search(r"[^\W\d_]", sub):
+                return
+            if sub.lower() in stopwords:
+                return
+            meaningful.append(sub)
+            prefixed = morph_prefix(
+                sub, suffixes=suffixes, endings=endings,
+                vowels=vowels, min_stem=min_stem,
+                trailing_vowel_drop=vowel_drop, fallback=fallback,
+            )
+            and_parts.append(prefixed)
+            or_parts.append(prefixed)
+
+        for raw_tok in re.findall(r'"[^"]+"|\S+', query):
+            if raw_tok.startswith('"') and raw_tok.endswith('"'):
+                phrase = raw_tok[1:-1].strip()
+                if not phrase:
+                    continue
+                if re.search(r"[^\w\s]", phrase):
+                    for sub in re.split(r"[^\w]+", phrase):
+                        _add_subtoken(sub)
+                else:
+                    meaningful.append(phrase)
+                    and_parts.append(raw_tok)
+                    or_parts.append(raw_tok)
+                continue
+            tok = raw_tok.strip('"').strip("*").strip()
+            if not tok or tok.upper() in {"AND", "OR", "NOT", "NEAR"}:
+                continue
+            for sub in re.split(r"[^\w]+", tok):
+                _add_subtoken(sub)
+
+        if len(meaningful) < 2:
+            result = None
+        else:
+            # Keep the first terms in user order. This is deterministic and
+            # caps both MATCH expression size and the broad OR retry cost.
+            meaningful = meaningful[:self._MAX_MEANINGFUL_TERMS]
+            and_parts = and_parts[:self._MAX_MEANINGFUL_TERMS]
+            or_parts = or_parts[:self._MAX_MEANINGFUL_TERMS]
+            result = {
+                "and": " AND ".join(and_parts) if len(and_parts) > 1 else and_parts[0],
+                "or": " OR ".join(or_parts),
+                "bare": " ".join(meaningful),
+                # Metadata only; callers never send it to FTS5.
+                "language": lang,
+            }
+
+        self._cache[cache_key] = result
+        self._cache.move_to_end(cache_key)
+        if len(self._cache) > self._CACHE_MAXSIZE:
+            self._cache.popitem(last=False)
+        return result

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -6,6 +6,7 @@ Must never import hermes_state (cycle); shared constants live in hermes_state_co
 
 import contextlib
 import logging
+import os
 import re
 import sqlite3
 import time
@@ -22,6 +23,11 @@ from hermes_state_common import (
 
 # Pre-split logger identity so log filtering/capture is unchanged.
 logger = logging.getLogger("hermes_state")
+
+# Natural-language expansion is dependency-free and shipped with this module.
+# Keep the low-level FTS API strict by default; conversational callers opt in
+# via ``natural_language=True`` (see SessionSearchMixin.search_messages).
+import hermes_state_nl_expansion as _nle
 
 # Characters FTS5's query grammar rejects outside a quoted phrase (anything missing
 # reaches MATCH raw and raises -> zero results). ``%`` is deliberately excluded: the
@@ -164,6 +170,33 @@ def _search_filter_clauses(
 
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
+
+    # Shared, bounded expansion cache.  NLSupport itself is dependency-free;
+    # a single instance avoids per-query allocation without retaining an unbounded
+    # record of user-entered queries.
+    _nl_support = _nle.NLSupport()
+
+    @staticmethod
+    def _log_nl_fallback(*, route: str, language: str, elapsed_ms: float, rows: int, chars: int) -> None:
+        """Emit one privacy-safe NL fallback event when explicitly enabled."""
+        if os.getenv("HERMES_SEARCH_NL_ROUTE_LOG", "").lower() not in {"1", "true", "yes"}:
+            return
+        logger.info(
+            "session search NL fallback: path=%s language=%s elapsed=%.0fms rows=%s chars=%s",
+            route, language, elapsed_ms, rows, chars,
+        )
+
+    @staticmethod
+    def _nl_eligible(query: str) -> bool:
+        """True only for plain conversational text, never FTS5 syntax.
+
+        ``search_messages`` is also a low-level API.  Explicit quotes, wildcard,
+        boolean and proximity operators are part of its public FTS5 contract and
+        must not be widened by a natural-language fallback.
+        """
+        if not query or any(char in query for char in ('"', '*')):
+            return False
+        return not re.search(r"\b(?:AND|OR|NOT|NEAR)\b", query, re.IGNORECASE)
 
     _SEARCH_MESSAGE_RESULT_FIELDS = (
         "id", "session_id", "role", "snippet", "timestamp", "tool_name", "source", "model", "session_started", "context"
@@ -1001,36 +1034,61 @@ class SessionSearchMixin:
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
         include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        natural_language: bool = False,
     ) -> List[Dict[str, Any]]:
         """:meth:`_search_messages_impl` plus one log line per slow search with the routing
-        path taken. Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call)."""
+        path taken. Threshold HERMES_SEARCH_SLOW_MS (default 1000; 0 logs every call).
+
+        ``natural_language`` opts conversational callers into a bounded, zero-result
+        FTS5 expansion fallback. It defaults to ``False`` so the explicit FTS5 syntax
+        (quoted phrases, boolean/proximity operators, wildcards) stays a stable low-level
+        API contract; only the ``session_search`` tool turns it on."""
         started = time.time()
         rows = None
+        search_route: Dict[str, str] = {}
         try:
             rows = self._search_messages_impl(
                 query, source_filter=source_filter, exclude_sources=exclude_sources, role_filter=role_filter,
-                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields)
+                limit=limit, offset=offset, sort=sort, include_inactive=include_inactive, fields=fields,
+                natural_language=natural_language, search_route=search_route)
             return rows
         finally:
             elapsed_ms = (time.time() - started) * 1000.0
             if elapsed_ms >= env_float("HERMES_SEARCH_SLOW_MS", 1000.0):
-                logger.info("slow session search: path=%s elapsed=%.0fms rows=%s query=%r",
-                            self._describe_search_path(query), elapsed_ms, len(rows) if rows is not None else "err",
-                            query[: 200])
+                route = search_route.get("path", self._describe_search_path(query))
+                # Search text may contain user data. Keep production telemetry
+                # aggregate-friendly by default; operators can explicitly opt into
+                # query-text diagnostics for a short troubleshooting window.
+                log_query = os.getenv("HERMES_SEARCH_LOG_QUERY", "").lower() in {"1", "true", "yes"}
+                if log_query:
+                    logger.info("slow session search: path=%s elapsed=%.0fms rows=%s chars=%s query=%r",
+                                route, elapsed_ms, len(rows) if rows is not None else "err", len(query), query[:200])
+                else:
+                    logger.info("slow session search: path=%s elapsed=%.0fms rows=%s chars=%s",
+                                route, elapsed_ms, len(rows) if rows is not None else "err", len(query))
 
     def _search_messages_impl(
         self, query: str, source_filter: List[str] = None, exclude_sources: List[str] = None,
         role_filter: List[str] = None, limit: int = 20, offset: int = 0, sort: str = None,
         include_inactive: bool = False, fields: Optional[Collection[str]] = None,
+        natural_language: bool = False, search_route: Optional[Dict[str, str]] = None,
     ) -> List[Dict[str, Any]]:
         """FTS5 search across session messages (keywords, ``"phrases"``, AND/OR/NOT, ``prefix*``).
         Returns snippet + session metadata + 1-message context per hit; ``fields`` selects a
         projection. ``sort``: None = BM25 rank; "newest"/"oldest" = timestamp then rank (the
         CJK LIKE fallback ignores it). Rewound rows (``active=0, compacted=0``) are excluded
-        by default; compaction-archived rows ARE included; ``include_inactive`` = every row."""
+        by default; compaction-archived rows ARE included; ``include_inactive`` = every row.
+
+        ``natural_language`` enables a bounded zero-result NL expansion fallback for
+        conversational callers; ``search_route`` records which route produced the final
+        rows so the wrapper can attribute slow-search telemetry accurately."""
         result_fields = self._search_message_fields(fields)
         if not query or not query.strip():
             return []
+        # Keep the caller's text for NL eligibility. Sanitization may insert
+        # protective quotes around punctuation (for example a French hyphen),
+        # which must not be mistaken for an explicit FTS phrase chosen by the caller.
+        raw_nl_query = query
         query = self._sanitize_fts5_query(query)
         if not query:
             return []
@@ -1091,7 +1149,35 @@ class SessionSearchMixin:
         # tokens). Gated on a miss so hits keep their ranking ("cat" may then match
         # "concatenate"). Skipped for role='tool' (both indexes exclude tool rows).
         if not matches and not is_cjk and not (bool(role_filter) and "tool" in role_filter):
-            fb_query = _quote_fts_tokens(query.strip('"').strip())
+            # ── NL expansion: stopwords + light morphology ──
+            # A natural-language question usually fails plain FTS5 twice:
+            # AND-between-tokens across messages and inflected word forms. Try
+            # prefixed AND first, then OR only in the explicit conversational
+            # mode. Message-level FTS may store the terms of a user question in
+            # adjacent turns, where strict AND cannot recall the session. This
+            # remains a zero-result fallback; explicit FTS5 syntax never enters
+            # this branch and the selected route is logged.
+            expanded = None
+            if natural_language and self._nl_eligible(raw_nl_query):
+                expanded = self._nl_support.expand_nl_query(raw_nl_query)
+            if expanded:
+                for _nl_key in ("and", "or"):
+                    _nl_started = time.perf_counter()
+                    _nl_matches = self._match_rows("messages_fts", expanded[_nl_key], **route)
+                    if _nl_matches:
+                        matches = _nl_matches
+                        _nl_route = f"nl_fts_{_nl_key}"
+                        if search_route is not None:
+                            search_route["path"] = _nl_route
+                        self._log_nl_fallback(
+                            route=_nl_route, language=expanded["language"],
+                            elapsed_ms=(time.perf_counter() - _nl_started) * 1000.0,
+                            rows=len(_nl_matches), chars=len(raw_nl_query),
+                        )
+                        break
+                # The substring-capable indexes below get the stopword-stripped
+                # query so they don't trip over function words either.
+            fb_query = _quote_fts_tokens((expanded["bare"] if expanded else query).strip('"').strip())
             # ── CJK-bigram route (messages_fts_cjk, cjk_unicode61) ────── When the bigram index is
             # available it serves EVERY CJK query shape the legacy code split between trigram (>=3
             # chars/token) and LIKE full scans (1-2 char tokens) — the whole point of the index (PR #65544).

--- a/scripts/nl_search_eval.py
+++ b/scripts/nl_search_eval.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Evaluate strict FTS5 versus opt-in NL search on privacy-safe corpora.
+
+Cases are synthetic and each is materialized in a separate temporary SQLite DB.
+The runner selects only cases whose ``packs`` are available in the checked-out
+branch, so a stacked core/Latin/Slavic PR remains self-validating.
+
+Usage:
+  PYTHONPATH=. python scripts/nl_search_eval.py
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs default
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs default,es,fr,de,pt,it
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs all --json-out /tmp/nl-eval.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import _NL_LANG_PACKS
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "tests" / "hermes_state" / "fixtures" / "nl_search_eval_v1.json"
+_GENERIC_DISTRACTORS = (
+    "generic scheduling record",
+    "unrelated visual dashboard",
+    "temporary document archive",
+    "network inventory note",
+    "ordinary release calendar",
+)
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[round((len(ordered) - 1) * fraction)]
+
+
+def resolve_packs(raw: str) -> set[str]:
+    """Validate a requested pack set against packs in this checkout."""
+    available = set(_NL_LANG_PACKS)
+    if raw == "all":
+        return available
+    selected = {item.strip() for item in raw.split(",") if item.strip()}
+    unknown = selected - available
+    if unknown:
+        raise ValueError(f"requested packs unavailable in this branch: {sorted(unknown)}")
+    return selected
+
+
+def select_cases(corpus: dict[str, Any], packs: set[str]) -> list[dict[str, Any]]:
+    cases = corpus["cases"] + corpus.get("adversarial_cases", [])
+    return [case for case in cases if set(case["packs"]).issubset(packs)]
+
+
+def case_relevant(case: dict[str, Any]) -> list[str]:
+    if "relevant" in case:
+        return case["relevant"]
+    return [case["target"]]
+
+
+def case_distractors(case: dict[str, Any]) -> list[str]:
+    return case.get("distractors", list(_GENERIC_DISTRACTORS))
+
+
+def evaluate_case(case: dict[str, Any], natural_language: bool) -> dict[str, Any]:
+    """Materialize one isolated relevance corpus and score the top five rows."""
+    relevant = case_relevant(case)
+    with tempfile.TemporaryDirectory(prefix="hermes-nl-eval-") as tmp:
+        db = SessionDB(db_path=Path(tmp) / "state.db")
+        relevant_sessions: set[str] = set()
+        for index, text in enumerate(relevant):
+            session_id = f"relevant-{case['id']}-{index}"
+            relevant_sessions.add(session_id)
+            db.create_session(session_id, source="eval")
+            db.append_message(session_id, "assistant", text)
+        for index, text in enumerate(case_distractors(case)):
+            session_id = f"distractor-{case['id']}-{index}"
+            db.create_session(session_id, source="eval")
+            db.append_message(session_id, "assistant", text)
+        started = time.perf_counter()
+        rows = db.search_messages(case["query"], limit=5, natural_language=natural_language)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        db.close()
+
+    ids = [row["session_id"] for row in rows]
+    ranks = [index + 1 for index, session_id in enumerate(ids) if session_id in relevant_sessions]
+    relevant_returned = len(ranks)
+    if relevant:
+        hit1 = bool(ranks and ranks[0] == 1)
+        recall5 = relevant_returned / len(relevant)
+        precision5 = relevant_returned / len(rows) if rows else 0.0
+        rr = 1.0 / ranks[0] if ranks else 0.0
+        absent_correct = None
+    else:
+        hit1 = rows == []
+        recall5 = 1.0 if not rows else 0.0
+        precision5 = 1.0 if not rows else 0.0
+        rr = 1.0 if not rows else 0.0
+        absent_correct = not rows
+    return {
+        "id": case["id"], "lang": case["lang"], "scenario": case["scenario"],
+        "latency_ms": elapsed_ms, "returned": len(rows), "relevant": len(relevant),
+        "relevant_returned": relevant_returned, "hit1": hit1, "recall5": recall5,
+        "precision5": precision5, "rr": rr, "absent_correct": absent_correct,
+    }
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, float | int]:
+    count = len(results)
+    absent = [row for row in results if row["absent_correct"] is not None]
+    return {
+        "cases": count,
+        "hit_at_1": sum(row["hit1"] for row in results) / count,
+        "recall_at_5": sum(row["recall5"] for row in results) / count,
+        "precision_at_5": sum(row["precision5"] for row in results) / count,
+        "mrr": sum(row["rr"] for row in results) / count,
+        "absent_query_accuracy": (
+            sum(row["absent_correct"] for row in absent) / len(absent) if absent else None
+        ),
+        "latency_p50_ms": percentile([row["latency_ms"] for row in results], 0.50),
+        "latency_p95_ms": percentile([row["latency_ms"] for row in results], 0.95),
+        "latency_mean_ms": statistics.fmean(row["latency_ms"] for row in results),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=CORPUS)
+    parser.add_argument("--packs", default="all", help="comma-separated installed packs or 'all'")
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--min-nl-recall", type=float)
+    parser.add_argument("--min-nl-precision", type=float)
+    parser.add_argument("--min-absent-accuracy", type=float)
+    args = parser.parse_args()
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    packs = resolve_packs(args.packs)
+    cases = select_cases(corpus, packs)
+    if not cases:
+        raise ValueError("pack selection chose zero evaluation cases")
+    modes = {
+        "strict_fts5": [evaluate_case(case, False) for case in cases],
+        "nl_opt_in": [evaluate_case(case, True) for case in cases],
+    }
+    report = {
+        "corpus_version": corpus["version"], "selected_packs": sorted(packs),
+        "corpus_cases": len(cases), "summary": {mode: summarize(rows) for mode, rows in modes.items()},
+        "by_case": modes,
+    }
+    for mode, summary in report["summary"].items():
+        absent = summary["absent_query_accuracy"]
+        absent_text = "n/a" if absent is None else f"{absent:.3f}"
+        print(
+            f"{mode}: cases={summary['cases']} hit@1={summary['hit_at_1']:.3f} "
+            f"recall@5={summary['recall_at_5']:.3f} precision@5={summary['precision_at_5']:.3f} "
+            f"MRR={summary['mrr']:.3f} absent={absent_text} "
+            f"p50={summary['latency_p50_ms']:.1f}ms p95={summary['latency_p95_ms']:.1f}ms"
+        )
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    nl_summary = report["summary"]["nl_opt_in"]
+    thresholds = {
+        "recall@5": (args.min_nl_recall, nl_summary["recall_at_5"]),
+        "precision@5": (args.min_nl_precision, nl_summary["precision_at_5"]),
+        "absent accuracy": (args.min_absent_accuracy, nl_summary["absent_query_accuracy"]),
+    }
+    failed = [
+        f"{name}={actual:.3f} < {minimum:.3f}"
+        for name, (minimum, actual) in thresholds.items()
+        if minimum is not None and (actual is None or actual < minimum)
+    ]
+    if failed:
+        print("NL evaluation threshold failed: " + ", ".join(failed))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_state/fixtures/nl_search_eval_v1.json
+++ b/tests/hermes_state/fixtures/nl_search_eval_v1.json
@@ -1,0 +1,666 @@
+{
+  "version": 2,
+  "description": "Privacy-safe multilingual NL session-search evaluation: synthetic pack-aware mechanism cases and adversarial relevance cases, independently materialized in temporary SQLite databases.",
+  "cases": [
+    {
+      "id": "en-01",
+      "lang": "default",
+      "query": "what did we decide about cluster backups",
+      "target": "cluster backup decision",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "en-02",
+      "lang": "default",
+      "query": "how are proxy services configured",
+      "target": "proxy service configuration",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "en-03",
+      "lang": "default",
+      "query": "where were deployment logs running",
+      "target": "deployment log runner",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-01",
+      "lang": "es",
+      "query": "dónde están las configuraciones del proxy",
+      "target": "configuración proxy",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-02",
+      "lang": "es",
+      "query": "cómo quedaron los servidores configurados",
+      "target": "servidor configurado",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-03",
+      "lang": "es",
+      "query": "cuándo ejecutaron las copias nocturnas",
+      "target": "copia nocturna ejecución",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-01",
+      "lang": "fr",
+      "query": "où sont les configurations du serveur",
+      "target": "configuration serveur",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-02",
+      "lang": "fr",
+      "query": "comment les sauvegardes fonctionnent-elles",
+      "target": "sauvegarde fonctionnement",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-03",
+      "lang": "fr",
+      "query": "pourquoi les déploiements échouaient",
+      "target": "déploiement échec",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-01",
+      "lang": "de",
+      "query": "wo sind die Konfigurationen des Servers",
+      "target": "Konfiguration Server",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-02",
+      "lang": "de",
+      "query": "wie laufen die Sicherungen nachts",
+      "target": "Sicherung Nachtlauf",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-03",
+      "lang": "de",
+      "query": "warum wurden die Dienste gestartet",
+      "target": "Dienst Start",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-01",
+      "lang": "pt",
+      "query": "onde estão as configurações do servidor",
+      "target": "configuração servidor",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-02",
+      "lang": "pt",
+      "query": "como funcionam os backups noturnos",
+      "target": "backup noturno funcionamento",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-03",
+      "lang": "pt",
+      "query": "quando os serviços reiniciaram",
+      "target": "serviço reinício",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-01",
+      "lang": "it",
+      "query": "dov'è la configurazione del server",
+      "target": "configurazione server",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-02",
+      "lang": "it",
+      "query": "quando girano i backup notturni",
+      "target": "backup notturno giro",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-03",
+      "lang": "it",
+      "query": "come funzionano i servizi distribuiti",
+      "target": "servizio distribuzione funzionamento",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-01",
+      "lang": "ru",
+      "query": "где находятся конфигурации серверов",
+      "target": "конфигурация сервер",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-02",
+      "lang": "ru",
+      "query": "как работают ночные резервные копии",
+      "target": "резервная копия ночь",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-03",
+      "lang": "ru",
+      "query": "когда перезапускали развернутые сервисы",
+      "target": "сервис перезапуск развертывание",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-01",
+      "lang": "be",
+      "query": "колькі сервераў з канфігурацыяй запушчана",
+      "target": "сервер канфігурацыя запуск",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-02",
+      "lang": "be",
+      "query": "дзе знаходзяцца рэзервовыя копіі",
+      "target": "рэзервовая копія знаходжанне",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-03",
+      "lang": "be",
+      "query": "калі працуюць начныя сэрвісы",
+      "target": "начны сэрвіс праца",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-01",
+      "lang": "uk",
+      "query": "скільки серверів конфігурації запущено",
+      "target": "сервер конфігурація запуск",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-02",
+      "lang": "uk",
+      "query": "де знаходяться резервні копії",
+      "target": "резервна копія знаходження",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-03",
+      "lang": "uk",
+      "query": "коли працюють нічні сервіси",
+      "target": "нічний сервіс робота",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-01",
+      "lang": "sr",
+      "query": "где су конфигурације сервера",
+      "target": "конфигурација сервер",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-02",
+      "lang": "sr",
+      "query": "како раде ноћне копије",
+      "target": "ноћна копија рад",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-03",
+      "lang": "sr",
+      "query": "када су сервиси покренути",
+      "target": "сервис покретање",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-01",
+      "lang": "bg",
+      "query": "къде са конфигурациите на сървъра",
+      "target": "конфигурация сървър",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-02",
+      "lang": "bg",
+      "query": "как работят нощните копия",
+      "target": "нощно копие работа",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-03",
+      "lang": "bg",
+      "query": "кога услугите стартираха",
+      "target": "услуга стартиране",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-01",
+      "lang": "mk",
+      "query": "каде се конфигурациите на серверот",
+      "target": "конфигурација сервер",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-02",
+      "lang": "mk",
+      "query": "како работат ноќните копии",
+      "target": "ноќна копија работа",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-03",
+      "lang": "mk",
+      "query": "кога сервисите стартуваа",
+      "target": "сервис стартување",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-01",
+      "lang": "hr",
+      "query": "gdje su konfiguracije poslužitelja",
+      "target": "konfiguracija poslužitelj",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-02",
+      "lang": "hr",
+      "query": "kako rade noćne kopije",
+      "target": "noćna kopija rad",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-03",
+      "lang": "hr",
+      "query": "kada su servisi pokrenuti",
+      "target": "servis pokretanje",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-01",
+      "lang": "cs",
+      "query": "kde jsou konfigurace serveru",
+      "target": "konfigurace server",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-02",
+      "lang": "cs",
+      "query": "jak fungují noční zálohy",
+      "target": "noční záloha fungování",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-03",
+      "lang": "cs",
+      "query": "kdy byly služby spuštěny",
+      "target": "služba spuštění",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-01",
+      "lang": "sk",
+      "query": "kde sú konfigurácie servera",
+      "target": "konfigurácia server",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-02",
+      "lang": "sk",
+      "query": "ako fungujú nočné zálohy",
+      "target": "nočná záloha fungovanie",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-03",
+      "lang": "sk",
+      "query": "kedy boli služby spustené",
+      "target": "služba spustenie",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    }
+  ],
+  "adversarial_cases": [
+    {
+      "id": "adv-en-exact",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "exact_hit",
+      "query": "backup policy",
+      "relevant": [
+        "backup policy retained for cluster"
+      ],
+      "distractors": [
+        "backup policy obsolete draft",
+        "release policy note"
+      ]
+    },
+    {
+      "id": "adv-en-adjacent",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "adjacent_turns",
+      "query": "why flux cluster backups",
+      "relevant": [
+        "flux reconciles deployments",
+        "cluster backups run nightly"
+      ],
+      "distractors": [
+        "flux capacitor note",
+        "calendar backup entry"
+      ]
+    },
+    {
+      "id": "adv-en-absent",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "absent",
+      "query": "luminous manganese theorem",
+      "relevant": [],
+      "distractors": [
+        "generic scheduling record",
+        "unrelated visual dashboard",
+        "temporary document archive"
+      ]
+    },
+    {
+      "id": "adv-en-syntax",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "fts_syntax",
+      "query": "backup NOT obsolete",
+      "relevant": [
+        "backup policy retained"
+      ],
+      "distractors": [
+        "backup obsolete draft",
+        "ordinary status note"
+      ]
+    },
+    {
+      "id": "adv-es-near",
+      "lang": "es",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "dónde están las configuraciones del proxy",
+      "relevant": [
+        "configuración proxy vigente"
+      ],
+      "distractors": [
+        "configuración temporal de monitor",
+        "proxy visual sin configuración"
+      ]
+    },
+    {
+      "id": "adv-fr-near",
+      "lang": "fr",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "comment fonctionnent les sauvegardes",
+      "relevant": [
+        "sauvegarde fonctionnement validé"
+      ],
+      "distractors": [
+        "fonctionnement visuel",
+        "sauvegarde temporaire supprimée"
+      ]
+    },
+    {
+      "id": "adv-it-route",
+      "lang": "it",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "routing",
+      "query": "quando girano i backup notturni",
+      "relevant": [
+        "backup notturno giro"
+      ],
+      "distractors": [
+        "backup diurno giro",
+        "notturno calendario"
+      ]
+    },
+    {
+      "id": "adv-ru-near",
+      "lang": "ru",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "где конфигурации прокси",
+      "relevant": [
+        "конфигурация прокси сохранена"
+      ],
+      "distractors": [
+        "конфигурация мониторинга",
+        "прокси временно удалён"
+      ]
+    },
+    {
+      "id": "adv-be-route",
+      "lang": "be",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "routing",
+      "query": "колькі сервераў запушчана",
+      "relevant": [
+        "сервер запуск завершаны"
+      ],
+      "distractors": [
+        "сервер русская заметка",
+        "запуск календаря"
+      ]
+    },
+    {
+      "id": "adv-sk-near",
+      "lang": "sk",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "cross_language",
+      "query": "ako fungujú nočné zálohy",
+      "relevant": [
+        "nočná záloha fungovanie"
+      ],
+      "distractors": [
+        "noční záloha česká poznámka",
+        "záloha vizuálneho návrhu"
+      ]
+    }
+  ]
+}

--- a/tests/hermes_state/test_nl_expansion_mechanism.py
+++ b/tests/hermes_state/test_nl_expansion_mechanism.py
@@ -1,0 +1,222 @@
+"""Tests for the NL query-expansion mechanism (language-agnostic contracts).
+
+The mechanism must work with the default pack only: stopword stripping,
+light stemming, additive fallback chain, graceful degradation for scripts
+without a pack. Language packs are pure data and tested separately.
+"""
+
+import json
+import re
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import (
+    _NL_LANG_PACKS,
+    NLSupport,
+    detect_lang,
+    morph_prefix,
+)
+
+
+class TestDetectLang:
+    def test_unknown_script_gets_default(self):
+        assert detect_lang("配置 服务器") == "default"
+
+    def test_registry_packs_conform_to_schema(self):
+        required = {
+            "stopwords", "affinity_stopwords", "suffixes", "endings",
+            "vowels", "min_stem", "trailing_vowel_drop", "fallback",
+        }
+        for lang, pack in _NL_LANG_PACKS.items():
+            missing = required - set(pack)
+            assert not missing, f"{lang} pack missing keys: {missing}"
+            assert pack["fallback"] in {"keep", "drop1"}, lang
+            assert pack["min_stem"] >= 3, lang
+
+
+class TestExpandEn:
+    @pytest.fixture()
+    def host(self):
+        return NLSupport()
+
+    def test_english_question_strips_stopwords_and_prefixes(self, host):
+        out = host.expand_nl_query("what did we decide about the configs?")
+        assert out is not None
+        assert out["and"] == "decide* AND about* AND config*"
+        assert out["bare"] == "decide about configs"
+
+    def test_two_meaningful_terms_minimum(self, host):
+        assert host.expand_nl_query("what the?") is None
+        assert host.expand_nl_query("config backup")["and"] == "config* AND backup*"
+
+    def test_short_tokens_untouched(self, host):
+        out = host.expand_nl_query("ssh api gateway")
+        assert "api" in out["bare"].split()
+        assert "ssh" in out["bare"].split()
+
+    def test_separated_compound_splits_into_subtokens(self, host):
+        out = host.expand_nl_query("check the ssh-config backup")
+        assert "config*" in out["and"]
+        assert "backup*" in out["and"]
+
+
+class TestMorphPrefix:
+    def test_english_suffix_strip(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("servers", **kw) == "server*"
+        assert morph_prefix("walked", **kw) == "walk*"
+        assert morph_prefix("config's", **kw) == "config*"
+
+    def test_min_stem_floor(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("api", **kw) == "api"      # < min_stem → untouched
+        assert morph_prefix("test", **kw) == "test*"   # == min_stem
+
+    def test_latin_stem_kept_when_no_suffix_matches(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("config", **kw) == "config*"
+        assert morph_prefix("testing", **kw) == "test*"
+
+    def test_drop1_fallback_for_fusional_pack_data(self):
+        """A hypothetical fusional pack: tail carries flexion → drop 1."""
+        assert (
+            morph_prefix(
+                "router",
+                suffixes=(), endings=frozenset(),
+                vowels="aeiou", min_stem=4,
+                trailing_vowel_drop=False, fallback="drop1",
+            )
+            == "route*"
+        )
+
+
+class TestAdditiveFallbackE2E:
+    """The fallback must fire only on a zero-result miss and never reorder."""
+
+    @pytest.fixture()
+    def db(self, tmp_path):
+        d = SessionDB(db_path=tmp_path / "state.db")
+        d.create_session("sess-en", source="cli")
+        d.append_message(
+            session_id="sess-en", role="user",
+            content="how do we deploy the k3s cluster backup",
+        )
+        d.append_message(
+            session_id="sess-en", role="assistant",
+            content="we decided about backups: deployment uses flux nightly",
+        )
+        yield d
+        d.close()
+
+    def test_exact_hit_not_replaced_by_expansion(self, db):
+        rows = db.search_messages("nightly backups")
+        assert rows
+        first = json.dumps(rows[0], ensure_ascii=False).lower()
+        assert "nightly" in first
+
+    def test_natural_language_is_opt_in(self, db):
+        query = "what did we decide about the backups?"
+        assert db.search_messages(query) == []
+        rows = db.search_messages(query, natural_language=True)
+        assert rows, "NL mode must recover the session"
+        assert "backup" in json.dumps(rows[:5], ensure_ascii=False).lower()
+
+    @pytest.mark.parametrize("query", [
+        '"exact phrase" backup',
+        "python NOT java",
+        "docker OR kubernetes",
+        "deploy* backup",
+        "NEAR(config backup, 5)",
+    ])
+    def test_fts_syntax_never_enters_nl_mode(self, db, query):
+        assert db.search_messages(query, natural_language=True) == db.search_messages(query)
+
+    def test_nl_path_preserves_source_and_role_filters(self, db):
+        rows = db.search_messages(
+            "what did we decide about the backups?",
+            natural_language=True,
+            source_filter=["cli"],
+            role_filter=["assistant"],
+        )
+        assert rows and all(row["source"] == "cli" for row in rows)
+        assert all(row["role"] == "assistant" for row in rows)
+
+    def test_nl_route_is_visible_in_slow_search_log(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            db.search_messages(
+                "what did we decide about the backups?", natural_language=True
+            )
+        assert any("path=nl_fts_and" in record.message for record in caplog.records)
+
+    def test_or_route_is_visible_when_terms_span_messages(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            rows = db.search_messages(
+                "flux cluster backups?", natural_language=True
+            )
+        assert rows
+        assert any("path=nl_fts_or" in record.message for record in caplog.records)
+
+    def test_nl_only_telemetry_is_opt_in_and_private(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_NL_ROUTE_LOG", "1")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            rows = db.search_messages(
+                "what did we decide about the backups?", natural_language=True
+            )
+        assert rows
+        events = [r.getMessage() for r in caplog.records if "NL fallback" in r.getMessage()]
+        assert len(events) == 1
+        assert "path=nl_fts_and" in events[0]
+        assert "language=default" in events[0]
+        assert "what did" not in events[0]
+
+    def test_sanitizer_quotes_do_not_block_nl_for_hyphenated_words(self, db):
+        db.append_message(
+            session_id="sess-en", role="assistant", content="sauvegarde fonctionnement"
+        )
+        rows = db.search_messages(
+            "comment les sauvegardes fonctionnent-elles", natural_language=True
+        )
+        assert rows
+        assert "sauvegarde" in json.dumps(rows, ensure_ascii=False)
+
+    def test_genuinely_absent_terms_stay_empty(self, db):
+        assert db.search_messages("quantum unicorn recipes", natural_language=True) == []
+
+
+class TestExpansionSafety:
+    def test_cache_is_bounded(self):
+        host = NLSupport()
+        for number in range(300):
+            host.expand_nl_query(f"question {number} about target")
+        assert len(host._cache) <= host._CACHE_MAXSIZE
+
+    def test_long_query_is_not_expanded_or_cached(self):
+        host = NLSupport()
+        query = "meaningful " * (host._MAX_QUERY_CHARS // 2)
+        assert len(query) > host._MAX_QUERY_CHARS
+        assert host.expand_nl_query(query) is None
+        assert query not in host._cache
+
+    def test_expansion_caps_meaningful_terms(self):
+        host = NLSupport()
+        out = host.expand_nl_query(" ".join(f"term{index}" for index in range(20)))
+        assert out is not None
+        assert out["and"].count(" AND ") + 1 == host._MAX_MEANINGFUL_TERMS

--- a/tests/hermes_state/test_nl_search_eval_fixture.py
+++ b/tests/hermes_state/test_nl_search_eval_fixture.py
@@ -1,0 +1,74 @@
+"""Contract checks for the privacy-safe, pack-aware NL evaluation corpus."""
+
+import json
+from pathlib import Path
+
+from scripts.nl_search_eval import resolve_packs, select_cases
+
+
+CORPUS = Path(__file__).parent / "fixtures" / "nl_search_eval_v1.json"
+
+
+def _corpus():
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def test_eval_corpus_is_versioned_private_safe_and_multilingual():
+    corpus = _corpus()
+    assert corpus["version"] == 2
+    mechanism = corpus["cases"]
+    adversarial = corpus["adversarial_cases"]
+    assert len(mechanism) >= 45
+    assert len(adversarial) >= 10
+    ids = [case["id"] for case in mechanism + adversarial]
+    assert len(ids) == len(set(ids))
+    languages = {case["lang"] for case in mechanism}
+    assert len(languages) == 15
+    for case in mechanism:
+        assert set(case) == {"id", "lang", "packs", "scenario", "query", "target"}
+        assert case["scenario"] == "morphology_stopwords"
+        assert set(case["packs"]).issubset(languages)
+    for case in adversarial:
+        assert {"id", "lang", "packs", "scenario", "query", "relevant", "distractors"} <= set(case)
+        assert case["scenario"] in {
+            "exact_hit", "adjacent_turns", "absent", "fts_syntax", "lexical_near_miss",
+            "routing", "cross_language",
+        }
+    for case in mechanism + adversarial:
+        payload = " ".join(str(value) for value in case.values()).lower()
+        assert not any(marker in payload for marker in ("http://", "https://", "@"))
+
+
+def test_pack_selection_makes_each_stacked_layer_self_validating():
+    corpus = _corpus()
+    core = select_cases(corpus, {"default"})
+    latin = select_cases(corpus, {"default", "es", "fr", "de", "pt", "it"})
+    full = select_cases(
+        corpus,
+        {"default", "es", "fr", "de", "pt", "it", "ru", "be", "uk", "sr", "bg", "mk", "hr", "cs", "sk"},
+    )
+    assert core and len(core) < len(latin) < len(full)
+    assert {case["lang"] for case in core} == {"default"}
+    assert {"es", "fr", "de", "pt", "it"}.issubset({case["lang"] for case in latin})
+    assert len({case["lang"] for case in full}) == 15
+
+
+def test_eval_runner_is_portable_and_reports_relevance_metrics():
+    runner = Path(__file__).parents[2] / "scripts" / "nl_search_eval.py"
+    text = runner.read_text(encoding="utf-8")
+    assert "TemporaryDirectory" in text
+    assert "natural_language=natural_language" in text
+    assert "precision_at_5" in text and "latency_p95_ms" in text
+    assert "absent_query_accuracy" in text and "--packs" in text
+    assert "SessionDB" in text and "state.db" in text
+    assert "/home/" not in text
+    assert "db_path=Path(\"/" not in text
+    assert "http://" not in text and "https://" not in text
+    assert "HERMES_SEARCH_NL_ROUTE_LOG" not in text
+    assert "default" in resolve_packs("all")
+    try:
+        resolve_packs("does-not-exist")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown pack must fail fast")

--- a/tests/tools/test_session_search_nl_opt_in.py
+++ b/tests/tools/test_session_search_nl_opt_in.py
@@ -1,0 +1,34 @@
+"""The conversational session-search tool must opt into NL expansion."""
+
+from tools import session_search_tool
+
+
+class _DB:
+    def __init__(self):
+        self.kwargs = None
+
+    def search_messages(self, **kwargs):
+        self.kwargs = kwargs
+        return []
+
+    def list_sessions(self, **kwargs):
+        return []
+
+    def fts_rebuild_status(self):
+        return None
+
+
+def test_discover_enables_natural_language_search():
+    db = _DB()
+    result = session_search_tool._discover(
+        db=db,
+        query="what did we decide about the backups?",
+        role_filter=None,
+        limit=3,
+        sort=None,
+        detail="adaptive",
+    )
+
+    assert db.kwargs is not None
+    assert db.kwargs["natural_language"] is True
+    assert '"count": 0' in result

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -266,7 +266,8 @@ def _discover(db, query: str, role_filter: Optional[List[str]], limit: int, sort
     raw_results, err = _loud(lambda: db.search_messages(
         query=query, role_filter=role_filter or ["user", "assistant"],
         exclude_sources=list(_HIDDEN_SESSION_SOURCES), limit=_DISCOVER_SCAN_LIMIT, offset=0, sort=sort,
-        fields=_DISCOVER_SEARCH_FIELDS), "FTS5 search failed: %s", "Search failed")
+        fields=_DISCOVER_SEARCH_FIELDS,
+        natural_language=True), "FTS5 search failed: %s", "Search failed")
     if err:
         return err
     # Demote cron rows below interactive ones BEFORE dedup so a high-volume cron corpus


### PR DESCRIPTION
## Summary

Session search uses SQLite FTS5, whose default token semantics can return no results for ordinary questions with stopwords or inflected terms. This PR adds a **bounded, opt-in recovery path** for the conversational `session_search` tool without changing the low-level FTS5 contract.

- `SessionDB.search_messages()` remains strict by default.
- Only `tools/session_search_tool.py` passes `natural_language=True`.
- After an exact, non-CJK zero-result miss, the opt-in path tries a prefixed `AND` query, then a prefixed `OR` query only if needed for terms split across adjacent message rows.
- Explicit FTS5 syntax is preserved: quoted phrases, `AND`/`OR`/`NOT`/`NEAR`, and wildcard queries bypass NL expansion.
- Expansion is dependency-free and bounded: 512 input characters, 8 meaningful terms, 256 cached entries.

Existing CJK, trigram, and LIKE fallbacks are unchanged, and the fallback reuses the existing `_match_rows` FTS runner, keeping the core integration to ~100 added lines. There are no schema changes or new dependencies. The branch is rebased onto the post-decomposition upstream (`f1ccf436a2`).

## Safety and observability

- Exact hits are returned unchanged; NL fallback runs only after a miss.
- `HERMES_SEARCH_NL_ROUTE_LOG=1` logs only actual NL fallback events: route, selected pack, elapsed time, result count, and query length.
- Slow-search telemetry is aggregate-friendly by default (path, ms, rows, query char count). Query text requires the explicit `HERMES_SEARCH_LOG_QUERY=1` troubleshooting override.

## Validation

```bash
PYTHONPATH=. python -m pytest \
  tests/hermes_state tests/test_search_slow_query_log.py \
  tests/tools/test_session_search_nl_opt_in.py -q --tb=short

PYTHONPATH=. python scripts/nl_search_eval.py --packs all \
  --min-nl-recall 0.95 --min-nl-precision 0.80 \
  --min-absent-accuracy 1.00
```

- `328 passed, 2 skipped`; `git diff --check` and `py_compile` clean.
- The privacy-safe, versioned core subset covers 7 default/English cases: morphology/stopwords, exact hit, adjacent turns, absent query, FTS syntax, and lexical near-miss.
  - strict FTS5: recall@5 `0.429`, MRR `0.357`
  - NL opt-in: recall@5 `1.000`, MRR `0.929`, absent-query accuracy `1.000`
  - controlled p95 latency: `11.7ms`
- The corpus is a reproducible regression test for mechanism behavior, **not** a production-population relevance claim.
- The reusable CI workflow applies the same pack-aware thresholds: recall@5 ≥ `0.95`, precision@5 ≥ `0.80`, absent-query accuracy = `1.00`.

## Full implementation and review order

The complete multilingual implementation is validated as a stacked series:

1. **This PR** — engine, strict opt-in policy, default/English pack, telemetry, and evaluation framework.
2. #100038 — Latin packs: `es`, `fr`, `de`, `pt`, `it`.
3. #100039 — Slavic packs.

The follow-up PRs remain intentionally **Draft**: GitHub cannot use a fork branch as the base of an upstream PR, so opening them for review now would show cumulative diffs. After this core lands, #100038 can be rebased onto `main` and reviewed as a small data-only change; #100039 follows the same pattern.

`docs/nl-search-language-packs.md` defines the future pack contribution contract: a normal synthetic case, an ambiguity/near-miss case where applicable, and explicit disclosure of any fluent-speaker review.