### PR TITLE
fix(openviking): route remember through session extraction

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -120,23 +120,24 @@ changes future writes, not the location of existing memories.
 | `viking_search` | Semantic search with fast/deep/auto modes |
 | `viking_read` | Read content at a viking:// URI (abstract/overview/full) |
 | `viking_browse` | Filesystem-style navigation (list/tree/stat) |
-| `viking_remember` | Store a fact directly with OpenViking `content/write` |
+| `viking_remember` | Submit a fact through OpenViking session memory extraction |
 | `viking_forget` | Delete one exact `viking://` memory file URI |
 | `viking_add_resource` | Ingest URLs/docs into the knowledge base |
 
 ## Memory Writes And Deletes
 
-`viking_remember` writes directly to OpenViking with `POST /api/v1/content/write`
-and `mode=create`. By default it creates files under explicit-uid
-`viking://user/<user>/memories/...` URIs. When a peer ID is configured, it keeps
-the existing `viking://user/<user>/peers/<peer>/memories/...` path. In both cases,
-`<user>` is resolved client-side from `/api/v1/system/status` (server-asserted
-current user). Hermes caches a confirmed user only for the active connection.
-If the probe fails, Hermes uses the configured user, or `default`, for that
-operation and retries the probe later. Explicit-uid URIs are canonical and
-work under every OpenViking auth mode and version; the `viking://~` alias only
-expands for USER/ADMIN roles, not the default dev mode.
-Explicit remembers do not depend on session commit extraction.
+`viking_remember` creates a one-shot `hermes-remember-<random>` OpenViking
+session, adds the fact as one message, and commits the session with no retained
+tail. The session remains available in OpenViking for audit. OpenViking then
+categorizes, merges, deduplicates, and indexes the result through its normal
+memory extraction pipeline. The tool returns the one-shot session ID and the
+extraction task ID when the server provides one. Extraction continues
+asynchronously after the tool returns.
+
+The optional category is an extraction hint. The fact is stored as a `user`
+message so `viking_remember` produces user memory. The one-shot session is
+separate from the live Hermes conversation, so an explicit remember does not
+commit or rotate the active conversation session.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
 local memory operation succeeds:

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -129,15 +129,30 @@ changes future writes, not the location of existing memories.
 `viking_remember` creates a one-shot `hermes-remember-<random>` OpenViking
 session, adds the fact as one message, and commits the session with no retained
 tail. The session remains available in OpenViking for audit. OpenViking then
-categorizes, merges, deduplicates, and indexes the result through its normal
-memory extraction pipeline. The tool returns the one-shot session ID and the
+classifies the source and can add, merge, or skip a memory through its normal
+extraction pipeline. The tool returns the one-shot session ID and the
 extraction task ID when the server provides one. Extraction continues
 asynchronously after the tool returns.
 
