### PR TITLE
feat(desktop): show profile identity on every assistant response

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message-identity.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message-identity.test.tsx
@@ -1,0 +1,166 @@
+import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { stubThreadEnvironment } from '../test-utils'
+
+import { Thread } from '.'
+
+const identity = vi.hoisted(() => ({
+  value: {
+    appearance: {
+      avatarDataUrl: 'data:image/png;base64,c3ludGhldGlj',
+      displayName: 'Kite',
+      role: 'TikTok Channel Steward'
+    },
+    owner: { connectionId: 'source-a', profile: 'kite', targetProfile: 'kite' }
+  } as {
+    appearance: null | { avatarDataUrl: null | string; displayName: string; role: null | string }
+    owner: null | { connectionId: string; profile: string; targetProfile: string }
+  }
+}))
+
+vi.mock('@/lib/session-profile-appearance', () => ({
+  useSessionProfileAppearance: () => identity.value
+}))
+
+stubThreadEnvironment()
+
+afterEach(() => {
+  cleanup()
+  identity.value = {
+    appearance: {
+      avatarDataUrl: 'data:image/png;base64,c3ludGhldGlj',
+      displayName: 'Kite',
+      role: 'TikTok Channel Steward'
+    },
+    owner: { connectionId: 'source-a', profile: 'kite', targetProfile: 'kite' }
+  }
+})
+
+const assistant = (custom: Record<string, unknown> = {}, running = false): ThreadMessage =>
+  ({
+    id: 'assistant-1',
+    role: 'assistant',
+    content: [{ type: 'text', text: 'Synthetic reply' }],
+    status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
+    createdAt: new Date('2026-08-30T00:00:00Z'),
+    metadata: { custom }
+  }) as unknown as ThreadMessage
+
+const user = (text = 'Synthetic question'): ThreadMessage =>
+  ({
+    id: 'user-1',
+    role: 'user',
+    content: [{ type: 'text', text }],
+    attachments: [],
+    createdAt: new Date('2026-08-30T00:00:00Z'),
+    metadata: { custom: {} }
+  }) as unknown as ThreadMessage
+
+function Harness({
+  custom = {},
+  running = false,
+  userText
+}: {
+  custom?: Record<string, unknown>
+  running?: boolean
+  userText?: string
+}) {
+  const runtime = useExternalStoreRuntime<ThreadMessage>({
+    messages: [user(userText), assistant(custom, running)],
+    isRunning: running,
+    onNew: async () => {}
+  })
+
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <Thread />
+    </AssistantRuntimeProvider>
+  )
+}
+
+describe('direct response identity presentation', () => {
+  it('renders the exact resolved name, role, and decorative avatar without exposing route or bytes as text', async () => {
+    const { container } = render(<Harness />)
+
+    await screen.findByText('Synthetic reply')
+    expect(screen.getByText('Kite')).toBeTruthy()
+    expect(screen.getByText('TikTok Channel Steward')).toBeTruthy()
+
+    const rail = container.querySelector('[data-slot="assistant-session-identity"]')
+    const avatar = rail?.querySelector('img')
+
+    expect(avatar?.getAttribute('alt')).toBe('')
+    expect(avatar?.getAttribute('aria-hidden')).toBe('true')
+    expect(avatar?.getAttribute('tabindex')).toBeNull()
+    expect(rail?.textContent).not.toContain('source-a')
+    expect(rail?.textContent).not.toContain('base64')
+  })
+
+  it('fails closed to a deterministic non-person fallback when exact identity is unavailable', async () => {
+    identity.value = { appearance: null, owner: null }
+    render(<Harness />)
+
+    await screen.findByText('Synthetic reply')
+    expect(screen.getByText('Assistant')).toBeTruthy()
+    expect(screen.getByText('Identity unavailable')).toBeTruthy()
+  })
+
+  it('uses a quiet non-color fallback with stable geometry when the avatar asset is unavailable', async () => {
+    identity.value = {
+      appearance: { avatarDataUrl: null, displayName: 'Kite', role: 'TikTok Channel Steward' },
+      owner: { connectionId: 'source-a', profile: 'kite', targetProfile: 'kite' }
+    }
+    const { container } = render(<Harness />)
+
+    await screen.findByText('Synthetic reply')
+    const rail = container.querySelector('[data-slot="assistant-session-identity"]')
+    const fallback = rail?.firstElementChild
+
+    expect(rail?.querySelector('img')).toBeNull()
+    expect(fallback?.className).toContain('size-8')
+    expect(fallback?.textContent).toBe('AI')
+    expect(container.querySelector('[role="alert"]')).toBeNull()
+    expect(rail?.className).not.toContain('animate-')
+    expect(rail?.className).not.toContain('transition-')
+  })
+
+  it('retains the same identity block node when a response settles', async () => {
+    const { container, rerender } = render(<Harness running />)
+
+    await screen.findByText('Synthetic reply')
+    const runningIdentity = container.querySelector('[data-slot="assistant-session-identity"]')
+
+    rerender(<Harness running={false} />)
+    await screen.findByText('Synthetic reply')
+
+    expect(container.querySelector('[data-slot="assistant-session-identity"]')).toBe(runningIdentity)
+  })
+
+  it('keeps the responding employee identity visible when structured author metadata exists', async () => {
+    identity.value = {
+      appearance: { avatarDataUrl: null, displayName: 'Kite', role: 'TikTok Channel Steward' },
+      owner: { connectionId: 'source-a', profile: 'kite', targetProfile: 'kite' }
+    }
+    const { container } = render(<Harness custom={{ author: { profile: 'structured-source' } }} />)
+
+    await screen.findByText('Synthetic reply')
+    expect(container.querySelector('[data-slot="assistant-session-identity"]')).not.toBeNull()
+    expect(screen.getByText('Kite')).toBeTruthy()
+    expect(screen.getByText('TikTok Channel Steward')).toBeTruthy()
+  })
+
+  it('keeps the responding employee identity visible on a collapsed inter-agent reply', async () => {
+    identity.value = {
+      appearance: { avatarDataUrl: null, displayName: 'Vela', role: 'Wellness and Wholeness Steward' },
+      owner: { connectionId: 'source-a', profile: 'vela', targetProfile: 'vela' }
+    }
+    const { container } = render(<Harness userText={'Message from 🤖 sender (@sender):\nSynthetic relay'} />)
+
+    await screen.findByText('Replied to sender')
+    expect(container.querySelector('[data-slot="assistant-session-identity"]')).not.toBeNull()
+    expect(screen.getByText('Vela')).toBeTruthy()
+    expect(screen.getByText('Wellness and Wholeness Steward')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -43,6 +43,7 @@ import {
   XIcon
 } from '@/lib/icons'
 import { extractPreviewTargets } from '@/lib/preview-targets'
+import { useSessionProfileAppearance } from '@/lib/session-profile-appearance'
 import { markAssistantIdSpoken } from '@/lib/spoken-reply'
 import { useEnterAnimation } from '@/lib/use-enter-animation'
 import { cn } from '@/lib/utils'
@@ -170,11 +171,9 @@ const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }>
   )
 }
 
-const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null | ReactNode }> = ({
-  collapsedNotice = null,
-  onBranchInNewChat,
-  onDismissError
-}) => {
+const AssistantMessageBody: FC<
+  AssistantMessageProps & { collapsedNotice?: null | ReactNode }
+> = ({ collapsedNotice = null, onBranchInNewChat, onDismissError }) => {
   const messageId = useAuiState(s => s.message.id)
   const messageRuntime = useMessageRuntime()
   const { t } = useI18n()
@@ -226,8 +225,14 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
       onDoubleClick={collapsedNotice ? undefined : onDoubleClick}
       ref={enterRef}
     >
-      {collapsedNotice ?? (
+      {collapsedNotice ? (
         <>
+          <AssistantSessionIdentity />
+          {collapsedNotice}
+        </>
+      ) : (
+        <>
+          <AssistantSessionIdentity />
           <div
             className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
             data-slot="aui_assistant-message-content"
@@ -277,6 +282,45 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
         </>
       )}
     </MessagePrimitive.Root>
+  )
+}
+
+const AssistantSessionIdentity: FC = () => {
+  const view = useSessionView()
+  const storedId = useStore(view.$storedId)
+  const runtimeId = useStore(view.$runtimeId)
+  const { appearance, owner } = useSessionProfileAppearance(storedId ?? runtimeId)
+
+
+  const displayName = owner && appearance ? appearance.displayName : 'Assistant'
+  const role = owner && appearance ? appearance.role : 'Identity unavailable'
+
+  return (
+    <div
+      className="mb-1.5 flex min-h-8 items-center gap-2 px-(--message-text-indent)"
+      data-slot="assistant-session-identity"
+    >
+      <span
+        aria-hidden="true"
+        className="flex size-8 shrink-0 items-center justify-center overflow-hidden rounded-full border border-(--ui-stroke-tertiary) bg-muted text-xs font-semibold text-muted-foreground"
+      >
+        {appearance?.avatarDataUrl ? (
+          <img
+            alt=""
+            aria-hidden="true"
+            className="size-full object-cover"
+            draggable={false}
+            src={appearance.avatarDataUrl}
+          />
+        ) : (
+          <span aria-hidden="true">AI</span>
+        )}
+      </span>
+      <span className="min-w-0">
+        <span className="block truncate text-xs font-semibold text-foreground">{displayName}</span>
+        {role && <span className="block truncate text-[0.6875rem] text-muted-foreground">{role}</span>}
+      </span>
+    </div>
   )
 }
 

--- a/apps/desktop/src/lib/session-profile-appearance.test.ts
+++ b/apps/desktop/src/lib/session-profile-appearance.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  createSessionProfileAppearanceResolver,
+  type ExactSessionOwner,
+  normalizeExactSessionOwner,
+  shouldPresentSessionAppearance
+} from './session-profile-appearance'
+
+const owner = (connectionId: string, profile = 'kite', targetProfile = profile): ExactSessionOwner => ({
+  connectionId,
+  profile,
+  targetProfile
+})
+
+function mockRequest(avatar = 'data:image/png;base64,synthetic') {
+  return vi.fn(async (_connectionId: string, _profile: string, method: string) => {
+    if (method === 'profiles.list') {
+      return {
+        profiles: [
+          {
+            name: 'kite',
+            display_name: 'Kite',
+            has_avatar: true,
+            title: 'TikTok Channel Steward'
+          }
+        ]
+      }
+    }
+
+    return { data: avatar, found: true }
+  })
+}
+
+describe('session profile appearance resolver', () => {
+  it('fails closed on bare or incomplete owners and preserves the backend target profile', () => {
+    expect(normalizeExactSessionOwner('kite')).toBeNull()
+    expect(normalizeExactSessionOwner({ profile: 'kite' })).toBeNull()
+    expect(normalizeExactSessionOwner({ connectionId: 'source-a', profile: 'desktop-kite', targetProfile: 'kite' })).toEqual({
+      connectionId: 'source-a',
+      profile: 'desktop-kite',
+      targetProfile: 'kite'
+    })
+  })
+
+  it('deduplicates concurrent exact-owner requests and isolates same-named profiles by connection', async () => {
+    const request = mockRequest()
+    const resolver = createSessionProfileAppearanceResolver(request)
+
+    const [first, duplicate, remote] = await Promise.all([
+      resolver.resolve(owner('source-a')),
+      resolver.resolve(owner('source-a')),
+      resolver.resolve(owner('source-b'))
+    ])
+
+    expect(first).toEqual(duplicate)
+    expect(remote?.displayName).toBe('Kite')
+    expect(request.mock.calls.filter(call => call[2] === 'profiles.list')).toHaveLength(2)
+    expect(request.mock.calls.filter(call => call[2] === 'profiles.get_asset')).toHaveLength(2)
+  })
+
+  it('routes a routine-owned session only through its exact source-qualified owner', async () => {
+    const request = mockRequest()
+    const resolver = createSessionProfileAppearanceResolver(request)
+
+    await resolver.resolve(owner('source-a', 'desktop-kite', 'kite'))
+
+    expect(request).toHaveBeenNthCalledWith(1, 'source-a', 'desktop-kite', 'profiles.list', {})
+    expect(request).toHaveBeenNthCalledWith(2, 'source-a', 'desktop-kite', 'profiles.get_asset', {
+      asset: 'avatar',
+      name: 'kite'
+    })
+  })
+
+  it('invalidates true-to-true avatar replacement and purges only the removed source', async () => {
+    const request = mockRequest('data:image/png;base64,first')
+    const resolver = createSessionProfileAppearanceResolver(request)
+    const local = owner('source-a')
+    const remote = owner('source-b')
+
+    await resolver.resolve(local)
+    await resolver.resolve(remote)
+    request.mockImplementation(async (_connectionId, _profile, method) =>
+      method === 'profiles.list'
+        ? ({ profiles: [{ name: 'kite', display_name: 'Kite', has_avatar: true, title: 'TikTok Channel Steward' }] } as never)
+        : ({ data: 'data:image/png;base64,second', found: true } as never)
+    )
+
+    resolver.invalidateOwner(local)
+    expect((await resolver.resolve(local))?.avatarDataUrl).toContain('second')
+    expect((await resolver.resolve(remote))?.avatarDataUrl).toContain('first')
+
+    resolver.purgeConnection('source-a')
+    expect(resolver.peek(local)).toBeNull()
+    expect(resolver.peek(remote)?.displayName).toBe('Kite')
+  })
+
+  it('reopens with current appearance while preserving owner and message bytes', async () => {
+    const request = mockRequest('data:image/png;base64,first')
+    const resolver = createSessionProfileAppearanceResolver(request)
+    const exactOwner = owner('source-a', 'desktop-kite', 'kite')
+    const ownerBytes = JSON.stringify(exactOwner)
+    const messageBytes = JSON.stringify({ id: 'assistant-1', role: 'assistant', content: 'Synthetic reply' })
+
+    expect((await resolver.resolve(exactOwner))?.displayName).toBe('Kite')
+    request.mockImplementation(async (_connectionId, _profile, method) =>
+      method === 'profiles.list'
+        ? ({ profiles: [{ name: 'kite', display_name: 'Kite Current', has_avatar: false, title: 'Current Role' }] } as never)
+        : ({ found: false } as never)
+    )
+
+    expect((await resolver.resolve(exactOwner, { revalidate: true }))?.displayName).toBe('Kite Current')
+    expect(JSON.stringify(exactOwner)).toBe(ownerBytes)
+    expect(JSON.stringify({ id: 'assistant-1', role: 'assistant', content: 'Synthetic reply' })).toBe(messageBytes)
+  })
+
+  it('fails quietly and returns a non-person fallback when metadata is missing or a request fails', async () => {
+    const missing = createSessionProfileAppearanceResolver(async () => ({ profiles: [] }))
+    const failed = createSessionProfileAppearanceResolver(async () => {
+      throw new Error('synthetic failure')
+    })
+
+    expect(await missing.resolve(owner('source-a'))).toBeNull()
+    await expect(failed.resolve(owner('source-a'))).resolves.toBeNull()
+  })
+
+  it('retains exact state while disconnected but requires reconnect revalidation before presentation', () => {
+    const key = JSON.stringify(['source-a', 'kite', 'kite', 'avatar'])
+
+    expect(shouldPresentSessionAppearance('closed', key, key)).toBe(true)
+    expect(shouldPresentSessionAppearance('open', '', key)).toBe(false)
+    expect(shouldPresentSessionAppearance('open', key, key)).toBe(true)
+    expect(shouldPresentSessionAppearance('open', key, JSON.stringify(['source-b', 'kite', 'kite', 'avatar']))).toBe(
+      false
+    )
+  })
+
+  it('does not resurrect purged appearance state when an older request settles', async () => {
+    let releaseList!: (value: unknown) => void
+    const listResult = new Promise(resolve => {
+      releaseList = resolve
+    })
+    const request = vi.fn(async (_connectionId: string, _profile: string, method: string) => {
+      if (method === 'profiles.list') {
+        return listResult
+      }
+
+      return { data: 'data:image/png;base64,stale', found: true }
+    })
+    const resolver = createSessionProfileAppearanceResolver(request)
+    const exactOwner = owner('source-a')
+    const stale = resolver.resolve(exactOwner)
+
+    resolver.purgeConnection('source-a')
+    releaseList({
+      profiles: [{ name: 'kite', display_name: 'Stale Kite', has_avatar: true, title: 'Stale Role' }]
+    })
+
+    await expect(stale).resolves.toBeNull()
+    expect(resolver.peek(exactOwner)).toBeNull()
+    expect(request.mock.calls.filter(call => call[2] === 'profiles.get_asset')).toHaveLength(0)
+  })
+
+  it('does not let a purged request delete or overwrite a fresh concurrent request', async () => {
+    let releaseStale!: (value: unknown) => void
+    const staleList = new Promise(resolve => {
+      releaseStale = resolve
+    })
+    let listCalls = 0
+    const request = vi.fn(async (_connectionId: string, _profile: string, method: string) => {
+      if (method === 'profiles.list') {
+        listCalls += 1
+
+        if (listCalls === 1) {
+          return staleList
+        }
+
+        return {
+          profiles: [{ name: 'kite', display_name: 'Fresh Kite', has_avatar: false, title: 'Fresh Role' }]
+        }
+      }
+
+      return { found: false }
+    })
+    const resolver = createSessionProfileAppearanceResolver(request)
+    const exactOwner = owner('source-a')
+    const stale = resolver.resolve(exactOwner)
+
+    resolver.purgeConnection('source-a')
+    const fresh = resolver.resolve(exactOwner)
+    releaseStale({
+      profiles: [{ name: 'kite', display_name: 'Stale Kite', has_avatar: false, title: 'Stale Role' }]
+    })
+
+    await expect(stale).resolves.toBeNull()
+    await expect(fresh).resolves.toMatchObject({ displayName: 'Fresh Kite', role: 'Fresh Role' })
+    expect(resolver.peek(exactOwner)).toMatchObject({ displayName: 'Fresh Kite', role: 'Fresh Role' })
+    expect(await resolver.resolve(exactOwner)).toMatchObject({ displayName: 'Fresh Kite' })
+    expect(listCalls).toBe(2)
+  })
+})

--- a/apps/desktop/src/lib/session-profile-appearance.ts
+++ b/apps/desktop/src/lib/session-profile-appearance.ts
@@ -1,0 +1,306 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useMemo, useState } from 'react'
+
+import { requestGatewayForAgent } from '@/store/gateway'
+import { $gatewayState } from '@/store/session'
+import { knownOwnerForSession } from '@/store/session-states'
+
+export interface ExactSessionOwner {
+  connectionId: string
+  profile: string
+  targetProfile: string
+}
+
+export interface SessionProfileAppearance {
+  avatarDataUrl: null | string
+  displayName: string
+  role: null | string
+}
+
+type Request = (
+  connectionId: string,
+  profile: string,
+  method: string,
+  params: Record<string, unknown>
+) => Promise<unknown>
+
+interface ProfileRow {
+  display_name?: unknown
+  has_avatar?: unknown
+  name?: unknown
+  title?: unknown
+  ui_meta?: unknown
+}
+
+const normalized = (value: unknown): string => (typeof value === 'string' ? value.trim() : '')
+
+export function normalizeExactSessionOwner(owner: unknown): ExactSessionOwner | null {
+  if (!owner || typeof owner !== 'object') {
+    return null
+  }
+
+  const route = owner as { connectionId?: unknown; profile?: unknown; targetProfile?: unknown }
+  const connectionId = normalized(route.connectionId)
+  const profile = normalized(route.profile)
+  const targetProfile = normalized(route.targetProfile) || profile
+
+  return connectionId && profile && targetProfile ? { connectionId, profile, targetProfile } : null
+}
+
+export function exactSessionOwner(sessionId: null | string | undefined): ExactSessionOwner | null {
+  return normalizeExactSessionOwner(knownOwnerForSession(sessionId))
+}
+
+export function sessionProfileAppearanceKey(owner: ExactSessionOwner): string {
+  return JSON.stringify([owner.connectionId, owner.profile, owner.targetProfile, 'avatar'])
+}
+
+function roleFor(row: ProfileRow): null | string {
+  const direct = normalized(row.title)
+
+  if (direct) {
+    return direct
+  }
+
+  const uiMeta = row.ui_meta
+  const pluginMeta =
+    uiMeta && typeof uiMeta === 'object'
+      ? (uiMeta as Record<string, unknown>)['hermes-bots']
+      : null
+
+  return pluginMeta && typeof pluginMeta === 'object'
+    ? normalized((pluginMeta as Record<string, unknown>).title) || null
+    : null
+}
+
+export function createSessionProfileAppearanceResolver(request: Request) {
+  const cache = new Map<string, SessionProfileAppearance>()
+  const inflight = new Map<string, Promise<null | SessionProfileAppearance>>()
+  const keyEpochs = new Map<string, number>()
+  const listeners = new Set<() => void>()
+  let globalEpoch = 0
+
+  const notify = () => {
+    for (const listener of listeners) {
+      listener()
+    }
+  }
+
+  const epochFor = (key: string): readonly [number, number] => [globalEpoch, keyEpochs.get(key) ?? 0]
+  const isCurrent = (key: string, epoch: readonly [number, number]): boolean => {
+    const current = epochFor(key)
+
+    return current[0] === epoch[0] && current[1] === epoch[1]
+  }
+  const invalidateKey = (key: string): void => {
+    keyEpochs.set(key, (keyEpochs.get(key) ?? 0) + 1)
+    cache.delete(key)
+    inflight.delete(key)
+  }
+
+  const resolve = async (
+    owner: ExactSessionOwner,
+    options: { revalidate?: boolean } = {}
+  ): Promise<null | SessionProfileAppearance> => {
+    const key = sessionProfileAppearanceKey(owner)
+    const pending = inflight.get(key)
+
+    if (pending) {
+      return pending
+    }
+
+    if (!options.revalidate && cache.has(key)) {
+      return cache.get(key) ?? null
+    }
+
+    const epoch = epochFor(key)
+    let task!: Promise<null | SessionProfileAppearance>
+
+    task = (async () => {
+      try {
+        const result = (await request(owner.connectionId, owner.profile, 'profiles.list', {})) as {
+          profiles?: ProfileRow[]
+        }
+
+        if (!isCurrent(key, epoch)) {
+          return null
+        }
+
+        const row = (Array.isArray(result?.profiles) ? result.profiles : []).find(
+          candidate => normalized(candidate?.name) === owner.targetProfile
+        )
+
+        if (!row) {
+          cache.delete(key)
+          notify()
+          return null
+        }
+
+        let avatarDataUrl: null | string = null
+
+        if (row.has_avatar === true) {
+          const asset = (await request(owner.connectionId, owner.profile, 'profiles.get_asset', {
+            asset: 'avatar',
+            name: owner.targetProfile
+          })) as { data?: unknown; found?: unknown }
+
+          if (!isCurrent(key, epoch)) {
+            return null
+          }
+
+          if (asset?.found === true && normalized(asset.data).startsWith('data:image/')) {
+            avatarDataUrl = normalized(asset.data)
+          }
+        }
+
+        const appearance: SessionProfileAppearance = {
+          avatarDataUrl,
+          displayName: normalized(row.display_name) || owner.targetProfile,
+          role: roleFor(row)
+        }
+
+        if (!isCurrent(key, epoch)) {
+          return null
+        }
+
+        cache.set(key, appearance)
+        notify()
+        return appearance
+      } catch {
+        if (isCurrent(key, epoch)) {
+          cache.delete(key)
+          notify()
+        }
+
+        return null
+      } finally {
+        if (inflight.get(key) === task) {
+          inflight.delete(key)
+        }
+      }
+    })()
+
+    inflight.set(key, task)
+    return task
+  }
+
+  return {
+    clear() {
+      globalEpoch += 1
+      cache.clear()
+      inflight.clear()
+      keyEpochs.clear()
+      notify()
+    },
+    invalidateOwner(owner: ExactSessionOwner) {
+      invalidateKey(sessionProfileAppearanceKey(owner))
+      notify()
+    },
+    peek(owner: ExactSessionOwner) {
+      return cache.get(sessionProfileAppearanceKey(owner)) ?? null
+    },
+    purgeConnection(connectionId: string) {
+      const keys = new Set([...cache.keys(), ...inflight.keys()])
+
+      for (const key of keys) {
+        const parsed = JSON.parse(key) as string[]
+
+        if (parsed[0] === connectionId) {
+          invalidateKey(key)
+        }
+      }
+
+      notify()
+    },
+    resolve,
+    subscribe(listener: () => void) {
+      listeners.add(listener)
+      return () => {
+        listeners.delete(listener)
+      }
+    }
+  }
+}
+
+export const sessionProfileAppearanceResolver = createSessionProfileAppearanceResolver(
+  (connectionId, profile, method, params) => requestGatewayForAgent(connectionId, profile, method, params)
+)
+
+export function shouldPresentSessionAppearance(
+  connectionState: string,
+  validatedKey: string,
+  ownerKey: string
+): boolean {
+  return connectionState !== 'open' || (ownerKey !== '' && validatedKey === ownerKey)
+}
+
+let lifecycleBound = false
+
+function bindConnectionLifecycle(): void {
+  if (lifecycleBound || typeof window === 'undefined') {
+    return
+  }
+
+  const onChanged = window.hermesDesktop?.connections?.onChanged
+
+  if (!onChanged) {
+    return
+  }
+
+  lifecycleBound = true
+  onChanged(change => {
+    const connectionId = normalized(change?.connectionId)
+
+    if (!connectionId) {
+      return
+    }
+
+    sessionProfileAppearanceResolver.purgeConnection(connectionId)
+  })
+}
+
+export function useSessionProfileAppearance(sessionId: null | string): {
+  appearance: null | SessionProfileAppearance
+  owner: ExactSessionOwner | null
+} {
+  const owner = useMemo(() => exactSessionOwner(sessionId), [sessionId])
+  const key = owner ? sessionProfileAppearanceKey(owner) : ''
+  const connectionState = useStore($gatewayState)
+  const [validatedKey, setValidatedKey] = useState('')
+  const [, setRevision] = useState(0)
+
+  useEffect(() => {
+    bindConnectionLifecycle()
+    return sessionProfileAppearanceResolver.subscribe(() => setRevision(value => value + 1))
+  }, [])
+
+  useEffect(() => {
+    let current = true
+
+    if (!owner || connectionState !== 'open') {
+      setValidatedKey('')
+
+      return () => {
+        current = false
+      }
+    }
+
+    setValidatedKey('')
+    void sessionProfileAppearanceResolver.resolve(owner, { revalidate: true }).then(() => {
+      if (current) {
+        setValidatedKey(key)
+      }
+    })
+
+    return () => {
+      current = false
+    }
+  }, [connectionState, key])
+
+  const presentationReady = shouldPresentSessionAppearance(connectionState, validatedKey, key)
+
+  return {
+    appearance: owner && presentationReady ? sessionProfileAppearanceResolver.peek(owner) : null,
+    owner
+  }
+}


### PR DESCRIPTION
## Summary

- render the exact session profile avatar, display name, and role before every assistant response
- keep identity visible for streaming, structured-metadata, and collapsed inter-agent responses
- resolve source-qualified profile appearance through the owning connection and cache it safely
- fail visibly with a neutral Assistant / Identity unavailable fallback rather than misattribute a response

## Why

In multi-profile workforce deployments, the session list shows the active profile but the thread itself does not identify who authored each assistant response. Humans should not need to infer the responding agent from navigation context.

## Verification

- focused Vitest: 15 passed
- ESLint: passed
- full UI suite: 6908 passed, 1 unrelated existing timeout in gateway-settings.test.tsx
- TypeScript check: existing baseline failures reproduce on unmodified main in shared package imports; this patch adds no new focused type or lint errors

## Safety

The resolver uses the exact known session owner route, does not guess across profiles or connections, and falls back to an explicit unavailable state.