### PR TITLE
feat(desktop): full built-in optional-skills catalog appears in Capabilities → Skills with one-click install

### DIFF
--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -592,6 +592,7 @@ const LOCAL_PRIMARY_SCOPED_ROUTES = new Set([
   'GET /api/skills/content',
   'PUT /api/skills/toggle',
   'POST /api/skills/hub/install',
+  'GET /api/skills/hub/official',
   'GET /api/skills/hub/preview',
   'GET /api/skills/hub/scan',
   'GET /api/skills/hub/search',

--- a/apps/desktop/src/api/skills.ts
+++ b/apps/desktop/src/api/skills.ts
@@ -1,4 +1,5 @@
 import type {
+  OfficialSkillInfo,
   SkillHubPreview,
   SkillHubScanResult,
   SkillHubSearchResponse,
@@ -95,6 +96,16 @@ export function editLearningNode(
 
 const HUB_REQUEST_TIMEOUT_MS = 45_000
 
+/** The full built-in optional-skills catalog (local checkout scan — fast),
+ *  with per-profile installed flags. Feeds the Capabilities Skills list's
+ *  "available to install" rows. */
+export function getOfficialSkills(profile?: ProfileScope): Promise<{ skills: OfficialSkillInfo[] }> {
+  return window.hermesDesktop.api<{ skills: OfficialSkillInfo[] }>({
+    ...capabilityScoped(profile),
+    path: '/api/skills/hub/official'
+  })
+}
+
 export function getSkillHubSources(profile?: null | string): Promise<SkillHubSourcesResponse> {
   return hermesApi<SkillHubSourcesResponse>({
     ...profileScoped(profile),
@@ -118,9 +129,9 @@ export function searchSkillsHub(
   })
 }
 
-export function previewSkillHub(identifier: string, profile?: null | string): Promise<SkillHubPreview> {
-  return hermesApi<SkillHubPreview>({
-    ...profileScoped(profile),
+export function previewSkillHub(identifier: string, profile?: ProfileScope): Promise<SkillHubPreview> {
+  return window.hermesDesktop.api<SkillHubPreview>({
+    ...capabilityScoped(profile),
     path: `/api/skills/hub/preview?identifier=${encodeURIComponent(identifier)}`,
     timeoutMs: HUB_REQUEST_TIMEOUT_MS
   })

--- a/apps/desktop/src/app/master-detail.tsx
+++ b/apps/desktop/src/app/master-detail.tsx
@@ -418,23 +418,27 @@ export function ListStripButton({
 }
 
 interface CapRowProps {
+  /** Rendered in the switch slot instead of the Switch (e.g. an Install
+   *  button for not-yet-installed catalog rows). */
+  action?: ReactNode
   active: boolean
   busy?: boolean
   enabled: boolean
   meta?: ReactNode
   onSelect: () => void
-  onToggle: (checked: boolean) => void
+  onToggle?: (checked: boolean) => void
   rowId?: string
   /** Second line under the name (category, description, status). Rows grow to h-11. */
   subtitle?: ReactNode
   title: string
-  toggleLabel: string
+  toggleLabel?: string
 }
 
 // The one row used by all three lists. Fixed height, always-visible switch —
 // state reads from the switch + dimmed title, toggling never requires
 // selecting first. Off rows dim; the switch itself dims when off.
 export function CapRow({
+  action,
   active,
   busy,
   enabled,
@@ -484,15 +488,19 @@ export function CapRow({
           </span>
         )}
       </RowButton>
-      <Switch
-        aria-label={toggleLabel}
-        checked={enabled}
-        className={cn('mr-1.5 shrink-0 cursor-pointer', !enabled && 'opacity-60')}
-        disabled={busy}
-        onCheckedChange={onToggle}
-        size="xs"
-        title={toggleLabel}
-      />
+      {action != null ? (
+        <span className="mr-1.5 flex shrink-0 items-center">{action}</span>
+      ) : (
+        <Switch
+          aria-label={toggleLabel ?? title}
+          checked={enabled}
+          className={cn('mr-1.5 shrink-0 cursor-pointer', !enabled && 'opacity-60')}
+          disabled={busy}
+          onCheckedChange={onToggle}
+          size="xs"
+          title={toggleLabel ?? title}
+        />
+      )}
     </div>
   )
 }

--- a/apps/desktop/src/app/skills/index.test.tsx
+++ b/apps/desktop/src/app/skills/index.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as HermesApi from '@/hermes'
 import { queryClient } from '@/lib/query-client'
+import type * as HubActions from '@/store/hub-actions'
 
 const getSkills = vi.fn()
 const getToolsets = vi.fn()
@@ -17,6 +18,7 @@ const selectToolsetProvider = vi.fn()
 const getUsageAnalytics = vi.fn()
 const getProfiles = vi.fn()
 const getSkillContent = vi.fn()
+const getOfficialSkills = vi.fn()
 
 // Partial mock: keep the real module (SkillsView pulls in @/store/profile,
 // whose import-time subscription calls setApiRequestProfile) and stub only the
@@ -33,13 +35,22 @@ vi.mock('@/hermes', async importOriginal => ({
   selectToolsetProvider: (toolset: string, provider: string) => selectToolsetProvider(toolset, provider),
   getUsageAnalytics: (days: number, profile?: null | string) => getUsageAnalytics(days, profile),
   getProfiles: () => getProfiles(),
-  getSkillContent: (name: string, profile?: null | string) => getSkillContent(name, profile)
+  getSkillContent: (name: string, profile?: null | string) => getSkillContent(name, profile),
+  getOfficialSkills: (profile?: null | string) => getOfficialSkills(profile)
 }))
 
 // Notifications hit nanostores/timers we don't care about here.
 vi.mock('@/store/notifications', () => ({
   notify: vi.fn(),
   notifyError: vi.fn()
+}))
+
+// The catalog Install button routes through the hub action pipeline — stub the
+// action entrypoint (real module kept: SkillsView reads $hubActions and the
+// query keys from it).
+vi.mock('@/store/hub-actions', async importOriginal => ({
+  ...(await importOriginal<typeof HubActions>()),
+  installHubSkill: vi.fn().mockResolvedValue(undefined)
 }))
 
 // The vision detail navigates to Settings → Models via useNavigate; spy on it
@@ -87,6 +98,7 @@ beforeEach(() => {
   setToolsetEnabled.mockResolvedValue({ ok: true, name: 'web', enabled: false })
   getToolsetConfig.mockResolvedValue({ has_category: true, active_provider: null, providers: [] })
   getUsageAnalytics.mockResolvedValue({ tools: [] })
+  getOfficialSkills.mockResolvedValue({ skills: [] })
   getSkillContent.mockResolvedValue({
     name: 'web-research',
     path: '/skills/web-research/SKILL.md',
@@ -432,5 +444,82 @@ describe('SkillsView toolset management', { timeout: 60_000 }, () => {
     } finally {
       delete (window as { hermesDesktop?: unknown }).hermesDesktop
     }
+  })
+
+  it('lists the built-in optional-skills catalog with Install buttons that route through the hub pipeline', async () => {
+    // The full official catalog renders BELOW the installed list; each row
+    // carries an Install button (no toggle until installed) that routes
+    // through the standard hub action pipeline scoped to the Capabilities
+    // profile. Already-installed catalog entries are filtered out.
+    const { installHubSkill } = await import('@/store/hub-actions')
+
+    getSkills.mockResolvedValue([
+      {
+        name: 'web-research',
+        description: 'Research the web',
+        category: 'research',
+        enabled: true,
+        usage: 3,
+        provenance: 'bundled'
+      }
+    ])
+    getOfficialSkills.mockResolvedValue({
+      skills: [
+        {
+          name: 'gif-search',
+          description: 'Search GIFs',
+          identifier: 'official/gifs/gif-search',
+          category: 'gifs',
+          installed: false,
+          tags: ['gifs']
+        },
+        {
+          name: 'web-research',
+          description: 'already here under a different source',
+          identifier: 'official/research/web-research',
+          category: 'research',
+          installed: false,
+          tags: []
+        },
+        {
+          name: 'ascii-art',
+          description: 'ASCII art',
+          identifier: 'official/creative/ascii-art',
+          category: 'creative',
+          installed: true,
+          tags: []
+        }
+      ]
+    })
+
+    const { SkillsView } = await import('./index')
+    await act(async () => {
+      render(
+        <QueryClientProvider client={queryClient}>
+          <MemoryRouter initialEntries={['/skills?tab=skills']}>
+            <SkillsView />
+          </MemoryRouter>
+        </QueryClientProvider>
+      )
+    })
+
+    // Catalog section header + the one genuinely-available row. Rows already
+    // installed (lock flag OR name collision with the installed list) are gone.
+    expect(await screen.findByText('Available to install')).toBeTruthy()
+    expect(await screen.findByText('gif-search')).toBeTruthy()
+    expect(screen.queryByText('ascii-art')).toBeNull()
+
+    // The installed skill still shows its toggle; the catalog row shows
+    // Install instead of a switch.
+    expect(screen.getByRole('switch', { name: 'web-research' })).toBeTruthy()
+    const install = screen.getByRole('button', { name: 'Install' })
+
+    await act(async () => {
+      fireEvent.click(install)
+    })
+
+    await waitFor(() =>
+      expect(vi.mocked(installHubSkill)).toHaveBeenCalledWith('official/gifs/gif-search', expect.anything())
+    )
   })
 })

--- a/apps/desktop/src/app/skills/index.tsx
+++ b/apps/desktop/src/app/skills/index.tsx
@@ -15,11 +15,13 @@ import type { DesktopRosterAgent } from '@/global'
 import {
   editLearningNode,
   getLearningNode,
+  getOfficialSkills,
   getProfiles,
   getSkillContent,
   getSkills,
   getToolsets,
   getUsageAnalytics,
+  previewSkillHub,
   type ProfileScope,
   profileScopeKey,
   setSkillEnabled,
@@ -28,14 +30,16 @@ import {
 import { useI18n } from '@/i18n'
 import { isDesktopToolsetVisible } from '@/lib/desktop-toolsets'
 import { compactNumber } from '@/lib/format'
+import { Loader2 } from '@/lib/icons'
 import { queryClient } from '@/lib/query-client'
 import { invalidateSlashCompletions } from '@/lib/slash-completion-cache'
 import { normalize } from '@/lib/text'
 import { useStoreSelector } from '@/lib/use-session-slice'
 import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
+import { $hubActions, installHubSkill, OFFICIAL_SKILLS_KEY } from '@/store/hub-actions'
 import { notify, notifyError } from '@/store/notifications'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
-import type { SkillInfo, ToolsetInfo } from '@/types/hermes'
+import type { OfficialSkillInfo, SkillInfo, ToolsetInfo } from '@/types/hermes'
 
 import { useOnProfileSwitch } from '../hooks/use-on-profile-switch'
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
@@ -145,6 +149,23 @@ function filteredSkills(skills: SkillInfo[], query: string, desc: boolean): Skil
         !q || includesQuery(skill.name, q) || includesQuery(skill.description, q) || includesQuery(skill.category, q)
     )
     .sort((a, b) => sign * (usageOf(b) - usageOf(a)) || asText(a.name).localeCompare(asText(b.name)))
+}
+
+// Catalog rows have no usage yet — plain A–Z, same query fields as installed
+// rows plus tags (the catalog's frontmatter tags are its richest search text).
+function filteredOfficial(skills: OfficialSkillInfo[], query: string): OfficialSkillInfo[] {
+  const q = normalize(query)
+
+  return skills
+    .filter(
+      skill =>
+        !q ||
+        includesQuery(skill.name, q) ||
+        includesQuery(skill.description, q) ||
+        includesQuery(skill.category, q) ||
+        skill.tags.some(tag => includesQuery(tag, q))
+    )
+    .sort((a, b) => asText(a.name).localeCompare(asText(b.name)))
 }
 
 const toolsetCalls = (toolset: ToolsetInfo, toolCalls: Record<string, number>): number =>
@@ -314,6 +335,17 @@ export function SkillsView({
     staleTime: 0
   })
 
+  // The built-in optional-skills catalog (optional-skills/ shipped with the
+  // repo) — rendered under the installed list with install buttons. Local
+  // checkout scan on the backend, so it's cheap; failures (older backend
+  // without the endpoint) just render no catalog rows.
+  const { data: officialData } = useQuery({
+    queryKey: [...OFFICIAL_SKILLS_KEY, scopeKey],
+    queryFn: () => getOfficialSkills(scopeProfile),
+    staleTime: 60_000,
+    retry: false
+  })
+
   // Optimistic write-through against the scoped Skills key: toggles/bulk/
   // archive repaint instantly; the next background refetch reconciles.
   const setSkills = useCallback(
@@ -332,12 +364,16 @@ export function SkillsView({
   const toolsetsSortDesc = useStore($toolsetsSortDesc)
   const [bulkBusy, setBulkBusy] = useState(false)
   const [selectedSkill, setSelectedSkill] = useState<string | null>(null)
+  // Catalog selection is separate from installed-skill selection: identifiers
+  // (official/<category>/<name>) vs names. Non-null wins the detail pane.
+  const [selectedOfficial, setSelectedOfficial] = useState<string | null>(null)
   const [selectedToolset, setSelectedToolset] = useState<string | null>(null)
 
   const refreshCapabilities = useCallback(async () => {
     await Promise.all([
       queryClient.invalidateQueries({ queryKey: SKILLS_QUERY_KEY }),
-      queryClient.invalidateQueries({ queryKey: TOOLSETS_QUERY_KEY })
+      queryClient.invalidateQueries({ queryKey: TOOLSETS_QUERY_KEY }),
+      queryClient.invalidateQueries({ queryKey: OFFICIAL_SKILLS_KEY })
     ])
 
     invalidateSlashCompletions()
@@ -395,12 +431,37 @@ export function SkillsView({
     toolCallsEpoch.current += 1
     setToolCalls(null)
     setScopeOverride(null)
+    setSelectedOfficial(null)
   })
 
   const visibleSkills = useMemo(
     () => (skills ? filteredSkills(skills, query, skillsSortDesc) : []),
     [query, skills, skillsSortDesc]
   )
+
+  // Installed-name set for the hub picker's already-installed guard — the
+  // UNFILTERED list on purpose (search must not make a skill look absent).
+  const installedSkillNames = useMemo(() => new Set((skills ?? []).map(s => s.name)), [skills])
+
+  // Catalog rows still available to install: drop entries whose lock says
+  // installed AND entries whose name already appears in the installed list
+  // (covers installs from before the lock existed, or by hand).
+  const visibleOfficial = useMemo(() => {
+    const catalog = (officialData?.skills ?? []).filter(s => !s.installed && !installedSkillNames.has(s.name))
+
+    return filteredOfficial(catalog, query)
+  }, [installedSkillNames, officialData, query])
+
+  // Identifiers with a hub install currently running — selected as a joined
+  // string so $hubActions' per-log-line churn doesn't re-render the list.
+  const runningInstallKey = useStoreSelector($hubActions, actions =>
+    Object.keys(actions)
+      .filter(key => actions[key]?.running)
+      .sort()
+      .join('|')
+  )
+
+  const runningInstalls = useMemo(() => new Set(runningInstallKey.split('|').filter(Boolean)), [runningInstallKey])
 
   const visibleToolsets = useMemo(
     () => (toolsets ? filteredToolsets(toolsets, query, toolCalls ?? {}, toolsetsSortDesc) : []),
@@ -412,10 +473,6 @@ export function SkillsView({
   // control that silently scoped to the current query would be a lie.
   const bulkSkills = skills ?? []
   const bulkToolsets = useMemo(() => (toolsets ?? []).filter(ts => isDesktopToolsetVisible(ts.name)), [toolsets])
-
-  // Installed-name set for the hub picker's already-installed guard — the
-  // UNFILTERED list on purpose (search must not make a skill look absent).
-  const installedSkillNames = useMemo(() => new Set((skills ?? []).map(s => s.name)), [skills])
 
   // Rotating placeholder nudges from the user's own data — teach that search
   // understands categories and tool names, not just titles.
@@ -451,6 +508,13 @@ export function SkillsView({
     [selectedSkill, visibleSkills]
   )
 
+  // A selected catalog row wins the detail pane; it clears when filtered out
+  // (or when its install finishes and the row leaves the catalog list).
+  const activeOfficial = useMemo(
+    () => visibleOfficial.find(s => s.identifier === selectedOfficial) ?? null,
+    [selectedOfficial, visibleOfficial]
+  )
+
   const activeToolset = useMemo(
     () => visibleToolsets.find(ts => ts.name === selectedToolset) ?? visibleToolsets[0] ?? null,
     [selectedToolset, visibleToolsets]
@@ -473,6 +537,16 @@ export function SkillsView({
       )
       notifyError(err, t.skills.failedToUpdate(skill.name))
     }
+  }
+
+  // Catalog install: routes through the standard hub action pipeline
+  // (background action + tailed log + query invalidation), same as the
+  // embedded hub picker — the row's button spins off ITS $hubActions entry
+  // and the finished install refetches both lists, flipping the row from the
+  // catalog section into the installed section with the normal toggle.
+  function handleInstallOfficial(skill: OfficialSkillInfo) {
+    notify({ kind: 'success', title: t.skills.hub.installStarted(skill.name), message: t.skills.hub.actionLog })
+    void installHubSkill(skill.identifier, scopeProfile).catch(err => notifyError(err, t.skills.hub.actionFailed))
   }
 
   async function handleToggleToolset(toolset: ToolsetInfo, enabled: boolean) {
@@ -700,6 +774,7 @@ export function SkillsView({
     setSkillEditor(null)
     setSkillDraft('')
     setArchiveTarget(null)
+    setSelectedOfficial(null)
   }
 
   // Scope-selector rows. Multi-connection desktops list every reachable
@@ -816,7 +891,7 @@ export function SkillsView({
               // short window shrinks the HUB, never the list: the sort strip
               // and "changes apply" footer can no longer be starved to 0px
               // and painted over by the hub header.
-              visibleSkills.length === 0 ? (
+              visibleSkills.length === 0 && visibleOfficial.length === 0 ? (
                 capabilityEmpty('skills')
               ) : (
                 <MasterDetail pane={skillEditorPane} resizeId="capabilities-split" split="wide">
@@ -842,27 +917,73 @@ export function SkillsView({
                   >
                     {visibleSkills.map(skill => (
                       <CapRow
-                        active={activeSkill?.name === skill.name}
+                        active={activeOfficial === null && activeSkill?.name === skill.name}
                         busy={bulkBusy}
                         enabled={skill.enabled}
                         key={skill.name}
                         meta={usageOf(skill) > 0 ? `×${compactNumber(usageOf(skill))}` : undefined}
-                        onSelect={() => setSelectedSkill(skill.name)}
+                        onSelect={() => {
+                          setSelectedSkill(skill.name)
+                          setSelectedOfficial(null)
+                        }}
                         onToggle={enabled => void handleToggleSkill(skill, enabled)}
                         subtitle={skillSubtitle(skill)}
                         title={skill.name}
                         toggleLabel={skill.name}
                       />
                     ))}
+                    {/* The built-in optional-skills catalog, below the
+                        installed list: every official skill Hermes ships but
+                        hasn't installed yet, with a one-click install that
+                        flips the row into the installed section above. */}
+                    {visibleOfficial.length > 0 && (
+                      <div className="flex h-7 shrink-0 items-end px-2 pb-1 text-[0.62rem] font-medium uppercase tracking-wide text-(--ui-text-quaternary)">
+                        {t.skills.officialCatalog}
+                      </div>
+                    )}
+                    {visibleOfficial.map(skill => {
+                      const installing = runningInstalls.has(skill.identifier)
+
+                      return (
+                        <CapRow
+                          action={
+                            <Button
+                              disabled={installing}
+                              onClick={() => handleInstallOfficial(skill)}
+                              size="xs"
+                              variant="text"
+                            >
+                              {installing && <Loader2 className="size-3 animate-spin" />}
+                              {installing ? t.skills.hub.installing : t.skills.hub.install}
+                            </Button>
+                          }
+                          active={activeOfficial?.identifier === skill.identifier}
+                          enabled={false}
+                          key={skill.identifier}
+                          onSelect={() => setSelectedOfficial(skill.identifier)}
+                          subtitle={prettyName(skill.category)}
+                          title={skill.name}
+                        />
+                      )
+                    })}
                   </ListColumn>
                   <DetailColumn footer={t.skills.changesApplyNewSessions}>
-                    {activeSkill && (
-                      <SkillDetail
-                        onArchive={() => setArchiveTarget(activeSkill.name)}
-                        onEdit={() => void openSkillEditor(activeSkill.name)}
+                    {activeOfficial ? (
+                      <OfficialSkillDetail
+                        installing={runningInstalls.has(activeOfficial.identifier)}
+                        onInstall={() => handleInstallOfficial(activeOfficial)}
                         profile={scopeProfile}
-                        skill={activeSkill}
+                        skill={activeOfficial}
                       />
+                    ) : (
+                      activeSkill && (
+                        <SkillDetail
+                          onArchive={() => setArchiveTarget(activeSkill.name)}
+                          onEdit={() => void openSkillEditor(activeSkill.name)}
+                          profile={scopeProfile}
+                          skill={activeSkill}
+                        />
+                      )
                     )}
                   </DetailColumn>
                 </MasterDetail>
@@ -1097,6 +1218,76 @@ function SkillDetail({
         </div>
       )}
       {contentQuery.isLoading ? (
+        <CountSkeleton />
+      ) : parsed ? (
+        <pre
+          className="overflow-auto whitespace-pre-wrap wrap-break-word rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3 font-mono text-[0.68rem] leading-relaxed"
+          data-selectable-text="true"
+        >
+          {parsed.body.trim() || t.skills.noDescription}
+        </pre>
+      ) : null}
+    </>
+  )
+}
+
+// Detail pane for a not-yet-installed catalog skill: metadata + full SKILL.md
+// via the hub preview endpoint (same resolver an install uses), plus the same
+// install button as the row.
+function OfficialSkillDetail({
+  installing,
+  onInstall,
+  profile,
+  skill
+}: {
+  installing: boolean
+  onInstall: () => void
+  profile?: ProfileScope
+  skill: OfficialSkillInfo
+}) {
+  const { t } = useI18n()
+
+  const previewQuery = useQuery({
+    queryKey: ['official-skill-preview', skill.identifier, profileScopeKey(profile)],
+    queryFn: () => previewSkillHub(skill.identifier, profile),
+    staleTime: 5 * 60_000,
+    retry: false
+  })
+
+  const parsed = useMemo(
+    () => (previewQuery.data?.skill_md ? parseFrontmatter(previewQuery.data.skill_md) : null),
+    [previewQuery.data]
+  )
+
+  return (
+    <>
+      <DetailHeader
+        description={asText(skill.description) || t.skills.noDescription}
+        pills={
+          <>
+            <PanelPill>{prettyName(skill.category)}</PanelPill>
+            <PanelPill tone="muted">{t.skills.officialPill}</PanelPill>
+          </>
+        }
+        title={skill.name}
+      />
+      <div className="flex items-center gap-2">
+        <Button disabled={installing} onClick={onInstall} size="xs" variant="textStrong">
+          {installing && <Loader2 className="size-3 animate-spin" />}
+          {installing ? t.skills.hub.installing : t.skills.hub.install}
+        </Button>
+      </div>
+      {parsed && parsed.meta.length > 0 && (
+        <div className="grid gap-1 rounded-lg border border-(--ui-stroke-tertiary) bg-(--ui-bg-quinary) p-3">
+          {parsed.meta.map(([key, value]) => (
+            <div className="flex gap-2 text-[0.68rem] leading-4" key={key}>
+              <span className="w-24 shrink-0 font-medium text-(--ui-text-tertiary)">{key}</span>
+              <span className="min-w-0 whitespace-pre-wrap break-words text-(--ui-text-secondary)">{value}</span>
+            </div>
+          ))}
+        </div>
+      )}
+      {previewQuery.isLoading ? (
         <CountSkeleton />
       ) : parsed ? (
         <pre

--- a/apps/desktop/src/hermes-parity.test.ts
+++ b/apps/desktop/src/hermes-parity.test.ts
@@ -4,6 +4,7 @@ import {
   getCuratorStatus,
   getMcpCatalog,
   getMemoryStatus,
+  getOfficialSkills,
   getSkillHubSources,
   getToolsetModels,
   installSkillFromHub,
@@ -36,6 +37,12 @@ describe('Hermes REST parity helpers (hub / mcp / maintenance)', () => {
     await getSkillHubSources()
 
     expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/skills/hub/sources', timeoutMs: 45_000 }))
+  })
+
+  it('loads the built-in optional-skills catalog', async () => {
+    await getOfficialSkills()
+
+    expect(api).toHaveBeenCalledWith(expect.objectContaining({ path: '/api/skills/hub/official' }))
   })
 
   it('encodes hub search params', async () => {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1334,6 +1334,8 @@ export const en: Translations = {
     archive: 'Archive',
     skillArchivedTitle: 'Skill archived',
     skillArchivedMessage: 'Restorable via hermes curator restore.',
+    officialCatalog: 'Available to install',
+    officialPill: 'Official',
     hub: {
       searchPlaceholder: 'Search the skill hub',
       search: 'Search',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1226,7 +1226,9 @@ export const ja = defineLocale({
     edit: '編集',
     archive: 'アーカイブ',
     skillArchivedTitle: 'スキルをアーカイブしました',
-    skillArchivedMessage: 'hermes curator restore で復元できます。'
+    skillArchivedMessage: 'hermes curator restore で復元できます。',
+    officialCatalog: 'インストール可能',
+    officialPill: '公式'
   },
 
   starmap: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1171,6 +1171,8 @@ export interface Translations {
     archive: string
     skillArchivedTitle: string
     skillArchivedMessage: string
+    officialCatalog: string
+    officialPill: string
     hub: {
       searchPlaceholder: string
       search: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1182,7 +1182,9 @@ export const zhHant = defineLocale({
     edit: '編輯',
     archive: '封存',
     skillArchivedTitle: '技能已封存',
-    skillArchivedMessage: '可透過 hermes curator restore 還原。'
+    skillArchivedMessage: '可透過 hermes curator restore 還原。',
+    officialCatalog: '可安裝',
+    officialPill: '官方'
   },
 
   starmap: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1523,6 +1523,8 @@ export const zh: Translations = {
     archive: '归档',
     skillArchivedTitle: '技能已归档',
     skillArchivedMessage: '可通过 hermes curator restore 恢复。',
+    officialCatalog: '可安装',
+    officialPill: '官方',
     hub: {
       searchPlaceholder: '搜索技能中心',
       search: '搜索',

--- a/apps/desktop/src/store/hub-actions.ts
+++ b/apps/desktop/src/store/hub-actions.ts
@@ -20,6 +20,10 @@ export const HUB_SOURCES_KEY = ['skill-hub-sources'] as const
 // The Capabilities Skills-list query key (see app/skills/index.tsx) — kept in
 // sync here so a hub (un)install updates the Skills tab, not just the hub.
 const SKILLS_LIST_KEY = ['skills-list'] as const
+// The built-in optional-skills catalog rows in the Skills tab: an install
+// flips one of them to an installed (toggle) row, so the catalog's
+// installed-flags must refetch alongside the skills list.
+export const OFFICIAL_SKILLS_KEY = ['official-skills'] as const
 // Non-identifier key for the fleet-wide "Update installed" action.
 export const UPDATE_ALL_KEY = '__update_all__'
 
@@ -119,6 +123,7 @@ async function runHubAction(
     // (un)install adds/removes a skill, so its count/rows must update too.
     void queryClient.invalidateQueries({ queryKey: HUB_SOURCES_KEY })
     void queryClient.invalidateQueries({ queryKey: SKILLS_LIST_KEY })
+    void queryClient.invalidateQueries({ queryKey: OFFICIAL_SKILLS_KEY })
     // …and the composer's `/` list, which caches the command catalog for an
     // hour and would otherwise keep offering the skill we just removed.
     invalidateSlashCompletions()

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1026,6 +1026,17 @@ export interface SkillInfo {
   provenance?: 'agent' | 'bundled' | 'hub'
 }
 
+/** One entry of the built-in optional-skills catalog (optional-skills/ in the
+ *  repo) — official skills that ship with Hermes but install on demand. */
+export interface OfficialSkillInfo {
+  category: string
+  description: string
+  identifier: string
+  installed: boolean
+  name: string
+  tags: string[]
+}
+
 export interface ToolsetInfo {
   configured: boolean
   description: string

--- a/hermes_cli/web_routers/skills.py
+++ b/hermes_cli/web_routers/skills.py
@@ -111,6 +111,41 @@ async def update_skills_hub(
     return {"ok": True, "pid": proc.pid, "name": "skills-update"}
 
 
+@hub_router.get("/api/skills/hub/official")
+async def list_official_skills(profile: Optional[str] = None):
+    """List the ENTIRE built-in optional-skills catalog shipped with the repo.
+
+    Backs the desktop Capabilities → Skills list: every official optional
+    skill appears alongside the installed skills with an install affordance.
+    Local-checkout scan only (no network), plus the per-profile installed
+    map so the UI can mark rows that are already installed.
+    """
+
+    def _run():
+        from tools.skills_hub import OptionalSkillSource
+
+        installed = _installed_hub_identifiers(profile)
+        out = []
+        for m in OptionalSkillSource().list_local():
+            payload = _skill_meta_to_payload(m)
+            ident = payload.get("identifier") or ""
+            # identifier format: official/<category>/<skill> (category dirs
+            # mirror skills/): surface the category for row subtitles.
+            rel = ident.split("/", 1)[-1] if "/" in ident else ident
+            payload["category"] = rel.split("/", 1)[0] if "/" in rel else "general"
+            payload["installed"] = ident in installed
+            out.append(payload)
+        return {"skills": out}
+
+    try:
+        return await asyncio.to_thread(_run)
+    except HTTPException:
+        raise
+    except Exception as exc:
+        _log.exception("official skills catalog listing failed")
+        raise HTTPException(status_code=502, detail=f"Official catalog failed: {exc}")
+
+
 @hub_router.get("/api/skills/hub/sources")
 async def list_skills_hub_sources(profile: Optional[str] = None):
     """List the configured skill-hub sources and installed-skill provenance.

--- a/tests/hermes_cli/test_dashboard_admin_endpoints.py
+++ b/tests/hermes_cli/test_dashboard_admin_endpoints.py
@@ -661,6 +661,42 @@ class TestSkillsHubSourcesEndpoint:
         assert isinstance(body["installed"], dict)
 
 
+class TestOfficialSkillsCatalogEndpoint:
+    @pytest.fixture(autouse=True)
+    def _setup(self, _isolate_hermes_home):
+        self.client, _ = _client()
+
+    def test_lists_full_catalog_with_installed_flags(self, monkeypatch):
+        # Serve the catalog from OptionalSkillSource.list_local() (no network),
+        # with the per-profile installed map marking already-installed rows.
+        metas = [
+            _FakeMeta("official/gifs/gif-search", "builtin", "official"),
+            _FakeMeta("official/creative/ascii-art", "builtin", "official"),
+        ]
+        monkeypatch.setattr(
+            "tools.skills_hub.OptionalSkillSource.list_local",
+            lambda self: metas,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.web_server._installed_hub_identifiers",
+            lambda profile=None: {"official/gifs/gif-search": {"name": "gif-search"}},
+        )
+        r = self.client.get("/api/skills/hub/official")
+        assert r.status_code == 200
+        skills = r.json()["skills"]
+        by_ident = {s["identifier"]: s for s in skills}
+        assert set(by_ident) == {
+            "official/gifs/gif-search",
+            "official/creative/ascii-art",
+        }
+        # Category derived from the identifier's directory segment.
+        assert by_ident["official/gifs/gif-search"]["category"] == "gifs"
+        assert by_ident["official/creative/ascii-art"]["category"] == "creative"
+        # Installed flag comes from the profile's hub lock.
+        assert by_ident["official/gifs/gif-search"]["installed"] is True
+        assert by_ident["official/creative/ascii-art"]["installed"] is False
+
+
 class TestSkillsHubPreviewEndpoint:
     @pytest.fixture(autouse=True)
     def _setup(self, _isolate_hermes_home):

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -3668,6 +3668,14 @@ class OptionalSkillSource(SkillSource):
             )
         return None
 
+    # -- catalog ----------------------------------------------------------
+
+    def list_local(self) -> List[SkillMeta]:
+        """Public catalog enumeration: every optional skill in the local
+        checkout, with frontmatter metadata. Backs the dashboard/desktop
+        "built-in optional skills" catalog surface."""
+        return self._scan_all()
+
     # -- internal helpers -------------------------------------------------
 
     def _get_github(self) -> "GitHubSource":

--- a/website/docs/user-guide/desktop.md
+++ b/website/docs/user-guide/desktop.md
@@ -182,7 +182,7 @@ When you have two or more [profiles](./profiles.md), the config-backed settings 
 
 The app also surfaces the broader Hermes management surface so you don't have to drop to a terminal:
 
-- **Skills** — browse, install, and manage [skills](./features/skills.md).
+- **Skills** — browse, install, and manage [skills](./features/skills.md). The Skills tab lists your installed skills with enable/disable toggles, and below them the full built-in optional-skills catalog that ships with Hermes — each entry has a one-click **Install** button that flips the row into the installed list once it finishes.
 - **Memory graph (Star Map)** — type `/journey` (aliases `/learning`, `/memory-graph`) in chat to open an interactive constellation of learned skills and memories over time, with a playback scrubber. Nodes can be edited or deleted right from the panel (skills are archived, memories removed). See [Learning Journey](./features/memory.md#learning-journey-journey).
 - **Cron** — view and manage [scheduled jobs](../reference/cli-commands.md#hermes-cron).
 - **Profiles** — switch between [Hermes profiles](./profiles.md) (isolated config/skills/sessions).


### PR DESCRIPTION
## Summary
The desktop Capabilities → Skills list now shows the entire built-in optional-skills catalog (137 skills) below the installed skills, each with a one-click Install button that flips into the standard enabled/disabled toggle once the install completes.

## Changes
- `hermes_cli/web_routers/skills.py`: new `GET /api/skills/hub/official` — enumerates `optional-skills/` via `OptionalSkillSource.list_local()` (local scan, no network) with per-profile installed flags from the hub lock
- `tools/skills_hub.py`: public `OptionalSkillSource.list_local()` catalog accessor
- `apps/desktop/src/app/skills/index.tsx`: "Available to install" section under the installed list — search/scope-selector integration, install spinners off `$hubActions`, and an `OfficialSkillDetail` pane (hub preview: frontmatter + full SKILL.md + Install button); rows already installed (lock flag or name collision) are filtered out
- `apps/desktop/src/app/master-detail.tsx`: `CapRow` gains an optional `action` slot (Install button renders where the Switch normally sits)
- `apps/desktop/src/store/hub-actions.ts`: finished hub actions also invalidate the catalog query, so the row flips sections without a manual refresh
- `apps/desktop/electron/connection-config.ts`: new endpoint routed with the skills family (primary backend, `?profile=` scoped — spawn + action-status poll stay on one process)
- i18n: `officialCatalog` / `officialPill` keys across en/ja/zh/zh-hant
- Docs: `website/docs/user-guide/desktop.md` Skills bullet updated

## Validation
| Check | Result |
|---|---|
| Backend E2E (isolated HERMES_HOME, real FastAPI app) | 137 skills returned; fresh home → all `installed: false`; lock entry flips the flag |
| `tests/hermes_cli/test_dashboard_admin_endpoints.py` | 42 passed (incl. new `TestOfficialSkillsCatalogEndpoint`) |
| Desktop vitest (`src/app/skills`, `src/i18n`, parity) | 52 passed (incl. new catalog + parity tests) |
| `tsc --noEmit`, eslint on touched files | clean |
| Live desktop rig (worktree renderer + worktree backend, CDP) | Catalog renders under installed list; clicked Install on `1password` → real `hermes skills install` ran, files landed in the sandbox HERMES_HOME, row flipped to an enabled toggle |

**Live repro:** worktree Electron build via CDP rig — before: Skills tab lists only installed skills; after: full catalog with Install buttons, and a live install flipped `1password` from Install button to enabled toggle (Skills count 54 → 55).

Screenshots:
- Catalog section + detail pane: https://files.catbox.moe/22giwn.png
- Post-install flip (1password now a toggled installed row): https://files.catbox.moe/p0hwyg.png

## Infographic

![Skills catalog built in](https://v3b.fal.media/files/b/0aa8a765/UCLPHMA1V3FiDoDxjPd2F_buDo4Cc3.png)
