### PR TITLE
fix(retry): extend Z.AI Coding adaptive 429 backoff to glm-5 family + code 1302

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -18,12 +18,13 @@ from typing import Any, Optional
 _jitter_counter = 0
 _jitter_lock = threading.Lock()
 
-# Z.AI Coding Plan's GLM-5.2 endpoint often returns HTTP 429 code 1305
-# ("The service may be temporarily overloaded...") for otherwise valid
-# Hermes requests. Short retries tend to hammer the same overloaded window;
-# after a few normal retries, progressively widen the wait window. Keep the
-# cap interactive-friendly: a simple TUI message should fail visibly in minutes,
-# not sit silent for 20+ minutes.
+# Z.AI Coding Plan's GLM-5 endpoints return transient HTTP 429s in two shapes:
+# code 1305 ("The service may be temporarily overloaded...") and code 1302
+# ("Rate limit reached for requests" — account/request-rate window, observed
+# 2026-08-31 sustaining ~2 minutes). Short retries tend to hammer the same
+# window; after a few normal retries, progressively widen the wait window.
+# Keep the cap interactive-friendly: a simple TUI message should fail visibly
+# in minutes, not sit silent for 20+ minutes.
 _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 
 # Number of initial short retries before the adaptive long-backoff tier kicks
@@ -140,23 +141,31 @@ def _error_text(error: Any) -> str:
 
 
 def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
-    """Return True for Z.AI Coding Plan transient overload 429s.
+    """Return True for transient Z.AI Coding Plan 429s worth of adaptive backoff.
 
