### PR TITLE
fix(state): retry deferred FTS rebuilds instead of treating leftover lock files as holders

### DIFF
--- a/gateway/session.py
+++ b/gateway/session.py
@@ -14,6 +14,7 @@ import logging
 import os
 import json
 import threading
+import time
 import uuid
 from pathlib import Path
 from datetime import datetime, timedelta
@@ -35,6 +36,11 @@ def _now() -> datetime:
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness`` into
 # ``HERMES_AUTO_CONTINUE_FRESHNESS`` at startup.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
+
+# In-process stale-FTS retry. Live write/search must not rebuild (#97940);
+# the gateway is a long-lived SessionDB opener, so "retry at next startup"
+# never happens until restart. A leftover empty lock file is not a holder.
+_FTS_STALE_RETRY_SECONDS = 60.0
 
 
 def auto_continue_freshness_window() -> float:
@@ -1288,6 +1294,9 @@ class SessionStore:
         self._dirty_transcripts: Dict[str, List[Dict[str, Any]]] = {}
         self._transcript_append_failures: Dict[str, int] = {}
         self._fts_rebuild_attempted = False
+        self._fts_rebuild_retry_after = 0.0
+        self._fts_stale_retry_thread: Optional[threading.Thread] = None
+        self._fts_stale_retry_stop = threading.Event()
         self._has_active_processes_fn = has_active_processes_fn
         # Whether to keep writing the legacy sessions.json mirror alongside
         # the primary gateway_routing table in state.db. Default True for
@@ -1348,6 +1357,7 @@ class SessionStore:
         except Exception:
             self._routing_home = None
         self._open_session_db_for_active_scope()
