### PR TITLE
fix(kanban): durable dispatcher lock - recheck, stale-holder steal, eligibility gate

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -335,7 +335,10 @@ model:
 # (kanban.dispatch_in_gateway: true) and hold the singleton dispatcher lock
 # (<kanban-root>/kanban/.dispatcher.lock). Every OTHER profile — especially
 # non-factory helper profiles and freshly created profiles — must keep the
-# dispatcher OFF:
+# dispatcher OFF. As a code-side backstop, only profiles named in
+# kanban.dispatch_profiles (default ["default"]) may even attempt the lock;
+# contenders re-check it on kanban.lock_takeover_interval (default 30s) so a
+# dead dispatcher-gateway is replaced within ~a minute.
 kanban:
   dispatch_in_gateway: false   # non-factory profiles must NEVER dispatch
   enabled: false               # mirror the same posture for the kanban toolset

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -330,7 +330,15 @@ model:
 # is spawned with the bundled sdlc-review skill and can approve, request changes
 # back to the original implementer, or escalate a genuine external blocker.
 # Disable this only when every review is performed manually from the dashboard.
+#
+# Single-dispatcher posture: ONLY ONE gateway may run the kanban dispatcher
+# (kanban.dispatch_in_gateway: true) and hold the singleton dispatcher lock
+# (<kanban-root>/kanban/.dispatcher.lock). Every OTHER profile — especially
+# non-factory helper profiles and freshly created profiles — must keep the
+# dispatcher OFF:
 kanban:
+  dispatch_in_gateway: false   # non-factory profiles must NEVER dispatch
+  enabled: false               # mirror the same posture for the kanban toolset
   review_dispatch: true
 
 # =============================================================================

--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -31,6 +31,33 @@ lock: a helper/secondary profile that accidentally flips `dispatch_in_gateway`
 on (or lacks an explicit `kanban:` section and inherits the default `true`)
 will silently race the default/factory gateway for every board.
 
+**Only explicitly allowed profiles may even attempt the lock.** Since the
+durable-lock rework (t_77f0d093), the dispatcher code gates on
+`kanban.dispatch_profiles` (default `["default"]`): a gateway whose profile is
+not named there logs "profile ... is not a dispatch profile" and never touches
+`.dispatcher.lock` — even if its own `dispatch_in_gateway` is true. Factory
+worker profiles (dev/lead/qa/reviewer), helpers and freshly created profiles
+therefore cannot steal the lock from the main gateway. A second dispatcher is
+an explicit opt-in:
+
+```yaml
+kanban:
+  dispatch_profiles: ["default", "dispatcher-2"]
+```
+
+**The lock is durable, not a boot-time decision.** The holder writes a lease
+record (owner pid/profile/host + per-tick heartbeat) into the lock file.
+Contender gateways that find the lock contended at boot do not give up
+forever: they re-check the flock every `kanban.lock_takeover_interval`
+(default 30s), so a dead dispatcher-gateway is replaced within ~a minute
+(incident 2026-08-13: the board starved for hours because nothing re-acquired
+the flock after the holder died). A lease whose heartbeat is stale while the
+owner pid is still alive means a wedged dispatcher loop — a live flock cannot
+be stolen, so contenders log a rate-limited warning telling ops to restart
+the owner gateway. A holder whose profile is not dispatch-eligible (or that
+has been challenged by an eligible contender) releases the lock and stands
+down on its next tick.
+
 **Fresh profiles are safe by default.** `hermes profile create <name>` (without
 `--clone`) seeds the new profile's `config.yaml` with the dispatcher off:
 

--- a/docs/kanban/multi-gateway.md
+++ b/docs/kanban/multi-gateway.md
@@ -23,6 +23,31 @@ each gateway polls only subscriptions for profiles whose platform adapters it
 hosts. The atomic event claim prevents duplicate delivery across watcher
 processes.
 
+**The dispatcher lock is a hard backstop, not a preference.** The gateway that
+runs the dispatcher holds an exclusive flock on
+`<kanban-root>/kanban/.dispatcher.lock` (the machine-global kanban root,
+shared across all profiles). A non-factory profile must **never** hold this
+lock: a helper/secondary profile that accidentally flips `dispatch_in_gateway`
+on (or lacks an explicit `kanban:` section and inherits the default `true`)
+will silently race the default/factory gateway for every board.
+
+**Fresh profiles are safe by default.** `hermes profile create <name>` (without
+`--clone`) seeds the new profile's `config.yaml` with the dispatcher off:
+
+```yaml
+kanban:
+  dispatch_in_gateway: false
+  enabled: false
+```
+
+So a brand-new non-factory profile starts its gateway without touching
+`.dispatcher.lock`. Factory dispatcher profiles (e.g. `default`, and any
+profile explicitly intended to dispatch) opt in with
+`dispatch_in_gateway: true` in their own config. If you clone a profile with
+`--clone` / `--clone-all`, the source's `kanban:` section is copied as-is —
+check it after cloning so a clone of the dispatcher doesn't become a second
+dispatcher by accident.
+
 ## Configuration
 
 On the dispatch-owning gateway (typically the `default` profile), no change is

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -11,10 +11,12 @@ behavior-neutral move that lifts ~1,000 LOC out of run.py.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import re
 import sqlite3
+import sys
 import time
 from contextvars import Context
 from pathlib import Path
@@ -170,6 +172,257 @@ def _release_singleton_lock(handle) -> None:
         pass
 
 
