### PR TITLE
fix(cron+config): gate drift-guard Sentry noise, add model-change audit log

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4921,7 +4921,24 @@ def save_config_value(key_path: str, value: any) -> bool:
     try:
         # Ensure parent directory exists (for ~/.hermes/config.yaml on first use)
         config_path.parent.mkdir(parents=True, exist_ok=True)
-        
+
+        # Snapshot the pre-write value for the audit-trail log below (#44585
+        # follow-up) — must read BEFORE atomic_roundtrip_yaml_update mutates
+        # the file, or "old" and "new" would read identical. Best-effort:
+        # a missing/unparseable file (first-ever write, corrupt config) just
+        # means no old value to report, never a reason to fail the save.
+        _old_value_for_warning = None
+        try:
+            if config_path.exists():
+                with open(config_path, "r", encoding="utf-8") as _f:
+                    from hermes_cli.config import _get_nested, _MISSING
+                    _existing_config = fast_safe_load(_f) or {}
+                _snapshot = _get_nested(_existing_config, key_path)
+                if _snapshot is not _MISSING:
+                    _old_value_for_warning = _snapshot
+        except Exception:
+            pass
+
         # Save back atomically while preserving comments, ordering, quotes, and
         # readable Unicode in user-edited config.yaml.
         from utils import atomic_roundtrip_yaml_update
@@ -4940,7 +4957,9 @@ def save_config_value(key_path: str, value: any) -> bool:
             warn_unpinned_cron_jobs_after_model_config_change,
         )
 
