### PR TITLE
fix(gateway): log secret_scope fallback in allowlist read

### DIFF
--- a/gateway/pairing.py
+++ b/gateway/pairing.py
@@ -167,7 +167,11 @@ def _read_allowlist_env(env_var: str) -> str:
             return (get_secret(env_var) or "").strip()
         except UnscopedSecretError:
             pass
-    except Exception:
+    except Exception as exc:
+        # If secret_scope itself is unavailable, surface the failure instead
+        # of silently degrading to os.getenv(), which can return another
+        # profile's value under multiplexing.
+        logger.debug("secret_scope unavailable for %s: %s", env_var, exc)
         pass
     return (os.getenv(env_var) or "").strip()
 


### PR DESCRIPTION
\`_read_allowlist_env\` tries scoped secret reads first, then silently falls back to \`os.getenv()\` if \`agent.secret_scope\` is unavailable or raises. Under profile-multiplexing that fallback can return another profile's allowlist value, making the gateway silently authorize the wrong set of users.

Change: log a debug message when secret_scope is unavailable so operators can detect misconfiguration, while preserving the existing fallback behavior.