### PR TITLE
fix(desktop): MEDIA tags accept filesystem paths containing spaces

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,4 +1,4 @@
-import { mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
+import { isPlausibleMediaPath, mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
 export type ArtifactKind = 'image' | 'file' | 'link'
@@ -28,7 +28,7 @@ export interface ArtifactLoadResult {
 
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
-const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+)[`"']?/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
 const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
 const WINDOWS_PATH_RE = /(^|[\s("'`])([A-Za-z]:[\\/][^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
@@ -73,7 +73,15 @@ function unquoteMediaValue(value: string): string {
 
 function collectMediaValues(text: string, pushValue: (value: string) => void): void {
   for (const match of text.matchAll(MEDIA_RE)) {
-    pushValue(unquoteMediaValue(match[1] || ''))
+    const raw = match[1] || ''
+
+    // skip captures that are a path followed by same-line prose — the
+    // `[^\n]+` bare alternative would otherwise produce a junk candidate
+    if (!isPlausibleMediaPath(raw)) {
+      continue
+    }
+
+    pushValue(unquoteMediaValue(raw))
   }
 }
 

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -477,6 +477,45 @@ describe('renderMediaTags', () => {
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
   })
+
+  it('keeps bare paths intact when they contain spaces', () => {
+    expect(
+      renderMediaTags(
+        'MEDIA:/Users/richardtang/MusicProduction/Ricktai/2026-08-29 - Not Today/audio/NotToday.wav'
+      )
+    ).toBe(
+      '[Audio: NotToday.wav](#media:%2FUsers%2Frichardtang%2FMusicProduction%2FRicktai%2F2026-08-29%20-%20Not%20Today%2Faudio%2FNotToday.wav)'
+    )
+    // spaces + non-media extension → file card path survives too
+    expect(renderMediaTags('MEDIA:/tmp/my folder/notes.lrc')).toBe(
+      '[File: notes.lrc](#media:%2Ftmp%2Fmy%20folder%2Fnotes.lrc)'
+    )
+  })
+
+  it('strips trailing sentence punctuation only from bare paths', () => {
+    expect(renderMediaTags('MEDIA:/tmp/voice.mp3.')).toBe('[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+    expect(renderMediaTags('MEDIA:/tmp/voice.mp3,')).toBe('[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+    // a quoted path is explicit: punctuation inside quotes is preserved
+    expect(renderMediaTags('MEDIA:"/tmp/file (1).mp4"')).toBe(
+      '[Video: file (1).mp4](#media:%2Ftmp%2Ffile%20(1).mp4)'
+    )
+    // a bare path ending in ")" is untouched — only [.,;:] is stripped
+    expect(renderMediaTags('MEDIA:/tmp/file (1).mp4')).toBe(
+      '[Video: file (1).mp4](#media:%2Ftmp%2Ffile%20(1).mp4)'
+    )
+  })
+
+  it('does not swallow same-line prose after a bare MEDIA tag', () => {
+    expect(renderMediaTags('MEDIA:/a/b.mp4 and here is the rest')).toBe(
+      '[Video: b.mp4](#media:%2Fa%2Fb.mp4) and here is the rest'
+    )
+    expect(renderMediaTags('MEDIA:/tmp/voice.mp3 — see below')).toBe(
+      '[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3) — see below'
+    )
+    expect(renderMediaTags('MEDIA:"/tmp/file (1).mp4" and prose')).toBe(
+      '[Video: file (1).mp4](#media:%2Ftmp%2Ffile%20(1).mp4) and prose'
+    )
+  })
 })
 
 describe('interleaved reasoning/text boundaries', () => {

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -1,4 +1,4 @@
-import { mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
+import { isPlausibleMediaPath, mediaDisplayLabel, mediaMarkdownHref } from '@/lib/media'
 
 import type { ChatMessage, ChatMessagePart } from './types'
 
@@ -10,19 +10,23 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+// MEDIA tags embed a filesystem path. Quoted forms (backtick / double /
+// single) are explicit and may contain any character. Bare paths capture the
+// REST OF THE LINE — not `\S+` — because real paths contain spaces (project
+// folders like "2026-08-29 - Not Today/audio/NotToday.wav"). The bare capture
+// is only accepted when the remainder is plausibly path-shaped; otherwise the
+// line match is left untouched so the inline parser below extracts the path
+// and preserves same-line prose (e.g. "MEDIA:/a/b.mp4 and here's more").
+const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|[^\n]+)[`"']?[\t ]*(\n|$)/g
 
+// Inline form stays conservative: a bare inline path with spaces is
+// ambiguous in prose, so only quoted forms accept spaces there.
 const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 
-function unquoteMediaPath(value: string): string {
-  const trimmed = value.trim()
-  const quote = trimmed[0]
-
-  return quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote) ? trimmed.slice(1, -1) : trimmed
-}
-
 function mediaLink(value: string): string {
-  const path = unquoteMediaPath(value)
+  const trimmed = value.trim()
+  const quoted = trimmed.length > 1 && ['"', "'", '`'].includes(trimmed[0]) && trimmed[0] === trimmed.at(-1)
+  const path = quoted ? trimmed.slice(1, -1) : trimmed.replace(/[.,;:]+$/, '')
 
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
@@ -31,7 +35,8 @@ export function renderMediaTags(text: string): string {
   return text
     .replace(
       MEDIA_LINE_RE,
-      (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
+      (match, lead: string, value: string, trailer: string) =>
+        isPlausibleMediaPath(value) ? `${lead}${mediaLink(value)}${trailer}` : match
     )
     .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
     .replace(/[ \t]+\n/g, '\n')

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -65,6 +65,40 @@ export function mediaName(path: string): string {
   }
 }
 
+// True when a bare MEDIA path capture is plausibly a filesystem path rather
+// than a path followed by same-line prose. Quoted values are explicit and
+// always plausible. Bare values must look rooted (absolute-ish) and, when they
+// contain multiple whitespace tokens, their LAST token must still be
+// filename-shaped — that rejects trailing prose like "and here's more" while
+// accepting "2026-08-29 - Not Today/audio/NotToday.wav".
+export function isPlausibleMediaPath(value: string): boolean {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return false
+  }
+
+  const quoted = trimmed.length > 1 && ['"', "'", '`'].includes(trimmed[0]) && trimmed[0] === trimmed.at(-1)
+
+  if (quoted) {
+    return true
+  }
+
+  if (!/^(?:\/|~\/|\.\/|\.\.\/|file:|[a-zA-Z]:[\\/]|\\\\)/.test(trimmed)) {
+    return false
+  }
+
+  const tokens = trimmed.split(/\s+/)
+
+  if (tokens.length === 1) {
+    return true
+  }
+
+  const last = tokens[tokens.length - 1]
+
+  return /[\\/]/.test(last) || /\.[a-zA-Z0-9]{1,8}$/.test(last) || /^\./.test(last)
+}
+
 export function mediaMarkdownHref(path: string): string {
   return `#media:${encodeURIComponent(path)}`
 }


### PR DESCRIPTION
## Bug

`MEDIA:/path` tags in assistant messages break when the filesystem path contains **spaces** — e.g. the very common macOS case `MEDIA:/Users/me/Music Production/Song - Final/audio/track.wav`. The card renders but the file lookup fails and the download link is dead.

## Root cause

Two parsers capture the bare (unquoted) path with `\S+`, which stops at the first whitespace:

- `apps/desktop/src/lib/chat-messages/parts.ts` — `MEDIA_LINE_RE` truncates `MEDIA:/Users/me/2026-08-29 - Not Today/audio/NotToday.wav` to `/Users/me/2026-08-29`, so `mediaKind()` falls back to `'file'` and the file doesn't exist at the truncated path.
- `apps/desktop/src/app/artifacts/artifact-utils.ts` — `MEDIA_RE` has the same `\S+` copy for artifact scanning.

Quoted forms (backtick / double / single) always worked — only bare paths with spaces broke.

## Fix

- Bare line captures now take the **rest of the line** (`[^\n]+`) so spaces survive, then are accepted only when `isPlausibleMediaPath()` passes: quoted values always; bare values must look rooted (absolute-ish) and, when multi-token, end in a **filename-shaped final token**. This rejects same-line trailing prose (`MEDIA:/a/b.mp4 and here's more`) — those lines fall through to the unchanged inline parser, which extracts the path and preserves the prose exactly as before.
- Shared helper `isPlausibleMediaPath()` lives in `apps/desktop/src/lib/media.ts`; both parsers use it (no more drift between the two copies).
- Trailing sentence punctuation (`.`, `,`, `;`, `:`) is stripped from bare paths only; quoted paths preserve all characters (`/tmp/file (1).mp4` bare also survives — `)` is not in the stripped class).
- Inline `MEDIA:` in prose intentionally stays conservative (bare `\S+`) since a spaced inline path is ambiguous; quoted inline paths with spaces already work.

## Tests

Added in `apps/desktop/src/lib/chat-messages.test.ts`:

- spaced bare path full round-trip with `%20` encoding (the exact failing macOS path shape)
- spaced path with a non-media extension (.lrc file card)
- trailing `.`/`,` stripped from bare paths; quoted and `)`-ending paths preserved
- same-line prose NOT swallowed: `MEDIA:/a/b.mp4 and here is the rest`, `MEDIA:/tmp/voice.mp3 — see below`, and quoted-with-prose all render the link + keep the prose

All 98 tests pass across `chat-messages`, `media`, `artifacts/index`, and the markdown suites.
