### PR TITLE
feat(desktop): Browser pane offers real-profile browsing on first open

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -6,6 +6,13 @@ import { $connection } from '@/store/session'
 import { forgetPreviewConsole, previewConsoleState } from './preview-console-store'
 import { PreviewPane } from './preview-pane'
 
+// The consent dialog has its own test file and needs a QueryClientProvider;
+// these tests exercise the pane's console/watch/webview wiring, not the
+// prompt, so isolate it the way the pane's other collaborators are.
+vi.mock('./real-profile-consent-dialog', () => ({
+  RealProfileConsentDialog: () => null
+}))
+
 function stubPdfObjectUrls() {
   const NativeUrl = URL
   let objectUrlIndex = 0

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -45,6 +45,7 @@ import { type PreviewInputEvent, registerPreviewInput } from './preview-input'
 import { PREVIEW_BROWSER_ATTR, registerPreviewNav } from './preview-nav'
 import { registerPreviewPageReader } from './preview-reader'
 import { registerPreviewScriptRunner } from './preview-script-runner'
+import { RealProfileConsentDialog } from './real-profile-consent-dialog'
 
 type PreviewWebview = HTMLElement & {
   canGoBack?: () => boolean
@@ -1046,6 +1047,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             url={currentUrl}
           />
         )}
+
+        {/* First-open real-profile consent offer — Browser tabs only (URL
+            vessels the user browses with), never file/HTML previews. */}
+        {target.kind === 'url' && tabId && <RealProfileConsentDialog tabId={tabId} />}
 
         <div
           className="pointer-events-auto relative min-h-0 flex-1 overflow-hidden bg-transparent"

