### PR TITLE
fix(agent): run init-time fallback for ANY exhausted primary provider (salvage #93439)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1390,14 +1390,71 @@ def init_agent(
                 if _routed_headers:
                     client_kwargs["default_headers"] = dict(_routed_headers)
             else:
-                # When the user explicitly chose a non-OpenRouter provider
-                # but no credentials were found, fail fast with a clear
-                # message instead of silently routing through OpenRouter.
+                # No credentials resolved for the configured provider.  Give
+                # the user-configured fallback chain a chance BEFORE failing
+                # (#17929) — regardless of WHICH provider failed.  An
+                # exhausted single-entry pool (typically ``openrouter``
+                # under free-tier daily quotas) must still reach the chain
+                # instead of dying at init with a misleading "No LLM
+                # provider configured" error.  Only providers explicitly
+                # chosen by name keep the dedicated missing-key diagnostic.
                 _explicit = (agent.provider or "").strip().lower()
-                if _explicit and _explicit not in {"auto", "openrouter", "custom"}:
-                    # Look up the actual env var name from the provider
-                    # config — some providers use non-standard names
-                    # (e.g. alibaba → DASHSCOPE_API_KEY, not ALIBABA_API_KEY).
+                # --- Init-time fallback (#17929) ---
+                _fb_entries = []
+                if isinstance(fallback_model, list):
+                    _fb_entries = [
+                        f for f in fallback_model
+                        if isinstance(f, dict) and f.get("provider") and f.get("model")
+                    ]
+                elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
+                    _fb_entries = [fallback_model]
+                _fb_resolved = False
+                for _fb in _fb_entries:
+                    try:
+                        from hermes_cli.fallback_config import resolve_entry_api_key
+                        _fb_explicit_key = resolve_entry_api_key(_fb)
+                        _fb_client, _fb_model = resolve_provider_client(
+                            _fb["provider"], model=_fb["model"], raw_codex=True,
+                            explicit_base_url=_fb.get("base_url"),
+                            explicit_api_key=_fb_explicit_key,
+                        )
+                    except Exception as _fb_exc:
+                        logger.debug(
+                            "Init-time fallback entry %s failed: %s",
+                            _fb.get("provider"), _fb_exc,
+                        )
+                        continue
+                    if _fb_client is not None:
+                        agent.provider = _fb["provider"]
+                        agent.model = _fb_model or _fb["model"]
+                        agent._fallback_activated = True
+                        client_kwargs = {
+                            "api_key": _fb_client.api_key,
+                            "base_url": str(_fb_client.base_url),
+                        }
+                        if _provider_timeout is not None:
+                            client_kwargs["timeout"] = _provider_timeout
+                        _fb_headers = getattr(_fb_client, "_custom_headers", None)
+                        if not _fb_headers:
+                            _fb_headers = getattr(_fb_client, "default_headers", None)
+                        if not _fb_headers:
+                            _fb_headers = getattr(_fb_client, "_default_headers", None)
+                        if _fb_headers:
+                            client_kwargs["default_headers"] = dict(_fb_headers)
+                        _fb_resolved = True
+                        break
+                if (
+                    not _fb_resolved
+                    and _explicit
+                    and _explicit not in {"auto", "openrouter", "custom"}
+                ):
+                    # Explicitly chosen non-OpenRouter provider with neither
+                    # credentials nor a usable fallback: fail fast with a
+                    # clear message instead of silently routing through
+                    # OpenRouter.  Look up the actual env var name from the
+                    # provider config — some providers use non-standard
+                    # names (e.g. alibaba → DASHSCOPE_API_KEY, not
+                    # ALIBABA_API_KEY).
                     _env_hint = f"{_explicit.upper()}_API_KEY"
                     try:
                         from hermes_cli.auth import PROVIDER_REGISTRY
@@ -1406,56 +1463,11 @@ def init_agent(
                             _env_hint = _pcfg.api_key_env_vars[0]
                     except Exception:
                         pass
-                    # --- Init-time fallback (#17929) ---
-                    _fb_entries = []
-                    if isinstance(fallback_model, list):
-                        _fb_entries = [
-                            f for f in fallback_model
-                            if isinstance(f, dict) and f.get("provider") and f.get("model")
-                        ]
-                    elif isinstance(fallback_model, dict) and fallback_model.get("provider") and fallback_model.get("model"):
-                        _fb_entries = [fallback_model]
-                    _fb_resolved = False
-                    for _fb in _fb_entries:
-                        try:
-                            from hermes_cli.fallback_config import resolve_entry_api_key
-                            _fb_explicit_key = resolve_entry_api_key(_fb)
-                            _fb_client, _fb_model = resolve_provider_client(
-                                _fb["provider"], model=_fb["model"], raw_codex=True,
-                                explicit_base_url=_fb.get("base_url"),
-                                explicit_api_key=_fb_explicit_key,
-                            )
-                        except Exception as _fb_exc:
-                            logger.debug(
-                                "Init-time fallback entry %s failed: %s",
-                                _fb.get("provider"), _fb_exc,
-                            )
-                            continue
-                        if _fb_client is not None:
-                            agent.provider = _fb["provider"]
-                            agent.model = _fb_model or _fb["model"]
-                            agent._fallback_activated = True
-                            client_kwargs = {
-                                "api_key": _fb_client.api_key,
-                                "base_url": str(_fb_client.base_url),
-                            }
-                            if _provider_timeout is not None:
-                                client_kwargs["timeout"] = _provider_timeout
-                            _fb_headers = getattr(_fb_client, "_custom_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "default_headers", None)
-                            if not _fb_headers:
-                                _fb_headers = getattr(_fb_client, "_default_headers", None)
-                            if _fb_headers:
-                                client_kwargs["default_headers"] = dict(_fb_headers)
-                            _fb_resolved = True
-                            break
-                    if not _fb_resolved:
-                        raise RuntimeError(
-                            f"Provider '{_explicit}' is set in config.yaml but no API key "
-                            f"was found. Set the {_env_hint} environment "
-                            f"variable, or switch to a different provider with `hermes model`."
-                        )
+                    raise RuntimeError(
+                        f"Provider '{_explicit}' is set in config.yaml but no API key "
+                        f"was found. Set the {_env_hint} environment "
+                        f"variable, or switch to a different provider with `hermes model`."
+                    )
                 if not getattr(agent, "_fallback_activated", False):
                     # No provider configured — reject with a clear message.
                     raise RuntimeError(

--- a/contributors/emails/vjpixel@users.noreply.github.com
+++ b/contributors/emails/vjpixel@users.noreply.github.com
@@ -1,0 +1,1 @@
+vjpixel

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -67,3 +67,67 @@ def test_init_raises_when_no_fallback_configured():
                 skip_memory=True,
                 fallback_model=None,
             )
+
+
+def test_init_tries_fallback_when_openrouter_pool_exhausted():
+    """Regression: an exhausted ``openrouter`` pool (single credential entry
+    in 429-cooldown) must still reach fallback_providers at init.
+
+    Before the fix, the init-time fallback block was nested inside the
+    ``_explicit not in {auto, openrouter, custom}`` guard, so the default
+    openrouter setup skipped the chain entirely and raised the misleading
+    "No LLM provider configured" RuntimeError (2026-08-23 outage).
+    """
+    fb = _mock_client(api_key="local-key-1234567890",
+                      base_url="http://127.0.0.1:11434/v1")
+
+    def fake_resolve(provider, model=None, raw_codex=False,
+                     explicit_base_url=None, explicit_api_key=None):
+        if provider == "custom" and explicit_base_url:
+            return fb, "qwen3.5:4b"
+        return None, None  # openrouter pool exhausted
+
+    with patch("agent.auxiliary_client.resolve_provider_client", side_effect=fake_resolve), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        agent = AIAgent(
+            provider="openrouter",
+            model="z-ai/glm-5.2:free",
+            api_key=None,
+            base_url=None,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=[
+                {"provider": "openrouter", "model": "poolside/laguna-s-2.1:free"},
+                {"provider": "custom", "model": "qwen3.5:4b",
+                 "base_url": "http://127.0.0.1:11434/v1"},
+            ],
+        )
+        assert agent.provider == "custom"
+        assert agent.model == "qwen3.5:4b"
+        assert agent._fallback_activated is True
+
+
+def test_init_openrouter_exhausted_without_chain_keeps_generic_error():
+    """openrouter exhausted + no usable fallback keeps the generic
+    'No LLM provider configured' error (not the named-provider one)."""
+    with patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)), \
+         patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()), \
+         patch("run_agent.check_toolset_requirements", return_value={}), \
+         patch("run_agent.OpenAI", return_value=MagicMock()):
+
+        with pytest.raises(RuntimeError, match="No LLM provider configured"):
+            AIAgent(
+                provider="openrouter",
+                model="z-ai/glm-5.2:free",
+                api_key=None,
+                base_url=None,
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                fallback_model=[{"provider": "openrouter",
+                                 "model": "poolside/laguna-s-2.1:free"}],
+            )


