### PR TITLE
fix(plugins): include compacted messages in achievement scans

### DIFF
--- a/plugins/hermes-achievements/dashboard/plugin_api.py
+++ b/plugins/hermes-achievements/dashboard/plugin_api.py
@@ -32,6 +32,7 @@ except Exception:  # Allows local unit tests without dashboard dependencies.
 router = APIRouter()
 
 SNAPSHOT_TTL_SECONDS = 120
+CHECKPOINT_SCHEMA_VERSION = 2
 _SCAN_LOCK = threading.Lock()
 _SNAPSHOT_CACHE: Optional[Dict[str, Any]] = None
 _SNAPSHOT_CACHE_AT = 0
@@ -233,18 +234,21 @@ def save_snapshot(data: Dict[str, Any]) -> None:
 def load_checkpoint() -> Dict[str, Any]:
     path = checkpoint_path()
     if not path.exists():
-        return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+        return {"schema_version": CHECKPOINT_SCHEMA_VERSION, "generated_at": 0, "sessions": {}}
     try:
         data = json.loads(path.read_text(encoding="utf-8"))
-        if isinstance(data, dict):
-            data.setdefault("schema_version", 1)
+        # Deliberately reuse the cache only when the schema matches exactly.
+        # v1 checkpoints were produced by the active-only scanner and therefore
+        # undercount lifetime achievements; do NOT restore lenient loading —
+        # discarding them forces a one-time full rescan with compacted history.
+        if isinstance(data, dict) and data.get("schema_version") == CHECKPOINT_SCHEMA_VERSION:
             data.setdefault("generated_at", 0)
             data.setdefault("sessions", {})
             if isinstance(data.get("sessions"), dict):
                 return data
     except Exception:
         pass
-    return {"schema_version": 1, "generated_at": 0, "sessions": {}}
+    return {"schema_version": CHECKPOINT_SCHEMA_VERSION, "generated_at": 0, "sessions": {}}
 
 
 def save_checkpoint(data: Dict[str, Any]) -> None:
@@ -649,7 +653,7 @@ def scan_sessions(
                 stats = dict(cached_stats)
                 reused += 1
             else:
-                messages = db.get_messages(sid)
+                messages = db.get_messages(sid, include_compacted=True)
                 stats = analyze_messages(sid, meta.get("title") or meta.get("preview") or "Untitled", messages)
                 rescanned += 1
 
@@ -680,7 +684,7 @@ def scan_sessions(
                     pass
 
         save_checkpoint({
-            "schema_version": 1,
+            "schema_version": CHECKPOINT_SCHEMA_VERSION,
             "generated_at": int(time.time()),
             "sessions": checkpoint_sessions,
         })

--- a/tests/plugins/test_achievements_plugin.py
+++ b/tests/plugins/test_achievements_plugin.py
@@ -69,6 +69,7 @@ class _FakeSessionDB:
         self.last_include_children: Optional[bool] = None
         self.list_calls = 0
         self.messages_calls = 0
+        self.last_include_compacted: Optional[bool] = None
 
     def list_sessions_rich(
         self,
@@ -100,8 +101,13 @@ class _FakeSessionDB:
             for i in range(effective)
         ]
 
-    def get_messages(self, session_id: str) -> List[Dict[str, Any]]:
+    def get_messages(
+        self,
+        session_id: str,
+        include_compacted: bool = False,
+    ) -> List[Dict[str, Any]]:
         self.messages_calls += 1
+        self.last_include_compacted = include_compacted
         return [
             {"role": "user", "content": f"ask {session_id}"},
             {
@@ -149,6 +155,49 @@ def test_scan_sessions_default_scans_all_history_not_first_200(plugin_api):
     )
     assert len(result["sessions"]) == 500
     assert result["scan_meta"]["sessions_total"] == 500
+
+
+def test_scan_sessions_includes_compacted_history(plugin_api):
+    """Lifetime achievements must include events moved into compacted history."""
+    fake_db = _FakeSessionDB(session_count=1)
+    original_get_messages = fake_db.get_messages
+
+    def get_messages_with_compacted_tts(
+        session_id: str,
+        include_compacted: bool = False,
+    ) -> List[Dict[str, Any]]:
+        messages = original_get_messages(session_id, include_compacted)
+        if include_compacted:
+            messages.append(
+                {
+                    "role": "assistant",
+                    "tool_calls": [{"function": {"name": "text_to_speech"}}],
+                }
+            )
+        return messages
+
+    fake_db.get_messages = get_messages_with_compacted_tts
+    _install_fake_session_db(plugin_api, fake_db)
+
+    result = plugin_api.scan_sessions()
+
+    assert fake_db.last_include_compacted is True
+    assert result["aggregate"]["tts_calls"] == 1
+
+
+def test_load_checkpoint_discards_active_only_scan_results(plugin_api):
+    """Cached stats from the active-only scanner must not survive the fix."""
+    path = plugin_api.checkpoint_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        '{"schema_version": 1, "generated_at": 1, '
+        '"sessions": {"session-1": {"stats": {"tts_calls": 1}}}}',
+        encoding="utf-8",
+    )
+
+    checkpoint = plugin_api.load_checkpoint()
+
+    assert checkpoint["sessions"] == {}
 
 
 def test_evaluate_all_first_run_returns_pending_and_starts_background_scan(plugin_api):


### PR DESCRIPTION
## What does this PR do?

The bundled `hermes-achievements` scanner undercounts lifetime, count-based achievements once sessions are compacted. It scans every session, but for each session it loads only **active** messages, so any messages and tool calls that have been moved into compacted history are silently dropped from the totals.

On my install this surfaced as `Voice Of The Machine` (a lifetime `text_to_speech` counter) showing `1/10` even though the session database held 102 real `text_to_speech` tool calls. 101 of them had been archived by context compaction (`active=0, compacted=1`), leaving exactly one active call — which matched the scanner's output of `1`.

Because these counters aggregate across a session's whole lifetime, this also means progress can **regress downward** over time: an achievement counter shrinks as older sessions get compacted, even though the underlying events happened.

## Related Issue

Fixes #100127

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

`plugins/hermes-achievements/dashboard/plugin_api.py`

- `scan_sessions()`: read full display history with `db.get_messages(sid, include_compacted=True)` instead of the active-only default. `get_messages` already returns active + compacted rows while excluding soft-deleted Undo/Rewind rows (`active=0, compacted=0`), and it deduplicates repeated compaction generations via `original_message_id`, so events are counted once and not double counted.
- Bump the persisted scan checkpoint to `CHECKPOINT_SCHEMA_VERSION = 2`. Per-session stats cached by the previous active-only scanner would otherwise pin achievements at the old undercount, so `load_checkpoint()` now discards any checkpoint whose `schema_version` does not match, forcing a one-time full rescan. `save_checkpoint()` writes the new version.

`tests/plugins/test_achievements_plugin.py`

- The fake session DB records the `include_compacted` argument.
- New `test_scan_sessions_includes_compacted_history`: asserts the scanner requests compacted history and counts a compacted-only `text_to_speech` tool call.
- New `test_load_checkpoint_discards_active_only_scan_results`: asserts a v1 checkpoint (cached active-only stats) is discarded on load.

## How to Test

1. `scripts/run_tests.sh tests/plugins/test_achievements_plugin.py plugins/hermes-achievements/tests/test_achievement_engine.py -q` → 18 passed.
2. The two new tests fail on `main` (active-only scan + surviving v1 checkpoint) and pass with this change.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(plugins):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-facing docs for the internal scan path)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (pure Python, no platform-specific code)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