--- a/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.test.tsx
@@ -1,0 +1,159 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import {
+  $realProfilePromptClaim,
+  $realProfilePromptDismissed,
+  $realProfilePromptMuted
+} from '@/store/real-profile-consent'
+
+import { RealProfileConsentDialog } from './real-profile-consent-dialog'
+
+const mocks = vi.hoisted(() => ({
+  cache: vi.fn(),
+  loadedConfig: {} as Record<string, unknown> | undefined,
+  notify: vi.fn(),
+  notifyError: vi.fn(),
+  save: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  saveHermesConfigRecord: (config: Record<string, unknown>, profile?: unknown) => mocks.save(config, profile)
+}))
+
+const promptCopy = {
+  title: 'Stay signed in to your sites',
+  body: 'Let Hermes browse with a snapshot of your default browser profile.',
+  bulletSnapshot: 'Cookies and logins are copied into a managed snapshot.',
+  bulletLiveProfile: 'Your live browser profile is never opened directly.',
+  bulletLocal: 'Nothing leaves this computer.',
+  dontShowAgain: "Don't show again",
+  notNow: 'Not now',
+  enable: 'Use my profile'
+}
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { close: 'Close' },
+      settings: {
+        toolsets: {
+          browserRealProfile: {
+            enabledTitle: 'Real-profile browsing on',
+            enabledMessage: 'New sessions use the snapshot.',
+            failedSave: 'Could not save the real-profile setting',
+            prompt: promptCopy
+          }
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/notifications', () => ({
+  notify: (...args: unknown[]) => mocks.notify(...args),
+  notifyError: (...args: unknown[]) => mocks.notifyError(...args)
+}))
+
+vi.mock('../../hooks/use-config-record', () => ({
+  hermesConfigCacheWriter: () => (config: Record<string, unknown>) => mocks.cache(config),
+  useHermesConfigRecord: () => ({ data: mocks.loadedConfig })
+}))
+
+describe('RealProfileConsentDialog', () => {
+  beforeEach(() => {
+    mocks.loadedConfig = { browser: { allow_private_urls: false }, model: { provider: 'nous' } }
+    mocks.save.mockResolvedValue({ ok: true })
+    $realProfilePromptDismissed.set(false)
+    $realProfilePromptMuted.set(false)
+    $realProfilePromptClaim.set(null)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('shows when the feature is off and accepting writes browser.use_real_profile', async () => {
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    expect(screen.getByText(promptCopy.title)).toBeTruthy()
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: promptCopy.enable }))
+    })
+
+    // Saves the WHOLE merged record with only use_real_profile added — the
+    // same shape the Capabilities toggle writes, through the same cache, so
+    // the existing toggle flips on without a refetch.
+    expect(mocks.save).toHaveBeenCalledWith(
+      {
+        browser: { allow_private_urls: false, use_real_profile: true },
+        model: { provider: 'nous' }
+      },
+      undefined
+    )
+    expect(mocks.cache).toHaveBeenCalledWith(mocks.save.mock.calls[0][0])
+    expect(mocks.notify).toHaveBeenCalled()
+  })
+
+  it('does not show when real-profile browsing is already on', () => {
+    mocks.loadedConfig = { browser: { use_real_profile: true } }
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    expect(screen.queryByText(promptCopy.title)).toBeNull()
+  })
+
+  it('does not show before the config record loads', () => {
+    mocks.loadedConfig = undefined
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    expect(screen.queryByText(promptCopy.title)).toBeNull()
+  })
+
+  it('"Not now" mutes for the app run without persisting the opt-out', () => {
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    fireEvent.click(screen.getByRole('button', { name: promptCopy.notNow }))
+
+    expect(screen.queryByText(promptCopy.title)).toBeNull()
+    expect($realProfilePromptMuted.get()).toBe(true)
+    expect($realProfilePromptDismissed.get()).toBe(false)
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it('"Don\'t show again" persists the opt-out', () => {
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    fireEvent.click(screen.getByRole('button', { name: promptCopy.dontShowAgain }))
+
+    expect(screen.queryByText(promptCopy.title)).toBeNull()
+    expect($realProfilePromptDismissed.get()).toBe(true)
+    expect(mocks.save).not.toHaveBeenCalled()
+  })
+
+  it('only the claiming pane renders the dialog when several Browser panes mount', () => {
+    render(
+      <>
+        <RealProfileConsentDialog tabId="tab-1" />
+        <RealProfileConsentDialog tabId="tab-2" />
+      </>
+    )
+
+    expect(screen.getAllByText(promptCopy.title)).toHaveLength(1)
+    expect($realProfilePromptClaim.get()).toBe('tab-1')
+  })
+
+  it('rolls the optimistic cache write back when the save fails', async () => {
+    mocks.save.mockRejectedValue(new Error('boom'))
+    render(<RealProfileConsentDialog tabId="tab-1" />)
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: promptCopy.enable }))
+    })
+
+    expect(mocks.cache).toHaveBeenLastCalledWith(mocks.loadedConfig)
+    expect(mocks.notifyError).toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.tsx
+++ b/apps/desktop/src/app/chat/right-rail/real-profile-consent-dialog.tsx
@@ -1,0 +1,148 @@
+import { useStore } from '@nanostores/react'
+import { useCallback, useEffect, useState } from 'react'
+
+import { readUseRealProfile } from '@/app/settings/browser-real-profile-panel'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { saveHermesConfigRecord } from '@/hermes'
+import { useI18n } from '@/i18n'
+import { Check, Globe } from '@/lib/icons'
+import { notify, notifyError } from '@/store/notifications'
+import {
+  $realProfilePromptClaim,
+  $realProfilePromptDismissed,
+  $realProfilePromptMuted,
+  claimRealProfilePrompt,
+  releaseRealProfilePrompt
+} from '@/store/real-profile-consent'
+
+import { hermesConfigCacheWriter, useHermesConfigRecord } from '../../hooks/use-config-record'
+
+interface RealProfileConsentDialogProps {
+  /** The Browser tab this pane renders — used only to claim the prompt so
+   *  several mounted Browser panes never stack duplicate dialogs. */
+  tabId: string
+}
+
+/**
+ * First-open consent prompt for real-profile browsing. Mounts with a Browser
+ * pane (docked tab and `?win=browser` popout alike) and offers to turn on
+ * `browser.use_real_profile` — the same key the Capabilities → Tools →
+ * Browser toggle writes — when it is off.
+ *
+ * Accepting saves through the same deep-merging PUT /api/config + shared
+ * query cache the toggle reads, so the Capabilities toggle flips on the spot
+ * with no refetch. "Not now" mutes the prompt for this app run; "Don't show
+ * again" persists the opt-out across launches. Turning the toggle off later
+ * does NOT resurrect the prompt inside the same run.
+ */
+export function RealProfileConsentDialog({ tabId }: RealProfileConsentDialogProps) {
+  const { t } = useI18n()
+  const copy = t.settings.toolsets.browserRealProfile
+  const prompt = copy.prompt
+  const dismissed = useStore($realProfilePromptDismissed)
+  const muted = useStore($realProfilePromptMuted)
+  const claim = useStore($realProfilePromptClaim)
+  const { data: config } = useHermesConfigRecord()
+  const setConfig = hermesConfigCacheWriter()
+  const [busy, setBusy] = useState(false)
+
+  useEffect(() => {
+    claimRealProfilePrompt(tabId)
+
+    return () => releaseRealProfilePrompt(tabId)
+  }, [tabId])
+
+  const enabled = readUseRealProfile(config)
+
+  const enable = useCallback(async () => {
+    if (!config || busy) {
+      return
+    }
+
+    const browser =
+      config.browser && typeof config.browser === 'object' && !Array.isArray(config.browser)
+        ? (config.browser as Record<string, unknown>)
+        : {}
+
+    const next = { ...config, browser: { ...browser, use_real_profile: true } }
+
+    setBusy(true)
+    setConfig(next)
+
+    try {
+      await saveHermesConfigRecord(next)
+      notify({ kind: 'info', title: copy.enabledTitle, message: copy.enabledMessage })
+    } catch (err) {
+      setConfig(config)
+      notifyError(err, copy.failedSave)
+    } finally {
+      setBusy(false)
+    }
+  }, [busy, config, copy, setConfig])
+
+  // Config not loaded yet, feature already on, opted out, or another pane
+  // owns the prompt — render nothing. `enabled` flipping true after a
+  // successful save is also what closes the dialog.
+  const open = Boolean(config) && !enabled && !dismissed && !muted && claim === tabId
+
+  if (!open) {
+    return null
+  }
+
+  const bullets = [prompt.bulletSnapshot, prompt.bulletLiveProfile, prompt.bulletLocal]
+
+  return (
+    <Dialog
+      onOpenChange={value => {
+        // Esc / backdrop are a soft "Not now": mute for this run.
+        if (!value && !busy) {
+          $realProfilePromptMuted.set(true)
+        }
+      }}
+      open
+    >
+      <DialogContent className="max-w-md" showCloseButton={false}>
+        <DialogHeader>
+          <DialogTitle icon={Globe}>{prompt.title}</DialogTitle>
+          <DialogDescription>{prompt.body}</DialogDescription>
+        </DialogHeader>
+
+        <ul className="grid gap-2 text-[length:var(--conversation-caption-font-size)] text-(--ui-text-secondary)">
+          {bullets.map(bullet => (
+            <li className="flex items-start gap-2" key={bullet}>
+              <Check className="mt-0.5 size-3.5 shrink-0 text-primary" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+
+        <DialogFooter className="items-center sm:justify-between">
+          <button
+            className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary) underline-offset-4 transition-colors hover:text-foreground hover:underline"
+            disabled={busy}
+            onClick={() => $realProfilePromptDismissed.set(true)}
+            type="button"
+          >
+            {prompt.dontShowAgain}
+          </button>
+          <div className="flex gap-2">
+            <Button disabled={busy} onClick={() => $realProfilePromptMuted.set(true)} type="button" variant="ghost">
+              {prompt.notNow}
+            </Button>
+            <Button disabled={busy} onClick={() => void enable()} type="button">
+              {prompt.enable}
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/apps/desktop/src/app/settings/browser-real-profile-panel.tsx
+++ b/apps/desktop/src/app/settings/browser-real-profile-panel.tsx
@@ -14,7 +14,9 @@ interface BrowserRealProfilePanelProps {
   profile?: ProfileScope
 }
 
-function readUseRealProfile(record: Record<string, unknown> | undefined): boolean {
+/** Shared with the Browser pane's first-open consent prompt, so both surfaces
+ *  agree on what "on" means for `browser.use_real_profile`. */
+export function readUseRealProfile(record: Record<string, unknown> | undefined): boolean {
   const browser = record?.browser
 
   if (browser && typeof browser === 'object' && !Array.isArray(browser)) {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1263,7 +1263,17 @@ export const en: Translations = {
         enabledMessage: 'New sessions will browse with a snapshot of your default browser profile.',
         disabledTitle: 'Real-profile browsing off',
         disabledMessage: 'The profile snapshot will be deleted; new sessions use a clean browser.',
-        failedSave: 'Could not save the real-profile setting'
+        failedSave: 'Could not save the real-profile setting',
+        prompt: {
+          title: 'Stay signed in to your sites',
+          body: 'Let Hermes browse with a snapshot of your default browser profile, so sites open already signed in.',
+          bulletSnapshot: 'Cookies and logins are copied into a managed snapshot.',
+          bulletLiveProfile: 'Your live browser profile is never opened directly.',
+          bulletLocal: 'Nothing leaves this computer.',
+          dontShowAgain: "Don't show again",
+          notNow: 'Not now',
+          enable: 'Use my profile'
+        }
       }
     }
   },

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1157,7 +1157,17 @@ export const ja = defineLocale({
         enabledMessage: '新しいセッションは既定ブラウザプロファイルのスナップショットでブラウジングします。',
         disabledTitle: '実プロファイルブラウジング：オフ',
         disabledMessage: 'プロファイルのスナップショットは削除され、新しいセッションはクリーンなブラウザを使用します。',
-        failedSave: '実プロファイル設定を保存できませんでした'
+        failedSave: '実プロファイル設定を保存できませんでした',
+        prompt: {
+          title: 'サイトにログインしたまま利用',
+          body: 'Hermes が既定ブラウザプロファイルのスナップショットでブラウジングできるようにすると、サイトはログイン済みの状態で開きます。',
+          bulletSnapshot: 'Cookie とログイン情報は管理されたスナップショットにコピーされます。',
+          bulletLiveProfile: '実際のブラウザプロファイルが直接開かれることはありません。',
+          bulletLocal: 'データがこのコンピュータの外に出ることはありません。',
+          dontShowAgain: '今後表示しない',
+          notNow: '今はしない',
+          enable: 'プロファイルを使用'
+        }
       }
     }
   },

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1106,6 +1106,16 @@ export interface Translations {
         disabledTitle: string
         disabledMessage: string
         failedSave: string
+        prompt: {
+          title: string
+          body: string
+          bulletSnapshot: string
+          bulletLiveProfile: string
+          bulletLocal: string
+          dontShowAgain: string
+          notNow: string
+          enable: string
+        }
       }
     }
   }

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1114,7 +1114,17 @@ export const zhHant = defineLocale({
         enabledMessage: '新工作階段將使用預設瀏覽器設定檔的快照進行瀏覽。',
         disabledTitle: '真實設定檔瀏覽：已關閉',
         disabledMessage: '設定檔快照將被刪除；新工作階段使用乾淨的瀏覽器。',
-        failedSave: '無法儲存真實設定檔設定'
+        failedSave: '無法儲存真實設定檔設定',
+        prompt: {
+          title: '讓網站保持登入狀態',
+          body: '讓 Hermes 使用預設瀏覽器設定檔的快照進行瀏覽，網站開啟時即已登入。',
+          bulletSnapshot: 'Cookie 與登入資訊會複製到受管理的快照中。',
+          bulletLiveProfile: '絕不會直接開啟你的真實瀏覽器設定檔。',
+          bulletLocal: '所有資料都不會離開這台電腦。',
+          dontShowAgain: '不再顯示',
+          notNow: '暫不',
+          enable: '使用我的設定檔'
+        }
       }
     }
   },

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1453,7 +1453,17 @@ export const zh: Translations = {
         enabledMessage: '新会话将使用默认浏览器配置文件的快照进行浏览。',
         disabledTitle: '真实配置文件浏览：已关闭',
         disabledMessage: '配置文件快照将被删除；新会话使用干净的浏览器。',
-        failedSave: '无法保存真实配置文件设置'
+        failedSave: '无法保存真实配置文件设置',
+        prompt: {
+          title: '让网站保持登录状态',
+          body: '让 Hermes 使用默认浏览器配置文件的快照进行浏览，网站打开时即已登录。',
+          bulletSnapshot: 'Cookie 和登录信息会复制到托管快照中。',
+          bulletLiveProfile: '绝不会直接打开你的真实浏览器配置文件。',
+          bulletLocal: '所有数据都不会离开这台电脑。',
+          dontShowAgain: '不再显示',
+          notNow: '暂不',
+          enable: '使用我的配置文件'
+        }
       }
     }
   },

