### PR TITLE
fix(gateway): honor server retry_after for flood-capped sends instead of plain-text fallback

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3157,6 +3157,16 @@ class BasePlatformAdapter(ABC):
         return any(pat in lowered for pat in _RETRYABLE_ERROR_PATTERNS)
 
     @staticmethod
+    def _is_rate_limited_error(error: Optional[str]) -> bool:
+        """Return True if the error string classifies as a rate limit / flood cap.
+
+        Single wrapper around :func:`classify_send_error` so the call sites in
+        :meth:`_send_with_retry` share one notion of "is this a rate limit" instead
+        of inline copies that could drift.
+        """
+        return classify_send_error(None, error or "") == "rate_limited"
+
+    @staticmethod
     def _is_timeout_error(error: Optional[str]) -> bool:
         """Return True for read/write timeouts — NOT retryable and NOT a plain-text
         fallback trigger, because the request may already have been delivered."""
@@ -3221,7 +3231,19 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
         error_str = result.error or ""
-        is_network = result.retryable or self._is_retryable_error(error_str)
+        # A rate-limited / flood-capped send is transient: it should back off
+        # (honoring the server's retry_after when present) rather than fall
+        # through to the plain-text fallback, which re-enters the ban and can
+        # truncate content.  Gate on the platform-neutral classifier as well so
+        # platforms that surface a rate limit without a retry_after field
+        # (e.g. Weixin raising a bare RuntimeError) get the same treatment.
+        is_rate_limited = self._is_rate_limited_error(error_str)
+        is_network = (
+            result.retryable
+            or is_rate_limited
+            or result.retry_after is not None
+            or self._is_retryable_error(error_str)
+        )
         # Timeouts: not safe to retry (may have delivered) and not a formatting error.
         if not is_network and self._is_timeout_error(error_str):
             return result
@@ -3242,10 +3264,36 @@ class BasePlatformAdapter(ABC):
                     logger.info("[%s] Send succeeded on retry %d", self.name, attempt)
                     return result
                 error_str = result.error or ""