+# ---------------------------------------------------------------------------
+# Dispatcher lock lease (t_fb4a7ca4, t_77f0d093)
+#
+# The singleton flock alone is released automatically when the owner process
+# dies, but nothing re-acquires it: every gateway checked the lock only at
+# boot, so a dead dispatcher-gateway left the board without a dispatcher
+# until the next container restart (incident 2026-08-13 15:13:44, board
+# 'factory' starved for hours with 7 ready / 0 running). The lease record
+# written INTO the lock file makes the holder observable (pid/profile/host/
+# heartbeats) and lets contenders detect a dead or wedged owner, reclaim a
+# stale lease, and force a misconfigured non-dispatch holder to stand down.
+# ---------------------------------------------------------------------------
+_DISPATCHER_LOCK_LEASE_VERSION = 1
+
+
+def _dispatcher_lease_identity(self: Any) -> dict:
+    """Return the identity fields of this gateway's lease record.
+
+    Stored on the mixin at acquisition time so the per-tick heartbeat can
+    rewrite the record without re-resolving the profile name.
+    """
+    return {
+        "version": _DISPATCHER_LOCK_LEASE_VERSION,
+        "profile": getattr(self, "_kanban_dispatcher_lease_profile", "default"),
+        "pid": os.getpid(),
+        "host": _dispatcher_hostname(),
+        "started_at": getattr(self, "_kanban_dispatcher_lease_started_at", 0),
+    }
+
+
+def _dispatcher_hostname() -> str:
+    try:
+        import socket
+        return socket.gethostname() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def _dispatcher_lease_profile() -> str:
+    """Best-effort name of the profile running this gateway.
+
+    Lease records are diagnostics AND the input to the dispatch-eligibility
+    gate, so a wrong label must never crash the dispatcher — every lookup
+    path degrades gracefully. The final fallback is ``"default"``: a
+    gateway launched without ``-p/--profile`` runs the default profile, and
+    in the shared-HERMES_HOME deployment ``get_active_profile_name()``
+    reports the same home for every gateway, so the argv flag is the only
+    accurate per-gateway signal and its absence means default.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        name = get_active_profile_name()
+        if name and name not in ("default", "custom"):
+            return name
+    except Exception:
+        pass
+    # Fall back to parsing our own argv for ``-p/--profile`` (the s6 run
+    # scripts launch ``hermes -p <profile> gateway run``).
+    try:
+        argv = sys.argv or []
+        for i, arg in enumerate(argv):
+            if arg in ("-p", "--profile") and i + 1 < len(argv):
+                return argv[i + 1]
+    except Exception:
+        pass
+    # No explicit profile flag: default profile gateway. A ``"custom"``
+    # HERMES_HOME with no flag is the only ambiguity; defaulting to
+    # "default" is safe because eligibility additionally requires
+    # ``kanban.dispatch_in_gateway`` and membership in
+    # ``kanban.dispatch_profiles`` (both defaulted for the default home).
+    return "default"
+
+
+def _write_dispatcher_lease(handle, identity: dict) -> None:
+    """Truncate-and-write the lease record (identity + fresh heartbeat)."""
+    if handle is None:
+        return
+    record = dict(identity)
+    record["heartbeat_at"] = int(time.time())
+    try:
+        handle.seek(0)
+        handle.truncate()
+        handle.write(json.dumps(record))
+        handle.flush()
+        os.fsync(handle.fileno())
+    except OSError:
+        pass
+
+
+def _read_dispatcher_lease(lock_path) -> dict:
+    """Read the owner lease record from the lock file. Never raises."""
+    try:
+        with open(str(lock_path), "r", encoding="utf-8") as fh:
+            data = fh.read()
+        if not data.strip():
+            return {}
+        record = json.loads(data)
+        return record if isinstance(record, dict) else {}
+    except (OSError, ValueError):
+        return {}
+
+
+def _lease_owner_alive(lease: dict) -> bool:
+    """Best-effort liveness of the lease-recorded owner pid.
+
+    On POSIX ``os.kill(pid, 0)`` is a pure liveness probe. On Windows it is
+    NOT a no-op (sends CTRL_C to the console group — see gateway.status
+    ``_pid_exists``), so fall back to ``True``: a wedged owner on Windows is
+    only detectable via the heartbeat timeout, which is fine because the
+    flock can never be stolen from a live process anyway.
+    """
+    pid = lease.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return False
+    if os.name == "nt":
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return True
+
+
+def _dispatcher_eligible_profiles(kanban_cfg) -> list:
+    """Profiles allowed to run the singleton dispatcher (``kanban.dispatch_profiles``).
+
+    Defaults to ``["default"]`` — only the default-profile gateway may hold
+    the dispatcher lock unless a deployment explicitly opts other profiles
+    in. This is the code-side half of the single-dispatcher posture: a
+    worker/helper profile that accidentally flips ``dispatch_in_gateway``
+    on (or inherits the default ``true``) must NOT race the main gateway
+    for the lock.
+    """
+    raw = kanban_cfg.get("dispatch_profiles") if isinstance(kanban_cfg, dict) else None
+    if raw is None:
+        return ["default"]
+    if isinstance(raw, str):
+        raw = [raw]
+    names = [str(p).strip() for p in raw if str(p).strip()]
+    return names or ["default"]
+
+
+def _dispatcher_profile_eligible(profile: str, kanban_cfg) -> bool:
+    """Return whether *profile* may hold the singleton dispatcher lock."""
+    if not profile or profile == "unknown":
+        return False
+    return profile in _dispatcher_eligible_profiles(kanban_cfg)
+
+
+def _dispatcher_holder_stealable(lease: dict, kanban_cfg) -> Optional[str]:
+    """Verdict on whether the recorded lock holder may be taken over.
+
+    Returns one of:
+
+    * ``"dead"`` — holder pid is gone; the flock was released by the kernel,
+      so a retry acquire succeeds immediately.
+    * ``"stale"`` — holder pid is alive but the heartbeat is older than
+      ``kanban.lock_lease_timeout``; the dispatcher loop is wedged. A live
+      flock cannot be stolen, so the contender warns and keeps retrying.
+    * ``"non_factory"`` — holder pid is alive and heartbeating but the
+      lease profile is not allowed to dispatch (``kanban.dispatch_profiles``
+      + ``dispatch_in_gateway``); the holder is misconfigured and should
+      stand down. The contender writes a challenge so the holder (running
+      this code) self-releases on its next tick.
+    * ``None`` — holder is healthy and entitled; do not touch it.
+
+    Profile eligibility is judged BEFORE the heartbeat: a misconfigured
+    non-dispatch holder must be challenged (so it steps down on its next
+    tick) even when its heartbeat is stale — a stale non_factory holder
+    would otherwise only ever be warned about.
+    """
+    if not lease:
+        # No lease record: nothing observable to judge. The flock itself
+        # decides — a contender simply retries the acquire.
+        return None
+    if not _lease_owner_alive(lease):
+        return "dead"
+    holder_profile = lease.get("profile") or ""
+    if not _dispatcher_profile_eligible(holder_profile, kanban_cfg):
+        return "non_factory"
+    try:
+        lease_timeout = float(kanban_cfg.get("lock_lease_timeout", 120) or 120)
+    except (TypeError, ValueError):
+        lease_timeout = 120.0
+    lease_timeout = max(lease_timeout, 10.0)
+    heartbeat_at = lease.get("heartbeat_at")
+    if isinstance(heartbeat_at, (int, float)) and heartbeat_at > 0:
+        if time.time() - heartbeat_at > lease_timeout:
+            return "stale"
+    return None
+
+
+def _dispatcher_takeover_challenge(lock_path, verdict: str, challenger: str) -> None:
+    """Write a takeover challenge into the lock file (best-effort).
+
+    The challenger does not hold the flock, but the file is world-writable
+    by design (it lives at the machine-global kanban root). The current
+    holder re-reads the lease every tick and — when it sees a challenge
+    from an eligible profile and/or discovers it is itself not eligible —
+    releases the lock and stands down, letting the challenger's next retry
+    acquire it. Pure advisory; a crash at any point just means the holder
+    keeps running until the normal recovery paths (dead/stale) apply.
+    """
+    try:
+        Path(lock_path).parent.mkdir(parents=True, exist_ok=True)
+        with open(str(lock_path), "r+", encoding="utf-8") as fh:
+            data = fh.read()
+            record = {}
+            if data.strip():
+                try:
+                    parsed = json.loads(data)
+                    if isinstance(parsed, dict):
+                        record = parsed
+                except ValueError:
+                    record = {}
+            record["challenge"] = {
+                "by": challenger,
+                "at": int(time.time()),
+                "reason": verdict,
+            }
+            fh.seek(0)
+            fh.truncate()
+            fh.write(json.dumps(record))
+            fh.flush()
+    except OSError:
+        pass
+
+
+def _dispatcher_holder_should_step_down(lease: dict, self_eligible: bool) -> bool:
+    """Return whether the current lock holder should voluntarily release.
+
+    True when the holder's own profile is no longer dispatch-eligible
+    (config flipped to ``dispatch_in_gateway: false``, or the profile was
+    removed from ``kanban.dispatch_profiles`` while running) or when an
+    eligible contender has written a takeover challenge naming a reason
+    (``non_factory`` / ``stale`` / ``dead``). Step-down is cooperative: the
+    holder releases the flock on its next tick so the contender's periodic
+    recheck can acquire it — a live flock can never be stolen.
+    """
+    if not self_eligible:
+        return True
+    challenge = lease.get("challenge") if isinstance(lease, dict) else None
+    if isinstance(challenge, dict) and challenge.get("by"):
+        return True
+    return False
+
+
 def _wake_scope_id(adapter: Any, sub: dict) -> Optional[str]:
     """Return the tenant scope (Slack workspace) a subscription's wake keys to.
 
@@ -216,9 +469,22 @@ class GatewayKanbanWatchersMixin:
         return getattr(self, "_kanban_dispatcher_lock_handle", None) is not None
 
     def _release_kanban_dispatcher_lock(self) -> None:
