### PR TITLE
fix(gemini): echo bridged tool_call name on the OpenAI-compatible path

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4546,6 +4546,60 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             "Pre-call sanitizer: removed %d duplicate tool_call_id reference(s)",
             removed_dupes,
         )
+
+    # 4. Align each tool result's wire-visible ``name`` with the function name
+    # of the call it answers. Google matches functionResponse.name against
+    # functionCall.name and rejects a mismatch with HTTP 400 "Request contains
+    # an invalid argument" (INVALID_ARGUMENT); behind an OpenAI-compatible
+    # gateway that surfaces only as a generic "Provider returned error".
+    #
+    # The mismatch is routine, not corruption. When tool_search defers
+    # MCP/plugin tools the model calls the bridge tool ``tool_call``, while
+    # ``make_tool_result_message()`` labels the result with the unwrapped
+    # internal tool name (``mcp__github__create_issue``) that dispatch, hooks,
+    # logging, and guardrails need. #72089 fixed exactly this for the native
+    # Gemini adapter, which now prefers ``tool_name_by_call_id`` over the
+    # result name; requests that reach Gemini through the OpenAI-compatible
+    # path (OpenRouter, Vertex/LiteLLM proxies, any OpenAI-shaped gateway) skip
+    # that translation entirely and still send the internal name on the wire.
+    #
+    # Normalizing here rather than in the OpenAI-compat serializer keeps it
+    # provider-agnostic: Gemini reaches Hermes under many model strings and
+    # base URLs, so sniffing for "is this really Google?" is unreliable, and
+    # every other provider either ignores the field or agrees with the call
+    # name. Runs on the per-call copy, so the stored trajectory keeps the real
+    # tool name for the session DB and the UI — only the wire payload changes.
+    # A no-op for the native Gemini path, which already resolves the same name.
+    call_names: Dict[str, str] = {}
+    for msg in messages:
+        if msg.get("role") == "assistant":
+            for tc in msg.get("tool_calls") or []:
+                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                nm = _ra().AIAgent._get_tool_call_name_static(tc)
+                if cid and nm:
+                    call_names[cid] = nm
+    realigned = 0
+    aligned: List[Dict[str, Any]] = []
+    for msg in messages:
+        if msg.get("role") == "tool":
+            cid = (msg.get("tool_call_id") or "").strip()
+            expected = call_names.get(cid)
+            current = msg.get("name")
+            # Only rewrite a name that is present and disagrees. A result with
+            # no ``name`` is already valid for Gemini (the id pairs it), so
+            # leave it absent rather than inventing a field: clean transcripts
+            # must still pass through byte-identical for prompt caching.
+            if expected and current and current != expected:
+                msg = {**msg, "name": expected}
+                realigned += 1
+        aligned.append(msg)
+    if realigned:
+        messages = aligned
+        _ra().logger.debug(
+            "Pre-call sanitizer: realigned %d tool result name(s) with their "
+            "tool_call function name",
+            realigned,
+        )
     return messages
 
 

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -4570,15 +4570,21 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
     # name. Runs on the per-call copy, so the stored trajectory keeps the real
     # tool name for the session DB and the UI — only the wire payload changes.
     # A no-op for the native Gemini path, which already resolves the same name.
+    # A result whose assistant call frame is missing entirely never reaches
+    # here — pass 1 above drops it as an orphan — so the only results this pass
+    # sees are ones whose call name is knowable.
     call_names: Dict[str, str] = {}
     for msg in messages:
         if msg.get("role") == "assistant":
             for tc in msg.get("tool_calls") or []:
-                cid = _ra().AIAgent._get_tool_call_id_static(tc)
+                # Strip on insert to match the lookup below (and pass 1's
+                # ``result_call_ids``), so an id that arrives padded still
+                # pairs instead of silently skipping realignment.
+                cid = (_ra().AIAgent._get_tool_call_id_static(tc) or "").strip()
                 nm = _ra().AIAgent._get_tool_call_name_static(tc)
                 if cid and nm:
                     call_names[cid] = nm
-    realigned = 0
+    realigned: List[Tuple[str, str]] = []
     aligned: List[Dict[str, Any]] = []
     for msg in messages:
         if msg.get("role") == "tool":
@@ -4591,14 +4597,15 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
             # must still pass through byte-identical for prompt caching.
             if expected and current and current != expected:
                 msg = {**msg, "name": expected}
