### PR TITLE
fix(gateway): keep multiplex handoffs responsive during slow secret reads

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2419,7 +2419,10 @@ def _current_max_iterations() -> int:
     return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
 
 
-from contextlib import contextmanager as _contextmanager
+from contextlib import (
+    asynccontextmanager as _asynccontextmanager,
+    contextmanager as _contextmanager,
+)
 
 
 # Platforms that bind a host TCP port (HTTP/webhook listeners). In a profile
@@ -2542,8 +2545,24 @@ async def _reclaim_stale(runner: object) -> None:
         )
 
 
+def _load_profile_secret_scope(profile_home: "Path") -> dict:
+    """Hydrate and load one profile's secrets under its home override."""
+    from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+    from agent.secret_scope import build_profile_secret_scope
+    from hermes_cli.env_loader import hydrate_profile_secret_sources
+
+    home_token = set_hermes_home_override(str(profile_home))
+    try:
+        hydrate_profile_secret_sources(Path(profile_home))
+        return build_profile_secret_scope(Path(profile_home))
+    finally:
+        reset_hermes_home_override(home_token)
+
+
 @_contextmanager
-def _profile_runtime_scope(profile_home: "Path"):
+def _profile_runtime_scope(
+    profile_home: "Path", prepared_secret_scope: Optional[dict] = None,
+):
     """Scope config/skills/memory AND credentials to a profile for one turn.
 
     Combines the two seams the multiplexer needs:
@@ -2563,20 +2582,30 @@ def _profile_runtime_scope(profile_home: "Path"):
     """
     from hermes_constants import set_hermes_home_override, reset_hermes_home_override
     from agent.secret_scope import (
-        build_profile_secret_scope,
         set_secret_scope,
         reset_secret_scope,
     )
-    from hermes_cli.env_loader import hydrate_profile_secret_sources
 
     home_token = set_hermes_home_override(str(profile_home))
-    hydrate_profile_secret_sources(Path(profile_home))
-    secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
+    secrets = (
+        prepared_secret_scope
+        if prepared_secret_scope is not None
+        else _load_profile_secret_scope(Path(profile_home))
+    )
+    secret_token = set_secret_scope(secrets)
     try:
         yield
     finally:
         reset_secret_scope(secret_token)
         reset_hermes_home_override(home_token)
+
+
+@_asynccontextmanager
+async def _async_profile_runtime_scope(profile_home: "Path"):
+    """Enter a profile scope without loading secret files on the event loop."""
+    secrets = await asyncio.to_thread(_load_profile_secret_scope, Path(profile_home))
+    with _profile_runtime_scope(Path(profile_home), secrets):
+        yield
 
 
 def load_gateway_config_for_runner() -> "GatewayConfig":
@@ -14720,7 +14749,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _phome is None:
                     await _reclaim_stale(self)
                 else:
-                    with _profile_runtime_scope(_phome):
+                    async with _async_profile_runtime_scope(_phome):
                         await _reclaim_stale(self)
             except Exception:
                 logger.debug("Stale-handoff reclaim failed", exc_info=True)
@@ -14732,7 +14761,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         if profile_home is None:
                             await _tick(profile_name)
                         else:
-                            with _profile_runtime_scope(profile_home):
+                            async with _async_profile_runtime_scope(profile_home):
                                 await _tick(profile_name)
                 except asyncio.CancelledError:
                     raise