-        """Clear notifier-visible ownership before releasing the OS lock."""
+        """Clear notifier-visible ownership before releasing the OS lock.
+
+        Also truncates the lease record out of the lock file so a
+        contender reading it after the release does not see a stale
+        owner identity (the flock itself is what matters for exclusion,
+        but a lingering record would mislead the takeover diagnostics).
+        """
         handle = getattr(self, "_kanban_dispatcher_lock_handle", None)
         self._kanban_dispatcher_lock_handle = None
+        if handle is not None:
+            try:
+                handle.seek(0)
+                handle.truncate()
+                handle.flush()
+            except OSError:
+                pass
         _release_singleton_lock(handle)
 
     async def _kanban_notifier_watcher(self, interval: float = 5.0) -> None:
@@ -1328,23 +1594,118 @@ class GatewayKanbanWatchersMixin:
         # wal_autocheckpoint=0 — concurrent manual WAL checkpoints can corrupt
         # index pages. The lock lives at the machine-global kanban root
         # (shared across profiles by design), so it serialises ALL gateways.
-        self._kanban_dispatcher_lock_handle = None
-        _lock_path = _kb.kanban_home() / "kanban" / ".dispatcher.lock"
-        _lock_handle, _lock_state = _acquire_singleton_lock(_lock_path)
-        if _lock_state == "contended":
+
+        # Dispatch-eligibility gate (t_77f0d093): only profiles explicitly
+        # allowed by kanban.dispatch_profiles (default ["default"]) may even
+        # attempt the lock. Factory worker profiles (dev/lead/qa/reviewer),
+        # helpers, and freshly created profiles must NOT race for it — a
+        # misconfigured worker gateway that flips dispatch_in_gateway on
+        # would otherwise steal the lock from the main gateway and starve
+        # the board (incident 2026-08-13: helper held the lock for hours).
+        _self_profile = _dispatcher_lease_profile()
+        if not _dispatcher_profile_eligible(_self_profile, kanban_cfg):
             logger.info(
-                "kanban dispatcher: another gateway already holds the dispatcher "
-                "lock (%s); this gateway will NOT dispatch.", _lock_path,
+                "kanban dispatcher: profile %r is not a dispatch profile "
+                "(kanban.dispatch_profiles=%r); this gateway will NOT "
+                "dispatch and does not touch the singleton lock.",
+                _self_profile, _dispatcher_eligible_profiles(kanban_cfg),
             )
             return
+
+        self._kanban_dispatcher_lock_handle = None
+        _lock_path = _kb.kanban_home() / "kanban" / ".dispatcher.lock"
+        try:
+            _takeover_interval = float(
+                kanban_cfg.get("lock_takeover_interval", 30) or 30
+            )
+        except (TypeError, ValueError):
+            _takeover_interval = 30.0
+        _takeover_interval = max(_takeover_interval, 5.0)  # sanity floor
+        try:
+            _lease_timeout = float(kanban_cfg.get("lock_lease_timeout", 120) or 120)
+        except (TypeError, ValueError):
+            _lease_timeout = 120.0
+        _lease_timeout = max(_lease_timeout, 10.0)
+
+        _lock_handle, _lock_state = _acquire_singleton_lock(_lock_path)
+        if _lock_state == "contended":
+            # Durable takeover (t_fb4a7ca4, t_77f0d093): the flock is
+            # released the moment the owner process dies, but a gateway
+            # that found the lock contended at boot must not give up
+            # forever. Re-check every kanban.lock_takeover_interval so a
+            # dead dispatcher-gateway is replaced within ~a minute, and
+            # use the lease record to detect a wedged owner or a
+            # misconfigured non-dispatch holder.
+            logger.info(
+                "kanban dispatcher: another gateway holds the dispatcher "
+                "lock (%s); standing by, will retry takeover every %.0fs "
+                "(lease timeout %.0fs)",
+                _lock_path, _takeover_interval, _lease_timeout,
+            )
+            _wedged_warned_at = 0.0
+            while _lock_state == "contended" and self._running:
+                _lease = _read_dispatcher_lease(_lock_path)
+                _verdict = _dispatcher_holder_stealable(_lease, kanban_cfg)
+                if _verdict == "dead":
+                    logger.info(
+                        "kanban dispatcher: lock holder pid=%s is dead; "
+                        "retrying takeover",
+                        _lease.get("pid"),
+                    )
+                elif _verdict == "non_factory":
+                    logger.warning(
+                        "kanban dispatcher: lock holder profile %r is not "
+                        "allowed to dispatch; writing takeover challenge "
+                        "and retrying",
+                        _lease.get("profile"),
+                    )
+                    _dispatcher_takeover_challenge(
+                        _lock_path, _verdict, _self_profile,
+                    )
+                elif _verdict == "stale":
+                    _now = time.monotonic()
+                    if _now - _wedged_warned_at >= 300:  # rate-limit
+                        _wedged_warned_at = _now
+                        logger.warning(
+                            "kanban dispatcher: lock holder pid=%s has a "
+                            "stale lease heartbeat (last %s); the dispatcher "
+                            "loop is wedged but the process is alive, so the "
+                            "flock cannot be stolen. Restart the holder "
+                            "gateway, or it will recover on its own once the "
+                            "process exits.",
+                            _lease.get("pid"), _lease.get("heartbeat_at"),
+                        )
+                _lock_handle, _lock_state = _acquire_singleton_lock(_lock_path)
+                if _lock_state == "contended":
+                    _slept = 0.0
+                    while _slept < _takeover_interval and self._running:
+                        await asyncio.sleep(min(0.5, _takeover_interval - _slept))
+                        _slept += 0.5
         if _lock_state == "held":
             self._kanban_dispatcher_lock_handle = _lock_handle  # hold for process lifetime
-            logger.info("kanban dispatcher: holding singleton dispatcher lock (%s)", _lock_path)
-        else:
+            self._kanban_dispatcher_lease_profile = _self_profile
+            self._kanban_dispatcher_lease_started_at = int(time.time())
+            _write_dispatcher_lease(_lock_handle, _dispatcher_lease_identity(self))
+            logger.info(
+                "kanban dispatcher: holding singleton dispatcher lock (%s) "
+                "as profile %r",
+                _lock_path, _self_profile,
+            )
+        elif _lock_state == "unavailable":
             logger.warning(
                 "kanban dispatcher: advisory lock unavailable at %s; proceeding "
                 "on config control alone.", _lock_path,
             )
+        else:
+            # Still contended: the gateway is shutting down while waiting
+            # for the takeover retry (self._running flipped False), or the
+            # lock never became available. Do not fall through into the
+            # dispatch loop without the lock.
+            logger.info(
+                "kanban dispatcher: lock %s still contended; not dispatching",
+                _lock_path,
+            )
+            return
 
         try:
             interval = float(kanban_cfg.get("dispatch_interval_seconds", 60) or 60)
@@ -1770,6 +2131,45 @@ class GatewayKanbanWatchersMixin:
             "kanban dispatcher: embedded in gateway (interval=%.1fs)", interval
         )
         while self._running:
