### PR TITLE
fix(gateway): remove stale progress before queued follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31995,25 +31995,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _ids_snapshot = list(_cleanup_msg_ids)
             _chat_id_snapshot = source.chat_id
             _adapter_snapshot = _cleanup_adapter
-            _loop_snapshot = asyncio.get_running_loop()
 
-            def _cleanup_temp_bubbles() -> None:
-                async def _delete_all() -> None:
-                    for _mid in _ids_snapshot:
-                        try:
-                            await _adapter_snapshot.delete_message(
-                                _chat_id_snapshot, _mid
-                            )
-                        except Exception:
-                            pass
-                try:
-                    safe_schedule_threadsafe(
-                        _delete_all(), _loop_snapshot,
-                        logger=logger,
-                        log_message="Temp bubble cleanup scheduling error",
-                    )
-                except Exception:
-                    pass
+            async def _cleanup_temp_bubbles() -> None:
+                _deleted = 0
+                _rejected = 0
+                _errors = 0
+                for _mid in _ids_snapshot:
+                    try:
+                        if await _adapter_snapshot.delete_message(
+                            _chat_id_snapshot, _mid
+                        ):
+                            _deleted += 1
+                        else:
+                            _rejected += 1
+                    except Exception:
+                        _errors += 1
+
+                _log_cleanup = (
+                    logger.warning if _rejected or _errors else logger.debug
+                )
+                _log_cleanup(
+                    "Temp bubble cleanup complete: deleted=%d rejected=%d errors=%d",
+                    _deleted,
+                    _rejected,
+                    _errors,
+                )
 
             try:
                 _cleanup_adapter.register_post_delivery_callback(

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -10,7 +10,6 @@ Failed runs skip cleanup so the bubbles remain as breadcrumbs.
 Adapters without ``delete_message`` silently no-op.
 """
 
-import asyncio
 import importlib
 import inspect as _inspect
 import sys
@@ -286,12 +285,7 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     cb = adapter.pop_post_delivery_callback(session_key)
     assert callable(cb)
     await _fire_post_delivery_cb(cb)
-    for _ in range(20):
-        await asyncio.sleep(0.01)
-        if adapter.deleted:
-            break
 
-    # Both effects land: the pre-existing callback fires AND the cleanup
-    # deletes at least one progress bubble.
+    # Both effects are complete at the post-delivery callback boundary.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1


### PR DESCRIPTION
## What does this PR do?

Temporary Telegram progress and Working messages are now deleted before the post-delivery callback completes. This keeps queued follow-up turns from starting while cleanup is still unobserved in the background.

### Symptom

With `display.platforms.telegram.cleanup_progress` enabled, progress messages can remain visible after the final response while the next queued turn begins.

### Impact

Telegram users can see stale tool-progress and Working messages from a completed turn, and queued follow-ups can overlap the prior turn's cleanup.

### Bug Cause

**Trigger:** `gateway/run.py` / `_cleanup_temp_bubbles`

**Causal chain:**
1. A successful turn registers temporary progress message IDs for post-delivery cleanup.
2. The synchronous callback schedules an async deletion future and immediately returns `None`.
3. Post-delivery consumers have no awaitable result, so they continue before deletion completes and cannot observe deletion failures.

**Why it is wrong:** The callback reports completion before the asynchronous work it owns has completed.

**Working sibling / contrast:** Post-delivery callback chaining already awaits callbacks that return an awaitable, so an async cleanup callback participates in the existing lifecycle correctly.

**Ruled out:** Callback replacement is not the cause; the regression reproduces with a pre-existing callback and both callbacks remain chained in registration order.

### Fix

Make cleanup itself async and await every `delete_message` call. Keep failures isolated per message and emit one bounded summary that distinguishes rejected deletions from exceptions. The regression test now requires deletion to be complete at the callback boundary instead of polling after callback return.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - await temporary-message deletion inside the post-delivery callback and summarize outcomes.
- `tests/gateway/test_run_cleanup_progress.py` - assert cleanup completion at the callback boundary.

## How to Test

1. Enable `display.platforms.telegram.cleanup_progress` and run a turn that emits tool progress.
2. Deliver the final response and invoke the registered post-delivery callback.
3. Confirm temporary messages are deleted before the callback returns.
4. Run:

```bash
scripts/run_tests.sh tests/gateway/test_post_delivery_callback_chaining.py tests/gateway/test_run_cleanup_progress.py -q
```

Result: 6 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation: N/A
- [x] `cli-config.yaml.example`: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changes
- [x] Cross-platform impact considered: the callback contract is platform-independent
- [x] Tool descriptions/schemas: N/A

## Screenshots / Logs

Automated regression coverage is included; no UI screenshot is required.
