### PR TITLE
feat(memory): integrate governed context-memory phases 1 and 2

### DIFF
--- a/agent/memory_consolidation.py
+++ b/agent/memory_consolidation.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from typing import Any
+
+from agent.memory_policy import validate_candidate
+from agent.memory_records import Candidate, CanonicalRecord, LifecycleStatus, MemoryClass, Scope
+
+
+MAX_CANDIDATES = 100
+
+
+@dataclass(frozen=True)
+class EvaluationFinding:
+    code: str
+    candidate_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ConsolidationProposal:
+    scope: Scope
+    memory_class: MemoryClass
+    candidate_ids: tuple[str, ...]
+    content: Mapping[str, Any]
+    supersedes_record_id: str | None
+    expected_canonical_version: int
+    evaluation_findings: tuple[EvaluationFinding, ...] = ()
+    approved: bool = field(default=False, init=False)
+    authoritative: bool = field(default=False, init=False)
+
+
+@dataclass(frozen=True)
+class ConsolidationResult:
+    proposal: ConsolidationProposal | None
+    findings: tuple[EvaluationFinding, ...]
+
+
+def _failed(*findings: EvaluationFinding) -> ConsolidationResult:
+    return ConsolidationResult(None, findings)
+
+
+def consolidate_candidates(
+    candidate_ids: tuple[str, ...],
+    candidates: tuple[Candidate, ...],
+    *,
+    expected_canonical_version: int,
+    active: CanonicalRecord | None = None,
+) -> ConsolidationResult:
+    if (
+        type(candidate_ids) is not tuple
+        or not candidate_ids
+        or len(candidate_ids) > MAX_CANDIDATES
+        or any(type(candidate_id) is not str or not candidate_id.strip() for candidate_id in candidate_ids)
+        or len(set(candidate_ids)) != len(candidate_ids)
+    ):
+        return _failed(EvaluationFinding("invalid_candidate_ids"))
+    if (
+        type(candidates) is not tuple
+        or not candidates
+        or len(candidates) != len(candidate_ids)
+        or any(type(candidate) is not Candidate for candidate in candidates)
+    ):
+        return _failed(EvaluationFinding("invalid_candidates"))
+    if type(expected_canonical_version) is not int or expected_canonical_version < 0:
+        return _failed(EvaluationFinding("invalid_expected_canonical_version"))
+    if active is not None and type(active) is not CanonicalRecord:
+        return _failed(EvaluationFinding("invalid_active_record"))
+
+    by_id = {candidate.content_hash(): candidate for candidate in candidates}
+    if len(by_id) != len(candidates):
+        return _failed(EvaluationFinding("duplicate_candidate"))
+    if set(candidate_ids) != set(by_id):
+        return _failed(EvaluationFinding("candidate_id_mismatch"))
+
+    ordered_ids = tuple(sorted(candidate_ids))
+    ordered = tuple(by_id[candidate_id] for candidate_id in ordered_ids)
+    first = ordered[0]
+    findings: list[EvaluationFinding] = []
+
+    for candidate_id, candidate in zip(ordered_ids, ordered):
+        findings.extend(EvaluationFinding(code, candidate_id) for code in validate_candidate(candidate))
+    if any(candidate.scope != first.scope for candidate in ordered[1:]):
+        findings.append(EvaluationFinding("candidate_scope_mismatch"))
+    if any(candidate.memory_class is not first.memory_class for candidate in ordered[1:]):
+        findings.append(EvaluationFinding("candidate_memory_class_mismatch"))
+    if any(candidate.content != first.content for candidate in ordered[1:]):
+        findings.append(EvaluationFinding("candidate_content_mismatch"))
+    target = first.lifecycle.supersedes_record_id
+    if any(candidate.lifecycle.supersedes_record_id != target for candidate in ordered[1:]):
+        findings.append(EvaluationFinding("candidate_supersession_mismatch"))
+
+    if active is None:
+        if expected_canonical_version != 0:
+            findings.append(EvaluationFinding("initial_version_must_be_zero"))
+        if target is not None:
+            findings.append(EvaluationFinding("unexpected_supersession_target"))
+    else:
+        if active.lifecycle.status is not LifecycleStatus.ACTIVE:
+            findings.append(EvaluationFinding("active_record_must_be_active"))
+        if first.scope != active.scope:
+            findings.append(EvaluationFinding("active_scope_mismatch"))
+        if first.memory_class is not active.memory_class:
+            findings.append(EvaluationFinding("active_memory_class_mismatch"))
+        if expected_canonical_version != active.version:
+            findings.append(EvaluationFinding("active_version_mismatch"))
+        if target != active.record_id:
+            findings.append(EvaluationFinding("active_supersession_target_mismatch"))
+
+    if findings:
+        return ConsolidationResult(None, tuple(findings))
+    proposal = ConsolidationProposal(
+        scope=first.scope,
+        memory_class=first.memory_class,
+        candidate_ids=ordered_ids,
+        content=first.content,
+        supersedes_record_id=target,
+        expected_canonical_version=expected_canonical_version,
+    )
+    return ConsolidationResult(proposal, ())

--- a/agent/memory_policy.py
+++ b/agent/memory_policy.py
@@ -1,0 +1,118 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from agent.memory_records import Approval, Candidate, CanonicalRecord, LifecycleStatus, MemoryClass, ReviewPacket
+
+
+@dataclass(frozen=True)
+class Authority:
+    rank: int
+    may_activate: bool
+
+
+_LIFECYCLE_TRANSITIONS = {
+    LifecycleStatus.PROPOSED: frozenset({
+        LifecycleStatus.ACTIVE,
+        LifecycleStatus.REJECTED,
+        LifecycleStatus.EXPIRED,
+    }),
+    LifecycleStatus.ACTIVE: frozenset({
+        LifecycleStatus.DISPUTED,
+        LifecycleStatus.SUPERSEDED,
+        LifecycleStatus.EXPIRED,
+    }),
+    LifecycleStatus.DISPUTED: frozenset({
+        LifecycleStatus.ACTIVE,
+        LifecycleStatus.SUPERSEDED,
+        LifecycleStatus.REJECTED,
+        LifecycleStatus.EXPIRED,
+    }),
+}
+_TERMINAL_LIFECYCLE_STATES = frozenset({
+    LifecycleStatus.SUPERSEDED,
+    LifecycleStatus.EXPIRED,
+    LifecycleStatus.REJECTED,
+})
+
+
+def evaluate_authority(candidate: Candidate) -> Authority:
+    ranks = {"direct_user": 100, "session_history": 60, "provider": 20, "model": 10}
+    rank = ranks.get(candidate.provenance.source_type, 0)
+    allowed = candidate.provenance.source_type == "direct_user" and not candidate.provenance.derived
+    return Authority(rank=rank, may_activate=allowed)
+
+
+def validate_lifecycle_transition(previous: LifecycleStatus, proposed: LifecycleStatus) -> tuple[str, ...]:
+    if type(previous) is not LifecycleStatus or type(proposed) is not LifecycleStatus:
+        return ("invalid_lifecycle_state",)
+    if previous is proposed:
+        return ("lifecycle_transition_noop",)
+    if previous in _TERMINAL_LIFECYCLE_STATES:
+        return ("terminal_lifecycle_state",)
+    if proposed not in _LIFECYCLE_TRANSITIONS.get(previous, frozenset()):
+        return ("invalid_lifecycle_transition",)
+    return ()
+
+
+def validate_candidate(candidate: Candidate) -> tuple[str, ...]:
+    findings: list[str] = []
+    if candidate.lifecycle.status is not LifecycleStatus.PROPOSED:
+        findings.append("candidate_must_be_proposed")
+    if candidate.memory_class is MemoryClass.T and candidate.lifecycle.expires_at is None:
+        findings.append("temporary_requires_expiry")
+    return tuple(findings)
+
+
+def validate_approval(packet: ReviewPacket, approval: Approval | None) -> tuple[str, ...]:
+    if approval is None or not approval.exact:
+        return ("exact_approval_required",)
+    if approval.packet_id != packet.packet_id:
+        return ("packet_id_mismatch",)
+    if approval.approver != "direct-user":
+        return ("direct_user_approval_required",)
+    return ()
+
+
+def _validate_packet(candidate: Candidate, packet: ReviewPacket | None) -> tuple[str, ...]:
+    if packet is None:
+        return ("exact_approval_required",)
+    if packet.scope != candidate.scope or packet.candidate_ids != (candidate.content_hash(),):
+        return ("packet_candidate_mismatch",)
+    return ()
+
+
+def validate_supersession(active: CanonicalRecord, proposed: Candidate, approval: Approval | None = None, packet: ReviewPacket | None = None) -> tuple[str, ...]:
+    if proposed.memory_class is MemoryClass.A and proposed.provenance.derived:
+        return ("derived_authorization_forbidden",)
+    if active.scope != proposed.scope:
+        return ("scope_change_forbidden",)
+    if active.memory_class is not proposed.memory_class:
+        return ("memory_class_change_forbidden",)
+    target = proposed.lifecycle.supersedes_record_id
+    if target is None:
+        return ("supersession_link_required",)
+    if target != active.record_id:
+        return ("supersession_target_mismatch",)
+    packet_findings = _validate_packet(proposed, packet)
+    if packet_findings:
+        return packet_findings
+    assert packet is not None
+    return validate_approval(packet, approval)
+
+
+def validate_transition(previous: CanonicalRecord | None, proposed: Candidate, approval: Approval | None = None, packet: ReviewPacket | None = None) -> tuple[str, ...]:
+    candidate_findings = validate_candidate(proposed)
+    if candidate_findings:
+        return candidate_findings
+    if proposed.memory_class is MemoryClass.A and proposed.provenance.derived:
+        return ("derived_authorization_forbidden",)
+    if previous is not None:
+        return validate_supersession(previous, proposed, approval, packet)
+    if proposed.lifecycle.supersedes_record_id is not None:
+        return ("supersession_target_missing",)
+    packet_findings = _validate_packet(proposed, packet)
+    if packet_findings:
+        return packet_findings
+    assert packet is not None
+    return validate_approval(packet, approval)

