### PR TITLE
fix(terminal): strict Linux-only gating for background-executor systemd scopes (#70716 follow-up)

### DIFF
--- a/.github/workflows/windows-venv-e2e.yml
+++ b/.github/workflows/windows-venv-e2e.yml
@@ -70,3 +70,11 @@ jobs:
           uv run --no-sync python -m pytest \
             tests/gateway/test_telegram_closewait_windows_live.py \
             -o addopts= -v -p no:cacheprovider
+
+      - name: Run background-executor spawn parity live E2E (#70716)
+        shell: bash
+        run: |
+          set -uo pipefail
+          uv run --no-sync python -m pytest \
+            tests/tools/test_process_registry_windows_live.py \
+            -o addopts= -v -p no:cacheprovider

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2285,6 +2285,77 @@ class TestSystemdCgroupIsolation:
 
         assert pr._stop_systemd_unit("hermes-worker-gone.scope") is True
 
+    def test_darwin_never_takes_scope_path_even_with_systemd_run_on_path(
+        self, registry, monkeypatch, _gateway_identity
+    ):
+        """macOS no-op guarantee (#70716 cross-platform audit).
+
+        With ``_IS_LINUX = False`` (darwin), the spawn path must be
+        byte-identical to the legacy path even when a ``systemd-run``
+        binary is somehow on PATH and the gateway identity checks pass:
+        no probe, no wrapping, no unit recorded.
+        """
+        import tools.process_registry as pr
+
+        fake_popen, captured = self._fake_popen_capture()
+
+        monkeypatch.setattr(pr, "_IS_LINUX", False)
+        monkeypatch.setattr(pr, "_IS_WINDOWS", False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr("tools.process_registry._find_shell", lambda: "/bin/bash")
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process", lambda: True
+        )
+        # If any branch consults the probe or builds a scope argv on darwin,
+        # fail loudly.
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/systemd-run")
+        scope_builds = []
+        real_build = pr._build_systemd_scope_argv
+        monkeypatch.setattr(
+            pr,
+            "_build_systemd_scope_argv",
+            lambda *a, **k: scope_builds.append(a) or real_build(*a, **k),
+        )
+        probe_runs = []
+
+        def fake_probe_run(argv, **kwargs):
+            probe_runs.append(argv)
+            return subprocess.CompletedProcess(args=argv, returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_probe_run)
+
+        with (
+            patch("subprocess.Popen", side_effect=fake_popen),
+            patch("threading.Thread", return_value=MagicMock()),
+            patch.object(registry, "_write_checkpoint"),
+        ):
+            session = registry.spawn_local("echo hello", cwd="/tmp")
+
+        argv = captured["argv"]
+        assert argv == ["/bin/bash", "-lic", "set +m; echo hello"], argv
+        assert captured["start_new_session"] is True
+        assert session.systemd_unit == ""
+        assert scope_builds == [], "darwin must never build a systemd scope argv"
+        assert probe_runs == [], "darwin must never run the systemd-run probe"
+
+    def test_probe_returns_false_off_linux(self, monkeypatch):
+        """``_systemd_run_user_scope_available`` is False on non-Linux even
+        when a ``systemd-run`` binary exists on PATH."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_IS_LINUX", False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/local/bin/systemd-run")
+        probe_runs = []
+        monkeypatch.setattr(
+            "subprocess.run",
+            lambda argv, **kwargs: probe_runs.append(argv)
+            or subprocess.CompletedProcess(args=argv, returncode=0),
+        )
+
+        assert pr._systemd_run_user_scope_available() is False
+        assert probe_runs == [], "non-Linux must not exec the probe"
+
 
 class TestNotificationRedaction:
     """Background-process notification delivery (completion_queue) applies the

--- a/tests/tools/test_process_registry_windows_live.py
+++ b/tests/tools/test_process_registry_windows_live.py
@@ -1,0 +1,103 @@
+"""LIVE Windows E2E for background-executor spawn parity (#70716 / PR salvage).
+
+Runs ONLY on a real Windows host (the on-demand ``windows-venv-e2e.yml``
+lane). The systemd cgroup-isolation feature for local background executors
+must be a strict no-op on Windows: jobs spawn exactly as before, output is
+captured, exit codes are correct, and no systemd code path is ever reached
+— even when the process claims gateway identity.
+
+These tests drive the REAL ``ProcessRegistry.spawn_local`` pipe path on the
+live Windows process table (real Popen, real Git Bash shell, real reader
+thread) — no mocked spawn.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform != "win32", reason="live Windows background-executor E2E"
+)
+
+
+@pytest.fixture()
+def registry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes-home"))
+    import tools.process_registry as pr
+
+    reg = pr.ProcessRegistry()
+    yield reg
+    for sid in list(reg._running):
+        try:
+            reg.kill_process(sid)
+        except Exception:
+            pass
+
+
+def _wait_exit(reg, sid, timeout=60):
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        sess = reg._finished.get(sid) or reg._running.get(sid)
+        if sess is not None and sess.exited:
+            return sess
+        time.sleep(0.2)
+    raise AssertionError(f"session {sid} did not exit within {timeout}s")
+
+
+class TestWindowsSpawnParity:
+    def test_background_job_runs_output_and_exit_code_unchanged(self, registry):
+        """Plain background job: spawned, output captured, exit code correct."""
+        session = registry.spawn_local("echo win-live-parity; exit 7")
+        done = _wait_exit(registry, session.id)
+
+        assert done.exit_code == 7
+        assert "win-live-parity" in done.output_buffer
+        # The systemd scope identity must never be recorded on Windows.
+        assert done.systemd_unit == ""
+
+    def test_gateway_identity_never_reaches_systemd_path_on_windows(
+        self, registry, monkeypatch
+    ):
+        """Even with full (faked) gateway identity, the Windows spawn takes
+        the legacy path: no scope argv is built, no probe runs, and the job
+        behaves exactly as without the identity."""
+        import tools.process_registry as pr
+
+        monkeypatch.setenv("_HERMES_GATEWAY", "1")
+        monkeypatch.setattr(
+            "gateway.status.get_running_pid",
+            lambda *, cleanup_stale=False: os.getpid(),
+        )
+        monkeypatch.setattr(
+            "gateway.restart.is_gateway_supervisor_process", lambda: True
+        )
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+
+        scope_builds = []
+        monkeypatch.setattr(
+            pr,
+            "_build_systemd_scope_argv",
+            lambda *a, **k: scope_builds.append(a) or a[0],
+        )
+
+        session = registry.spawn_local("echo win-live-gateway; exit 3")
+        done = _wait_exit(registry, session.id)
+
+        assert done.exit_code == 3
+        assert "win-live-gateway" in done.output_buffer
+        assert done.systemd_unit == ""
+        assert scope_builds == [], "Windows must never build a systemd scope argv"
+        # The availability probe must not have flipped to True on Windows.
+        assert pr._SYSTEMD_SCOPE_AVAILABLE is not True
+
+    def test_kill_process_windows_plain_path(self, registry):
+        """kill_process on Windows works without any systemd unit cleanup."""
+        session = registry.spawn_local("sleep 60")
+        time.sleep(1.0)
+        result = registry.kill_process(session.id)
+        assert result.get("status") in {"killed", "already_exited"}
+        assert session.systemd_unit == ""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -43,6 +43,10 @@ import uuid
 from pathlib import Path
 
 _IS_WINDOWS = platform.system() == "Windows"
+# systemd transient scopes exist only on Linux. Gate every scope-path branch
+# on this constant (not merely "not Windows") so macOS and other POSIX
+# platforms provably never touch systemd code (#70716 cross-platform audit).
+_IS_LINUX = platform.system() == "Linux"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
@@ -215,7 +219,7 @@ def _systemd_run_user_scope_available() -> bool:
             return False
 
         available = False
-        if not _IS_WINDOWS:
+        if _IS_LINUX:
             try:
                 import shutil
 
@@ -1098,7 +1102,7 @@ class ProcessRegistry:
                 # Wrap the PTY command in a systemd scope so interactive
                 # executors get their own cgroup, same as pipe mode.
                 pty_in_supervised_gateway = (
-                    not _IS_WINDOWS and _is_supervised_gateway_process()
+                    _IS_LINUX and _is_supervised_gateway_process()
                 )
                 pty_use_systemd_scope = (
                     pty_in_supervised_gateway and _systemd_run_user_scope_available()
@@ -1176,7 +1180,7 @@ class ProcessRegistry:
         # cgroup (and the messaging control plane with it). This applies to
         # both pipe mode and the PTY path above.
         shell_argv = [user_shell, "-lic", f"set +m; {safe_command}"]
-        in_supervised_gateway = not _IS_WINDOWS and _is_supervised_gateway_process()
+        in_supervised_gateway = _IS_LINUX and _is_supervised_gateway_process()
         use_systemd_scope = (
             in_supervised_gateway and _systemd_run_user_scope_available()
         )


### PR DESCRIPTION
## Summary

Cross-platform hardening + full live verification of @toprakeker's systemd cgroup isolation for background terminal executors (original PR #71378, first landed via #81264 with authorship preserved). This PR closes Teknium's cross-platform condition: the systemd-scope path is now **strictly gated on Linux**, with byte-identical fallback everywhere else, proven live on all three platforms' surfaces.

**What changed (this PR, 4 files, +189/−3):**

- `tools/process_registry.py`: new `_IS_LINUX` constant; every scope-path branch (availability probe, PTY wrap, pipe wrap) now gates on `_IS_LINUX` instead of `not _IS_WINDOWS`. Before this, macOS would have executed the `shutil.which("systemd-run")` probe (and wrapped the spawn if a Homebrew-style `systemd-run` shim ever appeared on PATH). Now non-Linux provably never touches systemd code.
- `tests/tools/test_process_registry.py`: two new unit tests — darwin no-op guarantee (no probe subprocess, no scope argv built, legacy argv byte-identical, no unit recorded, even with faked gateway identity + `systemd-run` on PATH) and `_systemd_run_user_scope_available()` returns False off Linux without exec'ing the probe.
- `tests/tools/test_process_registry_windows_live.py` (new): live windows-latest E2E driving the REAL `spawn_local` pipe path — jobs spawn, output captured, exit codes correct, systemd path never reached even under faked gateway identity.
- `.github/workflows/windows-venv-e2e.yml`: the new live test added to the on-demand lane's pytest list (permanent regression value — runs on every future `wine2e/**` proof push). ⚠️ Workflow-file edit — trips the ci-reviewed gate.

## Cross-platform audit table

| Platform | Path taken | Proof |
|---|---|---|
| Linux + systemd user bus + supervised gateway | `systemd-run --user --scope --unit=hermes-worker-<id>` with MemoryAccounting/MemoryMax/OOMPolicy=kill | Live on this box: worker cgroup `…/app.slice/hermes-worker-proc_cc777b686eb2.scope` vs parent `…/session-3.scope`; `systemctl --user show` ActiveState=active; after `kill_process`: LoadState=not-found |
| Linux WITHOUT user bus (containers, s6, WSL-no-systemd) | Probe fails → cached False → legacy spawn, no error | Live run with `DBUS_SESSION_BUS_ADDRESS`/`XDG_RUNTIME_DIR` stripped: `probe_available=false`, spawn clean, `exit=7`, output identical to baseline, `systemd_unit=""` |
| Linux, interactive CLI (no gateway identity) | Legacy spawn | Live baseline phase: `systemd_unit=""`, exit/output identical to scoped run |
| Windows | Legacy spawn — `_IS_LINUX=False` short-circuits before any systemd code | **Executed** windows-latest run: https://github.com/NousResearch/hermes-agent/actions/runs/33490029091 — 3/3 live tests passed (spawn parity, gateway-identity-no-systemd, kill path) |
| macOS | Legacy spawn — `_IS_LINUX=False`; probe never exec'd, scope argv never built | Enforced by explicit gating + unit test `test_darwin_never_takes_scope_path_even_with_systemd_run_on_path` (fails loudly if any branch touches systemd on darwin) |

## Linux live evidence (this box, systemd 255 user manager, temp HERMES_HOME)

**Live repro:** real `ProcessRegistry.spawn_local` through the actual executor path (gateway identity, temp `HERMES_HOME`) — before (legacy path): worker shares parent cgroup (the #70716 incident class: systemd-oomd killed the gateway control plane during a Codex PTY run); after (scope path): worker in its own transient scope, OOM contained to the child, parent survived.

- **Cgroup separation:** parent `0::/user.slice/user-1000.slice/session-3.scope`; child `0::/…/user@1000.service/app.slice/hermes-worker-proc_cc777b686eb2.scope`; `systemctl --user show` confirms ControlGroup + MemoryMax=4294967296.
- **OOM containment:** memory hog under `TERMINAL_LOCAL_MEMORY_MAX_MB=128` (MemorySwapMax clamped to 0 for the test because this host has 255 GiB swap): child killed with exit `-9` (SIGKILL by the kernel OOM killer inside the scope), scope went inactive, **parent survived** in its unchanged cgroup.
- **Output/exit plumbing unchanged:** plain `echo hello-w4-live; exit 7` run on legacy path and scope path — output and exit code byte-identical (`hello-w4-live`, exit 7).
- **Scope reaping:** after `kill_process`, unit `LoadState=not-found / ActiveState=inactive`.

## Tests

- `tests/tools/test_process_registry.py`: 93 passed, 4 skipped, 1 pre-existing env-specific failure (`TestCheckpoint::test_checkpoint_redacts_command_with_inline_secret` — fails identically on clean `origin/main`, unrelated).
- `TestSystemdCgroupIsolation`: 20/20 passed (18 existing + 2 new).
- Windows live lane: 3/3 passed on windows-latest (run above).
- `ruff check` clean on all touched files.

## Credit

Original implementation by @toprakeker (#71378, iterated through @roian6's real-systemd review to close PTY isolation, scope reaping, and `already_exited` gaps) — already on main with authorship preserved. This PR is the cross-platform gating follow-up.

## Follow-up (not in this PR)

- #97739 (admission control for background executors) stays separate — this PR only isolates the failure domain; it does not admission-control worker spawn volume.

## Infographic

![systemd-worker-scopes](https://v3b.fal.media/files/b/0aa8a873/SAhV7KPiVWonrFAiNtt1D_EYYEwm3C.png)