--- a/tests/gateway/test_handoff_watcher_multiprofile.py
+++ b/tests/gateway/test_handoff_watcher_multiprofile.py
@@ -15,6 +15,7 @@ These tests pin the two halves of the fix:
 """
 
 import asyncio
+import threading
 import types
 from pathlib import Path
 
@@ -111,14 +112,14 @@ async def test_watcher_enters_profile_scope_for_each_home(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             entered.append(self.home)
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _SpyScope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _SpyScope)
 
     async def _no_sleep(_seconds):
         return None
@@ -160,6 +161,108 @@ async def test_watcher_enters_profile_scope_for_each_home(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_slow_profile_secret_load_does_not_block_event_loop(monkeypatch, tmp_path):
+    """A slow profile ``.env`` read must not stall unrelated loop work."""
+    profile_home = tmp_path / "profiles" / "slow"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(
+        run,
+        "_handoff_watch_scopes",
+        lambda _runner: [(None, None), ("slow", profile_home)],
+    )
+
+    from agent import secret_scope
+
+    load_started = threading.Event()
+    ticker_progressed = threading.Event()
+    ticker_progressed_while_loading = []
+
+    def _slow_build(_home):
+        load_started.set()
+        ticker_progressed_while_loading.append(
+            ticker_progressed.wait(timeout=2)
+        )
+        return {}
+
+    monkeypatch.setattr(secret_scope, "build_profile_secret_scope", _slow_build)
+
+    class _DB:
+        async def list_pending_handoffs(self):
+            return []
+
+    fake = types.SimpleNamespace(
+        _session_db=_DB(),
+        _running=False,
+    )
+
+    async def _process_handoff(_row, _profile_name=None):
+        return None
+
+    fake._process_handoff = _process_handoff
+
+    real_sleep = asyncio.sleep
+
+    async def _skip_initial_delay(seconds):
+        await real_sleep(0 if seconds == 5 else seconds)
+
+    monkeypatch.setattr(run.asyncio, "sleep", _skip_initial_delay)
+    async def _ticker():
+        assert await asyncio.to_thread(load_started.wait, 5)
+        ticker_progressed.set()
+
+    watcher = asyncio.create_task(
+        run.GatewayRunner._handoff_watcher(fake, interval=0.0)
+    )
+    ticker = asyncio.create_task(_ticker())
+    await asyncio.wait_for(asyncio.gather(watcher, ticker), timeout=5)
+
+    assert ticker_progressed_while_loading == [True], (
+        "profile secret loading blocked the asyncio event loop until the "
+        "filesystem operation completed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_async_profile_scope_propagates_context_to_dispatch_task(
+    monkeypatch, tmp_path,
+):
+    """Off-loop loading must not move the installed ContextVars off-task."""
+    from agent import secret_scope
+    from hermes_constants import get_hermes_home
+
+    profile_home = tmp_path / "profiles" / "scoped"
+    secrets = {"PROFILE_TOKEN": "scoped-value"}
+    load_threads = []
+    loop_thread = threading.get_ident()
+
+    def _load(_home):
+        load_threads.append(threading.get_ident())
+        return secrets
+
+    monkeypatch.setattr(run, "_load_profile_secret_scope", _load)
+    original_scope = secret_scope.current_secret_scope()
+    original_home = get_hermes_home()
+    inherited = []
+
+    async def _capture_context():
+        inherited.append(
+            (secret_scope.current_secret_scope(), get_hermes_home())
+        )
+
+    async with run._async_profile_runtime_scope(profile_home):
+        assert secret_scope.current_secret_scope() is secrets
+        assert get_hermes_home() == profile_home
+        dispatch = asyncio.create_task(_capture_context())
+
+    await dispatch
+
+    assert load_threads and all(thread != loop_thread for thread in load_threads)
+    assert inherited == [(secrets, profile_home)]
+    assert secret_scope.current_secret_scope() is original_scope
+    assert get_hermes_home() == original_home
+
+
+@pytest.mark.asyncio
 async def test_each_scope_resolves_its_own_store_and_profile(monkeypatch):
     """The whole point: a DIFFERENT ``state.db`` per scope, and the profile
     name reaches ``_process_handoff`` so delivery uses that profile's adapter.
@@ -183,15 +286,15 @@ async def test_each_scope_resolves_its_own_store_and_profile(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             active["home"] = self.home
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             active["home"] = None
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _SpyScope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _SpyScope)
 
     async def _no_sleep(_seconds):
         return None