+            # Holder-side periodic recheck (t_77f0d093): re-read the lease
+            # every tick. If this gateway is no longer dispatch-eligible
+            # (kanban.dispatch_in_gateway flipped off, or the profile was
+            # removed from kanban.dispatch_profiles while running) or an
+            # eligible contender challenged the lease (non_factory holder),
+            # release the lock and stand down so the contender's takeover
+            # retry can acquire it. This is the holder half of "restarting
+            # a non-factory gateway no longer makes the main gateway lose
+            # the lock": a misconfigured holder self-heals within one tick.
+            if self._owns_kanban_dispatcher_lock():
+                try:
+                    _self_eligible = _dispatcher_profile_eligible(
+                        _self_profile, kanban_cfg,
+                    ) and bool(kanban_cfg.get("dispatch_in_gateway", True))
+                    _holder_lease = _read_dispatcher_lease(_lock_path)
+                    if _dispatcher_holder_should_step_down(
+                        _holder_lease, _self_eligible,
+                    ):
+                        _why = (
+                            "profile no longer dispatch-eligible"
+                            if not _self_eligible
+                            else "takeover challenge from "
+                            + str((_holder_lease.get("challenge") or {}).get("by"))
+                        )
+                        logger.warning(
+                            "kanban dispatcher: %s; releasing singleton "
+                            "dispatcher lock and standing down",
+                            _why,
+                        )
+                        self._release_kanban_dispatcher_lock()
+                        return
+                    _write_dispatcher_lease(
+                        self._kanban_dispatcher_lock_handle,
+                        _dispatcher_lease_identity(self),
+                    )
+                except Exception:
+                    logger.exception(
+                        "kanban dispatcher: holder lease recheck failed",
+                    )
             try:
                 # Reap zombie children before per-board work so a board DB
                 # failure cannot block cleanup of unrelated workers.

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -404,7 +404,9 @@ def _dispatcher_takeover_challenge(lock_path, verdict: str, challenger: str) -> 
         pass
 
 
-def _dispatcher_holder_should_step_down(lease: dict, self_eligible: bool) -> bool:
+def _dispatcher_holder_should_step_down(
+    lease: dict, self_eligible: bool, challenger_eligible: bool = True,
+) -> bool:
     """Return whether the current lock holder should voluntarily release.
 
     True when the holder's own profile is no longer dispatch-eligible
@@ -414,12 +416,18 @@ def _dispatcher_holder_should_step_down(lease: dict, self_eligible: bool) -> boo
     (``non_factory`` / ``stale`` / ``dead``). Step-down is cooperative: the
     holder releases the flock on its next tick so the contender's periodic
     recheck can acquire it — a live flock can never be stolen.
+
+    A challenge from a profile that is ITSELF not allowed to dispatch is
+    ignored: a rogue local process (or a misconfigured worker gateway)
+    must not be able to bounce a healthy dispatcher. ``challenger_eligible``
+    is computed by the caller from the challenge's ``by`` field against the
+    live ``kanban.dispatch_profiles`` config.
     """
     if not self_eligible:
         return True
     challenge = lease.get("challenge") if isinstance(lease, dict) else None
     if isinstance(challenge, dict) and challenge.get("by"):
-        return True
+        return bool(challenger_eligible)
     return False
 
 
@@ -2146,8 +2154,16 @@ class GatewayKanbanWatchersMixin:
                         _self_profile, kanban_cfg,
                     ) and bool(kanban_cfg.get("dispatch_in_gateway", True))
                     _holder_lease = _read_dispatcher_lease(_lock_path)
