### PR TITLE
fix(terminal): allow detached docker compose up

### DIFF
--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -79,3 +79,16 @@ class TestBackgroundGuidanceRecipes:
 
     def test_quoted_ampersand_not_flagged(self):
         assert _foreground_background_guidance('git commit -m "a & b"') is None
+
+    def test_attached_docker_compose_up_is_blocked(self):
+        msg = _foreground_background_guidance("docker compose up nextcloud-app")
+        assert msg is not None
+        assert "long-lived server/watch process" in msg
+
+    @pytest.mark.parametrize("detach_flag", ["-d", "--detach"])
+    def test_detached_docker_compose_up_is_allowed(self, detach_flag):
+        command = (
+            f"docker compose up {detach_flag} --no-deps "
+            "--force-recreate nextcloud-app"
+        )
+        assert _foreground_background_guidance(command) is None

--- a/tests/tools/test_blocked_command_guidance.py
+++ b/tests/tools/test_blocked_command_guidance.py
@@ -20,7 +20,7 @@ class TestParserLimitRecovery:
         from pathlib import Path
         saved = Path(m.group(1))
         assert saved.exists()
-        body = saved.read_text()
+        body = saved.read_text(encoding="utf-8")
         assert cmd in body
         assert body.startswith("#!/bin/bash")
         assert f"bash {saved}" in r["message"]
@@ -55,7 +55,7 @@ class TestParserLimitRecovery:
         d = tmp_path / ".hermes" / "cache" / "blocked-scripts"
         d.mkdir(parents=True)
         stale = d / "blocked-1-dead.sh"
-        stale.write_text("old")
+        stale.write_text("old", encoding="utf-8")
         os.utime(stale, (1, 1))
         _hardline_block_result(_PARSER_LIMIT_DESCRIPTION, "python3 -c 'y'")
         assert not stale.exists()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2689,7 +2689,6 @@ def _strip_quotes(command: str) -> str:
 
 _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\b(?:npm|pnpm|yarn|bun)\s+(?:run\s+)?(?:dev|start|serve|watch)\b", re.IGNORECASE),
-    re.compile(r"\bdocker\s+compose\s+up\b", re.IGNORECASE),
     re.compile(r"\bnext\s+dev\b", re.IGNORECASE),
     re.compile(r"\bvite(?:\s|$)", re.IGNORECASE),
     re.compile(r"\bnodemon\b", re.IGNORECASE),
@@ -2697,6 +2696,19 @@ _LONG_LIVED_FOREGROUND_PATTERNS = (
     re.compile(r"\bgunicorn\b", re.IGNORECASE),
     re.compile(r"\bpython(?:3)?\s+-m\s+http\.server\b", re.IGNORECASE),
 )
+
+_DOCKER_COMPOSE_UP_RE = re.compile(r"\bdocker\s+compose\s+up\b", re.IGNORECASE)
+_DOCKER_COMPOSE_DETACH_RE = re.compile(r"(?:^|\s)(?:-d|--detach)(?=\s|$)", re.IGNORECASE)
+_SHELL_COMMAND_SEPARATOR_RE = re.compile(r"&&|\|\||[;|\n]")
+
+
+def _has_attached_docker_compose_up(command: str) -> bool:
+    """Return True when any Compose up invocation runs in attached mode."""
+    for match in _DOCKER_COMPOSE_UP_RE.finditer(command):
+        trailing_segment = _SHELL_COMMAND_SEPARATOR_RE.split(command[match.end() :], maxsplit=1)[0]
+        if _DOCKER_COMPOSE_DETACH_RE.search(trailing_segment) is None:
+            return True
+    return False
 
 
 def _looks_like_help_or_version_command(command: str) -> bool:
@@ -2736,6 +2748,13 @@ def _foreground_background_guidance(command: str) -> str | None:
             "Foreground command uses '&' backgrounding. Re-send WITHOUT the '&' as "
             "terminal(command=\"<cmd>\", background=true) — add notify_on_complete=true "
             "for bounded jobs — then run health checks and tests in follow-up terminal calls."
+        )
+
+    if _has_attached_docker_compose_up(unquoted):
+        return (
+            "This foreground command appears to start a long-lived server/watch process. "
+            "Run it with background=true, verify readiness (health endpoint/log signal), "
+            "then execute tests in a separate command."
         )
 
     for pattern in _LONG_LIVED_FOREGROUND_PATTERNS:


### PR DESCRIPTION
## What does this PR do?

Allows bounded `docker compose up -d` and `docker compose up --detach` invocations to run through the terminal tool in foreground mode. Attached `docker compose up` remains guarded as a long-lived process.

The classifier now evaluates each matching Compose command segment independently, so a detached invocation cannot hide a later attached invocation behind a shell separator.

## Related Issue

Fixes #42620

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/terminal_tool.py`: distinguish attached and detached Compose `up` invocations within individual shell command segments.
- `tests/tools/test_blocked_command_guidance.py`: preserve the attached-mode positive control, cover both detach flag spellings, and satisfy the changed-file Windows encoding gate.

## How to Test

1. Run `python -m pytest -q tests/tools/test_blocked_command_guidance.py tests/tools/test_terminal_heredoc_background_guard.py`.
2. Confirm all 43 tests pass.
3. Run `python -m ruff check tools/terminal_tool.py tests/tools/test_blocked_command_guidance.py` and confirm it passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behaviour is covered by focused tests and helper docstring
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — pure command-string classification, no platform-specific APIs
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; schema remains accurate

## Screenshots / Logs

```text
43 passed in 5.79s
All checks passed!
No Windows footguns found (2 files scanned).
```