### PR DESCRIPTION
Salvages #93439 by @vjpixel onto current main with authorship preserved (cherry-pick of 911b82fa). Fixes #17929's init-time fallback gap.

## Problem

The #17929 init-time fallback block in `agent/agent_init.py` was nested inside the `_explicit not in {"auto", "openrouter", "custom"}` guard. Result: when the primary provider was `openrouter`, `auto`, or `custom` and its credential pool was exhausted (e.g. single free-tier key in 429-cooldown), init raised `No LLM provider configured` **without ever trying the operator-configured `fallback_providers` chain**. During the Aug-23 outage a healthy local Ollama fallback sat unused while every init died.

## Fix (@vjpixel)

- Un-nests the fallback block so the chain runs for **ANY** provider with no usable credentials.
- Fallback still traverses **only** the operator-configured `fallback_model` entries — no implicit default provider is ever adopted.
- Explicitly-named non-openrouter providers keep their dedicated missing-key diagnostic (`Provider 'X' is set in config.yaml but no API key was found…`) when both primary and chain fail.
- Extends `tests/run_agent/test_init_fallback_on_exhausted_pool.py` with 2 regression tests (exhausted openrouter pool reaches chain; exhausted openrouter without chain keeps generic error).

## Verification

**Live repro:** subprocess harness, temp `HERMES_HOME`, all `*_API_KEY` env vars scrubbed, primary `openrouter` with empty pool, `fallback_model` pointing at a `custom` provider backed by a local streaming-SSE stub server — before (origin/main worktree): `INIT_RAISED RuntimeError: No LLM provider configured. Run 'hermes model' to select a provider...` despite the healthy fallback stub; after (this branch): `INIT_OK provider=custom fallback_activated=True` and a real `run_conversation` round-trip against the stub returned `FALLBACK_STUB_OK: the local fallback provider answered.`

Tests:
- `tests/run_agent/test_init_fallback_on_exhausted_pool.py` — 4 passed
- `test_provider_fallback.py` + `test_fallback_credential_isolation.py` + `test_24996_fallback_exhaustion_cooldown.py` — 44 passed

Credit: @vjpixel (commit cherry-picked with original authorship). Includes `contributors/emails/` mapping for attribution CI. Refs #93439, #17929.

## Infographic

![init-fallback-any-provider](https://v3b.fal.media/files/b/0aa8a83e/up2NEkreu_R12ExHKkvgI_Y5Kicady.png)
