### PR TITLE
fix(email): fail when inbox selection is rejected

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -134,6 +134,25 @@ def _close_imap(imap: "imaplib.IMAP4") -> None:
             pass
 
 
+def _select_inbox(imap: "imaplib.IMAP4") -> None:
+    """Select INBOX or preserve the server's primary failure response.
+
+    ``imaplib`` does not raise when a server answers ``NO`` to ``SELECT``.
+    Continuing in the AUTH state makes the following UID SEARCH fail with a
+    misleading secondary error, so fail before issuing selected-state commands.
+    """
+    status, data = imap.select("INBOX")
+    if status == "OK":
+        return
+
+    detail: Any = data[0] if data else ""
+    if isinstance(detail, bytes):
+        detail = detail.decode("utf-8", errors="replace")
+    detail = str(detail).strip()
+    suffix = f": {detail}" if detail else ""
+    raise imaplib.IMAP4.error(f"SELECT INBOX failed ({status}){suffix}")
+
+
 def _create_ipv4_connection(
     host: str,
     port: int,
@@ -714,7 +733,7 @@ class EmailAdapter(BasePlatformAdapter):
                 imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
-                imap.select("INBOX")
+                _select_inbox(imap)
                 snapshot = self._seen_uids_snapshot.get(self._address)
                 if is_reconnect and snapshot is not None:
                     # Reconnect within the same process: restore the previous
@@ -859,7 +878,7 @@ class EmailAdapter(BasePlatformAdapter):
             try:
                 imap.login(self._address, self._password)
                 _send_imap_id(imap)
-                imap.select("INBOX")
+                _select_inbox(imap)
 
                 status, data = imap.uid("search", None, "UNSEEN")
                 if status != "OK" or not data or not data[0]:

--- a/tests/gateway/test_adapter_connect_classification.py
+++ b/tests/gateway/test_adapter_connect_classification.py
@@ -240,6 +240,7 @@ class TestEmailConnectClassification:
         from plugins.platforms.email import adapter as email_adapter
 
         imap = MagicMock()
+        imap.select.return_value = ("OK", [b"1"])
         imap.uid.return_value = ("OK", [b""])
         monkeypatch.setattr(email_adapter.imaplib, "IMAP4_SSL", lambda *a, **k: imap)
 
@@ -259,6 +260,7 @@ class TestEmailConnectClassification:
         from plugins.platforms.email import adapter as email_adapter
 
         imap = MagicMock()
+        imap.select.return_value = ("OK", [b"1"])
         imap.uid.return_value = ("OK", [b""])
         monkeypatch.setattr(email_adapter.imaplib, "IMAP4_SSL", lambda *a, **k: imap)
 

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -468,6 +468,7 @@ class TestConnectDisconnect(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         mock_imap.uid.return_value = ("OK", [b"1 2 3"])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
@@ -485,6 +486,25 @@ class TestConnectDisconnect(unittest.TestCase):
             adapter._running = False
             if adapter._poll_task:
                 adapter._poll_task.cancel()
+
+    def test_connect_rejects_failed_inbox_selection(self):
+        """A server-declined SELECT must fail before SEARCH or SMTP setup."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+        mock_imap.select.return_value = ("NO", [b"Mailbox unavailable"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap), patch(
+            "smtplib.SMTP"
+        ) as mock_smtp:
+            result = asyncio.run(adapter.connect())
+
+        self.assertFalse(result)
+        mock_imap.uid.assert_not_called()
+        mock_smtp.assert_not_called()
+        self.assertEqual(adapter.fatal_error_code, "email_imap_connect_error")
+        self.assertIn("Mailbox unavailable", adapter.fatal_error_message or "")
 
 
 class TestFetchNewMessages(unittest.TestCase):
@@ -513,6 +533,7 @@ class TestFetchNewMessages(unittest.TestCase):
         raw_email["Message-ID"] = "<msg@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
 
         def uid_handler(command, *args):
             if command == "search":
@@ -565,6 +586,7 @@ class TestPollLoop(unittest.TestCase):
         raw_email["Message-ID"] = "<inbox@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
 
         def uid_handler(command, *args):
             if command == "search":
@@ -596,6 +618,7 @@ class TestPollLoop(unittest.TestCase):
         adapter.set_fatal_error_handler(mock_fatal_handler)
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         mock_imap.login.side_effect = Exception("read operation timed out")
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
@@ -605,6 +628,28 @@ class TestPollLoop(unittest.TestCase):
         self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_failed")
         self.assertTrue(adapter.fatal_error_retryable)
         self.assertIn("read operation timed out", adapter.fatal_error_message)
+
+    def test_check_inbox_rejects_failed_inbox_selection(self):
+        """A SELECT NO response is a fetch failure, not an empty inbox."""
+        import asyncio
+
+        adapter = self._make_adapter()
+        notified = []
+
+        async def mock_fatal_handler(failed_adapter):
+            notified.append(failed_adapter)
+
+        adapter.set_fatal_error_handler(mock_fatal_handler)
+        mock_imap = MagicMock()
+        mock_imap.select.return_value = ("NO", [b"Mailbox unavailable"])
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            asyncio.run(adapter._check_inbox())
+
+        mock_imap.uid.assert_not_called()
+        self.assertEqual(notified, [adapter])
+        self.assertEqual(adapter.fatal_error_code, "email_imap_fetch_failed")
+        self.assertIn("Mailbox unavailable", adapter.fatal_error_message or "")
 
     def test_partial_batch_dispatched_before_escalation(self):
         """A mid-batch IMAP failure must dispatch the messages already
@@ -629,6 +674,7 @@ class TestPollLoop(unittest.TestCase):
         raw_email["Message-ID"] = "<batch1@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         fetches = []
 
         def uid_handler(command, *args):
@@ -665,6 +711,7 @@ class TestPollLoop(unittest.TestCase):
         raw_email["Message-ID"] = "<ok@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         fetches = []
 
         def uid_handler(command, *args):
@@ -700,6 +747,7 @@ class TestPollLoop(unittest.TestCase):
         good_email["Message-ID"] = "<good@test.com>"
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
 
         def uid_handler(command, *args):
             if command == "search":
@@ -751,6 +799,7 @@ class TestReconnectSeenUidsRestore(unittest.TestCase):
         import asyncio
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
 
         def uid_handler(command, *args):
             if command == "search":
@@ -897,6 +946,7 @@ class TestImapConnectionCleanup(unittest.TestCase):
         """IMAP logout() must be called even when uid fetch raises."""
         adapter = self._make_adapter()
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
 
         def uid_handler(command, *args):
             if command == "search":
@@ -939,6 +989,7 @@ class TestImapIdExtensionForNetEase(unittest.TestCase):
         adapter = self._make_adapter()
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         mock_imap.uid.return_value = ("OK", [b""])
 
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap), \

--- a/tests/gateway/test_email_robustness.py
+++ b/tests/gateway/test_email_robustness.py
@@ -54,6 +54,7 @@ class TestImapResponseGuard(unittest.TestCase):
             return ("NO", [])
 
         mock_imap = MagicMock()
+        mock_imap.select.return_value = ("OK", [b"1"])
         mock_imap.uid.side_effect = uid_handler
         with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
             return adapter._fetch_new_messages()


### PR DESCRIPTION
## Summary

- fail closed when an IMAP server rejects `SELECT INBOX`
- preserve the primary server response instead of continuing to a misleading `UID SEARCH` error
- apply the guard during initial connection and polling
- add behavioral regression coverage for both paths and make successful IMAP mocks explicit

## Problem

`imaplib.IMAP4.select()` returns a status tuple when the server answers `NO`; it does not raise. The email adapter ignored that status and continued while the connection was still in the authenticated state. The subsequent selected-state command then failed with a secondary error such as `SEARCH illegal in state AUTH`, obscuring the actual mailbox-selection failure.

## Verification

- `python -m pytest tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_adapter_connect_classification.py -q -o 'addopts='` -> 67 passed
- `python -m pytest tests/gateway/test_poller_fd_lifecycle.py -q -k Email -o 'addopts='` -> 2 passed, 7 deselected
- `python -m pytest tests/gateway -q -k email -o 'addopts='` -> 86 passed, 2 skipped, 7304 deselected
- `python -m ruff check plugins/platforms/email/adapter.py tests/gateway/test_email.py tests/gateway/test_email_robustness.py tests/gateway/test_adapter_connect_classification.py` -> passed
- `git diff --check` -> passed

The two new behavioral tests were also run against the old call sites and failed, confirming they detect the regression.

## Risk

Low. The change only rejects non-`OK` mailbox-selection responses that cannot support the selected-state commands the adapter is about to issue. Successful `SELECT` behavior is unchanged.
