### PR TITLE
fix(redact): cover Google OAuth client secrets

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -88,6 +88,7 @@ _PREFIX_PATTERNS = [
     r"xapp-\d+-[A-Za-z0-9-]{10,}",      # Slack app-Level token
     r"xox[baprs]-[A-Za-z0-9-]{10,}",    # Slack bot/app/user tokens
     r"AIza[A-Za-z0-9_-]{30,}",          # Google API keys
+    r"GOCSPX-[A-Za-z0-9_-]{10,}",       # Google OAuth client secrets
     r"pplx-[A-Za-z0-9]{10,}",           # Perplexity
     r"fal_[A-Za-z0-9_-]{10,}",          # Fal.ai
     r"fc-[A-Za-z0-9]{10,}",             # Firecrawl

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -64,6 +64,12 @@ class TestKnownPrefixes:
         result = redact_sensitive_text(token)
         assert "a" * 14 not in result
 
+    def test_google_oauth_client_secret_prefix(self):
+        token = "GOCSPX-" + "A" * 24
+        result = redact_sensitive_text(f"client_secret={token}")
+        assert token not in result
+        assert "A" * 24 not in result
+
 
 
 

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -284,6 +284,21 @@ class TestCaptureLogSnapshotRedaction:
         assert snap.full_text is not None
         assert _REDACT_FIXTURE_TOKEN not in snap.full_text
 
+    def test_redacts_google_oauth_client_secret_json_for_public_share(
+        self, hermes_home_with_secret
+    ):
+        from hermes_cli.debug import _capture_log_snapshot
+
+        secret = "GOCSPX-UNIQUELEAKPAYLOAD1234567890"
+        log_path = hermes_home_with_secret / "logs" / "agent.log"
+        log_path.write_text(f'{{"client_secret":"{secret}"}}\n')
+
+        snap = _capture_log_snapshot("agent", tail_lines=10)
+
+        assert "UNIQUELEAKPAYLOAD" not in snap.tail_text
+        assert snap.full_text is not None
+        assert "UNIQUELEAKPAYLOAD" not in snap.full_text
+
     def test_default_redacts_email_addresses_for_public_share(
         self, hermes_home_with_secret
     ):


### PR DESCRIPTION
## Summary
- Add Google OAuth client secret (`GOCSPX-...`) to the centralized secret-prefix redactor.
- Add direct redactor coverage and debug-share log snapshot regression coverage.

## Why
`hermes debug share` and other export paths rely on the shared redactor before content leaves the process. Google OAuth client secrets use the `GOCSPX-` prefix and were not covered by the known-prefix list, so a log line containing a JSON/form-style `client_secret` value could remain visible after redaction.

## Test Plan
- `python -m pytest tests/agent/test_redact.py tests/hermes_cli/test_debug.py -q`

Result on local checkout:

```text
152 passed in 1.52s
```

## Notes
- Test fixtures use synthetic token-shaped strings only; no real credentials are included.
- This keeps the existing redaction behavior and only extends the known-prefix table.