--- a/agent/memory_records.py
+++ b/agent/memory_records.py
@@ -1,0 +1,323 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from enum import Enum
+import hashlib
+import json
+import math
+from types import MappingProxyType
+from typing import Any
+
+
+class MemoryClass(Enum):
+    U = "U"
+    A = "A"
+    E = "E"
+    P = "P"
+    T = "T"
+    R = "R"
+    C = "C"
+
+
+class LifecycleStatus(Enum):
+    PROPOSED = "proposed"
+    ACTIVE = "active"
+    DISPUTED = "disputed"
+    SUPERSEDED = "superseded"
+    EXPIRED = "expired"
+    REJECTED = "rejected"
+
+
+_SOURCE_TYPES = frozenset({"direct_user", "session_history", "provider", "model"})
+_SOURCE_ACTORS = {
+    "direct_user": frozenset({"user"}),
+    "session_history": frozenset({"user", "assistant", "system"}),
+    "provider": frozenset({"provider", "model"}),
+    "model": frozenset({"model"}),
+}
+
+
+def _text(value: object, name: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise ValueError(f"{name} must be a nonblank string")
+    return value
+
+
+def _integer(value: object, name: str, minimum: int) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _timestamp(value: object, name: str) -> str:
+    text = _text(value, name)
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an ISO-8601 timestamp") from exc
+    if parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise ValueError(f"{name} must include a timezone")
+    return parsed.astimezone(timezone.utc).isoformat(timespec="microseconds").replace("+00:00", "Z")
+
+
+def _freeze(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, member in value.items():
+            _text(key, "content mapping key")
+            frozen[key] = _freeze(member)
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze(member) for member in value)
+    if type(value) is str:
+        return _text(value, "content string")
+    if type(value) is float:
+        if not math.isfinite(value):
+            raise ValueError("content floats must be finite")
+        return value
+    if value is None or type(value) in (int, bool):
+        return value
+    raise TypeError(f"unsupported content value: {type(value).__name__}")
+
+
+def _plain(value: Any) -> Any:
+    if isinstance(value, Mapping):
+        return {key: _plain(value[key]) for key in sorted(value)}
+    if isinstance(value, tuple):
+        return [_plain(member) for member in value]
+    return value
+
+
+def _digest(payload: Mapping[str, Any]) -> str:
+    encoded = json.dumps(_plain(payload), sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+@dataclass(frozen=True)
+class Scope:
+    profile_id: str
+    namespace: str
+    project_id: str
+
+    def __post_init__(self) -> None:
+        _text(self.profile_id, "profile_id")
+        _text(self.namespace, "namespace")
+        _text(self.project_id, "project_id")
+
+    def to_dict(self) -> dict[str, str]:
+        return {"profile_id": self.profile_id, "namespace": self.namespace, "project_id": self.project_id}
+
+
+@dataclass(frozen=True)
+class Provenance:
+    source_type: str
+    source_id: str
+    actor: str
+    derived: bool = False
+
+    def __post_init__(self) -> None:
+        _text(self.source_type, "source_type")
+        if self.source_type not in _SOURCE_TYPES:
+            raise ValueError("source_type is not supported")
+        _text(self.source_id, "source_id")
+        _text(self.actor, "actor")
+        if self.actor not in _SOURCE_ACTORS[self.source_type]:
+            raise ValueError("actor is not valid for source_type")
+        if type(self.derived) is not bool:
+            raise TypeError("derived must be bool")
+        if self.source_type == "direct_user" and self.derived:
+            raise ValueError("direct_user provenance cannot be derived")
+        if self.source_type in {"provider", "model"} and not self.derived:
+            raise ValueError(f"{self.source_type} provenance must be derived")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"source_type": self.source_type, "source_id": self.source_id, "actor": self.actor, "derived": self.derived}
+
+
+@dataclass(frozen=True)
+class Lifecycle:
+    status: LifecycleStatus
+    observed_at: str
+    effective_at: str | None = None
+    expires_at: str | None = None
+    supersedes_record_id: str | None = None
+
+    def __post_init__(self) -> None:
+        status = self.status
+        if type(status) is str:
+            try:
+                status = LifecycleStatus(status)
+            except ValueError as exc:
+                raise ValueError("status is not supported") from exc
+            object.__setattr__(self, "status", status)
+        elif type(status) is not LifecycleStatus:
+            raise TypeError("status must be LifecycleStatus")
+
+        observed = _timestamp(self.observed_at, "observed_at")
+        object.__setattr__(self, "observed_at", observed)
+        effective = None
+        if self.effective_at is not None:
+            effective = _timestamp(self.effective_at, "effective_at")
+            object.__setattr__(self, "effective_at", effective)
+        if status is LifecycleStatus.PROPOSED and effective is not None:
+            raise ValueError("effective_at is forbidden while proposed")
+        if status is not LifecycleStatus.PROPOSED and effective is None:
+            raise ValueError("effective_at is required after proposal")
+        if effective is not None and effective < observed:
+            raise ValueError("effective_at cannot precede observed_at")
+        if self.expires_at is not None:
+            expires = _timestamp(self.expires_at, "expires_at")
+            if expires < observed:
+                raise ValueError("expires_at cannot precede observed_at")
+            object.__setattr__(self, "expires_at", expires)
+        else:
+            expires = None
+        if status is LifecycleStatus.EXPIRED and expires is None:
+            raise ValueError("expires_at is required for expired lifecycle")
+        if status is LifecycleStatus.EXPIRED and effective is not None and expires is not None and effective < expires:
+            raise ValueError("effective_at cannot precede expires_at for expired lifecycle")
+        if self.supersedes_record_id is not None:
+            _text(self.supersedes_record_id, "supersedes_record_id")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "observed_at": self.observed_at,
+            "effective_at": self.effective_at,
+            "expires_at": self.expires_at,
+            "supersedes_record_id": self.supersedes_record_id,
+        }
+
+
+@dataclass(frozen=True)
+class Candidate:
+    memory_class: MemoryClass
+    scope: Scope
+    provenance: Provenance
+    lifecycle: Lifecycle
+    content: Mapping[str, Any]
+    confidence: float
+
+    def __post_init__(self) -> None:
+        if type(self.memory_class) is not MemoryClass:
+            raise TypeError("memory_class must be MemoryClass")
+        if type(self.scope) is not Scope or type(self.provenance) is not Provenance or type(self.lifecycle) is not Lifecycle:
+            raise TypeError("candidate envelope fields have invalid types")
+        if self.lifecycle.status is not LifecycleStatus.PROPOSED:
+            raise ValueError("candidate lifecycle must be proposed")
+        if not isinstance(self.content, Mapping):
+            raise TypeError("content must be a mapping")
+        if type(self.confidence) not in (int, float) or isinstance(self.confidence, bool) or not 0 <= self.confidence <= 1:
+            raise ValueError("confidence must be between zero and one")
+        if self.memory_class is MemoryClass.T and self.lifecycle.expires_at is None:
+            raise ValueError("temporary memory requires expires_at")
+        object.__setattr__(self, "content", _freeze(self.content))
+        object.__setattr__(self, "confidence", float(self.confidence))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"memory_class": self.memory_class.value, "scope": self.scope.to_dict(), "provenance": self.provenance.to_dict(), "lifecycle": self.lifecycle.to_dict(), "content": _plain(self.content), "confidence": self.confidence}
+
+    def content_hash(self) -> str:
+        return _digest(self.to_dict())
+
+
+@dataclass(frozen=True)
+class ReviewPacket:
+    packet_id: str
+    scope: Scope
+    candidate_ids: tuple[str, ...]
+    base_version: int
+
+    def __post_init__(self) -> None:
+        _text(self.packet_id, "packet_id")
+        if type(self.scope) is not Scope:
+            raise TypeError("scope must be Scope")
+        if type(self.candidate_ids) is not tuple or not self.candidate_ids:
+            raise TypeError("candidate_ids must be a nonempty tuple")
+        for candidate_id in self.candidate_ids:
+            _text(candidate_id, "candidate_ids")
+        _integer(self.base_version, "base_version", 0)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"packet_id": self.packet_id, "scope": self.scope.to_dict(), "candidate_ids": list(self.candidate_ids), "base_version": self.base_version}
+
+    def content_hash(self) -> str:
+        return _digest(self.to_dict())
+
+
+@dataclass(frozen=True)
+class Approval:
+    packet_id: str
+    approver: str
+    exact: bool
+
+    def __post_init__(self) -> None:
+        _text(self.packet_id, "packet_id")
+        _text(self.approver, "approver")
+        if type(self.exact) is not bool:
+            raise TypeError("exact must be bool")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"packet_id": self.packet_id, "approver": self.approver, "exact": self.exact}
+
+    def content_hash(self) -> str:
+        return _digest(self.to_dict())
+
+
+@dataclass(frozen=True)
+class CanonicalRecord:
+    record_id: str
+    version: int
+    memory_class: MemoryClass
+    scope: Scope
+    provenance: Provenance
+    lifecycle: Lifecycle
+    content: Mapping[str, Any]
+
+    def __post_init__(self) -> None:
+        _text(self.record_id, "record_id")
+        _integer(self.version, "version", 1)
+        if type(self.memory_class) is not MemoryClass or type(self.scope) is not Scope or type(self.provenance) is not Provenance or type(self.lifecycle) is not Lifecycle:
+            raise TypeError("record envelope fields have invalid types")
+        if self.lifecycle.status is LifecycleStatus.PROPOSED:
+            raise ValueError("canonical record lifecycle cannot be proposed")
+        if not isinstance(self.content, Mapping):
+            raise TypeError("content must be a mapping")
+        object.__setattr__(self, "content", _freeze(self.content))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"record_id": self.record_id, "version": self.version, "memory_class": self.memory_class.value, "scope": self.scope.to_dict(), "provenance": self.provenance.to_dict(), "lifecycle": self.lifecycle.to_dict(), "content": _plain(self.content)}
+
+    def content_hash(self) -> str:
+        return _digest(self.to_dict())
+
+
+@dataclass(frozen=True)
+class TransitionReceipt:
+    receipt_id: str
+    scope: Scope
+    record_id: str
+    from_version: int
+    to_version: int
+    transition: str
+    approval_hash: str
+
+    def __post_init__(self) -> None:
+        _text(self.receipt_id, "receipt_id")
+        if type(self.scope) is not Scope:
+            raise TypeError("scope must be Scope")
+        _text(self.record_id, "record_id")
+        _text(self.transition, "transition")
+        _text(self.approval_hash, "approval_hash")
+        _integer(self.from_version, "from_version", 0)
+        _integer(self.to_version, "to_version", 1)
+        if self.to_version != self.from_version + 1:
+            raise ValueError("receipt versions must be consecutive")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"receipt_id": self.receipt_id, "scope": self.scope.to_dict(), "record_id": self.record_id, "from_version": self.from_version, "to_version": self.to_version, "transition": self.transition, "approval_hash": self.approval_hash}
+
+    def content_hash(self) -> str:
+        return _digest(self.to_dict())

