### PR TITLE
fix(desktop): use Chromium's userns sandbox on Linux — no sudo, never --no-sandbox (salvage #98135 + #89349)

### DIFF
--- a/contributors/emails/a.dltorreruiz@gmail.com
+++ b/contributors/emails/a.dltorreruiz@gmail.com
@@ -1,0 +1,2 @@
+4dlt
+# PR #98135 attribution repair

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8260,6 +8260,29 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
     return True
 
 
+def _desktop_linux_needs_disable_setuid_sandbox(packaged_executable: Path) -> bool:
+    """Return True when Chromium should skip the present-but-non-setuid helper.
+
+    A user-owned ``chrome-sandbox`` still makes Chromium abort with
+    ``setuid_sandbox_host`` even when the namespace sandbox works. Passing
+    ``--disable-setuid-sandbox`` keeps the userns sandbox and avoids sudo.
+    Call only after ``_desktop_linux_sandbox_fixup`` succeeded without making
+    the helper root-owned 4755 (the userns path). Does not re-probe userns.
+    """
+    if sys.platform != "linux":
+        return False
+    sandbox = packaged_executable.parent / "chrome-sandbox"
+    try:
+        sandbox_lstat = sandbox.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISREG(sandbox_lstat.st_mode):
+        return False
+    if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return False
+    return True
+
+
 _LINUX_PASSWORD_STORES = frozenset({"gnome-libsecret", "kwallet", "kwallet5", "kwallet6", "basic"})
 
 
@@ -8654,6 +8677,8 @@ def cmd_gui(args: argparse.Namespace):
             launch_command.append("--no-sandbox")
         else:
             sys.exit(1)
