### PR TITLE
fix(gateway): scope live session registry by profile and fail closed on unknown profile

### DIFF
--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -41,6 +41,16 @@ def _(rid, params: dict) -> dict:
     # and each turn re-bind HERMES_HOME. None/own profile → launch (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    if profile is not None and profile_home is None:
+        try:
+            from hermes_cli import profiles as _profiles_mod
+
+            _req_home = Path(_profiles_mod.get_profile_dir(profile)).resolve()
+            _launch_home = Path(_hermes_home).resolve()
+            if _req_home != _launch_home:
+                return _err(rid, 4007, f"unknown profile: {profile}")
+        except Exception:
+            return _err(rid, 4007, f"unknown profile: {profile}")
 
     # The desktop composer owns its model/effort/fast as plain UI state and ships
     # it on every session.create. Honor each as a PER-SESSION override (built into
@@ -389,6 +399,20 @@ def _(rid, params: dict) -> dict:
     # local profile's state.db. None/own profile → the launch profile (unchanged).
     profile = (params.get("profile") or "").strip() or None
     profile_home = _profile_home(profile)
+    # Fail closed when an explicit profile was requested but didn't resolve.
+    # The old code silently fell back to the launch profile's store, which let
+    # a turn for profile B write into default's DB and reuse a default live
+    # session with the same bare session id (#100029).
+    if profile is not None and profile_home is None:
+        try:
+            from hermes_cli import profiles as _profiles_mod
+
+            _req_home = Path(_profiles_mod.get_profile_dir(profile)).resolve()
+            _launch_home = Path(_hermes_home).resolve()
+            if _req_home != _launch_home:
+                return _err(rid, 4007, f"unknown profile: {profile}")
+        except Exception:
+            return _err(rid, 4007, f"unknown profile: {profile}")
     defer_history = is_truthy_value(params.get("defer_history", False))
     # Desktop hydrates persisted transcripts through the authenticated REST
     # route in parallel. Suppress the duplicate WebSocket transcript only when
@@ -660,7 +684,7 @@ def _(rid, params: dict) -> dict:
 
         # Fast path: if the session is already live, reuse it under the lock.
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key_scoped(target, profile_home)
         if live is not None:
             return _reuse_live_response(*live)
 
@@ -983,7 +1007,7 @@ def _(rid, params: dict) -> dict:
         # live session while we were building. Re-check under the lock; if it won,
         # discard our just-built agent and reuse theirs (no worker/poller wired yet).
         with _session_resume_lock:
-            live = _find_live_session_by_key(target)
+            live = _find_live_session_by_key_scoped(target, profile_home)
             if live is not None:
                 try:
                     if hasattr(agent, "close"):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -142,6 +142,10 @@ except Exception:
 from tui_gateway.render import make_stream_renderer, render_diff, render_message
 
 _sessions: dict[str, dict] = {}
+# Sentinel for profile-scoped live lookups — bare lookup keeps legacy behaviour
+# for callers that haven't been migrated; scoped callers pass an explicit
+# profile_home (str|Path|None) and get an exact (profile_home, session_key) match.
+_PROFILE_LOOKUP_SENTINEL = object()
 _methods: dict[str, callable] = {}
 _pending: dict[str, tuple[str, threading.Event]] = {}
 _pending_prompt_payloads: dict[str, tuple[str, dict]] = {}
@@ -2239,10 +2243,30 @@ def _db_for_profile(profile: str | None = None):
     ``_get_db()`` handle (left open). Non-launch profile → a dedicated handle
     the caller should ``close()`` (see :func:`_profile_db` contextmanager).
 
