### PR TITLE
feat(discord): add owned status headline overlay

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -38,6 +38,7 @@ logger = logging.getLogger(__name__)
 
 _DISCORD_MARKDOWN_LINK_LABEL_RE = re.compile(r"([\\\[\]])")
 _DISCORD_URL_LABEL_SCHEME_RE = re.compile(r"^https?://", re.IGNORECASE)
+_STATUS_HEADLINE_GUILD_OWNERS: Dict[int, object] = {}
 
 
 def _format_discord_markdown_link(label: str, url: str) -> str:
@@ -1056,6 +1057,7 @@ class DiscordAdapter(BasePlatformAdapter):
     # incident delivered 60,698 chars as 31 messages).  Chunks beyond the
     # cap are replaced by a short notice.
     MAX_SPLIT_MESSAGES = 8
+    STATUS_HEADLINE_LOCK_SCOPE = "discord-status-sidebar-guild"
 
     # Auto-disconnect from voice channel after this many seconds of inactivity.
     # Config key: discord.voice_channel_inactivity_timeout_seconds (0 disables)
@@ -1122,6 +1124,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._typing_tasks: Dict[str, asyncio.Task] = {}
         self._bot_task: Optional[asyncio.Task] = None
         self._post_connect_task: Optional[asyncio.Task] = None
+        self._status_headline_task: Optional[asyncio.Task] = None
         # WebSocket-level liveness probe. Discord REST and Gateway are distinct
         # transports: a REST 200 cannot prove that this client is still receiving
         # Gateway events. Sample the current Discord WebSocket's ready/open/ACK
@@ -1368,6 +1371,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # on reconnect (see #18187). Without this, the old client remains
             # connected to Discord gateway and both fire on_message, causing
             # double responses.
+            await self._cancel_status_headline_task()
             if self._client is not None:
                 try:
                     if not self._client.is_closed():
@@ -1400,6 +1404,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 adapter_self._post_connect_task = asyncio.create_task(
                     adapter_self._run_post_connect_initialization()
                 )
+                adapter_self._ensure_status_headline_task()
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
 
@@ -2156,9 +2161,104 @@ class DiscordAdapter(BasePlatformAdapter):
         deadline = max(1.0, budget - headroom)
         return min(deadline, budget * 0.9)
 
+    def _status_headline_config(self) -> Optional[Dict[str, Any]]:
+        extra = self.config.extra if isinstance(getattr(self.config, "extra", None), dict) else {}
+        value = extra.get("status_sidebar")
+        if not isinstance(value, dict) or value.get("enabled") is not True:
+            return None
+        return value
+
+    def _ensure_status_headline_task(self) -> Optional[asyncio.Task]:
+        if self._status_headline_config() is None or self._client is None:
+            return None
+        task = getattr(self, "_status_headline_task", None)
+        if task is not None and not task.done():
+            return task
+        self._status_headline_task = asyncio.create_task(self._run_status_headline())
+        return self._status_headline_task
+
+    async def _cancel_status_headline_task(self) -> None:
+        task = getattr(self, "_status_headline_task", None)
+        if task is not None and not task.done():
+            task.cancel()
+            with suppress(asyncio.CancelledError):
+                await task
+        self._status_headline_task = None
+
+    async def _run_status_headline(self) -> None:
+        config = self._status_headline_config()
+        client = self._client
+        if config is None or client is None:
+            return
+        from plugins.platforms.discord.status_headline import StatusHeadline
+
+        try:
+            interval = max(
+                310.0,
+                float(config.get("refresh_interval_seconds", 310.0)),
+            )
+        except (TypeError, ValueError):
+            interval = 310.0
+        headline = None
+        owner_token = object()
+        owned_guild_id = None
+        lock_identity = None
+        try:
+            while self._client is client:
+                try:
+                    if headline is None:
+                        candidate = StatusHeadline(client, discord, config, self.gateway_runner)
+                        guild_id = candidate.guild_id
+                        if guild_id in _STATUS_HEADLINE_GUILD_OWNERS:
+                            raise RuntimeError(
+                                f"guild {guild_id} already has a status headline writer"
+                            )
+                        _STATUS_HEADLINE_GUILD_OWNERS[guild_id] = owner_token
+                        owned_guild_id = guild_id
+                        from gateway.status import acquire_scoped_lock
+
+                        try:
+                            identity = str(guild_id)
+                            acquired, _existing = acquire_scoped_lock(
+                                self.STATUS_HEADLINE_LOCK_SCOPE,
+                                identity,
+                                metadata={"guild_id": guild_id},
+                            )
+                            if not acquired:
+                                raise RuntimeError(
+                                    f"guild {guild_id} already has a status headline writer"
+                                )
+                        except BaseException:
+                            if _STATUS_HEADLINE_GUILD_OWNERS.get(guild_id) is owner_token:
+                                _STATUS_HEADLINE_GUILD_OWNERS.pop(guild_id, None)
+                            owned_guild_id = None
+                            raise
+                        headline = candidate
+                        lock_identity = identity
+                    await headline.run_once()
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    logger.warning("[%s] Status headline refused update: %s", self.name, exc)
+                await asyncio.sleep(interval)
+        finally:
+            if (
+                owned_guild_id is not None
+                and _STATUS_HEADLINE_GUILD_OWNERS.get(owned_guild_id) is owner_token
+            ):
+                try:
+                    if lock_identity is not None:
+                        from gateway.status import release_scoped_lock
+
+                        release_scoped_lock(self.STATUS_HEADLINE_LOCK_SCOPE, lock_identity)
+                finally:
+                    if _STATUS_HEADLINE_GUILD_OWNERS.get(owned_guild_id) is owner_token:
+                        _STATUS_HEADLINE_GUILD_OWNERS.pop(owned_guild_id, None)
+
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
         self._disconnecting = True
