### PR TITLE
fix(compression): stop busy steer from replaying an old request

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2970,6 +2970,8 @@ def _merge_anchor_into_user_message(target: dict, anchor: dict) -> None:
 CompressedUserTurnOutcome = Literal[
     "inserted",
     "merged",
+    "steer_inserted",
+    "steer_merged",
     "already_present",
     "placeholder_appended",
 ]
@@ -3022,6 +3024,31 @@ def _insert_real_user_anchor(messages: list, anchor: dict) -> CompressedUserTurn
     return "merged"
 
 
+def _pending_steer_user_anchor(messages: list) -> Optional[dict]:
+    """Return the newest steer that has not crossed an assistant boundary."""
+    from agent.prompt_builder import STEER_MARKER_CLOSE, STEER_MARKER_OPEN
+
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") == "assistant":
+            return None
+        if message.get("role") != "tool":
+            continue
+        text = _message_text(message).rstrip()
+        if not text.endswith(STEER_MARKER_CLOSE):
+            continue
+        marker_start = text.rfind(STEER_MARKER_OPEN)
+        if marker_start == -1:
+            continue
+        steer_text = text[
+            marker_start + len(STEER_MARKER_OPEN) : -len(STEER_MARKER_CLOSE)
+        ].strip()
+        if steer_text:
+            return {"role": "user", "content": steer_text}
+    return None
+
+
 def _ensure_compressed_has_user_turn(
     original_messages: list, compressed: list
 ) -> CompressedUserTurnOutcome:
@@ -3032,6 +3059,11 @@ def _ensure_compressed_has_user_turn(
         COMPRESSION_CONTINUATION_USER_CONTENT,
         _fresh_compaction_message_copy,
     )
+
+    steer_anchor = _pending_steer_user_anchor(original_messages)
+    if steer_anchor is not None:
+        outcome = _insert_real_user_anchor(compressed, steer_anchor)
+        return "steer_merged" if outcome == "merged" else "steer_inserted"
 
     for message in reversed(original_messages):
         if _is_real_user_message(message):

--- a/tests/agent/test_context_compressor_zero_user_provenance.py
+++ b/tests/agent/test_context_compressor_zero_user_provenance.py
@@ -20,6 +20,7 @@ from agent.conversation_compression import (
     _ensure_compressed_has_user_turn,
     compress_context,
 )
+from agent.prompt_builder import format_steer_marker
 from hermes_state import SessionDB
 from tools.process_registry import format_process_notification
 from tools.todo_tool import TODO_INJECTION_HEADER
@@ -236,6 +237,39 @@ def test_real_task_wins_over_trailing_max_iterations_nudge(compressor):
     idx = compressor._find_last_user_message_idx(messages, head_end=0)
     assert idx == 0, "nudge was selected as the anchor instead of the human task"
     assert messages[idx]["content"] == human["content"]
+
+
+def test_busy_steer_replaces_historical_user_anchor_after_compression():
+    original = [
+        {"role": "user", "content": "Run the historical deployment."},
+        {
+            "role": "assistant",
+            "content": "Working on it.",
+            "tool_calls": [
+                {"id": "c1", "function": {"name": "terminal", "arguments": "{}"}}
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "c1",
+            "content": "still running" + format_steer_marker(
+                "Cancel that deployment and inspect the logs instead."
+            ),
+        },
+    ]
+    compressed = [{"role": "assistant", "content": "Compression summary."}]
+
+    outcome = _ensure_compressed_has_user_turn(original, compressed)
+
+    assert outcome == "steer_inserted"
+    user_turns = [message for message in compressed if message.get("role") == "user"]
+    assert [message["content"] for message in user_turns] == [
+        "Cancel that deployment and inspect the logs instead."
+    ]
+    assert all(
+        "historical deployment" not in str(message.get("content"))
+        for message in compressed
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## What does this PR do?

Compression now preserves a pending busy steer as the active user intent instead of restoring an older, already-consumed request. This prevents a compressed session from dropping the user's latest correction and replaying historical work.

### Symptom

When `display.busy_input_mode: steer` delivers a follow-up during a tool batch, compression can omit that follow-up and restore an older user request as the active turn.

### Impact

Affected gateway conversations can continue with stale instructions after compression, causing previously consumed work to run again while the user's latest direction is lost.

### Bug Cause

**Trigger:** `agent/conversation_compression.py:_ensure_compressed_has_user_turn` when the compressed transcript has no non-scaffolding `role=user` row and the source tail contains a pending steer marker.

**Causal chain:**
1. Busy steering appends the latest user direction to a tool result to preserve provider role constraints.
2. User-turn restoration only recognizes `role=user`, so it skips the pending steer and scans backward to an older user row.
3. Compression inserts that historical row into the handoff as active intent.

**Why it is wrong:** The restoration path classified intent only by message role, even though busy steer intentionally carries typed user intent in the latest tool result.

**Working sibling / contrast:** Normal user turns already survive through `_is_real_user_message`; the failure is specific to pending steer intent encoded at the active tool boundary.

**Ruled out:** Session rotation is not the cause. In-place and rotating compression share the same restoration helper, and the focused reproduction fails before either persistence mode commits.

### Fix

Detect the canonical steer marker only in the current tool tail before any later assistant boundary, convert its payload into the compression user anchor, and give steer-derived outcomes distinct persistence classifications so rotation does not stamp an unrelated historical user row. A regression test proves the latest steer wins and the old request is absent.

## Related Issue

Closes #100053

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_compression.py` - restore pending steer payloads before falling back to historical user rows.
- `tests/agent/test_context_compressor_zero_user_provenance.py` - reproduce and guard the busy-steer compression boundary.

## How to Test

1. Construct a transcript with an older user request and a busy steer appended to the active tool result.
2. Run user-turn preservation against a compressed transcript with no real user row.
3. Verify the steer becomes the only user anchor and the historical request is absent.

```bash
scripts/run_tests.sh tests/agent/test_context_compressor_zero_user_provenance.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant regression test file and all 16 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are unchanged or N/A
- [x] `cli-config.yaml.example` is unchanged because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are unchanged because no workflow changed
- [x] Cross-platform impact was considered; the change is platform-independent Python logic
- [x] Tool descriptions and schemas are unchanged because no tool behavior changed

## Screenshots / Logs

N/A - the focused regression test captures the transcript-level failure and fix.
