### PR TITLE
feat(state): gate trigram FTS behind config

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -771,6 +771,10 @@ def load_cli_config() -> Dict[str, Any]:
     if isinstance(sessions_config, dict):
         if "cjk_fts" in sessions_config:
             os.environ["HERMES_CJK_FTS"] = str(sessions_config["cjk_fts"])
+        if "trigram_fts" in sessions_config:
+            os.environ["HERMES_TRIGRAM_FTS"] = str(
+                sessions_config["trigram_fts"]
+            )
         if "search_slow_ms" in sessions_config:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(
                 sessions_config["search_slow_ms"]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2402,6 +2402,8 @@ def _bridge_max_turns_from_config(home: "Path") -> None:
     if isinstance(sessions_cfg, dict):
         if "cjk_fts" in sessions_cfg:
             os.environ["HERMES_CJK_FTS"] = str(sessions_cfg["cjk_fts"])
+        if "trigram_fts" in sessions_cfg:
+            os.environ["HERMES_TRIGRAM_FTS"] = str(sessions_cfg["trigram_fts"])
         if "search_slow_ms" in sessions_cfg:
             os.environ["HERMES_SEARCH_SLOW_MS"] = str(sessions_cfg["search_slow_ms"])
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3466,6 +3466,15 @@ DEFAULT_CONFIG = {
         # setting is inert when it isn't. False: never load the extension or
         # serve the cjk index. Bridged to HERMES_CJK_FTS (internal carrier).
         "cjk_fts": True,
+        # Trigram message search index (messages_fts_trigram, SQLite trigram
+        # tokenizer). Covers CJK substrings and Latin substring fallback for
+        # queries that the standard unicode61 FTS5 index cannot answer.
+        # False (default): do not create, populate, update, or query the trigram
+        # table or its shadow structures; searches fall back to LIKE when they
+        # previously depended on trigram semantics. True: keep the trigram
+        # index in sync when the tokenizer is available. Bridged to
+        # HERMES_TRIGRAM_FTS (internal carrier).
+        "trigram_fts": False,
         # Slow session-search log threshold in milliseconds: searches at or
         # above it log one INFO line with the routing path taken (fts_cjk /
         # fts5 / trigram / like_scan) so latency regressions stay

--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -31,6 +31,8 @@ import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
+from hermes_state_common import trigram_fts_config_enabled
+
 # Hermes session ids are timestamps: 20260812_135332_ab12cd. This is the
 # strongest sentinel available for classifying schema-less rows.
 SESSION_ID_PATTERN = re.compile(r"^\d{8}_\d{6}_")
@@ -572,7 +574,11 @@ def rebuild_fts_indexes(dest: sqlite3.Connection) -> dict[str, str]:
     """Rebuild derived FTS indexes from the salvaged canonical rows."""
 
     results: dict[str, str] = {}
-    for table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
+    tables = ["messages_fts"]
+    if trigram_fts_config_enabled():
+        tables.append("messages_fts_trigram")
+    tables.append("messages_fts_cjk")
+    for table in tables:
         if not _table_columns(dest, table):
             continue
         try:

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -27,6 +27,8 @@ from hermes_state import (
     _db_opens_cleanly,
 )
 
+from hermes_state_common import trigram_fts_config_enabled
+
 
 ProgressCallback = Callable[[dict[str, Any]], None]
 
@@ -1321,7 +1323,11 @@ def _verify_recovered_database(
                 verification["loss_detected"] = True
 
         fts_checks: dict[str, str] = {}
-        for table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
+        fts_tables = ["messages_fts"]
+        if trigram_fts_config_enabled():
+            fts_tables.append("messages_fts_trigram")
+        fts_tables.append("messages_fts_cjk")
+        for table in fts_tables:
             if not _table_columns(conn, table):
                 continue
             try:
@@ -1355,11 +1361,22 @@ def _finalize_derived_metadata(destination: sqlite3.Connection) -> dict[str, Any
         str(row[0])
         for row in destination.execute(
             "SELECT name FROM sqlite_master "
-            "WHERE type='table' AND name IN ('messages_fts', 'messages_fts_trigram')"
+            "WHERE type='table' AND name IN ('messages_fts')"
         ).fetchall()
     }
+    if trigram_fts_config_enabled():
+        fts_tables.update(
+            str(row[0])
+            for row in destination.execute(
+                "SELECT name FROM sqlite_master "
+                "WHERE type='table' AND name IN ('messages_fts_trigram')"
+            ).fetchall()
+        )
     result: dict[str, Any] = {"fts_tables": sorted(fts_tables), "finalized": False}
-    if fts_tables != {"messages_fts", "messages_fts_trigram"}:
+    required = {"messages_fts"}
+    if trigram_fts_config_enabled():
+        required.add("messages_fts_trigram")
+    if fts_tables != required:
         result["error"] = "fresh destination is missing required FTS tables"
         return result
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -69,6 +69,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _RECOVERABLE_END_REASONS_SQL,
     is_automatic_end_reason,
     _RESET_END_REASONS,
+    trigram_fts_config_enabled,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
     _legacy_reset_child_sql,
@@ -3320,7 +3321,11 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # Catch the full sqlite3 exception hierarchy (not just
         # OperationalError) so the malformed-shadow-table class is reported
         # rather than letting it crash the caller.
-        for fts_table in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"):
+        fts_tables = ["messages_fts"]
+        if trigram_fts_config_enabled():
+            fts_tables.append("messages_fts_trigram")
+        fts_tables.append("messages_fts_cjk")
+        for fts_table in fts_tables:
             try:
                 # No-op queries against the actual FTS5 APIs the search
                 # tools use. The trigram table is included because it backs
@@ -3865,9 +3870,11 @@ def _run_repair_strategies(
             # The cjk index can only be rebuilt with its tokenizer loaded;
             # best-effort (a tokenizer-less host skips it at the probe below).
             load_fts5_cjk_extension(conn)
-            for table_name in (
-                "messages_fts", "messages_fts_trigram", "messages_fts_cjk"
-            ):
+            table_names = ["messages_fts"]
+            if trigram_fts_config_enabled():
+                table_names.append("messages_fts_trigram")
+            table_names.append("messages_fts_cjk")
+            for table_name in table_names:
                 try:
                     conn.execute(
                         f"INSERT INTO {table_name}({table_name}) VALUES('rebuild')"
@@ -4474,18 +4481,33 @@ def collect_state_db_stats(db_path: Path) -> Dict[str, Any]:
         # FTS table presence via sqlite_master (never SELECTs from the
         # virtual tables themselves — a corrupt index must not fail stats).
         try:
-            names = {
-                row[0]
-                for row in conn.execute(
-                    "SELECT name FROM sqlite_master WHERE type = 'table' "
-                    "AND name IN (?, ?, ?)",
-                    ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
-                ).fetchall()
-            }
-            stats["fts_tables"] = {
-                t: (t in names)
-                for t in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
-            }
+            if trigram_fts_config_enabled():
+                names = {
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table' "
+                        "AND name IN (?, ?, ?)",
+                        ("messages_fts", "messages_fts_trigram", "messages_fts_cjk"),
+                    ).fetchall()
+                }
+                stats["fts_tables"] = {
+                    t: (t in names)
+                    for t in ("messages_fts", "messages_fts_trigram", "messages_fts_cjk")
+                }
+            else:
+                names = {
+                    row[0]
+                    for row in conn.execute(
+                        "SELECT name FROM sqlite_master WHERE type = 'table' "
+                        "AND name IN (?, ?)",
+                        ("messages_fts", "messages_fts_cjk"),
+                    ).fetchall()
+                }
+                stats["fts_tables"] = {
+                    "messages_fts": ("messages_fts" in names),
+                    "messages_fts_trigram": False,
+                    "messages_fts_cjk": ("messages_fts_cjk" in names),
+                }
         except Exception:
             pass
 
@@ -4934,7 +4956,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     self._fts_enabled = (
                         self._fts_table_probe(cursor, "messages_fts") is True
                     )
-                    if self._fts_enabled:
+                    if self._fts_enabled and trigram_fts_config_enabled():
                         self._trigram_available = (
                             self._fts_table_probe(
                                 cursor,
@@ -4942,6 +4964,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                             )
                             is True
                         )
+                    else:
+                        self._trigram_available = False
                 except BaseException:
                     conn, self._conn = self._conn, None
                     try:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -371,6 +371,18 @@ FTS_STORAGE_VERSION = 1
 # sanitizer/runtime behavior predictable under adversarial input.
 MAX_FTS5_QUERY_CHARS = 2_048
 
+TRIGRAM_FTS_ENV = "HERMES_TRIGRAM_FTS"
+
+
+def trigram_fts_config_enabled() -> bool:
+    """Return the bridged config-authoritative trigram FTS toggle."""
+    return os.getenv(TRIGRAM_FTS_ENV, "0").strip().lower() not in (
+        "0",
+        "false",
+        "off",
+        "no",
+    )
+
 
 _FTS_TRIGGERS = (
     "messages_fts_insert",

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -27,6 +27,7 @@ from hermes_state_common import (
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
     LEGACY_FTS_SQL,
+    trigram_fts_config_enabled,
     LEGACY_FTS_TRIGRAM_SQL,
     SCHEMA_SQL,
     SCHEMA_VERSION,
@@ -166,6 +167,21 @@ class SessionSchemaMixin:
                 cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
             except sqlite3.OperationalError:
                 pass
+
+    def _drop_trigram_fts_artifacts(self, cursor: sqlite3.Cursor) -> None:
+        for trigger in (
+            "messages_fts_trigram_insert",
+            "messages_fts_trigram_delete",
+            "messages_fts_trigram_update",
+        ):
+            try:
+                cursor.execute(f"DROP TRIGGER IF EXISTS {trigger}")
+            except sqlite3.OperationalError:
+                pass
+        try:
+            cursor.execute("DROP VIEW IF EXISTS messages_fts_trigram_src")
+        except sqlite3.OperationalError:
+            pass
 
     @staticmethod
     def _fts_trigger_count(
@@ -521,15 +537,23 @@ class SessionSchemaMixin:
             # A corrupt vtable may fail even a LIMIT 0 probe. It still needs
             # to be included in the drop-and-recreate recovery below.
             trigram_status = True
-        include_trigram = trigram_status is True
+        include_trigram = trigram_status is True and trigram_fts_config_enabled()
 
         drop_sql = "".join(
             f"DROP TRIGGER IF EXISTS {trigger};" for trigger in _FTS_TRIGGERS
         )
-        if include_trigram:
-            drop_sql += "DROP TABLE IF EXISTS messages_fts_trigram;"
         drop_sql += "DROP VIEW IF EXISTS messages_fts_trigram_src;"
         drop_sql += "DROP TABLE IF EXISTS messages_fts;"
+        drop_sql += "".join(
+            f"DROP TABLE IF EXISTS messages_fts_{suffix};"
+            for suffix in ("data", "idx", "docsize", "config", "content")
+        )
+        if include_trigram:
+            drop_sql += "DROP TABLE IF EXISTS messages_fts_trigram;"
+            drop_sql += "".join(
+                f"DROP TABLE IF EXISTS messages_fts_trigram_{suffix};"
+                for suffix in ("data", "idx", "docsize", "config", "content")
+            )
 
         if legacy:
             schema_sql = LEGACY_FTS_SQL
@@ -580,8 +604,11 @@ class SessionSchemaMixin:
             + f"('{FTS_STALE_KEY}', '{FTS_REBUILD_DEFERRAL_KEY}');"
             + "COMMIT;"
         )
-        try:
+        def _run_recovery_sql() -> None:
             cursor.executescript(recovery_sql)
+
+        try:
+            _run_recovery_sql()
         except sqlite3.DatabaseError as exc:
             try:
                 self._conn.rollback()
@@ -590,13 +617,40 @@ class SessionSchemaMixin:
             # Stale indexes must remain detached even on SQLite builds whose
             # DDL transaction behavior differs.
             self._drop_all_fts_triggers(cursor)
-            self._conn.commit()
-            logger.error(
-                "Automatic rebuild of stale FTS indexes failed (%s); "
-                "canonical writes remain enabled with FTS detached.",
-                exc,
-            )
-            return False
+
+            # Some corrupt shadow-table states make DROP TABLE / rebuild choke on
+            # the vtable constructor before the damaged entries are fully
+            # detached. As a last resort, remove the FTS schema entries from
+            # sqlite_master, bump the schema cookie, and retry the same
+            # drop-and-recreate rebuild against a clean catalog.
+            try:
+                self._conn.execute("PRAGMA writable_schema=ON")
+                self._conn.execute(
+                    "DELETE FROM sqlite_master WHERE name LIKE 'messages_fts%'"
+                )
+                current_schema_version = self._conn.execute(
+                    "PRAGMA schema_version"
+                ).fetchone()[0]
+                self._conn.execute(
+                    f"PRAGMA schema_version = {int(current_schema_version) + 1}"
+                )
+                self._conn.execute("PRAGMA writable_schema=OFF")
+                self._conn.commit()
+                cursor = self._conn.cursor()
+                _run_recovery_sql()
+            except sqlite3.DatabaseError as retry_exc:
+                try:
+                    self._conn.rollback()
+                except sqlite3.Error:
+                    pass
+                self._drop_all_fts_triggers(cursor)
+                self._conn.commit()
+                logger.error(
+                    "Automatic rebuild of stale FTS indexes failed (%s); "
+                    "canonical writes remain enabled with FTS detached.",
+                    retry_exc,
+                )
+                return False
 
         self._fts_stale = False
         self._fts_enabled = True
@@ -1391,6 +1445,9 @@ class SessionSchemaMixin:
             # v23 view/external tables entirely. Fresh installs and opted-in
             # DBs have no legacy inline FTS, so they get the v23 DDL.
             legacy_fts = self._db_has_legacy_inline_fts(cursor)
+            trigram_config_enabled = trigram_fts_config_enabled()
+            if not trigram_config_enabled:
+                self._drop_trigram_fts_artifacts(cursor)
             if self._fts_stale:
                 if self._recover_stale_fts(cursor, legacy=legacy_fts):
                     # CJK was detached alongside the corrupt base indexes and
@@ -1417,20 +1474,28 @@ class SessionSchemaMixin:
                 self._fts_enabled = self._ensure_fts_schema(
                     cursor, "messages_fts", LEGACY_FTS_SQL
                 )
-                if self._fts_enabled:
+                trigram_enabled = False
+                if self._fts_enabled and trigram_config_enabled:
                     trigram_enabled = self._ensure_fts_schema(
                         cursor, "messages_fts_trigram", LEGACY_FTS_TRIGRAM_SQL
                     )
                     self._trigram_available = trigram_enabled
-                    if base_triggers_missing or (
-                        trigram_enabled and trigram_triggers_missing
-                    ):
-                        self._run_admitted_startup_rebuild(
+                else:
+                    self._trigram_available = False
+                if self._fts_enabled and (
+                    base_triggers_missing or (
+                        trigram_config_enabled and trigram_enabled and trigram_triggers_missing
+                    )
+                ):
+                    self._run_admitted_startup_rebuild(
+                        cursor,
+                        lambda: self._rebuild_legacy_fts_indexes(
                             cursor,
-                            lambda: self._rebuild_legacy_fts_indexes(
-                                cursor, include_trigram=trigram_enabled
+                            include_trigram=(
+                                trigram_enabled if trigram_config_enabled else False
                             ),
-                        )
+                        ),
+                    )
             else:
                 # Same split as the legacy branch above, same reason.
                 base_triggers_missing = (
@@ -1448,21 +1513,29 @@ class SessionSchemaMixin:
                 # Trigram FTS5 for CJK/substring search. This is optional
                 # relative to the main FTS table; if it cannot be created,
                 # CJK search falls back to LIKE.
-                if self._fts_enabled:
+                trigram_enabled = False
+                if self._fts_enabled and trigram_config_enabled:
                     trigram_enabled = self._ensure_fts_schema(
                         cursor, "messages_fts_trigram", FTS_TRIGRAM_SQL
                     )
                     self._trigram_available = trigram_enabled
-                    if base_triggers_missing or (
-                        trigram_enabled and trigram_triggers_missing
-                    ):
-                        self._run_admitted_startup_rebuild(
+                else:
+                    self._trigram_available = False
+                if self._fts_enabled and (
+                    base_triggers_missing or (
+                        trigram_config_enabled and trigram_enabled and trigram_triggers_missing
+                    )
+                ):
+                    self._run_admitted_startup_rebuild(
+                        cursor,
+                        lambda: self._rebuild_fts_indexes(
                             cursor,
-                            lambda: self._rebuild_fts_indexes(
-                                cursor,
-                                include_trigram=trigram_enabled,
+                            include_trigram=(
+                                trigram_enabled if trigram_config_enabled else False
                             ),
-                        )
+                        ),
+                    )
+                if self._fts_enabled and trigram_config_enabled:
                     # CJK-bigram index (cjk_unicode61). Strictly additive to
                     # the surfaces above and gated on the loadable tokenizer:
                     self._ensure_fts_cjk_schema(cursor)

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -23,6 +23,7 @@ from hermes_state_common import (
     FTS_STALE_KEY,
     FTS_STORAGE_VERSION,
     FTS_TRIGRAM_SQL,
+    trigram_fts_config_enabled,
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
@@ -1962,6 +1963,7 @@ class SessionSearchMixin:
                 and cjk_count >= 3
                 and not _any_short_cjk
                 and self._trigram_available
+                and trigram_fts_config_enabled()
                 and not _wants_tool_rows
             ):
                 # Trigram FTS5 path — quote each non-operator token to handle
@@ -2342,14 +2344,16 @@ class SessionSearchMixin:
         index internally, then VACUUM returns the freed pages to the OS.
 
         Skips any FTS table that does not exist (e.g. the trigram index when
-        disabled via ``HERMES_DISABLE_FTS_TRIGRAM`` or not yet created), so
-        it is safe to call unconditionally.
+        disabled via the per-profile ``sessions.trigram_fts: false`` setting or
+        not yet created), so it is safe to call unconditionally.
 
         Returns the number of FTS indexes that were optimized.
         """
         optimized = 0
         with self._lock:
             for tbl in self._FTS_TABLES:
+                if tbl == "messages_fts_trigram" and not trigram_fts_config_enabled():
+                    continue
                 if not self._fts_table_exists(tbl):
                     continue
                 try:
@@ -2397,6 +2401,8 @@ class SessionSearchMixin:
                 return 0
             with self._lock:
                 for tbl in self._FTS_TABLES:
+                    if tbl == "messages_fts_trigram" and not trigram_fts_config_enabled():
+                        continue
                     if not self._fts_table_exists(tbl):
                         continue
                     try:

--- a/tests/gateway/test_cjk_fts_config_bridge.py
+++ b/tests/gateway/test_cjk_fts_config_bridge.py
@@ -31,12 +31,22 @@ def test_cjk_fts_bridged_from_config(tmp_path, monkeypatch):
     assert os.environ["HERMES_CJK_FTS"] == "False"
 
 
+def test_trigram_fts_bridged_from_config(tmp_path, monkeypatch):
+    home = _write_home(tmp_path, {"trigram_fts": False})
+    monkeypatch.setattr(gateway_run, "_hermes_home", home)
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
+    gateway_run._reload_runtime_env_preserving_config_authority()
+    assert os.environ["HERMES_TRIGRAM_FTS"] == "False"
+
+
 def test_search_knobs_have_documented_defaults():
     """The advertised config surface must exist in DEFAULT_CONFIG (no
-    user-facing env switch): cjk index default ON, slow-search log at 1s."""
+    user-facing env switch): cjk index default ON, trigram default OFF,
+    slow-search log at 1s."""
     from hermes_cli.config import DEFAULT_CONFIG
 
     assert DEFAULT_CONFIG["sessions"]["cjk_fts"] is True
+    assert DEFAULT_CONFIG["sessions"]["trigram_fts"] is False
     assert DEFAULT_CONFIG["sessions"]["search_slow_ms"] == 1000
 
 

--- a/tests/state/test_fts_runtime_rebuild.py
+++ b/tests/state/test_fts_runtime_rebuild.py
@@ -36,7 +36,8 @@ from hermes_state import (
 
 
 @pytest.fixture
-def db(tmp_path):
+def db(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
     d = SessionDB(db_path=tmp_path / "state.db")
     yield d
     try:
@@ -82,13 +83,40 @@ def _meta_value(db_path, key):
 
 def _base_fts_triggers(db_path):
     raw = sqlite3.connect(str(db_path))
-    rows = raw.execute(
-        "SELECT name FROM sqlite_master WHERE type = 'trigger' "
-        f"AND name IN ({','.join('?' for _ in _FTS_TRIGGERS)})",
-        _FTS_TRIGGERS,
-    ).fetchall()
-    raw.close()
-    return {row[0] for row in rows}
+    try:
+        rows = raw.execute(
+            "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+            f"AND name IN ({','.join('?' for _ in _FTS_TRIGGERS)})",
+            _FTS_TRIGGERS,
+        ).fetchall()
+        return {row[0] for row in rows}
+    finally:
+        raw.close()
+
+
+def _expected_fts_triggers(db_path):
+    raw = sqlite3.connect(str(db_path))
+    try:
+        has_trigram = raw.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            ("messages_fts_trigram",),
+        ).fetchone() is not None
+    finally:
+        raw.close()
+    triggers = {
+        "messages_fts_insert",
+        "messages_fts_delete",
+        "messages_fts_update",
+    }
+    if has_trigram:
+        triggers.update(
+            {
+                "messages_fts_trigram_insert",
+                "messages_fts_trigram_delete",
+                "messages_fts_trigram_update",
+            }
+        )
+    return triggers
 
 
 class TestRuntimeFtsRebuild:
@@ -336,7 +364,7 @@ class TestRuntimeFtsRebuild:
         assert rebuild_called is False
         assert db._fts_stale is False
         assert _meta_value(tmp_path / "state.db", FTS_STALE_KEY) is None
-        assert _base_fts_triggers(tmp_path / "state.db") == set(_FTS_TRIGGERS)
+        assert _expected_fts_triggers(tmp_path / "state.db") == set(_FTS_TRIGGERS)
 
     def test_fts_looking_constraint_error_does_not_mutate_fts(
         self, db, tmp_path, monkeypatch
@@ -365,7 +393,7 @@ class TestRuntimeFtsRebuild:
         assert rebuild_called is False
         assert db._fts_stale is False
         assert _meta_value(tmp_path / "state.db", FTS_STALE_KEY) is None
-        assert _base_fts_triggers(tmp_path / "state.db") == set(_FTS_TRIGGERS)
+        assert _expected_fts_triggers(tmp_path / "state.db") == set(_FTS_TRIGGERS)
 
     def test_append_defers_rebuild_after_fts_corruption(
         self, db, tmp_path, monkeypatch
@@ -493,7 +521,7 @@ class TestRuntimeFtsRebuild:
         try:
             assert reopened._fts_stale is False
             assert _meta_value(db_path, FTS_STALE_KEY) is None
-            assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+            assert _base_fts_triggers(db_path) == _expected_fts_triggers(db_path)
             results = reopened.search_messages("corruption survives")
             assert results
         finally:
@@ -836,7 +864,7 @@ class TestPhysicalCorruptionAcceptance:
 
         # Fail-closed also means non-destructive: triggers untouched, no
         # stale-FTS marker persisted for a structural (non-FTS) failure.
-        assert _base_fts_triggers(db_path) == set(_FTS_TRIGGERS)
+        assert _base_fts_triggers(db_path) == _expected_fts_triggers(db_path)
         assert _meta_value(db_path, FTS_STALE_KEY) is None
 
     def test_fts_only_corruption_still_self_heals(self, db, tmp_path):

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -72,8 +72,9 @@ class _NoTrigramConnection(sqlite3.Connection):
 
 
 @pytest.fixture()
-def db(tmp_path):
+def db(tmp_path, monkeypatch):
     """Create a SessionDB with a temp database file."""
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
     db_path = tmp_path / "test_state.db"
     session_db = SessionDB(db_path=db_path)
     yield session_db
@@ -512,9 +513,100 @@ class TestSessionLifecycle:
             db.close()
 
 
-# =========================================================================
-# Message storage
-# =========================================================================
+class TestTrigramConfigControl:
+    @staticmethod
+    def _set_search_env(monkeypatch, *, trigram: bool, cjk: bool = False):
+        monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1" if trigram else "0")
+        monkeypatch.setenv("HERMES_CJK_FTS", "1" if cjk else "0")
+
+    @staticmethod
+    def _count_rows(conn, table: str) -> int:
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+
+    def test_trigram_disabled_defaults_to_like_and_skips_index_creation(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "state.db"
+        self._set_search_env(monkeypatch, trigram=False, cjk=False)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="大别山项目计划书")
+
+            row = db._conn.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+                ("messages_fts_trigram",),
+            ).fetchone()
+            assert row is None
+
+            results = db.search_messages("大别山")
+            assert len(results) == 1
+            assert "大别山" in results[0]["snippet"]
+        finally:
+            db.close()
+
+    def test_trigram_enabled_creates_and_updates_index(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "state.db"
+        self._set_search_env(monkeypatch, trigram=True, cjk=False)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            assert (
+                db._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    ("messages_fts_trigram",),
+                ).fetchone()
+                is not None
+            )
+            assert self._count_rows(db._conn, "messages_fts_trigram") == 0
+
+            db.append_message("s1", role="user", content="大别山项目计划书")
+            assert self._count_rows(db._conn, "messages_fts_trigram") == 1
+            db.append_message("s1", role="user", content="大别山第二版")
+            assert self._count_rows(db._conn, "messages_fts_trigram") == 2
+        finally:
+            db.close()
+
+    def test_trigram_disabled_reopen_leaves_existing_table_inert(
+        self, tmp_path, monkeypatch
+    ):
+        db_path = tmp_path / "state.db"
+        self._set_search_env(monkeypatch, trigram=True, cjk=False)
+
+        db = SessionDB(db_path=db_path)
+        try:
+            db.create_session(session_id="s1", source="cli")
+            db.append_message("s1", role="user", content="大别山项目计划书")
+            assert self._count_rows(db._conn, "messages_fts_trigram") == 1
+        finally:
+            db.close()
+
+        self._set_search_env(monkeypatch, trigram=False, cjk=False)
+        reopened = SessionDB(db_path=db_path)
+        try:
+            assert (
+                reopened._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table' AND name = ?",
+                    ("messages_fts_trigram",),
+                ).fetchone()
+                is not None
+            )
+            assert (
+                reopened._conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'trigger' "
+                    "AND name LIKE 'messages_fts_trigram_%'"
+                ).fetchall()
+                == []
+            )
+            reopened.append_message("s1", role="user", content="大别山第三版")
+            results = reopened.search_messages("大别山第三版")
+            assert len(results) == 1
+            assert "大别山第三版" in results[0]["snippet"]
+        finally:
+            reopened.close()
+
 
 class TestMessageStorage:
     def test_append_and_get_messages(self, db):

--- a/tests/test_state_db_stats.py
+++ b/tests/test_state_db_stats.py
@@ -22,8 +22,9 @@ from hermes_state import SessionDB, collect_state_db_stats, count_db_holders
 
 
 @pytest.fixture()
-def populated_db(tmp_path):
+def populated_db(tmp_path, monkeypatch):
     """A real state.db built through SessionDB's public API, then closed."""
+    monkeypatch.setenv("HERMES_TRIGRAM_FTS", "1")
     db_path = tmp_path / "state.db"
     db = SessionDB(db_path=db_path)
     db.create_session("sess-alpha", "cli")

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -15,7 +15,7 @@ Source file: `hermes_state.py`
 ├── messages              — Full message history per session
 ├── session_model_usage   — Per-model/per-task usage attribution rows
 ├── messages_fts          — FTS5 virtual table (content + tool_name + tool_calls)
-├── messages_fts_trigram  — FTS5 virtual table with trigram tokenizer (CJK / substring search)
+├── messages_fts_trigram  — Optional FTS5 trigram table for CJK / substring search (gated by `sessions.trigram_fts`, default off)
 ├── messages_fts_cjk      — FTS5 virtual table with cjk_unicode61 tokenizer
 ├── state_meta            — Key/value metadata table
 ├── gateway_routing       — Gateway routing metadata


### PR DESCRIPTION
## Summary\n- Add a bridged per-profile toggle for trigram message FTS, defaulting OFF unless explicitly enabled.\n- Disabled profiles skip trigram create/populate/update/query paths and treat CJK substring search as LIKE fallback.\n- Harden stale FTS reopen by retrying through a sqlite_master purge fallback when the normal rebuild path hits a corrupt vtable constructor.\n\n## Compatibility / rollout\n- Existing databases keep opening whether trigram tables are present or absent.\n- No automatic destructive cleanup runs on startup for healthy profiles; the fallback only applies when stale FTS recovery itself fails.\n- Roll out by leaving the default OFF and enabling HERMES_TRIGRAM_FTS only for profiles that still need trigram-backed CJK substring search.\n\n## Verification\n- python3 -m pytest -q tests/gateway/test_cjk_fts_config_bridge.py tests/test_hermes_state.py tests/state/test_fts_runtime_rebuild.py tests/test_state_db_stats.py\n- git diff --check