### PR TITLE
docs(user-stories): add Autumn Skerritt's Hermes story

### DIFF
--- a/website/src/data/userStories.json
+++ b/website/src/data/userStories.json
@@ -1,5 +1,16 @@
 [
   {
+    "id": "skerritt-non-coding-ai-agent-week",
+    "source": "blog",
+    "author": "Autumn Skerritt",
+    "url": "https://skerritt.blog/what-my-ai-agent-did-for-me-this-week-that-wasnt-coding/",
+    "date": "2026-08-31",
+    "category": "personal-assistant",
+    "headline": "What my AI agent did for me this week that wasn’t coding",
+    "quote": "From checking me in for a flight while I was drunk to chasing government refunds, planning cycle routes, and registering me for Council Tax. Here’s what I actually use an AI agent for outside of coding.",
+    "size": "lg"
+  },
+  {
     "id": "reddit-riceinmybelly-solo-jobsite",
     "source": "reddit",
     "author": "u/riceinmybelly",


### PR DESCRIPTION
## Summary

- add Autumn Skerritt’s blog post, “What My AI Agent Did for Me This Week (That Wasn’t Coding)”
- categorise it as a personal-assistant story and use the post’s own synopsis
- place the newest story first in the collage data

## Verification

- blog URL returns HTTP 200
- parsed `userStories.json` and verified required fields, unique story IDs, and a unique URL for the new entry
- `npx --yes npm@12 run build:fast` ✅

The build completed successfully. It reported the existing `/docs/llms.txt` and `/docs/llms-full.txt` broken-link warnings. The optional repository-wide `typecheck` is currently blocked before source checking by the upstream TypeScript 6 `baseUrl` deprecation (`TS5101`); this change does not touch TypeScript or `tsconfig`.