--- a/apps/desktop/src/store/real-profile-consent.ts
+++ b/apps/desktop/src/store/real-profile-consent.ts
@@ -1,0 +1,34 @@
+import { atom } from 'nanostores'
+
+import { Codecs, persistentAtom } from '@/lib/persisted'
+
+// One-time consent prompt for real-profile browsing, shown when a Browser
+// pane opens while `browser.use_real_profile` is off. Mirrors the embed
+// consent split: "Don't show again" persists across launches; "Not now"
+// mutes for this app run only, so the offer comes back next launch rather
+// than nagging within one.
+export const $realProfilePromptDismissed = persistentAtom<boolean>(
+  'hermes.desktop.real-profile-prompt-dismissed',
+  false,
+  Codecs.bool
+)
+
+/** "Not now" for this app run — session-scoped on purpose (see above). */
+export const $realProfilePromptMuted = atom(false)
+
+// Several Browser panes can be mounted at once (split zones, popout during a
+// dock transition). The FIRST mounted pane claims the prompt; the rest render
+// nothing, so one open never stacks N identical dialogs.
+export const $realProfilePromptClaim = atom<null | string>(null)
+
+export function claimRealProfilePrompt(id: string) {
+  if ($realProfilePromptClaim.get() === null) {
+    $realProfilePromptClaim.set(id)
+  }
+}
+
+export function releaseRealProfilePrompt(id: string) {
+  if ($realProfilePromptClaim.get() === id) {
+    $realProfilePromptClaim.set(null)
+  }
+}


