### PR TITLE
feat: add xKiro model provider

### DIFF
--- a/agent/anthropic_endpoints.py
+++ b/agent/anthropic_endpoints.py
@@ -205,6 +205,9 @@ def _requires_bearer_auth(base_url: str | None) -> bool:
         # Hostname match (not substring) so e.g. evil.com/palantirfoundry
         # paths don't trigger Bearer auth.
         or base_url_host_matches(normalized, "palantirfoundry.com")
+        # xKiro's /v1/messages endpoint accepts the same Bearer key as its
+        # OpenAI-compatible routes.
+        or base_url_host_matches(normalized, "api.xkiro.com")
         # CommandCode's /provider/v1/messages endpoint uses Bearer auth,
         # not Anthropic's native x-api-key header. Hostname match for the
         # same reason as above.

--- a/plugins/model-providers/xkiro/__init__.py
+++ b/plugins/model-providers/xkiro/__init__.py
@@ -1,0 +1,127 @@
+"""xKiro provider profile.
+
+xKiro exposes an OpenAI-compatible gateway for models from OpenAI, Anthropic,
+xAI, Moonshot, and other upstream providers. Model IDs use xKiro's full
+``vendor/model`` form, for example ``openai/gpt-5.6-luna``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import urllib.request
+
+from providers import register_provider
+from providers.base import ProviderProfile, _profile_user_agent
+
+logger = logging.getLogger(__name__)
+
+_XKIRO_BASE = "https://api.xkiro.com/v1"
+_XKIRO_MODELS_URL = f"{_XKIRO_BASE}/models"
+_XKIRO_ENV = ("XKIRO_API_KEY", "XKIRO_BASE_URL")
+
+
+def _fetch_xkiro_models(
+    *,
+    api_key: str | None = None,
+    timeout: float = 8.0,
+    base_url: str | None = None,
+) -> list[str] | None:
+    """Fetch xKiro's live model catalog, returning model IDs on success."""
+    caller_base = (base_url or "").strip()
+    models_url = (
+        caller_base.rstrip("/") + "/models"
+        if caller_base and caller_base.rstrip("/") != _XKIRO_BASE.rstrip("/")
+        else _XKIRO_MODELS_URL
+    )
+
+    try:
+        request = urllib.request.Request(models_url)
+        request.add_header("Accept", "application/json")
+        request.add_header("User-Agent", _profile_user_agent())
+        if api_key:
+            request.add_header("Authorization", f"Bearer {api_key}")
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+
+        models = payload.get("data", [])
+        return [
+            model["id"]
+            for model in models
+            if isinstance(model, dict) and isinstance(model.get("id"), str)
+        ]
+    except Exception as exc:
+        logger.debug("fetch_models(xkiro): %s", exc)
+        return None
+
+
+class XKiroProfile(ProviderProfile):
+    """xKiro's OpenAI-compatible chat-completions endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        return _fetch_xkiro_models(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+
+
+xkiro = XKiroProfile(
+    name="xkiro",
+    aliases=("xkiro-ai",),
+    api_mode="chat_completions",
+    env_vars=_XKIRO_ENV,
+    display_name="xKiro",
+    description="xKiro — multi-model API gateway",
+    signup_url="https://xkiro.com/",
+    base_url=_XKIRO_BASE,
+    models_url=_XKIRO_MODELS_URL,
+    # xKiro's catalog is intentionally live-only. Do not duplicate the live
+    # catalog here: a static fallback would become stale as models change.
+    fallback_models=(),
+    default_aux_model="qwen/qwen3.5-flash:free",
+)
+
+class XKiroAnthropicProfile(XKiroProfile):
+    """xKiro's Anthropic Messages-compatible endpoint."""
+
+    def fetch_models(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        timeout: float = 8.0,
+    ) -> list[str] | None:
+        models = _fetch_xkiro_models(
+            api_key=api_key,
+            base_url=base_url,
+            timeout=timeout,
+        )
+        if models is None:
+            return None
+        return [model for model in models if model.startswith("anthropic/claude-")]
+
+
+xkiro_anthropic = XKiroAnthropicProfile(
+    name="xkiro-anthropic",
+    aliases=("xkiro-claude",),
+    api_mode="anthropic_messages",
+    env_vars=("XKIRO_API_KEY", "XKIRO_ANTHROPIC_BASE_URL"),
+    display_name="xKiro (Anthropic)",
+    description="xKiro — multi-model API via Anthropic Messages",
+    signup_url="https://xkiro.com/",
+    base_url=_XKIRO_BASE,
+    models_url=_XKIRO_MODELS_URL,
+    fallback_models=(),
+    default_aux_model="",
+)
+
+
+register_provider(xkiro)
+register_provider(xkiro_anthropic)