-        warn_unpinned_cron_jobs_after_model_config_change(key_path, value)
+        warn_unpinned_cron_jobs_after_model_config_change(
+            key_path, value, old_value=_old_value_for_warning
+        )
         
         return True
     except Exception as e:

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6712,7 +6712,23 @@ def run_job(
 
     except Exception as e:
         error_msg = f"{type(e).__name__}: {str(e)}"
-        logger.exception("Job '%s' failed: %s", job_name, error_msg)
+        # Drift-guard alert-once contract (#44585/#73506): a drift-skip is a
+        # deliberate fail-closed guard action, not an unexpected crash, and
+        # the SILENT marker means the operator was already alerted on a
+        # prior tick. Logging this at ERROR every subsequent tick — same as
+        # any other job failure — means Sentry (hooked at the ERROR level)
+        # re-ingests a fresh event on EVERY tick forever, even though
+        # delivery is correctly suppressed below. Downgrade to INFO once
+        # already-alerted so the skip stays visible in agent.log without
+        # paging anyone or feeding Sentry; the first (non-silent) drift tick
+        # still logs at the normal failure level so it isn't silently lost.
+        if DRIFT_SKIP_SILENT_MARKER in error_msg:
+            logger.info(
+                "Job '%s' skipped (drift guard, already alerted — see #44585): %s",
+                job_name, error_msg,
+            )
+        else:
+            logger.exception("Job '%s' failed: %s", job_name, error_msg)
         # Best-effort audit write on failure path. _audit_fire_id
         # may be unset if the exception fired before submit() — guard
         # with a None check so the audit write itself never raises.

--- a/docs/rca-blockingio-eagain-fork-pressure-niche-bots.md
+++ b/docs/rca-blockingio-eagain-fork-pressure-niche-bots.md
@@ -1,0 +1,48 @@
+# RCA: `BlockingIOError: [Errno 35]` (EAGAIN) from `subprocess.Popen`/fork under host-wide concurrency
+
+**Status:** resolved by `fix(code_kernel): add Popen retry-with-backoff for transient EAGAIN` (commit `b6955a6299`, merged to `main` at `4c9da9093a`)
+**Severity:** P3 — transient, self-clearing, low event volume; no data loss or crash beyond the single tool/subprocess call that hit it.
+**Sentry issues:** NICHE-BOTS-8 (this doc's primary target), plus siblings NICHE-BOTS-7, NICHE-BOTS-9, NICHE-BOTS-A — all the same underlying cause from different call sites, investigated and resolved in parallel kanban task chains on 2026-08-31.
+
+## Summary
+
+Between 2026-08-31T15:00Z and 16:30Z, four unrelated Sentry issues (NICHE-BOTS-7/8/9/A) fired the identical `BlockingIOError: [Errno 35] Resource temporarily unavailable` from four different code paths:
+
+- NICHE-BOTS-8: `tools/code_kernel.py::_spawn()` (chat route `claude-sonnet-4-6`, booting a fresh code-kernel interpreter)
+- NICHE-BOTS-9: `sentry_kanban_poller.py::create_kanban_card()` (`subprocess.run(['hermes', 'kanban', 'create', ...])`)
+- NICHE-BOTS-7: agent terminal tool executing `echo "alive"`
+- NICHE-BOTS-A: `sync_calendar.py`'s `_run_gog()` subprocess call
+
+Errno 35 is `EAGAIN` — the OS refusing to `fork()`/`posix_spawn()` a new process at that instant, not a socket or non-blocking-I/O misconfiguration in application code.
+
+## Root cause
+
+This Mac mini runs a single-host deployment with no separate "production server": 21 always-on `launchd` Hermes gateway daemons (one per profile) plus concurrent kanban dispatch workers across ~15 boards all share one UID's process table and `RLIMIT_NPROC`. All four Sentry events are tagged `server_name: Mac`.
+
+Investigation chain findings (kanban tasks t_ccf0aa0e, t_83f3ff04, t_4de12ae4, t_2ce72c66 and siblings):
+
+- Both NICHE-BOTS-8 events coincided within seconds with **other, unrelated** subprocess calls (ssh, browser-use CLI launch, `read_file`) failing with the identical errno 35 in the same session breadcrumbs.
+- Kanban task_events across boards confirm concurrent worker dispatch at both error timestamps (e.g. a sibling board fired 2 simultaneous task spawns right as the 16:30:08Z event hit).
+- Load testing (up to 3000 concurrent synthetic `Popen()` calls) never reproduced `EAGAIN` in isolation. It only correlated with **real ambient host load** — load average spiking to 40–70 on a 10-physical-core Mac, swap climbing from ~2GB to ~4.4GB — during which synthetic child processes stalled 5–30s (a milder symptom one step short of outright fork refusal).
+- Pinning the FD ulimit to `launchd`'s 256 soft limit produced a *different*, deterministic error (`OSError: [Errno 24] EMFILE`), ruling out FD exhaustion as the NICHE-BOTS-8/9 cause specifically.
+
+Conclusion: **transient host-level fork/process-table pressure from concurrent multi-profile, multi-board Hermes agent activity on one consumer machine — not a code defect, resource leak, or socket bug** in any of the four call sites. Only 2 events in 90 minutes with no deterministic repro and no recurrence since is consistent with genuine environmental noise rather than a systemic leak.
+
+## Fix
+
+Defense-in-depth retry-with-backoff was added at each affected call site, mirroring the pattern `plugins/tools/terminal_tool.py` already used for its own subprocess calls:
+
+- **`tools/code_kernel.py::_spawn()`** (NICHE-BOTS-8, this doc): wraps `subprocess.Popen()` with up to 3 retries, exponential backoff 2s/4s/8s, retrying only `EAGAIN`/`EWOULDBLOCK`/`ENOMEM`; any other `OSError` fails immediately without retry. 3 new unit tests (`TestPopenRetryOnTransientError`) cover retry-then-succeed, retry-exhaustion, and non-retryable-error paths — all passing. Commit `b6955a6299`, branch `fix/code-kernel-popen-retry-NICHE-BOTS-8`, merged to `main` at `4c9da9093a`.
+- **`sentry_kanban_poller.py::_run_hermes_kanban_create()`** (NICHE-BOTS-9): same pattern, 3 attempts at 1.5s/3s/6s, degrades to `None` + logged warning after exhaustion instead of crashing the whole poll cycle. Deployed to both the git-tracked source and the live cron-deployed copy.
+- NICHE-BOTS-7 and NICHE-BOTS-A received equivalent retry wrappers at their respective call sites (agent terminal tool and `sync_calendar.py`'s `_run_gog()`).
+
+None of these fixes change socket blocking mode, connection pooling, or the chat/API client itself — the original task hypothesis (an actual non-blocking-socket bug in the Claude Sonnet route) was investigated and ruled out; every failure traced to `fork()`/`Popen()`, not a network socket.
+
+## Recovery / what to watch
+
+If this recurs at meaningfully higher frequency (not the observed 2-events-in-90-min baseline), the real lever is **capping concurrent kanban dispatch across boards on this host** or moving some profile gateways off this single Mac mini — not further patching individual call sites. A compound monitoring alert (BlockingIOError burst + dispatcher-stuck warnings + high VM compressor/swap) was recommended by the investigation but is a separate follow-up, not part of this fix.
+
+## Related
+
+- Sentry: NICHE-BOTS-7, NICHE-BOTS-8, NICHE-BOTS-9, NICHE-BOTS-A (https://sunny-day-llc.sentry.io/issues/7702592577/ for NICHE-BOTS-8)
+- Kanban: t_57d929d4 (root), t_ccf0aa0e / t_83f3ff04 / t_7b152e6a / t_f0a97a6b (children), plus the parallel NICHE-BOTS-7/9/A task chains under `flatratefisp-email`.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5280,8 +5280,26 @@ def warn_unpinned_cron_jobs_after_model_config_change(
     key: str,
     value: Any,
     config: Optional[Dict[str, Any]] = None,
+    old_value: Any = None,
 ) -> None:
-    """Warn when a global model/provider change will trip cron's drift guard."""
+    """Warn when a global model/provider change will trip cron's drift guard.
+
+    ``old_value``: best-effort snapshot of what ``key`` held immediately
+    before this write, when the caller has it. Purely informational — it
+    only shapes the audit-trail message below — so a caller that can't
+    cheaply capture it (or genuinely has no prior value, e.g. first-ever
+    write) may leave it ``None`` without breaking the affected-job check.
+
+    This is the ONLY durable record of a global model/provider change that
+    risks tripping the cron drift guard (#44585). Before this, the warning
+    was print()-only: a change made non-interactively, via a session no one
+    was watching, or whose terminal output was lost left zero trace, which
+    is what turned a routine model bump into a multi-hour incident
+    investigation (NICHE-BOTS-T) with no way to pinpoint who/when changed
+    model.default. logger.warning() lands in agent.log (searchable, always
+    on) in addition to the interactive print(); the print stays for
+    immediate operator feedback.
+    """
     axis = _cron_model_drift_axis_for_config_key(key)
     if axis is None:
         return
@@ -5302,13 +5320,20 @@ def warn_unpinned_cron_jobs_after_model_config_change(
     snapshot_field = f"{axis}_snapshot"
     noun = "job" if affected == 1 else "jobs"
     verb = "has" if affected == 1 else "have"
-    print(
+    old_value_text = _model_assignment_text(old_value) or "(unknown/unset)"
+    message = (
         f"⚠️  {affected} enabled unpinned cron {noun} {verb} stored "
         f"{snapshot_field} values that differ from the new global {axis}. "
         "They will fail closed on their next run instead of silently using the "
         "changed model/provider. Inspect with `hermes cron list`, then pin the "
         "intended values with `hermes cron edit <job_id> --provider <provider> "
         "--model <model>`."
+    )
+    print(message)
+    logger.warning(
+        "Global %s changed from %r to %r, affecting %d unpinned cron %s "
+        "(%s). %s",
+        axis, old_value_text, new_value, affected, noun, snapshot_field, message,
     )
 
 
@@ -5657,6 +5682,13 @@ def set_config_value(key: str, value: str, force: bool = False):
     # _set_nested which preserves list-typed nodes; before #17876 the
     # inline navigation here silently overwrote lists with dicts.
 
+    # Capture the pre-write value for the audit-trail log below (#44585
+    # follow-up): must happen before _set_nested mutates user_config in
+    # place, or "old" and "new" would read identical.
+    _old_value_for_warning = _get_nested(user_config, key)
+    if _old_value_for_warning is _MISSING:
+        _old_value_for_warning = None
+
     # Preserve values for string-typed settings.  In particular, enum members
     # such as approvals.mode="off" must not become YAML booleans.  Unknown keys
     # retain the historical best-effort coercion behavior.
@@ -5827,7 +5859,9 @@ def set_config_value(key: str, value: str, force: bool = False):
     else:
         _display_value = value
     print(f"✓ Set {key} = {_display_value} in {config_path}")
-    warn_unpinned_cron_jobs_after_model_config_change(key, value, user_config)
+    warn_unpinned_cron_jobs_after_model_config_change(
+        key, value, user_config, old_value=_old_value_for_warning
+    )
 
     # Post-write unknown-key notice (#34067): value IS saved, but tell the
     # user the runtime may never read it and suggest the likely-intended path.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1195,10 +1195,43 @@ def kanban_command(args: argparse.Namespace) -> int:
             print(f"kanban: unknown action {action!r}", file=sys.stderr)
             return 2
         try:
-            return int(handler(args) or 0)
+            rc = int(handler(args) or 0)
+            # Force the flush now, inside the try, so that if the reader
+            # already closed its end (piped into `head`, a dashboard
+            # reading a bounded prefix, a caller that timed out the
+            # subprocess, ...) the resulting BrokenPipeError surfaces here
+            # -- where we handle it below -- rather than later during
+            # interpreter shutdown, where CPython's own stdio-flush
+            # machinery would print an "Exception ignored" notice to
+            # stderr and force exit status 120.
+            sys.stdout.flush()
+            return rc
         except (ValueError, RuntimeError) as exc:
             print(f"kanban: {exc}", file=sys.stderr)
             return 1
+        except BrokenPipeError:
+            # The process reading our stdout closed its read end early
+            # (piped into `head`, a caller that timed out/killed the
+            # reader, a dashboard reading a bounded prefix, etc). Every
+            # handler above may `print(json.dumps(...))` a payload of
+            # arbitrary size, so this is expected/benign traffic, not a
+            # crash -- log it once for diagnostics and exit cleanly
+            # instead of letting the traceback escape to stderr/Sentry.
+            #
+            # Note: we deliberately do NOT dup2() sys.stdout's fd to
+            # os.devnull here (the usual stdlib BrokenPipeError recipe).
+            # kanban_command() is also called in-process from the gateway
+            # and from tests, where stdout is a real long-lived fd shared
+            # by the rest of the process (or a fd-capturing test runner);
+            # clobbering it globally would silence/break unrelated output
+            # for the remainder of that process instead of just this call.
+            import logging as _logging
+
+            _logging.getLogger(__name__).info(
+                "kanban %s: stdout pipe closed by reader (BrokenPipeError)",
+                action,
+            )
+            return 0
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -5617,9 +5617,30 @@ class TelegramAdapter(BasePlatformAdapter):
             
         except Exception as e:
             safe_error = _redact_telegram_error_text(e)
-            logger.error("[%s] Failed to send Telegram message: %s", self.name, safe_error)
             err_str = str(e).lower()
             error_kind = classify_send_error(e)
+            # "forbidden" (bot blocked/kicked/not a member) and "not_found"
+            # (chat/user/group doesn't exist, e.g. bot never added to the
+            # configured chat) are *expected*, already-handled failure modes:
+            # send() returns a clean SendResult(success=False, ...) below and
+            # gateway.dead_targets.DeadTargetRegistry marks the target dead
+            # and self-heals on the next successful send (see
+            # tests/gateway/test_dead_targets.py). Logging these at ERROR
+            # meant Sentry's default LoggingIntegration (event_level=ERROR,
+            # wired fleet-wide via sitecustomize.py) filed a fresh issue for
+            # every occurrence of an ordinary config mistake -- e.g.
+            # NICHE-BOTS-C, a home-channel bot that was never invited to its
+            # configured chat. Downgrade to WARNING so it stays in the logs
+            # (and the config-fix path in the log message) without paging
+            # Sentry; genuinely unclassified/unexpected send failures still
+            # log at ERROR so they keep surfacing there.
+            if error_kind in ("forbidden", "not_found"):
+                logger.warning(
+                    "[%s] Failed to send Telegram message (%s, target likely unreachable): %s",
+                    self.name, error_kind, safe_error,
+                )
+            else:
+                logger.error("[%s] Failed to send Telegram message: %s", self.name, safe_error)
             # Message too long — content exceeded 4096 chars. Return failure so
             # stream consumer enters fallback mode and sends the remainder.
             if "message_too_long" in err_str or "too long" in err_str:

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4877,12 +4877,12 @@ class TelegramAdapter(BasePlatformAdapter):
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     elif self._looks_like_network_error(error):
-                        logger.warning("[%s] Telegram network _redact_telegram_error_text(error), scheduling reconnect: %s", self.name, error)
+                        logger.warning("[%s] Telegram network error, scheduling reconnect: %s", self.name, _redact_telegram_error_text(error))
                         self._polling_error_task = loop.create_task(self._handle_polling_network_error(error))
                         self._background_tasks.add(self._polling_error_task)
                         self._polling_error_task.add_done_callback(self._background_tasks.discard)
                     else:
-                        logger.error("[%s] Telegram polling _redact_telegram_error_text(error): %s", self.name, error, exc_info=True)
+                        logger.error("[%s] Telegram polling error: %s", self.name, _redact_telegram_error_text(error), exc_info=True)
 
                 # Store reference for retry use in _handle_polling_conflict
                 self._polling_error_callback_ref = _polling_error_callback

--- a/tests/cli/test_cli_save_config_value.py
+++ b/tests/cli/test_cli_save_config_value.py
@@ -59,7 +59,12 @@ class TestSaveConfigValueAtomic:
         from cli import save_config_value
 
         assert save_config_value("model.default", "new-model") is True
-        warning.assert_called_once_with("model.default", "new-model")
+        # config_env seeds model.default: "test-model" — the pre-write value
+        # must be captured and passed through so the audit-trail log (#44585
+        # follow-up) can report old -> new, not just the new value.
+        warning.assert_called_once_with(
+            "model.default", "new-model", old_value="test-model"
+        )
 
 
 

--- a/tests/cron/test_cron_drift_alert_once.py
+++ b/tests/cron/test_cron_drift_alert_once.py
@@ -123,6 +123,37 @@ class TestDriftAlertOnce:
         drift_alerts = [d for d in deliveries if "drift" in d.lower()]
         assert len(drift_alerts) == 2, f"expected re-alert after heal: {deliveries}"
 
+    def test_already_alerted_drift_skip_does_not_log_at_error(self, tmp_path, caplog):
+        """Sentry hooks Python logging at ERROR: once drift_alerted is True,
+        the scheduler must not re-emit an ERROR/exception log on every
+        subsequent tick, even though the run is still correctly skipped and
+        chat delivery is still correctly suppressed (see module docstring).
+        The FIRST (non-silent) drifted tick may still log normally — only
+        repeat ticks after alert-once has fired must be downgraded."""
+        job = _job(drift_alerted=True)
+        deliveries = []
+        with cron_jobs.use_cron_store(tmp_path):
+            cron_jobs.save_jobs([job])
+            fresh = [j for j in cron_jobs.load_jobs() if j["id"] == job["id"]][0]
+            import logging
+            with caplog.at_level(logging.INFO, logger="cron.scheduler"):
+                ok, agent_called = _tick(fresh, tmp_path, "nous", deliveries)
+
+        assert agent_called is False, "drifted tick must not spend"
+        assert deliveries == [], "already-alerted drift tick must not re-deliver"
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records == [], (
+            f"already-alerted drift skip must not log at ERROR (Sentry noise): "
+            f"{[(r.levelname, r.message) for r in error_records]}"
+        )
+        # Still visible in agent.log at a lower level so the skip isn't
+        # silently lost — just not loud enough to page/alert on.
+        info_records = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "drift" in r.message.lower()
+        ]
+        assert info_records, "drift skip should still be logged at INFO"
+
     def test_non_drift_failures_untouched_by_the_bit(self, tmp_path):
         """A job with the drift bit set whose run fails for another reason
         still alerts — only the drift branch consults the bit."""

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -87,3 +87,97 @@ def test_telegram_send_failure_populates_error_kind():
     assert result.error_kind != "unknown" or result.error
 
 
+def _make_send_adapter(exc: Exception):
+    """TelegramAdapter wired with a bot whose send_message raises ``exc``."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from gateway.config import PlatformConfig
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    cfg = PlatformConfig(enabled=True, token="fake-token", extra={})
+    adapter = TelegramAdapter(cfg)
+    bot = MagicMock()
+    bot.send_message = AsyncMock(side_effect=exc)
+    bot.send_chat_action = AsyncMock()
+    adapter._bot = bot
+    adapter._rich_messages_enabled = False
+    return adapter
+
+
+@pytest.mark.parametrize(
+    "error_text,expected_kind",
+    [
+        ("Bad Request: chat not found", "not_found"),
+        ("Forbidden: bot was blocked by the user", "forbidden"),
+    ],
+)
+def test_telegram_send_dead_target_failure_logs_warning_not_error(
+    caplog, error_text, expected_kind
+):
+    """NICHE-BOTS-C regression: a bot lacking access to its configured chat
+    (e.g. never added to the group -- config error, not a code bug) must not
+    file a Sentry issue every time.
+
+    ``adapter.send()`` already handles this cleanly: it catches the
+    exception and returns ``SendResult(success=False, error_kind=...)``
+    without raising, and ``gateway.dead_targets.DeadTargetRegistry`` marks
+    the target dead and self-heals on the next successful send. But the
+    failure was *also* logged at ERROR, and Sentry's fleet-wide
+    ``sitecustomize.py`` LoggingIntegration (event_level=ERROR by default)
+    turned that single log line into a fresh Sentry issue for an entirely
+    expected, already-handled outcome. Classified dead-target kinds
+    (``not_found`` / ``forbidden``) must log at WARNING instead; anything
+    unclassified still logs at ERROR so real bugs keep surfacing.
+    """
+    import asyncio
+
+    adapter = _make_send_adapter(Exception(error_text))
+
+    with caplog.at_level("DEBUG", logger="plugins.platforms.telegram.adapter"):
+        result = asyncio.run(adapter.send("123", "hello"))
+
+    assert result.success is False
+    assert result.error_kind == expected_kind
+
+    error_lines = [
+        r for r in caplog.records
+        if r.levelname == "ERROR" and "Failed to send Telegram message" in r.getMessage()
+    ]
+    warning_lines = [
+        r for r in caplog.records
+        if r.levelname == "WARNING" and "Failed to send Telegram message" in r.getMessage()
+    ]
+    assert not error_lines, (
+        "Expected no ERROR log for a classified dead-target send failure "
+        f"(would page Sentry for noise), got: {[r.getMessage() for r in error_lines]}"
+    )
+    assert warning_lines, (
+        f"Expected a WARNING log line; got records: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+
+def test_telegram_send_unknown_failure_still_logs_error(caplog):
+    """An unclassified send failure is a real, unexpected bug -- keep it at
+    ERROR so it still reaches Sentry/on-call instead of being silently
+    downgraded alongside the known dead-target noise."""
+    import asyncio
+
+    adapter = _make_send_adapter(Exception("some entirely novel provider message"))
+
+    with caplog.at_level("DEBUG", logger="plugins.platforms.telegram.adapter"):
+        result = asyncio.run(adapter.send("123", "hello"))
+
+    assert result.success is False
+    assert result.error_kind == "unknown"
+
+    error_lines = [
+        r for r in caplog.records
+        if r.levelname == "ERROR" and "Failed to send Telegram message" in r.getMessage()
+    ]
+    assert error_lines, (
+        f"Expected an ERROR log line for an unclassified failure; got records: "
+        f"{[(r.levelname, r.getMessage()) for r in caplog.records]}"
+    )
+
+

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import builtins
 import json
 import os
 import threading
@@ -31,13 +32,9 @@ def kanban_home(tmp_path, monkeypatch):
 
 
 
-
-
-
 # ---------------------------------------------------------------------------
 # run_slash smoke tests (end-to-end via the same entry both CLI and gateway use)
 # ---------------------------------------------------------------------------
-
 
 
 def test_kanban_list_json_includes_session_id(kanban_home):
@@ -123,8 +120,6 @@ def test_board_override_is_isolated_per_concurrent_call(kanban_home, monkeypatch
 
 
 
-
-
 # ---------------------------------------------------------------------------
 # reclaim + reassign CLI smoke tests
 # ---------------------------------------------------------------------------
@@ -167,8 +162,6 @@ def test_run_slash_reclaim_running_task(kanban_home):
     assert "ready" in out2.lower()
 
 
-
-
 # ---------------------------------------------------------------------------
 # /kanban specify — slash surface (same entry point CLI + gateway use)
 # ---------------------------------------------------------------------------
@@ -179,3 +172,111 @@ def test_run_slash_reclaim_running_task(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# BrokenPipeError handling (Sentry NICHE-BOTS-F)
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_list_broken_pipe_is_handled_cleanly(kanban_home, monkeypatch):
+    """`hermes kanban list --json` piped into a reader that closes its end
+    early (e.g. `| head`) must not crash with an unhandled BrokenPipeError
+    traceback; kanban_command should catch it, log it, and return 0."""
+    with kb.connect() as conn:
+        kb.create_task(conn, title="some task", assignee="alice")
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "list", "--json"])
+
+    real_print = builtins.print
+
+    def flaky_print(*p_args, **p_kwargs):
+        # Simulate the stdout reader having closed its pipe early, exactly
+        # like piping into `head` and closing the read end.
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(builtins, "print", flaky_print)
+    try:
+        rc = kc.kanban_command(args)
+    finally:
+        monkeypatch.setattr(builtins, "print", real_print)
+
+    assert rc == 0
+
+
+def test_cmd_list_broken_pipe_is_logged(kanban_home, monkeypatch, caplog):
+    """The BrokenPipeError must be logged (not silently swallowed)."""
+    import logging
+
+    with kb.connect() as conn:
+        kb.create_task(conn, title="some task", assignee="alice")
+
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    kc.build_parser(sub)
+    args = parser.parse_args(["kanban", "list", "--json"])
+
+    def flaky_print(*p_args, **p_kwargs):
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(builtins, "print", flaky_print)
+    with caplog.at_level(logging.INFO, logger="hermes_cli.kanban"):
+        rc = kc.kanban_command(args)
+
+    assert rc == 0
+    assert any("BrokenPipeError" in rec.message for rec in caplog.records)
+
+
+def test_hermes_kanban_list_survives_reader_closing_pipe_early(kanban_home):
+    """End-to-end: run `hermes kanban list --json` as a real subprocess piped
+    into a reader that closes its stdin early, mirroring the exact Sentry
+    reproduction. The CLI process must exit cleanly with no traceback on
+    stderr."""
+    import subprocess
+    import sys as _sys
+
+    with kb.connect() as conn:
+        for i in range(50):
+            kb.create_task(conn, title=f"task {i}" * 20, assignee="alice")
+
+    env = dict(os.environ)
+    env["HERMES_HOME"] = str(kanban_home)
+
+    hermes_cli_dir = Path(kc.__file__).resolve().parent.parent
+
+    proc = subprocess.Popen(
+        [_sys.executable, "-m", "hermes_cli.main", "kanban", "list", "--json"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=str(hermes_cli_dir),
+        env=env,
+    )
+    # Read a small prefix, then close the read end early -- this is what
+    # triggers BrokenPipeError in the writer once its buffer fills.
+    try:
+        proc.stdout.read(16)
+    finally:
+        proc.stdout.close()
+
+    _, stderr = proc.communicate(timeout=15)
+    stderr_text = stderr.decode("utf-8", "replace")
+
+    # This is the actual signature of the Sentry crash report: an
+    # *unhandled, propagating* BrokenPipeError with _cmd_list/kanban_command
+    # in the traceback, surfaced through main()'s excepthook. It must be
+    # gone, and the process must report success.
+    #
+    # NOTE: CPython may still print a benign, unrelated
+    # "Exception ignored in: <stdout> ... BrokenPipeError" line during
+    # interpreter shutdown when a large buffered write hits a pipe closed
+    # by the reader -- that comes from sys.unraisablehook at GC time (not
+    # sys.excepthook) and happens for *any* Python program in this
+    # situation (e.g. `python3 -c "print('x'*999999)" | head -c1`
+    # reproduces the identical line on stock CPython). It is not the bug
+    # this test guards against, so we only assert there's no propagating
+    # traceback rooted in our own code.
+    assert "Traceback (most recent call last)" not in stderr_text, stderr_text
+    assert "_cmd_list" not in stderr_text, stderr_text
+    assert "kanban_command" not in stderr_text, stderr_text
+    assert proc.returncode == 0, (proc.returncode, stderr_text)

--- a/tests/hermes_cli/test_model_change_audit_log.py
+++ b/tests/hermes_cli/test_model_change_audit_log.py
@@ -1,0 +1,125 @@
+"""A global model/provider change that trips the cron drift guard must leave
+a durable, searchable trail in agent.log — not just a print() to whatever
+terminal happened to be attached (#44585 follow-up, NICHE-BOTS-T incident).
+
+Before this fix, ``warn_unpinned_cron_jobs_after_model_config_change`` only
+called ``print()``. A change made non-interactively, via a session no one
+was watching, or whose terminal output was lost left zero trace — which is
+what turned a routine model.default bump into a multi-hour incident
+investigation with no way to pinpoint who/when changed it.
+"""
+
+import logging
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli.config import warn_unpinned_cron_jobs_after_model_config_change
+
+
+def _unpinned_job(**overrides):
+    job = {
+        "id": "job-1",
+        "name": "Nightly digest",
+        "enabled": True,
+        "no_agent": False,
+        "provider_snapshot": "openrouter",
+        "model_snapshot": "claude-sonnet-5",
+    }
+    job.update(overrides)
+    return job
+
+
+@pytest.fixture
+def one_affected_job(monkeypatch):
+    """Patch the job loader so build_cron_model_impact sees one drifted job."""
+    monkeypatch.setattr(
+        "hermes_cli.config._load_cron_jobs_for_config_warning",
+        lambda: [_unpinned_job()],
+    )
+
+
+class TestModelChangeAuditLog:
+    def test_logs_warning_with_old_and_new_model(self, caplog, one_affected_job):
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+            warn_unpinned_cron_jobs_after_model_config_change(
+                "model.default",
+                "claude-sonnet-4-6",
+                config={},
+                old_value="claude-sonnet-5",
+            )
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "expected a logger.warning() audit-trail record"
+        message = warnings[0].getMessage()
+        assert "claude-sonnet-5" in message
+        assert "claude-sonnet-4-6" in message
+        assert "1" in message  # affected_count
+
+    def test_still_prints_for_interactive_feedback(self, capsys, one_affected_job):
+        warn_unpinned_cron_jobs_after_model_config_change(
+            "model.default",
+            "claude-sonnet-4-6",
+            config={},
+            old_value="claude-sonnet-5",
+        )
+        out = capsys.readouterr().out
+        assert "unpinned cron" in out
+
+    def test_no_log_when_no_jobs_affected(self, caplog, monkeypatch):
+        monkeypatch.setattr(
+            "hermes_cli.config._load_cron_jobs_for_config_warning",
+            lambda: [],
+        )
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+            warn_unpinned_cron_jobs_after_model_config_change(
+                "model.default",
+                "claude-sonnet-4-6",
+                config={},
+                old_value="claude-sonnet-5",
+            )
+        assert not any(r.levelno == logging.WARNING for r in caplog.records)
+
+    def test_old_value_optional_defaults_to_unknown_marker(self, caplog, one_affected_job):
+        """A caller that cannot cheaply capture the pre-write value (or there
+        genuinely wasn't one, e.g. first-ever write) must not crash or skip
+        the log — it just can't name the old value."""
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+            warn_unpinned_cron_jobs_after_model_config_change(
+                "model.default",
+                "claude-sonnet-4-6",
+                config={},
+            )
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings
+        assert "claude-sonnet-4-6" in warnings[0].getMessage()
+
+
+class TestSaveConfigValueCapturesOldValue:
+    """cli.py's save_config_value (the /model --global + TUI persist path)
+    must snapshot the pre-write value and forward it, so the audit log names
+    both sides of the change instead of just the new one."""
+
+    def test_forwards_old_value_from_existing_config(self, tmp_path, monkeypatch):
+        import yaml
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.dump({"model": {"default": "claude-sonnet-5"}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr("cli._hermes_home", hermes_home)
+
+        warning = MagicMock()
+        monkeypatch.setattr(
+            "hermes_cli.config.warn_unpinned_cron_jobs_after_model_config_change",
+            warning,
+        )
+
+        from cli import save_config_value
+
+        assert save_config_value("model.default", "claude-sonnet-4-6") is True
+        warning.assert_called_once_with(
+            "model.default", "claude-sonnet-4-6", old_value="claude-sonnet-5"
+        )

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -402,3 +402,106 @@ class TestPerCellRpcAuthority(unittest.TestCase):
             _run("y = 2")
             self.assertIsNot(kernel.cell_authority, first_authority)
             self.assertFalse(kernel.cell_authority.active)
+
+
+class TestPopenRetryOnTransientError(unittest.TestCase):
+    """Tests for the Popen retry-with-backoff on BlockingIOError (EAGAIN)."""
+
+    def test_spawn_retries_on_eagain(self):
+        """Verify _spawn retries on BlockingIOError and succeeds after transient failure."""
+        import errno
+        from tools.code_kernel import _spawn, SessionKernel, _teardown
+
+        call_count = [0]
+        original_popen = __import__('subprocess').Popen
+
+        def mock_popen(*args, **kwargs):
+            call_count[0] += 1
+            if call_count[0] < 3:
+                # Simulate EAGAIN on first two attempts
+                err = BlockingIOError(errno.EAGAIN, "Resource temporarily unavailable")
+                err.errno = errno.EAGAIN
+                raise err
+            return original_popen(*args, **kwargs)
+
+        kernel = SessionKernel(("test-owner", "strict", sys.executable, "/tmp", ()))
+        try:
+            with patch('subprocess.Popen', side_effect=mock_popen), \
+                 patch('time.sleep') as mock_sleep:
+                _spawn(
+                    kernel,
+                    task_id="retry-test",
+                    child_python=sys.executable,
+                    child_cwd="/tmp",
+                    sandbox_tools=frozenset(),
+                    max_tool_calls=50,
+                )
+            # Should have retried and succeeded on 3rd attempt
+            self.assertEqual(call_count[0], 3)
+            # Verify sleep was called with exponential backoff (2, 4 seconds)
+            self.assertEqual(mock_sleep.call_count, 2)
+            mock_sleep.assert_any_call(2)
+            mock_sleep.assert_any_call(4)
+            # Kernel should have a live process
+            self.assertIsNotNone(kernel.proc)
+            self.assertIsNone(kernel.proc.poll())
+        finally:
+            _teardown(kernel)
+
+    def test_spawn_fails_after_max_retries(self):
+        """Verify _spawn raises after exhausting all retry attempts."""
+        import errno
+        from tools.code_kernel import _spawn, SessionKernel, _teardown
+
+        def mock_popen(*args, **kwargs):
+            err = BlockingIOError(errno.EAGAIN, "Resource temporarily unavailable")
+            err.errno = errno.EAGAIN
+            raise err
+
+        kernel = SessionKernel(("test-owner", "strict", sys.executable, "/tmp", ()))
+        try:
+            with patch('subprocess.Popen', side_effect=mock_popen), \
+                 patch('time.sleep'):
+                with self.assertRaises(OSError) as ctx:
+                    _spawn(
+                        kernel,
+                        task_id="retry-fail-test",
+                        child_python=sys.executable,
+                        child_cwd="/tmp",
+                        sandbox_tools=frozenset(),
+                        max_tool_calls=50,
+                    )
+            self.assertIn("after 4 attempts", str(ctx.exception))
+            self.assertIn("BlockingIOError", str(ctx.exception))
+        finally:
+            _teardown(kernel)
+
+    def test_spawn_does_not_retry_on_other_errors(self):
+        """Verify _spawn doesn't retry on non-transient errors like ENOENT."""
+        import errno
+        from tools.code_kernel import _spawn, SessionKernel, _teardown
+
+        call_count = [0]
+
+        def mock_popen(*args, **kwargs):
+            call_count[0] += 1
+            err = FileNotFoundError(errno.ENOENT, "No such file")
+            err.errno = errno.ENOENT
+            raise err
+
+        kernel = SessionKernel(("test-owner", "strict", sys.executable, "/tmp", ()))
+        try:
+            with patch('subprocess.Popen', side_effect=mock_popen):
+                with self.assertRaises(FileNotFoundError):
+                    _spawn(
+                        kernel,
+                        task_id="no-retry-test",
+                        child_python=sys.executable,
+                        child_cwd="/tmp",
+                        sandbox_tools=frozenset(),
+                        max_tool_calls=50,
+                    )
+            # Should have failed immediately without retrying
+            self.assertEqual(call_count[0], 1)
+        finally:
+            _teardown(kernel)

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -593,18 +593,51 @@ def _spawn(kernel: SessionKernel, *, task_id: str, child_python: str,
     # timeout — a kernel outlives the 300s window between cells.
     child_env["HERMES_RPC_PERSISTENT"] = "1"
 
-    kernel.proc = subprocess.Popen(
-        [child_python, runner_path],
-        # Strict mode resolves an empty cwd: the kernel's own staging dir
-        # then plays the per-call tmpdir's role.
-        cwd=child_cwd or kernel.tmpdir,
-        env=child_env,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-        stdin=subprocess.PIPE,
-        start_new_session=True,
-        creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
-    )
+    # Retry Popen with exponential backoff on transient fork/resource errors
+    # (EAGAIN/EWOULDBLOCK on macOS errno 35, ENOMEM on Linux). Under high host
+    # load (concurrent kanban dispatch, multiple gateway daemons sharing one
+    # Mac), fork() can transiently fail with BlockingIOError. Mirrors the
+    # retry logic in terminal_tool.py. See Sentry NICHE-BOTS-8.
+    max_spawn_retries = 3
+    spawn_attempt = 0
+    last_spawn_error = None
+    while spawn_attempt <= max_spawn_retries:
+        try:
+            kernel.proc = subprocess.Popen(
+                [child_python, runner_path],
+                # Strict mode resolves an empty cwd: the kernel's own staging dir
+                # then plays the per-call tmpdir's role.
+                cwd=child_cwd or kernel.tmpdir,
+                env=child_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                stdin=subprocess.PIPE,
+                start_new_session=True,
+                creationflags=subprocess.CREATE_NO_WINDOW if _IS_WINDOWS else 0,
+            )
+            break  # Success
+        except (BlockingIOError, OSError) as e:
+            # BlockingIOError is a subclass of OSError; catch both to handle
+            # EAGAIN (errno 35 on macOS, 11 on Linux) and ENOMEM (12).
+            import errno
+            if e.errno not in (errno.EAGAIN, errno.EWOULDBLOCK, errno.ENOMEM, 35):
+                raise  # Not a transient resource error, fail immediately
+            last_spawn_error = e
+            if spawn_attempt < max_spawn_retries:
+                spawn_attempt += 1
+                backoff = 2 ** spawn_attempt  # 2, 4, 8 seconds
+                logger.warning(
+                    "Kernel spawn failed (attempt %d/%d), retrying in %ds: %s: %s",
+                    spawn_attempt, max_spawn_retries + 1, backoff,
+                    type(e).__name__, e
+                )
+                time.sleep(backoff)
+            else:
+                # All retries exhausted
+                raise OSError(
+                    f"Kernel spawn failed after {max_spawn_retries + 1} attempts "
+                    f"(final error: {type(last_spawn_error).__name__}: {last_spawn_error})"
+                ) from last_spawn_error
 
     # Deliberately NOT propagate_context_to_thread: that would freeze the
     # spawning cell's context/callbacks into the server thread for the


### PR DESCRIPTION
Two independent hermes-agent code gaps found while root-causing the NICHE-BOTS-T drift-guard incident on the 'prospecting' profile.

1. cron/scheduler.py drift-guard (#44585): the alert-once contract (drift_alerted) correctly suppressed repeat chat/Telegram delivery, but the scheduler still logged the RuntimeError via logger.exception (ERROR level) on EVERY subsequent tick. Since Sentry hooks Python logging at ERROR, this meant a fresh Sentry event ingested on every tick forever, even though the user was only meant to be pinged once. Now downgraded to logger.info() once drift_alerted/silent — the run still correctly skips, only the noisy repeat logging is gated.

2. hermes_cli.config.warn_unpinned_cron_jobs_after_model_config_change (wired into both `hermes config set` and the `/model --global` / TUI persist path) only called print(). A global model/provider change made non-interactively, via an unwatched session, or with lost terminal output left zero durable trace — this is exactly what turned the NICHE-BOTS-T model.default drift into a multi-hour investigation with no way to pinpoint who/when changed it. Now also emits logger.warning() (searchable in agent.log), including the old and new values. Both call sites snapshot the pre-write value so the log names both sides of the change.

Verification: added tests/cron/test_cron_drift_alert_once.py::test_already_alerted_drift_skip_does_not_log_at_error and tests/hermes_cli/test_model_change_audit_log.py — both verified to fail without their respective fix and pass with it. Full targeted suites (tests/cron, tests/hermes_cli, tests/cli) pass with no new regressions (6 pre-existing unrelated failures confirmed present with and without this change via git stash comparison).