+        await self._cancel_status_headline_task()
         # Cancel the liveness probe first so it can't fire a spurious fatal
         # error / reconnect while we're intentionally tearing the adapter down.
         await self._cancel_liveness_task()
@@ -2206,6 +2306,7 @@ class DiscordAdapter(BasePlatformAdapter):
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._status_headline_task = None
         self._liveness_task = None
         self._missed_message_backfill_task = None
 

--- a/plugins/platforms/discord/status_headline.py
+++ b/plugins/platforms/discord/status_headline.py
@@ -221,17 +221,13 @@ class StatusHeadline:
         role_id = _positive_int(record.get("helper_role_id"), "helper role id")
         category_id = _positive_int(record.get("category_id"), "category id")
         channel_ids = record.get("channel_ids")
-        if not isinstance(channel_ids, dict) or tuple(channel_ids) not in {
-            _LEGACY_ROWS,
-            _ALL_ROWS,
+        if not isinstance(channel_ids, dict) or frozenset(channel_ids) not in {
+            frozenset(_LEGACY_ROWS),
+            frozenset(_ALL_ROWS),
         }:
-            if not isinstance(channel_ids, dict) or frozenset(channel_ids) not in {
-                frozenset(_LEGACY_ROWS),
-                frozenset(_ALL_ROWS),
-            }:
-                raise RuntimeError(
-                    "Discord status headline ownership is not exact four- or five-row state"
-                )
+            raise RuntimeError(
+                "Discord status headline ownership is not exact four- or five-row state"
+            )
         ids = [self.guild_id, role_id, category_id]
         ids.extend(_positive_int(value, f"{key} row id") for key, value in channel_ids.items())
         if len(ids) != len(set(ids)):

--- a/plugins/platforms/discord/status_headline.py
+++ b/plugins/platforms/discord/status_headline.py
@@ -1,0 +1,405 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import math
+import re
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Mapping, Optional, Sequence
+
+from utils import atomic_json_write
+
+logger = logging.getLogger(__name__)
+
+_LEGACY_ROWS = ("model", "effort", "chatgpt", "claude")
+_ALL_ROWS = ("hermes", *_LEGACY_ROWS)
+_RECORD_KEYS = {
+    "version",
+    "guild_id",
+    "helper_role_id",
+    "category_id",
+    "channel_ids",
+}
+
+
+@dataclass(frozen=True)
+class QuotaSummary:
+    available: bool
+    remaining_percent: int | None = None
+    reset_at: datetime | None = None
+
+
+@dataclass(frozen=True)
+class StatusSnapshot:
+    hermes_version: str
+    model: str
+    effort: str
+    chatgpt: QuotaSummary
+    claude: QuotaSummary
+
+
+def _positive_int(value: Any, label: str) -> int:
+    if type(value) is not int or value <= 0:
+        raise RuntimeError(f"Discord status headline has invalid {label}")
+    return value
+
+
+def _display_model(value: str) -> str:
+    text = str(value or "").strip()
+    match = re.fullmatch(
+        r"(?:[^/]+/)?gpt-(\d+(?:\.\d+)*)(?:-([a-z0-9]+))?",
+        text,
+        re.IGNORECASE,
+    )
+    if not match:
+        return text or "Not configured"
+    version, suffix = match.groups()
+    return f"GPT-{version}" + (f" {suffix.title()}" if suffix else "")
+
+
+def _quota_summary(snapshot: Any, labels: tuple[str, ...]) -> QuotaSummary:
+    if snapshot is None:
+        return QuotaSummary(False)
+    preferred = {label.casefold() for label in labels}
+    window = next(
+        (
+            item
+            for item in (getattr(snapshot, "windows", ()) or ())
+            if str(getattr(item, "label", "")).casefold() in preferred
+        ),
+        None,
+    )
+    used = getattr(window, "used_percent", None) if window is not None else None
+    if not isinstance(used, (int, float)) or isinstance(used, bool) or not math.isfinite(used):
+        return QuotaSummary(False)
+    remaining = max(0, min(100, round(100 - float(used))))
+    reset_at = getattr(window, "reset_at", None)
+    return QuotaSummary(
+        True,
+        remaining,
+        reset_at if isinstance(reset_at, datetime) else None,
+    )
+
+
+async def collect_status_snapshot(runner: Any) -> StatusSnapshot:
+    from agent.account_usage import fetch_account_usage
+    from gateway.run import _resolve_gateway_model_context
+    from hermes_cli import __version__
+
+    model_context = await asyncio.to_thread(_resolve_gateway_model_context)
+    model = model_context.model
+    reasoning = None
+    resolver = getattr(runner, "_load_reasoning_config", None)
+    if callable(resolver):
+        try:
+            reasoning = resolver(model)
+        except Exception:
+            logger.debug("Discord status headline effort lookup failed", exc_info=True)
+    if reasoning and reasoning.get("enabled") is False:
+        effort = "Off"
+    elif reasoning and reasoning.get("effort"):
+        effort = str(reasoning["effort"]).strip().title()
+    else:
+        effort = "Default"
+
+    chatgpt_raw, claude_raw = await asyncio.gather(
+        asyncio.to_thread(fetch_account_usage, "openai-codex"),
+        asyncio.to_thread(fetch_account_usage, "anthropic"),
+    )
+    return StatusSnapshot(
+        hermes_version=str(__version__),
+        model=_display_model(model),
+        effort=effort,
+        chatgpt=_quota_summary(chatgpt_raw, ("Weekly",)),
+        claude=_quota_summary(
+            claude_raw,
+            ("Current week", "Seven-day", "7-day"),
+        ),
+    )
+
+
+def _reset_text(reset_at: datetime | None, now: datetime) -> str:
+    if reset_at is None:
+        return ""
+    if reset_at.tzinfo is None:
+        reset_at = reset_at.replace(tzinfo=timezone.utc)
+    seconds = max(0, int((reset_at - now).total_seconds()))
+    hours = math.ceil(seconds / 3600)
+    if hours >= 24:
+        days, remainder = divmod(hours, 24)
+        return f" · reset {days}d {remainder}h"
+    return f" · reset {hours}h"
+
+
+def _quota_name(label: str, quota: QuotaSummary, now: datetime) -> str:
+    if not quota.available or quota.remaining_percent is None:
+        return f"{label}: unavailable"
+    return (
+        f"{label}: {quota.remaining_percent}%"
+        f"{_reset_text(quota.reset_at, now)}"
+    )[:100]
+
+
+def channel_names(snapshot: StatusSnapshot, now: datetime | None = None) -> dict[str, str]:
+    now = now or datetime.now(timezone.utc)
+    return {
+        "hermes": f"Hermes v{snapshot.hermes_version}"[:100],
+        "model": f"Model: {snapshot.model}"[:100],
+        "effort": f"Effort: {snapshot.effort}"[:100],
+        "chatgpt": _quota_name("ChatGPT", snapshot.chatgpt, now),
+        "claude": _quota_name("Claude", snapshot.claude, now),
+    }
+
+
+class OwnershipStore:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+
+    def load(self) -> dict[str, Any]:
+        try:
+            value = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "Discord status headline requires existing schema-1 ownership"
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError("Discord status headline ownership is unreadable") from exc
+        if not isinstance(value, dict):
+            raise RuntimeError("Discord status headline ownership is malformed")
+        return value
+
+    def save(self, value: Mapping[str, Any]) -> None:
+        atomic_json_write(self.path, dict(value), sort_keys=True)
+
+
+class StatusHeadline:
+    """Maintain five rows on one pre-existing, exact-ID Discord surface."""
+
+    def __init__(
+        self,
+        client: Any,
+        discord_module: Any,
+        config: Mapping[str, Any],
+        runner: Any,
+        *,
+        ownership_path: Path | None = None,
+        snapshot_provider: Callable[[], Awaitable[StatusSnapshot]] | None = None,
+    ) -> None:
+        self.client = client
+        self.discord = discord_module
+        self.config = dict(config)
+        self.runner = runner
+        self.guild_id = _positive_int(self.config.get("guild_id"), "configured guild id")
+        self.category_name = str(
+            self.config.get("category_name") or "HERMES STATUS"
+        ).strip()
+        if not self.category_name:
+            raise RuntimeError("Discord status headline category name is empty")
+        if ownership_path is None:
+            from hermes_constants import get_default_hermes_root
+
+            ownership_path = (
+                get_default_hermes_root()
+                / "state"
+                / "discord-status-sidebar"
+                / f"{self.guild_id}.json"
+            )
+        self.store = OwnershipStore(ownership_path)
+        self.snapshot_provider = snapshot_provider or (
+            lambda: collect_status_snapshot(self.runner)
+        )
+
+    def _record(self) -> dict[str, Any]:
+        record = self.store.load()
+        if set(record) != _RECORD_KEYS or record.get("version") != 1:
+            raise RuntimeError("Discord status headline requires exact schema-1 ownership")
+        if record.get("guild_id") != self.guild_id:
+            raise RuntimeError("Discord status headline ownership guild differs from config")
+        role_id = _positive_int(record.get("helper_role_id"), "helper role id")
+        category_id = _positive_int(record.get("category_id"), "category id")
+        channel_ids = record.get("channel_ids")
+        if not isinstance(channel_ids, dict) or tuple(channel_ids) not in {
+            _LEGACY_ROWS,
+            _ALL_ROWS,
+        }:
+            if not isinstance(channel_ids, dict) or frozenset(channel_ids) not in {
+                frozenset(_LEGACY_ROWS),
+                frozenset(_ALL_ROWS),
+            }:
+                raise RuntimeError(
+                    "Discord status headline ownership is not exact four- or five-row state"
+                )
+        ids = [self.guild_id, role_id, category_id]
+        ids.extend(_positive_int(value, f"{key} row id") for key, value in channel_ids.items())
+        if len(ids) != len(set(ids)):
+            raise RuntimeError("Discord status headline ownership reuses an id")
+        return {**record, "channel_ids": dict(channel_ids)}
+
+    def _surface(
+        self,
+        record: Mapping[str, Any],
+        *,
+        inventory: Optional[Sequence[Any]] = None,
+    ) -> tuple[Any, Any, dict[str, Any]]:
+        guild = self.client.get_guild(self.guild_id)
+        if guild is None:
+            raise RuntimeError("Discord status headline guild is unavailable")
+        by_id = (
+            {getattr(item, "id", None): item for item in inventory}
+            if inventory is not None
+            else None
+        )
+        category = (
+            by_id.get(record["category_id"])
+            if by_id is not None
+            else guild.get_channel(record["category_id"])
+        )
+        role = guild.get_role(record["helper_role_id"])
+        if not isinstance(category, self.discord.CategoryChannel):
+            raise RuntimeError("Discord status headline owned category is unavailable")
+        if not isinstance(role, self.discord.Role):
+            raise RuntimeError("Discord status headline owned helper role is unavailable")
+        if str(getattr(category, "name", "")) != self.category_name:
+            raise RuntimeError("Discord status headline owned category name drifted")
+        member_roles = {
+            getattr(item, "id", None) for item in getattr(getattr(guild, "me", None), "roles", ())
+        }
+        if role.id not in member_roles:
+            raise RuntimeError("Discord status headline helper role assignment drifted")
+
+        rows: dict[str, Any] = {}
+        for key, row_id in record["channel_ids"].items():
+            row = by_id.get(row_id) if by_id is not None else guild.get_channel(row_id)
+            if not isinstance(row, self.discord.VoiceChannel):
+                raise RuntimeError(f"Discord status headline owned {key} row is unavailable")
+            if getattr(row, "category_id", None) != category.id:
+                raise RuntimeError(f"Discord status headline owned {key} row parent drifted")
+            if getattr(row, "overwrites", None) != getattr(category, "overwrites", None):
+                raise RuntimeError(f"Discord status headline owned {key} row overwrites drifted")
+            rows[key] = row
+
+        child_ids = (
+            {
+                getattr(item, "id", None)
+                for item in inventory
+                if getattr(item, "category_id", None) == category.id
+            }
+            if inventory is not None
+            else {
+                getattr(item, "id", None)
+                for item in getattr(category, "channels", ())
+            }
+        )
+        if child_ids != set(record["channel_ids"].values()):
+            raise RuntimeError("Discord status headline owned category topology drifted")
+        return guild, category, rows
+
+    async def _migrate(
+        self,
+        guild: Any,
+        category: Any,
+        rows: Mapping[str, Any],
+        record: dict[str, Any],
+        names: Mapping[str, str],
+    ) -> None:
+        model_position = getattr(rows["model"], "position", None)
+        if type(model_position) is not int or model_position < 0:
+            raise RuntimeError("Discord status headline Model row position is malformed")
+
+        pending = {**record, "pending": {"kind": "row:hermes"}}
+        self.store.save(pending)
+        created = await guild.create_voice_channel(
+            names["hermes"],
+            category=category,
+            overwrites=category.overwrites,
+            position=model_position,
+            reason="Add Hermes version to existing status headline",
+        )
+        created_id = _positive_int(getattr(created, "id", None), "created Hermes row id")
+        if created_id in {
+            self.guild_id,
+            record["helper_role_id"],
+            record["category_id"],
+            *record["channel_ids"].values(),
+        }:
+            raise RuntimeError("Discord status headline created row reuses an id")
+        migrated = {
+            **record,
+            "channel_ids": {**record["channel_ids"], "hermes": created_id},
+        }
+        self.store.save(migrated)
+
+    @staticmethod
+    def _ordered_row_ids(rows: Mapping[str, Any]) -> list[int]:
+        positioned = []
+        for row in rows.values():
+            position = getattr(row, "position", None)
+            row_id = getattr(row, "id", None)
+            if type(position) is not int or position < 0 or type(row_id) is not int:
+                raise RuntimeError("Discord status headline row position is malformed")
+            positioned.append((position, row_id))
+        return [row_id for _position, row_id in sorted(positioned)]
+
+    async def _refresh(
+        self,
+        guild: Any,
+        record: Mapping[str, Any],
+        rows: Mapping[str, Any],
+        names: Mapping[str, str],
+    ) -> None:
+        changed = False
+        for key in _ALL_ROWS:
+            row = rows[key]
+            if str(getattr(row, "name", "")) != names[key]:
+                await row.edit(
+                    name=names[key],
+                    reason="Refresh Hermes status headline",
+                )
+                changed = True
+
+        desired_ids = [rows[key].id for key in _ALL_ROWS]
+        if self._ordered_row_ids(rows) != desired_ids:
+            base = min(row.position for row in rows.values())
+            payload = [
+                {"id": rows[key].id, "position": base + offset}
+                for offset, key in enumerate(_ALL_ROWS)
+            ]
+            await guild._state.http.bulk_channel_update(
+                guild.id,
+                payload,
+                reason="Order Hermes status headline",
+            )
+            changed = True
+
+        if not changed:
+            return
+
+        inventory = await guild.fetch_channels()
+        _guild, _category, fresh_rows = self._surface(record, inventory=inventory)
+        if any(str(getattr(fresh_rows[key], "name", "")) != names[key] for key in _ALL_ROWS):
+            raise RuntimeError("Discord status headline name refresh did not converge")
+        if self._ordered_row_ids(fresh_rows) != [fresh_rows[key].id for key in _ALL_ROWS]:
+            raise RuntimeError("Discord status headline order refresh did not converge")
+
+    async def run_once(self) -> None:
+        if self.config.get("enabled") is not True:
+            return
+        record = self._record()
+        guild = self.client.get_guild(self.guild_id)
+        if guild is None:
+            raise RuntimeError("Discord status headline guild is unavailable")
+        inventory = await guild.fetch_channels()
+        guild, category, rows = self._surface(record, inventory=inventory)
+        snapshot = await self.snapshot_provider()
+        names = channel_names(snapshot)
+        if frozenset(record["channel_ids"]) == frozenset(_LEGACY_ROWS):
+            if self._ordered_row_ids(rows) != [rows[key].id for key in _LEGACY_ROWS]:
+                raise RuntimeError("Discord status headline legacy row order drifted")
+            await self._migrate(guild, category, rows, record, names)
+            record = self._record()
+            inventory = await guild.fetch_channels()
+            _guild, _category, rows = self._surface(record, inventory=inventory)
+        await self._refresh(guild, record, rows, names)

--- a/tests/gateway/test_discord_status_headline.py
+++ b/tests/gateway/test_discord_status_headline.py
@@ -1,0 +1,583 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import PlatformConfig
+from plugins.platforms.discord.adapter import DiscordAdapter
+from plugins.platforms.discord.status_headline import (
+    QuotaSummary,
+    StatusHeadline,
+    StatusSnapshot,
+    collect_status_snapshot,
+)
+
+
+class FakeRole:
+    def __init__(self, resource_id: int) -> None:
+        self.id = resource_id
+
+
+class FakeCategory:
+    def __init__(self, resource_id: int, overwrites: tuple) -> None:
+        self.id = resource_id
+        self.name = "STATUS"
+        self.overwrites = overwrites
+        self.voice_channels: list[FakeVoice] = []
+
+    @property
+    def channels(self):
+        return list(self.voice_channels)
+
+
+class FakeVoice:
+    def __init__(
+        self,
+        resource_id: int,
+        name: str,
+        *,
+        category_id: int,
+        position: int,
+        overwrites: tuple,
+    ) -> None:
+        self.id = resource_id
+        self.name = name
+        self.category_id = category_id
+        self.position = position
+        self.overwrites = overwrites
+        self.edits: list[dict] = []
+        self.deleted = False
+
+    async def edit(self, **changes):
+        self.edits.append(dict(changes))
+        for key, value in changes.items():
+            setattr(self, key, value)
+        return self
+
+    async def delete(self, *, reason: str):
+        del reason
+        self.deleted = True
+
+
+class FakeDiscord:
+    CategoryChannel = FakeCategory
+    Role = FakeRole
+    VoiceChannel = FakeVoice
+
+
+class FakeHTTP:
+    def __init__(self, guild) -> None:
+        self.guild = guild
+
+    async def bulk_channel_update(self, guild_id, payload, *, reason):
+        del reason
+        assert guild_id == self.guild.id
+        self.guild.bulk_updates.append([dict(item) for item in payload])
+        for item in payload:
+            self.guild.get_channel(item["id"]).position = item["position"]
+
+
+class FakeGuild:
+    def __init__(self) -> None:
+        self.id = 10
+        self.overwrites = (("everyone", False, False), ("helper", True, False))
+        self.role = FakeRole(30)
+        self.category = FakeCategory(20, self.overwrites)
+        names = (
+            (40, "Model: GPT-5.6 Sol"),
+            (41, "Effort: High"),
+            (42, "ChatGPT: unavailable"),
+            (43, "Claude: unavailable"),
+        )
+        self.category.voice_channels = [
+            FakeVoice(
+                resource_id,
+                name,
+                category_id=20,
+                position=position,
+                overwrites=self.overwrites,
+            )
+            for position, (resource_id, name) in enumerate(names, 10)
+        ]
+        self.me = SimpleNamespace(roles=[self.role])
+        self.created: list[FakeVoice] = []
+        self.bulk_updates: list[list[dict]] = []
+        self.fetch_count = 0
+        self._state = SimpleNamespace(http=FakeHTTP(self))
+
+    def get_role(self, resource_id: int):
+        return self.role if resource_id == self.role.id else None
+
+    def get_channel(self, resource_id: int):
+        if resource_id == self.category.id:
+            return self.category
+        return next(
+            (row for row in self.category.voice_channels if row.id == resource_id),
+            None,
+        )
+
+    async def fetch_channels(self):
+        self.fetch_count += 1
+        return [self.category, *self.category.voice_channels]
+
+    async def create_voice_channel(
+        self,
+        name: str,
+        *,
+        category,
+        overwrites,
+        position: int,
+        reason: str,
+    ):
+        del reason
+        row = FakeVoice(
+            44,
+            name,
+            category_id=category.id,
+            position=position,
+            overwrites=overwrites,
+        )
+        index = self.category.voice_channels.index(self.get_channel(40))
+        self.category.voice_channels.insert(index, row)
+        self.created.append(row)
+        return row
+
+
+FOUR_ROW_RECORD = {
+    "version": 1,
+    "guild_id": 10,
+    "helper_role_id": 30,
+    "category_id": 20,
+    "channel_ids": {
+        "model": 40,
+        "effort": 41,
+        "chatgpt": 42,
+        "claude": 43,
+    },
+}
+
+
+async def snapshot() -> StatusSnapshot:
+    return StatusSnapshot(
+        hermes_version="0.21.0",
+        model="GPT-5.6 Sol",
+        effort="High",
+        chatgpt=QuotaSummary(False),
+        claude=QuotaSummary(False),
+    )
+
+
+def test_snapshot_uses_current_gateway_model_context(monkeypatch) -> None:
+    import agent.account_usage as account_usage
+    import gateway.run as gateway_run
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_gateway_model_context",
+        lambda: SimpleNamespace(model="gpt-5.6-sol"),
+    )
+    monkeypatch.setattr(account_usage, "fetch_account_usage", lambda provider: None)
+    runner = SimpleNamespace(
+        _load_reasoning_config=lambda model: {"enabled": True, "effort": "high"}
+    )
+
+    result = asyncio.run(collect_status_snapshot(runner))
+
+    assert result.model == "GPT-5.6 Sol"
+    assert result.effort == "High"
+
+
+def test_default_ownership_path_is_shared_fleet_root(monkeypatch, tmp_path: Path) -> None:
+    import hermes_constants
+
+    fleet_root = tmp_path / "fleet"
+    profile_root = tmp_path / "profile"
+    monkeypatch.setattr(hermes_constants, "get_default_hermes_root", lambda: fleet_root)
+    monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: profile_root)
+
+    headline = StatusHeadline(
+        client=None,
+        discord_module=FakeDiscord,
+        config={"enabled": True, "guild_id": 10, "category_name": "STATUS"},
+        runner=None,
+        snapshot_provider=snapshot,
+    )
+
+    assert headline.store.path == fleet_root / "state" / "discord-status-sidebar" / "10.json"
+
+
+def test_exact_four_row_surface_adds_only_hermes_and_restarts_noop(
+    tmp_path: Path,
+) -> None:
+    asyncio.run(_exercise_four_row_migration(tmp_path))
+
+
+async def _exercise_four_row_migration(tmp_path: Path) -> None:
+    ownership = tmp_path / "10.json"
+    ownership.write_text(
+        json.dumps(FOUR_ROW_RECORD, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    guild = FakeGuild()
+    for row in guild.category.voice_channels:
+        row.name = f"stale-{row.id}"
+    create_voice_channel = guild.create_voice_channel
+
+    async def create_reordered_voice_channel(*args, **kwargs):
+        row = await create_voice_channel(*args, **kwargs)
+        row.name = "discord-normalized"
+        row.position = 99
+        guild.category.voice_channels.remove(row)
+        guild.category.voice_channels.append(row)
+        return row
+
+    guild.create_voice_channel = create_reordered_voice_channel
+    client = SimpleNamespace(get_guild=lambda guild_id: guild if guild_id == 10 else None)
+
+    headline = StatusHeadline(
+        client,
+        FakeDiscord,
+        {"enabled": True, "guild_id": 10, "category_name": "STATUS"},
+        runner=None,
+        ownership_path=ownership,
+        snapshot_provider=snapshot,
+    )
+    await headline.run_once()
+
+    assert [row.id for row in guild.created] == [44]
+    migrated = json.loads(ownership.read_text(encoding="utf-8"))
+    assert migrated == {
+        **FOUR_ROW_RECORD,
+        "channel_ids": {**FOUR_ROW_RECORD["channel_ids"], "hermes": 44},
+    }
+    expected_names = {
+        44: "Hermes v0.21.0",
+        40: "Model: GPT-5.6 Sol",
+        41: "Effort: High",
+        42: "ChatGPT: unavailable",
+        43: "Claude: unavailable",
+    }
+    assert {
+        row.id: row.name for row in guild.category.voice_channels
+    } == expected_names
+    assert {
+        row.id: row.position for row in guild.category.voice_channels
+    } == {44: 10, 40: 11, 41: 12, 42: 13, 43: 14}
+    assert guild.bulk_updates == [
+        [
+            {"id": 44, "position": 10},
+            {"id": 40, "position": 11},
+            {"id": 41, "position": 12},
+            {"id": 42, "position": 13},
+            {"id": 43, "position": 14},
+        ]
+    ]
+    assert guild.fetch_count == 3
+    assert all(
+        "position" not in edit
+        for row in guild.category.voice_channels
+        for edit in row.edits
+    )
+    edit_counts = {
+        row.id: len(row.edits) for row in guild.category.voice_channels
+    }
+    bulk_count = len(guild.bulk_updates)
+    fetch_count = guild.fetch_count
+
+    await headline.run_once()
+    restarted = StatusHeadline(
+        client,
+        FakeDiscord,
+        {"enabled": True, "guild_id": 10, "category_name": "STATUS"},
+        runner=None,
+        ownership_path=ownership,
+        snapshot_provider=snapshot,
+    )
+    await restarted.run_once()
+
+    assert [row.id for row in guild.created] == [44]
+    assert {
+        row.id: len(row.edits) for row in guild.category.voice_channels
+    } == edit_counts
+    assert len(guild.bulk_updates) == bulk_count
+    assert guild.fetch_count == fetch_count + 2
+
+
+def test_adapter_owns_exactly_one_headline_task_and_cancels_it() -> None:
+    asyncio.run(_exercise_adapter_task_lifecycle())
+
+
+def test_fresh_topology_drift_refuses_before_mutation(tmp_path: Path) -> None:
+    asyncio.run(_exercise_fresh_topology_refusal(tmp_path))
+
+
+async def _exercise_fresh_topology_refusal(tmp_path: Path) -> None:
+    ownership = tmp_path / "10.json"
+    ownership.write_text(
+        json.dumps(FOUR_ROW_RECORD, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    guild = FakeGuild()
+    foreign = FakeVoice(
+        99,
+        "foreign",
+        category_id=20,
+        position=14,
+        overwrites=guild.overwrites,
+    )
+
+    async def fresh_channels():
+        guild.fetch_count += 1
+        return [guild.category, *guild.category.voice_channels, foreign]
+
+    guild.fetch_channels = fresh_channels
+    client = SimpleNamespace(get_guild=lambda guild_id: guild if guild_id == 10 else None)
+    headline = StatusHeadline(
+        client,
+        FakeDiscord,
+        {"enabled": True, "guild_id": 10, "category_name": "STATUS"},
+        runner=None,
+        ownership_path=ownership,
+        snapshot_provider=snapshot,
+    )
+
+    with pytest.raises(RuntimeError, match="topology drifted"):
+        await headline.run_once()
+
+    assert guild.created == []
+    assert guild.bulk_updates == []
+    assert all(not row.edits for row in guild.category.voice_channels)
+
+
+async def _exercise_adapter_task_lifecycle() -> None:
+    adapter = object.__new__(DiscordAdapter)
+    adapter.config = PlatformConfig(
+        enabled=True,
+        token="not-used",
+        extra={"status_sidebar": {"enabled": True, "guild_id": 10}},
+    )
+    adapter._client = object()
+    adapter._status_headline_task = None
+    started = asyncio.Event()
+
+    async def run_forever():
+        started.set()
+        await asyncio.Event().wait()
+
+    adapter._run_status_headline = run_forever
+    first = adapter._ensure_status_headline_task()
+    assert first is adapter._ensure_status_headline_task()
+    await started.wait()
+
+    await adapter._cancel_status_headline_task()
+
+    assert first.done() and first.cancelled()
+    assert adapter._status_headline_task is None
+
+
+def test_invalid_headline_config_stays_noncritical() -> None:
+    asyncio.run(_exercise_invalid_config_containment())
+
+
+async def _exercise_invalid_config_containment() -> None:
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="not-used",
+            extra={"status_sidebar": {"enabled": True, "guild_id": "invalid"}},
+        )
+    )
+    adapter._client = object()
+    adapter.gateway_runner = None
+
+    task = asyncio.create_task(adapter._run_status_headline())
+    await asyncio.sleep(0)
+    assert not task.done()
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+
+def test_headline_task_holds_guild_lock_until_cancel(monkeypatch) -> None:
+    asyncio.run(_exercise_guild_lock(monkeypatch))
+
+
+async def _exercise_guild_lock(monkeypatch) -> None:
+    import gateway.status as gateway_status
+    import plugins.platforms.discord.status_headline as headline_module
+
+    acquired: list[tuple] = []
+    released: list[tuple] = []
+    started = asyncio.Event()
+    monkeypatch.setattr(
+        gateway_status,
+        "acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (
+            acquired.append((scope, identity, metadata)) or True,
+            None,
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_status,
+        "release_scoped_lock",
+        lambda scope, identity: released.append((scope, identity)),
+    )
+
+    class BlockingHeadline:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self.guild_id = 10
+
+        async def run_once(self):
+            started.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(headline_module, "StatusHeadline", BlockingHeadline)
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="not-used",
+            extra={"status_sidebar": {"enabled": True, "guild_id": 10}},
+        )
+    )
+    adapter._client = object()
+    adapter.gateway_runner = None
+
+    task = asyncio.create_task(adapter._run_status_headline())
+    await started.wait()
+    assert acquired == [
+        ("discord-status-sidebar-guild", "10", {"guild_id": 10})
+    ]
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert released == [("discord-status-sidebar-guild", "10")]
+
+
+def test_same_process_adapters_cannot_share_headline_guild(monkeypatch) -> None:
+    asyncio.run(_exercise_same_process_guild_exclusion(monkeypatch))
+
+
+async def _exercise_same_process_guild_exclusion(monkeypatch) -> None:
+    import gateway.status as gateway_status
+    import plugins.platforms.discord.status_headline as headline_module
+
+    acquired: list[str] = []
+    released: list[str] = []
+    entered: list[object] = []
+    first_started = asyncio.Event()
+
+    monkeypatch.setattr(
+        gateway_status,
+        "acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (
+            acquired.append(identity) or True,
+            {"pid": "same-process"},
+        ),
+    )
+    monkeypatch.setattr(
+        gateway_status,
+        "release_scoped_lock",
+        lambda scope, identity: released.append(identity),
+    )
+
+    class BlockingHeadline:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self.guild_id = 10
+
+        async def run_once(self):
+            entered.append(self)
+            first_started.set()
+            await asyncio.Event().wait()
+
+    monkeypatch.setattr(headline_module, "StatusHeadline", BlockingHeadline)
+
+    def adapter() -> DiscordAdapter:
+        value = DiscordAdapter(
+            PlatformConfig(
+                enabled=True,
+                token="not-used",
+                extra={"status_sidebar": {"enabled": True, "guild_id": 10}},
+            )
+        )
+        value._client = object()
+        value.gateway_runner = None
+        return value
+
+    owner_task = asyncio.create_task(adapter()._run_status_headline())
+    await first_started.wait()
+    rejected_task = asyncio.create_task(adapter()._run_status_headline())
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(entered) == 1
+    assert acquired == ["10"]
+
+    rejected_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await rejected_task
+    assert released == []
+
+    owner_task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await owner_task
+    assert released == ["10"]
+
+
+def test_headline_uses_established_refresh_interval_key(monkeypatch) -> None:
+    asyncio.run(_exercise_refresh_interval(monkeypatch))
+
+
+async def _exercise_refresh_interval(monkeypatch) -> None:
+    import gateway.status as gateway_status
+    import plugins.platforms.discord.adapter as adapter_module
+    import plugins.platforms.discord.status_headline as headline_module
+
+    delays: list[float] = []
+
+    class OneShotHeadline:
+        def __init__(self, *args, **kwargs):
+            del args, kwargs
+            self.guild_id = 10
+
+        async def run_once(self):
+            return None
+
+    async def stop_after_delay(delay: float):
+        delays.append(delay)
+        raise asyncio.CancelledError
+
+    monkeypatch.setattr(headline_module, "StatusHeadline", OneShotHeadline)
+    monkeypatch.setattr(adapter_module.asyncio, "sleep", stop_after_delay)
+    monkeypatch.setattr(
+        gateway_status,
+        "acquire_scoped_lock",
+        lambda scope, identity, metadata=None: (True, None),
+    )
+    monkeypatch.setattr(gateway_status, "release_scoped_lock", lambda scope, identity: None)
+    adapter = DiscordAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="not-used",
+            extra={
+                "status_sidebar": {
+                    "enabled": True,
+                    "guild_id": 10,
+                    "refresh_interval_seconds": 600,
+                }
+            },
+        )
+    )
+    adapter._client = object()
+    adapter.gateway_runner = None
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._run_status_headline()
+
+    assert delays == [600.0]


