### PR TITLE
fix(desktop): stop a busy remote host turning pooled probe misses into a fleet-wide reconnect storm

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14291,6 +14291,27 @@ ipcMain.handle('hermes:connection:revalidate', async () => {
   return remoteRevalidation.run(connectionPromise, async () => {
     const [result] = await Promise.all([
       revalidateRemoteConnection({
+        // The primary connection is alone on its gateway, so it cannot use the
+        // pooled host-event vote. Give it the same grace by other means: pause,
+        // confirm the SSH master is still up, and re-probe once. A backend that
+        // answers after the pause was busy, not dead — and keeping it avoids a
+        // whole-app reload for a load spike.
+        confirmDrop: {
+          backoff: async () => {
+            await sleep(HOST_EVENT_BACKOFF_MS)
+          },
+          transportAlive: async () => {
+            const conn = await connectionPromise.catch(() => null)
+
+            if (conn?.remoteKind !== 'ssh') {
+              return true
+            }
+
+            const state = sshConnections.get(sshScopeKey(primaryProfileKey()))
+
+            return state?.ssh ? await state.ssh.isAlive().catch(() => false) : false
+          }
+        },
         connectionPromise,
         currentConnectionPromise: () => backendConnectionState.getPromise(),
         log: rememberLog,

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -314,6 +314,9 @@ import * as remoteLifecycle from './remote-lifecycle'
 import {
   attachPowerResumeRemoteRevalidation,
   ensureHealthyPooledRemoteBackendForDispatch,
+  HOST_EVENT_BACKOFF_MS,
+  PooledRemoteDialGate,
+  RemoteHostEventTracker,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -1382,6 +1385,13 @@ const backendConnectionState = createBackendConnectionState<ReturnType<typeof sp
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
 const registryDispatchRevalidation = new RemoteRevalidationCoordinator()
+// One busy host makes every profile pooled on it miss its dispatch probe at
+// once; retiring each independently re-dials the whole fleet into the host
+// that was already saturated. These two bound that: the tracker classifies the
+// correlated misses as a host event so teardown is deferred and revalidated,
+// and the gate keeps recovery from landing as one burst of SSH handshakes.
+const registryHostEvents = new RemoteHostEventTracker()
+const registryDialGate = new PooledRemoteDialGate()
 // Single-owner reconnect/dial claim (#90812): reconnectGateway()'s in-flight
 // lock is per-renderer, so two windows racing one wake can both invoke the
 // backend ensure IPC and double-dial a pooled SSH backend. Main owns backend
@@ -11243,6 +11253,25 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       ensureHealthyPooledRemoteBackendForDispatch({
         connectionPromise,
         currentConnectionPromise: () => backendPool.get(key)?.connectionPromise || null,
+        hostEvent: {
+          backoff: async () => {
+            await sleep(HOST_EVENT_BACKOFF_MS)
+          },
+          classify: () => registryHostEvents.recordProbeFailure(String(id), key),
+          // The transport this descriptor rides. `-O check` against the live
+          // master is far cheaper than the teardown it is deciding against; a
+          // non-SSH remote has no such handle, so its re-probe alone decides.
+          hostAlive: async () => {
+            if (source.kind !== 'ssh') {
+              return true
+            }
+
+            const ssh = sshConnections.get(key)?.ssh
+
+            return ssh ? Boolean(await ssh.isAlive()) : false
+          }
+        },
+        log: rememberLog,
         probe: (connection, requestPath, options) => fetchJsonForBackend(connection, requestPath, options),
         reconnect: () => ensureRegistryBackend(id, profile),
         retire: async (error: any) => {
@@ -11277,21 +11306,26 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     remoteBaseUrl: null
   }
 
-  entry.connectionPromise = connectRegistryBackend(
-    source,
-    profile,
-    key,
-    entry,
-    resolveRegistrySshConfig(),
-    source.kind === 'ssh' ? resolveRegistryEffectiveFingerprint() : null,
-    managedUpdateCorrelation
-  ).catch(error => {
-    if (backendPool.get(key) === entry) {
-      backendPool.delete(key)
-    }
+  // Resolve the dial's inputs now, before the gate can defer it: a queued dial
+  // must use the settings that were current when it was requested.
+  const dialSshConfig = resolveRegistrySshConfig()
+  const dialFingerprint = source.kind === 'ssh' ? resolveRegistryEffectiveFingerprint() : null
 
-    throw error
-  })
+  // Staggered through the per-connection gate: a fleet-wide retire round would
+  // otherwise hand this host every SSH handshake + remote backend boot at once.
+  // A dial that finds a free slot is not delayed at all, so a lone reconnect
+  // stays as fast as it was.
+  entry.connectionPromise = registryDialGate
+    .run(String(id), () =>
+      connectRegistryBackend(source, profile, key, entry, dialSshConfig, dialFingerprint, managedUpdateCorrelation)
+    )
+    .catch(error => {
+      if (backendPool.get(key) === entry) {
+        backendPool.delete(key)
+      }
+
+      throw error
+    })
   backendPool.set(key, entry)
   startPoolIdleReaper()
 

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -263,6 +263,82 @@ describe('revalidateRemoteConnection', () => {
     await expect(revalidateRemoteConnection(rejected.options)).resolves.toEqual({ ok: true, rebuilt: false })
     expect(rejected.probe).not.toHaveBeenCalled()
   })
+
+  // The primary connection has no pool sibling to vote with, so it cannot use
+  // the pooled host-event signal. A busy host still makes its quick streak
+  // expire, and dropping it is a visible whole-app reload.
+  describe('drop confirmation', () => {
+    function confirmation(overrides: Record<string, unknown> = {}) {
+      return {
+        backoff: vi.fn(async () => undefined),
+        transportAlive: vi.fn(async () => true),
+        ...overrides
+      }
+    }
+
+    it('keeps a connection that answers the re-probe after the backoff', async () => {
+      const probe = vi
+        .fn()
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockRejectedValueOnce(new Error('ECONNRESET'))
+        .mockResolvedValueOnce({ ok: true })
+
+      const confirmDrop = confirmation()
+      const test = harness({ confirmDrop, probe })
+
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: false })
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: false })
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: false })
+
+      expect(confirmDrop.backoff).toHaveBeenCalledOnce()
+      expect(confirmDrop.transportAlive).toHaveBeenCalledOnce()
+      expect(probe).toHaveBeenCalledTimes(4)
+      expect(test.resetConnection).not.toHaveBeenCalled()
+      expect(test.log).toHaveBeenLastCalledWith(expect.stringContaining('answered after'))
+    })
+
+    it('still drops a connection whose re-probe fails after the backoff', async () => {
+      const probe = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+      const confirmDrop = confirmation()
+      const test = harness({ confirmDrop, probe })
+
+      await revalidateRemoteConnection(test.options)
+      await revalidateRemoteConnection(test.options)
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: true })
+
+      expect(confirmDrop.backoff).toHaveBeenCalledOnce()
+      expect(probe).toHaveBeenCalledTimes(4)
+      expect(test.resetConnection).toHaveBeenCalledOnce()
+      expect(test.log).toHaveBeenLastCalledWith(expect.stringContaining('dropping stale connection'))
+    })
+
+    it('drops without a re-probe when the transport itself is gone', async () => {
+      const probe = vi.fn().mockRejectedValue(new Error('ECONNRESET'))
+      const confirmDrop = confirmation({ transportAlive: vi.fn(async () => false) })
+      const test = harness({ confirmDrop, probe })
+
+      await revalidateRemoteConnection(test.options)
+      await revalidateRemoteConnection(test.options)
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: true })
+
+      // Three liveness probes and no fourth: a dead transport needs no re-probe.
+      expect(probe).toHaveBeenCalledTimes(3)
+      expect(test.resetConnection).toHaveBeenCalledOnce()
+    })
+
+    it('drops on the unchanged fast path when no confirmation is wired', async () => {
+      const probe = vi.fn().mockRejectedValue(new Error('offline'))
+      const test = harness({ probe })
+
+      await revalidateRemoteConnection(test.options)
+      await revalidateRemoteConnection(test.options)
+      await expect(revalidateRemoteConnection(test.options)).resolves.toEqual({ ok: true, rebuilt: true })
+
+      expect(probe).toHaveBeenCalledTimes(3)
+      expect(test.resetConnection).toHaveBeenCalledOnce()
+    })
+  })
 })
 
 describe('ensureHealthyPooledRemoteBackendForDispatch', () => {

--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -2,10 +2,16 @@ import { describe, expect, it, vi } from 'vitest'
 
 import {
   ensureHealthyPooledRemoteBackendForDispatch,
+  HOST_EVENT_DISTINCT_PROFILE_THRESHOLD,
+  HOST_EVENT_WINDOW_MS,
+  POOLED_REMOTE_DIAL_CONCURRENCY,
+  POOLED_REMOTE_DIAL_JITTER_MS,
   POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS,
+  PooledRemoteDialGate,
   REMOTE_LIVENESS_FAILURE_LIMIT,
   REMOTE_LIVENESS_FAILURE_WINDOW_MS,
   REMOTE_LIVENESS_TIMEOUT_MS,
+  RemoteHostEventTracker,
   RemoteLivenessTracker,
   RemoteRevalidationCoordinator,
   revalidatePooledRemoteBackends,
@@ -297,6 +303,257 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
     })
     expect(retire).toHaveBeenCalledOnce()
     expect(reconnect).toHaveBeenCalledOnce()
+  })
+
+  describe('host events', () => {
+    // One busy host, many pooled profiles: the harness models a whole
+    // connection so a probe failure can be correlated the way the real pool
+    // sees it, instead of one descriptor in isolation.
+    const hostHarness = () => {
+      const tracker = new RemoteHostEventTracker()
+      const state = { backendAnswers: true, backoffs: 0, hostReachable: true, probeFails: true }
+
+      const probe = vi.fn(async () => {
+        if (state.probeFails) {
+          throw new Error('read ECONNRESET')
+        }
+      })
+
+      const dispatch = (poolKey: string, connection: { baseUrl: string; mode: string }) => {
+        const connectionPromise = Promise.resolve(connection)
+        const retire = vi.fn(async () => {})
+        const reconnect = vi.fn(async () => connection)
+
+        const result = ensureHealthyPooledRemoteBackendForDispatch({
+          connectionPromise,
+          currentConnectionPromise: () => connectionPromise,
+          hostEvent: {
+            backoff: async () => {
+              state.backoffs += 1
+              // The backoff is where a busy host recovers; model that by
+              // letting the descriptor answer again once it has elapsed.
+              state.probeFails = !state.backendAnswers
+            },
+            classify: () => tracker.recordProbeFailure('conn:remote', poolKey),
+            hostAlive: async () => state.hostReachable
+          },
+          probe,
+          reconnect,
+          retire
+        })
+
+        return { connection, reconnect, result, retire }
+      }
+
+      return { dispatch, probe, state, tracker }
+    }
+
+    const descriptorFor = (poolKey: string) => ({ baseUrl: `http://127.0.0.1/${poolKey}`, mode: 'remote' })
+
+    it('defers teardown once distinct profiles fail together and keeps a descriptor that recovers', async () => {
+      const host = hostHarness()
+      const keys = ['conn:remote::alpha', 'conn:remote::beta', 'conn:remote::gamma']
+
+      const dispatches = keys.map(key => host.dispatch(key, descriptorFor(key)))
+
+      await Promise.all(dispatches.map(dispatch => dispatch.result))
+
+      // The first two are below the distinct-profile threshold, so they take
+      // the unchanged fast path; the third crosses it and must be spared.
+      expect(dispatches[2].retire).not.toHaveBeenCalled()
+      expect(dispatches[2].reconnect).not.toHaveBeenCalled()
+      await expect(dispatches[2].result).resolves.toBe(dispatches[2].connection)
+      expect(host.state.backoffs).toBe(1)
+    })
+
+    it('still retires a descriptor that is dead after the host-event backoff', async () => {
+      const host = hostHarness()
+      host.state.backendAnswers = false
+      const keys = ['conn:remote::alpha', 'conn:remote::beta', 'conn:remote::gamma']
+
+      const dispatches = keys.map(key => host.dispatch(key, descriptorFor(key)))
+
+      await Promise.all(dispatches.map(dispatch => dispatch.result))
+
+      expect(host.state.backoffs).toBe(1)
+      expect(dispatches[2].retire).toHaveBeenCalledOnce()
+      expect(dispatches[2].reconnect).toHaveBeenCalledOnce()
+    })
+
+    it('retires when the host itself is still unreachable after the backoff', async () => {
+      const host = hostHarness()
+      host.state.hostReachable = false
+      host.state.backendAnswers = true
+      const keys = ['conn:remote::alpha', 'conn:remote::beta', 'conn:remote::gamma']
+
+      const dispatches = keys.map(key => host.dispatch(key, descriptorFor(key)))
+
+      await Promise.all(dispatches.map(dispatch => dispatch.result))
+
+      expect(dispatches[2].retire).toHaveBeenCalledOnce()
+    })
+
+    it('retires a lone failing profile immediately, with no backoff', async () => {
+      const host = hostHarness()
+      const solo = host.dispatch('conn:remote::alpha', descriptorFor('alpha'))
+
+      await solo.result
+
+      expect(host.state.backoffs).toBe(0)
+      expect(solo.retire).toHaveBeenCalledOnce()
+      expect(solo.reconnect).toHaveBeenCalledOnce()
+    })
+  })
+})
+
+describe('RemoteHostEventTracker', () => {
+  it('classifies a host event only after enough DISTINCT profiles fail in the window', () => {
+    const tracker = new RemoteHostEventTracker()
+
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::one')).toBe(false)
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::two')).toBe(false)
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::three')).toBe(true)
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::four')).toBe(true)
+  })
+
+  it('never classifies one profile failing repeatedly as a host event', () => {
+    const tracker = new RemoteHostEventTracker()
+
+    for (let attempt = 0; attempt < HOST_EVENT_DISTINCT_PROFILE_THRESHOLD + 2; attempt += 1) {
+      expect(tracker.recordProbeFailure('conn:a', 'conn:a::one')).toBe(false)
+    }
+  })
+
+  it('tracks connections independently', () => {
+    const tracker = new RemoteHostEventTracker()
+
+    tracker.recordProbeFailure('conn:a', 'conn:a::one')
+    tracker.recordProbeFailure('conn:a', 'conn:a::two')
+
+    expect(tracker.recordProbeFailure('conn:b', 'conn:b::one')).toBe(false)
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::three')).toBe(true)
+  })
+
+  it('ages failures out of the window instead of latching', () => {
+    let now = 0
+    const tracker = new RemoteHostEventTracker(HOST_EVENT_DISTINCT_PROFILE_THRESHOLD, HOST_EVENT_WINDOW_MS, () => now)
+
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::one')).toBe(false)
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::two')).toBe(false)
+
+    now += HOST_EVENT_WINDOW_MS + 1
+
+    // The earlier two are stale, so an isolated later failure is not a herd.
+    expect(tracker.recordProbeFailure('conn:a', 'conn:a::three')).toBe(false)
+  })
+
+  it('rejects a threshold that could fire on a single profile', () => {
+    expect(() => new RemoteHostEventTracker(1)).toThrow(/at least 2/)
+  })
+})
+
+describe('PooledRemoteDialGate', () => {
+  const gateHarness = (limit = POOLED_REMOTE_DIAL_CONCURRENCY) => {
+    const delays: number[] = []
+    const releases: Array<() => void> = []
+    let concurrent = 0
+    let peak = 0
+
+    const gate = new PooledRemoteDialGate({
+      delay: async ms => {
+        delays.push(ms)
+      },
+      jitterMs: POOLED_REMOTE_DIAL_JITTER_MS,
+      limit,
+      random: () => 0.5
+    })
+
+    const dial = (connectionId: string) => {
+      const result = gate.run(connectionId, async () => {
+        concurrent += 1
+        peak = Math.max(peak, concurrent)
+
+        await new Promise<void>(resolve => {
+          releases.push(() => {
+            concurrent -= 1
+            resolve()
+          })
+        })
+
+        return connectionId
+      })
+
+      return result
+    }
+
+    return {
+      delays,
+      dial,
+      gate,
+      peak: () => peak,
+      releaseAll: async () => {
+        while (releases.length > 0) {
+          releases.shift()?.()
+          // Let the released slot's waiter be admitted before the next round.
+          await new Promise<void>(resolve => setTimeout(resolve, 0))
+        }
+      }
+    }
+  }
+
+  it('never lets one connection exceed the dial concurrency cap', async () => {
+    const harness = gateHarness()
+    const dials = Array.from({ length: 21 }, () => harness.dial('conn:remote'))
+
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(harness.gate.active('conn:remote')).toBe(POOLED_REMOTE_DIAL_CONCURRENCY)
+
+    await harness.releaseAll()
+    await Promise.all(dials)
+
+    expect(harness.peak()).toBe(POOLED_REMOTE_DIAL_CONCURRENCY)
+  })
+
+  it('jitters every queued admission but never the first ones', async () => {
+    const harness = gateHarness()
+    const dials = Array.from({ length: 5 }, () => harness.dial('conn:remote'))
+
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(harness.delays).toEqual([])
+
+    await harness.releaseAll()
+    await Promise.all(dials)
+
+    // Two callers were queued, so exactly two admissions paid jitter.
+    expect(harness.delays).toEqual([POOLED_REMOTE_DIAL_JITTER_MS / 2, POOLED_REMOTE_DIAL_JITTER_MS / 2])
+  })
+
+  it('does not make one connection wait behind another', async () => {
+    const harness = gateHarness(1)
+    const first = harness.dial('conn:one')
+    const second = harness.dial('conn:two')
+
+    await new Promise<void>(resolve => setTimeout(resolve, 0))
+
+    expect(harness.peak()).toBe(2)
+
+    await harness.releaseAll()
+    await Promise.all([first, second])
+  })
+
+  it('frees the slot when a dial rejects', async () => {
+    const gate = new PooledRemoteDialGate({ delay: async () => {}, limit: 1 })
+
+    await expect(
+      gate.run('conn:remote', () => {
+        throw new Error('ssh: connect to host remote port 22: Connection refused')
+      })
+    ).rejects.toThrow('Connection refused')
+
+    await expect(gate.run('conn:remote', async () => 'ok')).resolves.toBe('ok')
+    expect(gate.active('conn:remote')).toBe(0)
   })
 })
 

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -10,6 +10,21 @@ export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // One minute keeps a continuous outage together without carrying old failures.
 export const REMOTE_LIVENESS_FAILURE_WINDOW_MS = 60_000
 
