### PR TITLE
fix(gateway): pass config API key to model switch

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1821,6 +1821,7 @@ class GatewaySlashCommandsMixin:
                     current_model = model_cfg.get("default", "")
                     current_provider = model_cfg.get("provider", current_provider)
                     current_base_url = model_cfg.get("base_url", "")
+                    current_api_key = model_cfg.get("api_key", "") or ""
                 user_provs = cfg.get("providers")
                 try:
                     from hermes_cli.config import get_compatible_custom_providers

--- a/tests/gateway/test_model_command_custom_providers.py
+++ b/tests/gateway/test_model_command_custom_providers.py
@@ -68,3 +68,41 @@ async def test_direct_model_switch_offloads_to_thread(tmp_path, monkeypatch):
     # switch_model was offloaded to a worker thread, not run on the event loop.
     assert "_fake_switch" in offloaded
     assert result is not None and "nope" in result
+
+
+@pytest.mark.asyncio
+async def test_direct_custom_model_switch_uses_configured_api_key(tmp_path, monkeypatch):
+    """Gateway `/model` must authenticate the custom `/models` probe."""
+    from hermes_cli.model_switch import ModelSwitchResult
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "default": "gpt-5.6-sol",
+                    "provider": "custom",
+                    "base_url": "http://127.0.0.1:8317/v1",
+                    "api_key": "test-custom-key",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+    captured = {}
+
+    def _fake_switch(**kwargs):
+        captured.update(kwargs)
+        return ModelSwitchResult(success=False, error_message="stop after capture")
+
+    monkeypatch.setattr("hermes_cli.model_switch.switch_model", _fake_switch)
+
+    result = await _make_runner()._handle_model_command(_make_event("/model Kimi-K3"))
+
+    assert result is not None and "stop after capture" in result
+    assert captured["current_api_key"] == "test-custom-key"


### PR DESCRIPTION
## Summary
- read `model.api_key` from the active gateway profile when handling `/model`
- pass the configured key into the existing model-switch path so authenticated bare custom endpoints can probe `/models`
- add a regression test against the current `GatewayRunner` slash-command path

## Why a new PR

Supersedes #18685 after the gateway slash-command extraction moved the active handler from `gateway/run.py` to `gateway/slash_commands.py`. The earlier PR's diagnosis and regression-test direction remain correct, but its production hunk now targets inactive code.

PR and implementation author: @jizhaolu27-maker. Original diagnosis and earlier patch credit: @LeonSGP43, preserved as commit co-author.

Refs #18681, #19683, #22842.

## Reproduction on current main

On `21b2095d00a98b8ad7b5c60b10587619c852cdb8`, a gateway `/model Kimi-K3` request with:

```yaml
model:
  default: gpt-5.6-sol
  provider: custom
  base_url: http://127.0.0.1:8317/v1
  api_key: test-custom-key
```

passes `current_api_key=''` to `switch_model()`. The bare custom-provider branch reuses that value, so an authenticated `/models` endpoint receives an unauthenticated request.

## Tests

- Regression test before production fix: **1 failed, 1 passed**
- `uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_model_command_custom_providers.py -q` — **2 passed**
- `uv run --with pytest --with pytest-asyncio pytest tests/gateway/test_model_switch_persistence.py tests/gateway/test_model_command_context_offload.py tests/gateway/test_model_command_profile_config.py -q` — **8 passed**
- `git diff --check` — clean
