### PR TITLE
fix(photon): keep empty-message httpx timeouts out of the plain-text resend

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2559,7 +2559,11 @@ class PhotonAdapter(BasePlatformAdapter):
                 retryable=e.retryable,
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            # str(e) can be empty (e.g. httpx.ReadTimeout carries no message),
+            # and an empty error string slips past _send_with_retry's timeout
+            # guard, whose substring match then enables the plain-text resend
+            # of a request the sidecar may already have delivered.
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 

--- a/tests/plugins/platforms/photon/test_timeout_guard.py
+++ b/tests/plugins/platforms/photon/test_timeout_guard.py
@@ -1,0 +1,83 @@
+"""Photon send-path timeouts must not trigger the plain-text resend.
+
+httpx transport exceptions can stringify to an empty string — with the pinned
+``httpx==0.28.1``, ``str(httpx.ReadTimeout(""))`` is ``""``. ``_send_with_retry``
+classifies failures by substring on ``SendResult.error``, and its timeout guard
+returns False for empty input, so a ``/send`` whose HTTP reply was lost past
+the sidecar timeout fell through to the unconditional plain-text fallback and
+delivered the same message twice (issue #100034).
+
+These tests pin the guard end-to-end: an exception whose ``str()`` is empty
+must surface a classifiable error string, and the resend must never happen.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.photon import adapter as photon_adapter
+from plugins.platforms.photon.adapter import PhotonAdapter
+
+
+def _make_adapter(monkeypatch: pytest.MonkeyPatch) -> PhotonAdapter:
+    monkeypatch.setenv("PHOTON_PROJECT_ID", "test-project-id")
+    monkeypatch.setenv("PHOTON_PROJECT_SECRET", "test-project-secret")
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    return PhotonAdapter(cfg)
+
+
+@pytest.mark.asyncio
+async def test_empty_message_timeout_not_resent_as_plain_text(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+    paths: List[str] = []
+
+    async def _fake_sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        paths.append(path)
+        # Reply lost past the 30s sidecar timeout; str(exc) == "" on httpx 0.28.1.
+        raise httpx.ReadTimeout("")
+
+    async def _fake_sleep(
+        delay: float,
+    ) -> None:  # pragma: no cover - guard must return before any sleep
+        raise AssertionError("timeout guard must return before any retry sleep")
+
+    monkeypatch.setattr(photon_adapter.asyncio, "sleep", _fake_sleep)
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_sidecar_call)
+
+    result = await adapter._send_with_retry(
+        "space-1", "hello", max_retries=1, base_delay=0.25
+    )
+
+    # The original failure is returned as-is — no second /send for the
+    # plain-text fallback, because the request may already be delivered.
+    assert result.success is False
+    assert paths == ["/send"]
+    assert "ReadTimeout" in (result.error or "")
+    assert PhotonAdapter._is_timeout_error(result.error) is True
+
+
+@pytest.mark.asyncio
+async def test_sidecar_send_surfaces_exception_type_on_empty_message(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    adapter = _make_adapter(monkeypatch)
+
+    async def _fake_sidecar_call(path: str, body: Dict[str, Any]) -> Dict[str, Any]:
+        raise httpx.ReadTimeout("")
+
+    monkeypatch.setattr(adapter, "_sidecar_call", _fake_sidecar_call)
+
+    result = await adapter._sidecar_send(
+        "space-1", "hello", richlink=False, markdown=False
+    )
+
+    assert result.success is False
+    # The exception type keeps the error classifiable even when str(e) is empty.
+    assert (result.error or "").startswith("ReadTimeout")
+    assert PhotonAdapter._is_timeout_error(result.error) is True


### PR DESCRIPTION
## What does this PR do?

`_sidecar_send`'s generic exception handler stringified errors with bare `str(e)`. On the pinned `httpx==0.28.1`, `str(httpx.ReadTimeout(""))` is `""`, so a `/send` whose HTTP reply was lost past the 30s sidecar timeout produced a `SendResult` with an **empty** error string. `_send_with_retry` classifies failures by substring against `SendResult.error`, and its timeout guard (`_is_timeout_error`) returns `False` for empty input — the exact guard whose docstring says timeouts "should NOT trigger plain-text fallback — the request may have already been delivered" was defeated, and the unconditional plain-text fallback resent the message, so the user received it twice with no restart or provider replay involved.

The fix preserves the exception type when stringifying: `error=f"{type(e).__name__}: {e}"`. The resulting string (e.g. `ReadTimeout: `) matches the existing guard's substring check (`"readtimeout" in lowered`) while remaining non-retryable, so the send failure is returned as-is instead of being resent.

## Related Issue

Fixes #100034

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/photon/adapter.py` — `_sidecar_send`'s generic `except Exception` handler now prefixes the error with `type(e).__name__` so exceptions whose `str()` is empty stay classifiable by the existing timeout guard.
- `tests/plugins/platforms/photon/test_timeout_guard.py` — new regression tests: (1) end-to-end through `_send_with_retry`, a `httpx.ReadTimeout("")` from `_sidecar_call` must produce exactly one `/send` call (no plain-text resend) and a guard-matchable error string; (2) `_sidecar_send` surfaces the exception type even when `str(e)` is empty.

## How to Test

1. `pytest tests/plugins/platforms/photon/test_timeout_guard.py -q` — Observed result: 2 passed (both fail on unpatched `main`, confirming they pin the regression).
2. `pytest tests/plugins/platforms/photon/ -q` — Observed result: 133 passed.
3. `python -c "import httpx; print(repr(str(httpx.ReadTimeout(\"\"))))"` prints `''`, reproducing the empty-string condition on the pinned httpx version.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (inline comment at the fix site documents the constraint)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NouResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`