### PR TITLE
fix(gateway): warn on allowlist mirror write failures instead of silent pass

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -195,10 +195,12 @@ def _sync_allowlist_add(platform: str, user_id: str) -> None:
         from hermes_cli.config import save_env_value
 
         save_env_value(env_var, ",".join(ids))
-    except Exception:
+    except Exception as exc:
         # Best-effort: the pairing store grant still authorizes via the union,
         # so a failure here degrades to "grant recorded but not mirrored".
-        pass
+        # Surface the failure so operators can detect persistent config issues
+        # (disk full, permissions, profile-multiplex conflicts).
+        logger.warning("allowlist add failed for %s env=%s: %s", platform, env_var, exc)
 
 
 def _iter_live_gateway_adapters():
@@ -322,8 +324,8 @@ def _sync_allowlist_remove(platform: str, user_id: str) -> None:
             save_env_value(env_var, ",".join(remaining))
         else:
             remove_env_value(env_var)
-    except Exception:
-        pass
+    except Exception as exc:
+        logger.warning("allowlist remove failed for %s env=%s: %s", platform, env_var, exc)
     _sync_live_adapter_allowlist_remove(platform, user_id)
 
 


### PR DESCRIPTION
`_sync_allowlist_add` and `_sync_allowlist_remove` silently swallowed write failures from `hermes_cli.config.save_env_value` / `remove_env_value`. Under profile-multiplexing, disk-full, or permission errors this leaves the pairing store grant mirrored inconsistently with no operator signal.

Change: log a warning with platform/env/exception instead of `pass`. Behavior contract is preserved — grant still authorizes via the pairing-store union — but persistent misconfiguration is now visible.