### PR TITLE
fix(desktop): show active session in sidebar even when profile scope filters it

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -490,9 +490,25 @@ export function ChatSidebar({
   // rows, no project tree, no date or status dividers.
   const scopedSessions = useMemo(() => {
     const pool = showArchived ? archivedSessions : sessions
+    const filtered = filterSessionsByProfileScope(pool, profileScope)
 
-    return filterSessionsByProfileScope(pool, profileScope)
-  }, [sessions, archivedSessions, showArchived, profileScope])
+    // The active (focused) session must always be visible in the sidebar
+    // even when a stale profile filter would otherwise hide it. The backend
+    // returns it as the #1 recents row, but a case or scoping mismatch
+    // (e.g. Windows case-insensitive profile dirs) can make the scope
+    // filter drop it, leaving the user looking at a chat that has no row.
+    if (selectedSessionId) {
+      const hasActive = filtered.some(s => s.id === selectedSessionId)
+      if (!hasActive) {
+        const activeRow = pool.find(s => s.id === selectedSessionId)
+        if (activeRow) {
+          return [...filtered, activeRow]
+        }
+      }
+    }
+
+    return filtered
+  }, [sessions, archivedSessions, showArchived, profileScope, selectedSessionId])
 
   // One predicate for the status/project filters, so the flat list and the
   // project lanes narrow by the same rule. A project lane holds rows the loaded
@@ -531,10 +547,20 @@ export function ChatSidebar({
     prFilter.length > 0 ||
     (showAllProfiles && profileFilter.length > 0)
 
-  const visibleSessions = useMemo(
-    () => (filtersNarrow ? scopedSessions.filter(sessionMatchesFilters) : scopedSessions),
-    [scopedSessions, filtersNarrow, sessionMatchesFilters]
-  )
+  const visibleSessions = useMemo(() => {
+    const base = filtersNarrow ? scopedSessions.filter(sessionMatchesFilters) : scopedSessions
+
+    // The active session must survive any filter — the user is looking at
+    // this chat, so hiding its row while its tile is open is always wrong.
+    if (selectedSessionId && !base.some(s => s.id === selectedSessionId)) {
+      const activeRow = scopedSessions.find(s => s.id === selectedSessionId)
+      if (activeRow) {
+        return [...base, activeRow]
+      }
+    }
+
+    return base
+  }, [scopedSessions, filtersNarrow, sessionMatchesFilters, selectedSessionId])
 
   // Recents by activity (last_active || started_at). User send stamps
   // last_active immediately. Ordering by status doesn't sort here — it re-slots

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -62,9 +62,24 @@ const MESSAGING_EXCLUDED_SOURCES = ['cron', ...LOCAL_SESSION_SOURCE_IDS]
 function dropTombstoned(sessions: SessionInfo[]): SessionInfo[] {
   const tombstones = $removedSessionIds.get()
 
-  return tombstones.size
-    ? sessions.filter(s => !tombstones.has(s.id) && !(s._lineage_root_id && tombstones.has(s._lineage_root_id)))
-    : sessions
+  if (!tombstones.size) {
+    return sessions
+  }
+
+  // Never hide the currently viewed session behind a stale tombstone —
+  // the user is looking at this chat, and the backend still lists it
+  // (delete hasn't committed or the tombstone is stale). Hiding it
+  // makes the active session vanish from the sidebar while its tile
+  // is open.
+  const active = $selectedStoredSessionId.get()
+
+  return sessions.filter(s => {
+    if (active && (s.id === active || (s._lineage_root_id && s._lineage_root_id === active))) {
+      return true
+    }
+
+    return !tombstones.has(s.id) && !(s._lineage_root_id && tombstones.has(s._lineage_root_id))
+  })
 }
 
 // Rows a session refresh must preserve even if the aggregator omits them:

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -32,8 +32,10 @@ import type { ProfileInfo } from '@/types/hermes'
 
 // Canonical key for a profile: trimmed, empty → "default". Used everywhere we
 // compare a session's owning profile against the live gateway's profile.
+// Lower-cases so Windows case-insensitive filesystem aliases ("Default" on disk
+// vs "default" from the API) cannot hide a session from its own profile scope.
 export function normalizeProfileKey(name: string | null | undefined): string {
-  const value = (name ?? '').trim()
+  const value = (name ?? '').trim().toLowerCase()
 
   return value || 'default'
 }

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -499,7 +499,7 @@ export function resolveComposerSessionKey(
  *  either its live `id` or its `_lineage_root_id`. Optimistic deletes/archives
  *  drop the row from `previous` (and unpin it), so a removed session can't be
  *  resurrected here. */
-const profileKeyOf = (profile: null | string | undefined): string => (profile ?? '').trim() || 'default'
+const profileKeyOf = (profile: null | string | undefined): string => (profile ?? '').trim().toLowerCase() || 'default'
 
 function carriedConnectionId(prev: SessionInfo | undefined, incoming: SessionInfo): string | undefined {
   if (incoming.connection_id?.trim()) {
@@ -534,7 +534,7 @@ export function mergeSessionPage(
   // carry behavior below.
   // (Local normalize: importing @/store/profile here would be circular —
   // same '' → 'default' rule as normalizeProfileKey.)
-  const profileKeyOf = (session: SessionInfo) => (session.profile ?? '').trim() || 'default'
+  const profileKeyOf = (session: SessionInfo) => (session.profile ?? '').trim().toLowerCase() || 'default'
   const identity = (session: SessionInfo) => `${profileKeyOf(session)}::${session.id}`
 
   const lineageIdentity = (session: SessionInfo) =>


### PR DESCRIPTION
fix(desktop): show active session in sidebar even when profile scope filters it

The sidebar's backend returns the active desktop session as the first
recents row, but the renderer dropped it when the profile scope or
case normalization disagreed (Windows case-insensitive filesystem can
present 'Default' vs 'default') or when a stale tombstone hid the row
while its tile was still open.

- normalizeProfileKey and the session-store profile helpers now
  lower-case, matching the backend's canonical lower-case profile ids.
- dropTombstoned never hides the currently viewed session.
- ChatSidebar keeps the active (focused) session in both the profile-
  scoped and the filter-narrowed lists, so a transient mismatch never
  makes the open chat's row vanish.

Closes #100052