### PR TITLE
fix(desktop): keep idle sidebar rows on failed scans; retain list readers

### DIFF
--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -148,6 +148,11 @@ export interface SidebarSessionSlice {
   /** Per-profile tokens and spend over every session, not just this window.
    *  Absent from the legacy per-slice endpoint, which has no aggregate. */
   profiles_usage?: Record<string, { cost_usd: number; tokens: number }>
+  /** Profiles whose scan for THIS slice failed. Batched `/sidebar` stamps the
+   *  same profile errors on every slice (one DB open). Legacy per-slice calls
+   *  stamp only the slice that actually failed, so a cron I/O error cannot
+   *  carry-forward recents. */
+  errors?: Array<{ profile: string; error: string }>
 }
 
 /** Which profiles filled their per-profile window in a returned page. The
@@ -216,16 +221,24 @@ async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<S
     })
   ])
 
-  const errors = [...(recents.errors ?? []), ...(cron.errors ?? []), ...(messaging.errors ?? [])]
+  const recentsErrors = recents.errors ?? []
+  const cronErrors = cron.errors ?? []
+  const messagingErrors = messaging.errors ?? []
 
   return {
     recents: {
       profiles_truncated: profilesTruncatedFrom(recents.sessions, req.recentsLimit),
-      sessions: recents.sessions
+      sessions: recents.sessions,
+      ...(recentsErrors.length ? { errors: recentsErrors } : {})
     },
-    cron: { sessions: cron.sessions },
-    messaging: { sessions: messaging.sessions },
-    ...(errors.length ? { errors } : {})
+    cron: {
+      sessions: cron.sessions,
+      ...(cronErrors.length ? { errors: cronErrors } : {})
+    },
+    messaging: {
+      sessions: messaging.sessions,
+      ...(messagingErrors.length ? { errors: messagingErrors } : {})
+    }
   }
 }
 
@@ -288,9 +301,21 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 
   return {
-    recents: { ...result.recents, sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []) },
-    cron: { ...result.cron, sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []) },
-    messaging: { ...result.messaging, sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []) },
+    recents: {
+      ...result.recents,
+      sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
+    cron: {
+      ...result.cron,
+      sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
+    messaging: {
+      ...result.messaging,
+      sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []),
+      ...(result.errors?.length ? { errors: result.errors } : {})
+    },
     errors: result.errors
   }
 }

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -216,6 +216,57 @@ describe('refreshSessions identity + loading hygiene', () => {
     expect($sessions.get().map(s => s.id)).toEqual(['a'])
   })
 
+  it('keeps idle recents when the sidebar returns an empty page plus profile errors', async () => {
+    // Backend contract on disk I/O / lock: HTTP 200, recents=[], errors=[{profile}].
+    // mergeSessionPage only keeps working/pinned/selected, so Yesterday/This-week
+    // idle rows must be carried forward from the previous list — not clobbered.
+    const idle = [row('yesterday'), row('week')]
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: idle }))
+
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['yesterday', 'week'])
+
+    setSessionProfilesTruncated({ default: true })
+    setSessionProfilesUsage({ default: { cost_usd: 3, tokens: 30 } })
+    setMessagingTruncated(true)
+
+    listSidebarSessions.mockResolvedValue({
+      ...sidebar({ sessions: [] }),
+      errors: [{ error: 'disk I/O error', profile: 'default' }]
+    })
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get().map(s => s.id)).toEqual(['yesterday', 'week'])
+    expect($sessionProfilesTruncated.get()).toEqual({ default: true })
+    expect($sessionProfilesUsage.get()).toEqual({ default: { cost_usd: 3, tokens: 30 } })
+    expect($messagingTruncated.get()).toBe(true)
+  })
+
+  it('still accepts a genuine empty recents page when the backend reported no errors', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [row('a')] }))
+    const { result } = renderHook(() => useSessionListActions({ profileScope: 'default' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect($sessions.get()).toEqual([])
+  })
+
   it('drops tombstoned rows from the messaging slice and per-platform paging too (#50928)', async () => {
     // The same delete race exists on every ingestion point: the batched
     // refresh's messaging slice and the per-platform "load more" pager must

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -24,7 +24,9 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  carryForwardFailedProfileSessions,
   CRON_SECTION_LIMIT,
+  keepFailedProfileMeta,
   mergeSessionPage,
   MESSAGING_SECTION_LIMIT,
   setCronSessions,
@@ -198,7 +200,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       setMessagingSessions(prev => [
         ...prev.filter(s => !inPlatform(s)),
-        ...mergeSessionPage(prev.filter(inPlatform), incoming, sessionsToKeep())
+        ...mergeSessionPage(
+          prev.filter(inPlatform),
+          carryForwardFailedProfileSessions(prev.filter(inPlatform), incoming, result.errors),
+          sessionsToKeep()
+        )
       ])
 
       const total = result.total ?? incoming.length
@@ -282,13 +288,19 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // in-flight mutation and the backend page still carries the doomed row.
           // Honoring the optimistic tombstone keeps the removal from flashing back
           // (the tombstone self-clears once projects.tree confirms the delete).
-          const incoming = dropTombstoned(recents.sessions)
-
           // Signature-gate the swap (same pattern as cron/messaging): a refresh
           // that returns content-identical rows must keep the previous array
           // identity, or every sidebar memo keyed on $sessions recomputes and the
           // whole list re-renders once per turn/broadcast for nothing.
           setSessions(prev => {
+            const incoming = dropTombstoned(
+              carryForwardFailedProfileSessions(
+                prev,
+                recents.sessions ?? [],
+                recents.errors ?? result.errors
+              )
+            )
+
             const next = mergeSessionPage(prev, incoming, sessionsToKeep())
 
             return sameCronSignature(prev, next) ? prev : next
@@ -298,8 +310,9 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // top of the rows it already read (the old exact totals ran a COUNT(*)
           // per profile DB on every refresh). Reference-stable when unchanged so
           // the sidebar's group memos don't recompute per refresh.
+          const recentsErrors = recents.errors ?? result.errors
           setSessionProfilesTruncated(prev => {
-            const next = recents.profiles_truncated ?? {}
+            const next = keepFailedProfileMeta(prev, recents.profiles_truncated ?? {}, recentsErrors)
             const prevKeys = Object.keys(prev)
 
             return prevKeys.length === Object.keys(next).length && prevKeys.every(key => prev[key] === next[key])
@@ -309,7 +322,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           // Same identity gate: these totals only move when a session bills, and
           // a fresh object every refresh would repaint every profile header.
           setSessionProfilesUsage(prev => {
-            const next = recents.profiles_usage ?? {}
+            const next = keepFailedProfileMeta(prev, recents.profiles_usage ?? {}, recentsErrors)
             const prevKeys = Object.keys(prev)
 
             return prevKeys.length === Object.keys(next).length &&
@@ -322,16 +335,35 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
           // Cron section: latest N cron sessions (kept so a pinned cron run still
           // resolves via sessionByAnyId), signature-gated like above.
-          setCronSessions(prev => (sameCronSignature(prev, result.cron.sessions) ? prev : result.cron.sessions))
+          setCronSessions(prev => {
+            const incoming = carryForwardFailedProfileSessions(
+              prev,
+              result.cron.sessions ?? [],
+              result.cron.errors ?? result.errors
+            )
+
+            return sameCronSignature(prev, incoming) ? prev : incoming
+          })
 
           // Messaging sections: drop any non-messaging source the broad exclude
           // didn't catch (custom sources stay in local recents), then split per
           // platform in the UI.
-          const messagingRows = dropTombstoned(result.messaging.sessions.filter(s => isMessagingSource(s.source)))
+          const messagingErrors = result.messaging.errors ?? result.errors
+          setMessagingSessions(prev => {
+            const messagingRows = dropTombstoned(
+              carryForwardFailedProfileSessions(
+                prev,
+                (result.messaging.sessions ?? []).filter(s => isMessagingSource(s.source)),
+                messagingErrors
+              )
+            )
 
-          setMessagingSessions(prev => (sameCronSignature(prev, messagingRows) ? prev : messagingRows))
+            return sameCronSignature(prev, messagingRows) ? prev : messagingRows
+          })
           // Hit the cap → at least one platform may have more on disk than loaded.
-          setMessagingTruncated(result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT)
+          setMessagingTruncated(prev =>
+            messagingErrors?.length ? prev : result.messaging.sessions.length >= MESSAGING_SECTION_LIMIT
+          )
         }
       } finally {
         // Request identity preserves the zero-argument refresh contract across a

--- a/apps/desktop/src/hermes.test.ts
+++ b/apps/desktop/src/hermes.test.ts
@@ -290,6 +290,43 @@ describe('Hermes REST helpers', () => {
     expect(paths).toContainEqual(expect.stringContaining('exclude_sources=cron%2Ctool'))
   })
 
+  it('keeps per-slice errors on the legacy fallback so a cron failure does not taint recents', async () => {
+    resetSidebarBatchCapability()
+    const row = (id: string) => ({ id, title: id, profile: 'default' })
+
+    api.mockImplementation(({ path }: { path: string }) => {
+      if (path.startsWith('/api/profiles/sessions/sidebar')) {
+        return Promise.reject(
+          new Error('404: {"detail":"No such API endpoint: /api/profiles/sessions/sidebar"}')
+        )
+      }
+
+      if (path.includes('source=cron')) {
+        return Promise.resolve({
+          ...emptySessionsResponse,
+          sessions: [],
+          errors: [{ profile: 'default', error: 'disk I/O error' }]
+        })
+      }
+
+      return Promise.resolve({ ...emptySessionsResponse, sessions: [row('recent-1')] })
+    })
+
+    const result = await listSidebarSessions({
+      recentsProfile: 'default',
+      recentsLimit: 20,
+      recentsExclude: [],
+      cronLimit: 50,
+      messagingLimit: 100,
+      messagingExclude: []
+    })
+
+    expect(result.recents.sessions.map(s => s.id)).toEqual(['recent-1'])
+    expect(result.recents.errors).toBeUndefined()
+    expect(result.cron.errors).toEqual([{ profile: 'default', error: 'disk I/O error' }])
+    expect(result.errors).toBeUndefined()
+  })
+
   it('remembers endpoint-missing and skips re-probing the batched route on later refreshes', async () => {
     api.mockImplementation(({ path }: { path: string }) =>
       path.startsWith('/api/profiles/sessions/sidebar')

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -30,6 +30,7 @@ import {
   _resetLegacyDiscardForTests,
   _resetSessionOwnerHintsForTests,
   applyConfiguredDefaultProjectDir,
+  carryForwardFailedProfileSessions,
   commitWorkspaceCwdForSelectedSession,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
@@ -41,6 +42,7 @@ import {
   getSessionOwnerHint,
   getSessionOwnerHints,
   hydrateSessionOwnerHints,
+  keepFailedProfileMeta,
   knownSessionOwner,
   knownSessionProfile,
   mergeSessionPage,
@@ -670,6 +672,87 @@ describe('mergeSessionPage', () => {
 
     expect(merged.map(s => s.id)).toEqual(['bumped', 'survivor'])
     expect(merged[0]?.last_active).toBe(300)
+  })
+})
+
+describe('carryForwardFailedProfileSessions', () => {
+  it('is a no-op when the backend reported no profile errors', () => {
+    const previous = [session({ id: 'yesterday', profile: 'default' })]
+    const incoming = [session({ id: 'today', profile: 'default' })]
+
+    expect(carryForwardFailedProfileSessions(previous, incoming, undefined)).toBe(incoming)
+    expect(carryForwardFailedProfileSessions(previous, incoming, [])).toBe(incoming)
+  })
+
+  it('re-attaches idle rows for a profile whose slice failed (empty 200 + errors)', () => {
+    // Repro: current session is running, sidebar scan hits disk I/O, backend
+    // returns recents=[] with errors=[{profile:default}]. mergeSessionPage then
+    // keeps only working/pinned/selected and Yesterday/This-week vanish.
+    const previous = [
+      session({ id: 'running', last_active: 300, profile: 'default', title: 'Now' }),
+      session({ id: 'yesterday', last_active: 200, profile: 'default', title: 'Yesterday' }),
+      session({ id: 'week', last_active: 100, profile: 'default', title: 'This week' })
+    ]
+
+    const carried = carryForwardFailedProfileSessions(previous, [], [
+      { profile: 'default', error: 'disk I/O error' }
+    ])
+
+    expect(carried.map(s => s.id)).toEqual(['running', 'yesterday', 'week'])
+    expect(carried[1]).toBe(previous[1])
+  })
+
+  it('does not resurrect a successful profile’s omitted rows, and does not duplicate', () => {
+    const previous = [
+      session({ id: 'work-old', profile: 'work' }),
+      session({ id: 'home-idle', profile: 'default' }),
+      session({ id: 'home-fresh', profile: 'default' })
+    ]
+
+    const incoming = [session({ id: 'home-fresh', message_count: 4, profile: 'default' })]
+
+    const carried = carryForwardFailedProfileSessions(previous, incoming, [{ profile: 'work' }])
+
+    expect(carried.map(s => `${s.profile}:${s.id}`)).toEqual(['default:home-fresh', 'work:work-old'])
+  })
+
+  it('re-ranks carried rows by recency instead of parking them at the tail', () => {
+    const previous = [
+      session({ id: 'idle-newer', last_active: 500, profile: 'work' }),
+      session({ id: 'idle-older', last_active: 50, profile: 'work' })
+    ]
+
+    const incoming = [session({ id: 'home', last_active: 100, profile: 'default' })]
+
+    expect(
+      carryForwardFailedProfileSessions(previous, incoming, [{ profile: 'work' }]).map(s => s.id)
+    ).toEqual(['idle-newer', 'home', 'idle-older'])
+  })
+
+  it('treats a missing profile tag on the error as default', () => {
+    const previous = [session({ id: 'idle', profile: 'default' })]
+
+    expect(carryForwardFailedProfileSessions(previous, [], [{ error: 'disk I/O error' }]).map(s => s.id)).toEqual([
+      'idle'
+    ])
+  })
+})
+
+describe('keepFailedProfileMeta', () => {
+  it('is a no-op when the backend reported no profile errors', () => {
+    const incoming = { default: { cost_usd: 1, tokens: 2 } }
+
+    expect(keepFailedProfileMeta({ default: { cost_usd: 9, tokens: 9 } }, incoming, [])).toBe(incoming)
+  })
+
+  it('restores previous usage/truncated flags for profiles whose slice failed', () => {
+    const previous = { default: { cost_usd: 4, tokens: 40 }, work: { cost_usd: 1, tokens: 10 } }
+    const incoming = { work: { cost_usd: 2, tokens: 20 } }
+
+    expect(keepFailedProfileMeta(previous, incoming, [{ profile: 'default' }])).toEqual({
+      default: { cost_usd: 4, tokens: 40 },
+      work: { cost_usd: 2, tokens: 20 }
+    })
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -629,6 +629,85 @@ export function mergeSessionPage(
   return interleaved
 }
 
+function sidebarProfileKey(session: Pick<SessionInfo, 'profile'>): string {
+  return (session.profile ?? '').trim() || 'default'
+}
+
+function sessionListIdentity(session: Pick<SessionInfo, 'id' | 'profile'>): string {
+  return `${sidebarProfileKey(session)}::${session.id}`
+}
+
+/**
+ * Re-attach previous rows for profiles whose sidebar slice failed this refresh.
+ *
+ * The batched sidebar endpoint reports a disk I/O / lock failure as HTTP 200
+ * with `recents: []` and `errors: [{ profile }]`. `mergeSessionPage` only keeps
+ * working / pinned / selected ids, so idle Yesterday / This-week rows would
+ * otherwise vanish until a later successful scan (#73847, #88528).
+ *
+ * Successful profiles are left alone: their incoming page is still authoritative.
+ */
+export function carryForwardFailedProfileSessions(
+  previous: SessionInfo[],
+  incoming: SessionInfo[],
+  errors: Array<{ profile?: string; error?: string }> | undefined | null
+): SessionInfo[] {
+  if (!errors?.length || previous.length === 0) {
+    return incoming
+  }
+
+  const failed = new Set(errors.map(error => (error.profile ?? '').trim() || 'default'))
+  const incomingIds = new Set(incoming.map(sessionListIdentity))
+  const carried: SessionInfo[] = []
+
+  for (const session of previous) {
+    if (!failed.has(sidebarProfileKey(session)) || incomingIds.has(sessionListIdentity(session))) {
+      continue
+    }
+
+    carried.push(session)
+  }
+
+  if (carried.length === 0) {
+    return incoming
+  }
+
+  // Incoming-first concat parks the failed profile at the tail of an
+  // all-profiles list. Re-rank by the same recency key the backend uses.
+  const recency = (session: SessionInfo): number => Math.max(session.last_active || 0, session.started_at || 0)
+
+  return [...incoming, ...carried].sort((a, b) => recency(b) - recency(a))
+}
+
+/** Keep previous per-profile sidebar meta for profiles whose slice failed.
+ *
+ *  A failed scan returns `{}` / falsey truncated flags. Applying those
+ *  would zero usage and hide Load more under a list we just carried forward.
+ */
+export function keepFailedProfileMeta<T>(
+  previous: Record<string, T>,
+  incoming: Record<string, T>,
+  errors: Array<{ profile?: string; error?: string }> | undefined | null
+): Record<string, T> {
+  if (!errors?.length) {
+    return incoming
+  }
+
+  const next = { ...incoming }
+
+  for (const error of errors) {
+    const key = (error.profile ?? '').trim() || 'default'
+
+    if (Object.prototype.hasOwnProperty.call(previous, key)) {
+      next[key] = previous[key]
+    } else {
+      delete next[key]
+    }
+  }
+
+  return next
+}
+
 /** Raise a session in recents on user send (before stream / turn resolve). */
 export function touchSessionActivity(
   sessionId: string | null | undefined,

--- a/hermes_cli/sqlite_safe_read.py
+++ b/hermes_cli/sqlite_safe_read.py
@@ -73,6 +73,23 @@ logger = logging.getLogger(__name__)
 
 SQLITE_HEADER_MAGIC = b"SQLite format 3\x00"
 
+# Concurrent writers can surface these as OperationalError on a read that
+# does not need to fail the whole request. Shared so list/sidebar
+# classification cannot drift.
+TRANSIENT_SQLITE_MARKERS = (
+    "disk i/o",
+    "database is locked",
+    "database table is locked",
+    "busy",
+)
+
+
+def is_transient_sqlite_error(exc: BaseException) -> bool:
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    msg = str(exc).lower()
+    return any(marker in msg for marker in TRANSIENT_SQLITE_MARKERS)
+
 # Offset of the 4-byte big-endian page-count field in the SQLite header.
 _HEADER_PAGE_COUNT_OFFSET = 28
 

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -19,16 +19,18 @@ import inspect
 import json
 import logging
 import re
+import sqlite3
 import subprocess  # noqa: F401
 import sys  # noqa: F401
 import threading
-import time  # noqa: F401
+import time
 from collections import OrderedDict
 from pathlib import Path  # noqa: F401
 from typing import Any, Dict, List, Optional, Tuple  # noqa: F401
 
 from fastapi import APIRouter, HTTPException, Query  # noqa: F401
 
+from hermes_cli.sqlite_safe_read import is_transient_sqlite_error
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     ProfileCreate,
@@ -138,9 +140,56 @@ def _sidebar_profile_cache_put(key, value):
             _SIDEBAR_PROFILE_CACHE.popitem(last=False)
 
 
+# Last successful per-path sidebar slices. Independent of WAL fingerprint:
+# a 0-byte WAL changes the fingerprint, misses the TTL cache, and a failed
+# rescan would otherwise return recents=[] which the packaged Desktop
+# treats as an authoritative empty list.
+_LAST_GOOD_SIDEBAR_SLICES: dict = {}
+
+
 def _sidebar_profile_cache_clear():
     with _SIDEBAR_PROFILE_CACHE_LOCK:
         _SIDEBAR_PROFILE_CACHE.clear()
+        _LAST_GOOD_SIDEBAR_SLICES.clear()
+
+
+def _remember_sidebar_slices(db_path, slices) -> None:
+    _LAST_GOOD_SIDEBAR_SLICES[str(db_path)] = copy.deepcopy(slices)
+
+
+def _recall_sidebar_slices(db_path):
+    value = _LAST_GOOD_SIDEBAR_SLICES.get(str(db_path))
+    return copy.deepcopy(value) if value is not None else None
+
+
+# Concurrent writers (the live Desktop session flushing turns) can make a
+# read-only sidebar scan fail with SQLITE_IOERR / BUSY. Retry those queries
+# on an already-open connection; do not retry by open/close — POSIX close()
+# of any fd for this file cancels every lock this process holds.
+# Do not retry corruption — that would only delay the errors[] payload.
+_SQLITE_READ_RETRY_ATTEMPTS = 3
+_SQLITE_READ_RETRY_DELAY_S = 0.05
+
+
+def _transient_sqlite_error(exc: BaseException) -> bool:
+    return is_transient_sqlite_error(exc)
+
+
+def _retry_sqlite_read(fn, *, attempts: int = _SQLITE_READ_RETRY_ATTEMPTS, delay: float = _SQLITE_READ_RETRY_DELAY_S):
+    """Retry *fn* on transient OperationalError.
+
+    *fn* must be queries against a connection that is already open.
+    Wrapping connect/close here would cancel POSIX locks on sibling
+    writers in this process.
+    """
+    for index in range(attempts):
+        try:
+            return fn()
+        except Exception as exc:
+            if not _transient_sqlite_error(exc) or index == attempts - 1:
+                raise
+            time.sleep(delay * (index + 1))
+    raise RuntimeError("sqlite read retry exhausted")
 
 
 def _sidebar_singleflight_cache(func):
@@ -197,6 +246,11 @@ def _sidebar_singleflight_cache(func):
             if cached is not miss:
                 return cached
             result = func(*args, **kwargs)
+            # A 200 with errors[] is a failed profile scan, not a successful
+            # empty page. Caching it for the TTL keeps Yesterday/This-week
+            # dropped after the DB recovers.
+            if isinstance(result, dict) and result.get("errors"):
+                return result
             try:
                 snapshot = copy.deepcopy(result)
             except Exception:
@@ -292,7 +346,7 @@ def get_profiles_sessions(
         db_path = Path(home) / "state.db"
         if not db_path.exists():
             continue
-        try:
+        def _load_profile_page():
             # Read-only on the healthy path: this loop runs on every sidebar
             # refresh, so it must not routinely DDL/write-lock another
             # profile's live DB (see SessionDB read_only docstring). The
@@ -302,51 +356,55 @@ def get_profiles_sessions(
             # opens skip column reconciliation and would otherwise fail here
             # on every refresh until something else opened the DB writable.
             db = _open_session_db_at_path(db_path, read_only=True)
+            try:
+                def _read():
+                    rows = db.list_sessions_rich(
+                        source=source_filter,
+                        sources=source_list or None,
+                        exclude_sources=exclude_list or None,
+                        limit=per_profile,
+                        offset=0,
+                        min_message_count=min_message_count,
+                        include_archived=include_archived,
+                        archived_only=archived_only,
+                        order_by_last_active=order == "recent",
+                        # Same SQL-level blob skip as /api/sessions (see above).
+                        compact_rows=not full,
+                        include_pinned=True,
+                    )
+                    profile_total = db.session_count(
+                        source=source_filter,
+                        sources=source_list or None,
+                        exclude_sources=exclude_list or None,
+                        min_message_count=min_message_count,
+                        include_archived=include_archived,
+                        archived_only=archived_only,
+                        exclude_children=True,
+                    )
+                    return rows, profile_total
+
+                return _retry_sqlite_read(_read)
+            finally:
+                db.close()
+
+        try:
+            rows, profile_total = _load_profile_page()
         except Exception as exc:
             _warn_profile_read_error(name, exc)
             errors.append({"profile": name, "error": str(exc)})
             continue
-        try:
-            rows = db.list_sessions_rich(
-                source=source_filter,
-                sources=source_list or None,
-                exclude_sources=exclude_list or None,
-                limit=per_profile,
-                offset=0,
-                min_message_count=min_message_count,
-                include_archived=include_archived,
-                archived_only=archived_only,
-                order_by_last_active=order == "recent",
-                # Same SQL-level blob skip as /api/sessions (see above).
-                compact_rows=not full,
-                include_pinned=True,
+        total += profile_total
+        profile_totals[name] = profile_total
+        for s in rows:
+            s["profile"] = name
+            s["is_default_profile"] = name == "default"
+            s["is_active"] = (
+                s.get("ended_at") is None
+                and (now - s.get("last_active", s.get("started_at", 0))) < 300
             )
-            profile_total = db.session_count(
-                source=source_filter,
-                sources=source_list or None,
-                exclude_sources=exclude_list or None,
-                min_message_count=min_message_count,
-                include_archived=include_archived,
-                archived_only=archived_only,
-                exclude_children=True,
-            )
-            total += profile_total
-            profile_totals[name] = profile_total
-            for s in rows:
-                s["profile"] = name
-                s["is_default_profile"] = name == "default"
-                s["is_active"] = (
-                    s.get("ended_at") is None
-                    and (now - s.get("last_active", s.get("started_at", 0))) < 300
-                )
-                s["archived"] = bool(s.get("archived"))
-                s["pinned"] = bool(s.get("pinned"))
-                merged.append(s)
-        except Exception as exc:
-            _warn_profile_read_error(name, exc)
-            errors.append({"profile": name, "error": str(exc)})
-        finally:
-            db.close()
+            s["archived"] = bool(s.get("archived"))
+            s["pinned"] = bool(s.get("pinned"))
+            merged.append(s)
 
     sort_key = "last_active" if order == "recent" else "started_at"
     merged.sort(key=lambda s: s.get(sort_key) or s.get("started_at") or 0, reverse=True)
@@ -476,36 +534,46 @@ def get_profiles_sessions_sidebar(
         )
         slices = _sidebar_profile_cache_get(profile_cache_key)
         if slices is None:
-            try:
+            def _load_sidebar_slices():
                 # Read-only with the stale-schema heal — same contract as the
                 # per-slice endpoint above (one-time writable reconcile when the
                 # store predates a schema addition, plain read-only otherwise).
                 db = _open_session_db_at_path(db_path, read_only=True)
-            except Exception as exc:
-                _warn_profile_read_error(name, exc)
-                errors.append({"profile": name, "error": str(exc)})
-                continue
+                try:
+                    def _read():
+                        return {
+                            "recents": _slice(db, exclude=recents_exclude_list, cap=recents_cap),
+                            # Aggregated in SQL rather than over the recents window: the
+                            # window is a page, and a total that shrank when you scrolled
+                            # would be worse than no total at all.
+                            "usage": db.usage_totals(),
+                            "cron": _slice(db, source="cron", cap=cron_cap),
+                            "messaging": _slice(
+                                db,
+                                exclude=messaging_exclude_list,
+                                cap=messaging_cap,
+                            ),
+                        }
+
+                    return _retry_sqlite_read(_read)
+                finally:
+                    db.close()
+
             try:
-                slices = {
-                    "recents": _slice(db, exclude=recents_exclude_list, cap=recents_cap),
-                    # Aggregated in SQL rather than over the recents window: the
-                    # window is a page, and a total that shrank when you scrolled
-                    # would be worse than no total at all.
-                    "usage": db.usage_totals(),
-                    "cron": _slice(db, source="cron", cap=cron_cap),
-                    "messaging": _slice(
-                        db,
-                        exclude=messaging_exclude_list,
-                        cap=messaging_cap,
-                    ),
-                }
+                slices = _load_sidebar_slices()
+                _remember_sidebar_slices(db_path, slices)
                 _sidebar_profile_cache_put(profile_cache_key, slices)
             except Exception as exc:
-                _warn_profile_read_error(name, exc)
-                errors.append({"profile": name, "error": str(exc)})
-                continue
-            finally:
-                db.close()
+                slices = _recall_sidebar_slices(db_path)
+                if slices is None:
+                    _warn_profile_read_error(name, exc)
+                    errors.append({"profile": name, "error": str(exc)})
+                    continue
+                _log.warning(
+                    "sidebar scan failed for %s (%s); serving last good list",
+                    name,
+                    exc,
+                )
 
         profile_rows = slices["recents"]
         # A full window means more rows remain on disk. That is all the
@@ -1173,12 +1241,14 @@ async def export_profile_endpoint(name: str, body: ProfileExport):
 
     output = (body.output or "").strip()
     if not output:
+        from hermes_constants import get_hermes_home
+        staging = get_hermes_home() / "profile-exports"
         try:
-            output = str(profiles_mod.get_profile_export_path(name))
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
+            staging.mkdir(parents=True, exist_ok=True)
         except OSError as exc:
             raise HTTPException(status_code=500, detail=f"Could not create export directory: {exc}")
+        stamp = time.strftime("%Y%m%d-%H%M%S")
+        output = str(staging / f"{profiles_mod.normalize_profile_name(name)}-{stamp}.tar.gz")
 
     loop = asyncio.get_running_loop()
     try:

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -23,6 +23,7 @@ from fastapi import APIRouter, HTTPException, Query, Request  # noqa: F401
 from fastapi.encoders import jsonable_encoder
 from fastapi.responses import StreamingResponse
 
+from hermes_cli.sqlite_safe_read import is_transient_sqlite_error
 from hermes_cli.web_deps import late
 from hermes_cli.web_models import (
     BulkDeleteSessions,
@@ -197,6 +198,21 @@ def get_sessions(
             db.close()
     except HTTPException:
         raise
+    except sqlite3.OperationalError as exc:
+        _log.exception("GET /api/sessions failed")
+        # 503, not 500: the store is busy, not gone. Desktop must keep the
+        # previous sidebar instead of treating this as an authoritative empty
+        # list. Do not retry the open/close here — another close() in this
+        # process would cancel POSIX locks on the live writer.
+        transient = is_transient_sqlite_error(exc)
+        raise HTTPException(
+            status_code=503 if transient else 500,
+            detail=(
+                "Session store is busy (disk I/O or lock). Retry; the list was not cleared."
+                if transient
+                else "Internal server error"
+            ),
+        ) from exc
     except Exception:
         _log.exception("GET /api/sessions failed")
         raise HTTPException(status_code=500, detail="Internal server error")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12493,6 +12493,28 @@ _session_db_heal_exhausted: set = set()
 _session_db_heal_warned: set = set()
 
 
+_ro_session_db_cache: dict = {}
+_ro_session_db_cache_lock = threading.Lock()
+# Lost the retain race: extra readers we must not close() (POSIX).
+_ro_session_db_orphans: list = []
+
+
+def _ro_session_db_cache_clear():
+    """Test helper. Does not close cached connections (POSIX)."""
+    with _ro_session_db_cache_lock:
+        _ro_session_db_cache.clear()
+        _ro_session_db_orphans.clear()
+
+
+def _retain_readonly_session_db(db):
+    """Keep *db* for the process; make close() a no-op without wrapping.
+
+    A wrapper would break ``isinstance`` checks (heal tests swap in fakes).
+    """
+    db.close = lambda: None
+    return db
+
+
 def _open_session_db_at_path(db_path: Path, *, read_only: bool):
     """Open a SessionDB at an explicit path with an explicit access mode.
 
@@ -12507,13 +12529,34 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
     reconcile the store's own backend runs at startup. Tables created
     outside SCHEMA_SQL (telemetry ``tel_*``, FTS shadow tables) are
     deliberately outside both the probe and the heal.
+
+    Read-only opens are retained for the process lifetime: callers may
+    close() them, but that is ignored so a list poll cannot drop POSIX
+    locks on the live writer.
     """
     import sqlite3
 
+    from hermes_cli.sqlite_safe_read import is_transient_sqlite_error
     from hermes_state import SessionDB, is_malformed_schema_error
 
     if not read_only:
         return SessionDB(db_path=db_path, read_only=False)
+
+    cache_key = str(db_path)
+    with _ro_session_db_cache_lock:
+        cached = _ro_session_db_cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+    def _retain(db):
+        with _ro_session_db_cache_lock:
+            existing = _ro_session_db_cache.get(cache_key)
+            if existing is not None:
+                _retain_readonly_session_db(db)
+                _ro_session_db_orphans.append(db)
+                return existing
+            _ro_session_db_cache[cache_key] = _retain_readonly_session_db(db)
+            return _ro_session_db_cache[cache_key]
 
     def _needs_bootstrap() -> bool:
         try:
@@ -12537,13 +12580,21 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
             try:
                 for statement in _session_db_read_probe_statements():
                     conn.execute(statement).fetchone()
-            except BaseException:
+            except BaseException as exc:
+                if is_transient_sqlite_error(exc):
+                    _log.warning(
+                        "schema probe hit transient sqlite error on %s; "
+                        "serving the reader without a full probe: %s",
+                        db_path,
+                        exc,
+                    )
+                    return db
                 db.close()
                 raise
         return db
 
     try:
-        return _open_probed()
+        opened = _open_probed()
     except (sqlite3.DatabaseError, UnicodeDecodeError) as exc:
         message = str(exc).lower()
         stale_schema = "no such table" in message or "no such column" in message
@@ -12557,7 +12608,7 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
             raise
         SessionDB(db_path=db_path, read_only=False).close()
         try:
-            return _open_probed()
+            return _retain(_open_probed())
         except (sqlite3.DatabaseError, UnicodeDecodeError) as still_stale:
             message = str(still_stale).lower()
             if "no such table" not in message and "no such column" not in message:
@@ -12577,7 +12628,9 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
                     db_path,
                     still_stale,
                 )
-            return _open_probed()
+            return _retain(_open_probed())
+
+    return _retain(opened)
 
 
 def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5606,8 +5606,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if self._db_replaced or self._db_file_was_replaced():
             self._halt_db_replaced()
         logger.warning(
-            "state.db connection for %s was closed while a %s was still in "
-            "flight — reopening (teardown/worker race, #94736)",
+            "state.db connection for %s reopening after %s",
             self.db_path,
             context,
         )
@@ -5930,6 +5929,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # Set on the first compression-busy collision so the short wait is
         # measured from then, not from the start of the write.
         compression_deadline: Optional[float] = None
+        # One retry for IOERR on BEGIN IMMEDIATE only — the callback has
+        # not run, so there is no durable effect to replay. Never close()
+        # the writer to "heal" IOERR: POSIX close() of any fd for this
+        # file drops every lock this process holds (#99502, howtocorrupt).
+        ioerr_begin_retried = False
 
         # Transient engine-level error observed on contended WAL appends
         # (dual gateway/agent writers; FTS5 trigram sync holds the write
@@ -5943,6 +5947,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
 
         while True:
             self._raise_if_db_replaced()
+            fn_started = False
             try:
                 with self._lock:
                     if self._conn is None:
@@ -5951,6 +5956,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         self._reopen_after_close_locked(context="write")
                     self._conn.execute("BEGIN IMMEDIATE")
                     try:
+                        fn_started = True
                         result = fn(self._conn)
                         self._conn.commit()
                     except BaseException:
@@ -6003,7 +6009,17 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     ) from exc
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):
                     continue
-                # Non-lock error or patience exhausted — propagate.
+                if (
+                    "disk i/o" in err_msg
+                    and not fn_started
+                    and not ioerr_begin_retried
+                    and self._sleep_before_write_retry(deadline, patience_s)
+                ):
+                    ioerr_begin_retried = True
+                    continue
+                # Non-lock error, callback already ran, or patience exhausted.
+                # Do not close()+replay: settlement is unknown and close()
+                # drops POSIX locks for sibling connections in this process.
                 raise
             except sqlite3.DatabaseError as exc:
                 if _is_no_more_rows(exc) and self._sleep_before_write_retry(deadline, patience_s):

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -407,9 +407,32 @@ class SessionSchemaMixin:
                     return None
                 if "no such table" in str(exc).lower():
                     return False
+                msg = str(exc).lower()
+                # Concurrent writers (Desktop serve + gateway on a large WAL)
+                # can IOERR / lock this capability probe. Listing sessions
+                # does not need FTS. Re-raising 500s GET /api/sessions and
+                # the constructor then close()s this fd, which cancels POSIX
+                # locks for every other connection in the process — the
+                # documented route to a 0-byte WAL.
+                if any(
+                    marker in msg
+                    for marker in (
+                        "disk i/o",
+                        "database is locked",
+                        "database table is locked",
+                        "busy",
+                    )
+                ):
+                    logger.warning(
+                        "%s probe hit transient sqlite error; FTS disabled "
+                        "for this open: %s",
+                        table_name,
+                        exc,
+                    )
+                    return None
                 # Re-raise any other OperationalError (e.g. malformed schema,
                 # corrupt vtable that isn't a decode error).
-                if "decode to utf-8" not in str(exc).lower():
+                if "decode to utf-8" not in msg:
                     raise
             # Swallow: decode error means the index is degraded but the
             # store remains accessible. Writable init / recovery will
@@ -522,7 +545,10 @@ class SessionSchemaMixin:
             # A corrupt vtable may fail even a LIMIT 0 probe. It still needs
             # to be included in the drop-and-recreate recovery below.
             trigram_status = True
-        include_trigram = trigram_status is True
+        # False = no such table (skip trigram DDL). True = queryable.
+        # None = probe degraded (IOERR/lock) — the table likely exists and
+        # must still be dropped, or CREATE later collides.
+        include_trigram = trigram_status is not False
 
         drop_sql = "".join(
             f"DROP TRIGGER IF EXISTS {trigger};" for trigger in _FTS_TRIGGERS

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -1,6 +1,7 @@
 """Regression tests for dashboard sidebar scan coalescing."""
 
 import inspect
+import sqlite3
 import tempfile
 import threading
 import time
@@ -127,6 +128,89 @@ class SidebarCacheTests(unittest.TestCase):
         self.assertEqual(scan(), {"ok": True})
         self.assertEqual(scan(), {"ok": True})
         self.assertEqual(calls, 2)
+
+    def test_does_not_cache_payloads_that_carry_profile_errors(self):
+        # A 200 with errors=[]-nonempty is how a failed profile scan is
+        # reported. Caching it for the 5s TTL keeps the empty recents page
+        # in front of a recovered DB and the sidebar stays blank.
+        calls = 0
+
+        @profiles._sidebar_singleflight_cache
+        def scan():
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                return {"errors": [{"profile": "default", "error": "disk I/O error"}], "recents": {"sessions": []}}
+            return {"errors": [], "recents": {"sessions": [{"id": "yesterday"}]}}
+
+        first = scan()
+        second = scan()
+
+        self.assertEqual(first["errors"][0]["error"], "disk I/O error")
+        self.assertEqual(second["recents"]["sessions"], [{"id": "yesterday"}])
+        self.assertEqual(calls, 2)
+
+    def test_transient_sqlite_error_retries_ioerr_not_malformed(self):
+        self.assertTrue(
+            profiles._transient_sqlite_error(sqlite3.OperationalError("disk I/O error"))
+        )
+        self.assertTrue(
+            profiles._transient_sqlite_error(sqlite3.OperationalError("database is locked"))
+        )
+        self.assertFalse(
+            profiles._transient_sqlite_error(sqlite3.DatabaseError("database disk image is malformed"))
+        )
+        self.assertFalse(profiles._transient_sqlite_error(RuntimeError("disk I/O error")))
+
+    def test_retry_sqlite_read_recovers_after_disk_io_errors(self):
+        calls = 0
+
+        def flaky():
+            nonlocal calls
+            calls += 1
+            if calls < 3:
+                raise sqlite3.OperationalError("disk I/O error")
+            return {"ok": True}
+
+        with mock.patch.object(profiles.time, "sleep"):
+            self.assertEqual(profiles._retry_sqlite_read(flaky), {"ok": True})
+        self.assertEqual(calls, 3)
+
+    def test_failed_scan_serves_last_good_slices(self):
+        db_path = "/tmp/state.db"
+        good = {
+            "recents": [{"id": "yesterday", "pinned": False}],
+            "usage": {"tokens": 1},
+            "cron": [],
+            "messaging": [],
+        }
+        profiles._remember_sidebar_slices(db_path, good)
+        recalled = profiles._recall_sidebar_slices(db_path)
+        self.assertEqual(recalled["recents"][0]["id"], "yesterday")
+        recalled["recents"][0]["id"] = "mutated"
+        self.assertEqual(
+            profiles._recall_sidebar_slices(db_path)["recents"][0]["id"],
+            "yesterday",
+        )
+        profiles._sidebar_profile_cache_clear()
+        self.assertIsNone(profiles._recall_sidebar_slices(db_path))
+
+    def test_retry_sqlite_read_does_not_retry_malformed(self):
+        calls = 0
+
+        def corrupt():
+            nonlocal calls
+            calls += 1
+            raise sqlite3.DatabaseError("database disk image is malformed")
+
+        with self.assertRaises(sqlite3.DatabaseError):
+            profiles._retry_sqlite_read(corrupt)
+        self.assertEqual(calls, 1)
+
+    def test_retry_sqlite_read_doc_forbids_wrapping_connect_close(self):
+        source = inspect.getsource(profiles._retry_sqlite_read)
+        self.assertIn("already open", source)
+        self.assertNotIn("SessionDB", source)
 
     def test_can_be_disabled(self):
         calls = 0

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -319,6 +319,30 @@ class TestWebServerEndpoints:
                 monitor.close()
             writer.close()
 
+    def test_get_sessions_transient_ioerr_is_503(self, monkeypatch):
+        import sqlite3
+
+        from hermes_cli import web_server
+
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("disk I/O error")
+
+        monkeypatch.setattr(web_server, "_open_session_db_for_profile", boom)
+        response = self.client.get("/api/sessions?limit=1&offset=0")
+        assert response.status_code == 503
+
+    def test_get_sessions_non_transient_operational_error_is_500(self, monkeypatch):
+        import sqlite3
+
+        from hermes_cli import web_server
+
+        def boom(*_args, **_kwargs):
+            raise sqlite3.OperationalError("no such table: sessions")
+
+        monkeypatch.setattr(web_server, "_open_session_db_for_profile", boom)
+        response = self.client.get("/api/sessions?limit=1&offset=0")
+        assert response.status_code == 500
+
     def test_get_status_loads_gateway_config_off_event_loop(self, monkeypatch):
         """Cold gateway config loading must not block the WebSocket loop.
 

--- a/tests/test_fts_probe_transient_ioerr.py
+++ b/tests/test_fts_probe_transient_ioerr.py
@@ -1,0 +1,107 @@
+"""FTS capability probe must not 500 a session list on transient I/O.
+
+GET /api/sessions opens a short-lived read-only SessionDB. Its constructor
+probes ``messages_fts`` with ``SELECT * FROM … LIMIT 0``. A concurrent writer
+can make that probe raise SQLITE_IOERR. Re-raising used to:
+
+1. 500 the whole list (sidebar empty);
+2. ``close()`` the probe connection in the same process as the live writer,
+   which cancels POSIX locks and can truncate ``state.db-wal`` to 0 bytes.
+
+Listing sessions does not need FTS. Transient probe errors degrade search
+for that open and leave the connection up.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import Any
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+class _RaisingCursor:
+    def __init__(self, exc: BaseException):
+        self.exc = exc
+
+    def execute(self, _sql: str) -> Any:
+        raise self.exc
+
+
+def _probe_host() -> SessionDB:
+    return SessionDB.__new__(SessionDB)
+
+
+class TestFtsTableProbeTransient:
+    def test_disk_io_degrades_instead_of_raising(self):
+        host = _probe_host()
+        assert (
+            host._fts_table_probe(
+                _RaisingCursor(sqlite3.OperationalError("disk I/O error")),  # type: ignore[arg-type]
+                "messages_fts",
+            )
+            is None
+        )
+
+    def test_locked_degrades_instead_of_raising(self):
+        host = _probe_host()
+        assert (
+            host._fts_table_probe(
+                _RaisingCursor(sqlite3.OperationalError("database is locked")),  # type: ignore[arg-type]
+                "messages_fts",
+            )
+            is None
+        )
+
+    def test_malformed_vtable_still_raises(self):
+        host = _probe_host()
+        with pytest.raises(sqlite3.OperationalError, match="malformed"):
+            host._fts_table_probe(
+                _RaisingCursor(
+                    sqlite3.OperationalError(
+                        "malformed database schema (messages_fts) - table messages_fts already exists"
+                    )
+                ),  # type: ignore[arg-type]
+                "messages_fts",
+            )
+
+    def test_readonly_open_survives_fts_probe_ioerr(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        writable = SessionDB(db_path=db_path)
+        writable.create_session("probe-ioerr", source="cli")
+        writable.append_message("probe-ioerr", role="user", content="keep me")
+        writable.close()
+
+        real = SessionDB._fts_table_probe
+
+        def ioerr_probe(self, cursor, table_name):
+            return real(
+                self,
+                _RaisingCursor(sqlite3.OperationalError("disk I/O error")),  # type: ignore[arg-type]
+                table_name,
+            )
+
+        monkeypatch.setattr(SessionDB, "_fts_table_probe", ioerr_probe)
+
+        read_only = SessionDB(db_path=db_path, read_only=True)
+        try:
+            assert read_only._conn is not None
+            rows = read_only.list_sessions_rich(limit=10, compact_rows=True)
+            assert any(row["id"] == "probe-ioerr" for row in rows)
+        finally:
+            read_only.close()
+
+    def test_stale_fts_recovery_drops_trigram_when_probe_returns_none(self, monkeypatch):
+        host = SessionDB.__new__(SessionDB)
+        sqls: list[str] = []
+
+        class FakeCursor:
+            def executescript(self, sql):
+                sqls.append(sql)
+
+        monkeypatch.setattr(SessionDB, "_fts_table_probe", lambda self, cursor, table_name: None)
+        host._conn = type("C", (), {"rollback": lambda self: None, "commit": lambda self: None})()
+        assert host._recover_stale_fts_locked(FakeCursor(), legacy=False) is True
+        assert any("DROP TABLE IF EXISTS messages_fts_trigram" in sql for sql in sqls)

--- a/tests/test_state_db_notadb_fail_closed.py
+++ b/tests/test_state_db_notadb_fail_closed.py
@@ -1,11 +1,12 @@
 """Tests for fail-closed state.db NOTADB handling and journal-mode EIO retries.
 
-Covers the two independently-valuable pieces salvaged from the state.db
-hardening rollup:
+Covers:
 
-* fail closed when a live write connection reports ``file is not a database``;
-* transient ``disk i/o error`` retry in ``_on_disk_journal_mode`` so a
-  one-shot EIO doesn't push callers onto the fail-closed unknown-mode branch.
+* IOERR on BEGIN IMMEDIATE (callback has not run) may retry once on the
+  same connection — no close(), no replay of a started write (#99502);
+* IOERR after the callback mutates must NOT rerun the callback;
+* genuine on-disk NOTADB / replaced file still fail-closed (#89332);
+* transient ``disk i/o error`` retry in ``_on_disk_journal_mode``.
 """
 
 import sqlite3
@@ -16,36 +17,101 @@ import pytest
 from hermes_state import SessionDB, _on_disk_journal_mode
 
 
-class _NotADbOnce:
-    """Connection proxy that raises 'file is not a database' on execute."""
+class _BeginIoerrOnce:
+    """Fail the first BEGIN IMMEDIATE, then proxy to the real connection."""
 
     def __init__(self, real_conn):
         self._real = real_conn
+        self.begins = 0
 
-    def execute(self, *args, **kwargs):
-        raise sqlite3.DatabaseError("file is not a database")
+    def execute(self, sql, *args, **kwargs):
+        if str(sql).strip().upper().startswith("BEGIN") and self.begins == 0:
+            self.begins += 1
+            raise sqlite3.OperationalError("disk I/O error")
+        return self._real.execute(sql, *args, **kwargs)
 
     def __getattr__(self, name):
         return getattr(self._real, name)
 
 
-class TestFailClosedAfterNotADb:
-    def test_write_does_not_reopen_after_connection_identity_breaks(
-        self, tmp_path, monkeypatch
-    ):
-        """One connection cannot safely heal a shared DB identity change."""
+class TestWriteIoerrSettlement:
+    def test_begin_ioerr_retries_once_without_reopen(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(SessionDB, "_WRITE_PATIENCE_S", 2.0)
+        monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MIN_S", 0.001)
+        monkeypatch.setattr(SessionDB, "_WRITE_RETRY_MAX_S", 0.005)
         db = SessionDB(db_path=tmp_path / "state.db")
-        real_conn = db._conn
+        original = db._conn
+        connects = {"n": 0}
+        import hermes_state as hs
+
+        real_connect = hs._connect_tracked_db
+
+        def counting_connect(*args, **kwargs):
+            connects["n"] += 1
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr("hermes_state._connect_tracked_db", counting_connect)
+        try:
+            db._conn = _BeginIoerrOnce(original)  # type: ignore[assignment]
+            calls = {"n": 0}
+
+            def write(conn):
+                calls["n"] += 1
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES ('eio', 'ok') "
+                    "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+                )
+                return "done"
+
+            assert db._execute_write(write) == "done"
+            assert calls["n"] == 1
+            assert connects["n"] == 0
+            assert db.get_meta("eio") == "ok"
+        finally:
+            db._conn = original
+            db.close()
+
+    def test_ioerr_after_mutation_does_not_replay(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        try:
+            calls = {"n": 0}
+
+            def boom(conn):
+                calls["n"] += 1
+                conn.execute(
+                    "INSERT INTO state_meta (key, value) VALUES ('once', '1') "
+                    "ON CONFLICT(key) DO UPDATE SET value=excluded.value"
+                )
+                raise sqlite3.OperationalError("disk I/O error")
+
+            with pytest.raises(sqlite3.OperationalError, match="disk I/O"):
+                db._execute_write(boom)
+            assert calls["n"] == 1
+            assert db.get_meta("once") is None
+        finally:
+            db.close()
+
+    def test_notadb_does_not_reopen(self, tmp_path, monkeypatch):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real = db._conn
         try:
             db.create_session(session_id="s1", source="cli", model="test")
+
+            class Boom:
+                def execute(self, *args, **kwargs):
+                    raise sqlite3.DatabaseError("file is not a database")
+
+                def __getattr__(self, name):
+                    return getattr(real, name)
+
+            db._conn = Boom()  # type: ignore[assignment]
             reopen = MagicMock()
             monkeypatch.setattr("hermes_state._connect_tracked_db", reopen)
-            db._conn = _NotADbOnce(real_conn)
             with pytest.raises(sqlite3.DatabaseError, match="not a database"):
-                db.create_session(session_id="s2", source="cli", model="test")
+                db._execute_write(lambda conn: conn.execute("SELECT 1"))
             reopen.assert_not_called()
         finally:
-            db._conn = real_conn
+            db._conn = real
             db.close()
 
 


### PR DESCRIPTION
## Bug Description

While a Desktop session is running, two things happen on the same SQLite race (Desktop `hermes serve` + launchd gateway both writing a large WAL):

1. **Sidebar:** Yesterday / Earlier this week rows vanish, then reappear. `state.db` still has them.
2. **List 500 / WAL truncate:** sidebar polls `open` a `mode=ro` SessionDB and `close()` it. POSIX `close()` of any fd on `state.db` cancels every lock in the process, including the live writer, and can truncate `state.db-wal` to 0 bytes. The next `list_sessions_rich` is `SQLITE_IOERR` / malformed; packaged Desktop treats empty recents as authority.

Part of #73847
Part of #88528

## Root Cause

`GET /api/profiles/sessions/sidebar` reports a profile read failure as HTTP 200 with `recents=[]` and `errors=[{profile}]`. The renderer runs `mergeSessionPage(prev, incoming, working∪pinned∪selected)`, so an empty incoming page drops idle rows. The 5s singleflight cache then reuses that empty payload.

Independently, every list poll opened and closed a read-only connection in the same process as the Desktop writer. That is the POSIX lock-cancel path, not file replacement (#89332).

## Fix

- **Renderer:** `carryForwardFailedProfileSessions` re-attaches previous rows only for profiles named in `errors`. A genuine empty page (no `errors`) still clears the list. Per-slice errors so a cron I/O cannot taint recents. Keep previous usage/truncated flags for failed profiles.
- **Cache:** do not store sidebar responses that carry `errors`.
- **Read path:** retry transient SQLite `OperationalError` (disk I/O / locked / busy) on one already-open connection; do not retry `malformed`. FTS probe I/O degrades FTS for that open instead of `close()`+raise.
- **Retain readers:** cache read-only `SessionDB`s for the process lifetime; `close()` is a no-op (no wrapper — `isinstance` stays intact). Serve last-good sidebar slices when a rescan fails so packaged Desktop does not treat `[]` as authority.

Writer poison-reopen (`close()` + replay `_execute_write`) was **dropped** (review / #99502). Replaced or garbage files stay fail-closed (#89332).

## Relation to #100201

#100201 (merged) consolidates *in-process* gateway writers via a shared registry. It does not retain Desktop list readers or carry-forward failed sidebar scans. This PR is complementary, not a substitute.

## How to Verify

1. Idle Yesterday/This-week rows + a live session. Empty recents + `errors: [{profile: default}]` must keep idle rows. Empty recents and no errors must clear the list.
2. Schema-probe / FTS-probe `disk I/O` does not `close()` the reader next to a live writer.
3. A failed sidebar rescan returns the previous recents, not `[]`.

## Test Plan

- [x] Sidebar: `carryForwardFailedProfileSessions`, hook refresh empty+errors vs genuine empty, cache skip, IOERR retry / no-retry malformed, last-good slices
- [x] FTS probe transient IOERR degrades instead of raising
- [x] `tests/hermes_cli/test_profiles_sidebar_cache.py` + notadb fail-closed + web_server heal `isinstance` — pytest green on this SHA
- [x] vitest `session.test.ts` + `use-session-list-actions.test.tsx` (from earlier stack; renderer hunks unchanged)

## Risk Assessment

Low–medium. Error path only for the sidebar. No writer replay. Carry-forward is keyed by `profile::id` so it cannot stitch cross-profile twins (#92454). Read-only `close()` no-op does not wrap the object, so heal tests that `isinstance` SessionDB still pass.