--- a/plugins/model-providers/xkiro/plugin.yaml
+++ b/plugins/model-providers/xkiro/plugin.yaml
@@ -1,0 +1,5 @@
+name: xkiro-provider
+kind: model-provider
+version: 1.0.0
+description: xKiro multi-model API gateway via OpenAI Chat Completions and Anthropic Messages
+author: Joni

--- a/tests/test_xkiro_provider.py
+++ b/tests/test_xkiro_provider.py
@@ -1,0 +1,106 @@
+"""Tests for the bundled xKiro model-provider profile."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from unittest.mock import patch
+from urllib.error import URLError
+
+from providers import get_provider_profile
+
+
+class _Response:
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return None
+
+    def read(self):
+        return json.dumps(
+            {
+                "object": "list",
+                "data": [
+                    {"id": "openai/gpt-5.6-luna"},
+                    {"id": "x-ai/grok-4.6"},
+                    {"id": 123},
+                    {"name": "missing-id"},
+                ],
+            }
+        ).encode("utf-8")
+
+
+def test_xkiro_profile_is_registered():
+    profile = get_provider_profile("xkiro")
+
+    assert profile.name == "xkiro"
+    assert profile.display_name == "xKiro"
+    assert profile.api_mode == "chat_completions"
+    assert profile.base_url == "https://api.xkiro.com/v1"
+    assert profile.default_aux_model == "qwen/qwen3.5-flash:free"
+
+
+def test_xkiro_alias_resolves_to_profile():
+    assert get_provider_profile("xkiro-ai").name == "xkiro"
+    assert get_provider_profile("xkiro-claude").name == "xkiro-anthropic"
+
+
+def test_xkiro_anthropic_profile_is_registered():
+    profile = get_provider_profile("xkiro-anthropic")
+
+    assert profile.display_name == "xKiro (Anthropic)"
+    assert profile.api_mode == "anthropic_messages"
+    assert profile.base_url == "https://api.xkiro.com/v1"
+    assert profile.default_aux_model == ""
+
+
+def test_xkiro_anthropic_filters_catalog_to_claude_models():
+    profile = get_provider_profile("xkiro-anthropic")
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return None
+
+        def read(self):
+            return json.dumps(
+                {
+                    "data": [
+                        {"id": "anthropic/claude-sonnet-5"},
+                        {"id": "qwen/qwen3.5-flash:free"},
+                        {"id": "anthropic/claude-opus-5"},
+                    ]
+                }
+            ).encode("utf-8")
+
+    with patch.object(urllib.request, "urlopen", return_value=Response()):
+        models = profile.fetch_models(api_key="test-key")
+
+    assert models == ["anthropic/claude-sonnet-5", "anthropic/claude-opus-5"]
+
+
+def test_xkiro_fetch_models_parses_openai_catalog():
+    requests = []
+
+    def fake_urlopen(request, timeout):
+        requests.append((request, timeout))
+        return _Response()
+
+    profile = get_provider_profile("xkiro")
+    with patch.object(urllib.request, "urlopen", fake_urlopen):
+        models = profile.fetch_models(api_key="test-key", timeout=3)
+
+    assert models == ["openai/gpt-5.6-luna", "x-ai/grok-4.6"]
+    request, timeout = requests[0]
+    assert request.full_url == "https://api.xkiro.com/v1/models"
+    assert request.get_header("Authorization") == "Bearer test-key"
+    assert timeout == 3
+
+
+def test_xkiro_fetch_models_returns_none_on_network_failure():
+    profile = get_provider_profile("xkiro")
+    with patch.object(urllib.request, "urlopen", side_effect=URLError("blocked")):
+        assert profile.fetch_models(timeout=1) is None


### PR DESCRIPTION
## Summary

- Add xKiro as a first-class model provider.
- Support xKiro's OpenAI Chat Completions and Anthropic Messages APIs.
- Discover the live xKiro chat-model catalog without a stale static fallback.
- Restrict the Anthropic profile to `anthropic/claude-*` models.
- Route xKiro Anthropic Messages authentication through Bearer auth.

## Provider details

- Provider IDs: `xkiro`, `xkiro-anthropic`
- Aliases: `xkiro-ai`, `xkiro-claude`
- Base URL: `https://api.xkiro.com/v1`
- Credential: `XKIRO_API_KEY`
- Model IDs are preserved in xKiro's `vendor/model` format.

## Verification

- Focused provider and Anthropic tests: `137 passed`
- xKiro live catalog: `109` models, authenticated
- xKiro Free variants observed: `25`
- Free chat completion: passed
- Free streaming: passed
- Free tool calling: passed
- Free vision: passed with `qwen/qwen3-vl-plus:free`
- Anthropic `/v1/messages`: passed
- Hermes CLI with both xKiro profiles: passed

## Scope

This adds the LLM provider profiles. xKiro's separate audio, image-generation,
image-edit, and usage endpoints are outside the model-provider registry scope.
