### PR TITLE
fix(status): treat zombie check failure as dead pid instead of silent fallthrough

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -895,8 +895,13 @@ def _pid_exists(pid: int) -> bool:
                 )
                 if r.returncode == 0 and r.stdout.strip().startswith("Z"):
                     return False
-            except Exception:
-                pass
+            except Exception as exc:
+                # If we cannot determine zombie state, treat as dead rather
+                # than silently falling through to os.kill(), which cannot
+                # detect zombies on POSIX. A false "alive" here causes
+                # --replace to wait forever on a reaped PID.
+                logger.debug("zombie check failed for pid %s: %s", pid, exc)
+                return False
         except (IndexError, PermissionError, OSError):
             pass
         try:


### PR DESCRIPTION
`_pid_exists` has a documented zombie-detection path (issue #42126): on POSIX it checks `/proc/{pid}/stat` first, then falls back to `ps -o state`, then `os.kill(pid, 0)`. The problem is that failures in the zombie-detection helpers were swallowed with `except Exception: pass`, which made `_pid_exists` fall through to `os.kill(pid, 0)`. On POSIX, `os.kill(pid, 0)` returns success for zombies (they are still in the process table), so a zombie gateway is reported as alive. Under `systemd Restart=always` this means `--replace` waits forever on a dead PID and aborts with exit 1, causing a restart loop.

Change: on zombie-check failure, log debug and return `False` (treat as dead) instead of silently continuing. This keeps `_pid_exists` conservative: it can false-positive "dead" on a transient check error, but never false-positive "alive" on a zombie.