--- a/agent/memory_store.py
+++ b/agent/memory_store.py
@@ -1,0 +1,336 @@
+from __future__ import annotations
+
+from pathlib import Path
+import json
+import os
+import sqlite3
+import stat
+from typing import Any
+
+from agent.memory_policy import validate_approval
+from agent.memory_records import Approval, Candidate, CanonicalRecord, Lifecycle, LifecycleStatus, MemoryClass, Provenance, ReviewPacket, Scope, TransitionReceipt
+
+
+class VersionConflict(RuntimeError):
+    pass
+
+
+def _text(value: object, name: str) -> str:
+    if type(value) is not str or not value.strip():
+        raise ValueError(f"{name} must be a nonblank string")
+    return value
+
+
+def _integer(value: object, name: str, minimum: int) -> int:
+    if type(value) is not int or value < minimum:
+        raise ValueError(f"{name} must be an integer >= {minimum}")
+    return value
+
+
+def _limit(value: object) -> int:
+    result = _integer(value, "limit", 0)
+    if result > 500:
+        raise ValueError("limit must be <= 500")
+    return result
+
+
+def _optional_text(value: object, name: str) -> str | None:
+    return None if value is None else _text(value, name)
+
+
+def _optional_integer(value: object, name: str, minimum: int) -> int | None:
+    return None if value is None else _integer(value, name, minimum)
+
+
+def _json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=False, allow_nan=False)
+
+
+def _scope(profile: str, namespace: str, project: str) -> Scope:
+    return Scope(profile, namespace, project)
+
+
+def _reject_redirected_components(path: Path) -> None:
+    if not path.is_absolute():
+        raise ValueError("root must be absolute")
+    current = Path(path.anchor)
+    for part in path.parts[1:]:
+        if part in ("", ".", ".."):
+            raise ValueError("root contains an invalid component")
+        current = current / part
+        if not os.path.lexists(current):
+            continue
+        value = current.lstat()
+        if stat.S_ISLNK(value.st_mode):
+            raise ValueError("symlinked path component is forbidden")
+        if not stat.S_ISDIR(value.st_mode):
+            raise ValueError("path component must be a directory")
+
+
+def _validate_owned_directory(path: Path, name: str) -> None:
+    value = path.lstat()
+    if stat.S_ISLNK(value.st_mode):
+        raise ValueError(f"symlinked {name} is forbidden")
+    if not stat.S_ISDIR(value.st_mode):
+        raise ValueError(f"{name} must be a directory")
+    if value.st_uid != os.geteuid():
+        raise ValueError(f"{name} must be owned by the current user")
+
+
+def _validate_database(path: Path) -> None:
+    value = path.lstat()
+    if stat.S_ISLNK(value.st_mode):
+        raise ValueError("database symlink is forbidden")
+    if not stat.S_ISREG(value.st_mode):
+        raise ValueError("database must be a regular file")
+    if value.st_uid != os.geteuid():
+        raise ValueError("database must be owned by the current user")
+    if value.st_nlink != 1:
+        raise ValueError("database hard links are forbidden")
+
+
+class MemoryStore:
+    def __init__(self, root: Path | str, profile_id: str) -> None:
+        self.profile_id = _text(profile_id, "profile_id")
+        self.root = Path(root)
+        _reject_redirected_components(self.root)
+        self.root.mkdir(parents=True, mode=0o700, exist_ok=True)
+        _validate_owned_directory(self.root, "root")
+        self.state_dir = self.root / "state"
+        _reject_redirected_components(self.state_dir)
+        self.state_dir.mkdir(mode=0o700, exist_ok=True)
+        _validate_owned_directory(self.state_dir, "state directory")
+        self.path = self.state_dir / "context-memory.sqlite3"
+        self._closed = False
+        if os.path.lexists(self.path):
+            _validate_database(self.path)
+        else:
+            flags = os.O_RDWR | os.O_CREAT | os.O_EXCL | os.O_NOFOLLOW | os.O_CLOEXEC
+            fd = os.open(self.path, flags, 0o600)
+            os.close(fd)
+        try:
+            self._initialize()
+        except sqlite3.DatabaseError as exc:
+            self._closed = True
+            raise ValueError("database is not valid SQLite") from exc
+
+    def close(self) -> None:
+        self._closed = True
+
+    def __del__(self) -> None:
+        self.close()
+
+    def _connect(self) -> sqlite3.Connection:
+        if self._closed:
+            raise RuntimeError("store is closed")
+        _reject_redirected_components(self.state_dir)
+        _validate_owned_directory(self.state_dir, "state directory")
+        _validate_database(self.path)
+        connection = sqlite3.connect(self.path, timeout=30)
+        connection.row_factory = sqlite3.Row
+        connection.execute("PRAGMA journal_mode=DELETE")
+        connection.execute("PRAGMA synchronous=FULL")
+        connection.execute("PRAGMA foreign_keys=ON")
+        connection.execute("PRAGMA busy_timeout=30000")
+        return connection
+
+    def _initialize(self) -> None:
+        schema = """
+        CREATE TABLE IF NOT EXISTS candidates (
+          profile_id TEXT NOT NULL, namespace TEXT NOT NULL, project_id TEXT NOT NULL,
+          candidate_id TEXT NOT NULL, status TEXT NOT NULL, memory_class TEXT NOT NULL,
+          source_type TEXT NOT NULL, source_id TEXT NOT NULL, payload TEXT NOT NULL, content_hash TEXT NOT NULL,
+          PRIMARY KEY(profile_id, namespace, project_id, candidate_id));
+        CREATE INDEX IF NOT EXISTS idx_candidates_status ON candidates(profile_id,status,candidate_id);
+        CREATE INDEX IF NOT EXISTS idx_candidates_class ON candidates(profile_id,memory_class,candidate_id);
+        CREATE INDEX IF NOT EXISTS idx_candidates_namespace ON candidates(profile_id,namespace,candidate_id);
+        CREATE INDEX IF NOT EXISTS idx_candidates_project ON candidates(profile_id,project_id,candidate_id);
+        CREATE INDEX IF NOT EXISTS idx_candidates_scope ON candidates(profile_id,namespace,project_id,candidate_id);
+        CREATE INDEX IF NOT EXISTS idx_candidates_source ON candidates(profile_id,source_id,candidate_id);
+        CREATE TABLE IF NOT EXISTS candidate_events (
+          event_sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+          profile_id TEXT NOT NULL, namespace TEXT NOT NULL, project_id TEXT NOT NULL,
+          candidate_id TEXT NOT NULL, event TEXT NOT NULL);
+        CREATE INDEX IF NOT EXISTS idx_candidate_events_lookup ON candidate_events(profile_id,namespace,project_id,candidate_id,event_sequence);
+        CREATE TABLE IF NOT EXISTS review_packets (
+          profile_id TEXT NOT NULL, namespace TEXT NOT NULL, project_id TEXT NOT NULL,
+          packet_id TEXT NOT NULL, base_version INTEGER NOT NULL, payload TEXT NOT NULL, content_hash TEXT NOT NULL,
+          PRIMARY KEY(profile_id,namespace,project_id,packet_id));
+        CREATE INDEX IF NOT EXISTS idx_review_packets_namespace ON review_packets(profile_id,namespace,base_version,packet_id);
+        CREATE INDEX IF NOT EXISTS idx_review_packets_project ON review_packets(profile_id,project_id,base_version,packet_id);
+        CREATE INDEX IF NOT EXISTS idx_review_packets_base_version ON review_packets(profile_id,base_version,packet_id);
+        CREATE INDEX IF NOT EXISTS idx_review_packets_scope_version ON review_packets(profile_id,namespace,project_id,base_version,packet_id);
+        CREATE TABLE IF NOT EXISTS canonical_records (
+          profile_id TEXT NOT NULL, namespace TEXT NOT NULL, project_id TEXT NOT NULL,
+          record_id TEXT NOT NULL, version INTEGER NOT NULL, payload TEXT NOT NULL,
+          PRIMARY KEY(profile_id,namespace,project_id,record_id,version));
+        CREATE INDEX IF NOT EXISTS idx_canonical_versions ON canonical_records(profile_id,namespace,project_id,record_id,version);
+        CREATE TABLE IF NOT EXISTS transition_receipts (
+          profile_id TEXT NOT NULL, namespace TEXT NOT NULL, project_id TEXT NOT NULL,
+          receipt_id TEXT NOT NULL, record_id TEXT NOT NULL, to_version INTEGER NOT NULL, payload TEXT NOT NULL,
+          PRIMARY KEY(profile_id,namespace,project_id,receipt_id));
+        CREATE INDEX IF NOT EXISTS idx_receipts_record ON transition_receipts(profile_id,namespace,project_id,record_id,to_version);
+        """
+        with self._connect() as db:
+            db.executescript(schema)
+
+    def append_candidate(self, candidate: Candidate) -> str:
+        if type(candidate) is not Candidate or candidate.scope.profile_id != self.profile_id:
+            raise ValueError("candidate does not belong to store")
+        identity = candidate.content_hash(); payload = _json(candidate.to_dict())
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            cursor = db.execute("INSERT OR IGNORE INTO candidates VALUES (?,?,?,?,?,?,?,?,?,?)", (self.profile_id, candidate.scope.namespace, candidate.scope.project_id, identity, candidate.lifecycle.status.value, candidate.memory_class.value, candidate.provenance.source_type, candidate.provenance.source_id, payload, identity))
+            event = "appended" if cursor.rowcount == 1 else "duplicate"
+            db.execute("INSERT INTO candidate_events(profile_id,namespace,project_id,candidate_id,event) VALUES (?,?,?,?,?)", (self.profile_id, candidate.scope.namespace, candidate.scope.project_id, identity, event))
+        return identity
+
+    def count_candidates(self) -> int:
+        with self._connect() as db:
+            return int(db.execute("SELECT count(*) FROM candidates WHERE profile_id=?", (self.profile_id,)).fetchone()[0])
+
+    def query_candidates(self, *, status: str | None = None, memory_class: MemoryClass | None = None, namespace: str | None = None, project_id: str | None = None, source_id: str | None = None, limit: int = 100) -> list[Candidate]:
+        limit = _limit(limit); status = _optional_text(status, "status"); namespace = _optional_text(namespace, "namespace"); project_id = _optional_text(project_id, "project_id"); source_id = _optional_text(source_id, "source_id")
+        if status is not None:
+            try:
+                status = LifecycleStatus(status).value
+            except ValueError as exc:
+                raise ValueError("status is not supported") from exc
+        if memory_class is not None and type(memory_class) is not MemoryClass:
+            raise TypeError("memory_class must be MemoryClass")
+        if limit == 0:
+            return []
+        where = ["profile_id=?"]; values: list[Any] = [self.profile_id]
+        for column, value in (("status", status), ("memory_class", memory_class.value if memory_class else None), ("namespace", namespace), ("project_id", project_id), ("source_id", source_id)):
+            if value is not None:
+                where.append(f"{column}=?"); values.append(value)
+        values.append(limit)
+        with self._connect() as db:
+            rows = db.execute(f"SELECT payload FROM candidates WHERE {' AND '.join(where)} ORDER BY candidate_id LIMIT ?", values).fetchall()
+        return [self._candidate(json.loads(row["payload"])) for row in rows]
+
+    def candidate_events(self, candidate_id: str, *, namespace: str, project_id: str, limit: int = 100) -> list[dict[str, Any]]:
+        candidate_id = _text(candidate_id, "candidate_id"); namespace = _text(namespace, "namespace"); project_id = _text(project_id, "project_id"); limit = _limit(limit)
+        if limit == 0:
+            return []
+        with self._connect() as db:
+            rows = db.execute("SELECT event_sequence,event FROM candidate_events WHERE profile_id=? AND namespace=? AND project_id=? AND candidate_id=? ORDER BY event_sequence LIMIT ?", (self.profile_id, namespace, project_id, candidate_id, limit)).fetchall()
+        return [dict(row) for row in rows]
+
+    def append_review_packet(self, packet: ReviewPacket) -> str:
+        if type(packet) is not ReviewPacket or packet.scope.profile_id != self.profile_id:
+            raise ValueError("packet does not belong to store")
+        identity = packet.content_hash(); payload = _json(packet.to_dict())
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            db.execute("INSERT OR IGNORE INTO review_packets VALUES (?,?,?,?,?,?,?)", (self.profile_id, packet.scope.namespace, packet.scope.project_id, packet.packet_id, packet.base_version, payload, identity))
+            row = db.execute("SELECT content_hash FROM review_packets WHERE profile_id=? AND namespace=? AND project_id=? AND packet_id=?", (self.profile_id, packet.scope.namespace, packet.scope.project_id, packet.packet_id)).fetchone()
+            if row[0] != identity:
+                raise ValueError("packet_id already identifies different content")
+        return identity
+
+    def review_packet(self, packet_id: str, *, namespace: str, project_id: str) -> ReviewPacket | None:
+        packet_id = _text(packet_id, "packet_id"); namespace = _text(namespace, "namespace"); project_id = _text(project_id, "project_id")
+        with self._connect() as db:
+            row = db.execute("SELECT payload FROM review_packets WHERE profile_id=? AND namespace=? AND project_id=? AND packet_id=?", (self.profile_id, namespace, project_id, packet_id)).fetchone()
+        return None if row is None else self._packet(json.loads(row["payload"]))
+
+    def query_review_packets(self, *, base_version: int | None = None, namespace: str | None = None, project_id: str | None = None, limit: int = 100) -> list[ReviewPacket]:
+        base_version = _optional_integer(base_version, "base_version", 0); namespace = _optional_text(namespace, "namespace"); project_id = _optional_text(project_id, "project_id"); limit = _limit(limit)
+        if limit == 0:
+            return []
+        where = ["profile_id=?"]; values: list[Any] = [self.profile_id]
+        for column, value in (("base_version", base_version), ("namespace", namespace), ("project_id", project_id)):
+            if value is not None:
+                where.append(f"{column}=?"); values.append(value)
+        values.append(limit)
+        with self._connect() as db:
+            rows = db.execute(f"SELECT payload FROM review_packets WHERE {' AND '.join(where)} ORDER BY base_version,packet_id LIMIT ?", values).fetchall()
+        return [self._packet(json.loads(row["payload"])) for row in rows]
+
+    def commit_transition(self, record: CanonicalRecord, receipt: TransitionReceipt, *, expected_version: int, packet: ReviewPacket | None = None, approval: Approval | None = None, candidate: Candidate | None = None) -> None:
+        expected_version = _integer(expected_version, "expected_version", 0)
+        if type(record) is not CanonicalRecord or type(receipt) is not TransitionReceipt or record.scope.profile_id != self.profile_id or receipt.scope != record.scope:
+            raise ValueError("record and receipt scope must match store")
+        if record.memory_class is MemoryClass.A:
+            if record.provenance.source_type != "direct_user" or record.provenance.derived:
+                raise ValueError("class-A publication requires direct-user non-derived provenance")
+            candidate_matches = (
+                type(candidate) is Candidate
+                and candidate.memory_class is MemoryClass.A
+                and candidate.scope == record.scope
+                and candidate.provenance == record.provenance
+                and candidate.content == record.content
+                and candidate.lifecycle.observed_at == record.lifecycle.observed_at
+                and candidate.lifecycle.expires_at == record.lifecycle.expires_at
+                and candidate.lifecycle.supersedes_record_id == record.lifecycle.supersedes_record_id
+                and record.lifecycle.status is LifecycleStatus.ACTIVE
+            )
+            packet_matches = (
+                type(candidate) is Candidate
+                and type(packet) is ReviewPacket
+                and packet.scope == record.scope
+                and packet.base_version == expected_version
+                and packet.candidate_ids == (candidate.content_hash(),)
+            )
+            if not candidate_matches or not packet_matches or type(approval) is not Approval or receipt.approval_hash != approval.content_hash() or validate_approval(packet, approval):
+                raise ValueError("class-A publication requires an exact candidate-bound direct approval packet")
+        if record.version != expected_version + 1 or receipt.record_id != record.record_id or receipt.to_version != record.version or receipt.from_version != expected_version:
+            raise ValueError("receipt does not match record transition")
+        key = (self.profile_id, record.scope.namespace, record.scope.project_id, record.record_id)
+        record_payload = _json(record.to_dict()); receipt_payload = _json(receipt.to_dict())
+        with self._connect() as db:
+            db.execute("BEGIN IMMEDIATE")
+            old_record = db.execute("SELECT payload FROM canonical_records WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=? AND version=?", (*key, record.version)).fetchone()
+            old_receipt = db.execute("SELECT payload FROM transition_receipts WHERE profile_id=? AND namespace=? AND project_id=? AND receipt_id=?", (self.profile_id, record.scope.namespace, record.scope.project_id, receipt.receipt_id)).fetchone()
+            if old_record is not None or old_receipt is not None:
+                if old_record and old_receipt and old_record[0] == record_payload and old_receipt[0] == receipt_payload:
+                    return
+                raise VersionConflict("conflicting replay for committed identity")
+            current = int(db.execute("SELECT coalesce(max(version),0) FROM canonical_records WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=?", key).fetchone()[0])
+            if current != expected_version:
+                raise VersionConflict(f"expected version {expected_version}, found {current}")
+            db.execute("INSERT INTO canonical_records VALUES (?,?,?,?,?,?)", (*key, record.version, record_payload))
+            db.execute("INSERT INTO transition_receipts VALUES (?,?,?,?,?,?,?)", (self.profile_id, record.scope.namespace, record.scope.project_id, receipt.receipt_id, receipt.record_id, receipt.to_version, receipt_payload))
+
+    def canonical_history(self, record_id: str, *, namespace: str, project_id: str, min_version: int | None = None, max_version: int | None = None, limit: int = 100) -> list[CanonicalRecord]:
+        record_id = _text(record_id, "record_id"); namespace = _text(namespace, "namespace"); project_id = _text(project_id, "project_id"); min_version = _optional_integer(min_version, "min_version", 1); max_version = _optional_integer(max_version, "max_version", 1); limit = _limit(limit)
+        if min_version is not None and max_version is not None and min_version > max_version:
+            raise ValueError("min_version cannot exceed max_version")
+        if limit == 0:
+            return []
+        where = ["profile_id=?", "namespace=?", "project_id=?", "record_id=?"]; values: list[Any] = [self.profile_id, namespace, project_id, record_id]
+        if min_version is not None: where.append("version>=?"); values.append(min_version)
+        if max_version is not None: where.append("version<=?"); values.append(max_version)
+        values.append(limit)
+        with self._connect() as db:
+            rows = db.execute(f"SELECT payload FROM canonical_records WHERE {' AND '.join(where)} ORDER BY version LIMIT ?", values).fetchall()
+        return [self._record(json.loads(row["payload"])) for row in rows]
+
+    def transition_receipts(self, record_id: str, *, namespace: str, project_id: str, limit: int = 100) -> list[TransitionReceipt]:
+        record_id = _text(record_id, "record_id"); namespace = _text(namespace, "namespace"); project_id = _text(project_id, "project_id"); limit = _limit(limit)
+        if limit == 0:
+            return []
+        with self._connect() as db:
+            rows = db.execute("SELECT payload FROM transition_receipts WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=? ORDER BY to_version LIMIT ?", (self.profile_id, namespace, project_id, record_id, limit)).fetchall()
+        return [self._receipt(json.loads(row["payload"])) for row in rows]
+
+    @staticmethod
+    def _candidate(value: dict[str, Any]) -> Candidate:
+        s = value["scope"]
+        return Candidate(MemoryClass(value["memory_class"]), Scope(s["profile_id"], s["namespace"], s["project_id"]), Provenance(**value["provenance"]), Lifecycle(**value["lifecycle"]), value["content"], value["confidence"])
+
+    @staticmethod
+    def _packet(value: dict[str, Any]) -> ReviewPacket:
+        s = value["scope"]
+        return ReviewPacket(value["packet_id"], Scope(s["profile_id"], s["namespace"], s["project_id"]), tuple(value["candidate_ids"]), value["base_version"])
+
+    @staticmethod
+    def _record(value: dict[str, Any]) -> CanonicalRecord:
+        s = value["scope"]
+        return CanonicalRecord(value["record_id"], value["version"], MemoryClass(value["memory_class"]), Scope(s["profile_id"], s["namespace"], s["project_id"]), Provenance(**value["provenance"]), Lifecycle(**value["lifecycle"]), value["content"])
+
+    @staticmethod
+    def _receipt(value: dict[str, Any]) -> TransitionReceipt:
+        s = value.pop("scope")
+        return TransitionReceipt(scope=Scope(s["profile_id"], s["namespace"], s["project_id"]), **value)