-                realigned += 1
+                realigned.append((current, expected))
         aligned.append(msg)
     if realigned:
         messages = aligned
         _ra().logger.debug(
             "Pre-call sanitizer: realigned %d tool result name(s) with their "
-            "tool_call function name",
-            realigned,
+            "tool_call function name (%s)",
+            len(realigned),
+            ", ".join(f"{was} -> {now}" for was, now in realigned),
         )
     return messages
 

--- a/contributors/emails/yongliabc888@gmail.com
+++ b/contributors/emails/yongliabc888@gmail.com
@@ -1,0 +1,2 @@
+yongli-abc
+# PR #87629 salvage

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -1429,8 +1429,8 @@ def test_sanitize_realigns_bridged_tool_result_name_with_call_name():
     assert messages[2]["name"] == "mcp__github__create_issue"
 
 
-def test_sanitize_leaves_matching_and_unpaired_tool_result_names_alone():
-    """Directly-called tools already agree; an unpaired name is left as-is."""
+def test_sanitize_leaves_already_matching_tool_result_name_alone():
+    """A directly-called tool already agrees — nothing to rewrite."""
     from agent.agent_runtime_helpers import sanitize_api_messages
 
     messages = [
@@ -1462,3 +1462,35 @@ def test_sanitize_does_not_invent_a_name_on_unnamed_tool_results():
     ]
     out = sanitize_api_messages(list(messages))
     assert out == messages
+
+
+def test_sanitize_realigns_bridged_name_when_call_id_is_padded():
+    """Ids are stripped on both sides, so a padded id still pairs."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": " call_1 ", "type": "function",
+                         "function": {"name": "tool_call", "arguments": "{}"}}]},
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": "{}"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["name"] for m in out if m.get("role") == "tool"] == ["tool_call"]
+
+
+def test_sanitize_drops_bridged_result_whose_call_frame_was_pruned():
+    """A result cannot keep a stale name if it has no call frame to disagree
+    with: the orphan pass removes it before the realignment pass runs, so the
+    mismatch never reaches the provider."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        # assistant tool_calls frame dropped by compression
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": "{}"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m.get("role") for m in out] == ["user"]

--- a/tests/run_agent/test_message_sequence_repair.py
+++ b/tests/run_agent/test_message_sequence_repair.py
@@ -1388,3 +1388,77 @@ def test_sanitize_stubs_interrupted_first_occurrence_keeps_replay_pair():
     assert out[5]["content"] == "real result"
 
 