-    The coding-plan endpoint reports overload as HTTP 429 with body code 1305
-    and message "The service may be temporarily overloaded...". Treat only
-    that narrow shape specially so ordinary quota/billing 429s still fail fast
-    through the existing classifier.
+    Two production shapes qualify (both on the Coding Plan endpoint, GLM-5
+    family models, HTTP 429):
+    - code 1305 "The service may be temporarily overloaded..." (capacity), and
+    - code 1302 "Rate limit reached for requests" (account/request-rate limit).
+
+    The 1302 shape observed 2026-08-31 (~22:57) exhausted the default 3-attempt
+    budget in ~10s while the limit window lasted ~2 minutes, killing kanban
+    workers on their first LLM call (glm-5.3-flash). Ordinary quota/billing
+    429s on other providers/models still fail fast through the classifier.
     """
     base = (base_url or "").lower()
     model_name = (model or "").lower()
     status = getattr(error, "status_code", None)
     text = _error_text(error)
-    return (
-        status == 429
-        and "api.z.ai/api/coding/paas/v4" in base
-        and "glm-5.2" in model_name
-        and ("1305" in text or "temporarily overloaded" in text)
-    )
+    if status != 429:
+        return False
+    if "api.z.ai/api/coding/paas/v4" not in base:
+        return False
+    if "glm-5" not in model_name:
+        return False
+    if "1305" in text or "temporarily overloaded" in text:
+        return True
+    return "1302" in text or "rate limit reached" in text
 
 
 def adaptive_rate_limit_backoff(

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -169,6 +169,80 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
     assert long_waits == [30.0, 60.0, 90.0, 120.0]
 
 
+def _zai_rate_limit_error():
+    """The other transient Z.AI Coding Plan 429: code 1302 'Rate limit reached
+    for requests'. Observed in production 2026-08-31 (~22:57-22:59) killing
+    kanban workers on glm-5.3-flash that exhausted the old 3-attempt budget in
+    ~10s while the limit window lasted ~2 minutes (see crashed sessions
+    20260831_225716_bfbdb9 / 20260831_225816_374804)."""
+    return SimpleNamespace(
+        status_code=429,
+        message="Error code: 429 - {'error': {'code': '1302', 'message': 'Rate limit reached for requests'}}",
+        body={
+            "error": {
+                "code": "1302",
+                "message": "Rate limit reached for requests",
+            }
+        },
+    )
+
+
+def test_zai_coding_rate_limit_1302_gets_adaptive_backoff():
+    """Regression (2026-08-31 worker crashes): code-1302 429s on glm-5.3-flash
+    must match the Z.AI Coding adaptive policy so the retry loop extends its
+    ceiling and survives the ~2min account-wide limit window instead of exiting
+    at ~10s. Previously only glm-5.2 + code 1305 matched."""
+    assert is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.3-flash",
+        error=_zai_rate_limit_error(),
+    ) is True
+
+
+def test_zai_coding_rate_limit_1302_long_tier_reachable(monkeypatch):
+    """With the widened matcher, the 1302 error walks the same extended ceiling
+    and reaches the long-backoff tier within it."""
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    from agent.retry_utils import zai_coding_overload_retry_ceiling
+
+    err = _zai_rate_limit_error()
+    ceiling = zai_coding_overload_retry_ceiling()
+
+    long_waits = []
+    for attempt in range(1, ceiling):
+        _wait, policy = adaptive_rate_limit_backoff(
+            attempt,
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            model="glm-5.3-flash",
+            error=err,
+            default_wait=1.0,
+        )
+        if policy == "zai_coding_overload_long":
+            long_waits.append(_wait)
+
+    assert long_waits == [30.0, 60.0, 90.0, 120.0]
+
+
+def test_zai_coding_matcher_still_scoped_to_coding_endpoint_and_429():
+    """Widening must not leak: non-coding z.ai endpoints, non-429 errors, and
+    non-GLM-5 models stay outside the adaptive policy (they keep the ordinary
+    short retry path)."""
+    err = _zai_rate_limit_error()
+    # Wrong endpoint (public PAAS API, not the Coding Plan).
+    assert is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/paas/v4", model="glm-5.3-flash", error=err
+    ) is False
+    # Not a 429.
+    err_500 = SimpleNamespace(status_code=500, body=err.body)
+    assert is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4", model="glm-5.3-flash", error=err_500
+    ) is False
+    # Older GLM-4 family stays on the ordinary path.
+    assert is_zai_coding_overload_error(
+        base_url="https://api.z.ai/api/coding/paas/v4", model="glm-4.5-flash", error=err
+    ) is False
+
+
 # ---------------------------------------------------------------------------
 # parse_retry_after_seconds — shared Retry-After parser
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_kanban_loop_trace_gate.py
+++ b/tests/tools/test_kanban_loop_trace_gate.py
@@ -1,0 +1,159 @@
+"""Tests for the orchestrator loop-closure trace completion gate
+(card t_31b252aa; LOOP-CLOSURE LAW enforcement, tools/kanban_tools.py).
+
+The gate lives in ``_missing_loop_trace`` + the call inside
+``_handle_complete``.  It is scoped to profiles listed in
+``_LOOP_TRACE_REQUIRED_PROFILES`` (the orchestrator, "default") and
+rejects completions whose summary carries neither the four trace verbs
+(attempted / failed / verified / do-differently) nor the explicit
+"loop-closure: nothing new" escape hatch.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+TRACE = (
+    "shipped the gate. "
+    "attempted: code gate + tests. "
+    "failed: none. "
+    "verified: pytest green. "
+    "do-differently: n/a."
+)
+
+
+@pytest.fixture
+def worker_env(monkeypatch, tmp_path):
+    """Local copy of tests/tools/test_kanban_tools.py::worker_env —
+    isolated HERMES_HOME + a claimed task bound to HERMES_KANBAN_TASK."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "test-worker")
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    from pathlib import Path as _Path
+    monkeypatch.setattr(_Path, "home", lambda: tmp_path)
+
+    from hermes_cli import kanban_db as kb
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="loop-trace-gate-test", assignee="test-worker")
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    return tid
+
+
+@pytest.fixture
+def default_profile_env(worker_env, monkeypatch):
+    """worker_env but acting as the default (orchestrator) profile."""
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    return worker_env
+
+
+def _out_dict(out: str) -> dict:
+    return json.loads(out)
+
+
+# ---------------------------------------------------------------------------
+# Unit: _missing_loop_trace
+# ---------------------------------------------------------------------------
+
+class TestMissingLoopTraceUnit:
+    def test_other_profiles_exempt(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "frontend")
+        assert kt._missing_loop_trace("did stuff") is None
+
+    def test_default_traceless_rejected(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        msg = kt._missing_loop_trace("did stuff, all good")
+        assert msg is not None and "attempted" in msg
+
+    def test_default_full_trace_passes(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        assert kt._missing_loop_trace(TRACE) is None
+
+    def test_default_partial_trace_rejected(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        # missing 'do-differently'
+        partial = "attempted x. failed y. verified z."
+        msg = kt._missing_loop_trace(partial)
+        assert msg is not None and "do-differently" in msg
+
+    def test_nothing_new_escape_hatch(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        assert kt._missing_loop_trace("ran probe. loop-closure: nothing new") is None
+
+    def test_case_insensitive_verbs(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.setenv("HERMES_PROFILE", "default")
+        upper = TRACE.upper()
+        assert kt._missing_loop_trace(upper) is None
+
+    def test_unprofiled_env_falls_back_to_default(self, monkeypatch):
+        from tools import kanban_tools as kt
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        # fallback resolves to "default" -> gated
+        msg = kt._missing_loop_trace("plain summary")
+        assert msg is not None
+
+
+# ---------------------------------------------------------------------------
+# Integration: _handle_complete honours the gate
+# ---------------------------------------------------------------------------
+
+class TestCompleteGateIntegration:
+    def test_default_traceless_completion_rejected(self, default_profile_env):
+        from tools import kanban_tools as kt
+        out = kt._handle_complete({"summary": "all done, shipped it"})
+        d = _out_dict(out)
+        assert "error" in d
+        assert "LOOP-CLOSURE" in d["error"]
+        # task must still be in-flight (not done)
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        try:
+            t = kb.get_task(conn, default_profile_env)
+            assert t.status == "running", (
+                f"gate must leave task in-flight, got {t.status}"
+            )
+        finally:
+            conn.close()
+
+    def test_default_traced_completion_succeeds(self, default_profile_env):
+        from tools import kanban_tools as kt
+        out = kt._handle_complete({"summary": TRACE})
+        d = _out_dict(out)
+        assert d.get("ok") is True, d
+        from hermes_cli import kanban_db as kb
+        conn = kb.connect()
+        try:
+            t = kb.get_task(conn, default_profile_env)
+            assert t.status == "done"
+        finally:
+            conn.close()
+
+    def test_default_nothing_new_completion_succeeds(self, default_profile_env):
+        from tools import kanban_tools as kt
+        out = kt._handle_complete({
+            "summary": "probe re-run. loop-closure: nothing new"
+        })
+        d = _out_dict(out)
+        assert d.get("ok") is True, d
+
+    def test_worker_profile_unaffected(self, worker_env):
+        """worker_env sets HERMES_PROFILE=test-worker — no gate."""
+        from tools import kanban_tools as kt
+        out = kt._handle_complete({"summary": "plain worker summary"})
+        d = _out_dict(out)
+        assert d.get("ok") is True, d

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -692,6 +692,11 @@ def test_orchestrator_complete_any_task_allowed(monkeypatch, tmp_path):
     """Orchestrator profiles (no HERMES_KANBAN_TASK) can still complete
     any task via explicit task_id. The check only applies to workers."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    # Generic orchestrator profile — NOT "default": that profile carries
