### PR TITLE
fix(contributors): prevent case-insensitive email collisions

### DIFF
--- a/.github/workflows/contributor-check.yml
+++ b/.github/workflows/contributor-check.yml
@@ -21,6 +21,17 @@ jobs:
         with:
           fetch-depth: 0  # Full history needed for git log
 
+      - name: Reject case-insensitive contributor email collisions
+        run: |
+          # A same-case-folded pair works on Linux but cannot coexist on the
+          # case-insensitive filesystems macOS and Windows default to.
+          COLLISIONS=$(ls contributors/emails | awk '{ k = tolower($0); if (k in seen) print seen[k] " <-> " $0; else seen[k] = $0 }')
+          if [ -n "$COLLISIONS" ]; then
+            echo "Contributor email mapping filenames must be unique ignoring case:"
+            echo "$COLLISIONS"
+            exit 1
+          fi
+
       - name: Check for unmapped contributor emails
         id: check-emails
         run: |

--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent

--- a/contributors/emails/agent@agents-Mac-mini.local
+++ b/contributors/emails/agent@agents-Mac-mini.local
@@ -1,1 +1,0 @@
-momomojo

--- a/scripts/add_contributor.py
+++ b/scripts/add_contributor.py
@@ -66,6 +66,27 @@ def add_contributor(email: str, login: str, comment: str = "") -> int:
         print(f"error: {login!r} is not a valid GitHub login", file=sys.stderr)
         return 2
 
+    # These mapping names are email addresses, whose domain portion is
+    # case-insensitive.  More importantly, macOS and Windows commonly use
+    # case-insensitive filesystems, so two entries that differ only by case
+    # cannot coexist reliably.  Reject the second spelling before touching
+    # ``path``: ``Path.is_file()`` would otherwise resolve the alias on those
+    # filesystems and silently conceal the collision.
+    try:
+        casefolded_email = email.casefold()
+        for candidate in EMAILS_DIR.iterdir():
+            if candidate.is_file() and candidate.name.casefold() == casefolded_email:
+                if candidate.name != email:
+                    print(
+                        "error: contributor mapping already exists with different "
+                        f"casing: {candidate.name!r}; use one canonical spelling",
+                        file=sys.stderr,
+                    )
+                    return 1
+                break
+    except FileNotFoundError:
+        pass
+
     path = EMAILS_DIR / email
     existing = read_mapping_file(path) if path.is_file() else None
     if existing is None:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -44,6 +44,15 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 # This dict is kept only so existing history keeps resolving; the effective
 # AUTHOR_MAP below merges it with the directory (directory wins).
 LEGACY_AUTHOR_MAP = {
+    # Case-colliding pair — these two emails differ only by case, so they can
+    # never coexist as files under contributors/emails/ on the case-insensitive
+    # filesystems macOS and Windows default to (one shows as perpetually
+    # modified, breaking clean checkouts). The freeze on this dict exists to
+    # avoid merge conflicts; entries that are barred from the files directory
+    # have nowhere else to live. add_contributor.py already consults this map,
+    # so attempts to re-add either spelling as a file report "present" and stop.
+    "agent@agents-Mac-mini.local": "momomojo",  # 80b58ec7 (kanban goal_mode fix)
+    "agent@Agents-Mac-mini.local": "skip-agent",  # e6f59e5b (terminal FileProvider guard)
     "declanbatesmith@outlook.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option)
     "drbs2004@me.com": "cat-thats-fat",  # PR #60489 (desktop: first-run remote connection option; historical merge email)
     "122438640+ragingbulld@users.noreply.github.com": "ragingbulld",  # PR #65606 salvage (non-finite API wait deadlines; #65746)

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -95,6 +95,32 @@ def test_add_strips_at_prefix(emails_dir):
     assert read_mapping_file(emails_dir / "z@z.com") == "zeta"
 
 
+def test_add_rejects_case_insensitive_email_alias(emails_dir, capsys):
+    existing = emails_dir / "Agent@Agents-Mac-mini.local"
+    existing.parent.mkdir(parents=True, exist_ok=True)
+    existing.write_text("skip-agent\n", encoding="utf-8")
+
+    assert add_contributor("agent@agents-mac-mini.local", "skip-agent") == 1
+    assert "different casing" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    ("email", "login"),
+    [
+        ("agent@Agents-Mac-mini.local", "skip-agent"),
+        ("agent@agents-Mac-mini.local", "momomojo"),
+    ],
+)
+def test_add_reports_present_for_legacy_case_pair(
+    emails_dir, capsys, email, login
+):
+    # The case-colliding pair lives in LEGACY_AUTHOR_MAP precisely because it
+    # cannot exist as files; re-adding must not recreate a file.
+    assert add_contributor(email, login) == 0
+    assert "present" in capsys.readouterr().out
+    assert not (emails_dir / email).exists()
+
+
 def test_cli_entrypoint_end_to_end(tmp_path):
     # Run the real script in a subprocess against a temp repo layout.
     scripts = tmp_path / "scripts"


### PR DESCRIPTION
## Problem

`main` contains two contributor mappings whose filenames differ only by case. They coexist on Linux, but alias to one path on the case-insensitive filesystems macOS and Windows use by default, leaving the checkout perpetually dirty and breaking updater stash restoration.

Both spellings are load-bearing and map different real contributors:

- `agent@Agents-Mac-mini.local` authored `e6f59e5b` (`fix(terminal): avoid FileProvider reads in lifecycle guard`) and maps to `skip-agent`. The GitHub commit API has no linked login for this identity.
- `agent@agents-Mac-mini.local` authored `80b58ec7` (`fix(kanban): spawn goal_mode workers with -Q so the goal loop actually runs`) and maps to `momomojo`. The GitHub commit API also has no linked login for this identity.

Deleting both is not stable. Commit `693c0e1c` did that, but release attribution automation treats the emails as unmapped and recreated the mapping during release (`29112bef`), allowing the collision to return.

## Fix

- Delete both case-colliding files from `contributors/emails/`.
- Put both exact mappings in `LEGACY_AUTHOR_MAP` in `scripts/release.py`. The dictionary is normally frozen to avoid merge conflicts, but mappings barred from the one-file-per-email directory have no representable alternative. Both `add_contributor.py` and the contributor CI check already consult this map, so regeneration now short-circuits as `present`.
- Make `add_contributor.py` reject case-folded filename aliases before `Path.is_file()` can silently resolve one on APFS/NTFS.
- Add a required contributor-check scan that prints both sides of any future case-insensitive collision.
- Add regression coverage for alias rejection and for the legacy-pair `present` short-circuit.

The unrelated updater mutex artifacts are deliberately left out of this PR.

## Validation

```text
$ uv run --with pytest python -m pytest tests/scripts/test_contributor_map.py -q
..........                                                               [100%]
10 passed in 0.85s

$ COLLISIONS=$(ls contributors/emails | awk ...)
case-insensitive contributor collision scan: clean

$ python3 -c "... print(AUTHOR_MAP[uppercase], AUTHOR_MAP[lowercase])"
skip-agent momomojo

$ git diff origin/main --check
(clean)
```
