### PR TITLE
fix(gateway): stop NTP clock steps from reporting live gateways dead on macOS

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -415,6 +415,43 @@ def _get_process_start_time(pid: int) -> Optional[int]:
         return None
 
 
+# Tolerance for the ``start_time`` fingerprint comparison, in the units
+# ``_get_process_start_time`` returns (centiseconds on macOS/Windows).
+#
+# On Linux the fingerprint is /proc field 22 — clock ticks since BOOT — which no
+# wall-clock adjustment can move, so the comparison is exact there.  Everywhere
+# else psutil reports ``create_time()`` as an absolute UNIX epoch, and macOS
+# derives that from a wall clock that NTP steps: a single sub-second correction
+# re-dates every live process at once, so a gateway that never restarted starts
+# failing an exact match and every liveness surface reports it dead while its
+# cron ticker keeps firing.  Observed live on macOS: a 2.00s step desynced the
+# top-level ``start_time`` from the ``writer_start_time`` written by the same
+# call in the same file.
+#
+# 5s is far below the gap that separates a PID-reuse candidate (a new process
+# occupying a recycled PID started at a wholly different time, and one that must
+# ALSO pass the argv + HERMES_HOME identity check) yet comfortably above any
+# realistic NTP step on a running host.
+_START_TIME_MATCH_TOLERANCE = 500  # centiseconds (5s)
+
+
+def _start_times_match(recorded: Any, current: Any) -> bool:
+    """Return True when two start-time fingerprints identify the same process.
+
+    Returns True when either side is unknown: an absent fingerprint is not
+    evidence of a mismatch, and callers treat this as "no objection" rather
+    than proof of identity (they corroborate with argv/HERMES_HOME).
+    """
+    if recorded is None or current is None:
+        return True
+    try:
+        return abs(int(recorded) - int(current)) <= _START_TIME_MATCH_TOLERANCE
+    except (TypeError, ValueError):
+        # Unparseable fingerprint: same rule as absent — don't manufacture a
+        # mismatch from a corrupt field.
+        return True
+
+
 def get_process_start_time(pid: int) -> Optional[int]:
     """Public wrapper for retrieving a process start time when available."""
     return _get_process_start_time(pid)
@@ -1323,11 +1360,7 @@ def runtime_status_pid_is_live(record: Optional[dict[str, Any]]) -> bool:
         return False
     recorded_start = (record or {}).get("start_time")
     current_start = _get_process_start_time(pid)
-    if (
-        recorded_start is not None
-        and current_start is not None
-        and current_start != recorded_start
-    ):
+    if not _start_times_match(recorded_start, current_start):
         return False
     return True
 
