### PR TITLE
feat(model): offer to propagate a rotated API key to all profiles

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4586,14 +4586,18 @@ def save_env_value(key: str, value: str):
     # writer didn't match it, a save would append a SECOND line and a later
     # delete of that line would silently resurrect the old exported value
     # (#40041: "token detected but cannot be replaced through the UI").
-    found = False
-    for i, line in enumerate(lines):
-        if _env_line_defines_key(line, key):
-            lines[i] = f"{key}={serialized_value}\n"
-            found = True
-            break
-
-    if not found:
+    #
+    # A file can carry MORE than one line assigning the same key (hand-edits,
+    # partial writes from older versions). load_env() lets the LAST line win,
+    # so updating only the first match would leave a stale later line that
+    # resurrects the old value on the next load. Replace the FIRST matching
+    # line with the fresh assignment and drop every later duplicate.
+    match_indexes = [i for i, line in enumerate(lines) if _env_line_defines_key(line, key)]
+    if match_indexes:
+        lines[match_indexes[0]] = f"{key}={serialized_value}\n"
+        for i in reversed(match_indexes[1:]):
+            del lines[i]
+    else:
         # Ensure there's a newline at the end of the file before appending
         if lines and not lines[-1].endswith("\n"):
             lines[-1] += "\n"

--- a/hermes_cli/credential_lifecycle.py
+++ b/hermes_cli/credential_lifecycle.py
@@ -43,6 +43,7 @@ from typing import Any, Dict, List
 
 __all__ = [
     "save_provider_env_credential",
+    "propagate_provider_env_credential_to_profiles",
     "remove_provider_env_credential",
     "purge_env_credential_references",
 ]
@@ -281,6 +282,124 @@ def save_provider_env_credential(env_var: str, value: str) -> Dict[str, Any]:
         pass
 
     return {"ok": True, "key": env_var, "config_updates": config_updates}
