### PR TITLE
fix(mcp): don't instantiate _watch_stdio_children just to probe awaitability

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6186,7 +6186,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        and inspect.iscoroutinefunction(_watch_children)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:


### PR DESCRIPTION
## Problem

`tools/mcp_tool.py` probes the stdio child watcher with `inspect.isawaitable(_watch_children())`. The call instantiates the coroutine, the result is inspected and dropped, and Python reports on every MCP tool call:

```
tools/mcp_tool.py:6189: RuntimeWarning: coroutine 'MCPServerTask._watch_stdio_children' was never awaited
```

Seen on every stdio MCP call since v2026.8.31 (v0.21.0). Reported in #95938 and #96030.

## Fix

Ask `inspect.iscoroutinefunction(_watch_children)` about the function instead of calling it. The verdict is unchanged: a real coroutine method still takes the fast-fail race branch, and the MagicMock stubs used in tests (not coroutine functions) still take the plain-await fallback, exactly as the existing comment describes.

One line, no behavior change besides the warning.

Fixes #95938
Fixes #96030