--- a/tests/gateway/test_handoff_watcher_resilience.py
+++ b/tests/gateway/test_handoff_watcher_resilience.py
@@ -219,13 +219,13 @@ async def test_reclaim_runs_per_profile_store(monkeypatch):
         def __init__(self, home):
             self.home = home
 
-        def __enter__(self):
+        async def __aenter__(self):
             return self
 
-        def __exit__(self, *exc):
+        async def __aexit__(self, *exc):
             return False
 
-    monkeypatch.setattr(run, "_profile_runtime_scope", _Scope)
+    monkeypatch.setattr(run, "_async_profile_runtime_scope", _Scope)
 
     async def _no_sleep(_seconds):
         return None


### PR DESCRIPTION
## What does this PR do?

Multiplex gateways no longer freeze every hosted profile while the handoff watcher loads a secondary profile's secret files. Secret hydration and `.env` loading now run in a worker thread, while the profile home and secret ContextVars are still installed in the watcher task so handoff dispatch keeps the correct profile identity.

### Symptom

On a slow filesystem, `_handoff_watcher` can stop the shared asyncio event loop while entering a secondary profile runtime scope. The loop can then miss watchdog liveness probes and terminate the gateway with exit code 75.

### Impact

One slow profile secret read can interrupt all profiles and messaging sessions hosted by the multiplex gateway. The reported environment is Android/Termux with Ubuntu PRoot, where filesystem metadata and reads can be especially slow.

### Bug Cause

**Trigger:** `gateway/run.py:14749` and `gateway/run.py:14761` / `_handoff_watcher` enters a secondary profile runtime scope.

**Causal chain:**
1. The handoff watcher iterates secondary profile stores on the shared asyncio loop.
2. Synchronous profile scope setup hydrates secret sources and reads `.env` on that loop.
3. Slow filesystem I/O prevents unrelated liveness work from running, so the watchdog can terminate the whole multiplex gateway.

**Why it is wrong:** Profile secret hydration is blocking filesystem work and must not run on the long-lived gateway event loop.

**Working sibling / contrast:** SessionDB operations in the same watcher already use the asynchronous facade and execute their blocking I/O off-loop.

**Ruled out:** Raising the watchdog timeout does not remove the blocking call. The captured main-thread stack directly identifies profile secret loading rather than an ordinary Python exception or a worker-thread-only stall.

### Fix

- Add an asynchronous profile runtime scope that prepares secret material with `asyncio.to_thread()`.
- Install the prepared secret mapping and profile home ContextVars in the watcher task, preserving their inheritance by fire-and-forget dispatch tasks.
- Use the asynchronous scope for both startup reclaim and polling of secondary profile stores.
- Add regression coverage proving a controlled slow secret load does not block an independent loop task and that dispatch tasks inherit the correct profile context.

## Related Issue

Closes #100014

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - prepare handoff watcher profile secrets off-loop while preserving scoped ContextVars.
- `tests/gateway/test_handoff_watcher_multiprofile.py` - cover loop responsiveness and dispatch context inheritance.
- `tests/gateway/test_handoff_watcher_resilience.py` - exercise reclaim through the asynchronous profile scope.

## How to Test

1. Run the handoff watcher, multiplex profile, adapter startup, and secret scope regression suites.
2. Confirm the controlled slow secret loader observes an independent asyncio task progressing before the load completes.
3. Confirm all related tests pass:

```bash
scripts/run_tests.sh tests/gateway/test_handoff_watcher_multiprofile.py tests/gateway/test_handoff_watcher_resilience.py tests/gateway/test_handoff_watcher_async_db.py tests/gateway/test_handoff_secondary_profile_adapter.py tests/gateway/test_64674_multiplex_primary_token_scope.py tests/gateway/test_adapter_startup_secret_scope.py tests/gateway/test_multiplex_session_db_profile_scope.py tests/agent/test_secret_scope.py -q
```

Result: 145 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A, no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated timing and context propagation tests cover the regression.
