### PR TITLE
fix(photon): sidecar mirror, timeout guard, dedup persistence, messageId logging

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1444,6 +1444,17 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
                 base_time = now
         cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
+
+        # Fix #100030: croniter.get_next() returns the next occurrence STRICTLY
+        # AFTER base_time. If base_time is at or very slightly past a scheduled
+        # fire time (e.g., due to timezone conversion near a month boundary),
+        # the current period's fire is silently skipped. Detect this by checking
+        # if the previous fire time is within a small epsilon of base_time; if
+        # so, that previous fire IS the scheduled time for the current period.
+        prev_fire = cron.get_prev(datetime)
+        if prev_fire <= base_time and (base_time - prev_fire).total_seconds() < 60:
+            next_run = prev_fire
+
         return next_run.isoformat()
 
     return None

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1437,23 +1437,29 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         # the next run is anchored to the actual last execution time
         # rather than to an arbitrary restart time.
         base_time = now
+        using_last_run = False
         if last_run_at:
             try:
                 base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
+                using_last_run = True
             except Exception:
                 base_time = now
         cron = croniter(expr, base_time)
         next_run = cron.get_next(datetime)
 
         # Fix #100030: croniter.get_next() returns the next occurrence STRICTLY
-        # AFTER base_time. If base_time is at or very slightly past a scheduled
-        # fire time (e.g., due to timezone conversion near a month boundary),
-        # the current period's fire is silently skipped. Detect this by checking
-        # if the previous fire time is within a small epsilon of base_time; if
-        # so, that previous fire IS the scheduled time for the current period.
-        prev_fire = cron.get_prev(datetime)
-        if prev_fire <= base_time and (base_time - prev_fire).total_seconds() < 60:
-            next_run = prev_fire
+        # AFTER base_time. If base_time lands exactly on a scheduled fire time
+        # (e.g. due to timezone conversion near a month boundary), the current
+        # period's fire is silently skipped. Detect this by checking if the
+        # previous fire time is within a small epsilon of base_time; if so, use
+        # prev_fire as next_run.
+        # Only apply this catch-up when base is derived from "now" (not from
+        # last_run_at), because when the base IS the last completion time, we
+        # must always advance past it to avoid re-firing the same instant.
+        if not using_last_run:
+            prev_fire = cron.get_prev(datetime)
+            if prev_fire <= base_time and (base_time - prev_fire).total_seconds() < 60:
+                next_run = prev_fire
 
         return next_run.isoformat()
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -99,6 +99,68 @@ logger = logging.getLogger(__name__)
 _DEFAULT_SIDECAR_PORT = 8789
 _DEFAULT_SIDECAR_BIND = "127.0.0.1"
 
+# Photon dedup persistence file — stores seen/sent message IDs so a gateway
+# restart doesn't lose the dedup state and double-dispatch inbound messages
+# (#100032). Stored in the profile data dir so it survives restarts.
+_DEDUP_STATE_NAME = "photon-dedup.json"
+_DEDUP_STATE_MAX_IDS = 5000  # bound the on-disk state
+
+
+def _dedup_state_path() -> Path:
+    from hermes_constants import get_hermes_home
+
+    return get_hermes_home() / "runtime" / _DEDUP_STATE_NAME
+
+
+def _load_dedup_state() -> tuple[Dict[str, float], Dict[str, float]]:
+    """Load persisted dedup state from disk. Returns (seen, sent) dicts."""
+    path = _dedup_state_path()
+    if not path.exists():
+        return {}, {}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        seen = raw.get("seen", {}) if isinstance(raw, dict) else {}
+        sent = raw.get("sent", {}) if isinstance(raw, dict) else {}
+        # Validate: must be dict[str, float]
+        if not isinstance(seen, dict) or not isinstance(sent, dict):
+            return {}, {}
+        return (
+            {k: float(v) for k, v in seen.items() if isinstance(v, (int, float))},
+            {k: float(v) for k, v in sent.items() if isinstance(v, (int, float))},
+        )
+    except (OSError, ValueError, TypeError):
+        return {}, {}
+
+
+def _save_dedup_state(seen: Dict[str, float], sent: Dict[str, float]) -> None:
+    """Persist dedup state to disk atomically."""
+    import tempfile
+
+    path = _dedup_state_path()
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Bound the state: keep only the most recent entries
+        seen_items = sorted(seen.items(), key=lambda x: x[1], reverse=True)[:_DEDUP_STATE_MAX_IDS]
+        sent_items = sorted(sent.items(), key=lambda x: x[1], reverse=True)[:_DEDUP_STATE_MAX_IDS]
+        fd, tmp = tempfile.mkstemp(
+            dir=str(path.parent), prefix=".photon-dedup.", suffix=".tmp"
+        )
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(
+                    {"seen": dict(seen_items), "sent": dict(sent_items)},
+                    fh,
+                )
+            os.replace(tmp, path)
+        except BaseException:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+            raise
+    except OSError:
+        pass  # best-effort persistence
+
 # Photon iMessage messages from the SDK side have no documented hard
 # limit, but the underlying iMessage protocol limits practical message
 # size to ~16 KB.  Keep a conservative cap that matches BlueBubbles.
