### PR TITLE
fix(process-registry): pass the resolved cwd to env.execute in spawn_via_env

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -773,6 +773,52 @@ class TestSpawnEnvSanitization:
         # A failed launch must not be exposed as a running/tracked session.
         assert session.id not in registry._running
 
+    def test_spawn_via_env_passes_cwd_to_env_execute(self, registry):
+        """The resolved cwd must reach env.execute (#100020).
+
+        It used to be stored on the session record but never handed to the
+        execution call, so background commands ran in the sandbox's default
+        cwd and anything relative to the requested workdir failed."""
+        class FakeEnv:
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, command, **kwargs):
+                self.calls.append(kwargs)
+                return {"output": "123\n", "returncode": 0}
+
+        env = FakeEnv()
+
+        with patch("tools.process_registry.threading.Thread"), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(
+                env, "./gradlew test", cwd="/abs/worktree", timeout=30
+            )
+
+        assert session.pid == 123
+        assert env.calls and env.calls[0].get("cwd") == "/abs/worktree"
+        assert env.calls[0].get("timeout") == 30
+        assert env.calls[0].get("rewrite_compound_background") is False
+
+    def test_spawn_via_env_without_cwd_keeps_default_execution_dir(self, registry):
+        """No requested cwd still executes with the env's own default."""
+        class FakeEnv:
+            def __init__(self):
+                self.calls = []
+
+            def execute(self, command, **kwargs):
+                self.calls.append(kwargs)
+                return {"output": "456\n", "returncode": 0}
+
+        env = FakeEnv()
+
+        with patch("tools.process_registry.threading.Thread"), \
+            patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_via_env(env, "echo hello")
+
+        assert session.pid == 456
+        assert env.calls and env.calls[0].get("cwd") == ""
+
     def test_env_poller_quotes_temp_paths_with_spaces(self, registry):
         session = _make_session(sid="proc_space")
         session.exited = False

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1335,6 +1335,7 @@ class ProcessRegistry:
         try:
             result = env.execute(
                 bg_command,
+                cwd=cwd or "",
                 timeout=timeout,
                 rewrite_compound_background=False,
             )


### PR DESCRIPTION
## What does this PR do?

`terminal(background=true, workdir=...)` resolved the cwd correctly and `spawn_via_env` even stored it on the session record — but the launch call dropped it: `env.execute(bg_command, ...)` was invoked without a `cwd`, so the background wrapper ran in the sandbox's default directory and anything relative to the requested workdir failed with a misleading `bash: ./gradlew: No such file or directory`. The same command with `background=false` worked, because the foreground path does hand the cwd to `env.execute`.

This PR forwards the resolved `cwd` to `env.execute` inside `spawn_via_env` (`cwd or ""`), so background commands run in the requested workdir. `base.execute` resolves an empty cwd to the environment's own default, so callers without a workdir keep today's behaviour unchanged.

## Related Issue

Fixes #100020

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/process_registry.py`: `spawn_via_env` now passes the resolved `cwd` to the launch `env.execute` call (empty string keeps the environment default).
- `tests/tools/test_process_registry.py`: added `test_spawn_via_env_passes_cwd_to_env_execute` (the resolved cwd, timeout, and `rewrite_compound_background=False` all reach `env.execute`) and `test_spawn_via_env_without_cwd_keeps_default_execution_dir` (no cwd → empty string → env's own default).

## How to Test

1. `python -m pytest tests/tools/test_process_registry.py -q`
   - Observed result: 93 passed, 5 skipped (the 2 new tests fail with the fix stashed, pass with it applied — red→green verified).
2. `python -m pytest tests/tools/test_terminal_task_cwd.py tests/tools/test_terminal_none_command_guard.py -q`
   - Observed result: 9 passed (the terminal-side resolution chain that feeds `spawn_via_env` is unaffected).
3. `python -m ruff check tools/process_registry.py tests/tools/test_process_registry.py`
   - Observed result: All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