### PR DESCRIPTION
## Architecture disclosure

This is a direct built-in Discord adapter feature, not a plugin. A bounded plugin-seam probe found that targeted plugin unload leaves registered Discord platform-handler factories behind, so the public plugin lifecycle cannot provide the required one-writer/disposal contract without new host infrastructure.

## Summary

- Add an opt-in Hermes status headline to an already-owned schema-1 Discord status sidebar.
- Require the exact persisted guild, category, helper role, and four-row predecessor before migration.
- Persist a pending marker before creating the only permitted new resource: the Hermes voice row.
- Re-read ownership and authoritative Discord topology before and after mutation.
- Refresh the five owned row names and relative order in the same cycle.
- Keep presentation failures isolated from gateway health, model selection, launch, updates, and recovery.

## Safety properties

- Refuses cold-start, malformed, duplicate-ID, wrong-guild, foreign-child, missing-child, parent, overwrite, role, and order drift.
- Uses a process-local owner token plus the existing machine-scoped lock so multiplexed profiles cannot share one guild writer.
- Sends Discord's documented channel-position endpoint exactly the five persisted owned row IDs; no `VoiceChannel.edit(position=...)` bucket-wide payload.
- Performs fresh REST postcondition validation for topology, names, and effective `(position, id)` order.
- Preserves unresolved pending state after ambiguous create/persistence failure rather than inferring ownership or retrying creation.
- Starts one adapter-owned task across READY/RESUME and cancels it during disconnect or client replacement.

