### PR TITLE
fix(doctor): normalise socks:// proxy scheme before API connectivity probes

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -36,6 +36,7 @@ from hermes_cli.models import _HERMES_USER_AGENT
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from utils import base_url_host_matches
+from utils import normalize_proxy_env_vars
 
 
 _PROVIDER_ENV_HINTS = (
@@ -2727,6 +2728,11 @@ def run_doctor(args):
             check_info(note)
 
     _section("API Connectivity")
+    # Normalise Clash/Verge-style SOCKS proxy env vars (socks:// -> socks5://)
+    # so bare httpx probes don't fail with "Unknown scheme for proxy URL".
+    # Mirrors what the real LLM client paths (anthropic_adapter,
+    # auxiliary_client) already do via normalize_proxy_env_vars().
+    normalize_proxy_env_vars()
     # Refactor: every connectivity probe below is HTTP-bound and fully
     # independent. Running them in series spent ~5s wall on a typical
     # workstation (2s of that was boto3's IMDS lookup for AWS credentials,


### PR DESCRIPTION
## Bug

Clash/Verge-style proxy setups (common on Linux desktops running a system proxy) export SOCKS proxies as `ALL_PROXY=socks://127.0.0.1:PORT/` — missing the trailing `5`. httpx rejects that scheme outright with `Unknown scheme for proxy URL`.

This broke every bare-httpx probe in the `hermes doctor` API Connectivity section — OpenRouter, Hugging Face, Azure Foundry, Gemini, and ollama-cloud all reported failures purely from this proxy parsing issue, even when the underlying API was reachable and credentials were valid. Very confusing for anyone running a local SOCKS proxy.

## Fix

`utils.normalize_proxy_env_vars()` already exists and rewrites `socks://` → `socks5://` in-place — it's used by the real LLM client paths (`anthropic_adapter`, `auxiliary_client`) already. The doctor's API Connectivity section just never called it. One-line fix: call it once at the top of that section so the probes see the same normalised env the real agent runtime does.

## Verification

Reproduced the exact failing env (`ALL_PROXY=socks://127.0.0.1:PORT/`) via `env -i`, ran `hermes doctor` before and after the fix:
- Before: OpenRouter/HF/ollama-cloud probes fail with `Unknown scheme for proxy URL`
- After: all three pass; no change to probes when the proxy env is already well-formed (or absent)