### PR TITLE
fix(model-setup): auto-upgrade Azure Foundry GPT-5.x/o-series to Responses API

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -1434,6 +1434,24 @@ def _model_flow_azure_foundry(config, current_model=""):
         print("No model name provided. Cancelled.")
         return
 
+    # GPT-5.x / o-series / codex deployments on Azure Foundry only accept
+    # the Responses API — /chat/completions 400s with "The requested
+    # operation is unsupported." The transport auto-detect above only
+    # distinguishes OpenAI-style vs Anthropic-style (chat_completions vs
+    # anthropic_messages), so an OpenAI-style gpt-5.x/o-series/codex
+    # deployment picked here would otherwise be saved as plain
+    # chat_completions and fail at call time. Upgrade using the same
+    # per-model inference the main runtime resolver applies
+    # (azure_foundry_model_api_mode), unless the user is on the
+    # Anthropic-style wire (never upgrade that).
+    if api_mode == "chat_completions":
+        from hermes_cli.models import azure_foundry_model_api_mode
+
+        _inferred_mode = azure_foundry_model_api_mode(effective_model)
+        if _inferred_mode:
+            api_mode = _inferred_mode
+            print(f"✓ {effective_model} requires the Responses API on Azure Foundry — using {api_mode}")
+
     # ── Step 6: context-length lookup ────────────────────────────────
     ctx_len = azure_detect.lookup_context_length(
         effective_model,


### PR DESCRIPTION
## Bug

The Azure Foundry setup wizard (`hermes model` / `hermes fallback add`) only distinguishes OpenAI-style vs Anthropic-style transport during endpoint auto-detection. When a user picks an OpenAI-style deployment, `api_mode` is unconditionally written as `chat_completions` — but Azure rejects `/chat/completions` for GPT-5.x, o-series, and codex deployments with `400 The requested operation is unsupported.`, requiring the Responses API (`/responses`) instead.

`hermes_cli.models.azure_foundry_model_api_mode()` already implements this per-model inference and is used by the main runtime resolver (`_resolve_azure_foundry_runtime`), so an *existing* primary model auto-upgrades correctly at call time. The setup wizard never called it, so any GPT-5.x deployment added via the wizard was saved with the wrong `api_mode` and failed on first real use — a silent trap for anyone deploying a current-gen GPT model on their own Azure Foundry resource.

## Fix

After the model/deployment name is picked in the wizard, if the detected transport is `chat_completions`, run it through the existing `azure_foundry_model_api_mode()` helper and upgrade to `codex_responses` when the name matches a Responses-API-only family (gpt-5.x, codex, o1/o3/o4). Anthropic-style selections are untouched.

## Verification

Deployed `gpt-5.4-pro` on a live Azure Foundry resource, ran it through `hermes fallback add`:
- Before: wizard writes `api_mode: chat_completions`; real call 400s (`The requested operation is unsupported`), falls through the whole fallback chain
- Confirmed `azure_foundry_model_api_mode('gpt-5.4-pro')` correctly returns `codex_responses`
- After manually correcting `api_mode` to `codex_responses`: real chat completion succeeds end-to-end through `agent.auxiliary_client._resolve_fallback_entry` (the exact function the production fallback chain calls)