-The optional category is an extraction hint. The fact is stored as a `user`
-message so `viking_remember` produces user memory. The one-shot session is
-separate from the live Hermes conversation, so an explicit remember does not
-commit or rotate the active conversation session.
+The tool returns `status: submitted` because extraction can add a memory, merge
+the fact into an existing memory, or produce no memory operation. It does not
+promise that OpenViking created a distinct memory file. The fact is submitted
+as an unchanged `user` message so OpenViking owns the final classification.
+The legacy `category` argument is still accepted from existing callers but is
+not advertised or used. The one-shot session is separate from the live Hermes
+conversation, so an explicit remember does not commit or rotate the active
+conversation session.
+
+If the message request or commit fails, the error includes the canonical
+session URI, the failed stage, the observed message status, and an `ov session
+commit <session-id>` recovery command. Inspect the session first. An archive
+means the commit completed. A non-empty live `messages.jsonl` with no archive
+means the message was accepted but still needs a commit. An empty live file
+without an archive is ambiguous and must not trigger an automatic resubmission.
+Use the same OpenViking profile and credentials as Hermes for manual recovery.
+OpenViking server auto-commit is disabled by default, so an accepted message
+whose explicit commit fails normally remains live and unextracted until it is
+manually committed.
 
 Hermes built-in `memory` tool additions are mirrored to OpenViking after the
 local memory operation succeeds:

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -617,7 +617,9 @@ REMEMBER_SCHEMA = {
         "Submit important long-term information to OpenViking through session "
         "memory extraction. Success means the source was submitted, not that a "
         "distinct memory file was created. OpenViking can add, merge, or skip the "
-        "final memory. If the message is accepted but commit fails, it normally "
+        "final memory. Use this tool when OpenViking should decide how to retain "
+        "the information. Do not use it when an exact memory file or URI is "
+        "required. If the message is accepted but commit fails, it normally "
         "remains live and unextracted because server auto-commit is disabled by "
         "default; follow the returned recovery instructions."
     ),

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -614,21 +614,17 @@ BROWSE_SCHEMA = {
 REMEMBER_SCHEMA = {
     "name": "viking_remember",
     "description": (
-        "Explicitly submit a fact or memory to the OpenViking memory pipeline. "
-        "Use for important information the agent should remember long-term. "
-        "OpenViking automatically categorizes, merges, and indexes the memory."
+        "Submit important long-term information to OpenViking through session "
+        "memory extraction. Success means the source was submitted, not that a "
+        "distinct memory file was created. OpenViking can add, merge, or skip the "
+        "final memory. If the message is accepted but commit fails, it normally "
+        "remains live and unextracted because server auto-commit is disabled by "
+        "default; follow the returned recovery instructions."
     ),
     "parameters": {
         "type": "object",
         "properties": {
             "content": {"type": "string", "description": "The information to remember."},
-            "category": {
-                "type": "string",
-                "enum": ["preference", "entity", "event", "case", "pattern"],
-                "description": (
-                    "Optional extraction hint. OpenViking makes the final classification."
-                ),
-            },
         },
         "required": ["content"],
     },
@@ -5264,28 +5260,56 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not client:
             return tool_error("OpenViking server not connected")
 
-        category = str(args.get("category") or "").strip()
-        message_content = f"[Remember — {category}] {content}" if category else content
         session_id = f"hermes-remember-{uuid.uuid4().hex[:12]}"
+        session_uri = _user_scoped_uri(
+            self._user_space(client),
+            f"sessions/{session_id}",
+        )
+        recovery_command = f"ov session commit {session_id}"
+        recovery_note = (
+            "Inspect session_uri before recovery. If history/archive_* exists, do not "
+            "retry. If messages.jsonl contains the fact and no archive exists, run "
+            "recovery_command with the same OpenViking profile and credentials as "
+            "Hermes. Otherwise, do not resubmit automatically; report the uncertain "
+            "state to the user."
+        )
         message: Dict[str, Any] = {
             "role": "user",
-            "parts": [self._text_part(message_content)],
+            "parts": [self._text_part(content)],
         }
 
         # Use a dedicated session so explicit remember does not commit or
         # otherwise alter the live Hermes conversation session.
         try:
             client.post(f"/api/v1/sessions/{session_id}/messages", message)
+        except Exception as e:
+            logger.error("OpenViking remember message failed for %s: %s", session_id, e)
+            return tool_error(
+                f"Memory message submission failed for session {session_id}: {e}",
+                session_id=session_id,
+                session_uri=session_uri,
+                failure_stage="message",
+                message_status="unknown",
+                recovery_command=recovery_command,
+                recovery_note=recovery_note,
+            )
+
+        try:
             commit = self._unwrap_result(client.post(
                 f"/api/v1/sessions/{session_id}/commit",
                 {"keep_recent_count": 0},
             ))
             commit = commit if isinstance(commit, dict) else {}
             result: Dict[str, Any] = {
-                "status": "stored",
+                "status": "submitted",
                 "session_id": session_id,
+                "session_uri": session_uri,
+                "message_status": "accepted",
                 "extraction_status": str(commit.get("status") or "accepted"),
-                "message": "Memory stored in an OpenViking session and committed for extraction.",
+                "message": (
+                    "Memory source submitted to OpenViking session extraction. "
+                    "OpenViking may add, merge, or skip the final memory."
+                ),
             }
             if commit.get("task_id"):
                 result["task_id"] = commit["task_id"]
@@ -5293,8 +5317,16 @@ class OpenVikingMemoryProvider(MemoryProvider):
                 result["trace_id"] = commit["trace_id"]
             return json.dumps(result)
         except Exception as e:
-            logger.error("OpenViking remember session failed for %s: %s", session_id, e)
-            return tool_error(f"Failed to store memory in session {session_id}: {e}")
+            logger.error("OpenViking remember commit failed for %s: %s", session_id, e)
+            return tool_error(
+                f"Memory message was accepted, but commit failed for session {session_id}: {e}",
+                session_id=session_id,
+                session_uri=session_uri,
+                failure_stage="commit",
+                message_status="accepted",
+                recovery_command=recovery_command,
+                recovery_note=recovery_note,
+            )
 
     def _tool_forget(self, args: dict) -> str:
         uri, error = _validate_forget_memory_uri(args.get("uri"))

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -138,15 +138,6 @@ _SESSION_START_LIST_PARAMS = {
     "node_limit": 512,
 }
 
-# Maps the viking_remember `category` enum to a viking:// subdirectory.
-# Keep in sync with REMEMBER_SCHEMA.parameters.properties.category.enum.
-_CATEGORY_SUBDIR_MAP = {
-    "preference": "preferences",
-    "entity": "entities",
-    "event": "events",
-    "case": "cases",
-    "pattern": "patterns",
-}
 _DEFAULT_MEMORY_SUBDIR = "preferences"
 
 # Maps the built-in memory tool's `target` ("user" vs "memory") to a subdir
@@ -623,9 +614,9 @@ BROWSE_SCHEMA = {
 REMEMBER_SCHEMA = {
     "name": "viking_remember",
     "description": (
-        "Explicitly store a fact or memory in the OpenViking knowledge base. "
+        "Explicitly submit a fact or memory to the OpenViking memory pipeline. "
         "Use for important information the agent should remember long-term. "
-        "The system automatically categorizes and indexes the memory."
+        "OpenViking automatically categorizes, merges, and indexes the memory."
     ),
     "parameters": {
         "type": "object",
@@ -634,7 +625,9 @@ REMEMBER_SCHEMA = {
             "category": {
                 "type": "string",
                 "enum": ["preference", "entity", "event", "case", "pattern"],
-                "description": "Memory category (default: auto-detected).",
+                "description": (
+                    "Optional extraction hint. OpenViking makes the final classification."
+                ),
             },
         },
         "required": ["content"],
@@ -5267,30 +5260,41 @@ class OpenVikingMemoryProvider(MemoryProvider):
         if not content:
             return tool_error("content is required")
 
-        category = args.get("category", "")
-        subdir = _CATEGORY_SUBDIR_MAP.get(category, _DEFAULT_MEMORY_SUBDIR)
         client = self._ensure_client()
         if not client:
             return tool_error("OpenViking server not connected")
-        uri = self._build_memory_uri(subdir, client=client)
 
-        # Write directly via content/write API.
-        # This creates the file, stores the content, and queues vector indexing
-        # in a single call — no dependency on session commit / VLM extraction.
+        category = str(args.get("category") or "").strip()
+        message_content = f"[Remember — {category}] {content}" if category else content
+        session_id = f"hermes-remember-{uuid.uuid4().hex[:12]}"
+        message: Dict[str, Any] = {
+            "role": "user",
+            "parts": [self._text_part(message_content)],
+        }
+
+        # Use a dedicated session so explicit remember does not commit or
+        # otherwise alter the live Hermes conversation session.
         try:
-            result = client.post("/api/v1/content/write", {
-                "uri": uri,
-                "content": content,
-                "mode": "create",
-            })
-            written = result.get("result", {}).get("written_bytes", 0)
-            return json.dumps({
+            client.post(f"/api/v1/sessions/{session_id}/messages", message)
+            commit = self._unwrap_result(client.post(
+                f"/api/v1/sessions/{session_id}/commit",
+                {"keep_recent_count": 0},
+            ))
+            commit = commit if isinstance(commit, dict) else {}
+            result: Dict[str, Any] = {
                 "status": "stored",
-                "message": f"Memory stored ({written}b) and queued for vector indexing.",
-            })
+                "session_id": session_id,
+                "extraction_status": str(commit.get("status") or "accepted"),
+                "message": "Memory stored in an OpenViking session and committed for extraction.",
+            }
+            if commit.get("task_id"):
+                result["task_id"] = commit["task_id"]
+            if commit.get("trace_id"):
+                result["trace_id"] = commit["trace_id"]
+            return json.dumps(result)
         except Exception as e:
-            logger.error("OpenViking content/write failed: %s", e)
-            return tool_error(f"Failed to store memory: {e}")
+            logger.error("OpenViking remember session failed for %s: %s", session_id, e)
+            return tool_error(f"Failed to store memory in session {session_id}: {e}")
 
     def _tool_forget(self, args: dict) -> str:
         uri, error = _validate_forget_memory_uri(args.get("uri"))

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -971,8 +971,10 @@ class TestEnsureClientReloadsEnv:
             {"content": "stable fact"},
         ))
 
-        assert out["status"] == "stored"
+        assert out["status"] == "submitted"
         assert out["session_id"].startswith("hermes-remember-")
+        assert out["session_uri"] == f"viking://user/default/sessions/{out['session_id']}"
+        assert out["message_status"] == "accepted"
         assert out["extraction_status"] == "accepted"
         assert out["task_id"] == "task-remember"
         assert out["trace_id"] == "trace-remember"
@@ -992,21 +994,7 @@ class TestEnsureClientReloadsEnv:
             ),
         ]
 
-    @pytest.mark.parametrize(
-        "category",
-        [
-            "preference",
-            "entity",
-            "event",
-            "case",
-            "pattern",
-        ],
-    )
-    def test_remember_uses_category_as_user_memory_hint(
-        self,
-        monkeypatch,
-        category,
-    ):
+    def test_remember_accepts_legacy_category_but_submits_raw_user_text(self, monkeypatch):
         posts = []
 
         class _StubClient:
@@ -1023,17 +1011,16 @@ class TestEnsureClientReloadsEnv:
 
         out = json.loads(provider._tool_remember({
             "content": "stable fact",
-            "category": category,
+            "category": "preference",
         }))
 
         session_id = out["session_id"]
         message_path, message = posts[0]
         assert message_path == f"/api/v1/sessions/{session_id}/messages"
         assert message["role"] == "user"
-        assert message["parts"] == [
-            {"type": "text", "text": f"[Remember — {category}] stable fact"}
-        ]
+        assert message["parts"] == [{"type": "text", "text": "stable fact"}]
         assert "peer_id" not in message
+        assert "category" not in openviking_plugin.REMEMBER_SCHEMA["parameters"]["properties"]
         assert posts[1] == (
             f"/api/v1/sessions/{session_id}/commit",
             {"keep_recent_count": 0},
@@ -1061,7 +1048,31 @@ class TestEnsureClientReloadsEnv:
         assert second["session_id"].startswith("hermes-remember-")
         assert all("/api/v1/content/write" not in path for path, _ in posts)
 
-    def test_remember_reports_commit_failure_with_recoverable_session_id(self, monkeypatch):
+    def test_remember_reports_unknown_message_submission_failure(self, monkeypatch):
+        posts = []
+
+        class _StubClient:
+            def post(self, path, payload=None, **kwargs):
+                posts.append((path, payload or {}))
+                raise TimeoutError("message timeout")
+
+        provider = OpenVikingMemoryProvider()
+        provider._client = _StubClient()
+        monkeypatch.setattr(provider, "_ensure_client", lambda: provider._client)
+
+        out = json.loads(provider._tool_remember({"content": "stable fact"}))
+
+        assert out["error"].startswith("Memory message submission failed for session ")
+        assert out["error"].endswith(": message timeout")
+        assert out["failure_stage"] == "message"
+        assert out["message_status"] == "unknown"
+        assert out["session_uri"].endswith(f"/sessions/{out['session_id']}")
+        assert out["recovery_command"] == f"ov session commit {out['session_id']}"
+        assert "do not resubmit automatically" in out["recovery_note"]
+        assert len(posts) == 1
+        assert posts[0][0].endswith("/messages")
+
+    def test_remember_reports_commit_failure_with_recovery_command(self, monkeypatch):
         posts = []
 
         class _StubClient:
@@ -1078,9 +1089,14 @@ class TestEnsureClientReloadsEnv:
         out = json.loads(provider._tool_remember({"content": "stable fact"}))
 
         assert out["error"].startswith(
-            "Failed to store memory in session hermes-remember-"
+            "Memory message was accepted, but commit failed for session hermes-remember-"
         )
         assert out["error"].endswith(": commit rejected")
+        assert out["failure_stage"] == "commit"
+        assert out["message_status"] == "accepted"
+        assert out["session_uri"].endswith(f"/sessions/{out['session_id']}")
+        assert out["recovery_command"] == f"ov session commit {out['session_id']}"
+        assert "same OpenViking profile and credentials as Hermes" in out["recovery_note"]
         assert len(posts) == 2
         assert posts[0][0].endswith("/messages")
         assert posts[1][0].endswith("/commit")

--- a/tests/openviking_plugin/test_openviking.py
+++ b/tests/openviking_plugin/test_openviking.py
@@ -946,7 +946,15 @@ class TestEnsureClientReloadsEnv:
 
             def post(self, path, payload=None, **kwargs):
                 self.posts.append((path, payload or {}))
-                return {"result": {"written_bytes": 11}}
+                if path.endswith("/commit"):
+                    return {
+                        "result": {
+                            "status": "accepted",
+                            "task_id": "task-remember",
+                            "trace_id": "trace-remember",
+                        }
+                    }
+                return {"status": "ok"}
 
         monkeypatch.setattr("plugins.memory.openviking._VikingClient", _StubClient)
         monkeypatch.setenv("OPENVIKING_ENDPOINT", "https://openviking.example")
@@ -964,13 +972,118 @@ class TestEnsureClientReloadsEnv:
         ))
 
         assert out["status"] == "stored"