+    elif _desktop_linux_needs_disable_setuid_sandbox(packaged_executable):
+        launch_command.append("--disable-setuid-sandbox")
 
     launch_command.extend(config_electron_flags)
     print(f"→ Launching packaged Hermes Desktop: {' '.join(launch_command)}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -8174,6 +8174,37 @@ def _desktop_linux_needs_no_sandbox() -> bool:
         return False
 
 
+def _desktop_linux_userns_sandbox_available() -> bool:
+    """Return True when Chromium's unprivileged user-namespace sandbox works.
+
+    When an unprivileged process can create a user namespace, Chromium uses the
+    namespace sandbox and never consults the setuid ``chrome-sandbox`` helper,
+    so requiring the helper to be root-owned 4755 (and prompting for sudo) is
+    unnecessary. Probe the real capability with ``unshare`` instead of reading
+    distro-specific sysctls: the probe fails closed on hosts where user
+    namespaces are disabled or AppArmor-restricted, which then follow the
+    existing setuid-helper path.
+    """
+    if sys.platform != "linux":
+        return False
+    unshare = shutil.which("unshare")
+    if not unshare:
+        return False
+    try:
+        return (
+            subprocess.run(
+                [unshare, "--user", "--map-root-user", "true"],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=5,
+                check=False,
+            ).returncode
+            == 0
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+
+
 def _desktop_linux_sandbox_helper_is_regular_file(packaged_executable: Path) -> bool:
     """Return True when ``chrome-sandbox`` exists as a regular file."""
     if sys.platform != "linux":
@@ -8210,6 +8241,10 @@ def _desktop_linux_sandbox_fixup(packaged_executable: Path) -> bool:
         return False
 
     if sandbox_lstat.st_uid == 0 and stat.S_IMODE(sandbox_lstat.st_mode) == 0o4755:
+        return True
+
+    if _desktop_linux_userns_sandbox_available():
+        print("✓ Using Chromium's user-namespace sandbox (setuid helper not needed).")
         return True
 
     sudo = shutil.which("sudo")

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -316,6 +316,10 @@ linux_gate() {
   sb="$unpacked/chrome-sandbox"
   if [ ! -e "$sb" ]; then GATE=relaunch; return; fi
   if [ -u "$sb" ] && [ "$(stat -c %u "$sb" 2>/dev/null)" = "0" ]; then GATE=relaunch; return; fi
+  # Namespace sandbox usable => Electron never consults the setuid helper,
+  # so a non-root chrome-sandbox does not block relaunch (mirrors the
+  # _desktop_linux_userns_sandbox_available() probe in hermes_cli/main.py).
+  if unshare --user --map-root-user true 2>/dev/null; then GATE=relaunch; return; fi
 
   case "${ELECTRON_DISABLE_SANDBOX:-}" in 1|true|TRUE|True) GATE=relaunch; return ;; esac
   [ "$SANDBOX_FALLBACK" -eq 1 ] && { GATE=relaunch; return; }

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -130,7 +130,11 @@ def test_gui_installs_packages_and_launches_desktop_app(tmp_path, monkeypatch):
     assert install_env is not None and "PATH" in install_env
     assert mock_run.call_args_list[0].args[0] == ["/usr/bin/npm", "run", "pack"]
     assert mock_run.call_args_list[0].kwargs["cwd"] == desktop_dir
-    assert mock_run.call_args_list[1].args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args_list[1].args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
     assert mock_run.call_args_list[1].kwargs["cwd"] == desktop_dir
 
 
@@ -968,7 +972,11 @@ def test_gui_launches_even_when_desktop_entry_install_fails(tmp_path, monkeypatc
         cli_main.cmd_gui(_ns())
 
     assert exc.value.code == 0
-    assert mock_run.call_args.args[0] == [str(packaged_exe)]
+    launched = mock_run.call_args.args[0]
+    if sys.platform.startswith("linux"):
+        assert launched == [str(packaged_exe), "--disable-setuid-sandbox"]
+    else:
+        assert launched == [str(packaged_exe)]
 
 
 @pytest.mark.macos_only

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -1,0 +1,116 @@
+"""Tests for the Linux desktop sandbox-helper fixup and the userns probe.
+
+``_desktop_linux_sandbox_fixup`` historically demanded a root-owned 4755
+``chrome-sandbox`` on every Linux host and shelled out to ``sudo`` to get it
+— which fails silently when the desktop entry launches ``hermes desktop``
+without a TTY (#88032, #51327), and blocked the updater's relaunch gate
+(#58593). On hosts where unprivileged user namespaces work, Chromium uses
+its namespace sandbox and never consults the setuid helper, so the fixup now
+probes for that capability first and skips the sudo path entirely.
+"""
+
+from __future__ import annotations
+
+import stat
+import subprocess
+import sys
+from unittest.mock import patch
+
+from hermes_cli import main as cli_main
+
+
+class TestDesktopLinuxUsernsSandboxAvailable:
+    def test_false_on_non_linux(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "darwin")
+        assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_unshare_is_missing(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_true_when_probe_succeeds(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 0
+            assert cli_main._desktop_linux_userns_sandbox_available() is True
+        probe = run.call_args.args[0]
+        assert probe[0] == "/usr/bin/unshare"
+        assert "--user" in probe
+
+    def test_false_when_probe_fails(self, monkeypatch):
+        """EPERM from the kernel (userns disabled or AppArmor-restricted)."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(cli_main.subprocess, "run") as run:
+            run.return_value.returncode = 1
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+    def test_false_when_probe_raises(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "linux")
+        with patch.object(cli_main.shutil, "which", return_value="/usr/bin/unshare"), \
+             patch.object(
+                 cli_main.subprocess,
+                 "run",
+                 side_effect=subprocess.TimeoutExpired(cmd="unshare", timeout=5),
+             ):
+            assert cli_main._desktop_linux_userns_sandbox_available() is False
+
+
+class TestDesktopLinuxSandboxFixup:
+    def _fake_packaged_app(self, tmp_path):
+        """Unpacked-app layout with a non-root, non-setuid chrome-sandbox."""
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_userns_host_skips_sudo_and_succeeds(self, monkeypatch, tmp_path):
+        """A user-owned helper must not trigger sudo when userns works.
+
+        This is the .desktop-launch regression: no TTY means sudo cannot
+        prompt, so reaching the sudo path at all kills the launch.
+        """
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ), \
+             patch.object(cli_main.subprocess, "run") as run:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        run.assert_not_called()
+
+    def test_restricted_host_without_sudo_still_fails(self, monkeypatch, tmp_path):
+        """The pre-existing strict path is preserved when userns is unusable."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=False
+             ), \
+             patch.object(cli_main.shutil, "which", return_value=None):
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is False
+
+    def test_root_owned_setuid_helper_short_circuits(self, monkeypatch, tmp_path):
+        """A correctly configured helper wins before the userns probe runs."""
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available"
+             ) as probe:
+            assert cli_main._desktop_linux_sandbox_fixup(exe) is True
+        probe.assert_not_called()

--- a/tests/hermes_cli/test_linux_sandbox_fixup.py
+++ b/tests/hermes_cli/test_linux_sandbox_fixup.py
@@ -114,3 +114,50 @@ class TestDesktopLinuxSandboxFixup:
              ) as probe:
             assert cli_main._desktop_linux_sandbox_fixup(exe) is True
         probe.assert_not_called()
+
+
+class TestDesktopLinuxNeedsDisableSetuidSandbox:
+    def _fake_packaged_app(self, tmp_path):
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        sandbox = unpacked / "chrome-sandbox"
+        sandbox.write_text("", encoding="utf-8")
+        sandbox.chmod(0o755)
+        return exe
+
+    def test_true_for_user_owned_helper_when_userns_works(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        with patch.object(
+            cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+        ):
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is True
+
+    def test_false_for_root_owned_setuid_helper(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        exe = self._fake_packaged_app(tmp_path)
+        real_lstat = (exe.parent / "chrome-sandbox").lstat()
+
+        class _RootSetuidStat:
+            st_mode = stat.S_IFREG | 0o4755
+            st_uid = 0
+
+            def __getattr__(self, name):
+                return getattr(real_lstat, name)
+
+        with patch.object(cli_main.Path, "lstat", return_value=_RootSetuidStat()), \
+             patch.object(
+                 cli_main, "_desktop_linux_userns_sandbox_available", return_value=True
+             ) as probe:
+            assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False
+        probe.assert_not_called()
+
+    def test_false_when_helper_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(sys, "platform", "linux")
+        unpacked = tmp_path / "linux-unpacked"
+        unpacked.mkdir()
+        exe = unpacked / "Hermes"
+        exe.write_text("", encoding="utf-8")
+        assert cli_main._desktop_linux_needs_disable_setuid_sandbox(exe) is False


### PR DESCRIPTION
## Summary

Salvage of **#98135** (@kvnloo, primary) with the userns probe from **#89349** (@4dlt) — per Teknium's decision to take the namespace-sandbox direction. Fixes #51327 / #58593.

`hermes desktop` on Linux previously hard-required a root-owned 4755 `chrome-sandbox` and shelled out to `sudo chown/chmod` when it wasn't — aborting (or sudo-prompting) on hosts where Chromium's unprivileged user-namespace sandbox works fine and the setuid helper is never consulted.

**After this PR:**
- `_desktop_linux_userns_sandbox_available()` probes real kernel capability via `unshare --user --map-root-user true` (fails closed on restricted/AppArmor hosts). *(@4dlt, #89349)*
- Helper present but not root:4755 (e.g. user-owned 0755) + userns available → launch with `--disable-setuid-sandbox`, keeping the full namespace sandbox — **no sudo prompt, never `--no-sandbox`**. *(@kvnloo, #98135)*
- Userns blocked → existing sudo setuid-helper path runs unchanged as automatic fallback.
- Helper missing entirely → still a hard error (packaging bug, unchanged).
- `scripts/desktop-update/posix.sh` `linux_gate` mirrors the probe so the updater relaunch gate agrees with the launcher.

## Commits / attribution

| Commit | Author | From |
|---|---|---|
| userns probe + fixup short-circuit | @4dlt | #89349 |
| `--disable-setuid-sandbox` launch path + posix.sh gate | @kvnloo | #98135 |
| contributor email map | @kvnloo | #98135 |

Rebased onto current main (base was 325 commits behind); no conflicts, diff footprint verified as only the 5 intended files.

**Live repro:** real `hermes_cli.main` import harness on this Linux box (userns-capable kernel, real FS states, fake sudo shim logging invocations) — before (main): 0755 user-owned helper → `sudo chown root:root` invoked then **ABORT sys.exit(1)**; helper absent → ABORT; after (branch): 0755 → **LAUNCH with `--disable-setuid-sandbox`**, zero sudo invocations; 4755 user-owned → same; absent → still hard error as intended.

## Tests

- `tests/hermes_cli/test_linux_sandbox_fixup.py` + `test_gui_command.py`: **52 passed, 9 skipped**
- `tests/test_desktop_update_shim_progress.py` (posix.sh consumer): **5 passed**
- `bash -n scripts/desktop-update/posix.sh` clean

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8a83e/LEfmuQBzrkdPz-79IV3-1_HtF4jLXw.png)