+// A dispatch-probe miss is per-profile evidence, but the cause is often not.
+// When one remote host is briefly saturated, MANY pooled profiles on the SAME
+// connection miss their probe inside the same tick (measured: 21 profiles
+// within 40ms). Treating each miss independently retires and re-dials all of
+// them at once, which lands N SSH handshakes + N remote backend boots on the
+// host that was already too busy to answer — the misses cause the stampede
+// that causes the next round of misses. These constants classify that shape:
+// distinct PROFILES (never one profile failing repeatedly) failing on one
+// connection inside a short window is a host event, not N dead backends.
+export const HOST_EVENT_DISTINCT_PROFILE_THRESHOLD = 3
+export const HOST_EVENT_WINDOW_MS = 2_000
+// Long enough for a load spike to drain, short enough that a genuinely dead
+// backend still reconnects well inside the user's patience for one click.
+export const HOST_EVENT_BACKOFF_MS = 5_000
+
 export interface RemoteLivenessFailure {
   failures: number
   shouldReset: boolean
@@ -68,9 +83,185 @@ export class RemoteRevalidationCoordinator {
   }
 }
 
+/**
+ * Classifies correlated dispatch-probe failures on one connection as a HOST
+ * EVENT (the host is busy) rather than N independent dead backends.
+ *
+ * Keyed per connection id, counting DISTINCT pool keys inside a rolling
+ * window: one profile failing three times in a row is still one dead backend
+ * and must keep the existing fast retire path. Failures age out of the window
+ * on their own, so the classification is self-clearing — there is no latch to
+ * reset and no timer to own.
+ */
+export class RemoteHostEventTracker {
+  readonly #failuresByConnection = new Map<string, Map<string, number>>()
+  readonly #now: () => number
+  readonly #threshold: number
+  readonly #windowMs: number
+
+  constructor(
+    threshold = HOST_EVENT_DISTINCT_PROFILE_THRESHOLD,
+    windowMs = HOST_EVENT_WINDOW_MS,
+    now: () => number = Date.now
+  ) {
+    if (!Number.isInteger(threshold) || threshold < 2) {
+      throw new Error('Host event threshold must be an integer of at least 2.')
+    }
+
+    if (!Number.isFinite(windowMs) || windowMs < 1) {
+      throw new Error('Host event window must be positive.')
+    }
+
+    this.#threshold = threshold
+    this.#windowMs = windowMs
+    this.#now = now
+  }
+
+  /**
+   * Record one dispatch-probe failure. Returns true once enough DISTINCT pool
+   * keys on this connection have failed inside the window — including for the
+   * failure that crosses the threshold and every later one while it holds.
+   */
+  recordProbeFailure(connectionId: string, poolKey: string): boolean {
+    const now = this.#now()
+    let recent = this.#failuresByConnection.get(connectionId)
+
+    if (!recent) {
+      recent = new Map()
+      this.#failuresByConnection.set(connectionId, recent)
+    }
+
+    recent.set(poolKey, now)
+
+    for (const [key, at] of recent) {
+      if (now - at > this.#windowMs) {
+        recent.delete(key)
+      }
+    }
+
+    if (recent.size === 0) {
+      this.#failuresByConnection.delete(connectionId)
+    }
+
+    return recent.size >= this.#threshold
+  }
+
+  clear(connectionId?: string): void {
+    if (connectionId === undefined) {
+      this.#failuresByConnection.clear()
+
+      return
+    }
+
+    this.#failuresByConnection.delete(connectionId)
+  }
+}
+
+// Recovery must not become the next stampede: three in flight keeps a busy
+// host making progress without handing it 20+ handshakes at once, and a small
+// jitter stops each released batch from landing on the same millisecond.
+export const POOLED_REMOTE_DIAL_CONCURRENCY = 3
+export const POOLED_REMOTE_DIAL_JITTER_MS = 250
+
+export interface PooledRemoteDialGateOptions {
+  delay?: (ms: number) => Promise<void>
+  jitterMs?: number
+  limit?: number
+  random?: () => number
+}
+
+/**
+ * Caps how many pooled remote dials for ONE connection id may be in flight.
+ *
+ * BackendDialClaims already coalesces concurrent dials of a single pool key;
+ * this is the orthogonal bound across the keys that share a host. A caller
+ * that finds a free slot runs immediately and pays nothing, so single-profile
+ * reconnect stays as fast as it was; only callers that would have exceeded the
+ * cap wait, and they are admitted one at a time with jitter as slots free.
+ */
+export class PooledRemoteDialGate {
+  readonly #delay: (ms: number) => Promise<void>
+  readonly #jitterMs: number
+  readonly #lanes = new Map<string, { active: number; queue: Array<() => void> }>()
+  readonly #limit: number
+  readonly #random: () => number
+
+  constructor({
+    delay = ms => new Promise<void>(resolve => setTimeout(resolve, ms)),
+    jitterMs = POOLED_REMOTE_DIAL_JITTER_MS,
+    limit = POOLED_REMOTE_DIAL_CONCURRENCY,
+    random = Math.random
+  }: PooledRemoteDialGateOptions = {}) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error('Pooled remote dial concurrency must be a positive integer.')
+    }
+
+    if (!Number.isFinite(jitterMs) || jitterMs < 0) {
+      throw new Error('Pooled remote dial jitter must be zero or positive.')
+    }
+
+    this.#delay = delay
+    this.#jitterMs = jitterMs
+    this.#limit = limit
+    this.#random = random
+  }
+
+  /** In-flight dials for this connection id (test/diagnostic seam). */
+  active(connectionId: string): number {
+    return this.#lanes.get(connectionId)?.active || 0
+  }
+
+  async run<T>(connectionId: string, dial: () => Promise<T> | T): Promise<T> {
+    let lane = this.#lanes.get(connectionId)
+
+    if (!lane) {
+      lane = { active: 0, queue: [] }
+      this.#lanes.set(connectionId, lane)
+    }
+
+    if (lane.active >= this.#limit) {
+      await new Promise<void>(resolve => {
+        lane.queue.push(resolve)
+      })
+    } else {
+      lane.active += 1
+    }
+
+    try {
+      return await dial()
+    } finally {
+      const next = lane.queue.shift()
+
+      if (next) {
+        // Hand the slot straight to the next waiter rather than releasing it:
+        // a released slot could be claimed by a fresh caller, letting the
+        // waiter's own admission push the lane past the cap.
+        void this.#delay(this.#random() * this.#jitterMs).then(next)
+      } else {
+        lane.active -= 1
+
+        if (lane.active === 0 && this.#lanes.get(connectionId) === lane) {
+          this.#lanes.delete(connectionId)
+        }
+      }
+    }
+  }
+}
+
+export interface DispatchHostEventPolicy {
+  /** Sleep out the host-event backoff before revalidating the descriptor. */
+  backoff: () => Promise<void>
+  /** Record this failure; true when the connection is inside a host event. */
+  classify: () => boolean
+  /** Cheap host-level liveness (`ssh -O check`); false skips to teardown. */
+  hostAlive: () => Promise<boolean>
+}
+
 interface EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection extends RemoteConnectionDescriptor> {
   connectionPromise: Promise<TConnection>
   currentConnectionPromise: () => null | Promise<TConnection>
+  hostEvent?: DispatchHostEventPolicy
+  log?: (message: string) => void
   probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   reconnect: () => Promise<TConnection>
   retire: (error: unknown) => Promise<void> | void
@@ -83,18 +274,29 @@ interface EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection extends
  * prevent a late probe from tearing down a replacement installed by another
  * caller. The caller should single-flight this function per cached promise so
  * concurrent dispatches share one retire/reconnect sequence.
+ *
+ * When a `hostEvent` policy is supplied and it classifies this failure as one
+ * of many across the connection, teardown is DEFERRED: back off, confirm the
+ * host is still reachable, and re-probe the same descriptor. A descriptor that
+ * answers is kept as-is — the host was busy, not dead — which is what stops a
+ * host hiccup from turning into N teardowns plus N reconnects. A descriptor
+ * that still fails falls through to the unchanged retire/reconnect path.
  */
 export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection extends RemoteConnectionDescriptor>({
   connectionPromise,
   currentConnectionPromise,
+  hostEvent,
+  log,
   probe,
   reconnect,
   retire
 }: EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection>): Promise<TConnection> {
   let connection: TConnection
+  let descriptorResolved = false
 
   try {
     connection = await connectionPromise
+    descriptorResolved = true
 
     if (currentConnectionPromise() !== connectionPromise) {
       return reconnect()
@@ -104,6 +306,25 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
   } catch (error) {
+    // A descriptor whose boot never resolved has nothing to revalidate, so the
+    // host-event path only applies once a probe of a real descriptor failed.
+    if (descriptorResolved && hostEvent && currentConnectionPromise() === connectionPromise && hostEvent.classify()) {
+      log?.(
+        `Pooled remote backend failed its dispatch probe during a host event; deferring teardown for ${HOST_EVENT_BACKOFF_MS}ms before revalidating.`
+      )
+      await hostEvent.backoff()
+
+      if (currentConnectionPromise() !== connectionPromise) {
+        return reconnect()
+      }
+
+      if (await pooledRemoteBackendSurvivedHostEvent(connection!, hostEvent, probe)) {
+        log?.('Pooled remote backend answered after the host-event backoff; keeping the descriptor.')
+
+        return connection!
+      }
+    }
+
     if (currentConnectionPromise() === connectionPromise) {
       await retire(error)
     }
@@ -116,6 +337,31 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
   }
 
   return connection
+}
+
+/**
+ * Second chance for one descriptor after the host-event backoff: the transport
+ * must be up AND the backend must answer. Either miss means this really is a
+ * dead backend, so the caller retires it exactly as before.
+ */
+async function pooledRemoteBackendSurvivedHostEvent<TConnection extends RemoteConnectionDescriptor>(
+  connection: TConnection,
+  hostEvent: DispatchHostEventPolicy,
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
+): Promise<boolean> {
+  try {
+    if (!(await hostEvent.hostAlive())) {
+      return false
+    }
+
+    await probe(connection, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -35,7 +35,23 @@ interface RemoteConnectionDescriptor {
   mode?: null | string
 }
 
+/**
+ * Last look before the primary connection is dropped.
+ *
+ * The pooled path can recognise a busy host because many profiles miss at
+ * once. The primary connection is alone on its gateway, so it has no siblings
+ * to vote with — its only evidence is its own streak, and on a saturated host
+ * that streak expires in a few seconds of quick probes. Dropping it is a
+ * visible whole-app reload, so it is worth one pause plus one recheck first.
+ */
+export interface RemoteDropConfirmation {
+  backoff: () => Promise<void>
+  /** Cheap transport-level check (SSH master liveness), when one applies. */
+  transportAlive?: () => Promise<boolean>
+}
+
 export interface RevalidateRemoteConnectionOptions<TConnection extends RemoteConnectionDescriptor> {
+  confirmDrop?: RemoteDropConfirmation
   connectionPromise: Promise<TConnection>
   currentConnectionPromise: () => null | Promise<TConnection>
   log: (message: string) => void
@@ -645,6 +661,7 @@ export function attachPowerResumeRemoteRevalidation({
  * old async result cannot mutate or reset a replacement connection.
  */
 export async function revalidateRemoteConnection<TConnection extends RemoteConnectionDescriptor>({
+  confirmDrop,
   connectionPromise,
   currentConnectionPromise,
   log,
@@ -696,9 +713,48 @@ export async function revalidateRemoteConnection<TConnection extends RemoteConne
       return { ok: true, rebuilt: false }
     }
 
+    if (confirmDrop) {
+      log(
+        `Cached remote Hermes backend hit its liveness failure limit; confirming with a transport check and one re-probe after ${HOST_EVENT_BACKOFF_MS}ms before dropping.`
+      )
+      await confirmDrop.backoff()
+
+      if (currentConnectionPromise() !== connectionPromise) {
+        return { ok: true, rebuilt: false }
+      }
+
+      if (await cachedRemoteConnectionSurvivedBackoff(connection, confirmDrop, probe)) {
+        // recordFailure already consumed the streak when it tripped the limit,
+        // so the kept connection restarts from a clean slate.
+        tracker.recordSuccess(baseUrl)
+        log('Cached remote Hermes backend answered after the confirmation backoff; keeping the connection.')
+
+        return { ok: true, rebuilt: false }
+      }
+    }
+
     log('Cached remote Hermes backend failed liveness probe; dropping stale connection.')
     resetConnection()
 
     return { ok: true, rebuilt: true }
+  }
+}
+
+/** Transport first (cheap), then one real re-probe. Either failure drops. */
+async function cachedRemoteConnectionSurvivedBackoff<TConnection extends RemoteConnectionDescriptor>(
+  connection: TConnection,
+  confirmDrop: RemoteDropConfirmation,
+  probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
+): Promise<boolean> {
+  try {
+    if (confirmDrop.transportAlive && !(await confirmDrop.transportAlive())) {
+      return false
+    }
+
+    await probe(connection, '/api/status', { timeoutMs: REMOTE_LIVENESS_TIMEOUT_MS })
+
+    return true
+  } catch {
+    return false
   }
 }

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -225,10 +225,35 @@ describe('refreshProfiles shared rail list (#49289)', () => {
     const rejection = expect(refresh).rejects.toThrow('backend unavailable')
     await vi.advanceTimersByTimeAsync(500)
     await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
     await rejection
 
-    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(3)
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(5)
     expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'test1'])
+  })
+
+  it('rides out an ECONNRESET burst that outlasts the first three attempts', async () => {
+    // A busy remote host resets every in-flight request for several seconds.
+    // The old 500ms + 1000ms schedule gave up 1.5s in and left the rail on a
+    // loading state until some later poll; the backoff must span the burst.
+    $profiles.set([])
+    vi.mocked(getProfiles)
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockRejectedValueOnce(new Error('ECONNRESET'))
+      .mockResolvedValueOnce({ profiles: [profile('default', true), profile('healthops')] })
+
+    const refresh = refreshProfiles()
+    await vi.advanceTimersByTimeAsync(500)
+    await vi.advanceTimersByTimeAsync(1000)
+    await vi.advanceTimersByTimeAsync(2000)
+    await vi.advanceTimersByTimeAsync(4000)
+    await expect(refresh).resolves.toHaveLength(2)
+
+    expect(vi.mocked(getProfiles)).toHaveBeenCalledTimes(5)
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'healthops'])
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -92,7 +92,13 @@ export function refreshProfiles(): Promise<ProfileInfo[]> {
 
   const flight = (async () => {
     const epoch = profileListEpoch
-    const MAX_RETRIES = 2
+    // A busy remote host resets in-flight requests for several seconds at a
+    // time. The old 500ms + 1000ms schedule gave up 1.5s in, which left the
+    // rail on a loading state until some later poll happened to succeed. Five
+    // attempts over ~7.5s outlast that burst while still failing fast enough
+    // to surface a genuinely dead backend.
+    const MAX_RETRIES = 4
+    const MAX_RETRY_DELAY_MS = 4000
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       try {
@@ -113,10 +119,12 @@ export function refreshProfiles(): Promise<ProfileInfo[]> {
           throw error
         }
 
-        // Back off before retrying: 500ms, then 1000ms. Gives the remote proxy
-        // a window to finish routing after WebSocket-ready but pre-HTTP-proxy
-        // states (global remote mode, #70679).
-        await new Promise(resolve => setTimeout(resolve, 500 * (attempt + 1)))
+        // Back off before retrying: 500ms, 1s, 2s, then 4s. The first two
+        // steps are unchanged — they give the remote proxy a window to finish
+        // routing after WebSocket-ready but pre-HTTP-proxy states (global
+        // remote mode, #70679) — and the capped doubling covers a host-event
+        // reset burst without letting one refresh hang on indefinitely.
+        await new Promise(resolve => setTimeout(resolve, Math.min(500 * 2 ** attempt, MAX_RETRY_DELAY_MS)))
       }
     }
 


### PR DESCRIPTION
## What does this PR do?

Stops a briefly-overloaded remote host from turning the desktop app into a wall of loading screens, three ways: probe-miss storms on the pooled per-profile connections, a whole-app reload from the primary connection's liveness loop, and the renderer's profile refresh giving up mid-burst.

**Problem (measured on a live 25-profile install, from `desktop.log`).** When the remote host is briefly busy, many pooled profiles fail their dispatch probes near-simultaneously — we measured **21 profiles' probes failing within 40 ms of each other**, all `read ECONNRESET`. The retire path treats each as an independently dead backend, so 21 concurrent teardowns (each killing its remote `serve --isolated` and closing its own SSH master) are followed by 21 concurrent reconnects: 21 SSH handshakes plus 21 remote Python backend boots landing at once on the host that was already too busy to answer a status probe. The recovery amplifies the load that caused the misses. Result: fleet-wide 30–40 s "loading" stalls — **230 such stampedes in one day** on this install. Widening the probe budget reduces but does not stop it: the *correlation* is the bug, not the sensitivity.

**The primary connection has the same problem and no siblings to vote with.** After deploying the pooled fix locally we observed zero pooled teardowns, but still: `Cached remote Hermes backend failed liveness probe (4/5); keeping connection` followed seconds later by `... dropping stale connection`, a full `[boot] Resolving Hermes backend`, and a remote dashboard respawn — a visible whole-app reload while the host's load average was only ~5. The primary backend's only evidence is its own streak, and on a saturated host that streak expires in seconds of quick probes.

**Renderer.** `refreshProfiles` retried 3 times over ~1.5 s and then gave up (`[profiles] refreshProfiles failed after 3 attempt(s): ECONNRESET`), leaving the rail on a loading state until a later poll happened to succeed.

**Root cause.** `ensureHealthyPooledRemoteBackendForDispatch` (`electron/remote-liveness.ts`) has exactly one failure policy — retire, then reconnect — and `ensureRegistryBackend`'s `retire` closure (`electron/main.ts`) executes `stopPoolBackend` → `sshBootstrapCoordinator.cancelAndWait` → `teardownSshConnection` per profile. `RemoteRevalidationCoordinator` collapses concurrent dispatches *for one cached promise*, and `BackendDialClaims` coalesces dials *for one pool key* — neither sees N distinct keys sharing one host. Nothing in the path asks "is this one dead backend, or one busy host?"

**Fix.**
1. `RemoteHostEventTracker` (new, `remote-liveness.ts`): classifies **distinct pool keys** failing on one connectionId inside a short window (3 within 2000 ms) as a host event. While one is active, a dispatch failure does not tear down: it backs off 5 s, confirms the transport with the existing cheap `ssh -O check` (`ssh.isAlive()`), and re-probes the same descriptor. A descriptor that answers is kept — no teardown at all (the common busy-host case). One that still fails takes the existing retire/reconnect path unchanged.
2. `PooledRemoteDialGate` (new): caps in-flight dials per connectionId at 3 with jitter between queued admissions, so a genuine teardown round can never land 20+ SSH handshakes at once.
3. `revalidateRemoteConnection` gains an optional `confirmDrop`: at the moment it would reset the primary connection, it pauses `HOST_EVENT_BACKOFF_MS`, confirms the SSH master with `ssh.isAlive()`, and re-probes once. A backend that answers is kept; one that still fails, or whose transport is gone, drops on the unchanged path.
4. `refreshProfiles` (renderer, `src/store/profile.ts`) now runs five attempts with capped doubling (500 ms, 1 s, 2 s, 4 s ≈ 7.5 s), spanning a reset burst. The first two steps are unchanged, so the existing #70679 recovery behavior is untouched. No change to the store's shape, single-flight guard, or epoch invalidation.

**What deliberately did not change:** probe timeouts (that's #97914's lane); quit-time teardown; the post-resume sweep's retire path; the #91668 remote-serve kill; genuinely-dead detection (a backend that still fails after the recheck drops exactly as before). A lone profile failing with no host event never reaches the new code — it retires and reconnects exactly as before, and a dial that finds a free gate slot is admitted with zero delay. The host-event threshold counts distinct profiles only, so one profile failing repeatedly is never misread as a host event.

**Field results after deploying this locally:** teardown storms went from ~10/hour to zero over the observation window, and the primary-path confirmation was observed doing both of its jobs in production logs — keeping connections that answer the re-probe, and still dropping one that genuinely failed during a cold boot.

## Related Issue

Fixes #83134

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/remote-liveness.ts` — `RemoteHostEventTracker`, `PooledRemoteDialGate`, `RemoteDropConfirmation`/`confirmDrop` on `revalidateRemoteConnection`, `cachedRemoteConnectionSurvivedBackoff()`; named constants (`HOST_EVENT_DISTINCT_PROFILE_THRESHOLD = 3`, `HOST_EVENT_WINDOW_MS = 2000`, `HOST_EVENT_BACKOFF_MS = 5000`, `POOLED_REMOTE_DIAL_CONCURRENCY = 3`, `POOLED_REMOTE_DIAL_JITTER_MS = 250`)
- `apps/desktop/electron/main.ts` — wires the tracker + gate into the pooled dispatch/retire path and `confirmDrop` into the primary revalidation call site; hoists SSH config resolution so queued dials use request-time settings
- `apps/desktop/src/store/profile.ts` — retry schedule extended to five attempts with capped exponential backoff
- `apps/desktop/electron/remote-liveness.test.ts` + `apps/desktop/src/store/profile.test.ts` — 18 new cases

## How to Test

1. `cd apps/desktop && npx vitest run electron/remote-liveness.test.ts src/store/profile.test.ts` — 56 tests pass. All 18 new cases fail without the source change (verified: 13 failed on the pooled/host-event commit's base, 5 on the primary/renderer commit's base).
2. Reproduction of the original bug: on a Mac desktop connected to one SSH remote host running many profiles, saturate the remote host (heavy build or CPU load). Unfixed: `desktop.log` shows several profiles fail dispatch probes within milliseconds, then a fleet of `control master closed` + reconnects, and every pane flips to loading. Fixed: `... failed its dispatch probe` is followed by the host-event log line, a 5 s pause, and kept connections; any real teardowns reconnect at most 3 at a time.
3. Primary path: with the same load, watch for `Cached remote Hermes backend hit its liveness failure limit; confirming with a transport check and re-probe` — the connection is kept if the re-probe answers, dropped if not.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — nearest neighbors, all adjacent-but-different: #97914 (cheapens the probe itself — orthogonal; this PR handles a host that genuinely cannot answer in time), #94699 (introduced this path and its per-key coordinator), #97264/#97392 (defer teardown on bootstrap lease generation, not host health), #99178 (reconnect backoff on the gateway-WS/local path), #94642/#94665 (measured busy-host overload; resolved by raising timeouts), #94381/#94416 (argue retirement fires too *rarely* — that concerns a dead host lingering in the background; this defers only a dispatch-time teardown, by at most one 5 s backoff, and only while several profiles on the same host are failing together)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — honest annotation: this PR touches no Python files (TypeScript-only, `apps/desktop`), and on my machine the Python suite terminates mid-run on environment-dependent tests, so I'm relying on CI for that signal. What I ran fully for the code this PR changes: `npx vitest run` electron project (no new failures vs clean main: 1975 passed vs baseline 1958, the +17 are this PR's tests; the same 4 environment-dependent files fail identically on clean main), full renderer store suite (1357 passed), `tsc --noEmit` on all three tsconfigs, `eslint` + `prettier --check` clean on changed files
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), live against a 25-profile SSH remote fleet

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A beyond in-code docs: the new module-level doc comments on the tracker/gate document the behavior
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the host-event and confirm-drop paths are transport-agnostic; `transportAlive` returns `true` for non-SSH remotes so they fall through to the re-probe alone; Windows no-mux connections keep their existing lifecycle
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
