### PR TITLE
fix(agent): don't retry AgentRouter sensitive-words HTTP 500s

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -597,6 +597,7 @@ _PROVIDER_POLICY_BLOCKED_PATTERNS = [
 #     "usage policies" disambiguating from billing's "exceeded ... policy")
 #   • Anthropic safety refusal ("prompt was flagged by ... safety system")
 #   • OpenAI Responses content filter
+#   • new-api / AgentRouter local word-filter ("sensitive words detected")
 _CONTENT_POLICY_BLOCKED_PATTERNS = [
     # OpenAI Codex (#18028) — message may arrive without an HTTP status
     "flagged for possible cybersecurity risk",
@@ -625,6 +626,15 @@ _CONTENT_POLICY_BLOCKED_PATTERNS = [
     # filter name and is narrow enough that billing / format / auth error
     # strings will not collide. See #32421.
     "new_sensitive",
+    # new-api (QuantumNous) and gateways built on it — including
+    # AgentRouter ``https://agentrouter.org/v1`` — return HTTP 500 with
+    # the verbatim body "sensitive words detected" when their local
+    # word-filter rejects the request. Wrapped as InternalServerError,
+    # the generic 5xx rule retries the identical payload three times
+    # and surfaces "API failed after 3 retries". The phrase is the
+    # gateway's own error string and is narrow enough not to collide
+    # with billing / auth / format errors.
+    "sensitive words detected",
 ]
 
 # Auth patterns (non-status-code signals)

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -642,6 +642,22 @@ class TestClassifyApiError:
         assert result.should_fallback is True
         assert result.should_compress is False
 
+    def test_agentrouter_sensitive_words_500_is_content_policy_blocked(self):
+        # new-api / AgentRouter wrap a local word-filter refusal as HTTP 500
+        # "sensitive words detected". The generic 5xx rule would retry the
+        # identical payload three times; this must fail fast to fallback.
+        e = MockAPIError(
+            "HTTP 500: sensitive words detected "
+            "(request id: 20260901134627270862407sm2v4Hx5BiaTT)",
+            status_code=500,
+        )
+        result = classify_api_error(e, provider="custom", model="glm-5.3")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.should_compress is False
+        assert result.should_rotate_credential is False
+
 
 
 

--- a/tests/run_agent/test_18028_content_policy_blocked.py
+++ b/tests/run_agent/test_18028_content_policy_blocked.py
@@ -41,6 +41,33 @@ class TestContentPolicyBlockedClassification:
         assert result.should_compress is False
         assert result.should_rotate_credential is False
 
+    def test_agentrouter_sensitive_words_http_500(self):
+        """new-api/AgentRouter wraps the word-filter as InternalServerError.
+
+        Without this classification, HTTP 500 + "sensitive words detected"
+        burns api_max_retries on a deterministic refusal and surfaces
+        "API failed after 3 retries" — the same #18028 retry-burn class.
+        """
+        from agent.error_classifier import classify_api_error, FailoverReason
+
+        class _Err(Exception):
+            def __init__(self, msg, status_code):
+                super().__init__(msg)
+                self.status_code = status_code
+
+        e = _Err(
+            "Error code: 500 - {'error': {'message': 'sensitive words detected "
+            "(request id: 2026090113461892951841vt5clFqVF33mI)', "
+            "'type': 'new_api_error', 'code': 'local:sensitive_words'}}",
+            status_code=500,
+        )
+        result = classify_api_error(e, provider="custom", model="glm-5.3")
+        assert result.reason == FailoverReason.content_policy_blocked
+        assert result.retryable is False
+        assert result.should_fallback is True
+        assert result.should_compress is False
+        assert result.should_rotate_credential is False
+
 
 
 class TestContentPolicyTriggersClientErrorAbort:


### PR DESCRIPTION
## Summary
- AgentRouter and other new-api gateways return HTTP 500 `sensitive words detected` when their local word-filter rejects a request. Hermes treated that as a transient server error and retried the identical payload three times, then died with `API failed after 3 retries`.
- Classify the verbatim phrase as `content_policy_blocked` (same path as MiniMax `new_sensitive` / #18028) so the loop skips those retries and can jump to a configured fallback.
- This does not disable the provider filter. A new chat or a less-filtered provider is still the workaround when AgentRouter keeps blocking the history.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_error_classifier.py tests/run_agent/test_18028_content_policy_blocked.py -q`
- [ ] On AgentRouter + GLM: a chat that previously burned 3 retries on `sensitive words detected` should now fail fast with the content-policy message, and use `fallback_model` if configured.