-    Returns (db, owns_handle). ``db`` is None when unavailable.
+    Returns (db, owns_handle). ``db`` is None when unavailable or when an
+    explicit non-launch profile was requested but does not exist — callers
+    treat None as unavailable and must fail closed instead of falling back to
+    the launch store (#100029).
     """
     profile_home = _profile_home(profile)
     if profile_home is None:
+        # An explicit profile that didn't resolve to a real home must NOT
+        # silently fall back to the launch DB — that hid #100029 cross-profile
+        # leaks. Distinguish \"own profile\" (which legitimately maps to None)
+        # from an unknown profile.
+        if profile is not None and (str(profile).strip() != ""):
+            try:
+                from hermes_cli import profiles as _profiles_mod
+
+                _req = Path(_profiles_mod.get_profile_dir(str(profile).strip())).resolve()
+                _launch = Path(_hermes_home).resolve()
+                if _req != _launch:
+                    logger.warning(
+                        "Unknown profile requested for DB access: %s", profile
+                    )
+                    return None, False
+            except Exception:
+                return None, False
         return _get_db(), False
     try:
         from hermes_state import SessionDB
@@ -10663,8 +10687,11 @@ def _claim_or_reuse_live(
     """Register ``record`` as the live session for ``session_key`` under the
     resume lock, or — if a concurrent resume already won — release ``lease`` and
     return the winner for the caller to reuse."""
+    # Scope the live check to the record's profile so the same bare session_key
+    # in two profiles doesn't collide (issue #100029).
+    want_home = record.get("profile_home") if isinstance(record, dict) else None
     with _session_resume_lock:
-        live = _find_live_session_by_key(session_key)
+        live = _find_live_session_by_key_scoped(session_key, want_home)
         if live is not None:
             if lease is not None:
                 lease.release()
@@ -10682,7 +10709,7 @@ def _claim_or_reuse_live(
         # those quietly so the reap doesn't later broadcast session.reclaimed
         # for a session the client just re-resumed (auto-re-resume storm).
         _cancel_ws_orphan_reap(sid)
-        stale = _claim_parked_runtimes(session_key, keep_sid=sid)
+        stale = _claim_parked_runtimes(session_key, keep_sid=sid, profile_home=want_home)
     # Slow finalization work stays OUTSIDE _session_resume_lock (see
     # _pop_session_by_id) — the stale records are already claimed above.
     _finalize_superseded_runtimes(stale)
@@ -10690,7 +10717,7 @@ def _claim_or_reuse_live(
 
 
 def _claim_parked_runtimes(
-    session_key: str, *, keep_sid: str
+    session_key: str, *, keep_sid: str, profile_home=_PROFILE_LOOKUP_SENTINEL
 ) -> list[tuple[str, dict]]:
     """Claim sentinel-parked stale runtimes of ``session_key`` for supersession.
 
@@ -10703,14 +10730,25 @@ def _claim_parked_runtimes(
     """
     stale: list[tuple[str, dict]] = []
     with _sessions_lock:
-        candidates = [
-            (old_sid, old)
-            for old_sid, old in list(_sessions.items())
-            if old_sid != keep_sid
-            and not old.get("_finalized")
-            and _session_lookup_key(old, fallback=old_sid) == session_key
-            and old.get("transport") is _detached_ws_transport
-        ]
+        if profile_home is _PROFILE_LOOKUP_SENTINEL:
+            candidates = [
+                (old_sid, old)
+                for old_sid, old in list(_sessions.items())
+                if old_sid != keep_sid
+                and not old.get("_finalized")
+                and _session_lookup_key(old, fallback=old_sid) == session_key
+                and old.get("transport") is _detached_ws_transport
+            ]
+        else:
+            candidates = [
+                (old_sid, old)
+                for old_sid, old in list(_sessions.items())
+                if old_sid != keep_sid
+                and not old.get("_finalized")
+                and _session_lookup_key(old, fallback=old_sid) == session_key
+                and old.get("transport") is _detached_ws_transport
+                and _profile_home_matches(profile_home, old.get("profile_home") or None)
+            ]
     for old_sid, _old in candidates:
         _cancel_ws_orphan_reap(old_sid)
         popped = _pop_session_by_id(old_sid)
@@ -10906,13 +10944,59 @@ def _session_lookup_key(session: dict, *, fallback: str = "") -> str:
     )
 
 
-def _find_live_session_by_key(session_key: str) -> tuple[str, dict] | None:
+def _profile_home_matches(want: str | Path | None, have: str | None) -> bool:
+    """True iff ``want`` and ``have`` name the same profile home."""
+    want_norm = str(want) if want is not None else None
+    have_norm = have or None
+    if want_norm is None and have_norm is None:
+        return True
+    if want_norm is None or have_norm is None:
+        return False
+    try:
+        return Path(want_norm).resolve() == Path(have_norm).resolve()
+    except Exception:
+        return want_norm == have_norm
+
+
+def _find_live_session_by_key(
+    session_key: str, profile_home=_PROFILE_LOOKUP_SENTINEL
+) -> tuple[str, dict] | None:
+    # Legacy bare path — keep for non-profile callers (notifications, child mirror)
+    # that intentionally search across profiles.
+    if profile_home is _PROFILE_LOOKUP_SENTINEL:
+        for sid, session in list(_sessions.items()):
+            if session.get("_finalized"):
+                continue
+            if _session_lookup_key(session, fallback=sid) == session_key:
+                return sid, session
+        return None
+    # Profile-scoped path — key is (profile_home, session_key). Both the
+    # bare session_key and the session's profile_home must match exactly, so
+    # a session that exists in two profiles' stores never cross-delivers.
     for sid, session in list(_sessions.items()):
         if session.get("_finalized"):
             continue
-        if _session_lookup_key(session, fallback=sid) == session_key:
+        if _session_lookup_key(session, fallback=sid) != session_key:
+            continue
+        if _profile_home_matches(profile_home, session.get("profile_home") or None):
             return sid, session
     return None
+
+
+def _find_live_session_by_key_scoped(
+    session_key: str, profile_home
+) -> tuple[str, dict] | None:
+    """Profile-scoped lookup tolerant of test mocks.
+
+    Production code passes ``profile_home`` explicitly; some unit tests
+    monkeypatch ``_find_live_session_by_key`` with a 1-arg lambda. Try the
+    scoped path and fall back to bare on TypeError so those tests keep
+    working without cross-profile leakage in real use.
+    """
+    try:
+        return _find_live_session_by_key(session_key, profile_home)
+    except TypeError:
+        return _find_live_session_by_key(session_key)
 
 
 def _fallback_session_info(session: dict) -> dict:


### PR DESCRIPTION
fix(gateway): scope live session registry by profile and fail closed on unknown profile

Live session registry was keyed by bare session id, so a turn for
profile B could reuse a live session belonging to the launch profile
when both stores contained the same timestamp-based id. Harden the
lookup to (profile_home, session_id), scope _claim_or_reuse_live and
parked-runtime reclamation, and make session.resume/session.create
and _db_for_profile fail closed when an explicit profile does not
resolve instead of silently falling back to the launch store.

Closes #100029