### PR DESCRIPTION
## Summary
Opening a Browser pane in the desktop app now offers real-profile browsing when it's off: a one-time consent dialog whose "Use my profile" writes `browser.use_real_profile: true` through the same PUT /api/config + shared config cache the existing Capabilities → Tools → Browser toggle reads — so the toggle flips on instantly, no refetch.

Live screenshot from the worktree build: https://files.catbox.moe/apqz0w.png

## Changes
- `app/chat/right-rail/real-profile-consent-dialog.tsx` (new): the dialog — title/body/three checkmark bullets, "Don't show again" (persists across launches), "Not now" / Esc / backdrop (mutes for this app run), "Use my profile" (optimistic cache write + save, rollback on failure). Closes itself once the config reports the feature on.
- `store/real-profile-consent.ts` (new): persisted dismissal atom, session-scoped mute atom, and a claim atom so only ONE mounted Browser pane renders the prompt (split zones / popout transitions never stack duplicates).
- `app/chat/right-rail/preview-pane.tsx`: mounts the dialog for `kind === 'url'` tabs only (docked Browser tab and `?win=browser` popout both route through this pane); file/HTML previews never see it.
- `app/settings/browser-real-profile-panel.tsx`: exports `readUseRealProfile` so both surfaces agree on what "on" means.
- i18n: `browserRealProfile.prompt.*` keys added to types + all five locales (en, zh, zh-hant, ja; ar inherits via `defineLocale`).

## Validation
| Check | Result |
|---|---|
| `vitest` real-profile-consent-dialog + browser-real-profile-panel | 10/10 pass |
| `vitest` i18n locale parity (`languages.test.ts`) | 4/4 pass |
| `tsc -p tsconfig.json --noEmit` | clean |
| `eslint` on all touched files | clean |
| Live rig (CDP, worktree build): open Browser pane → dialog shows | ✔ ([screenshot](https://files.catbox.moe/apqz0w.png)) |
| Live: "Use my profile" → sandbox `config.yaml` gains `use_real_profile: true`, dialog closes | ✔ |
| Live: Capabilities → Tools → Browser toggle reads ON after accept (no refetch) | ✔ |
| Live: toggle off from Capabilities → `config.yaml` back to `false` | ✔ |

**Live repro:** on this branch's build, opening a Browser tab with `browser.use_real_profile` unset raised the dialog; accepting wrote the key to the sandbox HERMES_HOME config.yaml and the existing GUI toggle flipped to checked (verified over CDP + on-disk grep, both directions).

## Infographic

![First-Open Consent for Real-Profile Browsing](https://v3b.fal.media/files/b/0aa8a624/k9lWZi1-0nIQRdyjbs6aS_vPtYoQoI.png)
