### PR TITLE
fix(desktop): scope handoff config to session profile

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14825,6 +14825,73 @@ def test_session_most_recent_honors_params_profile(monkeypatch, tmp_path):
     assert resp["result"]["session_id"] == "ml-tip"
 
 
+def test_handoff_request_uses_session_profile_home(monkeypatch, tmp_path):
+    """Handoff validation must read the owning session's gateway config."""
+    import contextlib
+
+    from gateway.config import GatewayConfig, HomeChannel, Platform, PlatformConfig
+    from hermes_cli.config import get_hermes_home
+    from tui_gateway import methods_session
+
+    methods_session.register(server)
+    profile_home = tmp_path / "profiles" / "coder"
+    profile_home.mkdir(parents=True)
+    seen_homes = []
+
+    def load_config():
+        home = get_hermes_home()
+        seen_homes.append(home)
+        config = GatewayConfig()
+        if home == profile_home:
+            config.platforms[Platform.DISCORD] = PlatformConfig(
+                enabled=True,
+                home_channel=HomeChannel(
+                    platform=Platform.DISCORD,
+                    chat_id="discord-home",
+                    name="Hermes / #chat-coding",
+                ),
+            )
+        return config
+
+    class ProfileDB:
+        def get_session(self, _key):
+            return {"id": _key}
+
+        def request_handoff(self, _key, platform):
+            return platform == "discord"
+
+    @contextlib.contextmanager
+    def profile_db(_session):
+        yield ProfileDB()
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", load_config)
+    monkeypatch.setattr(server, "_ensure_session_db_row", lambda _session: None)
+    monkeypatch.setattr(server, "_session_db", profile_db)
+    server._sessions["handoff-profile"] = {
+        "running": False,
+        "session_key": "desktop-coder-session",
+        "profile_home": str(profile_home),
+    }
+    try:
+        resp = server.handle_request(
+            {
+                "id": "1",
+                "method": "handoff.request",
+                "params": {
+                    "session_id": "handoff-profile",
+                    "platform": "discord",
+                },
+            }
+        )
+    finally:
+        server._sessions.pop("handoff-profile", None)
+
+    assert "result" in resp, resp
+    assert resp["result"]["queued"] is True
+    assert seen_homes == [profile_home]
+    assert get_hermes_home() != profile_home
+
+
 def test_session_create_reports_requested_profile_name(monkeypatch, tmp_path):
     """Issue #62503: session.create info.profile_name must not always be launch."""
     profile_home = tmp_path / "profiles" / "mlperf"

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1613,7 +1613,8 @@ def _(rid, params: dict) -> dict:
     except (ValueError, KeyError):
         return _err(rid, 4024, f"unknown platform '{platform_name}'")
     try:
-        gw_config = load_gateway_config()
+        with _session_profile_runtime_scope(session):  # pyright: ignore[reportUndefinedVariable]
+            gw_config = load_gateway_config()
     except Exception as e:
         return _err(rid, 5021, f"could not load gateway config: {e}")
     pcfg = gw_config.platforms.get(platform)


### PR DESCRIPTION
## Summary

- scope Desktop `handoff.request` gateway-config validation to the owning runtime session's profile
- avoid trusting or requiring a duplicated client-supplied profile parameter
- add a regression test for an app-global dashboard launched under the default profile while handing off a non-default profile session

## Problem

In app-global Desktop mode, one dashboard process can serve sessions from multiple Hermes profiles. `handoff.request` resolves the runtime session correctly, but its preflight validation calls `load_gateway_config()` under the dashboard process's launch profile.

When the dashboard launches under `default` and a `coder` session has Discord enabled only in its own profile, `/handoff discord` incorrectly fails before queueing with:

```text
platform 'discord' is not configured/enabled in the gateway
```

The later multi-profile Gateway watcher path was fixed by #97338 / #91216. This is an earlier Desktop preflight path: the pending handoff row is never written.

## Fix

Load the Gateway config inside the existing `_session_profile_runtime_scope(session)`. The scope derives from the server-owned runtime session's `profile_home`, so it preserves profile isolation even when the client request omits `profile`. The context manager restores the previous Hermes home and secret scope on exit.

## Test plan

- `python3 -m pytest -q tests/test_tui_gateway_server.py -k 'handoff or params_profile or session_profile_home'`
  - `6 passed, 621 deselected`
- `python3 -m pytest -q tests/cli/test_handoff_slow_dispatch_timeout.py`
  - `9 passed`
- `python3 -m py_compile tui_gateway/methods_session.py tests/test_tui_gateway_server.py`
- `git diff --check`

The new regression omits `params.profile`, sets `profile_home` on the runtime session, verifies config loading under that home, queues the Discord handoff, and confirms the ambient Hermes home is restored afterward.