## Configuration

The feature is disabled unless `discord.status_sidebar.enabled` is exactly `true`. It uses the existing `guild_id`, `category_name`, and `refresh_interval_seconds` fields. Discord's rename-rate-limit floor remains 310 seconds.

## Test plan

- Focused Stats Headline tests: migration, restart no-op, fresh-topology refusal, model-context collection, shared ownership path, adapter lifecycle, malformed-config isolation, same-process guild exclusion, lock release, and configured refresh interval.
- Existing Discord connect/lifecycle tests.
- Ruff on all three changed Python files.
- Git diff whitespace validation.

Latest-main replay result: `22 passed`; Ruff and diff checks passed.

## Exact local candidate

- Upstream base: `f85edd3d940130cc8b6b173dfa77dd25e5610100`
- Candidate head: `b3640be58aacbbe1c1ef3ee48169adacf6225397`
- Candidate tree: `a037e2cafd4491040bfbc9226c9a696989b07b46`
- Commit count: 2
- Changed paths: 3
- Binary patch bytes: 41,496
- Binary patch SHA-256: `5d61100c8f3f5997ff5317972eae2f2fa98247451e84705ea8bcdb6fe35e62ef`

## Delivery status

Implementation and latest-upstream replay are locally qualified. The branch is published only for draft PR #100126. It has not been deployed, activated, or dogfooded against live Discord. `/health` is not treated as feature proof.