@@ -820,11 +882,12 @@ class PhotonAdapter(BasePlatformAdapter):
         self._respawn_lock: Optional[asyncio.Lock] = None
         # Lightweight in-memory dedup. The gRPC stream is at-least-once, so we
         # may see the same messageId more than once (e.g. after a reconnect).
+        # Persisted to disk so a gateway restart doesn't lose the dedup state
+        # and double-dispatch inbound messages (#100032).
         self._seen_messages: Dict[str, float] = {}
-        # Ids of messages WE sent (bounded, insertion-order eviction). Inbound
-        # reaction events are only routed to the agent when they target one of
-        # these — a tapback on a human↔human message is not addressed to us.
         self._sent_message_ids: Dict[str, float] = {}
+        # Load persisted dedup state on init
+        self._seen_messages, self._sent_message_ids = _load_dedup_state()
         # Latest inbound message id per chat (bounded). Lets the agent-facing
         # react action default to "the message that triggered me" without
         # requiring the model to thread message ids through tool calls.
@@ -1012,6 +1075,8 @@ class PhotonAdapter(BasePlatformAdapter):
                 pass
             self._http_client = None
         self._mark_disconnected()
+        # Persist dedup state on disconnect (#100032)
+        _save_dedup_state(self._seen_messages, self._sent_message_ids)
 
     def _dispatch_fatal_notification(self) -> None:
         """Notify the gateway of a fatal error from a detached task.
@@ -1190,6 +1255,8 @@ class PhotonAdapter(BasePlatformAdapter):
         if len(seen) > _DEDUP_MAX_SIZE:
             for old in list(seen.keys())[: len(seen) - _DEDUP_MAX_SIZE]:
                 del seen[old]
+        # Persist dedup state (#100032)
+        _save_dedup_state(self._seen_messages, self._sent_message_ids)
         return False
 
     async def _fffc_timeout_handler(self, chat_key: str, message_id: str) -> None:
@@ -2218,6 +2285,8 @@ class PhotonAdapter(BasePlatformAdapter):
         if len(sent) > self._SENT_IDS_MAX:
             for old in list(sent.keys())[: len(sent) - self._SENT_IDS_MAX]:
                 del sent[old]
+        # Persist dedup state (#100032)
+        _save_dedup_state(self._seen_messages, self._sent_message_ids)
 
     # A DM space is addressable two ways — the chat GUID (`any;-;+1555...`)
     # that inbound events carry, and the bare E.164 phone that home-channel

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2584,7 +2584,11 @@ class PhotonAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        msg_id = data.get("messageId")
+        logger.info(
+            "[photon] outbound sent: message_id=%s", msg_id or "none"
+        )
+        return SendResult(success=True, message_id=msg_id)
 
     async def _sidecar_send(
         self,
@@ -2630,7 +2634,11 @@ class PhotonAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        msg_id = data.get("messageId")
+        logger.info(
+            "[photon] outbound sent: message_id=%s", msg_id or "none"
+        )
+        return SendResult(success=True, message_id=msg_id)
 
     async def _sidecar_send_poll(
         self, space_id: str, title: str, options: list,
@@ -2656,7 +2664,11 @@ class PhotonAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        msg_id = data.get("messageId")
+        logger.info(
+            "[photon] outbound sent: message_id=%s", msg_id or "none"
+        )
+        return SendResult(success=True, message_id=msg_id)
 
     async def _sidecar_send_attachment(
         self,
@@ -2715,7 +2727,11 @@ class PhotonAdapter(BasePlatformAdapter):
         except Exception as e:
             return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
-        return SendResult(success=True, message_id=data.get("messageId"))
+        msg_id = data.get("messageId")
+        logger.info(
+            "[photon] outbound sent: message_id=%s", msg_id or "none"
+        )
+        return SendResult(success=True, message_id=msg_id)
 
     async def _sidecar_call(self, path: str, body: Dict[str, Any]) -> Dict[str, Any]:
         # Guard: adapter not yet connected (no sidecar address known).

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -2175,7 +2175,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 {"spaceId": chat_id, "text": text.strip(), "effect": effect.strip()},
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         return SendResult(success=True, message_id=data.get("messageId"))
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
@@ -2513,7 +2513,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 "/send-richlink", {"spaceId": space_id, "url": url}
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -2559,7 +2559,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 retryable=e.retryable,
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -2585,7 +2585,7 @@ class PhotonAdapter(BasePlatformAdapter):
         try:
             data = await self._sidecar_call("/send-poll", body)
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 
@@ -2644,7 +2644,7 @@ class PhotonAdapter(BasePlatformAdapter):
                 retryable=e.retryable,
             )
         except Exception as e:
-            return SendResult(success=False, error=str(e))
+            return SendResult(success=False, error=f"{type(e).__name__}: {e}")
         self._record_sent_message(data.get("messageId"))
         return SendResult(success=True, message_id=data.get("messageId"))
 

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -125,8 +125,10 @@ def _load_dedup_state() -> tuple[Dict[str, float], Dict[str, float]]:
         if not isinstance(seen, dict) or not isinstance(sent, dict):
             return {}, {}
         return (
-            {k: float(v) for k, v in seen.items() if isinstance(v, (int, float))},
-            {k: float(v) for k, v in sent.items() if isinstance(v, (int, float))},
+            # Reverse to oldest-first so runtime eviction (which deletes from
+            # the front of the dict) correctly keeps the most recent IDs.
+            {k: float(v) for k, v in sorted(seen.items(), key=lambda x: x[1]) if isinstance(v, (int, float))},
+            {k: float(v) for k, v in sorted(sent.items(), key=lambda x: x[1]) if isinstance(v, (int, float))},
         )
     except (OSError, ValueError, TypeError):
         return {}, {}
@@ -2243,7 +2245,14 @@ class PhotonAdapter(BasePlatformAdapter):
             )
         except Exception as e:
             return SendResult(success=False, error=f"{type(e).__name__}: {e}")
-        return SendResult(success=True, message_id=data.get("messageId"))
+        msg_id = data.get("messageId")
+        self._record_sent_message(msg_id)
+        logger.info(
+            "[photon] outbound sent (effect=%s): message_id=%s",
+            effect,
+            msg_id or "none",
+        )
+        return SendResult(success=True, message_id=msg_id)
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         now = time.time()

--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -48,12 +48,47 @@ SOURCE_SIDECAR_DIR = Path(__file__).parent / "sidecar"
 # The files that define the sidecar. Mirrored into the writable runtime dir
 # when the install tree is read-only. node_modules is deliberately absent —
 # it is either baked (managed image) or installed by npm in the mirror.
-_MIRROR_FILES = (
+#
+# The set is derived from index.mjs's relative import specifiers so it can't
+# drift from the actual module graph — unlisted sidecar modules caused crash-
+# loops on read-only installs (#100031).
+_MIRROR_FILES_BASE = (
     "index.mjs",
     "package.json",
     "package-lock.json",
     "patch-spectrum-mixed-attachments.mjs",
 )
+
+
+def _derive_sidecar_imports() -> frozenset:
+    """Parse index.mjs for relative import specifiers and return them.
+
+    The hardcoded ``_MIRROR_FILES_BASE`` can drift from the actual module graph
+    when a new relative import is added to index.mjs. This parses the real
+    import statements so the mirror set always matches what index.mjs actually
+    loads. Non-relative imports (node:*, bare package names) are excluded.
+    """
+    index_path = SOURCE_SIDECAR_DIR / "index.mjs"
+    if not index_path.exists():
+        return frozenset()
+    try:
+        content = index_path.read_text(encoding="utf-8")
+    except OSError:
+        return frozenset()
+    # Match: from "./foo.mjs" or from './foo.mjs' (relative only — ./ or ../)
+    return frozenset(re.findall(r"""from\s+["'](\.\/[^"']+)["']""", content))
+
+
+def _mirror_files() -> tuple:
+    """Full set of sidecar files to mirror.
+
+    Base files plus every relative import found in index.mjs. Deduplicated
+    and sorted for deterministic copy order.
+    """
+    imports = _derive_sidecar_imports()
+    files = set(_MIRROR_FILES_BASE)
+    files.update(imports)
+    return tuple(sorted(files))
 
 
 def dir_writable(path: Path) -> bool:
@@ -122,7 +157,7 @@ def resolve_sidecar_dir(source_dir: Optional[Path] = None) -> Path:
     mirror = get_hermes_home() / "photon" / "sidecar"
     try:
         mirror.mkdir(parents=True, exist_ok=True)
-        for name in _MIRROR_FILES:
+        for name in _mirror_files():
             src = source / name
             if not src.exists():
                 continue

--- a/plugins/platforms/photon/sidecar_paths.py
+++ b/plugins/platforms/photon/sidecar_paths.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import filecmp
 import logging
 import os
+import re
 import shutil
 from pathlib import Path
 from typing import Optional

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -863,8 +863,15 @@ class TestRunJobSessionPersistence:
                 return {"final_response": "ok"}
 
         class FakeFuture:
+            def __init__(self):
+                self._done = False
+
             def result(self):
+                self._done = True
                 return {"final_response": "ok"}
+
+            def done(self):
+                return self._done
 
         fake_future = FakeFuture()
         fake_pool = MagicMock()


### PR DESCRIPTION
## Summary
Fixes 6 open issues in the Photon (iMessage) adapter and cron scheduler.

## Issues Fixed
- **#100031**: Photon `_MIRROR_FILES` omits sidecar modules its own index.mjs imports (read-only installs crash-loop)
- **#100032**: Photon inbound dedupe is in-memory on an at-least-once stream; restart can double-dispatch a human-visible reply
- **#100033**: Photon outbound messageId is captured then dropped; no provider-accepted state is observable downstream
- **#100034**: Empty httpx timeout stringification defeats the double-send guard; adapter can resend a delivered message
- **#100030**: Cron scheduler skips monthly execution when jobs.json is resaved at month boundary (timezone/croniter base bug)
- **#100047**: Cron heartbeat test leaks background thread exception: FakeFuture has no done()

## Changes
### Photon adapter (`plugins/platforms/photon/adapter.py`)
- Derive `_MIRROR_FILES` from index.mjs's relative import specifiers so the mirror set always matches the actual module graph
- Persist dedup state to `~/.hermes/runtime/photon-dedup.json` (atomic JSON); load on init, save on record/is_duplicate/disconnect
- Log outbound messageId on every successful send path for delivery observability
- Preserve exception type name in SendResult error (`f"{type(e).__name__}: {e}"\ no longer bypasses the timeout guard

### Cron scheduler (`cron/jobs.py`, `tests/cron/test_scheduler.py`)
- When croniter base_time lands within 60s of a scheduled fire (e.g. timezone conversion at month boundary), use prev_fire instead of advancing past it
- FakeFuture test mock now implements `done()` so the inactivity watchdog loop doesn't leak AttributeError

## Test plan
- [ ] Verify sidecar mirror includes send-format.mjs and stream-staleness.mjs on read-only installs
- [ ] Verify dedup state file is created in `~/.hermes/runtime/photon-dedup.json`
- [ ] Verify state persists across gateway restarts
- [ ] Verify outbound log lines include message_id
- [ ] Verify monthly cron jobs fire correctly at month boundaries
- [ ] Verify cron heartbeat test passes without leaking exceptions