+        self._schedule_stale_fts_retry()
 
     def _open_session_db_for_active_scope(self, db_path: Optional[Path] = None):
         """Return the SessionDB for the profile scope active on this task.
@@ -4143,6 +4153,7 @@ class SessionStore:
                     # clear: replay any cap-dropped messages spooled to disk
                     # for this session (#78182).
                     self._drain_spooled_drops(session_id)
+                    self._schedule_stale_fts_retry()
                     return
                 continue
 
@@ -4237,25 +4248,80 @@ class SessionStore:
             return SessionDB._is_fts_write_corruption_error(exc)
         return False
 
+    def _schedule_stale_fts_retry(self) -> None:
+        """Retry deferred FTS recovery off the live write/search path.
+
+        Live append/search must not start a full rebuild (#97940). A
+        long-lived gateway never reopens SessionDB, so without this loop
+        a deferred startup recovery stays stale until restart (#100108).
+        """
+        db = getattr(self, "_db", None)
+        if db is None or not getattr(db, "_fts_stale", False):
+            return
+        retry = getattr(db, "retry_deferred_fts_recovery", None)
+        if not callable(retry):
+            return
+        thread = getattr(self, "_fts_stale_retry_thread", None)
+        if thread is not None and thread.is_alive():
+            return
+        stop = getattr(self, "_fts_stale_retry_stop", None)
+        if stop is None:
+            stop = threading.Event()
+            self._fts_stale_retry_stop = stop
+        if stop.is_set():
+            return
+
+        def _run() -> None:
+            delay = 0.0
+            while not stop.wait(delay):
+                current = getattr(self, "_db", None)
+                if current is None or not getattr(current, "_fts_stale", False):
+                    return
+                recover = getattr(current, "retry_deferred_fts_recovery", None)
+                if not callable(recover):
+                    return
+                try:
+                    if recover():
+                        return
+                except Exception:
+                    logger.warning(
+                        "stale state.db FTS retry failed", exc_info=True
+                    )
+                delay = _FTS_STALE_RETRY_SECONDS
+
+        self._fts_stale_retry_thread = threading.Thread(
+            target=_run,
+            name="hermes-fts-stale-retry",
+            daemon=True,
+        )
+        self._fts_stale_retry_thread.start()
+
     def _rebuild_fts_once(self) -> bool:
-        """Attempt FTS5 ``rebuild`` command once per store lifetime.
+        """Attempt FTS5 ``rebuild`` without burning the one-shot on deferral.
 
         Delegates to ``SessionDB.rebuild_fts()`` which handles locking and
         table-existence checks internally. Returns ``True`` when at least
-        one index was rebuilt.
+        one index was rebuilt. A foreign-holder skip or admission timeout
+        does not consume the attempt — the gateway stays up for days
+        (#100108).
         """
         if self._fts_rebuild_attempted:
             return False
-        self._fts_rebuild_attempted = True
+        now = time.monotonic()
+        if now < getattr(self, "_fts_rebuild_retry_after", 0.0):
+            return False
         db = self._db
         if db is None or not hasattr(db, "rebuild_fts"):
+            self._fts_rebuild_attempted = True
             return False
+        self._schedule_stale_fts_retry()
         # Guard against the same WAL split-brain risk as the automatic
         # rebuild paths: skip when a foreign process holds state.db or
         # its WAL sidecars open.
         if hasattr(db, "_foreign_state_db_holders"):
             foreign_holders = db._foreign_state_db_holders()
             if foreign_holders:
+                self._fts_rebuild_retry_after = now + _FTS_STALE_RETRY_SECONDS
                 logger.warning(
                     "Skipping Session DB FTS rebuild while foreign processes "
                     "hold the database or WAL sidecars (%s); canonical "
@@ -4264,16 +4330,22 @@ class SessionStore:
                 )
                 return False
         try:
+            rebuilt = db.rebuild_fts(timeout_seconds=0.0)
+        except TypeError:
             rebuilt = db.rebuild_fts()
         except Exception as exc:
+            self._fts_rebuild_attempted = True
             logger.warning("Session DB FTS rebuild failed: %s", exc)
             return False
         if rebuilt:
+            self._fts_rebuild_attempted = True
             logger.warning(
                 "Rebuilt %d Session DB FTS index(es) after append corruption",
                 rebuilt,
             )
-        return rebuilt > 0
+            return True
+        self._fts_rebuild_retry_after = now + _FTS_STALE_RETRY_SECONDS
+        return False
 
     def _clear_dirty_transcript(self, session_id: str) -> None:
         """Drop queued pending messages for a session.

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -79,6 +79,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _sql_session_last_active,
     _sql_session_last_active_by_id,
     escape_like as _escape_like,
+    is_advisory_lock_contention,
     DEFERRED_INDEX_SQL,
     FTS_CJK_STALE_KEY,
     FTS_REBUILD_DEFERRAL_KEY,
@@ -1758,13 +1759,14 @@ def _log_wal_reset_bug_once(
     # for git/pip/system Python installs (#75153).
     repair_hint = _wal_reset_repair_hint()
     logger.warning(
-        "%s: linked SQLite %s is vulnerable to the WAL-reset corruption "
+        "%s: linked SQLite %s in %s is vulnerable to the WAL-reset corruption "
         "bug (https://sqlite.org/wal.html#walresetbug) — %s. "
         "Upgrade to SQLite 3.51.3+ (or backports 3.50.7 / 3.44.6); "
         "%s. See `hermes doctor`. This warning fires once per "
         "process per database.",
         db_label,
         sqlite3.sqlite_version,
+        sys.executable,
         action,
         repair_hint,
     )
@@ -2315,7 +2317,16 @@ def _cross_process_repair_lock(db_path: Path):
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
                 break
-            except (BlockingIOError, OSError):
+            except (BlockingIOError, OSError) as exc:
+                if not is_advisory_lock_contention(exc):
+                    logger.warning(
+                        "Could not acquire state.db repair lock %s (%s) — "
+                        "skipping schema surgery. An empty leftover lock "
+                        "file is not a holder; only a live flock/msvcrt "
+                        "lock is.",
+                        lock_path, exc,
+                    )
+                    break
                 if time.monotonic() >= deadline:
                     break
                 time.sleep(_REPAIR_LOCK_POLL_SECONDS)
@@ -2323,7 +2334,8 @@ def _cross_process_repair_lock(db_path: Path):
             logger.warning(
                 "state.db repair lock %s held by another process for more "
                 "than %.0fs — skipping schema surgery in this process to "
-                "avoid racing the repairer.",
+                "avoid racing the repairer (leftover empty lock files "
+                "without a live flock do not block).",
                 lock_path, _REPAIR_LOCK_TIMEOUT_SECONDS,
             )
         yield acquired

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -7,6 +7,7 @@ hermes_state re-imports every name here for backward compatibility.
 """
 
 import contextlib
+import errno
 import logging
 import os
 import sys
@@ -876,6 +877,11 @@ END;
 # schema surgery runs on an EXCLUSIVE offline connection and can legitimately
 # take minutes in VACUUM, while runtime rebuilds run on live connections. The
 # timeout is sized for a full 'rebuild' of both indexes on a large DB.
+#
+# The *file* remaining on disk after a crash is not the lock. flock/msvcrt
+# attach to the open fd; an empty leftover ``*.lock`` with no live holder
+# must acquire immediately. Treating mtime as ownership (and unlinking the
+# file) would split the inode and let two rebuilds run at once.
 
 logger = logging.getLogger("hermes_state")
 
@@ -883,9 +889,30 @@ _FTS_REBUILD_LOCK_TIMEOUT_SECONDS = 120.0
 _FTS_REBUILD_LOCK_POLL_SECONDS = 0.1
 _IS_WINDOWS = sys.platform == "win32"
 
+# errno set for "someone else holds this advisory lock" — not I/O, NFS
+# ESTALE, ENOTSUP, or permission-to-create-the-file failures. Catching
+# every OSError as contention made a persistent filesystem error look
+# like a live 120s holder (#100108).
+_LOCK_CONTENTION_ERRNOS = {
+    errno.EAGAIN,
+    errno.EACCES,
+    errno.EWOULDBLOCK,
+}
+if hasattr(errno, "EDEADLK"):
+    _LOCK_CONTENTION_ERRNOS.add(errno.EDEADLK)
+
+
+def is_advisory_lock_contention(exc: BaseException) -> bool:
+    """True when *exc* means another process holds the advisory lock."""
+    if isinstance(exc, BlockingIOError):
+        return True
+    if not isinstance(exc, OSError):
+        return False
+    return exc.errno in _LOCK_CONTENTION_ERRNOS
+
 
 @contextlib.contextmanager
-def fts_rebuild_admission(db_path):
+def fts_rebuild_admission(db_path, *, timeout_seconds=None):
     """Serialize full structural FTS rebuilds on *db_path* across processes.
 
     Yields True when this process holds the rebuild authority, False when the
@@ -897,6 +924,11 @@ def fts_rebuild_admission(db_path):
     ``db_path`` may be a str or Path; None (in-memory DB / tests without a
     file path) yields True — a private in-memory DB has no cross-process
     surface.
+
+    *timeout_seconds* defaults to ``_FTS_REBUILD_LOCK_TIMEOUT_SECONDS``.
+    Opportunistic in-process retries pass ``0`` so a live holder does not
+    stall the caller for two minutes; a leftover empty lock file with no
+    flock still acquires on the first try.
     """
     if db_path is None:
         yield True
@@ -914,9 +946,14 @@ def fts_rebuild_admission(db_path):
         yield True
         return
 
+    timeout = (
+        _FTS_REBUILD_LOCK_TIMEOUT_SECONDS
+        if timeout_seconds is None
+        else max(float(timeout_seconds), 0.0)
+    )
     acquired = False
     try:
-        deadline = time.monotonic() + _FTS_REBUILD_LOCK_TIMEOUT_SECONDS
+        deadline = time.monotonic() + timeout
         while True:
             try:
                 if _IS_WINDOWS:
@@ -930,17 +967,34 @@ def fts_rebuild_admission(db_path):
                     fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
                 acquired = True
                 break
-            except (BlockingIOError, OSError):
+            except (BlockingIOError, OSError) as exc:
+                if not is_advisory_lock_contention(exc):
+                    logger.warning(
+                        "Could not acquire FTS rebuild lock %s (%s) — "
+                        "deferring this rebuild. An empty leftover lock file "
+                        "is not a holder; only a live flock/msvcrt lock is.",
+                        lock_path, exc,
+                    )
+                    break
                 if time.monotonic() >= deadline:
                     break
                 time.sleep(_FTS_REBUILD_LOCK_POLL_SECONDS)
         if not acquired:
-            logger.warning(
-                "FTS rebuild lock %s held by another process for more than "
-                "%.0fs — deferring this rebuild to avoid racing the holder "
-                "(the stale-FTS breadcrumb keeps it retryable).",
-                lock_path, _FTS_REBUILD_LOCK_TIMEOUT_SECONDS,
-            )
+            if timeout <= 0:
+                logger.warning(
+                    "FTS rebuild lock %s is busy — deferring this rebuild "
+                    "(leftover empty lock files without a live flock do not "
+                    "block; the stale-FTS breadcrumb keeps it retryable).",
+                    lock_path,
+                )
+            else:
+                logger.warning(
+                    "FTS rebuild lock %s held by another process for more than "
+                    "%.0fs — deferring this rebuild to avoid racing the holder "
+                    "(the stale-FTS breadcrumb keeps it retryable; leftover "
+                    "empty lock files without a live flock do not block).",
+                    lock_path, timeout,
+                )
         yield acquired
     finally:
         try:

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -43,6 +43,10 @@ logger = logging.getLogger("hermes_state")
 
 _FTS_HOLDER_ESCALATE_ATTEMPTS = 3
 _FTS_HOLDER_ESCALATE_SECONDS = 60.0
+# In-process stale-FTS retry cadence. Startup already waited the admission
+# timeout once; later retries are non-blocking (timeout=0) so a live holder
+# does not stall writers. Leftover empty lock files acquire immediately.
+_FTS_STALE_RETRY_SECONDS = 60.0
 
 # Cache for schema_read_probe_statements() — parsing SCHEMA_SQL spins up an
 # in-memory SQLite database, so derive the statements once per process.
@@ -422,7 +426,9 @@ class SessionSchemaMixin:
             )
             return None
 
-    def _recover_stale_fts(self, cursor: sqlite3.Cursor, *, legacy: bool) -> bool:
+    def _recover_stale_fts(
+        self, cursor: sqlite3.Cursor, *, legacy: bool, timeout_seconds=None
+    ) -> bool:
         """Atomically rebuild stale base/trigram indexes and resume syncing."""
         foreign_holders = self._foreign_state_db_holders()
         if foreign_holders:
@@ -502,7 +508,10 @@ class SessionSchemaMixin:
         # authority (fail closed). Losing the race means another process is
         # already performing this exact recovery; the stale breadcrumb stays
         # set, so this process simply keeps FTS detached and retries later.
-        with fts_rebuild_admission(getattr(self, "db_path", None)) as admitted:
+        with fts_rebuild_admission(
+            getattr(self, "db_path", None),
+            timeout_seconds=timeout_seconds,
+        ) as admitted:
             if not admitted:
                 logger.warning(
                     "Deferred stale state.db FTS rebuild: another process "
@@ -607,6 +616,43 @@ class SessionSchemaMixin:
             "restored sync triggers."
         )
         return True
+
+    def retry_deferred_fts_recovery(self) -> bool:
+        """Retry a deferred stale-FTS rebuild without reopening SessionDB.
+
+        Long-lived processes (gateway, interactive CLI) open state.db once.
+        ``_recover_stale_fts`` at that open fail-closes when foreign holders
+        or the rebuild lock are busy, and live write/search paths must not
+        start a full rebuild (#97940). This is the in-process retry those
+        paths were missing: non-blocking admission (timeout=0), so a leftover
+        empty lock file recovers immediately while a live holder is skipped
+        and tried again later.
+
+        Returns True when the index was rebuilt and sync triggers restored.
+        """
+        if not getattr(self, "_fts_stale", False):
+            return False
+        if getattr(self, "read_only", False) or getattr(self, "_conn", None) is None:
+            return False
+        now = time.monotonic()
+        if now < getattr(self, "_fts_stale_retry_after", 0.0):
+            return False
+        self._fts_stale_retry_after = now + _FTS_STALE_RETRY_SECONDS
+        with self._lock:
+            if self._conn is None or not self._fts_stale:
+                return False
+            cursor = self._conn.cursor()
+            legacy = self._db_has_legacy_inline_fts(cursor)
+            recovered = self._recover_stale_fts(
+                cursor, legacy=legacy, timeout_seconds=0.0
+            )
+            if recovered:
+                self._ensure_fts_cjk_schema(cursor)
+            try:
+                self._conn.commit()
+            except sqlite3.Error:
+                pass
+            return recovered
 
     @staticmethod
     def _parse_schema_columns(schema_sql: str) -> Dict[str, Dict[str, str]]:
@@ -1510,7 +1556,8 @@ class SessionSchemaMixin:
         breadcrumb is persisted, mirroring ``_enter_fts_fail_open``'s
         ordering contract: triggers must never be live over an index with an
         unrebuilt gap. FTS stays detached for this instance; the winner's
-        rebuild — or ``_recover_stale_fts`` at the next startup — restores
+        rebuild — or ``retry_deferred_fts_recovery`` in this process, or
+        ``_recover_stale_fts`` at the next startup — restores
         the index and triggers atomically.
         """
         with fts_rebuild_admission(getattr(self, "db_path", None)) as admitted:

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2365,7 +2365,7 @@ class SessionSearchMixin:
                     )
         return optimized
 
-    def rebuild_fts(self) -> int:
+    def rebuild_fts(self, *, timeout_seconds=None) -> int:
         """Rebuild FTS5 indexes from the canonical ``messages`` table.
 
         Uses the FTS5 ``'rebuild'`` command, which rewrites the internal
@@ -2382,13 +2382,20 @@ class SessionSearchMixin:
         FAILS CLOSED: if another process holds the rebuild lock beyond the
         bounded wait, this call defers (returns 0) rather than racing it.
         Callers already treat 0 as "rebuild made no progress" and fall back
-        to the stale-FTS breadcrumb path, which retries at next startup.
+        to the stale-FTS breadcrumb path, which retries in-process
+        (``retry_deferred_fts_recovery``) and at next startup.
+
+        *timeout_seconds* is forwarded to admission. Opportunistic callers
+        pass ``0`` so a live holder does not stall the request path.
 
         Safe to call when FTS tables don't exist (skips them).
         Returns the number of FTS indexes that were rebuilt.
         """
         rebuilt = 0
-        with fts_rebuild_admission(getattr(self, "db_path", None)) as admitted:
+        with fts_rebuild_admission(
+            getattr(self, "db_path", None),
+            timeout_seconds=timeout_seconds,
+        ) as admitted:
             if not admitted:
                 logger.warning(
                     "Deferred in-place FTS rebuild: another process holds "

--- a/tests/gateway/test_fts_rebuild_once_retry.py
+++ b/tests/gateway/test_fts_rebuild_once_retry.py
@@ -1,0 +1,62 @@
+"""Gateway FTS rebuild must not burn its one-shot on a deferred attempt (#100108)."""
+
+import threading
+
+from gateway.session import SessionStore
+
+
+class TestRebuildFtsOnceRetry:
+    def test_foreign_holder_skip_does_not_consume_the_attempt(self):
+        class FakeDb:
+            def __init__(self):
+                self.holders = [(4242, "/tmp/state.db")]
+                self.rebuilds = 0
+                self._fts_stale = False
+
+            def _foreign_state_db_holders(self):
+                return list(self.holders)
+
+            def rebuild_fts(self, *, timeout_seconds=None):
+                self.rebuilds += 1
+                return 1
+
+        store = object.__new__(SessionStore)
+        store._db = FakeDb()
+        store._fts_rebuild_attempted = False
+        store._fts_rebuild_retry_after = 0.0
+        store._fts_stale_retry_thread = None
+        store._fts_stale_retry_stop = threading.Event()
+
+        assert store._rebuild_fts_once() is False
+        assert store._fts_rebuild_attempted is False
+        assert store._db.rebuilds == 0
+
+        store._db.holders = []
+        store._fts_rebuild_retry_after = 0.0
+        assert store._rebuild_fts_once() is True
+        assert store._db.rebuilds == 1
+        assert store._fts_rebuild_attempted is True
+
+    def test_admission_timeout_does_not_consume_the_attempt(self):
+        class FakeDb:
+            def __init__(self):
+                self._fts_stale = False
+
+            def _foreign_state_db_holders(self):
+                return []
+
+            def rebuild_fts(self, *, timeout_seconds=None):
+                return 0
+
+        store = object.__new__(SessionStore)
+        store._db = FakeDb()
+        store._fts_rebuild_attempted = False
+        store._fts_rebuild_retry_after = 0.0
+        store._fts_stale_retry_thread = None
+        store._fts_stale_retry_stop = threading.Event()
+
+        assert store._rebuild_fts_once() is False
+        assert store._fts_rebuild_attempted is False
+        store._fts_rebuild_retry_after = 0.0
+        assert store._rebuild_fts_once() is False
+        assert store._fts_rebuild_attempted is False

--- a/tests/state/test_fts_rebuild_admission.py
+++ b/tests/state/test_fts_rebuild_admission.py
@@ -17,9 +17,11 @@ prove nothing.
 """
 
 import contextlib
+import errno
 import subprocess
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 import pytest
@@ -222,5 +224,80 @@ class TestSchemaPathAdmission:
         finally:
             d3.close()
         # Recovered: breadcrumb cleared, triggers restored.
+        assert _meta_value(db_path, FTS_STALE_KEY) is None
+        assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+
+
+class TestLeftoverLockFileIsNotAHolder:
+    def test_empty_lock_file_without_flock_admits_immediately(self, tmp_path):
+        """A leftover 0-byte ``*.lock`` is not ownership (#100108)."""
+        db_path = tmp_path / "state.db"
+        lock = _lock_file(db_path)
+        lock.write_bytes(b"")
+        t0 = time.monotonic()
+        with hermes_state_common.fts_rebuild_admission(db_path) as admitted:
+            assert admitted is True
+        assert time.monotonic() - t0 < 2.0
+
+    def test_non_contention_oserror_does_not_wait_out_timeout(
+        self, tmp_path, monkeypatch
+    ):
+        import fcntl
+
+        monkeypatch.setattr(
+            hermes_state_common, "_FTS_REBUILD_LOCK_TIMEOUT_SECONDS", 30.0
+        )
+
+        def _flock(*_args, **_kwargs):
+            raise OSError(getattr(errno, "ESTALE", errno.EIO), "stale handle")
+
+        monkeypatch.setattr(fcntl, "flock", _flock)
+        db_path = tmp_path / "state.db"
+        t0 = time.monotonic()
+        with hermes_state_common.fts_rebuild_admission(db_path) as admitted:
+            assert admitted is False
+        assert time.monotonic() - t0 < 2.0
+
+    def test_retry_deferred_fts_recovery_rebuilds_same_instance(
+        self, tmp_path, monkeypatch
+    ):
+        """Gateway-shaped: same SessionDB stays open and retries after deferral."""
+        import hermes_state_schema
+
+        monkeypatch.setattr(hermes_state_schema, "_FTS_STALE_RETRY_SECONDS", 0.0)
+        db_path = tmp_path / "state.db"
+        d = SessionDB(db_path=db_path)
+        if not d._fts_enabled:
+            d.close()
+            pytest.skip("FTS5 unavailable in this build")
+        d.create_session("s1", source="test")
+        d.append_message("s1", "user", "hello recovery path")
+        d.close()
+
+        raw = sqlite3.connect(str(db_path))
+        raw.execute(
+            "INSERT OR REPLACE INTO state_meta(key, value) VALUES (?, '1')",
+            (FTS_STALE_KEY,),
+        )
+        for trig in _FTS_TRIGGERS:
+            raw.execute(f"DROP TRIGGER IF EXISTS {trig}")
+        raw.commit()
+        raw.close()
+
+        holders = [(4242, str(db_path))]
+        monkeypatch.setattr(
+            SessionDB, "_foreign_state_db_holders", lambda self: list(holders)
+        )
+        d2 = SessionDB(db_path=db_path)
+        try:
+            assert d2._fts_stale is True
+            d2._fts_stale_retry_after = 0.0
+            assert d2.retry_deferred_fts_recovery() is False
+            holders.clear()
+            d2._fts_stale_retry_after = 0.0
+            assert d2.retry_deferred_fts_recovery() is True
+            assert d2._fts_stale is False
+        finally:
+            d2.close()
         assert _meta_value(db_path, FTS_STALE_KEY) is None
         assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)

--- a/tests/test_sqlite_wal_reset_gate.py
+++ b/tests/test_sqlite_wal_reset_gate.py
@@ -69,6 +69,7 @@ class TestApplyWalWalResetGate:
         assert mode == "delete"
         assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
         assert any("instead of enabling WAL" in r.getMessage() for r in caplog.records)
+        assert any(sys.executable in r.getMessage() for r in caplog.records)
         conn.close()
 
     def test_existing_wal_left_alone_when_vulnerable(


### PR DESCRIPTION
## Summary
- Long-lived processes (gateway) open `state.db` once. A fail-closed FTS rebuild deferral (foreign holders or the 120s admission wait) left search on LIKE until restart or a manual `hermes sessions optimize`. Retry that recovery off the live write/search path, and do not consume the gateway one-shot when the rebuild was only skipped.
- `flock`/`msvcrt` is the lock, not the leftover `state.db.fts_rebuild.lock` / `.repair.lock` files. Empty files with no live holder acquire immediately; non-contention `OSError` (e.g. ESTALE) no longer waits 120s pretending a process holds the lock. Do not unlink lock files by mtime — that splits the inode and reintroduces concurrent rebuilds.
- WAL-reset warnings now include `sys.executable` so a 3.45.1 log line can be matched to the process that actually linked that SQLite, not a different venv.

Fixes https://github.com/NousResearch/hermes-agent/issues/100108

## Test plan
- [x] `scripts/run_tests.sh tests/state/test_fts_rebuild_admission.py tests/gateway/test_fts_rebuild_once_retry.py tests/test_sqlite_wal_reset_gate.py tests/gateway/test_session.py tests/state/test_fts_runtime_rebuild.py tests/test_state_db_malformed_repair.py -q`
- [ ] Confirm a leftover empty `state.db.fts_rebuild.lock` does not block `rebuild_fts` / stale recovery when no process holds flock
- [ ] Confirm gateway FTS rebuild still skips while another Hermes process holds the DB, then retries after the holder is gone without a restart
