### PR TITLE
fix(docker): keep configured env when non-terminal tools start containers

### DIFF
--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -18,35 +18,6 @@ def test_terminal_env_config_reads_docker_network_toggle(monkeypatch):
     assert config["docker_network"] is False
 
 
-def test_sibling_container_config_sites_carry_docker_network():
-    """Every container_config dict that carries docker_run_as_host_user must
-    also carry docker_network — otherwise that code path silently falls back
-    to networked containers while the terminal path honors the lockdown
-    (the probe/exec asymmetry reported on issue #46358).
-    """
-    import ast
-    import inspect
-
-    import tools.code_execution_tool as code_execution_tool
-    import tools.file_tools as file_tools
-
-    for module in (terminal_tool, file_tools, code_execution_tool):
-        tree = ast.parse(inspect.getsource(module))
-        sites = 0
-        for node in ast.walk(tree):
-            if not isinstance(node, ast.Dict):
-                continue
-            keys = {k.value for k in node.keys if isinstance(k, ast.Constant)}
-            if "docker_run_as_host_user" in keys:
-                sites += 1
-                assert "docker_network" in keys, (
-                    f"{module.__name__} builds a container_config with "
-                    f"docker_run_as_host_user but without docker_network "
-                    f"(line {node.lineno})"
-                )
-        assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
-
-
 def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
     """Drive DockerEnvironment through the cross-process reuse path with a
     fake existing container whose NetworkMode is *existing_mode*.

--- a/tests/tools/test_file_tools_container_config.py
+++ b/tests/tools/test_file_tools_container_config.py
@@ -1,7 +1,10 @@
-"""Tests for docker container_config key propagation in file_tools."""
+"""Tests for container config propagation outside terminal commands."""
 
 from unittest.mock import patch, MagicMock
+
+import tools.code_execution_tool as code_execution_tool
 import tools.file_tools as file_tools
+import tools.terminal_tool as terminal_tool
 
 
 def _make_env_config(**overrides):
@@ -21,6 +24,8 @@ def _make_env_config(**overrides):
         "docker_volumes": [],
         "docker_mount_cwd_to_workspace": True,
         "docker_forward_env": ["MY_SECRET", "API_KEY"],
+        "docker_env": {"JAVA_HOME": "/opt/jdk", "GITHUB_ACTOR": "hermes"},
+        "docker_network": False,
     }
     base.update(overrides)
     return base
@@ -54,6 +59,14 @@ class TestFileToolsContainerConfig:
         cc = self._run(_make_env_config(docker_mount_cwd_to_workspace=True), "t1").get("container_config", {})
         assert cc.get("docker_mount_cwd_to_workspace") is True
 
+    def test_container_config_matches_terminal_creation_path(self):
+        """File-first container creation preserves every terminal setting."""
+        config = _make_env_config()
+
+        captured = self._run(config, "docker-env")
+
+        assert captured["container_config"] == terminal_tool._container_config_from_config(config)
+
 
     def test_cwd_only_raw_task_override_reaches_file_environment(self):
         """CWD-only task overrides collapse to default but must keep their cwd."""
@@ -65,3 +78,25 @@ class TestFileToolsContainerConfig:
 
         assert captured["task_id"] == "default"
         assert captured["cwd"] == "/workspace/session"
+
+
+def test_code_execution_container_config_matches_terminal_creation_path():
+    """Execute-code-first creation preserves every terminal setting."""
+    config = _make_env_config()
+    captured = {}
+    mock_env = MagicMock()
+
+    def fake_create_env(**kwargs):
+        captured.update(kwargs)
+        return mock_env
+
+    with patch("tools.terminal_tool._get_env_config", return_value=config), \
+         patch("tools.terminal_tool._task_env_overrides", {}), \
+         patch("tools.terminal_tool._active_environments", {}), \
+         patch("tools.terminal_tool._creation_locks", {}), \
+         patch("tools.terminal_tool._creation_locks_lock", __import__("threading").Lock()), \
+         patch("tools.terminal_tool._create_environment", side_effect=fake_create_env), \
+         patch("tools.terminal_tool._start_cleanup_thread"):
+        code_execution_tool._get_or_create_env("execute-code-env")
+
+    assert captured["container_config"] == terminal_tool._container_config_from_config(config)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -873,6 +873,7 @@ def _get_or_create_env(task_id: str):
         _active_environments, _env_lock, _create_environment,
         _get_env_config, _last_activity, _start_cleanup_thread,
         _creation_locks, _creation_locks_lock, _task_env_overrides,
+        _container_config_from_config, _is_container_backend,
         _resolve_container_task_id, _resolve_task_host_cwd,
     )
 
@@ -914,19 +915,8 @@ def _get_or_create_env(task_id: str):
         cwd = overrides.get("cwd") or config["cwd"]
 
         container_config = None
-        from tools.terminal_tool import _is_container_backend as _is_container
-
-        if _is_container(env_type):
-            container_config = {
-                "container_cpu": config.get("container_cpu", 1),
-                "container_memory": config.get("container_memory", 5120),
-                "container_disk": config.get("container_disk", 51200),
-                "container_persistent": config.get("container_persistent", True),
-                "vercel_runtime": config.get("vercel_runtime", ""),
-                "docker_volumes": config.get("docker_volumes", []),
-                "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                "docker_network": config.get("docker_network", True),
-            }
+        if _is_container_backend(env_type):
+            container_config = _container_config_from_config(config)
 
         ssh_config = None
         if env_type == "ssh":

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1416,6 +1416,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
         _resolve_container_task_id,
         _resolve_task_host_cwd,
         _is_unusable_container_cwd,
+        _container_config_from_config,
+        _is_container_backend,
         _CONTAINER_BACKENDS,
     )
     import time
@@ -1521,21 +1523,8 @@ def _get_file_ops(task_id: str = "default") -> ShellFileOperations:
             logger.info("Creating new %s environment for task %s...", env_type, task_id[:8])
 
             container_config = None
-            from tools.terminal_tool import _is_container_backend as _is_container
-
-            if _is_container(env_type):
-                container_config = {
-                    "container_cpu": config.get("container_cpu", 1),
-                    "container_memory": config.get("container_memory", 5120),
-                    "container_disk": config.get("container_disk", 51200),
-                    "container_persistent": config.get("container_persistent", True),
-                    "vercel_runtime": config.get("vercel_runtime", ""),
-                    "docker_volumes": config.get("docker_volumes", []),
-                    "docker_mount_cwd_to_workspace": config.get("docker_mount_cwd_to_workspace", False),
-                    "docker_forward_env": config.get("docker_forward_env", []),
-                    "docker_run_as_host_user": config.get("docker_run_as_host_user", False),
-                    "docker_network": config.get("docker_network", True),
-                }
+            if _is_container_backend(env_type):
+                container_config = _container_config_from_config(config)
 
             ssh_config = None
             if env_type == "ssh":


### PR DESCRIPTION
## What does this PR do?

Docker users who invoke a file tool or `execute_code` before the terminal now get the same configured container environment as terminal-first sessions. Previously, those creation paths silently dropped `terminal.docker_env`, which could break CLI authentication, package access, and JDK selection for the lifetime of the reused container.

### Symptom

When a non-terminal tool creates the Docker container first, configured variables such as `JAVA_HOME`, `GITHUB_ACTOR`, and `CLAUDE_CONFIG_DIR` are absent from the container and remain absent from later commands.

### Impact

Affected Docker sessions can report missing authentication, fail GitHub Packages access, or select the wrong JDK even though `terminal.docker_env` is configured correctly.

### Bug Cause

**Trigger:** `tools/file_tools.py:_get_file_ops` and `tools/code_execution_tool.py:_get_or_create_env` when either path creates a container before a terminal command.

**Causal chain:**
1. A file tool or `execute_code` requests the session environment before the terminal tool does.
2. That path builds a partial `container_config` dictionary which omits `docker_env` and other terminal container settings.
3. `_create_environment` receives an empty explicit environment and creates a reusable container without the configured variables.

**Why it is wrong:** Container behavior depends on which tool happens to create the shared environment first, despite all paths reading the same terminal configuration.

**Working sibling / contrast:** Terminal commands and lazy terminal bring-up already use `_container_config_from_config`, which includes `docker_env` and the complete container setting set.

**Ruled out:** `DockerEnvironment` itself already normalizes and applies explicit environment values at container creation. The values are lost before that layer receives them.

### Fix

Use the terminal tool's shared `_container_config_from_config` builder from both non-terminal creation paths. Behavioral regression tests now assert that file-tool-first and execute-code-first creation pass exactly the same container configuration as terminal creation, including explicit environment values and the network toggle.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` - reuse the canonical container configuration builder.
- `tools/code_execution_tool.py` - reuse the same builder for execute-code-first containers.
- `tests/tools/test_file_tools_container_config.py` - verify both non-terminal paths preserve the complete terminal container configuration.
- `tests/tools/test_docker_network_config.py` - remove the source-shape assertion superseded by executable behavior coverage.

## How to Test

1. Configure `terminal.docker_env` with a test value and start a session using the Docker backend.
2. Invoke `read_file` or `execute_code` before the first terminal command.
3. Confirm the created container contains the configured value, then run:

```bash
scripts/run_tests.sh tests/tools/test_file_tools_container_config.py tests/tools/test_docker_network_config.py -q
```

Local result: 8 passed on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all relevant tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by executable regression tests.
