### PR TITLE
feat(agent): in-process memory watchdog — thread-stack forensics + contained exit before kernel OOM

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2063,6 +2063,26 @@ def init_agent(
         except Exception:
             pass
 
+    # Process-level memory watchdog (agent.memory_watchdog config section).
+    # Samples own RSS on a daemon thread and (a) logs + dumps all thread
+    # stacks when a warn threshold is crossed, (b) exits the process with a
+    # distinctive code before the kernel OOM killer has to fire when a hard
+    # threshold is configured. One thread per process — idempotent across
+    # the per-request AIAgent instances that serve/gateway create.
+    try:
+        from agent.memory_watchdog import (
+            resolve_settings as _resolve_memory_watchdog_settings,
+            start_memory_watchdog,
+        )
+
+        start_memory_watchdog(
+            _resolve_memory_watchdog_settings(
+                _agent_section.get("memory_watchdog")
+            )
+        )
+    except Exception:
+        logger.debug("memory watchdog start failed", exc_info=True)
+
     # Bot Mode teammate protocol section (tools/bot_mode_probe.py) — pure
     # filesystem reads, no warm needed. Silent on non-Bot-Mode installs.
     agent._bot_mode_protocol = bool(_agent_section.get("bot_mode_protocol", True))

--- a/agent/memory_watchdog.py
+++ b/agent/memory_watchdog.py
@@ -1,0 +1,292 @@
+"""In-process memory watchdog for agent backends.
+
+Catches unbounded memory growth inside a running Hermes agent process
+(CLI, gateway turn, desktop/serve backend, cron run) *before* the kernel
+OOM killer has to fire, and leaves a forensic record — a faulthandler dump
+of every thread stack — pointing at the code that was ballooning.
+
+Why this exists
+---------------
+Two Hermes desktop backends were kernel-OOM-killed on a 27 GB host within
+15 minutes of each other (19.5 GB and 23 GB ``anon-rss``; the second kill
+took the NoMachine session down with it). The growth (~200 MB/s) happened
+inside silent terminal-wait windows while the backend sat in its poll loop,
+and because the process died to the kernel OOM killer there was **zero
+in-process evidence** of which code path was allocating. The victims were
+never observed trimming; every post-mortem was a kernel task table, not a
+stack trace.
+
+The watchdog is deliberately a containment + forensics net, not a cure:
+the leak itself has to be found and fixed (see the linked issue/PR), but
+until then this bounds the blast radius (the process dies *before* the
+machine freezes; supervisors restart it) and turns the next occurrence
+from "kernel table forensics" into "here is the stack that ballooned".
+
+Design constraints (from the incidents and the shutdown watchdog pattern
+in ``gateway/shutdown_watchdog.py``):
+
+* The kill path must survive a wedged/GIL-starved main loop: it uses only
+  ``/proc`` reads (psutil fallback), ``faulthandler.dump_traceback`` (async
+  signal under the hood, works while threads are stuck) and ``os._exit``.
+* Never raises, never blocks: a forensics failure must not take the
+  agent down (same contract as ``gateway.lifecycle_ledger``).
+* One thread per process, not per agent: ``hermes serve``/gateway create a
+  fresh AIAgent per request; without a process-level guard the watchdog
+  itself would leak a thread per agent (the openrouter-prewarm guard in
+  ``agent.agent_init`` exists for exactly this class of bug).
+* Opt-in hard kill, default-on warn: the warn threshold produces a log
+  line + a full thread-stack dump to a file on first crossing; the hard
+  threshold (if configured) exits the process with a distinctive code so
+  the supervisor restarts it instead of the kernel OOM-killing the machine
+  into a freeze.
+
+Config (``agent.memory_watchdog`` in config.yaml)::
+
+    agent:
+      memory_watchdog:
+        enabled: true           # default true — warn-only unless thresholds set
+        interval_s: 30          # sample cadence (default 30, min 5)
+        warn_threshold_kib: 0   # KiB of RSS that triggers a warn dump; 0 = off
+        hard_threshold_kib: 0   # KiB that triggers contained exit; 0 = off
+
+Both thresholds default to 0 (feature silent) so the schema default is a
+pure no-op; the desktop/gateway deployments that need containment set
+them explicitly. Warn fires at most once per growth episode (re-arms when
+RSS falls back below the threshold); hard exit is naturally one-shot.
+
+Exit code: ``MEMORY_WATCHDOG_EXIT_CODE`` (42). Distinctive so a supervisor
+or user can tell "watchdog contained a runaway" from a crash; the number
+is not used by any other ``os._exit`` site in the tree (search before
+reusing).
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import logging
+import os
+import sys
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Distinct from every other os._exit site in the tree (gateway uses 0 and
+# 75; verified by grep before picking). 42: "the answer", not a secret.
+MEMORY_WATCHDOG_EXIT_CODE = 42
+
+DEFAULT_INTERVAL_S = 30.0
+MIN_INTERVAL_S = 5.0
+
+_DUMP_RELATIVE = ("logs", "agent-memory-watchdog.log")
+
+# Process-level singletons: one watchdog per OS process, regardless of how
+# many AIAgent instances are created inside it (gateway/serve create one
+# per request). Guards against thread-per-agent leaks.
+_thread_lock = threading.Lock()
+_thread: Optional[threading.Thread] = None
+_stop_event = threading.Event()
+_settings: Dict[str, Any] = {}
+
+
+def _sample_rss_kib() -> int:
+    """Cheap own-RSS read. Never raises; 0 = unknown (sampling skipped)."""
+    # /proc first (sub-millisecond, no dependency), psutil fallback for
+    # macOS/WSL corner cases. Same shape as gateway.lifecycle_ledger.
+    try:
+        with open("/proc/self/status", "r", encoding="utf-8") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1])  # value is in kB
+    except Exception:
+        pass
+    try:
+        import psutil
+
+        return psutil.Process(os.getpid()).memory_info().rss // 1024
+    except Exception:
+        pass
+    return 0
+
+
+def _watchdog(
+    *,
+    interval_s: float,
+    warn_threshold_kib: int,
+    hard_threshold_kib: int,
+    dump_path: Optional[Path],
+) -> None:
+    """Sample-and-trip loop. Runs on the watchdog daemon thread."""
+    warn_armed = True
+    while not _stop_event.wait(interval_s):
+        rss = _sample_rss_kib()
+        if rss == 0:
+            continue  # sampling unavailable (e.g. exotic platform) — no-op
+        if warn_threshold_kib and rss >= warn_threshold_kib and warn_armed:
+            warn_armed = False
+            _fire_warn(rss, dump_path)
+        elif warn_threshold_kib and rss < warn_threshold_kib * 0.9:
+            # Hysteresis: re-arm only once RSS falls 10% below the
+            # threshold, so an RSS hovering at the line cannot flap between
+            # armed/disarmed on every sample.
+            warn_armed = True
+        if hard_threshold_kib and rss >= hard_threshold_kib:
+            _fire_exit(rss, dump_path)
+            return  # unreachable when _fire_exit succeeds
+
+
+def _fire_warn(rss_kib: int, dump_path: Optional[Path]) -> None:
+    """Log + dump all thread stacks to the dump file (best-effort)."""
+    try:
+        logger.warning(
+            "[memory-watchdog] RSS %d KiB crossed warn threshold — dumping "
+            "all thread stacks to %s",
+            rss_kib,
+            dump_path,
+        )
+    except Exception:
+        pass
+    if dump_path is None:
+        return
+    try:
+        dump_path.parent.mkdir(parents=True, exist_ok=True)
+        with open(dump_path, "a", encoding="utf-8") as fh:
+            fh.write(
+                f"--- memory-watchdog warn {time.strftime('%Y-%m-%dT%H:%M:%S')} "
+                f"pid={os.getpid()} rss_kib={rss_kib} ---\n"
+            )
+            fh.flush()
+            faulthandler.dump_traceback(file=fh, all_threads=True)
+    except Exception:
+        logger.debug("[memory-watchdog] warn dump failed", exc_info=True)
+
+
+def _fire_exit(rss_kib: int, dump_path: Optional[Path]) -> None:
+    """Log + dump + contained exit. The whole path is GIL-resilient."""
+    try:
+        logger.critical(
+            "[memory-watchdog] RSS %d KiB crossed hard threshold — exiting "
+            "with code %d (contained; supervisor will restart). Stacks "
+            "dumped to %s",
+            rss_kib,
+            MEMORY_WATCHDOG_EXIT_CODE,
+            dump_path,
+        )
+    except Exception:
+        path = f"{dump_path}"
+        print(
+            f"[memory-watchdog] RSS {rss_kib} KiB crossed hard threshold; "
+            f"exiting {MEMORY_WATCHDOG_EXIT_CODE}; dump: {path}",
+            file=sys.stderr,
+        )
+    try:
+        if dump_path is not None:
+            dump_path.parent.mkdir(parents=True, exist_ok=True)
+            with open(dump_path, "a", encoding="utf-8") as dfh:
+                dfh.write(
+                    f"--- memory-watchdog EXIT {time.strftime('%Y-%m-%dT%H:%M:%S')} "
+                    f"pid={os.getpid()} rss_kib={rss_kib} ---\n"
+                )
+                dfh.flush()
+                faulthandler.dump_traceback(file=dfh, all_threads=True)
+    except Exception:
+        pass
+    os._exit(MEMORY_WATCHDOG_EXIT_CODE)
+
+
+def _resolve_dump_path() -> Optional[Path]:
+    """``<HERMES_HOME>/logs/agent-memory-watchdog.log`` — never raises."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home().joinpath(*_DUMP_RELATIVE)
+    except Exception:
+        return None
+
+
+def _normalize_threshold(value: Any) -> int:
+    """Positive int KiB or 0 (off). Junk → 0, never an exception."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return 0
+    return n if n > 0 else 0
+
+
+def _normalize_interval(value: Any) -> float:
+    """Positive float seconds, clamped to ≥ MIN_INTERVAL_S. Junk → default."""
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return DEFAULT_INTERVAL_S
+    if f <= 0:
+        return DEFAULT_INTERVAL_S
+    return max(f, MIN_INTERVAL_S)
+
+
+def resolve_settings(section: Any) -> Dict[str, Any]:
+    """Resolve ``agent.memory_watchdog`` config into effective settings.
+
+    Tolerant: a malformed or missing section yields the schema default
+    (warn-only, thresholds 0 = silent no-op). Never raises.
+    """
+    if not isinstance(section, dict):
+        section = {}
+    enabled = section.get("enabled", True)
+    if not isinstance(enabled, bool):
+        enabled = True
+    return {
+        "enabled": enabled,
+        "interval_s": _normalize_interval(section.get("interval_s", DEFAULT_INTERVAL_S)),
+        "warn_threshold_kib": _normalize_threshold(section.get("warn_threshold_kib", 0)),
+        "hard_threshold_kib": _normalize_threshold(section.get("hard_threshold_kib", 0)),
+    }
+
+
+def start_memory_watchdog(settings: Dict[str, Any]) -> Optional[threading.Thread]:
+    """Start the process-level watchdog thread (idempotent per process).
+
+    First call wins: later AIAgent instances in the same process (serve /
+    gateway create one per request) adopt the already-running thread. The
+    thread samples at the *first* caller's cadence — deployments that need
+    a different cadence set it in config, not per-request.
+    """
+    global _thread
+    if not isinstance(settings, dict) or not settings.get("enabled", True):
+        return _thread
+    with _thread_lock:
+        if _thread is not None and _thread.is_alive():
+            return _thread
+        interval_s = _normalize_interval(settings.get("interval_s", DEFAULT_INTERVAL_S))
+        warn_threshold_kib = _normalize_threshold(settings.get("warn_threshold_kib", 0))
+        hard_threshold_kib = _normalize_threshold(settings.get("hard_threshold_kib", 0))
+        if warn_threshold_kib <= 0 and hard_threshold_kib <= 0:
+            # Both thresholds off: nothing to watch. Don't spawn a thread
+            # that only sleeps. (enabled=true with no thresholds is the
+            # schema default state — silent no-op.)
+            return None
+        dump_path = _resolve_dump_path()
+        _stop_event.clear()
+        _thread = threading.Thread(
+            target=_watchdog,
+            kwargs={
+                "interval_s": interval_s,
+                "warn_threshold_kib": warn_threshold_kib,
+                "hard_threshold_kib": hard_threshold_kib,
+                "dump_path": dump_path,
+            },
+            daemon=True,
+            name="agent-memory-watchdog",
+        )
+        _thread.start()
+        return _thread
+
+
+def stop_memory_watchdog() -> None:
+    """Test/reset hook: stop the process-level thread."""
+    global _thread
+    with _thread_lock:
+        _stop_event.set()
+        _thread = None

--- a/tests/agent/test_memory_watchdog.py
+++ b/tests/agent/test_memory_watchdog.py
@@ -1,0 +1,235 @@
+"""Tests for agent/memory_watchdog.py — the agent-process memory watchdog.
+
+Covers:
+* resolve_settings: defaults (silent no-op), malformed sections, threshold
+  and interval normalization (junk → safe defaults, never raises)
+* start_memory_watchdog: idempotence per process, no thread when disabled,
+  no thread when both thresholds are 0, first-caller cadence wins
+* _watchdog loop: warn fires once per growth episode and re-arms via the
+  10% hysteresis band; hard threshold exits (tested via _fire_exit
+  monkeypatch — an os._exit in-process would kill the test runner)
+* _sample_rss_kib: /proc path on Linux, psutil fallback, 0 on failure
+* _fire_warn: writes the dump file with the header + thread stacks
+* resolve_settings tolerance: never raises on junk input
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import agent.memory_watchdog as mw
+
+
+@pytest.fixture(autouse=True)
+def _reset_process_singletons():
+    """Isolate the process-level singleton state between tests."""
+    mw.stop_memory_watchdog()
+    mw._settings = {}
+    yield
+    mw.stop_memory_watchdog()
+    mw._settings = {}
+
+
+# ---------------------------------------------------------------------------
+# resolve_settings
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSettings:
+    def test_default_section_is_silent_noop(self):
+        # enabled defaults true but both thresholds 0 → nothing to watch
+        s = mw.resolve_settings(None)
+        assert s == {
+            "enabled": True,
+            "interval_s": 30.0,
+            "warn_threshold_kib": 0,
+            "hard_threshold_kib": 0,
+        }
+
+    def test_explicit_thresholds_roundtrip(self):
+        s = mw.resolve_settings(
+            {"enabled": True, "interval_s": 10, "warn_threshold_kib": 2048, "hard_threshold_kib": 4096}
+        )
+        assert s["warn_threshold_kib"] == 2048
+        assert s["hard_threshold_kib"] == 4096
+        assert s["interval_s"] == 10.0
+
+    def test_malformed_section_falls_back_to_defaults(self):
+        for junk in ("nope", 123, [1, 2], {"enabled": "banana", "warn_threshold_kib": "x"}):
+            s = mw.resolve_settings(junk)
+            assert s["enabled"] is True
+            assert s["warn_threshold_kib"] == 0
+            assert s["hard_threshold_kib"] == 0
+            assert s["interval_s"] == 30.0
+
+    def test_enabled_false_disables(self):
+        s = mw.resolve_settings({"enabled": False, "warn_threshold_kib": 1024})
+        assert s["enabled"] is False
+
+    def test_negative_threshold_means_off(self):
+        s = mw.resolve_settings({"warn_threshold_kib": -5, "hard_threshold_kib": -1})
+        assert s["warn_threshold_kib"] == 0
+        assert s["hard_threshold_kib"] == 0
+
+    def test_interval_floor(self):
+        assert mw.resolve_settings({"interval_s": 0.1, "warn_threshold_kib": 1})["interval_s"] == 5.0
+        assert mw.resolve_settings({"interval_s": -3})["interval_s"] == 30.0
+        assert mw.resolve_settings({"interval_s": "junk"})["interval_s"] == 30.0
+
+
+# ---------------------------------------------------------------------------
+# start_memory_watchdog — process-level singleton behavior
+# ---------------------------------------------------------------------------
+
+
+class TestStartWatchdog:
+    def test_no_thread_when_disabled(self):
+        assert mw.start_memory_watchdog({"enabled": False, "warn_threshold_kib": 1024}) is None
+
+    def test_no_thread_when_both_thresholds_off(self):
+        # Schema default state: enabled=true, thresholds 0 → silent no-op.
+        assert mw.start_memory_watchdog(mw.resolve_settings(None)) is None
+
+    def test_start_returns_thread(self):
+        t = mw.start_memory_watchdog({"warn_threshold_kib": 10**9})
+        assert t is not None and t.is_alive()
+        assert t.daemon is True
+        assert t.name == "agent-memory-watchdog"
+
+    def test_idempotent_per_process(self):
+        t1 = mw.start_memory_watchdog({"warn_threshold_kib": 10**9, "interval_s": 60})
+        t2 = mw.start_memory_watchdog({"warn_threshold_kib": 10**9, "interval_s": 5})
+        assert t1 is t2  # same thread object — no per-request leak
+        assert t2 is not None and t2.is_alive()
+
+    def test_stop_then_restart_starts_new_thread(self):
+        t1 = mw.start_memory_watchdog({"warn_threshold_kib": 10**9})
+        mw.stop_memory_watchdog()
+        t2 = mw.start_memory_watchdog({"warn_threshold_kib": 10**9})
+        assert t1 is not t2
+        assert t2 is not None and t2.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# _watchdog loop — warn episode + hysteresis re-arm (no real exit)
+# ---------------------------------------------------------------------------
+
+
+class TestWatchdogLoop:
+    def test_warn_fires_once_per_episode_then_rearms(self, tmp_path, monkeypatch):
+        fired = []
+
+        def fake_fire_warn(rss, path):
+            fired.append(rss)
+
+        monkeypatch.setattr(mw, "_fire_warn", fake_fire_warn)
+        monkeypatch.setattr(mw, "_fire_exit", lambda rss, path: None)
+        stop = threading.Event()
+        monkeypatch.setattr(mw, "_stop_event", stop)
+        # Sample sequence: cross (fire), stay above (no re-fire), drop into
+        # the re-arm band (< 90%), stay under, cross again (fire), stay.
+        samples = iter([1200, 1300, 850, 960, 1100, 1100])
+        monkeypatch.setattr(mw, "_sample_rss_kib", lambda: next(samples, 850))
+
+        t = threading.Thread(
+            target=mw._watchdog,
+            kwargs={
+                "interval_s": 0.02,
+                "warn_threshold_kib": 1000,
+                "hard_threshold_kib": 0,
+                "dump_path": tmp_path / "dump.log",
+            },
+            daemon=True,
+        )
+        t.start()
+
+        time.sleep(0.5)
+        stop.set()
+        t.join(timeout=2)
+        assert not t.is_alive()
+        # Warn fired exactly at the two crossings, not on every sample
+        # above the line, and re-armed after the band dip.
+        assert len(fired) == 2
+
+    def test_hard_threshold_calls_exit(self, tmp_path, monkeypatch):
+        exits = []
+        monkeypatch.setattr(mw, "_fire_exit", lambda rss, path: exits.append(rss))
+        stop = threading.Event()
+        monkeypatch.setattr(mw, "_stop_event", stop)
+        monkeypatch.setattr(mw, "_sample_rss_kib", lambda: 5_000_000)
+
+        t = threading.Thread(
+            target=mw._watchdog,
+            kwargs={
+                "interval_s": 0.02,
+                "warn_threshold_kib": 0,
+                "hard_threshold_kib": 1_000_000,
+                "dump_path": tmp_path / "dump.log",
+            },
+            daemon=True,
+        )
+        t.start()
+        t.join(timeout=2)
+        assert not t.is_alive()
+        assert exits == [5_000_000]
+
+
+# ---------------------------------------------------------------------------
+# Sampling
+# ---------------------------------------------------------------------------
+
+
+class TestSampling:
+    def test_proc_path_returns_positive_int_on_linux(self):
+        rss = mw._sample_rss_kib()
+        assert isinstance(rss, int)
+        assert rss > 0  # the test process itself always has RSS on Linux
+
+    def test_all_paths_failing_returns_zero(self, monkeypatch):
+        # /proc unavailable AND psutil unimportable → 0, never raises.
+        import sys
+
+        def broken_open(*args, **kwargs):
+            raise OSError("no proc")
+
+        monkeypatch.setitem(sys.modules, "psutil", None)
+        monkeypatch.setattr("builtins.open", broken_open)
+        assert mw._sample_rss_kib() == 0
+
+
+# ---------------------------------------------------------------------------
+# _fire_warn dump file
+# ---------------------------------------------------------------------------
+
+
+class TestFireWarn:
+    def test_dump_written_with_header_and_stacks(self, tmp_path, caplog):
+        dump = tmp_path / "watchdog" / "dump.log"
+        with caplog.at_level(logging.WARNING, logger="agent.memory_watchdog"):
+            mw._fire_warn(123_456, dump)
+        assert dump.exists()
+        content = dump.read_text(encoding="utf-8")
+        assert "memory-watchdog warn" in content
+        assert "rss_kib=123456" in content
+        assert "Current thread" in content  # faulthandler stacks present
+        assert any("memory-watchdog" in r.message for r in caplog.records)
+
+    def test_dump_failure_never_raises(self, tmp_path, monkeypatch):
+        # Unwritable dump location: _fire_warn must swallow and continue.
+        dump = tmp_path / "nope" / "dump.log"
+        monkeypatch.setattr(Path, "mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError("denied")))
+        mw._fire_warn(1, dump)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# Exit code
+# ---------------------------------------------------------------------------
+
+
+def test_exit_code_distinctive():
+    assert mw.MEMORY_WATCHDOG_EXIT_CODE == 42

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1108,6 +1108,24 @@ When a budget is set, two things happen:
 
 The budget is per `run_conversation` turn (it resets on each user message) and the feature is completely dormant when unset — no clock reads, no injection, no timeout changes.
 
+## Memory Watchdog
+
+The agent process samples its own RSS on a daemon thread and can act **before** the kernel OOM killer has to. Two independent thresholds, both off by default (the feature is a silent no-op unless you set a threshold):
+
+```yaml
+agent:
+  memory_watchdog:
+    enabled: true           # default — sampling only runs when a threshold is set
+    interval_s: 30          # sample cadence in seconds (default 30, minimum 5)
+    warn_threshold_kib: 0   # RSS in KiB that triggers a warn + thread-stack dump; 0 = off
+    hard_threshold_kib: 0   # RSS in KiB that triggers a contained exit; 0 = off
+```
+
+- **`warn_threshold_kib`** — when crossed, Hermes logs a warning and dumps every thread's stack to `~/.hermes/logs/agent-memory-watchdog.log`. This is the forensic tool: if a backend ever starts ballooning, you get the exact code path as a stack trace instead of a kernel OOM table. Fires once per growth episode (re-arms after RSS falls back below 90% of the threshold).
+- **`hard_threshold_kib`** — when crossed, the same dump is written and the process exits with a distinctive code (`42`) so a supervisor (`systemd`, the desktop, the gateway) restarts it cleanly instead of the kernel OOM-killing the machine into a freeze. Opt-in: set it only where you want containment (e.g. `MemoryMax`-style deployment).
+
+The watchdog is GIL-resilient — the sample/dump/exit path uses only `/proc` reads, `faulthandler` and `os._exit`, so it fires even when the main loop is wedged. It runs once per process (not per conversation): gateway and `hermes serve` create a fresh agent per request, and the watchdog thread is shared.
+
 ## Verify-on-Stop (coding verification)
 
 When enabled, Hermes refuses to accept a final answer on a turn where the agent edited code in a workspace but produced no fresh verification evidence (a passing test run, build, lint, etc.) — it injects a synthetic follow-up asking the agent to verify or explain why it can't. Doc/markdown/skill-only edits never trigger it, and the loop is bounded so it can never trap the agent.


### PR DESCRIPTION
## What does this PR do?

Adds an in-process memory watchdog to agent backends: a daemon thread that samples the process's own RSS and acts **before** the kernel OOM killer has to — turning "machine froze, kernel killed the fattest process, no evidence" into "contained exit + a stack trace of the code that was ballooning".

**The incident that motivated this** (27 GB host, two kernel-OOM kills 15 minutes apart):

| Kill | Victim | anon-rss | Context |
|------|--------|----------|---------|
| 09:15:22 | desktop `serve` backend (PID 3860835) | 19.5 GB | invoked by ollama's allocation; victim sat ~6.5 min in a silent pytest terminal wait |
| 09:29:49 | desktop `serve` backend (PID 3869288) | 23 GB | grew ~600 MB → 23 GB in 10.5 min (~28 MB/s) during a silent 600 s terminal wait; second OOM took the NoMachine session down with it |

Both victims died during the *same* silent-window pattern: a long terminal tool call whose wait loop stopped cooperating, a deadline cascade firing (420 s sequential-tool timeout → 602 s wait-bound abandoned → event-loop stalls 16 s → 162 s → 220 s with "GIL pressure" logged), and unbounded memory growth inside the backend process itself. Because the kernel OOM killer did the dying, there was **zero in-process evidence** of which code path was allocating — every post-mortem was a kernel task table. The leak itself still needs finding and fixing; this PR is the containment + forensics net that makes the *next* occurrence diagnosable.

**What the watchdog does:**

- **Warn threshold** (`warn_threshold_kib`): on crossing, logs a warning and dumps **every thread's stack** via `faulthandler` to `~/.hermes/logs/agent-memory-watchdog.log`. Fires once per growth episode (re-arms via a 10% hysteresis band). This is the forensic tool — the exact allocation code path lands in a file before the process is at risk.
- **Hard threshold** (`hard_threshold_kib`, opt-in): same dump, then `os._exit(42)` — a distinctive, currently-unused exit code — so a supervisor (systemd, the desktop, the gateway) restarts the process cleanly instead of the kernel OOM-killing the machine into a freeze that also takes down unrelated sessions (NoMachine in our case).
- **GIL-resilient**: the sample → dump → exit path uses only `/proc` reads (psutil fallback), `faulthandler.dump_traceback` (async signal under the hood — works while threads are stuck) and `os._exit`. It fires even when the main loop is wedged, which is precisely the failure mode observed.
- **One thread per process, not per agent**: `hermes serve`/gateway create a fresh AIAgent per request; without a process-level singleton guard the watchdog itself would leak a thread per agent (the `openrouter-prewarm` guard in `agent_init` exists for exactly this class of bug).
- **Both thresholds default 0** — the feature is a silent no-op unless explicitly configured. No behavior change for anyone who doesn't opt in.

Design follows the repo's own conventions: the sample/dump/exit pattern mirrors `gateway/shutdown_watchdog.py` (faulthandler dump + metadata + `os._exit` for supervisor restart), the RSS sampling shape mirrors `gateway/lifecycle_ledger.sample_memory()` (/proc first, psutil fallback, never raises), and the config style follows `agent.run_budget_seconds` (additive subsection, malformed config falls back to safe defaults).

## Related Issue

No existing issue covers this failure mode (searched open issues/PRs for OOM/memory/watchdog — the open memory bugs target the desktop renderer and gateway exits, not agent-backend runaways). The root-cause hunt for the underlying leak continues separately; this PR is the safety net so the next occurrence is diagnosable and non-fatal.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- `agent/memory_watchdog.py` (new): the watchdog — RSS sampling loop, warn/hard thresholds with hysteresis, faulthandler stack dumps, contained exit, config resolution (tolerant of malformed sections, never raises)
- `agent/agent_init.py`: start the watchdog in `init_agent` (after the `environment_probe` block), idempotent per process, guarded by try/except so a watchdog failure can never break agent startup
- `tests/agent/test_memory_watchdog.py` (new): 19 tests — config resolution (defaults, malformed input, interval floors), process-level idempotence, warn-episode semantics + hysteresis re-arm, hard-threshold exit (via monkeypatched `_fire_exit` — a real `os._exit` would kill the test runner), sampling fallbacks, dump-file contents, never-raises contracts
- `website/docs/user-guide/configuration.md`: new "Memory Watchdog" section documenting the config keys, thresholds, and tradeoffs

## How to Test

1. `pytest tests/agent/test_memory_watchdog.py tests/agent/test_deadline.py -o 'addopts=' -q` → 74 passed
2. Wider regression around the touchpoint: `pytest tests/agent/test_meta_agent_init.py tests/agent/test_tool_guardrails.py tests/agent/test_deadline.py tests/agent/test_memory_watchdog.py tests/run_agent/test_memory_provider_init.py -o 'addopts=' -q` → 95 passed
3. Live smoke: configure `agent.memory_watchdog` with thresholds, instantiate an agent, confirm `agent-memory-watchdog` thread starts, second instantiation returns the same thread (idempotent), RSS sampling returns a live value, and `/proc`-unavailable platforms degrade to psutil/0 without raising
4. Warn-path proof: set `warn_threshold_kib` below current RSS → `~/.hermes/logs/agent-memory-watchdog.log` contains the header + all thread stacks

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't duplicate — the open memory issues target other surfaces (desktop renderer #46082, #80527; gateway WSL2 exits #95189)
- [x] My PR contains **only** changes related to this fix/feature
- [ ] I've run `pytest tests/ -q` and all tests pass — *(ran targeted suites: memory_watchdog, deadline, meta_agent_init, tool_guardrails, memory_provider_init — 95 passed; the full ~3000-test suite was not run in this session for time reasons)*
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04 (kernel 6.8)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (configuration.md)
- [x] I've updated `cli-config.yaml.example` — *(checked: the file documents top-level agent keys with a pointer to the reference docs; the additive `agent.memory_watchdog` subsection follows the same pattern as `agent.empty_response_guard`, which also has no example entry — matching house style)*
- [ ] N/A `CONTRIBUTING.md`/`AGENTS.md` — no architecture/workflow change
- [x] I've considered cross-platform impact: `/proc` first with psutil fallback; the Windows `/proc` open fails cleanly into the fallback; faulthandler and `os._exit` are cross-platform
- [x] N/A tool descriptions/schemas