@@ -1563,11 +1596,7 @@ def get_runtime_status_running_pid(
 
     recorded_start = payload.get("start_time")
     current_start = _get_process_start_time(pid)
-    if (
-        recorded_start is not None
-        and current_start is not None
-        and current_start != recorded_start
-    ):
+    if not _start_times_match(recorded_start, current_start):
         return None
 
     # When no explicit expected_home is given (active profile context),
@@ -1669,7 +1698,9 @@ def acquire_scoped_lock(scope: str, identity: str, metadata: Optional[dict[str, 
                 if (
                     existing.get("start_time") is not None
                     and current_start is not None
-                    and current_start != existing.get("start_time")
+                    and not _start_times_match(
+                        existing.get("start_time"), current_start
+                    )
                 ):
                     stale = True
                 # When start_time comparison is unavailable on either side

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -327,6 +327,103 @@ class TestGatewayRuntimeStatus:
                 == 139
             ), cmdline
 
+    def test_start_times_match_tolerates_wall_clock_step(self):
+        """A small start-time delta is a clock correction, not a different process.
+
+        On platforms without ``/proc`` the fingerprint is
+        ``psutil.create_time()`` — an absolute UNIX epoch derived from a wall
+        clock that NTP steps.  A single correction re-dates every live process
+        at once, so exact equality declares healthy gateways dead.  Deltas far
+        larger than any plausible NTP step must still be rejected.
+        """
+        base = 178822529997
+
+        # Clock corrections — same process.
+        assert status._start_times_match(base, base)
+        assert status._start_times_match(base, base - 200)  # the observed 2.00s step
+        assert status._start_times_match(base, base + 200)  # and the other direction
+        assert status._start_times_match(base, base - status._START_TIME_MATCH_TOLERANCE)
+
+        # Beyond tolerance — a genuinely different process.
+        assert not status._start_times_match(
+            base, base - status._START_TIME_MATCH_TOLERANCE - 1
+        )
+        assert not status._start_times_match(base, base - 22500)  # PID reuse, ~225s apart
+
+    def test_start_times_match_treats_unusable_fingerprints_as_no_objection(self):
+        """An absent or corrupt fingerprint is not evidence of a mismatch.
+
+        Callers corroborate identity with argv + HERMES_HOME; a missing
+        start_time must not by itself veto a live gateway.
+        """
+        assert status._start_times_match(None, 178822529997)
+        assert status._start_times_match(178822529997, None)
+        assert status._start_times_match(None, None)
+        assert status._start_times_match("not-a-number", 178822529997)
+
+    def test_runtime_status_running_pid_survives_wall_clock_step(self, monkeypatch):
+        """Regression (macOS, live): NTP re-dated a running gateway to death.
+
+        ``hermes profile list`` and the dashboard reported a profile stopped
+        while its cron ticker kept firing seconds earlier.  The state file held
+        the same fingerprint twice, written by one ``_build_pid_record()`` call,
+        and they disagreed by exactly 2.00s — the top-level ``start_time`` had
+        been stamped either side of a clock correction.  The argv + HERMES_HOME
+        identity check passed; only the exact start-time comparison objected.
+        """
+        coder_home = Path("/opt/data/profiles/coder")
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "-p", "coder", "gateway", "run"],
+            "start_time": 178822529997,
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes -p coder gateway run"
+        )
+        # The live process reads back 2.00s earlier than the recorded stamp.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178822529797)
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+            == 139
+        )
+        assert status.runtime_status_pid_is_live(payload)
+
+    def test_runtime_status_running_pid_still_rejects_pid_reuse_after_clock_step(
+        self, monkeypatch
+    ):
+        """The clock tolerance must not blunt the PID-reuse guard.
+
+        A recycled PID belongs to a process started at a wholly different time,
+        far outside any NTP step, and must still be rejected even though its
+        command line would otherwise satisfy the profile check.
+        """
+        coder_home = Path("/opt/data/profiles/coder")
+        payload = {
+            "pid": 139,
+            "gateway_state": "running",
+            "kind": "hermes-gateway",
+            "argv": ["hermes", "-p", "coder", "gateway", "run"],
+            "start_time": 178822529997,
+        }
+
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: True)
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "hermes -p coder gateway run"
+        )
+        # Same PID, but this process started ~225s later: a different process.
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 178822552497)
+
+        assert (
+            status.get_runtime_status_running_pid(payload, expected_home=coder_home)
+            is None
+        )
+        assert not status.runtime_status_pid_is_live(payload)
+
 
     def test_command_line_belongs_to_profile_normalizes_separators(self):
         """A Windows argv renders HERMES_HOME with backslashes while the


### PR DESCRIPTION
## Symptom

On macOS, `hermes profile list` and the dashboard report a gateway as
`stopped` while the process is alive and its cron ticker keeps firing.

Observed live on a Mac with 9 days uptime:

```
$ hermes profile list
  analyst          claude-opus-5     stopped

$ python3 -c "import time; print(time.time() - float(open('profiles/analyst/cron/ticker_last_success').read()))"
32.4          # the ticker succeeded 32 seconds ago
```

A dead gateway cannot update that heartbeat. The gateway was fine; the
liveness check was wrong.

## Root cause

`_get_process_start_time()` returns a PID-reuse fingerprint:

| Platform | Source | Clock |
|---|---|---|
| Linux | `/proc/<pid>/stat` field 22 | ticks since **boot** — immune to NTP |
| macOS / Windows | `psutil.Process(pid).create_time()` ×100 | absolute **UNIX epoch** |

The liveness checks compared recorded vs live with **exact equality**. macOS
derives `create_time()` from a wall clock that NTP steps, so a single
correction re-dates every live process at once and a gateway that never
restarted starts failing the match.

The state file makes this visible — it holds the same fingerprint twice,
written by a single `_build_pid_record()` call, and they disagree:

```json
"start_time":        178822529997,      // top-level, stamped after the step
"platforms": {"slack": {
    "writer_start_time": 178822529797   // matches the live process exactly
}}
```

Exactly 200 centiseconds = 2.00s. On the affected host the clock was
oscillating ±2s, so this could recur at any time.

Instrumenting the resolution shows the failure precisely:

```
recorded 178822529997   live 178822529797
argv-match True         <- argv + HERMES_HOME identity check PASSES
RESULT   None           <- but the clock fingerprint vetoes it first
```

The stronger evidence was already available and already passing.

## Fix

Route every start-time comparison through a new `_start_times_match()` that
allows a 5s tolerance, and treats an absent or unparseable fingerprint as "no
objection" rather than manufacturing a mismatch.

Three call sites shared the flaw:

| Site | Function | Harm |
|---|---|---|
| ~1600 | `get_runtime_status_running_pid` | `profile list` / dashboard report dead |
| ~1360 | `runtime_status_pid_is_live` | bogus "stale gateway_state.json" warning |
| ~1698 | `acquire_scoped_lock` | **steals a live gateway's credential lock** |

The third is the damaging one. Two profiles sharing a Slack bot token, one
falsely judged stale, and the scoped lock is handed away from a gateway that
is still running.

### Why 5s is safe

PID-reuse defence is preserved. A recycled PID belongs to a process started at
a wholly different time (minutes apart in practice, far outside any NTP step),
**and** must independently pass the argv + HERMES_HOME check in
`_record_matches_live_gateway_pid`. This demotes the clock fingerprint from a
veto to corroboration; it does not remove a layer.

Linux behaviour is unchanged in practice — boot-relative ticks never drift, so
the comparison stays effectively exact there.

### Alternative considered: a boot-relative fingerprint on macOS

`psutil.boot_time()` exists, so `create_time() - boot_time()` looked like it
could reproduce the Linux property. Measured on the affected host:

```
now - boot_time() = 824948.851
monotonic()       = 824960.621
                    11.77s apart
```

The two are corrected independently, so the difference is not invariant.
There is no stable boot-relative process fingerprint available on macOS;
tolerance is the workable approach.

## Tests

Four regression tests in `tests/gateway/test_status.py`:

- `test_start_times_match_tolerates_wall_clock_step` — table-driven: equal, ±2s
  step, exactly at tolerance → match; 1 centisecond beyond, and a ~225s gap →
  no match
- `test_start_times_match_treats_unusable_fingerprints_as_no_objection` —
  `None` on either side, and an unparseable value
- `test_runtime_status_running_pid_survives_wall_clock_step` — the reported
  failure, end to end
- `test_runtime_status_running_pid_still_rejects_pid_reuse_after_clock_step` —
  the guard still bites

**Verified they fail on the unfixed tree** (3 of the 4 — the reuse-rejection
test correctly passes both ways):

```
$ git stash push gateway/status.py && scripts/run_tests.sh tests/gateway/test_status.py -q
FAILED ...::test_start_times_match_tolerates_wall_clock_step
FAILED ...::test_start_times_match_treats_unusable_fingerprints_as_no_objection
FAILED ...::test_runtime_status_running_pid_survives_wall_clock_step
=== Summary: 75 tests passed, 3 failed ===

$ git stash pop && scripts/run_tests.sh tests/gateway/test_status.py -q
=== Summary: 78 tests passed, 0 failed ===
```

`tests/gateway/` + `tests/cron/` were also run before and after the change:
the same 4 pre-existing failures appear either way
(`test_scale_to_zero.py`, `test_systemd_notify.py` — Linux-only;
`test_buzz_adapter.py` — a macOS path-length limit), so none are introduced
here.

## Reproducing without waiting for an NTP step

```python
from pathlib import Path
from gateway.status import read_runtime_status, get_runtime_status_running_pid

payload = {
    "pid": <live gateway pid>,
    "gateway_state": "running",
    "kind": "hermes-gateway",
    "argv": ["hermes", "-p", "coder", "gateway", "run"],
    "start_time": <live fingerprint> + 200,   # simulate a 2s step
}
get_runtime_status_running_pid(payload, expected_home=Path("..."))
# before: None   after: the pid
```