-                server_retry_after = result.retry_after  # None unless the server asked again
-                if not (result.retryable or self._is_retryable_error(error_str)):
-                    break  # non-transient now — fall through to plain-text fallback
-            else:  # retries exhausted — notify user
+                if result.retry_after is not None:
+                    server_retry_after = result.retry_after
+                # The failure kind can change between attempts (a transient error may
+                # later surface as a flood/rate-limit, or a rate-limited send may give
+                # way to a permanent formatting error). Reclassify from the refreshed
+                # error_str on every attempt so the break/continue decision below
+                # reflects the current attempt, not a stale first-send classification.
+                is_rate_limited = self._is_rate_limited_error(error_str)
+                if not (
+                    result.retryable
+                    or is_rate_limited
+                    or result.retry_after is not None
+                    or self._is_retryable_error(error_str)
+                ):
+                    break  # error switched to non-transient — fall through to plain-text fallback
+            else:
+                # All retries exhausted (loop completed without break) — notify user.
+                # If the final failure is a rate-limit / still carries a server
+                # retry_after, do NOT send the delivery-failure notice now: the notice
+                # send would land inside the same flood penalty and re-enter the ban
+                # (a fourth send at t=378 in an [0, 189, 378, 378] sequence). Return
+                # the typed failure so the delivery ledger owns redelivery after the
+                # cooldown instead — no extra sleep or request needed.
+                if self._is_rate_limited_error(error_str) or result.retry_after is not None:
+                    logger.error(
+                        "[%s] Rate-limited send exhausted retries; returning typed failure "
+                        "for redelivery (no notice sent inside active flood penalty): %s",
+                        self.name, error_str,
+                    )
+                    return result
                 logger.error("[%s] Failed to deliver response after %d retries: %s", self.name, max_retries, error_str)
                 notice = (
                     "\u26a0\ufe0f Message delivery failed after multiple attempts. "
@@ -3255,7 +3303,18 @@ class BasePlatformAdapter(ABC):
                 except Exception as notify_err:
                     logger.debug("[%s] Could not send delivery-failure notice: %s", self.name, notify_err)
                 return result
-        # Non-network / post-retry formatting failure: try plain text as fallback
+        # Non-network / post-retry formatting failure: try plain text as fallback.
+        # Never attempt a truncating plain-text fallback for a rate-limited /
+        # flood-capped send: it re-enters the server ban and would drop the tail
+        # of the message.  Return the typed failure so the delivery ledger owns
+        # redelivery after the cooldown instead.
+        if self._is_rate_limited_error(error_str):
+            logger.error(
+                "[%s] Rate-limited send not retried via plain-text fallback; "
+                "returning typed failure for redelivery: %s",
+                self.name, error_str,
+            )
+            return result
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await _send(f"(Response formatting failed, plain text:)\n\n{content[:3500]}")
         if not fallback_result.success:

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -77,6 +77,32 @@ class TestIsTimeoutError:
 
 
 # ---------------------------------------------------------------------------
+# _is_rate_limited_error
+# ---------------------------------------------------------------------------
+
+class TestIsRateLimitedError:
+    def test_none_is_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error(None)
+
+    def test_empty_is_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error("")
+
+    def test_flood_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error("flood control exceeded, retry in 60 seconds")
+
+    def test_too_many_requests_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error("Too Many Requests: rate limit reached")
+
+    def test_weixin_rate_limit_text_is_rate_limited(self):
+        assert _StubAdapter._is_rate_limited_error(
+            "iLink sendmessage rate limited; cooldown active for 42.0s"
+        )
+
+    def test_formatting_error_not_rate_limited(self):
+        assert not _StubAdapter._is_rate_limited_error("Bad Request: can't parse entities")
+
+
+# ---------------------------------------------------------------------------
 # _send_with_retry — success on first attempt
 # ---------------------------------------------------------------------------
 
@@ -205,4 +231,114 @@ class TestSendWithRetryAfter:
         # Second sleep should use the retry_after from the second result
         second_sleep = mock_sleep.call_args_list[1][0][0]
         assert second_sleep >= 29.0  # 30 - 1 (max jitter)
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — rate-limited sends (flood control) without retry_after
+# ---------------------------------------------------------------------------
+# Platforms like Weixin surface a rate limit as a bare error with NO retry_after
+# field.  These must still be treated as transient (back off / retry) rather than
+# falling through to the truncating plain-text fallback, which would re-enter the
+# server ban and drop the tail of the message.
+
+class TestSendWithRetryRateLimited:
+    @pytest.mark.asyncio
+    async def test_rate_limited_no_retry_after_backs_off_and_retries(self):
+        """A flood/rate-limit error WITHOUT retry_after still counts as network
+        (retryable) because classify_send_error == 'rate_limited', so it retries
+        and succeeds instead of falling through to plain-text fallback."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="flood control exceeded, timeout 30 seconds"),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=1.0)
+        # Must have slept (backoff), i.e. treated as transient — NOT immediate fallback
+        assert mock_sleep.called
+        assert result.success
+        assert len(adapter._send_calls) == 2
+        # No plain-text fallback content on either call
+        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_exhausted_returns_typed_failure_not_fallback(self):
+        """When retries on a rate-limited send are exhausted, return the typed
+        failure for ledger redelivery. Never the truncating plain-text fallback,
+        and — because the final failure is still inside the flood penalty — never
+        a delivery-failure notice send that would re-enter the ban. 1 initial + 2
+        retries = 3 sends, no fourth notice send."""
+        adapter = _StubAdapter()
+        flood = SendResult(success=False, error="flood control exceeded, retry in 60 seconds")
+        adapter._send_results = [flood, flood, flood]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=2, base_delay=0)
+        assert not result.success
+        # 1 initial + 2 retries = 3 sends; NO delivery-failure notice (4th send)
+        # is sent inside the active flood penalty
+        assert len(adapter._send_calls) == 3
+        # The only sends are the retries — no truncating "plain text" fallback and
+        # no notice triggered inside the flood penalty
+        for chat_id, content in adapter._send_calls:
+            assert "plain text" not in content.lower(), \
+                f"rate-limited send must not fall through to plain-text fallback, got: {content[:40]!r}"
+            assert "delivery failed" not in content.lower() and \
+                   "Message delivery failed" not in content, \
+                "no notice send inside active flood penalty"
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — failure-kind transitions between attempts
+# ---------------------------------------------------------------------------
+# is_rate_limited is recomputed from the refreshed error_str on every retry, so
+# the loop's continue/break decision reflects the CURRENT attempt, not the
+# initial send's classification. These cover the two transitions that a stale
+# classification would get wrong.
+
+class TestSendWithRetryFailureTypeTransitions:
+    @pytest.mark.asyncio
+    async def test_rate_limited_then_formatting_error_stops_retrying_and_falls_back(self):
+        """A rate-limited first attempt followed by a PERMANENT formatting error
+        on retry must stop retrying that permanent error and reach the existing
+        plain-text fallback — not keep retrying it (as a stale, still-true
+        is_rate_limited would)."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="flood control exceeded, retry in 60 seconds"),
+            SendResult(success=False, error="Bad Request: can't parse entities"),
+            # fallback send (auto-succeeds via _next_result)
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "**bold**", max_retries=3, base_delay=0)
+        # The formatting error was not retried further: exactly 1 retry then the
+        # plain-text fallback. 1 initial + 1 retry + 1 fallback = 3 sends.
+        assert len(adapter._send_calls) == 3
+        # The permanent formatting error switched attempts to non-transient:
+        # we fall through to (and return) the plain-text fallback.
+        assert "plain text" in adapter._send_calls[-1][1].lower()
+        assert result.success  # fallback succeeded
+        # No delivery-failure notice was sent (this is a formatting fallback, not network exhaustion)
+        assert "delivery failed" not in adapter._send_calls[-1][1].lower()
+
+    @pytest.mark.asyncio
+    async def test_transient_then_rate_limited_then_success_preserves_retry_budget(self):
+        """A transient network error followed by a rate-limited attempt must NOT
+        break the retry loop early: a later rate-limited result is still
+        transient, so the remaining retry budget is preserved and the send goes
+        on to succeed."""
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: connection refused"),
+            SendResult(success=False, error="flood control exceeded, retry in 30 seconds"),
+            SendResult(success=True, message_id="ok"),
+        ]
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await adapter._send_with_retry("chat1", "hello", max_retries=3, base_delay=0)
+        # Initial + retry(rate-limited) + retry(success) = 3 sends, recovered.
+        assert result.success
+        assert len(adapter._send_calls) == 3
+        # The rate-limited attempt was treated as transient (not a break), so no
+        # delivery-failure notice and no plain-text fallback.
+        assert all("plain text" not in c[1].lower() for c in adapter._send_calls)
+        assert "delivery failed" not in adapter._send_calls[-1][1].lower()
 