--- a/tests/agent/test_memory_consolidation.py
+++ b/tests/agent/test_memory_consolidation.py
@@ -1,0 +1,131 @@
+from __future__ import annotations
+
+from dataclasses import replace
+import importlib
+
+from agent.memory_records import Candidate, CanonicalRecord, Lifecycle, LifecycleStatus, MemoryClass, Provenance, Scope
+
+
+def module():
+    return importlib.import_module("agent.memory_consolidation")
+
+
+def candidate(*, project: str = "alpha", source: str = "source", value: str = "same", memory_class: MemoryClass = MemoryClass.U, supersedes: str | None = None) -> Candidate:
+    return Candidate(
+        memory_class,
+        Scope("profile", "project", project),
+        Provenance("direct_user", source, "user"),
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z", supersedes_record_id=supersedes),
+        {"value": value},
+        0.8,
+    )
+
+
+def active(*, version: int = 3) -> CanonicalRecord:
+    item = candidate()
+    return CanonicalRecord(
+        "record-1",
+        version,
+        item.memory_class,
+        item.scope,
+        item.provenance,
+        Lifecycle(LifecycleStatus.ACTIVE, observed_at=item.lifecycle.observed_at, effective_at="2026-01-02T00:00:00Z"),
+        {"value": "old"},
+    )
+
+
+def codes(result) -> tuple[str, ...]:
+    return tuple(finding.code for finding in result.findings)
+
+
+def test_consolidation_is_order_independent_and_inert() -> None:
+    api = module()
+    first = candidate(source="one")
+    second = candidate(source="two")
+    ids = (first.content_hash(), second.content_hash())
+
+    left = api.consolidate_candidates(tuple(reversed(ids)), (second, first), expected_canonical_version=0)
+    right = api.consolidate_candidates(ids, (first, second), expected_canonical_version=0)
+
+    assert left == right
+    assert left.findings == ()
+    assert left.proposal is not None
+    assert left.proposal.candidate_ids == tuple(sorted(ids))
+    assert dict(left.proposal.content) == {"value": "same"}
+    assert left.proposal.approved is False
+    assert left.proposal.authoritative is False
+    assert left.proposal.evaluation_findings == ()
+    assert first.lifecycle.status is LifecycleStatus.PROPOSED
+    assert second.lifecycle.status is LifecycleStatus.PROPOSED
+
+
+def test_candidate_ids_are_nonempty_unique_and_bounded() -> None:
+    api = module()
+    item = candidate()
+    identity = item.content_hash()
+
+    assert codes(api.consolidate_candidates((), (), expected_canonical_version=0)) == ("invalid_candidate_ids",)
+    assert codes(api.consolidate_candidates((identity, identity), (item, item), expected_canonical_version=0)) == ("invalid_candidate_ids",)
+    too_many = tuple(f"candidate-{index}" for index in range(api.MAX_CANDIDATES + 1))
+    assert codes(api.consolidate_candidates(too_many, (), expected_canonical_version=0)) == ("invalid_candidate_ids",)
+
+
+def test_candidate_ids_exactly_match_candidate_content_hashes() -> None:
+    api = module()
+    item = candidate()
+    result = api.consolidate_candidates(("wrong-id",), (item,), expected_canonical_version=0)
+    assert codes(result) == ("candidate_id_mismatch",)
+    assert result.proposal is None
+
+
+def test_mixed_scope_fails_closed() -> None:
+    api = module()
+    alpha = candidate(project="alpha", source="one")
+    beta = candidate(project="beta", source="two")
+    result = api.consolidate_candidates((alpha.content_hash(), beta.content_hash()), (alpha, beta), expected_canonical_version=0)
+    assert codes(result) == ("candidate_scope_mismatch",)
+    assert result.proposal is None
+
+
+def test_mixed_memory_class_and_content_fail_closed_in_stable_order() -> None:
+    api = module()
+    first = candidate(source="one", value="first")
+    second = candidate(source="two", value="second", memory_class=MemoryClass.C)
+    result = api.consolidate_candidates((second.content_hash(), first.content_hash()), (second, first), expected_canonical_version=0)
+    assert codes(result) == ("candidate_memory_class_mismatch", "candidate_content_mismatch")
+    assert result.proposal is None
+
+
+def test_initial_proposal_requires_version_zero_and_no_supersession() -> None:
+    api = module()
+    item = candidate(supersedes="record-1")
+    result = api.consolidate_candidates((item.content_hash(),), (item,), expected_canonical_version=2)
+    assert codes(result) == ("initial_version_must_be_zero", "unexpected_supersession_target")
+    assert result.proposal is None
+
+
+def test_supersession_proposal_carries_exact_active_precondition() -> None:
+    api = module()
+    current = active(version=3)
+    first = candidate(source="one", value="new", supersedes=current.record_id)
+    second = candidate(source="two", value="new", supersedes=current.record_id)
+    result = api.consolidate_candidates((second.content_hash(), first.content_hash()), (second, first), expected_canonical_version=3, active=current)
+
+    assert result.findings == ()
+    assert result.proposal is not None
+    assert result.proposal.supersedes_record_id == current.record_id
+    assert result.proposal.expected_canonical_version == current.version
+    assert result.proposal.scope == current.scope
+    assert result.proposal.memory_class is current.memory_class
+
+
+def test_stale_or_wrong_active_state_fails_closed() -> None:
+    api = module()
+    current = active(version=3)
+    item = candidate(value="new", supersedes=current.record_id)
+    stale = api.consolidate_candidates((item.content_hash(),), (item,), expected_canonical_version=2, active=current)
+    assert codes(stale) == ("active_version_mismatch",)
+
+    disputed = replace(current, lifecycle=replace(current.lifecycle, status=LifecycleStatus.DISPUTED))
+    wrong_state = api.consolidate_candidates((item.content_hash(),), (item,), expected_canonical_version=3, active=disputed)
+    assert codes(wrong_state) == ("active_record_must_be_active",)

