### PR TITLE
fix(gateway): keep the drain-marker read off the event loop

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9876,7 +9876,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         while self._running:
             try:
-                if drain_requested():
+                # drain_requested() does a synchronous read_text() on the
+                # marker file. At this 1s cadence that puts a blocking disk
+                # read on the event loop ~86k times a day; when the host is
+                # under I/O pressure a single read can stall for 30s+ and
+                # take every platform heartbeat down with it. Off-thread it.
+                if await asyncio.to_thread(drain_requested):
                     self._enter_external_drain()
                     # API and cron work live outside messaging's
                     # _running_agents map. Refresh the aggregate while an


### PR DESCRIPTION
## Summary

Salvage of #99884 by @RFingAdam — moves the 1 Hz `drain_requested()` poll in `_drain_control_watcher` off the event loop via `asyncio.to_thread`, so the synchronous marker-file `read_text()` can no longer block the loop thread.

## Why

`drain_requested()` does a synchronous `Path.read_text()` on the drain marker. The watcher polls it every second on the event loop — ~86k blocking reads/day. Normally page-cache-fast, but on a host under I/O pressure a single read can stall 30s+, taking every platform heartbeat down with it. The reporter hit this on a swapping self-hosted gateway:

```
WARNING discord.gateway: Shard ID None heartbeat blocked for more than 30 seconds.
WARNING hermes_plugins.discord_platform.adapter: [Discord] Discord Gateway WebSocket unhealthy (socket_clo...)
```

Every bot went quiet while systemd still reported the service active.

## Changes

- `gateway/run.py` `_drain_control_watcher`: `if drain_requested():` → `if await asyncio.to_thread(drain_requested):` (+ rationale comment)

Semantics unchanged: `drain_control` never raises, the existing `try/except` still applies, and `to_thread` at 1 Hz reuses a pooled worker thread (no thread churn).

## Validation

| Check | Result |
|---|---|
| tests/gateway/test_external_drain_control.py | 18 passed |
| py_compile gateway/run.py | ok |
| Cherry-pick onto current main | clean, no conflicts |

## Provenance

Cherry-picked from #99884 with @RFingAdam's authorship preserved (numbered-noreply email, attribution auto-skips).

Closes #99884