### PR DESCRIPTION
## Summary

Fixes a Telegram send-path bug that amplifies flooding and can lock the bot out of sending for an hour+.

The Telegram adapter's fail-closed flood path (`_flood_cap_result` in `plugins/platforms/telegram/adapter.py`) returns a `SendResult` carrying `retry_after` (the server's FloodWait seconds) but does **not** set `retryable=True`. `_send_with_retry` in `gateway/platforms/base.py` gated its retry-with-backoff path purely on `result.retryable or self._is_retryable_error(error)`, and the `flood_control:<n>` error string is not in `_RETRYABLE_ERROR_PATTERNS`. Result: an over-cap FloodWait **skips backoff entirely** and falls straight into the plain-text fallback send, which immediately re-hits the same ban.

Repeated while a long ban is active, this renews the FloodWait and keeps the bot from delivering anything for tens of minutes. Observed in production: **~35x send amplification against a 1h+ ban** (130 real responses -> ~4,600 send attempts), across 6 separate days.

## Fix

Four coordinated changes to `_send_with_retry` in `gateway/platforms/base.py` (+1 `_is_rate_limited_error` helper):

1. **Treat rate-limit as transient.** Gate retry on `classify_send_error(...) == "rate_limited"` in addition to `retryable`/`retry_after`, so flood-capped sends from *any* platform — including Weixin, which surfaces a bare `RuntimeError` with no `retry_after` — route into the retry path instead of the truncating plain-text fallback.
2. **Honor server `retry_after` as the backoff delay** (Telegram FloodWait seconds) instead of the default exponential schedule. Retry-aware: a retry that itself returns a new `retry_after` re-honors it.
3. **Reclassify per attempt, never reuse the first-send classification**, so the in-loop break/continue reflects the *current* failure kind (covers transient → flood, and rate-limited → permanent-formatting transitions).
4. **Never take the truncating plain-text fallback for a rate-limited send** — return the typed failure so the delivery ledger owns redelivery after the cooldown. And when retries exhaust on a still-rate-limited / retry_after-carrying failure, return **before** the delivery-failure notice: the notice send would land inside the same flood penalty and re-enter the ban (`[0, 189, 378, 378]` → `[0, 189, 378]`; no 4th send). Ordinary exhausted *network* errors keep the existing notice behavior.

Timeout results are unaffected: `retry_after` is `None` for them, so `is_network` stays `False` and the no-duplicate-on-timeout guarantee is preserved.

## Files changed

- `gateway/platforms/base.py`: `_is_rate_limited_error` helper + rewritten `_send_with_retry`.
- `tests/gateway/test_send_retry.py`: 10 new regression tests — rate-limit classifier, rate-limited-without-`retry_after` retries-and-succeeds, rate-limited exhaustion returns a typed failure (no fallback, no notice inside the penalty), and failure-kind transitions between attempts.

Rebased onto current `main` (resolves a 5000+ commit drift / CONFLICTING state). Reviewer feedback from a third-party deployment confirmed the root cause independently and identified the retry-loop `else`-branch notice issue; that is folded in and covered by an updated regression test.

## Test plan

```
pytest tests/gateway/test_send_retry.py        # 22 passed (incl. 10 new)
pytest tests/gateway/test_slack_send_retry.py tests/gateway/test_send_error_classification.py  # 19 passed
```

Run locally against current `main` (Python 3.11 / 3.12). CI on this fork-PR awaits maintainer approval to execute (`action_required`).

## Relationship to #103669 (flood-ledger redelivery)

This PR is the **inline-retry half** of the FloodWait handling: it makes an over-cap send honor the server's `retry_after` and back off *inside* `_send_with_retry`. #103669 (`fix/ledger-flood-retry` by @AlexxRussell) is the **deferred half**: it assigns long flood waits to the delivery ledger's scheduled redelivery. The two are complementary, not duplicates — #103669 touches `_finalize_delivery_obligation` / `delivery_ledger.py` (the post-exhaustion path), while this PR fixes the inline retry loop itself (the pre-exhaustion path). Ownership boundary is explicit: **inline backoff here, ledger redelivery there.** Happy to rebase or adjust this PR to land cleanly alongside #103669 either order.