--- a/tests/agent/test_memory_policy.py
+++ b/tests/agent/test_memory_policy.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from agent.memory_policy import (
+    evaluate_authority,
+    validate_approval,
+    validate_lifecycle_transition,
+    validate_supersession,
+    validate_transition,
+)
+from agent.memory_records import Approval, Candidate, CanonicalRecord, Lifecycle, LifecycleStatus, MemoryClass, Provenance, ReviewPacket, Scope
+
+
+def make(memory_class: MemoryClass = MemoryClass.U, *, derived: bool = False, rule: str = "hold", supersedes: str | None = None) -> Candidate:
+    return Candidate(
+        memory_class=memory_class,
+        scope=Scope("profile", "project", "alpha"),
+        provenance=Provenance("provider" if derived else "direct_user", "source", "model" if derived else "user", derived),
+        lifecycle=Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z", supersedes_record_id=supersedes),
+        content={"rule": rule},
+        confidence=0.5,
+    )
+
+
+def exact(candidate: Candidate, version: int) -> tuple[ReviewPacket, Approval]:
+    packet = ReviewPacket("packet", candidate.scope, (candidate.content_hash(),), version)
+    return packet, Approval("packet", "direct-user", True)
+
+
+def active(candidate: Candidate, record_id: str = "record-1") -> CanonicalRecord:
+    return CanonicalRecord(
+        record_id,
+        1,
+        candidate.memory_class,
+        candidate.scope,
+        candidate.provenance,
+        Lifecycle(
+            LifecycleStatus.ACTIVE,
+            observed_at=candidate.lifecycle.observed_at,
+            effective_at="2026-01-02T00:00:00Z",
+        ),
+        candidate.content,
+    )
+
+
+def test_authority_comes_from_provenance_not_confidence() -> None:
+    direct = make()
+    history = Candidate(
+        MemoryClass.U,
+        direct.scope,
+        Provenance("session_history", "earlier-turn", "assistant", True),
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"),
+        {"rule": "historical"},
+        1.0,
+    )
+    derived = make(derived=True)
+    assert evaluate_authority(direct).rank > evaluate_authority(history).rank > evaluate_authority(derived).rank
+    assert not evaluate_authority(derived).may_activate
+
+
+def test_initial_authorization_requires_exact_direct_user_approval() -> None:
+    candidate = make(MemoryClass.A)
+    packet, approval = exact(candidate, 0)
+    assert validate_transition(None, candidate, None, packet) == ("exact_approval_required",)
+    assert validate_transition(None, candidate, Approval("packet", "model", True), packet) == ("direct_user_approval_required",)
+    assert validate_transition(None, candidate, approval, packet) == ()
+
+
+def test_f5_initial_derived_authorization_is_rejected_even_with_direct_approval() -> None:
+    candidate = make(MemoryClass.A, derived=True)
+    packet, approval = exact(candidate, 0)
+    assert validate_transition(None, candidate, approval, packet) == ("derived_authorization_forbidden",)
+
+
+def test_direct_supersession_rejects_derived_authorization_first() -> None:
+    previous = active(make(MemoryClass.A, rule="hold"))
+    replacement = make(MemoryClass.A, derived=True, rule="deploy", supersedes=previous.record_id)
+    packet, approval = exact(replacement, 3)
+    assert validate_supersession(previous, replacement, approval, packet) == ("derived_authorization_forbidden",)
+
+
+def test_supersession_requires_a_matching_packet() -> None:
+    previous = active(make(MemoryClass.A, rule="old"))
+    replacement = make(MemoryClass.A, rule="new", supersedes=previous.record_id)
+    packet, approval = exact(replacement, 2)
+    assert validate_approval(packet, approval) == ()
+    assert validate_supersession(previous, replacement, approval, packet) == ()
+    assert validate_supersession(previous, replacement, Approval("other", "direct-user", True), packet) == ("packet_id_mismatch",)
+
+
+def test_every_activation_requires_exact_direct_user_approval() -> None:
+    candidate = make(MemoryClass.U)
+    packet, approval = exact(candidate, 0)
+    assert validate_transition(None, candidate, None, packet) == ("exact_approval_required",)
+    assert validate_transition(None, candidate, Approval("packet", "model", True), packet) == ("direct_user_approval_required",)
+    assert validate_transition(None, candidate, approval, packet) == ()
+
+
+def test_supersession_requires_exact_target_and_preserves_class() -> None:
+    previous = active(make(MemoryClass.U, rule="old"))
+    missing = make(MemoryClass.U, rule="new")
+    packet, approval = exact(missing, 1)
+    assert validate_supersession(previous, missing, approval, packet) == ("supersession_link_required",)
+
+    wrong = make(MemoryClass.U, rule="new", supersedes="other")
+    packet, approval = exact(wrong, 1)
+    assert validate_supersession(previous, wrong, approval, packet) == ("supersession_target_mismatch",)
+
+    changed_class = make(MemoryClass.P, rule="new", supersedes=previous.record_id)
+    packet, approval = exact(changed_class, 1)
+    assert validate_supersession(previous, changed_class, approval, packet) == ("memory_class_change_forbidden",)
+
+
+def test_initial_candidate_cannot_claim_supersession() -> None:
+    candidate = make(supersedes="record")
+    packet, approval = exact(candidate, 0)
+    assert validate_transition(None, candidate, approval, packet) == ("supersession_target_missing",)
+
+
+def test_lifecycle_transition_matrix_is_explicit_and_terminal_states_stay_terminal() -> None:
+    allowed = (
+        (LifecycleStatus.PROPOSED, LifecycleStatus.ACTIVE),
+        (LifecycleStatus.PROPOSED, LifecycleStatus.REJECTED),
+        (LifecycleStatus.PROPOSED, LifecycleStatus.EXPIRED),
+        (LifecycleStatus.ACTIVE, LifecycleStatus.DISPUTED),
+        (LifecycleStatus.ACTIVE, LifecycleStatus.SUPERSEDED),
+        (LifecycleStatus.ACTIVE, LifecycleStatus.EXPIRED),
+        (LifecycleStatus.DISPUTED, LifecycleStatus.ACTIVE),
+        (LifecycleStatus.DISPUTED, LifecycleStatus.SUPERSEDED),
+        (LifecycleStatus.DISPUTED, LifecycleStatus.REJECTED),
+        (LifecycleStatus.DISPUTED, LifecycleStatus.EXPIRED),
+    )
+    for previous, proposed in allowed:
+        assert validate_lifecycle_transition(previous, proposed) == ()
+    for terminal in (LifecycleStatus.SUPERSEDED, LifecycleStatus.EXPIRED, LifecycleStatus.REJECTED):
+        assert validate_lifecycle_transition(terminal, LifecycleStatus.ACTIVE) == ("terminal_lifecycle_state",)
+    assert validate_lifecycle_transition(LifecycleStatus.ACTIVE, LifecycleStatus.PROPOSED) == ("invalid_lifecycle_transition",)
+    assert validate_lifecycle_transition(LifecycleStatus.ACTIVE, LifecycleStatus.ACTIVE) == ("lifecycle_transition_noop",)