+                    _challenge = _holder_lease.get("challenge") or {}
+                    _challenger = (
+                        _challenge.get("by") if isinstance(_challenge, dict) else None
+                    )
+                    _challenger_eligible = (
+                        isinstance(_challenger, str)
+                        and _dispatcher_profile_eligible(_challenger, kanban_cfg)
+                    )
                     if _dispatcher_holder_should_step_down(
-                        _holder_lease, _self_eligible,
+                        _holder_lease, _self_eligible, _challenger_eligible,
                     ):
                         _why = (
                             "profile no longer dispatch-eligible"

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2858,6 +2858,25 @@ DEFAULT_CONFIG = {
         # only if you run the dispatcher as a separate systemd unit or
         # don't want the gateway to spawn workers.
         "dispatch_in_gateway": True,
+        # Profiles allowed to hold the machine-global singleton dispatcher
+        # lock (<kanban-root>/kanban/.dispatcher.lock). Defaults to
+        # ["default"] — ONLY the default-profile gateway may dispatch unless
+        # a deployment explicitly opts other profiles in. A worker/helper
+        # profile that flips dispatch_in_gateway on (or inherits the default
+        # true) must NOT race the main gateway for the lock; naming it here
+        # is the explicit opt-in for a second dispatcher.
+        "dispatch_profiles": ["default"],
+        # Seconds a contender gateway waits between dispatcher-lock takeover
+        # retries. When the lock owner dies, the kernel releases the flock
+        # and the next retry acquires it, so the board recovers within
+        # roughly this interval instead of starving until a container
+        # restart.
+        "lock_takeover_interval": 30,
+        # Seconds a lock lease heartbeat may be silent before contenders
+        # treat the holder as wedged (alive pid + stale heartbeat = stuck
+        # dispatcher loop; a live flock cannot be stolen, so they warn and
+        # keep retrying).
+        "lock_lease_timeout": 120,
         # Automatically claim tasks in the first-class review column and spawn
         # the assigned profile with the bundled sdlc-review skill. Disable for
         # boards where every review is performed manually from the dashboard.

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1332,6 +1332,38 @@ def create_profile(
         except Exception:
             pass  # best-effort — don't fail profile creation over this
 
+    # Seed a minimal config.yaml for fresh (non-clone) profiles so the kanban
+    # dispatcher stays OFF by default. A profile whose config.yaml lacks an
+    # explicit ``kanban:`` section inherits DEFAULT_CONFIG's
+    # ``dispatch_in_gateway: true``, which makes its gateway try to acquire
+    # the singleton dispatcher lock (<kanban-root>/kanban/.dispatcher.lock)
+    # and race the default/factory gateway for the same board. The helper
+    # profile hit exactly this (it briefly held the factory dispatcher lock).
+    # Non-factory profiles must never hold that lock; factory dispatcher
+    # profiles opt in explicitly (``dispatch_in_gateway: true``) in their own
+    # config. Skipped when the profile already has a config (--clone /
+    # --clone-all copy it from the source, kanban section included).
+    config_path = profile_dir / "config.yaml"
+    if not config_path.exists():
+        try:
+            from hermes_cli.config_defaults import DEFAULT_CONFIG as _DEFAULT_CONFIG
+            _version = int(_DEFAULT_CONFIG.get("_config_version", 1) or 1)
+            config_path.write_text(
+                "# Kanban dispatcher ownership (single-dispatcher posture):\n"
+                "# non-factory profiles must NOT hold the kanban dispatcher lock\n"
+                "# (<kanban-root>/kanban/.dispatcher.lock). Only the default/factory\n"
+                "# gateway dispatches; flip dispatch_in_gateway to true ONLY for\n"
+                "# profiles explicitly intended to be factory dispatchers.\n"
+                f"_config_version: {_version}\n"
+                "kanban:\n"
+                "  dispatch_in_gateway: false\n"
+                "  enabled: false\n",
+                encoding="utf-8",
+            )
+            os.chmod(str(config_path), 0o644)
+        except Exception:
+            pass  # best-effort — profile creation must not fail over this
+
     # Write the opt-out marker so seed_profile_skills() and `hermes update`'s
     # all-profile sync loop both skip this profile for bundled-skill seeding.
     if no_skills:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1031,11 +1031,17 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     import sqlite3
 
     from gateway.run import GatewayRunner
+    import gateway.kanban_watchers as _kw
     import hermes_cli.config as _cfg_mod
     import hermes_cli.kanban_db as _kb
 
     runner = object.__new__(GatewayRunner)
     runner._running = True
+    # The dispatcher runs as the default-profile gateway (kanban.
+    # dispatch_profiles defaults to ["default"]); pin the identity so the
+    # eligibility gate (t_77f0d093) does not reject the test process's own
+    # profile (e.g. a factory worker running pytest).
+    monkeypatch.setattr(_kw, "_dispatcher_lease_profile", lambda: "default")
     corrupt_db = tmp_path / "kanban.db"
     corrupt_db.write_text("not sqlite", encoding="utf-8")
 

--- a/tests/hermes_cli/test_kanban_dispatcher_lock_durable.py
+++ b/tests/hermes_cli/test_kanban_dispatcher_lock_durable.py
@@ -1,0 +1,478 @@
+"""Durable dispatcher singleton-lock handling (t_77f0d093).
+
+Regression tests for the durable dispatcher lock on top of the t_fb4a7ca4
+lease/takeover work:
+
+D1 — eligibility gate: only profiles named in ``kanban.dispatch_profiles``
+     (default ``["default"]``) may even attempt the singleton lock. Factory
+     worker profiles (dev/lead/qa/reviewer), helpers and freshly created
+     profiles must NOT race for it, so a misconfigured worker gateway that
+     flips ``dispatch_in_gateway`` on cannot steal the lock from the main
+     gateway and starve the board.
+
+D2 — stale/dead holder recovery: a contender that found the lock contended
+     at boot does not give up forever. It re-checks on
+     ``kanban.lock_takeover_interval``; when the holder's process died the
+     kernel already released the flock, so the retry acquires it (board
+     recovers within the recheck interval instead of starving until a
+     container restart). A stale heartbeat with a live pid is a wedged
+     dispatcher loop — a live flock cannot be stolen — so the contender
+     warns and keeps retrying instead of pretending to take over.
+
+D3 — non-factory-profile lock stealing: when the lease shows a holder whose
+     profile is not allowed to dispatch, the contender writes a takeover
+     challenge into the lease file and the holder (running this code)
+     releases the lock on its next tick and stands down, so the
+     challenger's retry acquires it. A healthy, entitled holder is never
+     touched.
+
+D4 — holder-side periodic recheck: the lock owner re-reads its own lease
+     every tick, refreshes the heartbeat, and steps down (releasing the
+     flock) the moment it is no longer dispatch-eligible or an eligible
+     contender challenged it. This is the holder half of "restarting a
+     non-factory gateway no longer makes the main gateway lose the lock".
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.kanban_watchers import (
+    GatewayKanbanWatchersMixin,
+    _acquire_singleton_lock,
+    _dispatcher_eligible_profiles,
+    _dispatcher_holder_should_step_down,
+    _dispatcher_holder_stealable,
+    _dispatcher_lease_identity,
+    _dispatcher_lease_profile,
+    _dispatcher_profile_eligible,
+    _dispatcher_takeover_challenge,
+    _lease_owner_alive,
+    _read_dispatcher_lease,
+    _release_singleton_lock,
+    _write_dispatcher_lease,
+)
+
+DEFAULT_CFG = {
+    "dispatch_in_gateway": True,
+    "dispatch_profiles": ["default"],
+    "lock_takeover_interval": 30,
+    "lock_lease_timeout": 120,
+}
+
+
+def _lease_stub(profile="default"):
+    """A stand-in for the mixin with just the lease identity attributes."""
+    return SimpleNamespace(
+        _kanban_dispatcher_lease_profile=profile,
+        _kanban_dispatcher_lease_started_at=int(time.time()),
+    )
+
+
+def _spawn_holder(lock_path: Path, profile: str, sleep: float = 60.0):
+    """Spawn a subprocess that flocks *lock_path* and writes a lease record.
+
+    Returns the Popen handle. The subprocess owns the real OS flock, so the
+    parent's ``_acquire_singleton_lock`` returns ``contended`` until it dies.
+    """
+    script = (
+        "import fcntl, json, os, sys, time\n"
+        f"p = {str(lock_path)!r}\n"
+        "f = open(p, 'a+')\n"
+        "assert fcntl.flock(f.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB) is None\n"
+        "rec = {'version': 1, 'profile': %r, 'pid': os.getpid(),\n"
+        "       'host': 'test-host', 'started_at': int(time.time()),\n"
+        "       'heartbeat_at': int(time.time())}\n"
+        "f.seek(0); f.truncate(); f.write(json.dumps(rec)); f.flush()\n"
+        "print('LOCKED', flush=True)\n"
+        "time.sleep(%r)\n"
+    ) % (profile, sleep)
+    proc = subprocess.Popen(
+        [sys.executable, "-c", script],
+        stdout=subprocess.PIPE,
+        text=True,
+    )
+    line = proc.stdout.readline().strip()
+    assert line == "LOCKED", f"holder subprocess failed: {line!r}"
+    return proc
+
+
+# ---------------------------------------------------------------------------
+# D1: dispatch-eligibility gate
+# ---------------------------------------------------------------------------
+
+
+def test_eligibility_gate_defaults_to_default_profile():
+    """Only the default profile is eligible unless dispatch_profiles opts in."""
+    assert _dispatcher_eligible_profiles({}) == ["default"]
+    assert _dispatcher_eligible_profiles({"dispatch_profiles": ["default"]}) == ["default"]
+    assert _dispatcher_profile_eligible("default", {}) is True
+    # Factory worker profiles must NOT race for the lock.
+    for worker in ("factory-dev", "factory-lead", "factory-qa", "factory-reviewer", "helper"):
+        assert _dispatcher_profile_eligible(worker, {}) is False, worker
+    # Explicit opt-in is the only way a second dispatcher is allowed.
+    cfg = {"dispatch_profiles": ["default", "factory-dispatcher"]}
+    assert _dispatcher_profile_eligible("factory-dispatcher", cfg) is True
+    assert _dispatcher_profile_eligible("factory-reviewer", cfg) is False
+    # An unknown/label-less profile is never eligible.
+    assert _dispatcher_profile_eligible("unknown", {}) is False
+    assert _dispatcher_profile_eligible("", {}) is False
+    # String form is accepted for convenience.
+    assert _dispatcher_eligible_profiles({"dispatch_profiles": "default"}) == ["default"]
+
+
+def test_lease_profile_labeling_for_gateways(monkeypatch):
+    """A gateway launched without -p is the default profile, not 'unknown'."""
+    from hermes_cli import profiles
+    # Shared-HERMES_HOME deployment: every gateway's home resolves to the
+    # default, so the argv -p flag is the per-gateway signal.
+    monkeypatch.setattr(profiles, "get_active_profile_name", lambda: "default")
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "gateway", "run"],
+    )
+    assert _dispatcher_lease_profile() == "default"
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "-p", "factory-reviewer", "gateway", "run"],
+    )
+    assert _dispatcher_lease_profile() == "factory-reviewer"
+    monkeypatch.setattr(
+        sys, "argv", ["hermes", "gateway", "run", "--profile", "factory-qa"],
+    )
+    assert _dispatcher_lease_profile() == "factory-qa"
+
+
+# ---------------------------------------------------------------------------
+# D2: stale/dead holder recovery
+# ---------------------------------------------------------------------------
+
+
+def test_holder_stealable_verdicts():
+    """The reclaimability verdict: dead / stale / non_factory / healthy."""
+    # Healthy, entitled holder: never touch.
+    healthy = {
+        "pid": os.getpid(),
+        "profile": "default",
+        "heartbeat_at": int(time.time()),
+    }
+    assert _dispatcher_holder_stealable(healthy, DEFAULT_CFG) is None
+    # Missing lease record: flock-only takeover (retry), nothing to judge.
+    assert _dispatcher_holder_stealable({}, DEFAULT_CFG) is None
+    # Dead pid -> dead.
+    dead = subprocess.Popen([sys.executable, "-c", "pass"])
+    dead.wait(timeout=10)
+    assert _dispatcher_holder_stealable(
+        {"pid": dead.pid, "profile": "default", "heartbeat_at": int(time.time())},
+        DEFAULT_CFG,
+    ) == "dead"
+    # Alive pid + stale heartbeat -> stale (wedged loop; flock not stealable).
+    stale = {
+        "pid": os.getpid(),
+        "profile": "default",
+        "heartbeat_at": int(time.time()) - 10_000,
+    }
+    assert _dispatcher_holder_stealable(stale, DEFAULT_CFG) == "stale"
+    # Alive + heartbeating but a non-dispatch profile -> non_factory.
+    misconfigured = {
+        "pid": os.getpid(),
+        "profile": "factory-reviewer",
+        "heartbeat_at": int(time.time()),
+    }
+    assert _dispatcher_holder_stealable(misconfigured, DEFAULT_CFG) == "non_factory"
+    # non_factory beats stale: a misconfigured holder must be challenged
+    # even when its heartbeat also went stale.
+    misconfigured_stale = {
+        "pid": os.getpid(),
+        "profile": "factory-reviewer",
+        "heartbeat_at": int(time.time()) - 10_000,
+    }
+    assert _dispatcher_holder_stealable(misconfigured_stale, DEFAULT_CFG) == "non_factory"
+
+
+def test_dead_holder_lock_recovered_on_recheck(tmp_path):
+    """A dead holder's flock is released by the kernel; the next recheck
+    acquires it — the board recovers within the recheck interval."""
+    lock_path = tmp_path / "dispatcher.lock"
+    proc = _spawn_holder(lock_path, profile="factory-reviewer")
+    try:
+        # Alive holder -> contended.
+        h, s = _acquire_singleton_lock(lock_path)
+        assert s == "contended"
+        assert h is None
+        lease = _read_dispatcher_lease(lock_path)
+        assert _dispatcher_holder_stealable(lease, DEFAULT_CFG) in (
+            "non_factory", "dead",
+        )
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+    # Dead holder -> the retry acquire (the takeover loop's next recheck)
+    # succeeds immediately.
+    h, s = _acquire_singleton_lock(lock_path)
+    assert s == "held", "flock must be acquirable right after owner death"
+    _release_singleton_lock(h)
+
+
+def test_stale_holder_not_stolen_while_alive(tmp_path):
+    """A live pid with a stale heartbeat is a wedged loop: warn, never steal."""
+    lock_path = tmp_path / "dispatcher.lock"
+    proc = _spawn_holder(lock_path, profile="default")
+    try:
+        # Age the heartbeat in the lease file (holder is still alive).
+        lease = _read_dispatcher_lease(lock_path)
+        lease["heartbeat_at"] = int(time.time()) - 10_000
+        lock_path.write_text(json.dumps(lease), encoding="utf-8")
+        assert _dispatcher_holder_stealable(lease, DEFAULT_CFG) == "stale"
+        # The flock is still held by the live process -> contended.
+        h, s = _acquire_singleton_lock(lock_path)
+        assert s == "contended"
+        assert h is None
+        # No challenge is written for a mere stale verdict, and the holder
+        # does not step down without one.
+        assert _dispatcher_holder_should_step_down(
+            _read_dispatcher_lease(lock_path), self_eligible=True,
+        ) is False
+    finally:
+        proc.kill()
+        proc.wait(timeout=10)
+
+
+# ---------------------------------------------------------------------------
+# D3: non-factory-profile lock stealing
+# ---------------------------------------------------------------------------
+
+
+def test_non_factory_holder_challenge_and_steal(tmp_path):
+    """A misconfigured non-dispatch holder is reclaimed cooperatively:
+    contender challenges -> holder steps down -> contender's retry acquires."""
+    lock_path = tmp_path / "dispatcher.lock"
+
+    # The misconfigured holder (e.g. the factory-reviewer gateway that
+    # inherited dispatch_in_gateway=true): alive, heartbeating, wrong profile.
+    holder_handle, holder_state = _acquire_singleton_lock(lock_path)
+    assert holder_state == "held"
+    try:
+        _write_dispatcher_lease(
+            holder_handle, _dispatcher_lease_identity(_lease_stub("factory-reviewer")),
+        )
+
+        # Contender (the default gateway): the holder is stealable.
+        lease = _read_dispatcher_lease(lock_path)
+        assert _dispatcher_holder_stealable(lease, DEFAULT_CFG) == "non_factory"
+
+        # The contender writes a takeover challenge; a live flock cannot be
+        # stolen, so its acquire stays contended until the holder yields.
+        _dispatcher_takeover_challenge(lock_path, "non_factory", "default")
+        h, s = _acquire_singleton_lock(lock_path)
+        assert s == "contended"
+        assert h is None
+
+        # Holder side (running the durable code): the challenge plus its own
+        # non-eligibility both trigger step-down on the next tick.
+        challenged = _read_dispatcher_lease(lock_path)
+        assert challenged.get("challenge", {}).get("by") == "default"
+        assert _dispatcher_holder_should_step_down(challenged, self_eligible=True) is True
+        assert _dispatcher_holder_should_step_down(challenged, self_eligible=False) is True
+
+        # The holder releases (its _release_kanban_dispatcher_lock path
+        # truncates the lease, mirroring the mixin).
+        holder_handle.seek(0)
+        holder_handle.truncate()
+        holder_handle.flush()
+        _release_singleton_lock(holder_handle)
+        holder_handle = None
+
+        # The contender's next periodic recheck acquires the freed flock.
+        h, s = _acquire_singleton_lock(lock_path)
+        assert s == "held"
+        _write_dispatcher_lease(h, _dispatcher_lease_identity(_lease_stub("default")))
+        lease = _read_dispatcher_lease(lock_path)
+        assert lease.get("profile") == "default"
+        _release_singleton_lock(h)
+    finally:
+        if holder_handle is not None:
+            _release_singleton_lock(holder_handle)
+
+
+def test_healthy_holder_never_challenged(tmp_path):
+    """A healthy, entitled holder is left alone: no challenge, no step-down."""
+    lock_path = tmp_path / "dispatcher.lock"
+    holder_handle, s = _acquire_singleton_lock(lock_path)
+    assert s == "held"
+    try:
+        _write_dispatcher_lease(
+            holder_handle, _dispatcher_lease_identity(_lease_stub("default")),
+        )
+        lease = _read_dispatcher_lease(lock_path)
+        assert _dispatcher_holder_stealable(lease, DEFAULT_CFG) is None
+        assert _dispatcher_holder_should_step_down(lease, self_eligible=True) is False
+        assert "challenge" not in _read_dispatcher_lease(lock_path)
+    finally:
+        _release_singleton_lock(holder_handle)
+
+
+# ---------------------------------------------------------------------------
+# D4: the dispatcher watcher loop (boot-contended -> takeover -> step-down)
+# ---------------------------------------------------------------------------
+
+
+class _FakeRunner(GatewayKanbanWatchersMixin):
+    """Minimal stand-in for GatewayRunner: just the attrs the dispatcher
+    watcher touches (plus the mixin's lock helpers), with the heavy tick
+    internals stubbed via monkeypatch in the test."""
+
+    def __init__(self):
+        self._running = True
+        self._kanban_dispatcher_lock_handle = None
+
+
+class _InstantAsync:
+    """asyncio stand-in whose sleep() yields once and returns instantly, so
+    the watcher's retry loop and tick cadence run without wall-clock waits
+    while still letting the test coroutine interleave on the event loop."""
+
+    @staticmethod
+    async def sleep(_seconds):
+        import asyncio
+        await asyncio.sleep(0)
+
+    def __getattr__(self, name):
+        import asyncio
+        return getattr(asyncio, name)
+
+
+def _patch_watcher_deps(monkeypatch, tmp_path, kanban_cfg):
+    """Route the watcher's kanban_db / config / sleep deps away from the
+    live board and the live dispatcher lock, and make time instant."""
+    import gateway.kanban_watchers as kw
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.config as hc_config
+
+    monkeypatch.setattr(kb, "kanban_home", lambda: tmp_path)
+    monkeypatch.setattr(kb, "list_boards", lambda *a, **kw: [])
+    monkeypatch.setattr(kb, "reap_worker_zombies", lambda: [])
+    monkeypatch.setattr(kb, "review_dispatch_enabled", lambda: False)
+    monkeypatch.setattr(hc_config, "load_config", lambda: {"kanban": kanban_cfg})
+    monkeypatch.setattr(kw, "_kanban_dispatch_allowed", lambda: True)
+    # The test process may itself run under a non-default HERMES_HOME (e.g.
+    # a factory worker profile); pin the gateway identity the watcher sees.
+    monkeypatch.setattr(kw, "_dispatcher_lease_profile", lambda: "default")
+    monkeypatch.setattr(kw, "asyncio", _InstantAsync())
+    return kw
+
+
+@pytest.mark.asyncio
+async def test_watcher_contended_at_boot_takes_over_after_holder_death(
+    tmp_path, monkeypatch,
+):
+    """Requirement (a) end-to-end: a gateway that found the lock contended
+    at boot does NOT give up — when the holder dies, the next recheck
+    acquires the lock and the dispatcher comes up."""
+    lock_path = tmp_path / "kanban" / ".dispatcher.lock"
+    lock_path.parent.mkdir(parents=True)
+    holder = _spawn_holder(lock_path, profile="factory-reviewer")
+
+    cfg = {
+        "dispatch_in_gateway": True,
+        "dispatch_profiles": ["default"],
+        "lock_takeover_interval": 30,
+        "lock_lease_timeout": 120,
+        "dispatch_interval_seconds": 1,
+        "auto_decompose": False,
+    }
+    kw = _patch_watcher_deps(monkeypatch, tmp_path, cfg)
+    runner = _FakeRunner()
+
+    task = asyncio.create_task(runner._kanban_dispatcher_watcher())
+    try:
+        # Boot: contended (holder alive) -> the watcher must NOT return.
+        for _ in range(50):
+            await asyncio.sleep(0)
+        assert runner._kanban_dispatcher_lock_handle is None
+        assert not task.done(), "watcher must keep retrying, not give up at boot"
+
+        # Holder dies -> the retry acquires the freed flock.
+        holder.kill()
+        holder.wait(timeout=10)
+        for _ in range(200):
+            if runner._kanban_dispatcher_lock_handle is not None:
+                break
+            await asyncio.sleep(0)
+        assert runner._kanban_dispatcher_lock_handle is not None, (
+            "watcher must take over the lock within the recheck interval"
+        )
+        lease = _read_dispatcher_lease(lock_path)
+        assert lease.get("profile") == "default"
+        assert lease.get("pid") == os.getpid()
+        assert isinstance(lease.get("heartbeat_at"), int)
+    finally:
+        if holder.poll() is None:
+            holder.kill()
+            holder.wait(timeout=10)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+
+@pytest.mark.asyncio
+async def test_watcher_holder_steps_down_on_takeover_challenge(tmp_path, monkeypatch):
+    """Requirement (b)/(c) end-to-end, holder half: after acquiring the
+    lock, the watcher re-reads the lease every tick and releases + stands
+    down when an eligible contender challenges it (non_factory steal)."""
+    lock_path = tmp_path / "kanban" / ".dispatcher.lock"
+    lock_path.parent.mkdir(parents=True)
+
+    cfg = {
+        "dispatch_in_gateway": True,
+        "dispatch_profiles": ["default"],
+        "lock_takeover_interval": 30,
+        "lock_lease_timeout": 120,
+        "dispatch_interval_seconds": 1,
+        "auto_decompose": False,
+    }
+    kw = _patch_watcher_deps(monkeypatch, tmp_path, cfg)
+    runner = _FakeRunner()
+
+    task = asyncio.create_task(runner._kanban_dispatcher_watcher())
+    try:
+        # Acquire (no contention at boot).
+        for _ in range(200):
+            if runner._kanban_dispatcher_lock_handle is not None:
+                break
+            await asyncio.sleep(0)
+        assert runner._kanban_dispatcher_lock_handle is not None
+        lease = _read_dispatcher_lease(lock_path)
+        assert lease.get("profile") == "default"
+
+        # A contender challenges the lease (simulating a more privileged
+        # gateway taking over a misconfigured holder).
+        _dispatcher_takeover_challenge(lock_path, "non_factory", "default")
+
+        # The holder's next tick sees the challenge and stands down.
+        for _ in range(200):
+            if runner._kanban_dispatcher_lock_handle is None:
+                break
+            await asyncio.sleep(0)
+        assert runner._kanban_dispatcher_lock_handle is None, (
+            "holder must release the lock when challenged"
+        )
+        assert task.done(), "watcher must return after standing down"
+        # The lock is free for the challenger's retry.
+        h, s = _acquire_singleton_lock(lock_path)
+        assert s == "held"
+        _release_singleton_lock(h)
+    finally:
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass

--- a/tests/hermes_cli/test_kanban_dispatcher_lock_durable.py
+++ b/tests/hermes_cli/test_kanban_dispatcher_lock_durable.py
@@ -278,8 +278,17 @@ def test_non_factory_holder_challenge_and_steal(tmp_path):
         # non-eligibility both trigger step-down on the next tick.
         challenged = _read_dispatcher_lease(lock_path)
         assert challenged.get("challenge", {}).get("by") == "default"
-        assert _dispatcher_holder_should_step_down(challenged, self_eligible=True) is True
-        assert _dispatcher_holder_should_step_down(challenged, self_eligible=False) is True
+        assert _dispatcher_holder_should_step_down(
+            challenged, self_eligible=True, challenger_eligible=True,
+        ) is True
+        assert _dispatcher_holder_should_step_down(
+            challenged, self_eligible=False,
+        ) is True
+        # A challenge from a profile that is itself not allowed to dispatch
+        # must NOT bounce a healthy holder.
+        assert _dispatcher_holder_should_step_down(
+            challenged, self_eligible=True, challenger_eligible=False,
+        ) is False
 
         # The holder releases (its _release_kanban_dispatcher_lock path
         # truncates the lease, mirroring the mixin).

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -174,6 +174,31 @@ class TestCreateProfile:
 
 
 
+    def test_fresh_profile_seeds_kanban_dispatcher_off(self, profile_env):
+        """Fresh (non-clone) profiles get a config.yaml that keeps the kanban
+        dispatcher OFF by default.
+
+        A profile whose config.yaml lacks an explicit ``kanban:`` section
+        inherits ``kanban.dispatch_in_gateway: true`` from DEFAULT_CONFIG,
+        which makes its gateway try to acquire the singleton dispatcher lock
+        (``<kanban-root>/kanban/.dispatcher.lock``) and race the
+        default/factory gateway. Non-factory profiles must never hold that
+        lock; the seeded default keeps them out of the dispatcher race.
+        """
+        import stat
+        profile_dir = create_profile("coder", no_alias=True)
+        config_path = profile_dir / "config.yaml"
+        assert config_path.exists(), "fresh profile should get a seeded config.yaml"
+        config = yaml.safe_load(config_path.read_text())
+        assert config["_config_version"] == DEFAULT_CONFIG["_config_version"]
+        kanban = config["kanban"]
+        assert kanban["dispatch_in_gateway"] is False
+        assert kanban["enabled"] is False
+        mode = stat.S_IMODE(config_path.stat().st_mode)
+        assert mode == 0o644
+
+
+
 
     def test_clone_config_copies_files(self, profile_env):
         tmp_path = profile_env

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -89,6 +89,17 @@ Creates a new profile.
 
 Creating a profile does **not** make that profile directory the default project/workspace directory for terminal commands. If you want a profile to start in a specific project, set `terminal.cwd` in that profile's `config.yaml`.
 
+**Kanban dispatcher default:** a fresh profile (no `--clone`) gets a seeded
+`config.yaml` containing `kanban: {dispatch_in_gateway: false, enabled: false}`.
+This keeps every non-factory profile out of the kanban dispatcher race: only the
+gateway that is explicitly meant to dispatch (e.g. `default`) keeps
+`dispatch_in_gateway: true` and holds the singleton
+`<kanban-root>/kanban/.dispatcher.lock`. A profile whose `config.yaml` lacks a
+`kanban:` section inherits `dispatch_in_gateway: true` from the defaults — a
+helper profile's gateway would then silently become a second dispatcher, so keep
+the section explicit. Cloning copies the source's `kanban:` section as-is; check
+it after cloning.
+
 **Examples:**
 
 ```bash

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -97,8 +97,10 @@ gateway that is explicitly meant to dispatch (e.g. `default`) keeps
 `<kanban-root>/kanban/.dispatcher.lock`. A profile whose `config.yaml` lacks a
 `kanban:` section inherits `dispatch_in_gateway: true` from the defaults — a
 helper profile's gateway would then silently become a second dispatcher, so keep
-the section explicit. Cloning copies the source's `kanban:` section as-is; check
-it after cloning.
+the section explicit. Only profiles named in `kanban.dispatch_profiles`
+(default `["default"]`) may even attempt the lock; contenders re-check it every
+`kanban.lock_takeover_interval` (default 30s) instead of giving up at boot.
+Cloning copies the source's `kanban:` section as-is; check it after cloning.
 
 **Examples:**
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -224,12 +224,19 @@ up on the next tick (60s by default).
 ```yaml
 # config.yaml
 kanban:
-  dispatch_in_gateway: true        # default
+  dispatch_in_gateway: true        # the DISPATCHING gateway (default/factory)
   dispatch_interval_seconds: 60    # default
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
                                    # for human-only review boards.
 ```
+
+Every **non-dispatching** gateway must set `dispatch_in_gateway: false` (fresh
+profiles created with `hermes profile create <name>` are seeded this way, along
+with `enabled: false`), so its gateway never races for the singleton
+`.dispatcher.lock`. A profile whose `config.yaml` has no `kanban:` section at
+all inherits `dispatch_in_gateway: true` from the defaults — which makes a
+helper profile's gateway silently try to become a second dispatcher.
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
 for debugging. Standard gateway supervision applies: run `hermes gateway
@@ -1048,7 +1055,14 @@ dispatch and delivery have separate owners:
 
 - **Dispatch stays single-owner.** Exactly one gateway keeps
   `kanban.dispatch_in_gateway: true` and runs the dispatcher; every other
-  gateway sets it to `false`.
+  gateway sets it to `false`. The dispatcher gateway holds an exclusive flock
+  on `<kanban-root>/kanban/.dispatcher.lock`; a non-factory profile must never
+  hold that lock. Fresh profiles (`hermes profile create <name>` without
+  `--clone`) are seeded with `kanban.dispatch_in_gateway: false` +
+  `kanban.enabled: false` precisely so a new gateway never races for the lock.
+  A profile whose `config.yaml` lacks an explicit `kanban:` section inherits
+  `dispatch_in_gateway: true` from the defaults — keep the section explicit in
+  every non-factory profile.
 - **Notification delivery is profile-owned.** Every gateway — including
   non-dispatch ones — runs the notifier and polls only subscriptions stamped
   with a profile whose platform adapters it hosts. A task created from the

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -1062,7 +1062,14 @@ dispatch and delivery have separate owners:
   `kanban.enabled: false` precisely so a new gateway never races for the lock.
   A profile whose `config.yaml` lacks an explicit `kanban:` section inherits
   `dispatch_in_gateway: true` from the defaults — keep the section explicit in
-  every non-factory profile.
+  every non-factory profile. As a code-side backstop, only profiles named in
+  `kanban.dispatch_profiles` (default `["default"]`) may even attempt the
+  lock, so a misconfigured worker/helper gateway cannot steal it. The lock is
+  durable: contenders re-check the flock every `kanban.lock_takeover_interval`
+  (default 30s) instead of giving up at boot, a dead holder's lock is
+  recovered within that interval, and a holder whose profile is no longer
+  dispatch-eligible (or is challenged by an eligible contender) releases it
+  and stands down on its next tick.
 - **Notification delivery is profile-owned.** Every gateway — including
   non-dispatch ones — runs the notifier and polls only subscriptions stamped
   with a profile whose platform adapters it hosts. A task created from the

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -40,6 +40,19 @@ hermes profile create mybot
 
 Creates a fresh profile with bundled skills seeded. Run `mybot setup` to configure API keys, model, and gateway tokens.
 
+A fresh profile (no `--clone`) is seeded with the kanban dispatcher **off** — its
+`config.yaml` ships with `kanban: {dispatch_in_gateway: false, enabled: false}`.
+This is the single-dispatcher posture: only the profile that is explicitly meant
+to dispatch (e.g. `default`) keeps `dispatch_in_gateway: true`. A profile without
+an explicit `kanban:` section inherits `dispatch_in_gateway: true` from the
+defaults and its gateway would race for the singleton dispatcher lock
+(`<kanban-root>/kanban/.dispatcher.lock`) — a non-factory profile must never hold
+that lock. See the [multi-gateway
+guide](https://github.com/NousResearch/hermes-agent/blob/main/docs/kanban/multi-gateway.md) for
+details. Cloning with `--clone` / `--clone-all` copies the source profile's
+`kanban:` section as-is — verify it after cloning so a clone of the dispatcher
+doesn't become a second dispatcher.
+
 If you plan to use this profile as a kanban worker (or want the kanban orchestrator to route work to it), pass `--description "<role>"` at create time so the orchestrator knows what it's good at:
 
 ```bash

--- a/website/docs/user-guide/profiles.md
+++ b/website/docs/user-guide/profiles.md
@@ -47,7 +47,11 @@ to dispatch (e.g. `default`) keeps `dispatch_in_gateway: true`. A profile withou
 an explicit `kanban:` section inherits `dispatch_in_gateway: true` from the
 defaults and its gateway would race for the singleton dispatcher lock
 (`<kanban-root>/kanban/.dispatcher.lock`) — a non-factory profile must never hold
-that lock. See the [multi-gateway
+that lock. As a code-side backstop, only profiles named in
+`kanban.dispatch_profiles` (default `["default"]`) may even attempt the lock,
+and contenders re-check it every `kanban.lock_takeover_interval` (default 30s)
+instead of giving up at boot, so a dead dispatcher-gateway is replaced within
+~a minute. See the [multi-gateway
 guide](https://github.com/NousResearch/hermes-agent/blob/main/docs/kanban/multi-gateway.md) for
 details. Cloning with `--clone` / `--clone-all` copies the source profile's
 `kanban:` section as-is — verify it after cloning so a clone of the dispatcher


### PR DESCRIPTION
## Problem

A gateway that holds the singleton kanban dispatcher lock keeps it across its
whole lifetime. If that holder is not actually eligible to dispatch (a
non-factory profile), or its lease goes stale while the process stays alive,
the lock is never released and the board stops being dispatched entirely.

Observed on a self-hosted multi-profile install: a `helper`-profile gateway held
the lock while the factory board sat idle for ~30h. `ready` was empty because
`scheduled` tasks past their `ready_time` were never promoted, so the existing
health check ("ready queue non-empty but 0 workers spawned") never fired and the
stall was silent. Restarting the holder did not help — the replacement
re-acquired the lock and reproduced the same state.

## Change

- `fix(kanban)`: durable dispatcher lock — periodic holder-side lease recheck,
  steal from stale/dead/non-factory holders, and a `dispatch_profiles`
  eligibility gate. Step-down is cooperative; a live `flock` is never stolen.
- `fix(profiles)`: seed fresh non-factory profiles with
  `kanban.dispatch_in_gateway=false` so they do not take a lock they cannot use.
- Tests for the eligibility gate, stale/dead recovery, non-factory steal, and
  the watcher takeover loop.
- Docs for `dispatch_profiles` eligibility and durable-lock semantics.

## Verification

`90 passed, 2 skipped` on `tests/hermes_cli/test_kanban_dispatcher_lock_durable.py`,
`test_profiles.py`, `test_kanban_core_functionality.py`, rebased onto current
`main` (`b0d2148b4`).