+
+
+def _iter_profile_env_paths() -> List[tuple]:
+    """(name, path) for every profile-scoped ``.env`` besides the active home.
+
+    Enumerates the SAME homes ``hermes profile list`` shows: the default home
+    (``~/.hermes/.env`` when running inside ``~/.hermes/profiles/<name>``) and
+    every sibling profile under the shared ``profiles/`` root. The ACTIVE home
+    is excluded — the caller just saved the key there and it is the source of
+    truth. Homes without a ``.env`` are skipped: propagation must never
+    introduce a credential into a profile that deliberately keeps the var
+    unset (an isolated test/staging profile must stay keyless).
+    """
+    from hermes_constants import (
+        get_default_hermes_root,
+        get_hermes_home,
+    )
+
+    active = get_hermes_home().resolve()
+    root = get_default_hermes_root()
+
+    candidates: List[tuple] = []
+    if root == active:
+        # Running in the default home — profiles live under root/profiles/.
+        profiles_root = root / "profiles"
+    else:
+        # Running inside a profile — include the default home as a candidate.
+        candidates.append(("default", root / ".env"))
+        profiles_root = root / "profiles"
+    if profiles_root.is_dir():
+        for entry in sorted(profiles_root.iterdir()):
+            if not entry.is_dir() or entry.name.startswith("."):
+                # Skip tombstones like ``profiles/.deleted`` (see
+                # ``named_profile_home``) and other hidden entries.
+                continue
+            candidates.append((entry.name, entry / ".env"))
+
+    out: List[tuple] = []
+    seen = {str(active)}
+    for name, env_path in candidates:
+        resolved_parent = env_path.parent.resolve()
+        if str(resolved_parent) in seen:
+            continue
+        if not env_path.exists():
+            continue
+        seen.add(str(resolved_parent))
+        out.append((name, env_path))
+    return out
+
+
+def propagate_provider_env_credential_to_profiles(
+    env_var: str, value: str, *, apply: bool = True
+) -> Dict[str, Any]:
+    """Copy a just-saved credential to every OTHER profile that defines the var.
+
+    A rotated provider key is one credential for the whole machine, but the
+    ``hermes model`` / ``hermes setup`` flows only write the ACTIVE profile's
+    ``.env``. Every sibling profile that shares the provider keeps running on
+    the dead key (401s, stalled cron jobs) until the user re-runs the wizard
+    N times. This is the explicit multi-profile propagation step the save
+    flows now offer after a key rotation.
+
+    Only profiles whose ``.env`` ALREADY defines ``env_var`` are updated:
+    propagation mirrors an existing credential, it must not provision one
+    into a profile that intentionally keeps the var unset. Profiles with a
+    DIFFERENT value are updated too — a rotation replaces the machine-wide
+    credential, and the old value is by definition dead. (A profile with a
+    deliberately different key is rare; if it exists, the user simply
+    re-runs the wizard inside that profile after propagation.)
+
+    ``apply=False`` is a dry run for the caller's prompt: it reports which
+    profiles WOULD be updated, without writing anything.
+
+    ``config.yaml`` mirrors (``model.api_key``) holding the OLD value are
+    scrubbed per target profile too, mirroring
+    :func:`save_provider_env_credential`'s #62269 fix across homes.
+
+    Secrecy contract holds: returns per-profile key NAMES and status only,
+    never credential material.
+    """
+    from hermes_constants import (
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    from hermes_cli.config import load_env, save_env_value
+
+    updated: List[str] = []
+    in_sync: List[str] = []
+    skipped: List[str] = []
+    for name, env_path in _iter_profile_env_paths():
+        token = set_hermes_home_override(str(env_path.parent))
+        try:
+            target_env = load_env()
+            old_value = target_env.get(env_var)
+            if old_value is None:
+                # Profile never configured this credential — leave it alone.
+                skipped.append(name)
+                continue
+            if old_value == value:
+                # Already holds the new key — nothing to propagate.
+                in_sync.append(name)
+                continue
+            if apply:
+                save_env_value(env_var, value)
+                # save_env_value can silently no-op (managed-scope guard).
+                # Verify the write landed before reporting the profile as
+                # updated — a false "updated" would hide a stale key.
+                if load_env().get(env_var) != value:
+                    skipped.append(name)
+                    continue
+                _scrub_config_yaml_mirrors(old_value, value)
+        except Exception:
+            skipped.append(name)
+            continue
+        finally:
+            reset_hermes_home_override(token)
+        updated.append(name)
+    return {"updated": updated, "in_sync": in_sync, "skipped": skipped}
 
 
 def remove_provider_env_credential(env_var: str) -> Dict[str, Any]:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5425,6 +5425,60 @@ def _prompt_api_key(
 
     key_env = pconfig.api_key_env_vars[0] if pconfig.api_key_env_vars else ""
 
+    def _maybe_offer_profile_propagation(new_key: str) -> None:
+        """After a key save, offer to mirror it into sibling profiles.
+
+        Profiles have isolated ``.env`` stores by design — but a rotated
+        provider key is one credential for the whole machine. Without this
+        step every sibling profile that shares the provider keeps running on
+        the dead key until the user re-runs the wizard N times. Opt-in and
+        explicit (default No): a profile may deliberately hold a DIFFERENT
+        key, and only the user knows whether that is intentional.
+        """
+        if not key_env or not new_key:
+            return
+        try:
+            from hermes_cli.credential_lifecycle import (
+                propagate_provider_env_credential_to_profiles,
+            )
+        except Exception:
+            return
+        try:
+            dry = propagate_provider_env_credential_to_profiles(
+                key_env, new_key, apply=False
+            )
+        except Exception:
+            return
+        targets = dry.get("updated") or []
+        if not targets:
+            return
+        try:
+            print(
+                f"  {len(targets)} other profile(s) use {key_env} with a "
+                f"stale value: {', '.join(targets)}"
+            )
+            answer = input(
+                f"  Propagate the new key to all {len(targets)} profile(s)? [y/N]: "
+            ).strip().lower()
+        except (KeyboardInterrupt, EOFError):
+            print()
+            return
+        if answer not in {"y", "yes"}:
+            return
+        try:
+            result = propagate_provider_env_credential_to_profiles(
+                key_env, new_key, apply=True
+            )
+        except Exception:
+            print("  Propagation failed — other profiles keep the old key.")
+            return
+        done = result.get("updated") or []
+        failed = result.get("skipped") or []
+        if done:
+            print(f"  Key propagated to: {', '.join(done)}")
+        if failed:
+            print(f"  Could not update: {', '.join(failed)}")
+
     def _prompt_new_key(*, allow_lmstudio_default: bool) -> str:
         if provider_id == "lmstudio" and allow_lmstudio_default:
             prompt = f"{key_env} (Enter for no-auth default {LMSTUDIO_NOAUTH_PLACEHOLDER!r}): "
@@ -5450,6 +5504,7 @@ def _prompt_api_key(
             return "", True
         save_env_value(key_env, new_key)
         print("API key saved.")
+        _maybe_offer_profile_propagation(new_key)
         print()
         return new_key, False
 
@@ -5482,6 +5537,7 @@ def _prompt_api_key(
             return existing_key, False
         save_env_value(key_env, new_key)
         print("  API key updated.")
+        _maybe_offer_profile_propagation(new_key)
         print()
         return new_key, False
 

--- a/tests/hermes_cli/test_profile_credential_propagation.py
+++ b/tests/hermes_cli/test_profile_credential_propagation.py
@@ -1,0 +1,323 @@
+"""Cross-profile propagation of a rotated provider credential.
+
+``hermes model`` / ``hermes setup`` only write the ACTIVE profile's ``.env``.
+A rotated provider key is one credential for the whole machine, so sibling
+profiles that share the provider keep running on the dead key. These tests
+drive the real propagation path against real on-disk fixtures in a temp
+HERMES_HOME: default home + sibling profiles under ``profiles/``.
+
+All fake secrets are constructed at runtime so no key-shaped literal ever
+lands in the repo.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+ENV_VAR = "DEEPSEEK_API_KEY"
+OLD_KEY = "dk-" + "a" * 24
+NEW_KEY = "dk-" + "b" * 24
+
+
+@pytest.fixture
+def multi_profile_home(monkeypatch, tmp_path):
+    """HERMES_HOME at the default home, with sibling profiles pre-created.
+
+    Layout:
+
+        <home>/.env                      — active (default) home, OLD_KEY
+        <home>/profiles/alpha/.env       — OLD_KEY (should be updated)
+        <home>/profiles/beta/.env        — var absent (must stay untouched)
+        <home>/profiles/gamma/.env       — NEW_KEY already (in sync)
+        <home>/profiles/empty/           — profile without .env (skipped)
+        <home>/profiles/.deleted/        — tombstone dir (must be ignored)
+    """
+    home = tmp_path / "multi_home"
+    home.mkdir()
+    profiles = home / "profiles"
+    profiles.mkdir()
+    (profiles / ".deleted").mkdir()
+
+    (home / ".env").write_text(f"{ENV_VAR}={OLD_KEY}\n", encoding="utf-8")
+    for name, key in (("alpha", OLD_KEY), ("beta", ""), ("gamma", NEW_KEY)):
+        p = profiles / name
+        p.mkdir()
+        # beta gets an .env WITHOUT the var — it must stay untouched.
+        (p / ".env").write_text(
+            f"{ENV_VAR}={key}\n" if key else "OTHER_TOKEN=zz\n", encoding="utf-8"
+        )
+    (profiles / "empty").mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    from hermes_cli.config import invalidate_env_cache
+
+    invalidate_env_cache()
+    return home
+
+
+def _invalidate():
+    from hermes_cli.config import invalidate_env_cache
+
+    invalidate_env_cache()
+
+
+def _read_env_value(path):
+    from hermes_cli.config import load_env
+
+    token = None
+    from hermes_constants import set_hermes_home_override
+
+    token = set_hermes_home_override(str(path.parent))
+    try:
+        return load_env().get(ENV_VAR)
+    finally:
+        from hermes_constants import reset_hermes_home_override
+
+        reset_hermes_home_override(token)
+
+
+# ---------------------------------------------------------------------------
+# propagate_provider_env_credential_to_profiles
+# ---------------------------------------------------------------------------
+
+
+def test_propagation_updates_stale_sibling_only(multi_profile_home):
+    from hermes_cli.credential_lifecycle import (
+        propagate_provider_env_credential_to_profiles,
+    )
+
+    result = propagate_provider_env_credential_to_profiles(ENV_VAR, NEW_KEY)
+
+    assert result["updated"] == ["alpha"]
+    assert "gamma" in result["in_sync"]
+    assert "beta" in result["skipped"]
+    # Alpha got the new key; gamma still has it; beta stayed untouched.
+    assert _read_env_value(multi_profile_home / "profiles" / "alpha" / ".env") == NEW_KEY
+    assert _read_env_value(multi_profile_home / "profiles" / "gamma" / ".env") == NEW_KEY
+    assert _read_env_value(multi_profile_home / "profiles" / "beta" / ".env") is None
+    # A profile without .env must not gain one.
+    assert not (multi_profile_home / "profiles" / "empty" / ".env").exists()
+    # The active (default) home keeps its own value — propagation never
+    # touches the home the save already wrote.
+    assert _read_env_value(multi_profile_home / ".env") == OLD_KEY
+
+
+def test_propagation_from_profile_updates_default_home(monkeypatch, tmp_path):
+    home = tmp_path / "root"
+    home.mkdir()
+    (home / ".env").write_text(f"{ENV_VAR}={OLD_KEY}\n", encoding="utf-8")
+    worker = home / "profiles" / "worker"
+    worker.mkdir(parents=True)
+    (worker / ".env").write_text(f"{ENV_VAR}=dk-{'c' * 24}\n", encoding="utf-8")
+    # sister profile, also stale
+    sister = home / "profiles" / "sister"
+    sister.mkdir()
+    (sister / ".env").write_text(f"{ENV_VAR}={OLD_KEY}\n", encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(worker))
+    _invalidate()
+
+    from hermes_cli.credential_lifecycle import (
+        propagate_provider_env_credential_to_profiles,
+    )
+
+    result = propagate_provider_env_credential_to_profiles(ENV_VAR, NEW_KEY)
+
+    assert sorted(result["updated"]) == ["default", "sister"]
+    assert _read_env_value(home / ".env") == NEW_KEY
+    assert _read_env_value(sister / ".env") == NEW_KEY
+    # The active profile's own .env was NOT rewritten by propagation (the
+    # wizard already wrote the key there before propagating).
+    assert _read_env_value(worker / ".env") != NEW_KEY
+
+
+def test_dry_run_writes_nothing(multi_profile_home):
+    from hermes_cli.credential_lifecycle import (
+        propagate_provider_env_credential_to_profiles,
+    )
+
+    result = propagate_provider_env_credential_to_profiles(
+        ENV_VAR, NEW_KEY, apply=False
+    )
+
+    assert result["updated"] == ["alpha"]
+    assert _read_env_value(multi_profile_home / "profiles" / "alpha" / ".env") == OLD_KEY
+
+
+def test_duplicate_key_lines_are_collapsed(multi_profile_home):
+    """A target .env with the key assigned twice keeps dead until collapsed.
+
+    load_env() lets the LAST assignment win, so a stale duplicate line
+    resurrects the old value even after the first line was updated. The
+    propagation write must leave exactly ONE assignment behind.
+    """
+    alpha_env = multi_profile_home / "profiles" / "alpha" / ".env"
+    alpha_env.write_text(
+        f"{ENV_VAR}={OLD_KEY}\nOTHER_TOKEN=zz\n{ENV_VAR}=dk-{NEW_KEY[3:]}x\n",
+        encoding="utf-8",
+    )
+
+    from hermes_cli.credential_lifecycle import (
+        propagate_provider_env_credential_to_profiles,
+    )
+
+    result = propagate_provider_env_credential_to_profiles(ENV_VAR, NEW_KEY)
+
+    assert result["updated"] == ["alpha"]
+    text = alpha_env.read_text(encoding="utf-8")
+    assert text.count(f"{ENV_VAR}=") == 1
+    assert f"{ENV_VAR}={NEW_KEY}" in text
+    assert "OTHER_TOKEN=zz" in text
+    assert _read_env_value(alpha_env) == NEW_KEY
+
+
+def test_config_yaml_mirror_scrubbed_per_profile(multi_profile_home):
+    """A sibling's config.yaml mirror of the OLD key follows the rotation."""
+    alpha = multi_profile_home / "profiles" / "alpha"
+    (alpha / "config.yaml").write_text(
+        f"model:\n  api_key: {OLD_KEY}\n", encoding="utf-8"
+    )
+
+    from hermes_cli.credential_lifecycle import (
+        propagate_provider_env_credential_to_profiles,
+    )
+
+    result = propagate_provider_env_credential_to_profiles(ENV_VAR, NEW_KEY)
+
+    assert result["updated"] == ["alpha"]
+    text = (alpha / "config.yaml").read_text(encoding="utf-8")
+    assert OLD_KEY not in text
+    assert NEW_KEY in text
+
+
+# ---------------------------------------------------------------------------
+# _prompt_api_key — the wizard offers propagation after a key save
+# ---------------------------------------------------------------------------
+
+
+def _pconfig():
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    return PROVIDER_REGISTRY["deepseek"]
+
+
+def test_prompt_replace_offers_and_applies_propagation(multi_profile_home, capsys):
+    from hermes_cli import main as m
+
+    with patch("builtins.input", side_effect=["r", "y"]), patch(
+        "hermes_cli.secret_prompt.masked_secret_prompt", return_value=NEW_KEY
+    ):
+        key, abort = m._prompt_api_key(
+            _pconfig(), OLD_KEY, provider_id="deepseek"
+        )
+
+    assert key == NEW_KEY
+    assert abort is False
+    assert (
+        _read_env_value(multi_profile_home / "profiles" / "alpha" / ".env") == NEW_KEY
+    )
+    out = capsys.readouterr().out
+    assert "stale value: alpha" in out
+    assert "Key propagated to: alpha" in out
+
+
+def test_prompt_replace_propagation_declined_by_default(multi_profile_home, capsys):
+    from hermes_cli import main as m
+
+    with patch("builtins.input", side_effect=["r", ""]), patch(
+        "hermes_cli.secret_prompt.masked_secret_prompt", return_value=NEW_KEY
+    ):
+        key, abort = m._prompt_api_key(
+            _pconfig(), OLD_KEY, provider_id="deepseek"
+        )
+
+    assert key == NEW_KEY
+    assert abort is False
+    # Sibling profiles keep the old key when the user declines.
+    assert (
+        _read_env_value(multi_profile_home / "profiles" / "alpha" / ".env") == OLD_KEY
+    )
+
+
+def test_prompt_no_siblings_no_extra_prompt(tmp_path, monkeypatch, capsys):
+    """Without sibling profiles the flow must not ask anything extra."""
+    home = tmp_path / "solo_home"
+    home.mkdir()
+    (home / ".env").write_text(f"{ENV_VAR}={OLD_KEY}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _invalidate()
+
+    from hermes_cli import main as m
+
+    inputs = []
+
+    def fake_input(prompt=""):
+        inputs.append(prompt)
+        return "r"
+
+    with patch("builtins.input", side_effect=fake_input), patch(
+        "hermes_cli.secret_prompt.masked_secret_prompt", return_value=NEW_KEY
+    ):
+        key, abort = m._prompt_api_key(
+            _pconfig(), OLD_KEY, provider_id="deepseek"
+        )
+
+    assert key == NEW_KEY
+    assert abort is False
+    # Exactly one prompt: the K/R/C menu. No propagation follow-up.
+    assert len(inputs) == 1
+    assert "Propagate" not in capsys.readouterr().out
+
+
+def test_save_env_value_collapses_duplicate_key_lines(tmp_path, monkeypatch):
+    """save_env_value must leave exactly ONE assignment per key.
+
+    load_env() lets the LAST matching line win, so keeping a later duplicate
+    after updating the first would resurrect the old value on next load.
+    """
+    home = tmp_path / "solo_home"
+    home.mkdir()
+    env_file = home / ".env"
+    env_file.write_text(
+        f"{ENV_VAR}={OLD_KEY}\nOTHER_TOKEN=zz\n{ENV_VAR}=dk-{'e' * 24}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    _invalidate()
+
+    from hermes_cli.config import save_env_value
+
+    save_env_value(ENV_VAR, NEW_KEY)
+
+    text = env_file.read_text(encoding="utf-8")
+    assert text.count(f"{ENV_VAR}=") == 1
+    assert f"{ENV_VAR}={NEW_KEY}" in text
+    assert "OTHER_TOKEN=zz" in text
+    _invalidate()
+    from hermes_cli.config import load_env
+
+    assert load_env()[ENV_VAR] == NEW_KEY
+
+
+def test_prompt_first_time_key_offers_propagation(multi_profile_home, capsys):
+    """First-time key entry also propagates when accepted."""
+    (multi_profile_home / ".env").write_text("", encoding="utf-8")
+    _invalidate()
+
+    from hermes_cli import main as m
+
+    with patch("builtins.input", side_effect=["y"]), patch(
+        "hermes_cli.secret_prompt.masked_secret_prompt", return_value=NEW_KEY
+    ):
+        key, abort = m._prompt_api_key(
+            _pconfig(), "", provider_id="deepseek"
+        )
+
+    assert key == NEW_KEY
+    assert abort is False
+    assert (
+        _read_env_value(multi_profile_home / "profiles" / "alpha" / ".env") == NEW_KEY
+    )
+    assert "Key propagated to: alpha" in capsys.readouterr().out


### PR DESCRIPTION
## Problem

`hermes model` / `hermes setup` write a provider API key only to the ACTIVE profile's `.env`. Profiles are isolated by design, but a rotated provider key is one credential for the whole machine: after `hermes model` [R]eplace, every sibling profile that shares the provider keeps running on the dead key — 401s, stalled cron jobs, dead kanban workers — until the user re-runs the wizard once per profile.

## What this adds

After a key save (first-time entry or [R]eplace) in `_prompt_api_key`:

1. **Dry-run enumerate sibling homes** — the default home (when running inside a profile) plus every profile under `profiles/`. Only homes whose `.env` already defines the env var are candidates; a profile that never configured the credential stays untouched.
2. **If at least one holds a stale value, offer one prompt**: `Propagate the new key to all N profile(s)? [y/N]` — opt-in, default No. A sibling may deliberately hold a different key; only the user knows.
3. **On yes, write the key via the same `save_env_value` path the active home gets** (context-local `set_hermes_home_override`, so atomic write, quoting, export-line handling and permissions behave identically), and scrub per-target-home `config.yaml` mirrors of the old value — the #62269 fix applied across homes.

## Included bug fix (same bug class)

`save_env_value` updated only the FIRST line assigning a key, but `load_env()` lets the LAST line win. A `.env` carrying duplicate assignments (hand-edits, partial writes) kept a stale later line that resurrected the old value on the next load. The writer now collapses duplicates to a single assignment.

## Tests

New `tests/hermes_cli/test_profile_credential_propagation.py` (10 tests, E2E against a real multi-profile temp `HERMES_HOME`):

- stale sibling updated; already-in-sync / var-absent / no-.env siblings untouched
- running inside a profile updates the default home + siblings
- `apply=False` dry run writes nothing
- duplicate key lines collapsed (propagation + `save_env_value` directly)
- config.yaml mirror scrubbed per profile
- wizard prompts/applies/declines; no extra prompt when there are no siblings
- first-time entry path offers propagation too

Existing suites green: `test_credential_lifecycle.py`, `test_prompt_api_key.py`, `test_model_flow_pooled_credentials.py`, `test_env_custom_keys.py`, `test_env_export_line_lifecycle.py`, `test_env_sanitize_on_load.py`, `test_get_env_value_scope.py`, `test_env_load_cache.py`.

Note: one pre-existing failure on current `main` unrelated to this change (`test_cmd_update.py::TestCmdUpdateMigrationPrompt::test_version_bump_only_applies_silently_without_prompt`, verified failing with the working tree stashed).