+    # the loop-closure trace completion gate (t_31b252aa) which would
+    # reject this trace-less summary and mask the ownership behaviour
+    # under test here.
+    monkeypatch.setenv("HERMES_PROFILE", "test-orchestrator")
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -212,6 +212,66 @@ def _enforce_worker_task_ownership(tid: str) -> Optional[str]:
     return None
 
 
+# Profiles whose kanban_complete summaries MUST carry an explicit
+# loop-closure trace.  Fleet Loop Digest 2026-08-31 Week 1 found 0/15
+# audited done cards with the trace despite the LOOP-CLOSURE LAW text
+# shipping in every SOUL.md / system prompt — awareness alone does not
+# enforce behaviour, so the completion path hard-gates it.  Card
+# t_31b252aa.  Only the orchestrator profile is scoped for now; extend
+# this set as the weekly Fleet Loop Optimizer audit (Mon 09:00) widens
+# enforcement.
+_LOOP_TRACE_REQUIRED_PROFILES = frozenset({"default"})
+
+# A summary passes when it contains the explicit nothing-new escape
+# hatch or all four trace verbs (the audit regex the weekly optimizer
+# runs is kept intentionally looser — this gate enforces the strict
+# form at write time so audits stay clean).
+_LOOP_TRACE_NOTHING_NEW = "loop-closure: nothing new"
+_LOOP_TRACE_VERBS = ("attempted", "failed", "verified", "do-differently")
+
+
+def _active_profile() -> str:
+    """Best-effort acting-profile name (env first, config fallback)."""
+    name = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if name:
+        return name
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _missing_loop_trace(summary: Optional[str]) -> Optional[str]:
+    """Return a rejection message when a required trace is absent.
+
+    Applies only to profiles listed in ``_LOOP_TRACE_REQUIRED_PROFILES``
+    (the orchestrator).  The check is purely textual on the summary +
+    legacy result field, runs BEFORE any DB mutation, and returns a
+    retryable tool_error — the task stays in-flight so the worker can
+    simply re-call kanban_complete with the trace appended.
+    """
+    if _active_profile() not in _LOOP_TRACE_REQUIRED_PROFILES:
+        return None
+    text = str(summary or "")
+    if _LOOP_TRACE_NOTHING_NEW in text.lower():
+        return None
+    lowered = text.lower()
+    missing = [v for v in _LOOP_TRACE_VERBS if v not in lowered]
+    if missing:
+        return (
+            "kanban_complete blocked by LOOP-CLOSURE LAW gate: summary "
+            f"lacks the execution trace (missing: {', '.join(missing)}). "
+            "Append 2-3 lines to the summary in the form "
+            "'attempted: ... / failed: ... / verified: ... / "
+            "do-differently: ...', or state 'loop-closure: nothing new' "
+            "if the run genuinely produced no lesson. Task is still "
+            "in-flight — retry kanban_complete with the same handoff "
+            "plus the trace."
+        )
+    return None
+
+
 def _connect(board: Optional[str] = None):
     """Import + connect lazily so the module imports cleanly in non-kanban
     contexts (e.g. test rigs that import every tool module).
@@ -737,6 +797,12 @@ def _handle_complete(args: dict, **kw) -> str:
         return tool_error(
             "provide at least one of: summary (preferred), result"
         )
+    # LOOP-CLOSURE LAW gate (card t_31b252aa): scoped to the
+    # orchestrator profile — reject trace-less completion summaries
+    # BEFORE any DB mutation so the worker can retry cheaply.
+    loop_trace_err = _missing_loop_trace(summary or result)
+    if loop_trace_err:
+        return tool_error(loop_trace_err)
     if metadata is not None and not isinstance(metadata, dict):
         return tool_error(
             f"metadata must be an object/dict, got {type(metadata).__name__}"
@@ -1778,7 +1844,13 @@ KANBAN_COMPLETE_SCHEMA = {
         "in ``artifacts`` — the gateway notifier will upload them as "
         "native attachments to the human who subscribed to the task, "
         "so the deliverable lands in their chat alongside the summary "
-        "instead of being a path they have to fetch by hand."
+        "instead of being a path they have to fetch by hand. "
+        "LOOP-CLOSURE LAW: the summary MUST end with a 2-3 line "
+        "execution trace — 'attempted: ... / failed: ... / verified: "
+        "... / do-differently: ...' — or the explicit line "
+        "'loop-closure: nothing new' when the run genuinely taught "
+        "nothing. Trace-less completions are rejected (enforced for "
+        "the orchestrator profile)."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Problem
Production incident 2026-08-31 ~22:57: kanban workers (model glm-5.3-flash via the Z.AI Coding endpoint) died on their FIRST LLM call during a ~2min account-wide ZAI rate-limit window. The 429 (code 1302 'Rate limit reached for requests') exhausted the default 3-attempt retry budget in ~10s -> terminal exit -> the worker crash-looped and its task was blocked.

The adaptive long-backoff schedule (30/60/90/120s + raised retry ceiling) already existed but was gated to glm-5.2 + code 1305 only.

## Fix
Widen the Z.AI Coding overload matcher to the whole GLM-5 family and the 1302 rate-limit shape, keeping it scoped to Z.AI coding-plan base URLs. Retry ceiling raised 3->8 (~341s total backoff budget) for that error class.

## Verification
- tests/test_retry_utils.py: 14/14 green
- run_agent rate/retry subset: 25/25 green
- live venv import verified; production rerun of the affected task survived past the original 120s death window and completed (21 tool calls)
