### PR TITLE
fix(email): run blocking IMAP/SMTP connect off the event loop

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -669,6 +669,60 @@ class EmailAdapter(BasePlatformAdapter):
             # Retry with IPv4 only.
             return _connect(ipv4_only=True)
 
+    def _test_imap_connection(self, is_reconnect: bool) -> None:
+        """Blocking IMAP connect+login+prime, run off the event loop via executor.
+
+        The handle is closed in ``finally`` — before this, a failure in
+        login/select/search left the TCP socket open with no owner, leaking
+        one fd per connect attempt. Under the gateway's reconnect watcher
+        (fresh adapter instance per retry) against an unreachable/proxied
+        host this grew monotonically until fd exhaustion on macOS's 256 soft
+        limit (#79889).
+        """
+        imap = None
+        try:
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap.login(self._address, self._password)
+            _send_imap_id(imap)
+            imap.select("INBOX")
+            snapshot = self._seen_uids_snapshot.get(self._address)
+            if is_reconnect and snapshot is not None:
+                # Reconnect within the same process: restore the previous
+                # adapter's seen-UID baseline instead of re-marking the whole
+                # mailbox. Mail that arrived during the outage stays UNSEEN
+                # relative to the baseline and is dispatched by the next poll
+                # instead of being silently skipped.
+                self._seen_uids = set(snapshot)
+                self._trim_seen_uids()
+                logger.info(
+                    "[Email] IMAP reconnect test passed. Restored %d seen UIDs; "
+                    "messages received during the outage will be processed.",
+                    len(self._seen_uids),
+                )
+            else:
+                # First connect (or no snapshot): mark all existing messages as
+                # seen so we only process new ones.
+                status, data = imap.uid("search", None, "ALL")
+                if status == "OK" and data and data[0]:
+                    for uid in data[0].split():
+                        self._seen_uids.add(uid)
+                # Keep only the most recent UIDs to prevent unbounded growth
+                self._trim_seen_uids()
+                logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
+        finally:
+            if imap is not None:
+                _close_imap(imap)
+        self._seen_uids_snapshot[self._address] = set(self._seen_uids)
+
+    def _test_smtp_connection(self) -> None:
+        """Blocking SMTP connect+login test, run off the event loop via executor."""
+        smtp = self._connect_smtp()
+        try:
+            smtp.login(self._address, self._password)
+        finally:
+            smtp.quit()
+        logger.info("[Email] SMTP connection test passed.")
+
     async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to the IMAP server and start polling for new messages."""
         # Validate up front so a missing host surfaces as an actionable config
@@ -701,48 +755,17 @@ class EmailAdapter(BasePlatformAdapter):
             )
             return False
 
+        # IMAP/SMTP connect+login are blocking calls (imaplib/smtplib have no
+        # asyncio support) with 30s socket timeouts each. Run them in a
+        # thread so an unreachable mail server doesn't stall the shared
+        # gateway event loop — every other platform (qqbot heartbeats
+        # included) shares this loop and was seeing multi-second stutters
+        # every retry cycle while this blocked in-line (#qq-heartbeat-stall).
+        loop = asyncio.get_running_loop()
         try:
-            # Test IMAP connection. The handle is closed in ``finally`` —
-            # before this, a failure in login/select/search left the TCP
-            # socket open with no owner, leaking one fd per connect attempt.
-            # Under the gateway's reconnect watcher (fresh adapter instance
-            # per retry) against an unreachable/proxied host this grew
-            # monotonically until fd exhaustion on macOS's 256 soft limit
-            # (#79889).
-            imap = None
-            try:
-                imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
-                imap.login(self._address, self._password)
-                _send_imap_id(imap)
-                imap.select("INBOX")
-                snapshot = self._seen_uids_snapshot.get(self._address)
-                if is_reconnect and snapshot is not None:
-                    # Reconnect within the same process: restore the previous
-                    # adapter's seen-UID baseline instead of re-marking the whole
-                    # mailbox. Mail that arrived during the outage stays UNSEEN
-                    # relative to the baseline and is dispatched by the next poll
-                    # instead of being silently skipped.
-                    self._seen_uids = set(snapshot)
-                    self._trim_seen_uids()
-                    logger.info(
-                        "[Email] IMAP reconnect test passed. Restored %d seen UIDs; "
-                        "messages received during the outage will be processed.",
-                        len(self._seen_uids),
-                    )
-                else:
-                    # First connect (or no snapshot): mark all existing messages as
-                    # seen so we only process new ones.
-                    status, data = imap.uid("search", None, "ALL")
-                    if status == "OK" and data and data[0]:
-                        for uid in data[0].split():
-                            self._seen_uids.add(uid)
-                    # Keep only the most recent UIDs to prevent unbounded growth
-                    self._trim_seen_uids()
-                    logger.info("[Email] IMAP connection test passed. %d existing messages skipped.", len(self._seen_uids))
-            finally:
-                if imap is not None:
-                    _close_imap(imap)
-            self._seen_uids_snapshot[self._address] = set(self._seen_uids)
+            await loop.run_in_executor(
+                None, self._test_imap_connection, is_reconnect
+            )
         except Exception as e:
             logger.error("[Email] IMAP connection failed: %s", e)
             # Always set an explicit fatal code (OOF-156): returning False
@@ -763,13 +786,7 @@ class EmailAdapter(BasePlatformAdapter):
             return False
 
         try:
-            # Test SMTP connection
-            smtp = self._connect_smtp()
-            try:
-                smtp.login(self._address, self._password)
-            finally:
-                smtp.quit()
-            logger.info("[Email] SMTP connection test passed.")
+            await loop.run_in_executor(None, self._test_smtp_connection)
         except smtplib.SMTPAuthenticationError as e:
             logger.error("[Email] SMTP authentication failed: %s", e)
             # Typed auth failure (535 & friends): bad or revoked credentials

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -487,6 +487,76 @@ class TestConnectDisconnect(unittest.TestCase):
                 adapter._poll_task.cancel()
 
 
+class TestConnectDoesNotBlockEventLoop(unittest.TestCase):
+    """connect()'s IMAP/SMTP work must run off the event loop.
+
+    Regression test: connect() used to call imaplib.IMAP4_SSL(...) and
+    _connect_smtp() directly (blocking stdlib clients, 30s socket
+    timeouts) in-line in an async method. A slow/unreachable mail server
+    froze the entire shared gateway event loop for the length of the
+    timeout, starving unrelated concurrent work (observed: QQBot
+    heartbeats firing 30+s late and getting RST'd by the QQ gateway,
+    which had already timed out the session and closed it).
+    """
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+        return adapter
+
+    def test_slow_imap_connect_does_not_stall_other_tasks(self):
+        """A slow IMAP4_SSL() call must not freeze concurrently scheduled tasks."""
+        import asyncio
+        import time
+
+        adapter = self._make_adapter()
+        ticks = []
+
+        def slow_imap4_ssl(*args, **kwargs):
+            # Simulate a stalled/unreachable server hitting its socket
+            # timeout: real, synchronous blocking sleep — same as
+            # imaplib/smtplib actually do on a hung connect().
+            time.sleep(0.3)
+            raise OSError("simulated IMAP connect timeout")
+
+        async def ticker():
+            # Runs concurrently with connect(). If connect() blocks the
+            # loop in-line, this never gets scheduled until connect()
+            # returns, so `ticks` stays (near) empty.
+            while True:
+                ticks.append(time.monotonic())
+                await asyncio.sleep(0.02)
+
+        async def scenario():
+            with patch("imaplib.IMAP4_SSL", side_effect=slow_imap4_ssl):
+                task = asyncio.create_task(ticker())
+                result = await adapter.connect()
+                task.cancel()
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+                return result
+
+        result = asyncio.run(scenario())
+
+        self.assertFalse(result)  # IMAP connect failed, as simulated
+        # A blocked event loop would let the ticker run 0-1 times in
+        # 0.3s; a healthy one runs it roughly every 20ms (~10+ times).
+        self.assertGreater(
+            len(ticks), 5,
+            f"event loop appears blocked during connect() — ticker only "
+            f"ran {len(ticks)} time(s) while a slow IMAP connect was in flight",
+        )
+
+
 class TestFetchNewMessages(unittest.TestCase):
     """Test IMAP message fetching logic."""
 


### PR DESCRIPTION
## What does this PR do?

`EmailAdapter.connect()` calls `imaplib.IMAP4_SSL(...)` and `_connect_smtp()` — both blocking stdlib clients with 30s socket timeouts — directly in-line inside an `async def` method, with no `run_in_executor` wrapping. Every reconnect retry against an unreachable/misconfigured mail server freezes the entire shared gateway asyncio event loop for up to ~30-60s, starving unrelated concurrent work on other platforms.

This is a distinct code path from the agent/tool-execution event-loop starvation already fixed via the owned `ThreadPoolExecutor` in `gateway/run.py` (#33727, #21026, both closed `sweeper:implemented-on-main`) — that fix covers `run_sync`/tool execution, not platform adapters' own connection setup code, so this adapter's `connect()` slipped through.

This PR extracts the IMAP test+prime and SMTP test bodies into plain sync helper methods (`_test_imap_connection`, `_test_smtp_connection`) and dispatches them via `await loop.run_in_executor(None, ...)`, matching the pattern already used elsewhere in this same file (`_check_inbox`, `send`, `send_image`, `send_document`). No behavior change: same exceptions, same `_set_fatal_error()` calls, same retryable/non-retryable classification.

## Related Issue

Fixes #100077

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/email/adapter.py`: extracted the blocking IMAP/SMTP connection-test bodies out of `connect()` into `_test_imap_connection()` / `_test_smtp_connection()`, called via `loop.run_in_executor(None, ...)` instead of in-line.
- `tests/gateway/test_email.py`: added `TestConnectDoesNotBlockEventLoop.test_slow_imap_connect_does_not_stall_other_tasks`, a regression test that runs a concurrently-scheduled asyncio task alongside `connect()` while `imaplib.IMAP4_SSL` blocks (real `time.sleep`), and asserts the concurrent task keeps making progress — i.e. the event loop isn't frozen.

## How to Test

1. Reproduction (real-world): configure QQBot + an unreachable/misconfigured Email account (bad SMTP/IMAP host). Watch the QQBot WebSocket disconnect every ~6 minutes in lockstep with the email adapter's SMTP connect timeout — see #100077 for the full packet-capture evidence chain.
2. Unit test: `pytest tests/gateway/test_email.py -q` — 40 passed, including the new regression test which fails on `main` (event loop stalls ~0.3s, ticker gets ≤1 tick) and passes with this fix (ticker gets 10+ ticks during the same blocking call).
3. Also ran the full email test surface: `pytest tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_email_charset_fallback.py tests/gateway/test_email_secret_scope.py tests/skills/test_email_inbox_triage_skill.py -q` — 72 passed.
4. `ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py` — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (see #100077 for the related-issue analysis vs #33727/#21026/#20531)
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` for the affected surface (full email test suite, 72 passed) and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (native, dual-boot), Python 3.11.15

### Documentation & Housekeeping

- [x] N/A — no docs/config-key/architecture changes; this is an internal implementation fix with unchanged public behavior

## Screenshots / Logs

Full packet-capture timeline and log correlation showing the failure mode and confirming the fix are in #100077.