+        assert out["session_id"].startswith("hermes-remember-")
+        assert out["extraction_status"] == "accepted"
+        assert out["task_id"] == "task-remember"
+        assert out["trace_id"] == "trace-remember"
         assert len(instances) == 2
-        assert instances[1].posts[0][0] == "/api/v1/content/write"
-        assert instances[1].posts[0][1]["content"] == "stable fact"
-        assert instances[1].posts[0][1]["mode"] == "create"
-        assert instances[1].posts[0][1]["uri"].startswith(
-            "viking://user/default/peers/hermes/memories/"
+        session_id = out["session_id"]
+        assert instances[1].posts == [
+            (
+                f"/api/v1/sessions/{session_id}/messages",
+                {
+                    "role": "user",
+                    "parts": [{"type": "text", "text": "stable fact"}],
+                },
+            ),
+            (
+                f"/api/v1/sessions/{session_id}/commit",
+                {"keep_recent_count": 0},
+            ),
+        ]
+
+    @pytest.mark.parametrize(
+        "category",
+        [
+            "preference",
+            "entity",
+            "event",
+            "case",
+            "pattern",
+        ],
+    )
+    def test_remember_uses_category_as_user_memory_hint(
+        self,
+        monkeypatch,
+        category,
+    ):
+        posts = []
+
+        class _StubClient:
+            def post(self, path, payload=None, **kwargs):
+                posts.append((path, payload or {}))
+                if path.endswith("/commit"):
+                    return {"result": {"status": "accepted", "task_id": "task-1"}}
+                return {"status": "ok"}
+
+        provider = OpenVikingMemoryProvider()
+        provider._client = _StubClient()
+        provider._agent = "hermes"
+        monkeypatch.setattr(provider, "_ensure_client", lambda: provider._client)
+
+        out = json.loads(provider._tool_remember({
+            "content": "stable fact",
+            "category": category,
+        }))
+
+        session_id = out["session_id"]
+        message_path, message = posts[0]
+        assert message_path == f"/api/v1/sessions/{session_id}/messages"
+        assert message["role"] == "user"
+        assert message["parts"] == [
+            {"type": "text", "text": f"[Remember — {category}] stable fact"}
+        ]
+        assert "peer_id" not in message
+        assert posts[1] == (
+            f"/api/v1/sessions/{session_id}/commit",
+            {"keep_recent_count": 0},
         )
+
+    def test_remember_uses_a_distinct_one_shot_session_for_each_call(self, monkeypatch):
+        posts = []
+
+        class _StubClient:
+            def post(self, path, payload=None, **kwargs):
+                posts.append((path, payload or {}))
+                if path.endswith("/commit"):
+                    return {"result": {"status": "accepted"}}
+                return {"status": "ok"}
+
+        provider = OpenVikingMemoryProvider()
+        provider._client = _StubClient()
+        monkeypatch.setattr(provider, "_ensure_client", lambda: provider._client)
+
+        first = json.loads(provider._tool_remember({"content": "first"}))
+        second = json.loads(provider._tool_remember({"content": "second"}))
+
+        assert first["session_id"] != second["session_id"]
+        assert first["session_id"].startswith("hermes-remember-")
+        assert second["session_id"].startswith("hermes-remember-")
+        assert all("/api/v1/content/write" not in path for path, _ in posts)
+
+    def test_remember_reports_commit_failure_with_recoverable_session_id(self, monkeypatch):
+        posts = []
+
+        class _StubClient:
+            def post(self, path, payload=None, **kwargs):
+                posts.append((path, payload or {}))
+                if path.endswith("/commit"):
+                    raise RuntimeError("commit rejected")
+                return {"status": "ok"}
+
+        provider = OpenVikingMemoryProvider()
+        provider._client = _StubClient()
+        monkeypatch.setattr(provider, "_ensure_client", lambda: provider._client)
+
+        out = json.loads(provider._tool_remember({"content": "stable fact"}))
+
+        assert out["error"].startswith(
+            "Failed to store memory in session hermes-remember-"
+        )
+        assert out["error"].endswith(": commit rejected")
+        assert len(posts) == 2
+        assert posts[0][0].endswith("/messages")
+        assert posts[1][0].endswith("/commit")
 
     def test_concurrent_refresh_does_not_return_stale_client(self, monkeypatch):
         refresh_entered = threading.Event()

--- a/tests/plugins/memory/test_openviking_optional_peer.py
+++ b/tests/plugins/memory/test_openviking_optional_peer.py
@@ -321,11 +321,25 @@ def test_wire_requests_keep_writes_and_session_messages_in_the_selected_scope(
         payload for path, _, payload in records if path == "/api/v1/content/write"
     ]
     prefix = f"peers/{peer}/" if peer else ""
-    assert {write["content"] for write in writes} == {"I like tea", "I like coffee"}
+    assert {write["content"] for write in writes} == {"I like coffee"}
     assert all(
         write["uri"].startswith(f"viking://user/alice/{prefix}memories/")
         for write in writes
     )
+    remember_messages = [
+        (path, payload)
+        for path, _, payload in records
+        if path.startswith("/api/v1/sessions/hermes-remember-")
+        and path.endswith("/messages")
+    ]
+    assert len(remember_messages) == 1
+    remember_path, remember_message = remember_messages[0]
+    remember_session = remember_path.removesuffix("/messages")
+    assert remember_message == {
+        "role": "user",
+        "parts": [{"type": "text", "text": "I like tea"}],
+    }
+    assert any(path == f"{remember_session}/commit" for path, _, _ in records)
     batches = [
         payload["messages"]
         for path, _, payload in records

--- a/tests/plugins/memory/test_openviking_optional_peer.py
+++ b/tests/plugins/memory/test_openviking_optional_peer.py
@@ -290,7 +290,7 @@ def test_wire_requests_keep_writes_and_session_messages_in_the_selected_scope(
         result = json.loads(
             provider.handle_tool_call("viking_remember", {"content": "I like tea"})
         )
-        assert result["status"] == "stored"
+        assert result["status"] == "submitted"
         provider.on_memory_write("add", "user", "I like coffee")
         provider.sync_turn("hello", "hi", session_id="peer-test")
         assert provider._drain_writers("peer-test", timeout=5.0)


### PR DESCRIPTION
## What does this PR do?

`viking_remember` currently writes plain Markdown through `POST /api/v1/content/write`. This bypasses OpenViking's memory extraction pipeline, including its normal classification and merge decisions.

This PR routes explicit remembers through a one-shot `hermes-remember-<random>` session. Hermes adds the fact as a user message and commits the session with no retained tail. OpenViking then performs its normal asynchronous extraction.

Successful calls return `status: submitted` because extraction can add, merge, or skip the final memory. The response includes the canonical session URI, message status, task ID, trace ID, and extraction status when available. The final memory URI is not returned because OpenViking chooses it during extraction.

Message and commit failures are reported separately. Errors include the failed stage, observed message status, canonical session URI, and a manual `ov session commit` recovery command. Hermes does not retry uncertain submissions automatically.

Normal Hermes session sync and the built-in `memory` tool mirror are unchanged.

## Related Issue

Related to #86316. This fixes the explicit `viking_remember` path. The separate built-in memory mirror still uses direct writes and is not changed here.

This also changes the direct-write assumption in #98412 because the final memory URI is no longer known when `viking_remember` returns.

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- Route `viking_remember` through one-shot OpenViking sessions.
- Submit the original user text and let OpenViking classify it.
- Continue accepting the legacy `category` input without advertising or writing it into the session.
- Report asynchronous submission accurately and return session and task metadata.
- Distinguish message failures from commit failures and provide manual recovery details.
- Update the provider documentation and regression tests.

## How to Test

```bash
scripts/run_tests.sh tests/openviking_plugin/ \
  tests/plugins/memory/test_openviking_provider.py \
  tests/plugins/memory/test_openviking_optional_peer.py
```

The focused suites pass with 150 tests. A live test against the current local OpenViking source completed the extraction task with `memory_write: 1` and confirmed that the archived session contains the original text without a category prefix.

## Checklist

- [x] Read the Contributing Guide
- [x] Used a Conventional Commit message
- [x] Searched existing PRs and issues
- [x] Kept the PR focused
- [x] Added regression and partial-failure tests
- [x] Updated the OpenViking provider README
- [x] Updated the tool description and schema text
- [x] Tested on macOS 26.6 arm64
- [x] Ruff and whitespace checks pass
