### PR TITLE
fix(cron): preserve monthly next_run on jobs.json resave at month boundary with timezone-aware croniter base

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1119,7 +1119,9 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 "reinstall hermes-agent or run 'pip install croniter' in your runtime env.",
                 expr)
             return None
-        return croniter(expr, base_time).get_next(datetime).isoformat()
+        # croniter may return naive on some platforms/versions; ensure aware so stored
+        # next_run_at preserves the correct UTC offset across DST (#100030).
+        return _ensure_aware(croniter(expr, base_time).get_next(datetime)).isoformat()
     return None
 
 
@@ -1929,7 +1931,37 @@ def _rederive_repeat_for_schedule_change(
     updates["repeat"] = repeat
 
 
-def _apply_schedule_update(updated: Dict[str, Any], updates: Dict[str, Any], job_id: str) -> None:
+def _preserved_resave_next_run(
+    original: Optional[Dict[str, Any]], updated_schedule: Dict[str, Any]
+) -> Optional[str]:
+    """Stored ``next_run_at`` to keep when a resave leaves the cron expr unchanged (#100030).
+
+    Recomputing from now (croniter strictly-after) at a month boundary would jump a monthly
+    "0 0 1 * *" from Sep 1 to Oct 1, skipping the run. None = nothing safe to preserve.
+    """
+    try:
+        old = original.get("schedule") if isinstance(original, dict) else None
+        old_expr = old.get("expr") if isinstance(old, dict) else None
+        new_expr = updated_schedule.get("expr") if isinstance(updated_schedule, dict) else None
+        existing = original.get("next_run_at") if isinstance(original, dict) else None
+        if not (old_expr and new_expr == old_expr and isinstance(existing, str)
+                and updated_schedule.get("kind") == "cron"):
+            return None
+        existing_dt = _ensure_aware(datetime.fromisoformat(existing))
+        if not _cron_next_run_matches_expr(updated_schedule, existing_dt):
+            return None
+        age = (_hermes_now() - existing_dt).total_seconds()
+        if age < 0 or 0 <= age <= _compute_grace_seconds(updated_schedule):
+            return existing
+    except Exception:
+        pass
+    return None
+
+
+def _apply_schedule_update(
+    updated: Dict[str, Any], updates: Dict[str, Any], job_id: str,
+    original: Optional[Dict[str, Any]] = None,
+) -> None:
     """Parse a string schedule, refresh ``schedule_display`` and (unless paused) ``next_run_at``."""
     updated_schedule = updated["schedule"]
     if isinstance(updated_schedule, str):
@@ -1938,8 +1970,12 @@ def _apply_schedule_update(updated: Dict[str, Any], updates: Dict[str, Any], job
     updated["schedule_display"] = updates.get(
         "schedule_display", updated_schedule.get("display", updated.get("schedule_display")))
     if updated.get("state") != "paused":
-        updated["next_run_at"] = _next_run_or_reject_past_oneshot(
-            updated_schedule, updated.get("name", job_id), updated_schedule, "update ")
+        preserved = _preserved_resave_next_run(original, updated_schedule)
+        if preserved is not None:
+            updated["next_run_at"] = preserved
+        else:
+            updated["next_run_at"] = _next_run_or_reject_past_oneshot(
+                updated_schedule, updated.get("name", job_id), updated_schedule, "update ")
 
 
 def _fill_missing_next_run(updated: Dict[str, Any]) -> None:
@@ -1987,7 +2023,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
         ) and _normalized_inference_axes(updated) != previous_inference_axes
 
         if "schedule" in updates:
-            _apply_schedule_update(updated, updates, job_id)
+            _apply_schedule_update(updated, updates, job_id, job)
         if inference_fields_changed:
             snapshots = _compute_provider_model_snapshots(
                 provider=updated.get("provider"),

--- a/tests/cron/test_resave_preserves_next_run_100030.py
+++ b/tests/cron/test_resave_preserves_next_run_100030.py
@@ -1,0 +1,48 @@
+"""Resaving jobs.json with an unchanged cron expr must not skip the current run (#100030)."""
+
+import pytest
+from datetime import datetime
+
+from cron.jobs import (
+    create_job,
+    get_job,
+    load_jobs,
+    save_jobs,
+    update_job,
+    _hermes_now,
+)
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def test_resave_same_cron_expr_preserves_current_fire(tmp_cron_dir):
+    """A resave (same expr) keeps the stored next_run instead of recomputing from now.
+
+    Without the fix, croniter's strictly-after semantics recompute the *next* minute,
+    skipping the current minute's execution — the monthly "0 0 1 * *" variant of this
+    jumped from Sep 1 to Oct 1.
+    """
+    job = create_job(prompt="tick", schedule="* * * * *", name="per-minute")
+    current_fire = _hermes_now().replace(second=0, microsecond=0)
+    jobs = load_jobs()
+    assert len(jobs) == 1
+    jobs[0]["next_run_at"] = current_fire.isoformat()
+    save_jobs(jobs)
+
+    updated = update_job(job["id"], {"schedule": dict(get_job(job["id"])["schedule"])})
+    assert updated["next_run_at"] == current_fire.isoformat()
+
+
+def test_resave_changed_expr_recomputes(tmp_cron_dir):
+    """A genuine expr change must NOT preserve the stale next_run."""
+    job = create_job(prompt="tick", schedule="* * * * *", name="per-minute")
+    updated = update_job(job["id"], {"schedule": "0 * * * *"})
+    assert updated["schedule"]["expr"] == "0 * * * *"
+    assert datetime.fromisoformat(updated["next_run_at"]).minute == 0


### PR DESCRIPTION
fix(cron): preserve monthly next_run on jobs.json resave at month boundary with timezone-aware croniter base

Resaving jobs.json at the month boundary (e.g. 0 0 1 * * at Sep 1 00:00:01 IDT) recomputed next_run from now using croniter strictly-after semantics, jumping from Sep 1 to Oct 1 and skipping the scheduled execution. The UTC/local conversion (IDT UTC+3) amplified the window where base matched the target instant.

- compute_next_run: ensure base and result are timezone-aware in Hermes timezone so croniter evaluates wall-clock correctly and preserves offset across DST
- update_job: when schedule expr unchanged and stored next_run still matches expr and is still upcoming or within catch-up grace, preserve it instead of recomputing from now

Closes #100030