--- a/tests/agent/test_memory_records.py
+++ b/tests/agent/test_memory_records.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+from collections.abc import MutableMapping
+from dataclasses import replace
+import math
+from typing import Any, cast
+
+import pytest
+
+from agent.memory_records import Approval, Candidate, CanonicalRecord, Lifecycle, LifecycleStatus, MemoryClass, Provenance, ReviewPacket, Scope, TransitionReceipt, _digest
+
+
+def scoped(project: str = "alpha") -> Scope:
+    return Scope("profile", "project", project)
+
+
+def proposed(**changes: object) -> Candidate:
+    original = Candidate(MemoryClass.U, scoped(), Provenance("direct_user", "message", "user"), Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"), {"policy": {"enabled": True}}, 0.5)
+    return replace(original, **changes)
+
+
+def test_f7_scope_and_packet_text_are_nonblank() -> None:
+    for bad in ("", "   "):
+        with pytest.raises(ValueError):
+            Scope("profile", "project", bad)
+        with pytest.raises(ValueError, match="candidate_ids"):
+            ReviewPacket("packet", scoped(), (bad,), 0)
+
+
+def test_f7_candidate_ids_reject_wrong_containers_and_versions() -> None:
+    for invalid in ("one", b"one", ["one"]):
+        with pytest.raises((TypeError, ValueError)):
+            ReviewPacket("packet", scoped(), invalid, 0)  # type: ignore[arg-type]
+    for invalid in (True, -1, 1.0, "1"):
+        with pytest.raises((TypeError, ValueError)):
+            ReviewPacket("packet", scoped(), ("one",), invalid)  # type: ignore[arg-type]
+
+
+def test_f7_mapping_content_is_required_and_deeply_frozen() -> None:
+    with pytest.raises(TypeError, match="mapping"):
+        proposed(content=["not", "mapping"])
+    source = {"nested": {"values": [1]}}
+    item = proposed(content=source); digest = item.content_hash(); source["nested"]["values"].append(2)
+    assert item.content_hash() == digest
+    assert item.to_dict()["content"] == {"nested": {"values": [1]}}
+    with pytest.raises(TypeError):
+        cast(MutableMapping[str, Any], item.content)["new"] = 1
+
+
+@pytest.mark.parametrize("content", [{"": 1}, {"key": "   "}, {"key": math.nan}, {"key": math.inf}, {"key": -math.inf}])
+def test_f7_blank_and_nonfinite_content_is_rejected(content: object) -> None:
+    with pytest.raises((TypeError, ValueError), match="content"):
+        proposed(content=content)
+
+
+def test_runtime_memory_class_is_exact() -> None:
+    with pytest.raises(TypeError, match="memory_class"):
+        proposed(memory_class="A")  # type: ignore[arg-type]
+    assert [entry.value for entry in MemoryClass] == ["U", "A", "E", "P", "T", "R", "C"]
+
+
+def test_f8_transition_receipt_identity_includes_full_scope() -> None:
+    alpha = TransitionReceipt("receipt", scoped("alpha"), "record", 0, 1, "publish", "approval")
+    beta = TransitionReceipt("receipt", scoped("beta"), "record", 0, 1, "publish", "approval")
+    assert alpha.content_hash() != beta.content_hash()
+    assert alpha.to_dict()["scope"] == scoped("alpha").to_dict()
+
+
+def test_all_transition_records_have_stable_distinct_hashes() -> None:
+    item = proposed(); packet = ReviewPacket("packet", scoped(), (item.content_hash(),), 0); approval = Approval("packet", "direct-user", True)
+    record = CanonicalRecord("record", 1, item.memory_class, item.scope, item.provenance, Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-01T00:00:00Z", effective_at="2026-01-02T00:00:00Z"), item.content)
+    receipt = TransitionReceipt("receipt", scoped(), "record", 0, 1, "publish", approval.content_hash())
+    assert len({packet.content_hash(), approval.content_hash(), record.content_hash(), receipt.content_hash()}) == 4
+
+
+def test_f10_digest_boundary_rejects_nonfinite_values_directly() -> None:
+    for value in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError):
+            _digest({"value": value})
+
+
+def test_lifecycle_states_are_exact_and_unknown_values_fail_closed() -> None:
+    assert [state.value for state in LifecycleStatus] == [
+        "proposed", "active", "disputed", "superseded", "expired", "rejected"
+    ]
+    with pytest.raises(ValueError, match="status"):
+        Lifecycle("unknown", observed_at="2026-01-01T00:00:00Z")  # type: ignore[arg-type]
+
+
+def test_lifecycle_timestamps_and_links_reject_inconsistent_values() -> None:
+    with pytest.raises(ValueError, match="observed_at"):
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="not-a-timestamp")
+    with pytest.raises(ValueError, match="effective_at"):
+        Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-02T00:00:00Z")
+    with pytest.raises(ValueError, match="effective_at"):
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-02T00:00:00Z", effective_at="2026-01-01T00:00:00Z")
+    with pytest.raises(ValueError, match="expires_at"):
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-02T00:00:00Z", expires_at="2026-01-01T00:00:00Z")
+    with pytest.raises(ValueError, match="supersedes_record_id"):
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-02T00:00:00Z", supersedes_record_id=" ")
+    with pytest.raises(ValueError, match="expires_at"):
+        Lifecycle(
+            LifecycleStatus.EXPIRED,
+            observed_at="2026-01-01T00:00:00Z",
+            effective_at="2026-01-03T00:00:00Z",
+        )
+    with pytest.raises(ValueError, match="effective_at"):
+        Lifecycle(
+            LifecycleStatus.EXPIRED,
+            observed_at="2026-01-01T00:00:00Z",
+            effective_at="2026-01-02T00:00:00Z",
+            expires_at="2026-01-03T00:00:00Z",
+        )
+
+
+def test_lifecycle_identity_includes_time_and_supersession() -> None:
+    first = proposed(lifecycle=Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"))
+    later = proposed(lifecycle=Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-02T00:00:00Z"))
+    replacement = proposed(lifecycle=Lifecycle(
+        LifecycleStatus.PROPOSED,
+        observed_at="2026-01-01T00:00:00Z",
+        supersedes_record_id="record-1",
+    ))
+    assert len({first.content_hash(), later.content_hash(), replacement.content_hash()}) == 3
+
+
+def test_provenance_rejects_unknown_source_and_actor_shapes() -> None:
+    with pytest.raises(ValueError, match="source_type"):
+        Provenance("unknown", "source", "user")
+    with pytest.raises(ValueError, match="actor"):
+        Provenance("direct_user", "source", " ")
+    with pytest.raises(ValueError, match="actor"):
+        Provenance("direct_user", "source", "intruder")
+    with pytest.raises(ValueError, match="derived"):
+        Provenance("direct_user", "source", "user", True)
+    with pytest.raises(ValueError, match="derived"):
+        Provenance("provider", "source", "provider", False)

--- a/tests/agent/test_memory_store.py
+++ b/tests/agent/test_memory_store.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+import os
+import sqlite3
+
+import pytest
+
+from agent.memory_records import Approval, Candidate, CanonicalRecord, Lifecycle, LifecycleStatus, MemoryClass, Provenance, ReviewPacket, Scope, TransitionReceipt
+from agent.memory_store import MemoryStore, VersionConflict, _json
+
+
+def scope(project: str) -> Scope:
+    return Scope("profile", "project", project)
+
+
+def candidate(project: str, *, source: str = "shared", cls: MemoryClass = MemoryClass.U) -> Candidate:
+    return Candidate(cls, scope(project), Provenance("direct_user", source, "user"), Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"), {"value": source}, 0.8)
+
+
+def record(project: str, version: int, value: str) -> CanonicalRecord:
+    return CanonicalRecord("record", version, MemoryClass.U, scope(project), Provenance("direct_user", "source", "user"), Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-01T00:00:00Z", effective_at="2026-01-02T00:00:00Z"), {"value": value})
+
+
+def receipt(project: str, version: int) -> TransitionReceipt:
+    return TransitionReceipt(f"receipt-{version}", scope(project), "record", version - 1, version, "publish", "approval")
+
+
+def test_f8_candidate_filters_are_independent_and_project_isolated(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    store.append_candidate(candidate("alpha", cls=MemoryClass.C)); store.append_candidate(candidate("beta", cls=MemoryClass.C))
+    assert [x.scope.project_id for x in store.query_candidates(project_id="alpha", limit=10)] == ["alpha"]
+    for kwargs in ({"status": "proposed"}, {"memory_class": MemoryClass.C}, {"namespace": "project"}, {"source_id": "shared"}):
+        assert len(store.query_candidates(**kwargs, limit=10)) == 2
+
+
+def test_store_rejects_cross_profile_candidates(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    foreign = Candidate(
+        MemoryClass.U,
+        Scope("other-profile", "project", "alpha"),
+        Provenance("direct_user", "source", "user"),
+        Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"),
+        {"value": "foreign"},
+        0.8,
+    )
+    with pytest.raises(ValueError, match="does not belong"):
+        store.append_candidate(foreign)
+
+
+def test_f6_candidate_event_history_is_bounded(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile"); item = candidate("alpha")
+    for _ in range(3): store.append_candidate(item)
+    assert len(store.candidate_events(item.content_hash(), namespace="project", project_id="alpha", limit=2)) == 2
+    assert store.candidate_events(item.content_hash(), namespace="project", project_id="alpha", limit=0) == []
+
+
+def test_f6_concurrent_identical_review_packet_is_idempotent(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile"); packet = ReviewPacket("packet", scope("alpha"), ("candidate",), 4)
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        results = list(workers.map(lambda _: store.append_review_packet(packet), range(24)))
+    assert set(results) == {packet.content_hash()}
+    assert store.query_review_packets(base_version=4, project_id="alpha", limit=10) == [packet]
+
+
+def test_f6_transition_replay_is_sequentially_and_concurrently_idempotent(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile"); rec = record("alpha", 1, "a"); proof = receipt("alpha", 1)
+    store.commit_transition(rec, proof, expected_version=0); store.commit_transition(rec, proof, expected_version=0)
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        list(workers.map(lambda _: store.commit_transition(rec, proof, expected_version=0), range(24)))
+    assert store.canonical_history("record", namespace="project", project_id="alpha", limit=10) == [rec]
+    assert store.transition_receipts("record", namespace="project", project_id="alpha", limit=10) == [proof]
+
+
+def test_f6_conflicting_transition_replay_fails_closed(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile"); store.commit_transition(record("alpha", 1, "a"), receipt("alpha", 1), expected_version=0)
+    with pytest.raises(VersionConflict):
+        store.commit_transition(record("alpha", 1, "different"), receipt("alpha", 1), expected_version=0)
+
+
+def test_f8_equal_receipt_ids_are_project_isolated(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    store.commit_transition(record("alpha", 1, "a"), receipt("alpha", 1), expected_version=0)
+    store.commit_transition(record("beta", 1, "b"), receipt("beta", 1), expected_version=0)
+    assert store.transition_receipts("record", namespace="project", project_id="alpha", limit=10) == [receipt("alpha", 1)]
+    assert store.transition_receipts("record", namespace="project", project_id="beta", limit=10) == [receipt("beta", 1)]
+
+
+def query_plan(store: MemoryStore, sql: str, values: tuple[object, ...]) -> str:
+    with store._connect() as db:
+        return " ".join(str(row[3]) for row in db.execute("EXPLAIN QUERY PLAN " + sql, values))
+
+
+def test_f9_independent_filter_queries_use_leading_indexes(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    cases = [
+        ("SELECT payload FROM candidates WHERE profile_id=? AND project_id=? ORDER BY candidate_id LIMIT ?", ("profile", "alpha", 10), "idx_candidates_project"),
+        ("SELECT payload FROM candidates WHERE profile_id=? AND namespace=? ORDER BY candidate_id LIMIT ?", ("profile", "project", 10), "idx_candidates_namespace"),
+        ("SELECT payload FROM review_packets WHERE profile_id=? AND base_version=? ORDER BY base_version,packet_id LIMIT ?", ("profile", 4, 10), "idx_review_packets_base_version"),
+        ("SELECT payload FROM review_packets WHERE profile_id=? AND project_id=? ORDER BY base_version,packet_id LIMIT ?", ("profile", "alpha", 10), "idx_review_packets_project"),
+    ]
+    for sql, values, index in cases:
+        assert index in query_plan(store, sql, values)
+
+
+def test_f7_public_query_and_version_inputs_reject_malformed_values(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    for invalid in (True, -1, 501, 1.5, "1"):
+        with pytest.raises((TypeError, ValueError)):
+            store.query_candidates(limit=invalid)  # type: ignore[arg-type]
+    for invalid in (True, -1, 1.5, "1"):
+        with pytest.raises((TypeError, ValueError)):
+            store.query_review_packets(base_version=invalid)  # type: ignore[arg-type]
+        with pytest.raises((TypeError, ValueError)):
+            store.commit_transition(record("alpha", 1, "a"), receipt("alpha", 1), expected_version=invalid)  # type: ignore[arg-type]
+    for kwargs in ({"project_id": " "}, {"namespace": b"project"}, {"memory_class": "U"}):
+        with pytest.raises((TypeError, ValueError)):
+            store.query_candidates(**kwargs)  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="status"):
+        store.query_candidates(status="unknown")
+
+
+def test_f9_every_list_query_has_a_finite_limit(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    calls = [lambda n: store.query_candidates(limit=n), lambda n: store.query_review_packets(limit=n), lambda n: store.candidate_events("id", namespace="project", project_id="alpha", limit=n), lambda n: store.canonical_history("record", namespace="project", project_id="alpha", limit=n), lambda n: store.transition_receipts("record", namespace="project", project_id="alpha", limit=n)]
+    for call in calls:
+        with pytest.raises(ValueError, match="limit"):
+            call(501)
+
+
+def test_f9_symlinked_root_state_and_database_are_rejected(tmp_path: Path) -> None:
+    target = tmp_path / "target"; target.mkdir(); root_link = tmp_path / "root-link"; root_link.symlink_to(target, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        MemoryStore(root_link, "profile")
+    root = tmp_path / "root"; root.mkdir(); (root / "state").symlink_to(target, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        MemoryStore(root, "profile")
+    root2 = tmp_path / "root2"; state = root2 / "state"; state.mkdir(parents=True); outside = tmp_path / "outside"; outside.write_bytes(b"sentinel"); (state / "context-memory.sqlite3").symlink_to(outside)
+    with pytest.raises(ValueError, match="symlink"):
+        MemoryStore(root2, "profile")
+    assert outside.read_bytes() == b"sentinel"
+
+
+def test_store_revalidates_final_path_and_rejects_a_symlink_swap(tmp_path: Path) -> None:
+    root = tmp_path / "root"; store = MemoryStore(root, "profile"); outside = tmp_path / "outside"; outside.write_bytes(b"sentinel")
+    moved = root / "state" / "moved.sqlite3"; os.rename(store.path, moved); store.path.symlink_to(outside)
+    with pytest.raises(ValueError, match="symlink"):
+        store.append_candidate(candidate("alpha"))
+    assert outside.read_bytes() == b"sentinel"
+
+
+def test_f5_store_boundary_requires_exact_candidate_bound_class_a(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    direct_candidate = Candidate(MemoryClass.A, scope("alpha"), Provenance("direct_user", "source", "user"), Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"), {"value": "a"}, 0.8)
+    direct = CanonicalRecord("record", 1, MemoryClass.A, direct_candidate.scope, direct_candidate.provenance, Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-01T00:00:00Z", effective_at="2026-01-02T00:00:00Z"), direct_candidate.content)
+    approval = Approval("packet", "direct-user", True)
+    proof = TransitionReceipt("receipt", scope("alpha"), "record", 0, 1, "publish", approval.content_hash())
+    packet = ReviewPacket("packet", scope("alpha"), (direct_candidate.content_hash(),), 0)
+    derived_candidate = Candidate(MemoryClass.A, scope("alpha"), Provenance("provider", "source", "model", True), Lifecycle(LifecycleStatus.PROPOSED, observed_at="2026-01-01T00:00:00Z"), {"value": "a"}, 0.8)
+    derived = CanonicalRecord("derived", 1, MemoryClass.A, derived_candidate.scope, derived_candidate.provenance, Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-01T00:00:00Z", effective_at="2026-01-02T00:00:00Z"), derived_candidate.content)
+    with pytest.raises(ValueError, match="direct-user non-derived"):
+        store.commit_transition(derived, TransitionReceipt("derived-r", scope("alpha"), "derived", 0, 1, "publish", approval.content_hash()), expected_version=0, packet=ReviewPacket("packet", scope("alpha"), (derived_candidate.content_hash(),), 0), approval=approval, candidate=derived_candidate)
+    bad_packets = (
+        ReviewPacket("packet", scope("alpha"), (direct_candidate.content_hash(), "other"), 0),
+        ReviewPacket("packet", scope("alpha"), (direct_candidate.content_hash(),), 1),
+        ReviewPacket("packet", scope("alpha"), ("not-the-candidate",), 0),
+    )
+    for bad_packet in bad_packets:
+        with pytest.raises(ValueError, match="candidate-bound"):
+            store.commit_transition(direct, proof, expected_version=0, packet=bad_packet, approval=approval, candidate=direct_candidate)
+    changed = CanonicalRecord("record", 1, MemoryClass.A, direct_candidate.scope, direct_candidate.provenance, Lifecycle(LifecycleStatus.ACTIVE, observed_at="2026-01-01T00:00:00Z", effective_at="2026-01-02T00:00:00Z"), {"value": "changed"})
+    with pytest.raises(ValueError, match="candidate-bound"):
+        store.commit_transition(changed, proof, expected_version=0, packet=packet, approval=approval, candidate=direct_candidate)
+    with pytest.raises(ValueError, match="candidate-bound"):
+        store.commit_transition(direct, proof, expected_version=0, packet=packet, approval=approval)
+    store.commit_transition(direct, proof, expected_version=0, packet=packet, approval=approval, candidate=direct_candidate)
+
+
+def class_a_transition(
+    tmp_path: Path,
+    *,
+    candidate_observed_at: str = "2026-01-01T00:00:00Z",
+    record_observed_at: str = "2026-01-01T00:00:00Z",
+    candidate_supersedes: str | None = None,
+    record_supersedes: str | None = None,
+) -> tuple[MemoryStore, CanonicalRecord, TransitionReceipt, ReviewPacket, Approval, Candidate]:
+    item = Candidate(
+        MemoryClass.A,
+        scope("alpha"),
+        Provenance("direct_user", "source", "user"),
+        Lifecycle(
+            LifecycleStatus.PROPOSED,
+            observed_at=candidate_observed_at,
+            supersedes_record_id=candidate_supersedes,
+        ),
+        {"value": "approved"},
+        0.8,
+    )
+    canonical = CanonicalRecord(
+        "record",
+        1,
+        MemoryClass.A,
+        item.scope,
+        item.provenance,
+        Lifecycle(
+            LifecycleStatus.ACTIVE,
+            observed_at=record_observed_at,
+            effective_at="2026-02-02T00:00:00Z",
+            supersedes_record_id=record_supersedes,
+        ),
+        item.content,
+    )
+    packet = ReviewPacket("packet", item.scope, (item.content_hash(),), 0)
+    approval = Approval("packet", "direct-user", True)
+    proof = TransitionReceipt("receipt", item.scope, "record", 0, 1, "publish", approval.content_hash())
+    return MemoryStore(tmp_path, "profile"), canonical, proof, packet, approval, item
+
+
+def test_class_a_publication_rejects_unapproved_observed_at(tmp_path: Path) -> None:
+    store, canonical, proof, packet, approval, item = class_a_transition(
+        tmp_path,
+        record_observed_at="2026-02-01T00:00:00Z",
+    )
+
+    with pytest.raises(ValueError, match="candidate-bound"):
+        store.commit_transition(canonical, proof, expected_version=0, packet=packet, approval=approval, candidate=item)
+
+    assert store.canonical_history("record", namespace="project", project_id="alpha") == []
+
+
+def test_class_a_publication_rejects_different_supersession_target(tmp_path: Path) -> None:
+    store, canonical, proof, packet, approval, item = class_a_transition(
+        tmp_path,
+        candidate_supersedes="approved-target",
+        record_supersedes="different-target",
+    )
+
+    with pytest.raises(ValueError, match="candidate-bound"):
+        store.commit_transition(canonical, proof, expected_version=0, packet=packet, approval=approval, candidate=item)
+
+    assert store.canonical_history("record", namespace="project", project_id="alpha") == []
+
+
+def test_class_a_initial_publication_rejects_unapproved_supersession(tmp_path: Path) -> None:
+    store, canonical, proof, packet, approval, item = class_a_transition(
+        tmp_path,
+        candidate_supersedes=None,
+        record_supersedes="unapproved-target",
+    )
+
+    with pytest.raises(ValueError, match="candidate-bound"):
+        store.commit_transition(canonical, proof, expected_version=0, packet=packet, approval=approval, candidate=item)
+
+    assert store.canonical_history("record", namespace="project", project_id="alpha") == []
+
+
+def test_f6_historical_and_concurrent_transition_replay_is_idempotent(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    first = record("alpha", 1, "one"); first_receipt = receipt("alpha", 1)
+    second = record("alpha", 2, "two"); second_receipt = receipt("alpha", 2)
+    store.commit_transition(first, first_receipt, expected_version=0)
+    store.commit_transition(second, second_receipt, expected_version=1)
+    store.commit_transition(first, first_receipt, expected_version=0)
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        list(workers.map(lambda _: store.commit_transition(first, first_receipt, expected_version=0), range(16)))
+    conflicting_receipt = TransitionReceipt("receipt-1-other", scope("alpha"), "record", 0, 1, "publish", "approval")
+    with pytest.raises(VersionConflict):
+        store.commit_transition(first, conflicting_receipt, expected_version=0)
+    with pytest.raises(VersionConflict):
+        store.commit_transition(record("alpha", 1, "changed"), first_receipt, expected_version=0)
+    def conflicting(_: int) -> type[BaseException] | None:
+        try:
+            store.commit_transition(record("alpha", 1, "changed"), first_receipt, expected_version=0)
+        except BaseException as exc:
+            return type(exc)
+        return None
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        assert set(workers.map(conflicting, range(16))) == {VersionConflict}
+
+
+def test_f6_conflicting_review_packet_replay_fails(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    store.append_review_packet(ReviewPacket("same", scope("alpha"), ("one",), 0))
+    with pytest.raises(ValueError, match="different content"):
+        store.append_review_packet(ReviewPacket("same", scope("alpha"), ("two",), 0))
+
+
+def test_f9_every_independent_list_filter_has_an_index_plan(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    cases = [
+        ("SELECT payload FROM candidates WHERE profile_id=? AND status=? ORDER BY candidate_id LIMIT ?", ("profile", "proposed", 10), "idx_candidates_status"),
+        ("SELECT payload FROM candidates WHERE profile_id=? AND memory_class=? ORDER BY candidate_id LIMIT ?", ("profile", "U", 10), "idx_candidates_class"),
+        ("SELECT payload FROM candidates WHERE profile_id=? AND source_id=? ORDER BY candidate_id LIMIT ?", ("profile", "source", 10), "idx_candidates_source"),
+        ("SELECT payload FROM review_packets WHERE profile_id=? AND namespace=? ORDER BY base_version,packet_id LIMIT ?", ("profile", "project", 10), "idx_review_packets_namespace"),
+        ("SELECT event FROM candidate_events WHERE profile_id=? AND namespace=? AND project_id=? AND candidate_id=? ORDER BY event_sequence LIMIT ?", ("profile", "project", "alpha", "candidate", 10), "idx_candidate_events_lookup"),
+        ("SELECT payload FROM canonical_records WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=? ORDER BY version LIMIT ?", ("profile", "project", "alpha", "record", 10), "idx_canonical_versions"),
+        ("SELECT payload FROM transition_receipts WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=? ORDER BY to_version LIMIT ?", ("profile", "project", "alpha", "record", 10), "idx_receipts_record"),
+    ]
+    for sql, values, index in cases:
+        assert index in query_plan(store, sql, values)
+
+
+def test_f7_all_public_query_parameters_reject_wrong_shapes(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    calls = [
+        lambda: store.query_candidates(status=MemoryClass.U),  # type: ignore[arg-type]
+        lambda: store.query_candidates(memory_class="U"),  # type: ignore[arg-type]
+        lambda: store.query_candidates(project_id=" "),
+        lambda: store.query_review_packets(base_version=True),
+        lambda: store.candidate_events("candidate", namespace="project", project_id="alpha", limit=1.5),  # type: ignore[arg-type]
+        lambda: store.canonical_history("record", namespace="project", project_id="alpha", min_version=False),
+        lambda: store.transition_receipts("record", namespace="project", project_id="alpha", limit="10"),  # type: ignore[arg-type]
+    ]
+    for call in calls:
+        with pytest.raises((TypeError, ValueError)):
+            call()
+
+
+def test_f9_hardlinks_nonregular_and_non_sqlite_files_are_rejected(tmp_path: Path) -> None:
+    for kind in ("hardlink", "fifo", "not-sqlite"):
+        root = tmp_path / kind; state = root / "state"; state.mkdir(parents=True)
+        database = state / "context-memory.sqlite3"
+        if kind == "hardlink":
+            source = tmp_path / "source.sqlite3"; source.touch(); os.link(source, database)
+        elif kind == "fifo":
+            os.mkfifo(database)
+        else:
+            database.write_bytes(b"not a sqlite database")
+        with pytest.raises(ValueError):
+            MemoryStore(root, "profile")
+
+
+def test_store_has_no_identity_sidecar_and_uses_delete_journal(tmp_path: Path) -> None:
+    root = tmp_path / "root"; store = MemoryStore(root, "profile")
+    assert not (root / "state" / "context-memory.identity").exists()
+    with store._connect() as db:
+        assert db.execute("PRAGMA journal_mode").fetchone()[0].lower() == "delete"
+        assert db.execute("PRAGMA synchronous").fetchone()[0] == 2
+
+
+def test_transition_fault_rolls_back_record_and_receipt_together(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    with store._connect() as db:
+        db.execute(
+            "CREATE TRIGGER reject_receipt BEFORE INSERT ON transition_receipts "
+            "BEGIN SELECT RAISE(ABORT, 'injected fault'); END"
+        )
+    with pytest.raises(sqlite3.IntegrityError, match="injected fault"):
+        store.commit_transition(record("alpha", 1, "one"), receipt("alpha", 1), expected_version=0)
+    assert store.canonical_history("record", namespace="project", project_id="alpha") == []
+    assert store.transition_receipts("record", namespace="project", project_id="alpha") == []
+
+
+
+def test_f6_receipt_only_conflict_and_concurrent_conflicting_packets_fail_closed(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    first = record("alpha", 1, "one")
+    store.commit_transition(first, receipt("alpha", 1), expected_version=0)
+    conflicting_receipt = TransitionReceipt("different-receipt", scope("alpha"), "record", 0, 1, "publish", "approval")
+    with pytest.raises(VersionConflict):
+        store.commit_transition(first, conflicting_receipt, expected_version=0)
+
+    left = ReviewPacket("shared-id", scope("alpha"), ("left",), 0)
+    right = ReviewPacket("shared-id", scope("alpha"), ("right",), 0)
+    def append_conflict(index: int) -> tuple[str, str]:
+        packet = left if index % 2 == 0 else right
+        try:
+            return ("ok", store.append_review_packet(packet))
+        except ValueError:
+            return ("conflict", packet.content_hash())
+    with ThreadPoolExecutor(max_workers=8) as workers:
+        outcomes = list(workers.map(append_conflict, range(32)))
+    assert {kind for kind, _ in outcomes} == {"ok", "conflict"}
+    persisted = store.review_packet("shared-id", namespace="project", project_id="alpha")
+    assert persisted in (left, right)
+    assert {value for kind, value in outcomes if kind == "ok"} == {persisted.content_hash()}
+
+
+def test_f10_intermediate_path_attacks_fail_closed(tmp_path: Path) -> None:
+    outside = tmp_path / "outside"; outside.mkdir()
+    intermediate = tmp_path / "intermediate"; intermediate.symlink_to(outside, target_is_directory=True)
+    with pytest.raises(ValueError, match="symlink"):
+        MemoryStore(intermediate / "child", "profile")
+    blocked = tmp_path / "blocked"; blocked.write_text("not a directory")
+    with pytest.raises((ValueError, OSError)):
+        MemoryStore(blocked / "child", "profile")
+
+
+
+
+def test_f10_canonical_history_min_max_and_range_use_canonical_index(tmp_path: Path) -> None:
+    store = MemoryStore(tmp_path, "profile")
+    base = "SELECT payload FROM canonical_records WHERE profile_id=? AND namespace=? AND project_id=? AND record_id=?"
+    cases = [
+        (base + " AND version>=? ORDER BY version LIMIT ?", ("profile", "project", "alpha", "record", 1, 10)),
+        (base + " AND version<=? ORDER BY version LIMIT ?", ("profile", "project", "alpha", "record", 2, 10)),
+        (base + " AND version>=? AND version<=? ORDER BY version LIMIT ?", ("profile", "project", "alpha", "record", 1, 2, 10)),
+    ]
+    for sql, values in cases:
+        assert "idx_canonical_versions" in query_plan(store, sql, values)
+
+
+def test_f10_storage_serializer_rejects_nonfinite_values_directly() -> None:
+    for value in (float("nan"), float("inf"), float("-inf")):
+        with pytest.raises(ValueError):
+            _json({"value": value})


### PR DESCRIPTION
## Summary
- add governed context-memory record, policy, and canonical store primitives
- add a pure, inert consolidation proposal API with no persistence or publication authority
- add focused Phase 1 and Phase 2 test coverage

## Verification
- clean selected-base baseline: `137 passed`
- expected RED: pytest exit `2` with four collection errors before product materialization
- focused Phase 1 + Phase 2 packet: `60 passed`
- selected-base memory regression: `137 passed`
- candidate-attributable regressions: `0`
- forbidden network attempts: `0`

## Scope
- exactly eight added files
- no runtime activation, installation, migration, deployment, persistence integration, or publication path

Verified local receipt: `b5174b2dc920925ec0731557d58ac3af927391aca8dc4f7b0ddcf07a8f5ce4d9`