### PR TITLE
fix(tts): stop the hourly cache sweep from deleting TTS voice memos

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -988,19 +988,33 @@ async def cache_image_from_url(url: str, ext: str = ".jpg", retries: int = 2) ->
                 raise
 
 
-def _cleanup_cache_dir(cache_dir: Path, max_age_hours: int) -> int:
+def _cleanup_cache_dir(
+    cache_dir: Path,
+    max_age_hours: int,
+    sticky_prefixes: tuple = (),
+) -> int:
     """
     Delete files in *cache_dir* older than *max_age_hours*.
 
-    Shared implementation behind every ``cleanup_*_cache`` helper — one loop,
+    Shared implementation behind every ``cleanup_*_cache`` helper - one loop,
     not N copies.  Returns the number of files removed.
+
+    *sticky_prefixes* names file prefixes that must NEVER be swept regardless
+    of age: TTS-generated voice memos share the audio cache with inbound
+    platform voice notes, but a memo is a user artifact promised persistence
+    by the text_to_speech contract - silently deleting it 24h later is data
+    loss, not cache management (#100075).
     """
     import time
 
     cutoff = time.time() - (max_age_hours * 3600)
     removed = 0
     for f in cache_dir.iterdir():
-        if f.is_file() and f.stat().st_mtime < cutoff:
+        if not f.is_file():
+            continue
+        if sticky_prefixes and f.name.startswith(sticky_prefixes):
+            continue
+        if f.stat().st_mtime < cutoff:
             try:
                 f.unlink()
                 removed += 1
@@ -1134,9 +1148,15 @@ def cleanup_audio_cache(max_age_hours: int = 24) -> int:
     """
     Delete cached audio files older than *max_age_hours*.
 
-    Returns the number of files removed.
+    Returns the number of files removed. TTS-generated voice memos
+    (``tts_*`` prefix, written by tools/tts_tool.py) are excluded: they
+    share this cache with inbound platform voice notes but are user
+    artifacts the text_to_speech contract promises persistent, so the
+    hourly housekeeping sweep must never delete them (#100075).
     """
-    return _cleanup_cache_dir(get_audio_cache_dir(), max_age_hours)
+    return _cleanup_cache_dir(
+        get_audio_cache_dir(), max_age_hours, sticky_prefixes=("tts_",)
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_audio_cache.py
+++ b/tests/gateway/test_audio_cache.py
@@ -81,6 +81,22 @@ class TestCleanupAudioCache:
         assert removed == 0
         assert recent.exists()
 
+    def test_tts_voice_memos_survive_the_sweep(self):
+        """#100075: TTS-generated files (tts_* prefix) share the audio
+        cache with inbound voice notes, but they are user artifacts the
+        text_to_speech contract promises persistent — the hourly sweep
+        must never delete them, regardless of age."""
+        cache_dir = get_audio_cache_dir()
+        memo = cache_dir / "tts_20260901_120000_000000.mp3"
+        memo.write_text("voice memo")
+        memo_mtime = time.time() - 48 * 3600  # two days old — past cutoff
+        os.utime(memo, (memo_mtime, memo_mtime))
+
+        removed = cleanup_audio_cache(max_age_hours=24)
+
+        assert memo.exists(), "TTS memo must survive the cache sweep"
+        assert removed == 0
+
 
 # ---------------------------------------------------------------------------
 # TestUnifiedMediaCacheCleanup — video + screenshot ride the same shared loop

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -3511,7 +3511,10 @@ def text_to_speech_tool(
 
     On messaging platforms, the returned MEDIA:<path> tag is intercepted
     by the send pipeline and delivered as a native voice message.
-    In CLI mode, the file is saved to ~/voice-memos/.
+    On every surface (CLI included) the default output directory is the
+    gateway audio cache (``~/.hermes/cache/audio``); TTS-generated files
+    (``tts_*``) are excluded from the hourly cache sweep and persist until
+    the user deletes them (#100075).
 
     Args:
         text: The text to convert to speech. Provider-specific per-request
@@ -4497,7 +4500,7 @@ from tools.registry import registry, tool_error
 
 TTS_SCHEMA = {
     "name": "text_to_speech",
-    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. In CLI mode, saves to ~/voice-memos/. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
+    "description": "Convert text to speech audio. Returns a MEDIA: path that the platform delivers as native audio. Compatible providers render as a voice bubble on Telegram; otherwise audio is sent as a regular attachment. Default output directory is the gateway audio cache (~/.hermes/cache/audio); tts_* files are exempt from the hourly cache sweep. Voice and provider are user-configured (built-in providers like edge/openai or custom command providers under tts.providers.<name>), not model-selected.",
     "parameters": {
         "type": "object",
         "properties": {


### PR DESCRIPTION
Fixes #100075

## Problem

`text_to_speech` documented `~/voice-memos/` as the CLI output location (docstring `tts_tool.py:3514` + tool schema `:4500`), but every surface writes to the **gateway audio cache** — the same directory `cleanup_audio_cache` sweeps **once per hour** with a **24h max age** (`gateway/run.py` housekeeping → `base.py:1133`). A generated voice memo was silently deleted ~24h later while the tool contract promised persistence; the failure was invisible until the user went looking for the file. Contract and behavior were exact opposites.

## Fix (maintainer's option 2 from the issue)

**(a) Make memos survive the sweep:** `_cleanup_cache_dir` gains `sticky_prefixes`; `cleanup_audio_cache` passes `("tts_",)` — TTS-generated files are named `tts_{timestamp}.{fmt}` by `tts_tool.py:3250-3256`, so the prefix cleanly separates user artifacts from inbound platform voice notes (which remain swept as before).

**(b) Fix the contract:** docstring and tool-schema description now state the real default output dir (`~/.hermes/cache/audio`) and the sweep exemption, instead of the fictional `~/voice-memos/`.

## Verification

`tests/gateway/test_audio_cache.py`: **7/7 pass**, including the new regression test — a `tts_*` file backdated 48h (past the 24h cutoff) **survives** the sweep while the existing old-file removal tests stay green.