+
+
+# ── Bridged tool_call: wire-visible response name must echo the call name ──
+# Google matches functionResponse.name against functionCall.name and rejects a
+# mismatch with HTTP 400 INVALID_ARGUMENT. #72089 fixed this for the native
+# Gemini adapter; requests reaching Gemini through an OpenAI-compatible
+# gateway (OpenRouter, Vertex/LiteLLM proxies) skip that translation, so the
+# chokepoint sanitizer has to hold the same invariant.
+
+
+def test_sanitize_realigns_bridged_tool_result_name_with_call_name():
+    """A tool_search-bridged result must go on the wire as ``tool_call``.
+
+    The executor labels the result with the unwrapped internal tool name for
+    dispatch/hooks/logging; Gemini sees that as a functionResponse whose name
+    does not match its functionCall and 400s.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "file an issue"},
+        {"role": "assistant", "content": "",
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {
+                             "name": "tool_call",
+                             "arguments": ('{"name": "mcp__github__create_issue",'
+                                           ' "arguments": {"title": "Bug"}}'),
+                         }}]},
+        {"role": "tool", "name": "mcp__github__create_issue",
+         "tool_name": "mcp__github__create_issue",
+         "tool_call_id": "call_1", "content": '{"number": 123}'},
+    ]
+    out = sanitize_api_messages(list(messages))
+    result = [m for m in out if m.get("role") == "tool"][0]
+    assert result["name"] == "tool_call"
+    # The internal name stays available for the session DB / UI, and the
+    # caller's own message objects are untouched (per-call copy only).
+    assert result["tool_name"] == "mcp__github__create_issue"
+    assert messages[2]["name"] == "mcp__github__create_issue"
+
+
+def test_sanitize_leaves_matching_and_unpaired_tool_result_names_alone():
+    """Directly-called tools already agree; an unpaired name is left as-is."""
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "weather?"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {"name": "get_weather", "arguments": "{}"}}]},
+        {"role": "tool", "name": "get_weather",
+         "tool_call_id": "call_1", "content": "sunny"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert [m["name"] for m in out if m.get("role") == "tool"] == ["get_weather"]
+
+
+def test_sanitize_does_not_invent_a_name_on_unnamed_tool_results():
+    """A result with no ``name`` is already valid — the id pairs it.
+
+    Adding the field would make clean transcripts non-identical on the wire
+    and needlessly perturb prompt caching.
+    """
+    from agent.agent_runtime_helpers import sanitize_api_messages
+
+    messages = [
+        {"role": "user", "content": "run it"},
+        {"role": "assistant", "content": None,
+         "tool_calls": [{"id": "call_1", "type": "function",
+                         "function": {"name": "terminal", "arguments": "{}"}}]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "ok"},
+    ]
+    out = sanitize_api_messages(list(messages))
+    assert out == messages


### PR DESCRIPTION
## Summary
Gemini via any OpenAI-compatible gateway no longer 400s after a Tool Search–bridged MCP tool call; the tool result's wire-visible `name` now echoes the `tool_call` function name it answers, holding the #72089 invariant on the OpenAI-compat path (OpenRouter, Vertex/LiteLLM proxies) as well as the native Gemini one.

Root cause: when tool_search defers MCP/plugin tools, the model calls the bridge tool `tool_call`, but `make_tool_result_message()` labels the result with the unwrapped internal tool name (`mcp__github__create_issue`) that dispatch, hooks, logging, and guardrails need. Google matches `functionResponse.name` against `functionCall.name` and rejects the mismatch with HTTP 400 `INVALID_ARGUMENT` — behind OpenRouter that surfaces only as a bare "Provider returned error", and the poisoned pair fails every later turn of the session.

## Changes
- `agent/agent_runtime_helpers.py` — new pass 4 in `sanitize_api_messages()`: build `{tool_call_id: function name}` from the assistant turns, then realign any tool result whose `name` is present and disagrees. Runs on the per-call copy only, so the stored trajectory keeps the real internal tool name; a result with no `name` is left absent (clean transcripts pass through byte-identical for prompt caching).
- `tests/run_agent/test_message_sequence_repair.py` — three regression tests: bridged name realigned (internal `tool_name` and caller's own message objects untouched), matching names left alone, no name invented on unnamed results.
- `contributors/emails/yongliabc888@gmail.com` — attribution mapping for the original author.

## Credit
Salvage of #87629 by @yongli-abc — both commits cherry-picked onto current `main` with authorship preserved. The only conflict resolution: #87629's base predated the positional-prune rework of `test_message_sequence_repair.py` (#94704); the stale-context tail of the old dedup test was dropped in favor of main's rewritten version, and the three new tests were appended intact. Follow-up commit 3d45ea8973 (strip call ids on insert, name the realignments in the log) also carried over verbatim.

Fixes #87628

## Validation
| | Before (main) | After (this PR) |
|---|---|---|
| Bridged tool result on wire | internal `mcp__…` name → Gemini 400 | echoes `tool_call` → 200 |
| Clean transcripts | byte-identical | byte-identical (same-object passthrough) |

- `tests/run_agent/test_message_sequence_repair.py`: 58 passed on this branch; primary regression test fails on `origin/main` with the exact reported symptom (`'mcp__github__create_issue' != 'tool_call'`).
- `tests/agent/test_prompt_caching.py` + `tests/agent/test_gemini_native_adapter.py` + `tests/agent/transports/test_chat_completions_empty_tool_calls.py`: 88 passed.
- Full `tests/run_agent/`: 1684 passed (1 pre-existing local failure reproduces on main).
- E2E probe (real imports, isolated HERMES_HOME): 8/8 — realignment fires, inputs never mutated, cache-pure no-op on clean transcripts, pass-2 stub injection agrees, orphan results dropped first, SDK-object tool_calls pair, parallel calls rewrite only the mismatched one, system messages untouched.
- Every consumer of the tool `name` field audited: Anthropic / Codex Responses / Bedrock pair by id and ignore `name`; chat-completions transport is the intended fix target; native Gemini path already resolves via `tool_name_by_call_id` (#72089) so this is a no-op there.
- ruff clean; ty new-issues: none (2 pre-existing diagnostics on main-blamed lines).

## Test plan
- Reviewers: `pytest tests/run_agent/test_message_sequence_repair.py -q` (58 passed).
- Live repro per #87628: OpenRouter profile on a Gemini model with an MCP server configured; any deferred MCP tool call previously poisoned the session — now completes.
