### PR TITLE
fix(desktop): keep default profile reachable in condensed fleet rail

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -350,7 +350,19 @@ describe('ProfileRail fleet mode', () => {
     // 11 named on Pandora + local (default, omer) + vps (default) = 14 > 13.
     const container = await renderFleet()
 
-    expect(screen.getByRole('button', { name: 'Profiles' })).toBeTruthy()
+    const trigger = screen.getByRole('button', { name: 'Profiles' })
+    expect(trigger).toBeTruthy()
+    expect(trigger.querySelector('.codicon-home')).toBeTruthy()
     expect(container.querySelector('[data-slot="profile-rail-rest-square"]')).toBeNull()
+
+    // The fleet pill only enables all-profiles browsing; unlike the
+    // single-gateway pill it cannot return to default. Keep the active
+    // gateway's home route in the condensed dropdown so crossing the collapse
+    // threshold never strands the user on a named profile.
+    fireEvent.pointerDown(trigger, { button: 0, pointerType: 'mouse' })
+    const defaultItem = screen.getByRole('menuitemradio', { name: 'default' })
+    expect(defaultItem).toBeTruthy()
+    fireEvent.click(defaultItem)
+    expect(selectProfile).toHaveBeenCalledWith('default')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -448,6 +448,11 @@ export function ProfileRail() {
         // reorder, no long-press recolor, no per-square context menu — Manage
         // covers rename/delete at this scale.
         <div className="flex min-w-0 flex-1 items-center gap-1">
+          {/* In fleet mode the pinned pill is an all-profiles action, not the
+              default↔all toggle used by the single-gateway rail. The expanded
+              fleet strip carries its own default home square, so the condensed
+              dropdown must carry that same route or default becomes unreachable
+              as soon as the whole fleet crosses the collapse threshold. */}
           <ProfileDropdown
             activeKey={isAll ? null : activeKey}
             colors={colors}
@@ -455,7 +460,7 @@ export function ProfileRail() {
             onImport={() => void runImportProfileFlow()}
             onSelect={selectProfile}
             onSelectRest={switchToRest}
-            profiles={named}
+            profiles={fleet && defaultProfile ? [defaultProfile, ...named] : named}
             restGroups={restGroups}
           />
         </div>
@@ -765,7 +770,7 @@ function ProfileDropdown({
                 <ProfileGlyph
                   aria-hidden="true"
                   color={resolveProfileColor(activeProfile.name, colors)}
-                  isDefault={false}
+                  isDefault={activeProfile.is_default}
                   name={activeProfile.name}
                 />
                 <span className="truncate">{profileLabel(activeProfile)}</span>
@@ -791,6 +796,7 @@ function ProfileDropdown({
           {profiles.map(profile => (
             <ProfileDropdownItem
               color={resolveProfileColor(profile.name, colors)}
+              isDefault={profile.is_default}
               key={profile.name}
               label={profileLabel(profile)}
               name={profile.name}
@@ -832,7 +838,17 @@ function ProfileDropdown({
 
 // One dropdown row per profile — its own component so each row can own a
 // hover-intent prewarm timer (see useProfilePrewarm).
-function ProfileDropdownItem({ color, label, name }: { color: null | string; label: string; name: string }) {
+function ProfileDropdownItem({
+  color,
+  isDefault,
+  label,
+  name
+}: {
+  color: null | string
+  isDefault: boolean
+  label: string
+  name: string
+}) {
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
 
   return (
@@ -843,7 +859,7 @@ function ProfileDropdownItem({ color, label, name }: { color: null | string; lab
       value={name}
     >
       <span className="flex min-w-0 items-center gap-1.5">
-        <ProfileGlyph aria-hidden="true" color={color} isDefault={false} name={name} />
+        <ProfileGlyph aria-hidden="true" color={color} isDefault={isDefault} name={name} />
         <span className="truncate">{label}</span>
       </span>
     </DropdownMenuRadioItem>


### PR DESCRIPTION
## Bug Description

When the profile rail is in both fleet mode and condensed mode, the active gateway's default profile is not reachable from the UI.

This occurs when multiple gateways are registered and the total number of profiles/agents exceeds the rail's condensation threshold. The condensed dropdown contains only named profiles, while the fleet pill only enables the all-profiles view. If the user is browsing all profiles or is on a named profile, there is no route back to the active gateway's default profile.

## Root Cause

The expanded fleet rail renders a dedicated default home square inside the active gateway group. The condensed path replaces that strip with `ProfileDropdown`, but passes only the `named` profiles. At the same time, the fleet pill is intentionally an all-profiles action rather than the single-gateway default/all toggle.

The combination removes the active gateway's default route only after the whole fleet crosses the condensed threshold.

## Fix

- Include the active gateway's default profile in the condensed dropdown when fleet mode is active.
- Preserve the single-gateway behavior, where the pinned default/all control remains the default route.
- Propagate `is_default` to dropdown glyphs so the default profile uses the home icon in both the trigger and menu item.
- Add a regression test that opens the condensed fleet dropdown, verifies the default home route is present, and confirms selecting it calls `selectProfile('default')`.

## How to Verify

1. Register more than one gateway.
2. Ensure the combined fleet contains more than 13 profiles/agents so the profile rail condenses.
3. Open the profile dropdown for the active gateway.
4. Confirm the default profile is present with a home icon.
5. Select it and confirm the workspace switches to the default profile.

## Test Plan

- [x] Added regression coverage for the condensed fleet threshold path.
- [x] `npm run test:ui -- src/app/chat/sidebar/profile-rail-connect.test.tsx src/app/chat/sidebar/profile-rail-fleet.test.tsx` (13 passed)
- [x] `npm run typecheck`
- [x] Targeted ESLint for both changed files
- [x] `npm run build`

## Risk Assessment

Low — the default entry is added only to the fleet-mode condensed dropdown. The expanded fleet rail and the single-gateway condensed behavior remain unchanged.
