### PR TITLE
feat(session-search): add Slavic language packs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,16 @@ jobs:
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
 
+      - name: Run NL search evaluation gate
+        run: |
+          source .venv/bin/activate
+          # "all" resolves against packs actually present in this branch:
+          # core validates default, Latin validates default+Latin, and the
+          # final stacked branch validates the full registry.
+          python scripts/nl_search_eval.py --packs all \
+            --min-nl-recall 0.95 --min-nl-precision 0.80 \
+            --min-absent-accuracy 1.00
+
   e2e:
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/docs/nl-search-language-pack-validation.md
+++ b/docs/nl-search-language-pack-validation.md
@@ -1,0 +1,41 @@
+# NL search language-pack validation ledger
+
+This ledger makes language-pack assumptions reviewable. The expansion mechanism
+is deliberately heuristic: the links below are review anchors for tokenization,
+function words and inflection examples; they do **not** claim that an external
+institution endorsed this implementation.
+
+A pack is eligible for upstream review only when its PR includes synthetic and
+adversarial regression coverage. A fluent-speaker review remains requested for
+any pack that changes routing or morphology beyond the cases below; contributors
+must record that review in their PR without publishing personal information.
+
+| Pack | Script / family | Validation anchors | Current regression evidence |
+|---|---|---|---|
+| `default` | Latin / English | [Merriam-Webster Dictionary](https://www.merriam-webster.com/) | morphology, exact, adjacent-turn, absent, FTS syntax |
+| `es` | Latin / Romance | [Real Academia Española](https://www.rae.es/) | morphology + lexical near-miss |
+| `fr` | Latin / Romance | [Académie française](https://www.academie-francaise.fr/) | morphology, punctuation/hyphenation, lexical near-miss |
+| `de` | Latin / Germanic | [Duden](https://www.duden.de/) | morphology |
+| `pt` | Latin / Romance | [Academia das Ciências de Lisboa](https://www.acad-ciencias.pt/) | morphology |
+| `it` | Latin / Romance | [Accademia della Crusca](https://accademiadellacrusca.it/) | morphology + Italian/Croatian routing ambiguity |
+| `ru` | Cyrillic / East Slavic | [Gramota.ru](https://gramota.ru/) | morphology + lexical near-miss |
+| `be` | Cyrillic / East Slavic | [National Academy of Sciences of Belarus](https://nasb.gov.by/) | Belarusian/Russian routing ambiguity |
+| `uk` | Cyrillic / East Slavic | [Institute of Ukrainian Language](https://iul-nasu.org.ua/) | morphology |
+| `sr` | Cyrillic / South Slavic | [Institute for the Serbian Language](https://isj.sanu.ac.rs/) | morphology |
+| `bg` | Cyrillic / South Slavic | [Institute for Bulgarian Language](https://ibl.bas.bg/) | definite/plural morphology |
+| `mk` | Cyrillic / South Slavic | [Institute of Macedonian Language](https://imj.ukim.edu.mk/) | definite morphology |
+| `hr` | Latin / South Slavic | [Institute of Croatian Language](https://ihjj.hr/) | morphology |
+| `cs` | Latin / West Slavic | [Institute of the Czech Language](https://ujc.cas.cz/) | morphology |
+| `sk` | Latin / West Slavic | [Ľudovít Štúr Institute of Linguistics](https://www.juls.savba.sk/) | Slovak routing + cross-language near miss |
+
+## Contribution rule
+
+Before changing an existing pack or adding another one:
+
+1. cite the applicable anchor or a more precise authoritative grammar in the PR;
+2. add a normal synthetic case and an ambiguity/near-miss case where relevant;
+3. run `scripts/nl_search_eval.py --packs ...` for the branch's available packs;
+4. state whether a fluent-speaker review occurred. Do not infer or invent it.
+
+The project intentionally prefers explicit incomplete validation over a claim
+that a heuristic represents production-grade morphological analysis.

--- a/docs/nl-search-language-packs.md
+++ b/docs/nl-search-language-packs.md
@@ -1,0 +1,60 @@
+# Natural-language session-search language packs
+
+Language packs are data-only registry entries in `hermes_state_nl_expansion.py`.
+They must not change the session-search pipeline.
+
+## Required evidence for a new pack
+
+A contribution must include all of the following:
+
+1. **Schema data**: `stopwords`, `affinity_stopwords`, morphology settings and
+   a conservative `min_stem` precision floor.
+2. **Routing coverage**: at least one query with a language-specific affinity
+   marker, plus an ambiguity case for every script/lexical neighbour that could
+   otherwise win detection.
+3. **Search coverage**: at least three privacy-safe synthetic cases spanning
+   stopword removal, inflection and an ordinary query. Add the pack name to
+   each case's `packs` field in `nl_search_eval_v1.json`.
+4. **Adversarial coverage**: add a lexical-near-miss or cross-language cognate
+   case when the new language shares vocabulary with an existing pack.
+5. **Human validation**: a fluent speaker or a documented authoritative grammar
+   source must review stopwords, affinity markers and morphology assumptions.
+   Record the source/reviewer in the PR body; do not add personal identifiers
+   to the repository.
+
+## Evaluation protocol
+
+Run the pack-aware harness against only the packs present on the branch:
+
+```bash
+PYTHONPATH=. python scripts/nl_search_eval.py --packs default,new-pack
+```
+
+The runner creates one temporary SQLite database per case. It reports
+`hit@1`, `recall@5`, `precision@5`, MRR, absent-query accuracy, and p50/p95
+latency. It is a controlled mechanism regression suite, not a claim about
+population-level relevance.
+
+## Review boundaries
+
+- `SessionDB.search_messages()` remains strict by default.
+- Only conversational callers opt into `natural_language=True`.
+- Explicit FTS5 syntax is never expanded.
+- New packs may not add runtime dependencies or database schema changes.
+- Keep broad OR recovery behind the explicit conversational path and include
+  a relevance counterexample whenever its vocabulary is widened.
+
+## Controlled rollout
+
+`HERMES_SEARCH_NL_ROUTE_LOG=1` emits only successful NL fallback events:
+route, selected language, elapsed time, result count and query length. Query
+text stays out of logs. Use this in a bounded rollout to determine whether a
+pack is selected and useful before proposing it as a default behavior change.
+
+For temporary text-level diagnostics only:
+
+```bash
+HERMES_SEARCH_LOG_QUERY=1
+```
+
+Do not enable that setting as a normal production default.

--- a/hermes_state_nl_expansion.py
+++ b/hermes_state_nl_expansion.py
@@ -1,0 +1,256 @@
+# Natural-language query expansion for FTS5 session search.
+#
+# This module implements language-agnostic NL expansion: stopword removal,
+# light suffix stripping, and prefix wildcards for inflectional languages.
+# Language data lives in ``_NL_LANG_PACKS`` as pure dictionaries — adding a
+# language is just adding a new entry, no mechanism changes required.
+#
+# Usage in hermes_state_search.py:
+#   try:
+#       from . import hermes_state_nl_expansion as _nle
+#   except ImportError:
+#       _nle = None  # optional feature, don't break core search
+#   ...
+#   nl_support = _nle.NLSupport() if _nle else None
+#   ...
+#   expanded = nl_support.expand_nl_query(query) if nl_support else None
+
+from __future__ import annotations
+
+import re
+from collections import OrderedDict
+from typing import Any, Collection, Dict, List, Optional, Tuple
+
+
+# ---------------------------------------------------------------------------
+# Pack schema (all fields documented inline above each pack below)
+# ---------------------------------------------------------------------------
+#   stopwords           frozenset[str]   words dropped from the query
+#   affinity_stopwords  frozenset[str]   small function-word set used ONLY
+#                                        for language detection scoring
+#   suffixes            tuple[str, ...]  light suffixes stripped first
+#   endings             frozenset[str]   2-char flexion endings → drop 2
+#   vowels              str              vowel set for trailing-vowel drop
+#   trailing_vowel_drop bool             tail vowel counts as flexion
+#   min_stem            int              shortest prefix kept (precision)
+#   fallback            str              "keep" (stem already) | "drop1"
+
+
+# ===========================================================================
+# LANGUAGE PACKS — pure data, no logic
+# ===========================================================================
+_NL_LANG_PACKS: Dict[str, Dict[str, Any]] = {
+    "default": {
+        # English + conservative universal layer. Latin terms are usually
+        # already stems after suffix strip; keep them whole with *.
+        "stopwords": frozenset(
+            """
+            a an and are as at be but by for if in into is it no not of on or
+            s such t that the their then there these they this to was we will
+            with you your do does did how what why when where which who whom
+            whose can could should would may might must shall please help show
+            find tell explain check make give get
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(),  # default is fallback, no score
+        "suffixes": ("ing", "ed", "es", "'s", "s"),
+        "endings": frozenset(),
+        "vowels": "",
+        "trailing_vowel_drop": False,
+        "min_stem": 4,
+        "fallback": "keep",
+    },
+}
+
+
+# ===========================================================================
+# DETECTION
+# ===========================================================================
+def detect_lang(query: str) -> str:
+    """Pick a language pack for the raw query (two-stage detection).
+
+    Stage 1 — script: non-Latin scripts are unambiguous. Cyrillic anywhere
+    in the query narrows candidates to ru/be/uk. Everything else falls
+    through to stage 2.
+
+    Stage 2 — affinity: each pack's ``affinity_stopwords`` (small function-
+    word set) is scored against query tokens; the best-scoring pack wins.
+    Ties and zero scores degrade to ``default``.
+    """
+    if re.search(r"[а-яё]", query, re.IGNORECASE):
+        # Among Cyrillic packs, choose the best-affinity one
+        tokens = set(re.findall(r"[^\W_]+", query.lower()))
+        best_score, best_lang = 0, "ru"  # ru is the largest Cyrillic pack
+        for lang, pack in _NL_LANG_PACKS.items():
+            if lang == "default":
+                continue
+            aff = pack.get("affinity_stopwords")
+            if not aff:
+                continue
+            score = len(tokens & aff)
+            if score > best_score:
+                best_score = score
+                best_lang = lang
+        return best_lang
+
+    # Latin-script or digits-only: score all packs
+    tokens = set(re.findall(r"[^\W_]+", query.lower()))
+    best_lang, best_score = "default", 0
+    for lang, pack in _NL_LANG_PACKS.items():
+        aff = pack.get("affinity_stopwords")
+        if not aff:
+            continue  # default has no affinity set
+        score = len(tokens & aff)
+        if score > best_score:
+            best_lang, best_score = lang, score
+    return best_lang
+
+
+# ===========================================================================
+# MORPHOLOGY + EXPANSION
+# ===========================================================================
+def morph_prefix(
+    tok: str,
+    *,
+    suffixes: Tuple[str, ...] = (),
+    endings: Collection[str] = frozenset(),
+    vowels: str = "",
+    min_stem: int = 4,
+    trailing_vowel_drop: bool = True,
+    fallback: str = "drop1",
+) -> str:
+    """Prefix wildcard for one term; heuristics guided by pack data.
+
+    Inflection lives in the suffix for most natural languages. The heuristic
+    is recall-oriented and needs no morphology library:
+
+      - explicit light ``suffixes`` (s/es/ed/ing/'s …) stripped first
+        when enough stem remains;
+      - trailing vowel → drop that one char, when the pack says the tail
+        is flexion ("servers"→"server*");
+      - 2-char flexion ``endings`` → drop 2;
+      - otherwise the pack ``fallback`` decides: ``keep`` (Latin stems
+        are usually already the stem: "config"→"config*") or
+        ``drop1`` (agglutinative tails carry flexion).
+
+    Tokens shorter than ``min_stem`` are returned unchanged.
+    """
+    if len(tok) < min_stem:
+        return tok
+    low = tok.lower()
+    # 1. Explicit suffix strip (highest priority)
+    for suf in suffixes:
+        if suf and low.endswith(suf) and len(tok) - len(suf) >= min_stem:
+            return f"{tok[: len(tok) - len(suf)]}*"
+    # 2. Trailing vowel drop
+    if trailing_vowel_drop and vowels and low[-1] in vowels:
+        return f"{tok[:-1]}*"
+    # 3. 2-char endings table
+    if len(tok) >= min_stem + 2 and tok[-2:].lower() in endings:
+        return f"{tok[:-2]}*"
+    # 4. Default fallback
+    if fallback == "keep":
+        return f"{tok}*"
+    if len(tok) == min_stem:
+        return f"{tok}*"
+    return f"{tok[:-1]}*"
+
+
+class NLSupport:
+    """Build bounded FTS5 expansions for plain conversational text."""
+
+    _CACHE_MAXSIZE = 256
+    # Expansion adds up to two FTS5 retries. Bound it independently of the
+    # caller so a long conversational prompt cannot amplify search work.
+    _MAX_QUERY_CHARS = 512
+    _MAX_MEANINGFUL_TERMS = 8
+
+    def __init__(self) -> None:
+        # Queries originate with users; do not retain an unbounded input log.
+        self._cache: OrderedDict[str, Optional[Dict[str, str]]] = OrderedDict()
+
+    def expand_nl_query(self, query: str) -> Optional[Dict[str, str]]:
+        """Expand a natural-language query into FTS5-friendly variants.
+
+        Returns ``None`` when the query has fewer than two meaningful terms
+        (nothing to gain from expansion) or is entirely stopwords.
+        """
+        # Do not cache or expand unusually long user input. Search still
+        # continues through the existing bounded fallback chain unchanged.
+        if len(query) > self._MAX_QUERY_CHARS:
+            return None
+
+        # Check cache first
+        cache_key = query
+        if cache_key in self._cache:
+            self._cache.move_to_end(cache_key)
+            return self._cache[cache_key]
+
+        lang = detect_lang(query)
+        pack = _NL_LANG_PACKS.get(lang, _NL_LANG_PACKS["default"])
+        stopwords = pack["stopwords"]
+        suffixes = tuple(pack.get("suffixes", ()))
+        endings = pack.get("endings", frozenset())
+        vowels = pack.get("vowels", "")
+        min_stem = pack.get("min_stem", 4)
+        vowel_drop = bool(pack.get("trailing_vowel_drop", True))
+        fallback = pack.get("fallback", "drop1")
+
+        meaningful: List[str] = []
+        and_parts: List[str] = []
+        or_parts: List[str] = []
+
+        def _add_subtoken(sub: str) -> None:
+            if not sub or not re.search(r"[^\W\d_]", sub):
+                return
+            if sub.lower() in stopwords:
+                return
+            meaningful.append(sub)
+            prefixed = morph_prefix(
+                sub, suffixes=suffixes, endings=endings,
+                vowels=vowels, min_stem=min_stem,
+                trailing_vowel_drop=vowel_drop, fallback=fallback,
+            )
+            and_parts.append(prefixed)
+            or_parts.append(prefixed)
+
+        for raw_tok in re.findall(r'"[^"]+"|\S+', query):
+            if raw_tok.startswith('"') and raw_tok.endswith('"'):
+                phrase = raw_tok[1:-1].strip()
+                if not phrase:
+                    continue
+                if re.search(r"[^\w\s]", phrase):
+                    for sub in re.split(r"[^\w]+", phrase):
+                        _add_subtoken(sub)
+                else:
+                    meaningful.append(phrase)
+                    and_parts.append(raw_tok)
+                    or_parts.append(raw_tok)
+                continue
+            tok = raw_tok.strip('"').strip("*").strip()
+            if not tok or tok.upper() in {"AND", "OR", "NOT", "NEAR"}:
+                continue
+            for sub in re.split(r"[^\w]+", tok):
+                _add_subtoken(sub)
+
+        if len(meaningful) < 2:
+            result = None
+        else:
+            # Keep the first terms in user order. This is deterministic and
+            # caps both MATCH expression size and the broad OR retry cost.
+            meaningful = meaningful[:self._MAX_MEANINGFUL_TERMS]
+            and_parts = and_parts[:self._MAX_MEANINGFUL_TERMS]
+            or_parts = or_parts[:self._MAX_MEANINGFUL_TERMS]
+            result = {
+                "and": " AND ".join(and_parts) if len(and_parts) > 1 else and_parts[0],
+                "or": " OR ".join(or_parts),
+                "bare": " ".join(meaningful),
+                # Metadata only; callers never send it to FTS5.
+                "language": lang,
+            }
+
+        self._cache[cache_key] = result
+        self._cache.move_to_end(cache_key)
+        if len(self._cache) > self._CACHE_MAXSIZE:
+            self._cache.popitem(last=False)
+        return result

--- a/hermes_state_nl_expansion.py
+++ b/hermes_state_nl_expansion.py
@@ -60,6 +60,130 @@ _NL_LANG_PACKS: Dict[str, Dict[str, Any]] = {
         "min_stem": 4,
         "fallback": "keep",
     },
+    # --- Latin-script language packs (pure data) --------------------------
+    "es": {
+        "stopwords": frozenset(
+            """
+            el la los las un una unos unas y o u pero si no de del al en con
+            por para sin sobre entre como que qué cuál cuáles cuándo dónde
+            quién quiénes cuánto cuántos mi mis tu tus su sus nuestro nuestra
+            nuestros nuestras vuestro vuestra vuestros vuestras es son era
+            eran será serán estar está están este esta estos estas ese esa
+            esos esas aquel aquella hay habia han he has hemos hacer haz
+            dime muestra explicar comprueba revisar decir porfavor
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            el los las unos unas del al que qué cuál cuándo dónde cómo
+            por para con sin sobre y o u pero es son está están hay
+            """.split()
+        ),
+        "suffixes": ("ando", "iendo", "aron", "ción", "ciones", "mente", "es", "s", "o", "a"),
+        "endings": frozenset({"ar", "er", "ir", "os", "as", "es", "ón", "an", "en", "ía"}),
+        "vowels": "aeiouáéíóúü",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "fr": {
+        "stopwords": frozenset(
+            """
+            le la les un une des du au aux et ou mais si ne pas de en dans sur
+            sous avec sans pour par comme que quoi quel quelle quels quelles
+            quand où qui combien mon ma mes ton ta tes son sa ses notre nos
+            votre vos leur leurs est sont était était sera seront ce cet cette
+            ces il elle ils elles je tu nous vous on faire dis disons montre
+            explique vérifie dis-moi s'il
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            le les des du au aux et ou mais ne pas que quoi quel quelle
+            quand où qui est sont cette ces pour par sur dans avec sans
+            """.split()
+        ),
+        "suffixes": ("ement", "ation", "eux", "eaux", "ent", "ante", "ants", "es", "e", "s"),
+        "endings": frozenset({"nt", "ez", "ai", "oi", "on", "ie", "ux", "eau", "ée", "és"}),
+        "vowels": "aeiouàâäéèêëîïôöùûüÿ",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "de": {
+        "stopwords": frozenset(
+            """
+            der die das ein eine einen einem einer eines und oder aber wenn
+            von vom zu zum zur im in an am auf aus bei mit nach über unter
+            für um durch gegen ohne wie was wer wen wem wo wann warum welche
+            welcher welches welchen meinem meiner mein meine dein deine sein
+            seine ihr ihre unser unsere ist sind war waren wird werden würde
+            würden hat haben hatte hatten kann müssen soll soll
+            machen sag sagst zeig erkläre prüfe bitte
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            der die das ein eine einen dem den des und oder aber wie was
+            wer wo wann warum mit von zu zum zur im in auf aus bei für
+            ist sind war wird werden kann nicht auch noch schon
+            """.split()
+        ),
+        "suffixes": ("ung", "ungen", "keit", "heit", "lich", "isch", "end", "er", "es", "en", "em", "e", "n", "s"),
+        "endings": frozenset({"en", "er", "es", "em", "st", "te", "un", "ig", "ich"}),
+        "vowels": "aeiouäöü",
+        "trailing_vowel_drop": False,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "pt": {
+        "stopwords": frozenset(
+            """
+            o a os as um uma uns umas e ou mas se não de do da dos das no na
+            nos nas em por pelo pela com sem sob sobre entre como que qual
+            quais quando onde quem quanto meu minha meus minhas teu tua seu
+            sua nosso nossa é são era eram será estar está estão este esta
+            esses essas aquele aquela há fazer diz mostra explica verifica
+            porfavor
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            os as uns umas do da dos das no na nos nas em pelo pela com sem
+            que qual quando onde quem é são não e ou mas mas sobre está estão
+            """.split()
+        ),
+        "suffixes": ("ando", "endo", "ção", "ções", "mente", "aram", "eria", "aria", "es", "s", "o", "a"),
+        "endings": frozenset({"ar", "er", "ir", "os", "as", "es", "ão", "am", "em", "ia"}),
+        "vowels": "aeiouáâãàéêíóôõú",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "it": {
+        "stopwords": frozenset(
+            """
+            il lo la i gli le un uno una di del della dei degli delle in nel
+            nella con sul sulla su per tra fra senza come che cosa quale quali
+            quando dove chi quanto mio mia miei mie tuo tua suo sua nostro
+            nostra è sono era erano sarà stare sta stanno fare dimmi mostra
+            spiega controlla per favore
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            i il lo gli le un uno una di del della dei degli delle nel nella
+            sul sulla che cosa quale quando dove chi è sono non e o ma per
+            con su tra fra senza come
+            """.split()
+        ),
+        "suffixes": ("ando", "endo", "zione", "zioni", "mente", "ato", "ata", "iti", "ate", "ono", "ano", "i", "e", "o", "a"),
+        "endings": frozenset({"re", "si", "ci", "gi", "io", "ia", "ua", "uo", "ò", "à"}),
+        "vowels": "aeiouàèéìòù",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
 }
 
 

--- a/hermes_state_nl_expansion.py
+++ b/hermes_state_nl_expansion.py
@@ -60,6 +60,229 @@ _NL_LANG_PACKS: Dict[str, Dict[str, Any]] = {
         "min_stem": 4,
         "fallback": "keep",
     },
+    # --- Cyrillic packs (script selection + word-score refinement) --------
+    "ru": {
+        # Russian flexes by suffix across cases/numbers. The 2-char ending
+        # table plus trailing-vowel drop cover frequent forms like
+        # «алиасов»→«алиас*», «серверы»→«сервер*».
+        "stopwords": frozenset(
+            """
+            в во и с со на по за из у о к от до для при без над под про между через
+            перед после об а но или же бы ли то это тот та те эта эти этот
+            что как где когда какой какая какое какие каким каком каких сколько почему зачем кто чего
+            чем чём кому кого
+            мой моя мои моё мое твой твоя твои наша наш наши ваша ваш ваши его её ее
+            их там тут здесь
+            есть был была было были будет будут
+            все всё ещё еще уже очень можно нужно надо нельзя
+            сделать сделай сделайте помоги помогите проверь проверьте покажи покажите
+            расскажи расскажите объясни объясните напиши напишите добавь добавьте
+            найди найдите посмотри посмотрите оцени оцените запусти запустите
+            установи установите настрой настройте проанализируй сравни прописано
+            который которая которое которые которого
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            в во на по из у о к от до для что как где когда какой какая
+            сколько почему зачем это или но мой наш все ещё уже можно
+            нужно надо есть был была было которые
+            """.split()
+        ),
+        "suffixes": ("ами", "ями", "иях", "ях", "ов", "ев", "ей", "ой", "ый", "ий", "ая", "яя", "ое", "ее", "ые", "ие", "ет", "ут", "ют", "ат", "ят", "ла", "ло", "ли", "ть"),
+        "endings": frozenset({"ов", "ев", "ём", "ах", "ях", "ом", "ам", "ям", "ей", "ий", "ый", "ой", "ую", "юю", "ая", "яя", "ое", "ее", "ие", "ые", "им", "ым", "их", "ых", "ую"}),
+        "vowels": "аеёиоуыэюя",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "be": {
+        # Belarusian: similar to Russian but with differences in dative case
+        # (-ому/-эму vs -ому/-ему) and accusative (-ага/-яга vs -ага/-яга).
+        # Many Russian patterns apply, but specific stop-words and affixes differ.
+        "stopwords": frozenset(
+            """
+            ў з ды ў за над пад паміж праз перад пасля пра аб але ці ці ня што як дзе калі які якая якое якія колькі
+            чаму навошта хто чаго чым чым каму каго
+            мой мая мае маё твае твая твае яго яе іх
+            наш наша нашы ваша ваша вашы іх ён яна яны мы вы яны
+            таксама тут гэты гэтая гэта тыя гэтых гэтым гэтай
+            няма было была было будуць робіць
+            усё яшчэ яшчэ ўжо вельмі можна трэба нельга
+            зрабіць зрабіце дапамажы дапамажыце праверце паглядзіце растлумачце напішыце дадайце знайдзіце пазнайте запускайце наладзьце
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            ды ня быць жыць колькі сервераў ніякі ніхто нічога цёмны цёмная блізу побач адразу зараз кожны
+            """.split()
+        ),
+        "suffixes": ("амі", "ямі", "ах", "ях", "ав", "еў", "ей", "ой", "ы", "я", "а", "я", "ое", "ее", "ыя", "ія", "ець", "уць", "юць", "ац", "яц", "ла", "ло", "лі", "ць"),
+        "endings": frozenset({"ав", "еў", "ом", "ам", "ям", "эй", "ій", "ы", "я", "ую", "юю", "ая", "яя", "ое", "ее", "ія", "ыя", "ім", "ым", "іх", "ых", "ую"}),
+        "vowels": "аеёіоўыэюя",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "uk": {
+        # Ukrainian: richer vowel system than Russian (и, ї, є), different
+        # plural/morphological patterns, more verb conjugation flexibility.
+        "stopwords": frozenset(
+            """
+            і з в у за над під між через перед після про чи або чи не що як де коли який яка яке які скільки
+            чому навіщо хто чого чим чим кому когось
+            мій моя мої моє твій твоя твої твоє його її наш наша наші ваше ваша ваші своє
+            він вона воно вони ми ви я вони
+            також тут цей ця це ці той та те ті
+            немає було була буде будуть робити
+            ще вже дуже можна треба не можна
+            зробити зробіть допоможіть допомогти перевірте подивіться розкажіть напишіть додайте знайдіть побачте запустіть налаштуйте проаналізуй порівняй
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            з в у за на під між через перед після про чи що як де коли який скільки
+            чому не може бути з ним ними цим нашим нашими цій цьому цієї цього цих цьому цьому наших
+            він вона воно вони вже ще можна треба
+            """.split()
+        ),
+        "suffixes": ("ами", "ями", "ах", "ях", "ів", "їв", "ост", "ість", "ості", "істі", "еть", "уть", "ють", "аць", "яць", "ати", "яти", "ала", "ало", "али", "ять"),
+        "endings": frozenset({"ів", "їв", "ом", "ам", "ям", "ій", "ий", "і", "ю", "єю", "єю", "ая", "яя", "еє", "іє", "ії", "ими", "ями", "их", "іх", "ю", "єм", "ім"}),
+        "vowels": "аеёіїоуыэюя",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    # --- Slavic language packs (Cyrillic + Latin variants) ------------------
+    "sr": {
+        # Serbian: standard Cyrillic orthography. Morphologically similar to
+        # Russian/Bulgarian but with specific stop-word frequency patterns.
+        "stopwords": frozenset(
+            """
+            у и са на по за из од до у о к от за при без над под преко између пред после око али или да ли је који које која које колико
+            зашто због чега како гдје када шта тко ту овдје тај та она оне они то ти ви не могу треба морам направити направи помогни помоги провери провјери покажи покажите прочитај прочитајте објасни објасните додај додајте
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            у и са на по од до за при без али или је који која која која колико зашто как га дје кад не могу треба
+            """.split()
+        ),
+        "suffixes": ("ама", "ема", "ах", "ях", "ова", "ева", "ијех", "ојих", "их", "их", "еј", "иј"),
+        "endings": frozenset({"ов", "ев", "ом", "ам", "ям", "ей", "ий", "ый", "ой", "ую", "юю", "ая", "яя", "ое", "ее", "ие", "ые"}),
+        "vowels": "аеёиоуыэюя",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "bg": {
+        # Bulgarian: lost cases compared to Russian, richer prefix system,
+        # definite articles are suffixes (-ът, -та, -то). Shorter words than Russian.
+        "stopwords": frozenset(
+            """
+            в и от на при без над под между през преди след около но или да ли който която което които колко
+            защо заради какъв каква какви къде кога какво кой коя кои той тя то те тези този тази тези него нея ни нас вас те
+            може трябва искам искам искам искам искам искам искам искам искам искам искам искам
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            в и от на при без над под между през преди след около но или да ли който колко защо какъв къде кога не може нужно
+            """.split()
+        ),
+        "suffixes": ("ваща", "вашите", "вали", "ване", "ности", "ите", "вал", "вала", "ния", "ние", "ност", "тва", "ве", "та", "то", "те"),
+        "endings": frozenset({"ва", "ве", "во", "ва", "ти", "ли", "ни", "не", "ме", "ре", "де", "ле", "се"}),
+        "vowels": "аеииоуъюя",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "mk": {
+        # Macedonian: very close to Bulgarian but different article suffixes.
+        # Fewer case variations than Russian. Uses both Cyrillic and Latin; here covering Cyrillic.
+        "stopwords": frozenset(
+            """
+            во и со од на под преку помеѓу пред зад после за низ кон ама но или дали кој која кое кои колку
+            зошто поради што каков каква какви каде кога тој таа тоа тие ние вие ќе биде сум би можам треба сакам
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            во и со од на под преку помеѓу пред зад после за низ кон ама но или дали кој колку зошто што каде кога не биде
+            """.split()
+        ),
+        "suffixes": ("ите", "ва", "ве", "во", "та", "те", "то", "ти", "ни", "ме", "ре", "де", "ле", "си"),
+        "endings": frozenset({"ва", "ве", "во", "та", "ти", "ли", "ни", "ме", "ре", "де", "ле", "си"}),
+        "vowels": "аеиеоуи",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "hr": {
+        # Croatian (Latin script): shares base morphology with Serbian/Bosnian
+        # but uses Latin orthography. Very similar to sr/bs in inflection.
+        "stopwords": frozenset(
+            """
+            u i sa na po za iz od do u o k za pri bez nad pod preko između pred poslije oko ali ili da li je koji koje koja koje koliko
+            zasto zbog cime kako gdje kad sta tko tu gdje taj ta one oni to ti vi ne mogu treba moram napraviti napravi pomogni provjeri pokazi objasni dodaj
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            u i sa na po za od pri bez ali li je koji koliko zasto kako gdje kad ne mogu treba
+            """.split()
+        ),
+        "suffixes": ("ama", "ema", "ah", "ovah", "ova", "evih", "iju", "iju", "ej", "ij"),
+        "endings": frozenset({"ov", "ev", "om", "am", "im", "ej", "ij", "uy", "oy", "uyu", "uyu", "aya", "yaya", "oe", "eee", "ie", "ye"}),
+        "vowels": "aeiouy",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "cs": {
+        # Czech: complex inflection (7 cases), rich consonant clusters, short vowels.
+        # Highly fusional — stems often change completely.
+        "stopwords": frozenset(
+            """
+            v a s s na po mezi přes před po nad pod s se ke z u o od do pro při bez nade pode pro před po mezi před za ale nebo jestli
+            který která které kolik jak kde kdy co ten ta ty tato tato tady já my vy oni on ona ono
+            může chce musí budu bude chtít potřebuji mohu mám
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            v s na po mezi přes před za nad pod s ke z u o od do pro při bez ale nebo jestli který kolik jak kde kdy co ten ta
+            """.split()
+        ),
+        "suffixes": ("ám", "ám", "ách", "ích", "ím", "ém", "ou", "ou", "ých", "ých", "ému", "ému", "ého", "éha", "ího", "ého"),
+        "endings": frozenset({"am", "em", "im", "om", "um", "ý", "á", "é", "í", "ó", "ú", "ů", "ov", "ev", "iv"}),
+        "vowels": "aeiouýúěščřžďťň",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
+    "sk": {
+        # Slovak: very close to Czech but with more long vowels, some phonetic simplifications.
+        # Similar morphology, different stopword frequency.
+        "stopwords": frozenset(
+            """
+            v a s na po medzi cez pred po nad pod s sa ku z u o od do pre pri bez nad pod medzi cez pred za alebo či
+            ktorý ktorá ktoré koľko aký aká aké kedy kde čo ten tá tie táto táto tu ja my vy oni on ona ono
+            môže chcieť musieť budem bude chcem potrebujem môžem mám
+            """.split()
+        ),
+        "affinity_stopwords": frozenset(
+            """
+            v s na po medzi cez pred za nad pod s ku z u o od do pre pri bez alebo či ako ktorý koľko aký kde kedy čo ten tá
+            """.split()
+        ),
+        "suffixes": ("ám", "ám", "ách", "och", "ím", "ém", "ou", "ou", "ých", "ých", "ému", "ému", "ého", "ého", "ieho", "ého"),
+        "endings": frozenset({"am", "em", "im", "om", "um", "ý", "á", "e", "i", "o", "u", "ov", "ev", "iv"}),
+        "vowels": "aeiouýäú",
+        "trailing_vowel_drop": True,
+        "min_stem": 4,
+        "fallback": "drop1",
+    },
     # --- Latin-script language packs (pure data) --------------------------
     "es": {
         "stopwords": frozenset(
@@ -90,7 +313,7 @@ _NL_LANG_PACKS: Dict[str, Dict[str, Any]] = {
         "stopwords": frozenset(
             """
             le la les un une des du au aux et ou mais si ne pas de en dans sur
-            sous avec sans pour par comme que quoi quel quelle quels quelles
+            sous avec sans pour par comme comment que quoi quel quelle quels quelles
             quand où qui combien mon ma mes ton ta tes son sa ses notre nos
             votre vos leur leurs est sont était était sera seront ce cet cette
             ces il elle ils elles je tu nous vous on faire dis disons montre

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -51,8 +51,40 @@ _FTS5_SPECIAL_CHARS = '+{}():"^@/#&|~[]<>,;!?$=\\\''
 _FTS5_SPECIAL_RE = re.compile(f"[{re.escape(_FTS5_SPECIAL_CHARS)}]")
 
 
+# Query expansion is dependency-free and shipped with this module. Keep the
+# low-level FTS API strict by default; conversational callers opt in explicitly.
+import hermes_state_nl_expansion as _nle
+
+
 class SessionSearchMixin:
     """See module docstring — mixin for SessionDB (Search cluster)."""
+
+    # Shared, bounded expansion cache.  NLSupport itself is dependency-free;
+    # keeping one instance avoids per-query allocation without retaining an
+    # unbounded record of user-entered queries.
+    _nl_support = _nle.NLSupport()
+
+    @staticmethod
+    def _log_nl_fallback(*, route: str, language: str, elapsed_ms: float, rows: int, chars: int) -> None:
+        """Emit one privacy-safe NL fallback event when explicitly enabled."""
+        if os.getenv("HERMES_SEARCH_NL_ROUTE_LOG", "").lower() not in {"1", "true", "yes"}:
+            return
+        logger.info(
+            "session search NL fallback: path=%s language=%s elapsed=%.0fms rows=%s chars=%s",
+            route, language, elapsed_ms, rows, chars,
+        )
+
+    @staticmethod
+    def _nl_eligible(query: str) -> bool:
+        """True only for plain conversational text, never FTS5 syntax.
+
+        ``search_messages`` is also a low-level API.  Explicit quotes,
+        wildcard, boolean and proximity operators are part of its public FTS5
+        contract and must not be widened by natural-language fallback.
+        """
+        if not query or any(char in query for char in ('"', '*')):
+            return False
+        return not re.search(r"\b(?:AND|OR|NOT|NEAR)\b", query, re.IGNORECASE)
 
     _SEARCH_MESSAGE_RESULT_FIELDS = (
         "id",
@@ -1349,6 +1381,66 @@ class SessionSearchMixin:
                 run = 0
         return run == 1
 
+    def _run_fts5_search(
+        self,
+        fts_query: str,
+        *,
+        order_by_sql: str,
+        include_inactive: bool,
+        source_filter: List[str] = None,
+        exclude_sources: List[str] = None,
+        role_filter: List[str] = None,
+        limit: int = 20,
+        offset: int = 0,
+    ) -> Optional[List[Dict[str, Any]]]:
+        """Run a raw FTS5 query against the main ``messages_fts`` table.
+
+        Unlike ``search_messages``' inline SQL this takes the MATCH
+        expression verbatim (no extra quoting) — used by the NL-expansion
+        fallback which already builds a syntactically valid query with prefix
+        wildcards and OR groups. Returns rows in the same shape as the main
+        path, or ``None`` when the query fails at runtime so the caller can
+        continue down the fallback chain.
+        """
+        fts_where = ["messages_fts MATCH ?"]
+        fts_params: list = [fts_query]
+        if not include_inactive:
+            fts_where.append("(m.active = 1 OR m.compacted = 1)")
+        if source_filter is not None:
+            fts_where.append(f"s.source IN ({','.join('?' for _ in source_filter)})")
+            fts_params.extend(source_filter)
+        if exclude_sources is not None:
+            fts_where.append(f"s.source NOT IN ({','.join('?' for _ in exclude_sources)})")
+            fts_params.extend(exclude_sources)
+        if role_filter:
+            fts_where.append(f"m.role IN ({','.join('?' for _ in role_filter)})")
+            fts_params.extend(role_filter)
+        fts_sql = f"""
+            SELECT
+                m.id,
+                m.session_id,
+                m.role,
+                snippet(messages_fts, -1, '>>>', '<<<', '...', 40) AS snippet,
+                m.timestamp,
+                m.tool_name,
+                s.source,
+                s.model,
+                s.started_at AS session_started
+            FROM messages_fts
+            JOIN messages m ON m.id = messages_fts.rowid
+            JOIN sessions s ON s.id = m.session_id
+            WHERE {' AND '.join(fts_where)}
+            {order_by_sql}
+            LIMIT ? OFFSET ?
+        """
+        fts_params.extend([limit, offset])
+        with self._read_ctx() as conn:
+            try:
+                cursor = conn.execute(fts_sql, fts_params)
+            except sqlite3.OperationalError:
+                return None
+            return [dict(row) for row in cursor.fetchall()]
+
     @staticmethod
     def _trigram_eligible_tokens(query: str) -> bool:
         """True when every non-operator token is long enough for the trigram
@@ -1455,8 +1547,13 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        natural_language: bool = False,
     ) -> List[Dict[str, Any]]:
         """Instrumented wrapper around :meth:`_search_messages_impl`.
+
+        ``natural_language`` opts conversational callers into a bounded,
+        zero-result FTS5 expansion fallback. It defaults to ``False`` so
+        explicit FTS5 syntax remains a stable low-level API contract.
 
         Logs one line per slow search with the routing path taken, so
         production latency stays attributable per query shape (the 2026-07
@@ -1466,6 +1563,7 @@ class SessionSearchMixin:
         """
         started = time.time()
         rows = None
+        search_route: Dict[str, str] = {}
         try:
             rows = self._search_messages_impl(
                 query,
@@ -1477,6 +1575,8 @@ class SessionSearchMixin:
                 sort=sort,
                 include_inactive=include_inactive,
                 fields=fields,
+                natural_language=natural_language,
+                search_route=search_route,
             )
             return rows
         finally:
@@ -1486,13 +1586,24 @@ class SessionSearchMixin:
                 threshold = 1000.0
             elapsed_ms = (time.time() - started) * 1000.0
             if elapsed_ms >= threshold:
-                logger.info(
-                    "slow session search: path=%s elapsed=%.0fms rows=%s query=%r",
-                    self._describe_search_path(query),
-                    elapsed_ms,
-                    len(rows) if rows is not None else "err",
-                    query[:200],
-                )
+                route = search_route.get("path", self._describe_search_path(query))
+                # Search text may contain user data. Keep production telemetry
+                # aggregate-friendly by default; operators can explicitly opt
+                # into text diagnostics for a short troubleshooting window.
+                log_query = os.getenv("HERMES_SEARCH_LOG_QUERY", "").lower() in {
+                    "1", "true", "yes",
+                }
+                if log_query:
+                    logger.info(
+                        "slow session search: path=%s elapsed=%.0fms rows=%s chars=%s query=%r",
+                        route, elapsed_ms, len(rows) if rows is not None else "err",
+                        len(query), query[:200],
+                    )
+                else:
+                    logger.info(
+                        "slow session search: path=%s elapsed=%.0fms rows=%s chars=%s",
+                        route, elapsed_ms, len(rows) if rows is not None else "err", len(query),
+                    )
 
     def _describe_search_path(self, query: str) -> str:
         """Best-effort name of the routing path a query takes (log-only)."""
@@ -1749,6 +1860,8 @@ class SessionSearchMixin:
         sort: str = None,
         include_inactive: bool = False,
         fields: Optional[Collection[str]] = None,
+        natural_language: bool = False,
+        search_route: Optional[Dict[str, str]] = None,
     ) -> List[Dict[str, Any]]:
         """
         Full-text search across session messages using FTS5.
@@ -1786,6 +1899,11 @@ class SessionSearchMixin:
         if not query or not query.strip():
             return []
 
+        # Keep the caller's text for NL eligibility. Sanitization may insert
+        # protective quotes around punctuation (for example a French hyphen),
+        # which must not be mistaken for an explicit FTS phrase chosen by the
+        # caller.
+        raw_nl_query = query
         query = self._sanitize_fts5_query(query)
         if not query:
             return []
@@ -2209,7 +2327,46 @@ class SessionSearchMixin:
             and not is_cjk
             and not (bool(role_filter) and "tool" in role_filter)
         ):
-            _fb_query = query.strip('"').strip()
+            # ── NL expansion: stopwords + light morphology ──
+            # A natural-language question usually fails plain FTS5 twice:
+            # AND-between-tokens across messages and inflected word forms.
+            # Try prefixed AND first, then OR only for the explicit
+            # conversational mode. Message-level FTS may store the terms of a
+            # user question in adjacent turns, where strict AND cannot recall
+            # the session. This remains a zero-result fallback; explicit FTS
+            # syntax never enters this branch and the selected route is logged.
+            expanded = None
+            if natural_language and self._nl_eligible(raw_nl_query):
+                expanded = self._nl_support.expand_nl_query(raw_nl_query)
+            if expanded:
+                for _nl_key in ("and", "or"):
+                    _nl_started = time.perf_counter()
+                    _nl_matches = self._run_fts5_search(
+                        expanded[_nl_key],
+                        order_by_sql=order_by_sql,
+                        include_inactive=include_inactive,
+                        source_filter=source_filter,
+                        exclude_sources=exclude_sources,
+                        role_filter=role_filter,
+                        limit=limit,
+                        offset=offset,
+                    )
+                    if _nl_matches:
+                        matches = _nl_matches
+                        _nl_route = f"nl_fts_{_nl_key}"
+                        if search_route is not None:
+                            search_route["path"] = _nl_route
+                        self._log_nl_fallback(
+                            route=_nl_route,
+                            language=expanded["language"],
+                            elapsed_ms=(time.perf_counter() - _nl_started) * 1000.0,
+                            rows=len(_nl_matches),
+                            chars=len(raw_nl_query),
+                        )
+                        break
+            # The substring-capable indexes below get the stopword-stripped
+            # query so they don't trip over function words either.
+            _fb_query = (expanded["bare"] if expanded else query).strip('"').strip()
             if self._fts_cjk_available:
                 cjk_fb = self._run_trigram_search(
                     _fb_query,

--- a/scripts/nl_search_eval.py
+++ b/scripts/nl_search_eval.py
@@ -1,0 +1,185 @@
+#!/usr/bin/env python3
+"""Evaluate strict FTS5 versus opt-in NL search on privacy-safe corpora.
+
+Cases are synthetic and each is materialized in a separate temporary SQLite DB.
+The runner selects only cases whose ``packs`` are available in the checked-out
+branch, so a stacked core/Latin/Slavic PR remains self-validating.
+
+Usage:
+  PYTHONPATH=. python scripts/nl_search_eval.py
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs default
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs default,es,fr,de,pt,it
+  PYTHONPATH=. python scripts/nl_search_eval.py --packs all --json-out /tmp/nl-eval.json
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import tempfile
+import time
+from pathlib import Path
+from typing import Any
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import _NL_LANG_PACKS
+
+ROOT = Path(__file__).resolve().parents[1]
+CORPUS = ROOT / "tests" / "hermes_state" / "fixtures" / "nl_search_eval_v1.json"
+_GENERIC_DISTRACTORS = (
+    "generic scheduling record",
+    "unrelated visual dashboard",
+    "temporary document archive",
+    "network inventory note",
+    "ordinary release calendar",
+)
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    return ordered[round((len(ordered) - 1) * fraction)]
+
+
+def resolve_packs(raw: str) -> set[str]:
+    """Validate a requested pack set against packs in this checkout."""
+    available = set(_NL_LANG_PACKS)
+    if raw == "all":
+        return available
+    selected = {item.strip() for item in raw.split(",") if item.strip()}
+    unknown = selected - available
+    if unknown:
+        raise ValueError(f"requested packs unavailable in this branch: {sorted(unknown)}")
+    return selected
+
+
+def select_cases(corpus: dict[str, Any], packs: set[str]) -> list[dict[str, Any]]:
+    cases = corpus["cases"] + corpus.get("adversarial_cases", [])
+    return [case for case in cases if set(case["packs"]).issubset(packs)]
+
+
+def case_relevant(case: dict[str, Any]) -> list[str]:
+    if "relevant" in case:
+        return case["relevant"]
+    return [case["target"]]
+
+
+def case_distractors(case: dict[str, Any]) -> list[str]:
+    return case.get("distractors", list(_GENERIC_DISTRACTORS))
+
+
+def evaluate_case(case: dict[str, Any], natural_language: bool) -> dict[str, Any]:
+    """Materialize one isolated relevance corpus and score the top five rows."""
+    relevant = case_relevant(case)
+    with tempfile.TemporaryDirectory(prefix="hermes-nl-eval-") as tmp:
+        db = SessionDB(db_path=Path(tmp) / "state.db")
+        relevant_sessions: set[str] = set()
+        for index, text in enumerate(relevant):
+            session_id = f"relevant-{case['id']}-{index}"
+            relevant_sessions.add(session_id)
+            db.create_session(session_id, source="eval")
+            db.append_message(session_id, "assistant", text)
+        for index, text in enumerate(case_distractors(case)):
+            session_id = f"distractor-{case['id']}-{index}"
+            db.create_session(session_id, source="eval")
+            db.append_message(session_id, "assistant", text)
+        started = time.perf_counter()
+        rows = db.search_messages(case["query"], limit=5, natural_language=natural_language)
+        elapsed_ms = (time.perf_counter() - started) * 1000.0
+        db.close()
+
+    ids = [row["session_id"] for row in rows]
+    ranks = [index + 1 for index, session_id in enumerate(ids) if session_id in relevant_sessions]
+    relevant_returned = len(ranks)
+    if relevant:
+        hit1 = bool(ranks and ranks[0] == 1)
+        recall5 = relevant_returned / len(relevant)
+        precision5 = relevant_returned / len(rows) if rows else 0.0
+        rr = 1.0 / ranks[0] if ranks else 0.0
+        absent_correct = None
+    else:
+        hit1 = rows == []
+        recall5 = 1.0 if not rows else 0.0
+        precision5 = 1.0 if not rows else 0.0
+        rr = 1.0 if not rows else 0.0
+        absent_correct = not rows
+    return {
+        "id": case["id"], "lang": case["lang"], "scenario": case["scenario"],
+        "latency_ms": elapsed_ms, "returned": len(rows), "relevant": len(relevant),
+        "relevant_returned": relevant_returned, "hit1": hit1, "recall5": recall5,
+        "precision5": precision5, "rr": rr, "absent_correct": absent_correct,
+    }
+
+
+def summarize(results: list[dict[str, Any]]) -> dict[str, float | int]:
+    count = len(results)
+    absent = [row for row in results if row["absent_correct"] is not None]
+    return {
+        "cases": count,
+        "hit_at_1": sum(row["hit1"] for row in results) / count,
+        "recall_at_5": sum(row["recall5"] for row in results) / count,
+        "precision_at_5": sum(row["precision5"] for row in results) / count,
+        "mrr": sum(row["rr"] for row in results) / count,
+        "absent_query_accuracy": (
+            sum(row["absent_correct"] for row in absent) / len(absent) if absent else None
+        ),
+        "latency_p50_ms": percentile([row["latency_ms"] for row in results], 0.50),
+        "latency_p95_ms": percentile([row["latency_ms"] for row in results], 0.95),
+        "latency_mean_ms": statistics.fmean(row["latency_ms"] for row in results),
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--corpus", type=Path, default=CORPUS)
+    parser.add_argument("--packs", default="all", help="comma-separated installed packs or 'all'")
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--min-nl-recall", type=float)
+    parser.add_argument("--min-nl-precision", type=float)
+    parser.add_argument("--min-absent-accuracy", type=float)
+    args = parser.parse_args()
+    corpus = json.loads(args.corpus.read_text(encoding="utf-8"))
+    packs = resolve_packs(args.packs)
+    cases = select_cases(corpus, packs)
+    if not cases:
+        raise ValueError("pack selection chose zero evaluation cases")
+    modes = {
+        "strict_fts5": [evaluate_case(case, False) for case in cases],
+        "nl_opt_in": [evaluate_case(case, True) for case in cases],
+    }
+    report = {
+        "corpus_version": corpus["version"], "selected_packs": sorted(packs),
+        "corpus_cases": len(cases), "summary": {mode: summarize(rows) for mode, rows in modes.items()},
+        "by_case": modes,
+    }
+    for mode, summary in report["summary"].items():
+        absent = summary["absent_query_accuracy"]
+        absent_text = "n/a" if absent is None else f"{absent:.3f}"
+        print(
+            f"{mode}: cases={summary['cases']} hit@1={summary['hit_at_1']:.3f} "
+            f"recall@5={summary['recall_at_5']:.3f} precision@5={summary['precision_at_5']:.3f} "
+            f"MRR={summary['mrr']:.3f} absent={absent_text} "
+            f"p50={summary['latency_p50_ms']:.1f}ms p95={summary['latency_p95_ms']:.1f}ms"
+        )
+    if args.json_out:
+        args.json_out.write_text(json.dumps(report, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    nl_summary = report["summary"]["nl_opt_in"]
+    thresholds = {
+        "recall@5": (args.min_nl_recall, nl_summary["recall_at_5"]),
+        "precision@5": (args.min_nl_precision, nl_summary["precision_at_5"]),
+        "absent accuracy": (args.min_absent_accuracy, nl_summary["absent_query_accuracy"]),
+    }
+    failed = [
+        f"{name}={actual:.3f} < {minimum:.3f}"
+        for name, (minimum, actual) in thresholds.items()
+        if minimum is not None and (actual is None or actual < minimum)
+    ]
+    if failed:
+        print("NL evaluation threshold failed: " + ", ".join(failed))
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_state/fixtures/nl_search_eval_v1.json
+++ b/tests/hermes_state/fixtures/nl_search_eval_v1.json
@@ -1,0 +1,666 @@
+{
+  "version": 2,
+  "description": "Privacy-safe multilingual NL session-search evaluation: synthetic pack-aware mechanism cases and adversarial relevance cases, independently materialized in temporary SQLite databases.",
+  "cases": [
+    {
+      "id": "en-01",
+      "lang": "default",
+      "query": "what did we decide about cluster backups",
+      "target": "cluster backup decision",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "en-02",
+      "lang": "default",
+      "query": "how are proxy services configured",
+      "target": "proxy service configuration",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "en-03",
+      "lang": "default",
+      "query": "where were deployment logs running",
+      "target": "deployment log runner",
+      "packs": [
+        "default"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-01",
+      "lang": "es",
+      "query": "dónde están las configuraciones del proxy",
+      "target": "configuración proxy",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-02",
+      "lang": "es",
+      "query": "cómo quedaron los servidores configurados",
+      "target": "servidor configurado",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "es-03",
+      "lang": "es",
+      "query": "cuándo ejecutaron las copias nocturnas",
+      "target": "copia nocturna ejecución",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-01",
+      "lang": "fr",
+      "query": "où sont les configurations du serveur",
+      "target": "configuration serveur",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-02",
+      "lang": "fr",
+      "query": "comment les sauvegardes fonctionnent-elles",
+      "target": "sauvegarde fonctionnement",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "fr-03",
+      "lang": "fr",
+      "query": "pourquoi les déploiements échouaient",
+      "target": "déploiement échec",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-01",
+      "lang": "de",
+      "query": "wo sind die Konfigurationen des Servers",
+      "target": "Konfiguration Server",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-02",
+      "lang": "de",
+      "query": "wie laufen die Sicherungen nachts",
+      "target": "Sicherung Nachtlauf",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "de-03",
+      "lang": "de",
+      "query": "warum wurden die Dienste gestartet",
+      "target": "Dienst Start",
+      "packs": [
+        "default",
+        "de"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-01",
+      "lang": "pt",
+      "query": "onde estão as configurações do servidor",
+      "target": "configuração servidor",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-02",
+      "lang": "pt",
+      "query": "como funcionam os backups noturnos",
+      "target": "backup noturno funcionamento",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "pt-03",
+      "lang": "pt",
+      "query": "quando os serviços reiniciaram",
+      "target": "serviço reinício",
+      "packs": [
+        "default",
+        "pt"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-01",
+      "lang": "it",
+      "query": "dov'è la configurazione del server",
+      "target": "configurazione server",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-02",
+      "lang": "it",
+      "query": "quando girano i backup notturni",
+      "target": "backup notturno giro",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "it-03",
+      "lang": "it",
+      "query": "come funzionano i servizi distribuiti",
+      "target": "servizio distribuzione funzionamento",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-01",
+      "lang": "ru",
+      "query": "где находятся конфигурации серверов",
+      "target": "конфигурация сервер",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-02",
+      "lang": "ru",
+      "query": "как работают ночные резервные копии",
+      "target": "резервная копия ночь",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "ru-03",
+      "lang": "ru",
+      "query": "когда перезапускали развернутые сервисы",
+      "target": "сервис перезапуск развертывание",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-01",
+      "lang": "be",
+      "query": "колькі сервераў з канфігурацыяй запушчана",
+      "target": "сервер канфігурацыя запуск",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-02",
+      "lang": "be",
+      "query": "дзе знаходзяцца рэзервовыя копіі",
+      "target": "рэзервовая копія знаходжанне",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "be-03",
+      "lang": "be",
+      "query": "калі працуюць начныя сэрвісы",
+      "target": "начны сэрвіс праца",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-01",
+      "lang": "uk",
+      "query": "скільки серверів конфігурації запущено",
+      "target": "сервер конфігурація запуск",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-02",
+      "lang": "uk",
+      "query": "де знаходяться резервні копії",
+      "target": "резервна копія знаходження",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "uk-03",
+      "lang": "uk",
+      "query": "коли працюють нічні сервіси",
+      "target": "нічний сервіс робота",
+      "packs": [
+        "default",
+        "uk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-01",
+      "lang": "sr",
+      "query": "где су конфигурације сервера",
+      "target": "конфигурација сервер",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-02",
+      "lang": "sr",
+      "query": "како раде ноћне копије",
+      "target": "ноћна копија рад",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sr-03",
+      "lang": "sr",
+      "query": "када су сервиси покренути",
+      "target": "сервис покретање",
+      "packs": [
+        "default",
+        "sr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-01",
+      "lang": "bg",
+      "query": "къде са конфигурациите на сървъра",
+      "target": "конфигурация сървър",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-02",
+      "lang": "bg",
+      "query": "как работят нощните копия",
+      "target": "нощно копие работа",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "bg-03",
+      "lang": "bg",
+      "query": "кога услугите стартираха",
+      "target": "услуга стартиране",
+      "packs": [
+        "default",
+        "bg"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-01",
+      "lang": "mk",
+      "query": "каде се конфигурациите на серверот",
+      "target": "конфигурација сервер",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-02",
+      "lang": "mk",
+      "query": "како работат ноќните копии",
+      "target": "ноќна копија работа",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "mk-03",
+      "lang": "mk",
+      "query": "кога сервисите стартуваа",
+      "target": "сервис стартување",
+      "packs": [
+        "default",
+        "mk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-01",
+      "lang": "hr",
+      "query": "gdje su konfiguracije poslužitelja",
+      "target": "konfiguracija poslužitelj",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-02",
+      "lang": "hr",
+      "query": "kako rade noćne kopije",
+      "target": "noćna kopija rad",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "hr-03",
+      "lang": "hr",
+      "query": "kada su servisi pokrenuti",
+      "target": "servis pokretanje",
+      "packs": [
+        "default",
+        "hr"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-01",
+      "lang": "cs",
+      "query": "kde jsou konfigurace serveru",
+      "target": "konfigurace server",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-02",
+      "lang": "cs",
+      "query": "jak fungují noční zálohy",
+      "target": "noční záloha fungování",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "cs-03",
+      "lang": "cs",
+      "query": "kdy byly služby spuštěny",
+      "target": "služba spuštění",
+      "packs": [
+        "default",
+        "cs"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-01",
+      "lang": "sk",
+      "query": "kde sú konfigurácie servera",
+      "target": "konfigurácia server",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-02",
+      "lang": "sk",
+      "query": "ako fungujú nočné zálohy",
+      "target": "nočná záloha fungovanie",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    },
+    {
+      "id": "sk-03",
+      "lang": "sk",
+      "query": "kedy boli služby spustené",
+      "target": "služba spustenie",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "morphology_stopwords"
+    }
+  ],
+  "adversarial_cases": [
+    {
+      "id": "adv-en-exact",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "exact_hit",
+      "query": "backup policy",
+      "relevant": [
+        "backup policy retained for cluster"
+      ],
+      "distractors": [
+        "backup policy obsolete draft",
+        "release policy note"
+      ]
+    },
+    {
+      "id": "adv-en-adjacent",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "adjacent_turns",
+      "query": "why flux cluster backups",
+      "relevant": [
+        "flux reconciles deployments",
+        "cluster backups run nightly"
+      ],
+      "distractors": [
+        "flux capacitor note",
+        "calendar backup entry"
+      ]
+    },
+    {
+      "id": "adv-en-absent",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "absent",
+      "query": "luminous manganese theorem",
+      "relevant": [],
+      "distractors": [
+        "generic scheduling record",
+        "unrelated visual dashboard",
+        "temporary document archive"
+      ]
+    },
+    {
+      "id": "adv-en-syntax",
+      "lang": "default",
+      "packs": [
+        "default"
+      ],
+      "scenario": "fts_syntax",
+      "query": "backup NOT obsolete",
+      "relevant": [
+        "backup policy retained"
+      ],
+      "distractors": [
+        "backup obsolete draft",
+        "ordinary status note"
+      ]
+    },
+    {
+      "id": "adv-es-near",
+      "lang": "es",
+      "packs": [
+        "default",
+        "es"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "dónde están las configuraciones del proxy",
+      "relevant": [
+        "configuración proxy vigente"
+      ],
+      "distractors": [
+        "configuración temporal de monitor",
+        "proxy visual sin configuración"
+      ]
+    },
+    {
+      "id": "adv-fr-near",
+      "lang": "fr",
+      "packs": [
+        "default",
+        "fr"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "comment fonctionnent les sauvegardes",
+      "relevant": [
+        "sauvegarde fonctionnement validé"
+      ],
+      "distractors": [
+        "fonctionnement visuel",
+        "sauvegarde temporaire supprimée"
+      ]
+    },
+    {
+      "id": "adv-it-route",
+      "lang": "it",
+      "packs": [
+        "default",
+        "it"
+      ],
+      "scenario": "routing",
+      "query": "quando girano i backup notturni",
+      "relevant": [
+        "backup notturno giro"
+      ],
+      "distractors": [
+        "backup diurno giro",
+        "notturno calendario"
+      ]
+    },
+    {
+      "id": "adv-ru-near",
+      "lang": "ru",
+      "packs": [
+        "default",
+        "ru"
+      ],
+      "scenario": "lexical_near_miss",
+      "query": "где конфигурации прокси",
+      "relevant": [
+        "конфигурация прокси сохранена"
+      ],
+      "distractors": [
+        "конфигурация мониторинга",
+        "прокси временно удалён"
+      ]
+    },
+    {
+      "id": "adv-be-route",
+      "lang": "be",
+      "packs": [
+        "default",
+        "be"
+      ],
+      "scenario": "routing",
+      "query": "колькі сервераў запушчана",
+      "relevant": [
+        "сервер запуск завершаны"
+      ],
+      "distractors": [
+        "сервер русская заметка",
+        "запуск календаря"
+      ]
+    },
+    {
+      "id": "adv-sk-near",
+      "lang": "sk",
+      "packs": [
+        "default",
+        "sk"
+      ],
+      "scenario": "cross_language",
+      "query": "ako fungujú nočné zálohy",
+      "relevant": [
+        "nočná záloha fungovanie"
+      ],
+      "distractors": [
+        "noční záloha česká poznámka",
+        "záloha vizuálneho návrhu"
+      ]
+    }
+  ]
+}

--- a/tests/hermes_state/test_nl_expansion_mechanism.py
+++ b/tests/hermes_state/test_nl_expansion_mechanism.py
@@ -1,0 +1,222 @@
+"""Tests for the NL query-expansion mechanism (language-agnostic contracts).
+
+The mechanism must work with the default pack only: stopword stripping,
+light stemming, additive fallback chain, graceful degradation for scripts
+without a pack. Language packs are pure data and tested separately.
+"""
+
+import json
+import re
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import (
+    _NL_LANG_PACKS,
+    NLSupport,
+    detect_lang,
+    morph_prefix,
+)
+
+
+class TestDetectLang:
+    def test_unknown_script_gets_default(self):
+        assert detect_lang("配置 服务器") == "default"
+
+    def test_registry_packs_conform_to_schema(self):
+        required = {
+            "stopwords", "affinity_stopwords", "suffixes", "endings",
+            "vowels", "min_stem", "trailing_vowel_drop", "fallback",
+        }
+        for lang, pack in _NL_LANG_PACKS.items():
+            missing = required - set(pack)
+            assert not missing, f"{lang} pack missing keys: {missing}"
+            assert pack["fallback"] in {"keep", "drop1"}, lang
+            assert pack["min_stem"] >= 3, lang
+
+
+class TestExpandEn:
+    @pytest.fixture()
+    def host(self):
+        return NLSupport()
+
+    def test_english_question_strips_stopwords_and_prefixes(self, host):
+        out = host.expand_nl_query("what did we decide about the configs?")
+        assert out is not None
+        assert out["and"] == "decide* AND about* AND config*"
+        assert out["bare"] == "decide about configs"
+
+    def test_two_meaningful_terms_minimum(self, host):
+        assert host.expand_nl_query("what the?") is None
+        assert host.expand_nl_query("config backup")["and"] == "config* AND backup*"
+
+    def test_short_tokens_untouched(self, host):
+        out = host.expand_nl_query("ssh api gateway")
+        assert "api" in out["bare"].split()
+        assert "ssh" in out["bare"].split()
+
+    def test_separated_compound_splits_into_subtokens(self, host):
+        out = host.expand_nl_query("check the ssh-config backup")
+        assert "config*" in out["and"]
+        assert "backup*" in out["and"]
+
+
+class TestMorphPrefix:
+    def test_english_suffix_strip(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("servers", **kw) == "server*"
+        assert morph_prefix("walked", **kw) == "walk*"
+        assert morph_prefix("config's", **kw) == "config*"
+
+    def test_min_stem_floor(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("api", **kw) == "api"      # < min_stem → untouched
+        assert morph_prefix("test", **kw) == "test*"   # == min_stem
+
+    def test_latin_stem_kept_when_no_suffix_matches(self):
+        p = _NL_LANG_PACKS["default"]
+        kw = dict(
+            suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+            min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+            fallback=p["fallback"],
+        )
+        assert morph_prefix("config", **kw) == "config*"
+        assert morph_prefix("testing", **kw) == "test*"
+
+    def test_drop1_fallback_for_fusional_pack_data(self):
+        """A hypothetical fusional pack: tail carries flexion → drop 1."""
+        assert (
+            morph_prefix(
+                "router",
+                suffixes=(), endings=frozenset(),
+                vowels="aeiou", min_stem=4,
+                trailing_vowel_drop=False, fallback="drop1",
+            )
+            == "route*"
+        )
+
+
+class TestAdditiveFallbackE2E:
+    """The fallback must fire only on a zero-result miss and never reorder."""
+
+    @pytest.fixture()
+    def db(self, tmp_path):
+        d = SessionDB(db_path=tmp_path / "state.db")
+        d.create_session("sess-en", source="cli")
+        d.append_message(
+            session_id="sess-en", role="user",
+            content="how do we deploy the k3s cluster backup",
+        )
+        d.append_message(
+            session_id="sess-en", role="assistant",
+            content="we decided about backups: deployment uses flux nightly",
+        )
+        yield d
+        d.close()
+
+    def test_exact_hit_not_replaced_by_expansion(self, db):
+        rows = db.search_messages("nightly backups")
+        assert rows
+        first = json.dumps(rows[0], ensure_ascii=False).lower()
+        assert "nightly" in first
+
+    def test_natural_language_is_opt_in(self, db):
+        query = "what did we decide about the backups?"
+        assert db.search_messages(query) == []
+        rows = db.search_messages(query, natural_language=True)
+        assert rows, "NL mode must recover the session"
+        assert "backup" in json.dumps(rows[:5], ensure_ascii=False).lower()
+
+    @pytest.mark.parametrize("query", [
+        '"exact phrase" backup',
+        "python NOT java",
+        "docker OR kubernetes",
+        "deploy* backup",
+        "NEAR(config backup, 5)",
+    ])
+    def test_fts_syntax_never_enters_nl_mode(self, db, query):
+        assert db.search_messages(query, natural_language=True) == db.search_messages(query)
+
+    def test_nl_path_preserves_source_and_role_filters(self, db):
+        rows = db.search_messages(
+            "what did we decide about the backups?",
+            natural_language=True,
+            source_filter=["cli"],
+            role_filter=["assistant"],
+        )
+        assert rows and all(row["source"] == "cli" for row in rows)
+        assert all(row["role"] == "assistant" for row in rows)
+
+    def test_nl_route_is_visible_in_slow_search_log(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            db.search_messages(
+                "what did we decide about the backups?", natural_language=True
+            )
+        assert any("path=nl_fts_and" in record.message for record in caplog.records)
+
+    def test_or_route_is_visible_when_terms_span_messages(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            rows = db.search_messages(
+                "flux cluster backups?", natural_language=True
+            )
+        assert rows
+        assert any("path=nl_fts_or" in record.message for record in caplog.records)
+
+    def test_nl_only_telemetry_is_opt_in_and_private(self, db, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_SEARCH_NL_ROUTE_LOG", "1")
+        with caplog.at_level("INFO", logger="hermes_state"):
+            rows = db.search_messages(
+                "what did we decide about the backups?", natural_language=True
+            )
+        assert rows
+        events = [r.getMessage() for r in caplog.records if "NL fallback" in r.getMessage()]
+        assert len(events) == 1
+        assert "path=nl_fts_and" in events[0]
+        assert "language=default" in events[0]
+        assert "what did" not in events[0]
+
+    def test_sanitizer_quotes_do_not_block_nl_for_hyphenated_words(self, db):
+        db.append_message(
+            session_id="sess-en", role="assistant", content="sauvegarde fonctionnement"
+        )
+        rows = db.search_messages(
+            "comment les sauvegardes fonctionnent-elles", natural_language=True
+        )
+        assert rows
+        assert "sauvegarde" in json.dumps(rows, ensure_ascii=False)
+
+    def test_genuinely_absent_terms_stay_empty(self, db):
+        assert db.search_messages("quantum unicorn recipes", natural_language=True) == []
+
+
+class TestExpansionSafety:
+    def test_cache_is_bounded(self):
+        host = NLSupport()
+        for number in range(300):
+            host.expand_nl_query(f"question {number} about target")
+        assert len(host._cache) <= host._CACHE_MAXSIZE
+
+    def test_long_query_is_not_expanded_or_cached(self):
+        host = NLSupport()
+        query = "meaningful " * (host._MAX_QUERY_CHARS // 2)
+        assert len(query) > host._MAX_QUERY_CHARS
+        assert host.expand_nl_query(query) is None
+        assert query not in host._cache
+
+    def test_expansion_caps_meaningful_terms(self):
+        host = NLSupport()
+        out = host.expand_nl_query(" ".join(f"term{index}" for index in range(20)))
+        assert out is not None
+        assert out["and"].count(" AND ") + 1 == host._MAX_MEANINGFUL_TERMS

--- a/tests/hermes_state/test_nl_lang_pack_lat.py
+++ b/tests/hermes_state/test_nl_lang_pack_lat.py
@@ -1,0 +1,103 @@
+"""Tests for the Latin-script language packs (es/fr/de/pt/it + default).
+
+Each pack must: be selected by stopword affinity, strip its stopwords,
+stem real flexions into prefixes the unicode61 tokenizer can wildcard,
+and never crash on accented input. No mechanism changes here.
+"""
+
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import _NL_LANG_PACKS, NLSupport, detect_lang
+
+
+def _pack_kwargs(lang: str) -> dict:
+    p = _NL_LANG_PACKS[lang]
+    return dict(
+        suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+        min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+        fallback=p["fallback"],
+    )
+
+
+class TestLatinPackDetection:
+    @pytest.mark.parametrize("query,lang", [
+        ("dónde está la configuración del servidor", "es"),
+        ("où est la configuration du serveur", "fr"),
+        ("wo ist die Konfiguration des Servers", "de"),
+        ("onde está a configuração do servidor", "pt"),
+        ("dov'è la configurazione del server", "it"),
+        ("quando girano i backup notturni", "it"),  # must beat Croatian's shared 'i'
+        ("what about the server config", "default"),  # EN → default fallback
+    ])
+    def test_affinity_detection(self, query, lang):
+        assert detect_lang(query) == lang
+
+
+class TestLatinPackExpansion:
+    """E2E through _expand_nl_query with each pack's own data."""
+
+    @pytest.fixture()
+    def host(self):
+        return NLSupport()
+
+    def test_spanish_question(self, host):
+        out = host.expand_nl_query("¿dónde está la configuración del servidor?")
+        assert out is not None
+        assert "configuración" in out["bare"]
+        # stopword 'del/la/está' stripped
+        assert "está" not in f" {out['bare']} "
+        assert "del" not in out["bare"].split()
+
+    def test_french_question(self, host):
+        out = host.expand_nl_query("où est la configuration du serveur")
+        assert out is not None
+        assert "serveu*" in out["and"] or "serveur*" in out["and"]
+        assert "la" not in out["bare"].split()
+
+    def test_german_question(self, host):
+        out = host.expand_nl_query("wo ist die Konfiguration des Servers")
+        assert out is not None
+        assert "Server*" in out["and"]
+        assert "die" not in out["bare"].split()
+        assert "ist" not in out["bare"].split()
+
+    def test_portuguese_question(self, host):
+        out = host.expand_nl_query("onde está a configuração do servidor")
+        assert out is not None
+        # -ção flexion strips via the pack suffix table
+        assert "configura*" in out["and"]
+        assert "está" not in out["bare"].split()
+
+    def test_italian_question(self, host):
+        out = host.expand_nl_query("dov'è la configurazione del server")
+        assert out is not None
+        # -zione flexion strips via the pack suffix table
+        assert "configura*" in out["and"]
+        assert "della" not in out["bare"].split()
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("sess-es", source="cli")
+    d.append_message(
+        session_id="sess-es", role="user", content="configuración proxy documentada"
+    )
+    d.append_message(
+        session_id="sess-es", role="assistant", content="proxy configurado con traefik"
+    )
+    yield d
+    d.close()
+
+
+class TestSpanishE2E:
+    def test_inflected_question_finds_session(self, db):
+        query = "¿dónde están las configuraciones del proxy?"
+        assert db.search_messages(query) == []  # strict low-level FTS5 API
+        rows = db.search_messages(query, natural_language=True)
+        assert rows, "conversational ES query must reach 'configuré/configurado'"
+        blob = json.dumps(rows, ensure_ascii=False).lower()
+        assert "proxy" in blob or "configur" in blob

--- a/tests/hermes_state/test_nl_lang_pack_slavic.py
+++ b/tests/hermes_state/test_nl_lang_pack_slavic.py
@@ -1,0 +1,160 @@
+"""Tests for the Slavic language packs (ru/be/uk + sr/bg/mk + cs/sk/hr).
+
+Cyrillic and Latin Slavic packs are tested together since detection
+uses script → affinity routing: Cyrillic queries score across all
+Cyrillic packs, Latin Slavic packs score among Latin-script candidates.
+"""
+
+import json
+
+import pytest
+
+from hermes_state import SessionDB
+from hermes_state_nl_expansion import _NL_LANG_PACKS, NLSupport, detect_lang
+
+
+def _slavic_kwargs(lang: str) -> dict:
+    p = _NL_LANG_PACKS[lang]
+    return dict(
+        suffixes=p["suffixes"], endings=p["endings"], vowels=p["vowels"],
+        min_stem=p["min_stem"], trailing_vowel_drop=p["trailing_vowel_drop"],
+        fallback=p["fallback"],
+    )
+
+
+class TestSlavicPackDetection:
+    @pytest.mark.parametrize("query,expected_pack", [
+        ("сколько алиасов в конфиге", "ru"),
+        ("скільки аліасів у конфігу", "uk"),
+        ("няма ды ці быць у каго блізу", "be"),  # unique Belarusian markers
+        ("колькі сервераў", "be"),  # common Belarusian question, not Russian
+        ("колико аласа у конфигу", "sr"),  # Serbian Cyrillic
+        ("колко аликса в конфиг", "bg"),   # Bulgarian
+        ("koliko alasa u konfiguraciji", "hr"),  # Croatian Latin
+        ("kolik aliasů v konfiguraci", "cs"),    # Czech
+        ("koľko aliasov v konfigurácii", "sk"),  # Slovak
+    ])
+    def test_cyrillic_affinity_routing(self, query, expected_pack):
+        """Cyrillic queries should route through script detection + affinity scoring."""
+        result = detect_lang(query)
+        assert result == expected_pack, f"'{query}' → {result} (expected {expected_pack})"
+
+    def test_english_question_gets_default(self):
+        """English questions should never hit a Slavic pack."""
+        assert detect_lang("what is the server config") == "default"
+
+
+class TestSlavicMorphology:
+    """Test that real inflections from each Slavic pack stem correctly."""
+
+    @pytest.fixture()
+    def host(self):
+        return NLSupport()
+
+    def test_ru_inflections(self, host):
+        out = host.expand_nl_query("сколько серверов в конфиге прописано")
+        assert out is not None
+        # "серверов" → "сервер*" (2-char ending table)
+        assert "сервер*" in out["and"] or "сервер" in out["bare"]
+        # stopwords "сколько", "прописано" stripped
+        sw = {"сколько", "прописано"}
+        for word in out["bare"].split():
+            assert word.lower() not in sw, f"{word} should be stripped"
+
+    def test_uk_inflections(self, host):
+        out = host.expand_nl_query("скільки серверів прописано")
+        assert out is not None
+        # Ukrainian endings differ from Russian
+        assert any(s.startswith("серве") for s in out["and"].split())
+
+    def test_sr_inflections(self, host):
+        """Serbian Cyrillic inflection."""
+        out = host.expand_nl_query("колико аласа у конфигу је прописан")
+        assert out is not None
+        # Should contain stemmed forms
+        bare = out["bare"]
+        assert "алас" in bare or "ала" in bare
+
+    def test_bg_inflections(self, host):
+        """Bulgarian loses cases but has rich prefixes."""
+        out = host.expand_nl_query("колко сървъри са записани")
+        assert out is not None
+        bare = out["bare"]
+        assert "сърв" in bare or "сервер" in bare
+
+    def test_cs_inflections(self, host):
+        """Czech with rich consonant clusters and long vowels."""
+        out = host.expand_nl_query("kolik aliasů je v konfiguraci nastaveno")
+        assert out is not None
+        bare = out["bare"]
+        assert "alias" in bare or "konfigur" in bare
+
+    def test_sk_inflections(self, host):
+        """Slovak close to Czech but different stopwords."""
+        out = host.expand_nl_query("koľko aliasov je v konfigurácii zadaných")
+        assert out is not None
+        bare = out["bare"]
+        assert "alias" in bare or "konfigur" in bare
+
+    def test_be_inflections(self, host):
+        out = host.expand_nl_query("колькі сервераў прапісана")
+        assert out is not None
+        # Belarusian -аў ending → stem
+        bare = out["bare"]
+        assert "сервер" in bare or "сервера" in bare
+
+    def test_bg_inflections(self, host):
+        out = host.expand_nl_query("колко сервери са записани")
+        assert out is not None
+        # Bulgarian -и plural suffix
+        assert "серв" in out["and"] or "сервер" in out["bare"]
+
+    def test_cs_inflections(self, host):
+        out = host.expand_nl_query("kolik aliasů je v konfiguraci")
+        assert out is not None
+        # Czech -ů plural
+        bare = out["bare"]
+        assert "alias" in bare or "konfigur" in bare
+
+    def test_slovak_question(self, host):
+        out = host.expand_nl_query("koľko aliasov je v konfigurácii")
+        assert out is not None
+        # Slovak -ov suffix
+        bare = out["bare"]
+        assert "alias" in bare or "konfigur" in bare
+
+    @pytest.mark.parametrize("query,lang,expected", [
+        ("кога услугите стартираха", "bg", "услуг*"),
+        ("каде се конфигурациите на серверот", "mk", "конфигураци*"),
+        ("ako fungujú nočné zálohy", "sk", "záloh*"),
+    ])
+    def test_eval_regressions(self, host, query, lang, expected):
+        assert detect_lang(query) == lang
+        out = host.expand_nl_query(query)
+        assert out is not None and expected in out["or"]
+
+
+@pytest.fixture()
+def db(tmp_path):
+    d = SessionDB(db_path=tmp_path / "state.db")
+    d.create_session("sess-cyrillic", source="cli")
+    d.append_message(
+        session_id="sess-cyrillic", role="user",
+        content="сервер конфігурація запущений",
+    )
+    d.append_message(
+        session_id="sess-cyrillic", role="assistant",
+        content="сервер конфігурація запущений на traefik",
+    )
+    yield d
+    d.close()
+
+
+class TestSlavicE2E:
+    def test_ukrainian_question_finds_session(self, db):
+        query = "скільки серверів конфігурації запущено?"
+        assert db.search_messages(query) == []  # strict low-level FTS5 API
+        rows = db.search_messages(query, natural_language=True)
+        assert rows, "conversational Ukrainian query must find Cyrillic session"
+        blob = json.dumps(rows, ensure_ascii=False).lower()
+        assert "сервер" in blob or "конф" in blob

--- a/tests/hermes_state/test_nl_search_eval_fixture.py
+++ b/tests/hermes_state/test_nl_search_eval_fixture.py
@@ -1,0 +1,74 @@
+"""Contract checks for the privacy-safe, pack-aware NL evaluation corpus."""
+
+import json
+from pathlib import Path
+
+from scripts.nl_search_eval import resolve_packs, select_cases
+
+
+CORPUS = Path(__file__).parent / "fixtures" / "nl_search_eval_v1.json"
+
+
+def _corpus():
+    return json.loads(CORPUS.read_text(encoding="utf-8"))
+
+
+def test_eval_corpus_is_versioned_private_safe_and_multilingual():
+    corpus = _corpus()
+    assert corpus["version"] == 2
+    mechanism = corpus["cases"]
+    adversarial = corpus["adversarial_cases"]
+    assert len(mechanism) >= 45
+    assert len(adversarial) >= 10
+    ids = [case["id"] for case in mechanism + adversarial]
+    assert len(ids) == len(set(ids))
+    languages = {case["lang"] for case in mechanism}
+    assert len(languages) == 15
+    for case in mechanism:
+        assert set(case) == {"id", "lang", "packs", "scenario", "query", "target"}
+        assert case["scenario"] == "morphology_stopwords"
+        assert set(case["packs"]).issubset(languages)
+    for case in adversarial:
+        assert {"id", "lang", "packs", "scenario", "query", "relevant", "distractors"} <= set(case)
+        assert case["scenario"] in {
+            "exact_hit", "adjacent_turns", "absent", "fts_syntax", "lexical_near_miss",
+            "routing", "cross_language",
+        }
+    for case in mechanism + adversarial:
+        payload = " ".join(str(value) for value in case.values()).lower()
+        assert not any(marker in payload for marker in ("http://", "https://", "@"))
+
+
+def test_pack_selection_makes_each_stacked_layer_self_validating():
+    corpus = _corpus()
+    core = select_cases(corpus, {"default"})
+    latin = select_cases(corpus, {"default", "es", "fr", "de", "pt", "it"})
+    full = select_cases(
+        corpus,
+        {"default", "es", "fr", "de", "pt", "it", "ru", "be", "uk", "sr", "bg", "mk", "hr", "cs", "sk"},
+    )
+    assert core and len(core) < len(latin) < len(full)
+    assert {case["lang"] for case in core} == {"default"}
+    assert {"es", "fr", "de", "pt", "it"}.issubset({case["lang"] for case in latin})
+    assert len({case["lang"] for case in full}) == 15
+
+
+def test_eval_runner_is_portable_and_reports_relevance_metrics():
+    runner = Path(__file__).parents[2] / "scripts" / "nl_search_eval.py"
+    text = runner.read_text(encoding="utf-8")
+    assert "TemporaryDirectory" in text
+    assert "natural_language=natural_language" in text
+    assert "precision_at_5" in text and "latency_p95_ms" in text
+    assert "absent_query_accuracy" in text and "--packs" in text
+    assert "SessionDB" in text and "state.db" in text
+    assert "/home/" not in text
+    assert "db_path=Path(\"/" not in text
+    assert "http://" not in text and "https://" not in text
+    assert "HERMES_SEARCH_NL_ROUTE_LOG" not in text
+    assert "default" in resolve_packs("all")
+    try:
+        resolve_packs("does-not-exist")
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("unknown pack must fail fast")

--- a/tests/test_search_slow_query_log.py
+++ b/tests/test_search_slow_query_log.py
@@ -24,7 +24,17 @@ def test_slow_log_emitted_at_zero_threshold(db, monkeypatch, caplog):
     slow = [r for r in caplog.records if "slow session search" in r.getMessage()]
     assert slow, "threshold 0 must log every search"
     msg = slow[0].getMessage()
-    assert "path=" in msg and "rows=1" in msg
+    assert "path=" in msg and "rows=1" in msg and "chars=" in msg
+    assert "query=" not in msg and "graphiti" not in msg
+
+
+def test_query_text_requires_explicit_opt_in(db, monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_SEARCH_SLOW_MS", "0")
+    monkeypatch.setenv("HERMES_SEARCH_LOG_QUERY", "true")
+    with caplog.at_level(logging.INFO, logger="hermes_state"):
+        db.search_messages("graphiti", limit=5)
+    slow = [r for r in caplog.records if "slow session search" in r.getMessage()]
+    assert "query='graphiti'" in slow[0].getMessage()
 
 
 def test_no_log_under_threshold(db, monkeypatch, caplog):

--- a/tests/tools/test_session_search_nl_opt_in.py
+++ b/tests/tools/test_session_search_nl_opt_in.py
@@ -1,0 +1,31 @@
+"""The conversational session-search tool must opt into NL expansion."""
+
+from tools import session_search_tool
+
+
+class _DB:
+    def __init__(self):
+        self.kwargs = None
+
+    def search_messages(self, **kwargs):
+        self.kwargs = kwargs
+        return []
+
+    def list_sessions(self, **kwargs):
+        return []
+
+
+def test_discover_enables_natural_language_search():
+    db = _DB()
+    result = session_search_tool._discover(
+        db=db,
+        query="what did we decide about the backups?",
+        role_filter=None,
+        limit=3,
+        sort=None,
+        detail="adaptive",
+    )
+
+    assert db.kwargs is not None
+    assert db.kwargs["natural_language"] is True
+    assert '"count": 0' in result

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -790,6 +790,7 @@ def _discover(
             offset=0,
             sort=sort,
             fields=_DISCOVER_SEARCH_FIELDS,
+            natural_language=True,
         )
     except Exception as e:
         logging.error("FTS5 search failed: %s", e, exc_info=True)


### PR DESCRIPTION
## Summary

> **Stacked follow-up: review after #100037 and #100038.** GitHub cannot use a fork branch as an upstream PR base, so this draft is cumulative over `main`; its incremental diff is language data and tests only.

Adds nine Slavic data packs to the validated registry:

- Cyrillic: Russian (`ru`), Belarusian (`be`), Ukrainian (`uk`), Serbian (`sr`), Bulgarian (`bg`), Macedonian (`mk`)
- Latin: Croatian (`hr`), Czech (`cs`), Slovak (`sk`)

Russian is one optional data pack, not a special mechanism. Cyrillic detection narrows by script, then uses affinity markers; Latin Slavic packs participate in the shared Latin affinity route.

Regression coverage includes:

```text
колькі сервераў                     → be, not ru
кога услугите стартираха            → bg
каде се конфигурациите на серверот  → mk
ako fungujú nočné zálohy            → sk
```

## Evidence

```bash
PYTHONPATH=. python scripts/nl_search_eval.py --packs all \
  --min-nl-recall 0.95 --min-nl-precision 0.80 \
  --min-absent-accuracy 1.00
```

- `364 passed, 2 skipped` on the refreshed final stack.
- The complete registry evaluates 55 controlled privacy-safe cases:
  - strict FTS5: recall@5 `0.055`, MRR `0.045`
  - NL opt-in: hit@1 `0.964`, recall@5 `0.982`, precision@5 `0.930`, MRR `0.973`
  - absent-query accuracy `1.000`, controlled p95 latency `4.3ms`
- The corpus covers morphology/stopwords, exact hits, adjacent turns, absent queries, FTS syntax, lexical near-misses and cross-language routing ambiguities. It is a controlled regression evaluation, not a production-population quality claim.
- `docs/nl-search-language-pack-validation.md` is a review ledger: it records authoritative anchors and regression evidence, while explicitly requiring future contributors to disclose any fluent-speaker review rather than inventing it.

## Stack order

1. #100037 — engine + default/English + evaluation framework
2. #100038 — Latin data packs
3. **this PR** — Slavic data packs

No dependencies added.