### PR TITLE
fix(security): gate terminal writes to Hermes-root credential stores

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -323,6 +323,93 @@ class TestTeePattern:
             assert key is None
 
 
+class TestHermesCredentialStoreWriteProtection:
+    """Terminal-side pairing for the Hermes-root credential stores.
+
+    ``agent/file_safety`` already denies these to write_file/patch and
+    classifies ``mcp-tokens/`` and ``pairing/`` as ``"credential"``, but the
+    terminal path had no matching rule — so ``echo x >>
+    ~/.hermes/mcp-tokens/github.json`` was auto-approved. Same unpaired-theater
+    shape as ``TestHermesConfigWriteProtection`` above, and the same
+    live-bearer-token class the media denylist already pairs.
+    """
+
+    CREDENTIAL_PATHS = (
+        "~/.hermes/mcp-tokens/github.json",
+        "~/.hermes/mcp-tokens/github.client.json",
+        "~/.hermes/pairing/device.json",
+        "~/.hermes/.anthropic_oauth.json",
+        "$HERMES_HOME/mcp-tokens/github.json",
+        "$HOME/.hermes/pairing/device.json",
+    )
+
+    def test_every_write_vector_is_gated(self):
+        for path in self.CREDENTIAL_PATHS:
+            for vector in (
+                "echo x >> {p}",
+                "echo x > {p}",
+                "echo x | tee -a {p}",
+                "cp /tmp/evil {p}",
+                "mv /tmp/evil {p}",
+                "install -m600 /tmp/c {p}",
+                "sed -i 's/a/b/' {p}",
+            ):
+                command = vector.format(p=path)
+                dangerous, key, _ = detect_dangerous_command(command)
+                assert dangerous is True, command
+                assert key is not None, command
+
+    def test_session_state_is_not_gated_here(self):
+        """``sessions/`` and ``state.db`` are application-owned transcript state
+        denied to stop history falsification, NOT credentials. The media
+        denylist keeps them out for the same reason (#41071), so this rule must
+        not claim them."""
+        for command in (
+            "echo x >> ~/.hermes/sessions/state.db",
+            "sed -i 's/a/b/' ~/.hermes/state.db",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+            assert key is None, command
+
+    def test_ordinary_hermes_root_writes_stay_safe(self):
+        """Only the credential stores are gated — logs, skills, and generated
+        cache artifacts under ~/.hermes must remain writable."""
+        for command in (
+            "echo x >> ~/.hermes/logs/agent.log",
+            "cp new.md ~/.hermes/skills/mine/SKILL.md",
+            "echo x > ~/.hermes/notes.txt",
+            "install -m644 /tmp/f ~/.hermes/cache/images/out.png",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+            assert key is None, command
+
+    def test_near_miss_and_non_hermes_paths_stay_safe(self):
+        """Prefix matching must not catch similarly-named siblings, and the
+        rule is anchored to the Hermes root rather than the bare directory
+        name."""
+        for command in (
+            "echo x >> ~/.hermes/mcp-tokens-backup.json",
+            "echo x >> ~/.hermes/pairing-notes.md",
+            "echo x >> ~/mcp-tokens/github.json",
+            "echo x >> /opt/app/pairing/device.json",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+    def test_reads_out_of_credential_stores_stay_safe(self):
+        """Only the write DESTINATION is gated. Reading out is covered by the
+        read guard and the media denylist, mirroring ~/.ssh behaviour."""
+        for command in (
+            "cat ~/.hermes/mcp-tokens/github.json",
+            "cp ~/.hermes/pairing/device.json /tmp/x",
+            "grep -r tok ~/.hermes/mcp-tokens/",
+        ):
+            dangerous, key, _ = detect_dangerous_command(command)
+            assert dangerous is False, command
+
+
 class TestHermesConfigWriteProtection:
     """Terminal-side pairing for the file_tools write_file/patch deny on
     ~/.hermes/config.yaml (#14639). config.yaml IS the security policy

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -407,6 +407,20 @@ _HERMES_CONFIG_PATH = (
     r'(?:\$hermes_home|\$\{hermes_home\})/)'
     r'config\.yaml\b'
 )
+# Hermes-root credential stores. `agent/file_safety` already denies these to
+# write_file/patch — classifying mcp-tokens/ and pairing/ as "credential" — but
+# the terminal side had no rule, so `echo x >> ~/.hermes/mcp-tokens/x.json` was
+# auto-approved: the unpaired theater _HERMES_CONFIG_PATH names above, over live
+# MCP OAuth bearer tokens, device-pairing material, and the Anthropic PKCE
+# refresh store. Directory forms are PREFIX matches. sessions/ and state.db are
+# excluded — application-owned transcript state denied to stop history
+# falsification, not credentials, and the media denylist skips them too (#41071).
+_HERMES_CREDENTIAL_PATH = (
+    r'(?:~\/\.hermes/|'
+    r'(?:\$home|\$\{home\})/\.hermes/|'
+    r'(?:\$hermes_home|\$\{hermes_home\})/)'
+    r'(?:mcp-tokens(?:/|$)|pairing(?:/|$)|\.anthropic_oauth\.json\b)'
+)
 _PROJECT_ENV_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*\.env(?:\.[^/\s"\'`]+)*)'
 _PROJECT_CONFIG_PATH = r'(?:(?:/|\.{1,2}/)?(?:[^\s/"\'`]+/)*config\.yaml)'
 _SHELL_RC_FILES = (
@@ -433,12 +447,14 @@ _SENSITIVE_WRITE_TARGET = (
     rf'{_SSH_SENSITIVE_PATH}|'
     rf'{_HERMES_ENV_PATH}|'
     rf'{_HERMES_CONFIG_PATH}|'
+    rf'{_HERMES_CREDENTIAL_PATH}|'
     rf'{_SHELL_RC_FILES}|'
     rf'{_CREDENTIAL_FILES})'
 )
 _USER_SENSITIVE_WRITE_TARGET = (
     rf'(?:{_SSH_SENSITIVE_PATH}|'
     rf'{_SHELL_RC_FILES}|'
+    rf'{_HERMES_CREDENTIAL_PATH}|'
     rf'{_CREDENTIAL_FILES})'
 )
 _PROJECT_SENSITIVE_WRITE_TARGET = rf'(?:{_PROJECT_ENV_PATH}|{_PROJECT_CONFIG_PATH})'


### PR DESCRIPTION
## What does this PR do?

Closes an unpaired guard. `agent/file_safety` already denies the Hermes-root credential stores to `write_file`/`patch` — and classifies `mcp-tokens/` and `pairing/` as `"credential"` — but the terminal path had no matching rule, so shell writes were auto-approved.

That is the exact shape `_HERMES_CONFIG_PATH` calls out in its own comment ("otherwise the deny is unpaired theater"), and the same live-bearer-token class the media denylist already pairs in `gateway/platforms/base.py`.

Measured on current `origin/main`, across seven write vectors (`>>`, `>`, `tee -a`, `cp` dest, `mv` dest, `install`, `sed -i`):

| Path | file-write guard | terminal |
|---|---|---|
| `mcp-tokens/github.json` | DENIED | **0/7** |
| `mcp-tokens/github.client.json` | DENIED | **0/7** |
| `pairing/device.json` | DENIED | **0/7** |
| `.anthropic_oauth.json` | DENIED | **0/7** |
| `config.yaml` *(control)* | — | 7/7 |
| `.env` *(control)* | DENIED | 7/7 |

All **42** vector/target combinations were ungated. All 42 are now gated, including the `$HERMES_HOME/` and `$HOME/.hermes/` spellings.

What each store holds:

- **`mcp-tokens/`** — live MCP OAuth access tokens (`<server>.json`) plus dynamically-registered client credentials (`<server>.client.json`), per `tools/mcp_oauth.py`.
- **`pairing/`** — device-pairing material.
- **`.anthropic_oauth.json`** — the Anthropic PKCE refresh-credential store.

Directory forms are prefix matches, so any file beneath them is covered rather than only the canonical filename.

## Scope: `sessions/` deliberately excluded

Re-measuring surfaced `sessions/state.db` as write-denied too, which my first pass had assumed was a negative control. It is **not** in this class. `file_safety`'s own comment scopes that deny to *"session transcripts are application-owned state ... can falsify conversation history and invalidate resume/compression state"* — a data-integrity concern, not a credential one. The media denylist keeps them out for the same reason (`#41071`). Gating them here would misclassify them, so `test_session_state_is_not_gated_here` pins them as unaffected.

## How Has This Been Tested?

`tests/tools/test_approval.py` → **123 passed, 0 failed**. Six approval-consuming suites → **280 passed, 0 failed**, under a normal multi-segment `HOME`.

- **Positive control** — reverting `tools/approval.py` while keeping the new tests fails *exactly* `test_every_write_vector_is_gated` while all four negative-control tests pass. They discriminate.
- **Negative controls, 13 commands unflagged 0/13** — session state; ordinary `~/.hermes` writes (`logs/agent.log`, `skills/mine/SKILL.md`, `notes.txt`, `cache/images/out.png`); near-miss names (`mcp-tokens-backup.json`, `pairing-notes.md`); non-Hermes lookalikes (`~/mcp-tokens/`, `/opt/app/pairing/`); and reads out of the stores (`cat`, `cp … /tmp/x`, `grep -r`).

`ruff check` clean. `ty` reports 7 diagnostics in `tools/approval.py` on both this branch and unmodified `origin/main` — **0 introduced**.

### One pre-existing behaviour, documented not hidden

`.anthropic_oauth.json.bak-notes` **does** flag, because `\b` treats `.` and `-` as word boundaries. That is pre-existing behaviour of every shipped pattern — verified on unmodified `main` for `.env.bak-notes`, `config.yaml.bak-notes`, `.bashrc.bak-notes` and `.netrc.bak-notes`. It is excluded from the negative controls rather than asserted either way.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] 🔧 Refactor

## Related Issue

No existing issue — I searched issues and PRs for the Hermes-root credential terminal gap and found none. Happy to file one first if you prefer that order.

Sibling of #99201 (`$HOME` credential *directories*) and #99182 (bare `$HOME` credential *files* in media delivery). Disjoint paths; this one adds a single new pattern constant.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have added tests that prove my fix is effective (with a positive control proving they fail without it)
- [x] New and existing unit tests pass locally with my changes
- [x] Comments explain the non-obvious parts (why `sessions/` is excluded, which guard this pairs with)
