### PR TITLE
fix(gateway): prevent reconnect replay from losing session events

### DIFF
--- a/apps/desktop/src/app/contrib/wiring-routing.test.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.test.ts
@@ -1,6 +1,39 @@
 import { describe, expect, it } from 'vitest'
 
-import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
+import {
+  findStoredIdForRuntimeId,
+  resolveReplayHydrationTarget,
+  resolveRoutingSessionId,
+  resolveSessionRpcOwner
+} from './wiring-routing'
+
+describe('resolveReplayHydrationTarget', () => {
+  const rows = [
+    { id: 'same-id', profile: 'default' },
+    { connection_id: 'background-b', id: 'same-id', profile: 'default' }
+  ]
+
+  it('pins a background replay to its exact connection instead of the ambient source', () => {
+    expect(
+      resolveReplayHydrationTarget(rows, {
+        connectionId: 'background-b',
+        profile: 'default'
+      })
+    ).toEqual({
+      row: rows[1],
+      scope: { connectionId: 'background-b', profile: 'default' }
+    })
+  })
+
+  it('fails closed when the known row owner disagrees with the replay source', () => {
+    expect(
+      resolveReplayHydrationTarget([{ connection_id: 'active-a', id: 'same-id', profile: 'default' }], {
+        connectionId: 'background-b',
+        profile: 'default'
+      })
+    ).toBeUndefined()
+  })
+})
 
 describe('findStoredIdForRuntimeId', () => {
   it('reverse-resolves a runtime id to its stored id', () => {

--- a/apps/desktop/src/app/contrib/wiring-routing.ts
+++ b/apps/desktop/src/app/contrib/wiring-routing.ts
@@ -5,7 +5,37 @@
  * React/Electron controller module.
  */
 
+import type { ReplayGapSource } from '@/store/gateway'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
+
+export function resolveReplayHydrationTarget<
+  T extends { connection_id?: null | string; profile?: null | string }
+>(candidates: T[], source: ReplayGapSource): { row: T; scope: { connectionId: null | string; profile: string } } | undefined {
+  const sourceProfile = (source.profile ?? '').trim() || 'default'
+
+  const profileCandidates = candidates.filter(candidate => {
+    const ownerProfile = (candidate.profile ?? '').trim() || 'default'
+
+    return ownerProfile === sourceProfile
+  })
+
+  const row =
+    profileCandidates.find(candidate => (candidate.connection_id ?? '').trim() === source.connectionId) ??
+    profileCandidates.find(candidate => {
+      const ownerConnectionId = (candidate.connection_id ?? '').trim()
+
+      return !ownerConnectionId
+    })
+
+  if (!row) {
+    return undefined
+  }
+
+  return {
+    row,
+    scope: { connectionId: source.connectionId, profile: sourceProfile }
+  }
+}
 
 /**
  * Resolve a runtime session id back to its stored id by reverse-scanning the

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -45,6 +45,7 @@ import { $desktopBoot } from '@/store/boot'
 import { requestVoiceConversationStart } from '@/store/composer'
 import { $activeConnectionId } from '@/store/connections'
 import { $cronReviewRequest, setCronFocusJobId } from '@/store/cron'
+import type { ReplayGapSource } from '@/store/gateway'
 import { $pinnedSessionIds, pinSession, restoreWorktree, unpinSession } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { $previewTarget } from '@/store/preview'
@@ -154,6 +155,7 @@ import { $restartPreviewServer, useTitlebarToolContributions } from './panes'
 import { createSessionRpcDispatcher } from './session-rpc-dispatcher'
 import { ChatRoutesSurface, SidebarSurface, StatusbarSurface, TerminalSurface } from './surfaces'
 import type { WiringActions, WiringApi } from './types'
+import { resolveReplayHydrationTarget } from './wiring-routing'
 
 // Overlay views the controller mounts over the shell — lazy, load on demand.
 // The workspace-route full-page views (skills/messaging/artifacts) are the
@@ -381,13 +383,26 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     async (
       attempts = 1,
       storedSessionId = selectedStoredSessionIdRef.current,
-      runtimeSessionId = activeSessionIdRef.current
+      runtimeSessionId = activeSessionIdRef.current,
+      replaySource?: ReplayGapSource
     ) => {
       if (!storedSessionId || !runtimeSessionId) {
         return false
       }
 
-      const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
+      const candidates = $sessions.get().filter(session => sessionMatchesStoredId(session, storedSessionId))
+      const replayTarget = replaySource ? resolveReplayHydrationTarget(candidates, replaySource) : undefined
+      const storedSession = replaySource ? replayTarget?.row : candidates[0]
+
+      if (!storedSession) {
+        // A replay gap must never hydrate an identically named session from a
+        // different backend. Leave the gap unresolved so the socket retries.
+        return false
+      }
+
+      const storedProfile = replaySource
+        ? replayTarget?.scope
+        : storedSession.profile
 
       for (let index = 0; index < Math.max(1, attempts); index += 1) {
         try {
@@ -802,10 +817,10 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       closeAllTerminals()
     },
     handleGatewayEvent: handleGatewayEventWithPlugins,
-    resyncReplaySession: runtimeSessionId => {
+    resyncReplaySession: (runtimeSessionId, source) => {
       const state = sessionStateByRuntimeIdRef.current.get(runtimeSessionId)
 
-      return tryHydrateFromStoredSession(3, state?.storedSessionId, runtimeSessionId)
+      return tryHydrateFromStoredSession(3, state?.storedSessionId, runtimeSessionId, source)
     },
     onConnectionReady: c => {
       connectionRef.current = c

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -377,14 +377,14 @@ export function ContribWiring({ children }: { children: ReactNode }) {
 
   // Post-turn rehydrate from stored history (same behavior as DesktopController,
   // including finished-todos restoration).
-  const hydrateFromStoredSession = useCallback(
+  const tryHydrateFromStoredSession = useCallback(
     async (
       attempts = 1,
       storedSessionId = selectedStoredSessionIdRef.current,
       runtimeSessionId = activeSessionIdRef.current
     ) => {
       if (!storedSessionId || !runtimeSessionId) {
-        return
+        return false
       }
 
       const storedProfile = $sessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))?.profile
@@ -415,7 +415,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
             clearSessionTodos(runtimeSessionId)
           }
 
-          return
+          return true
         } catch {
           // Best-effort fallback when live stream payloads are empty.
         }
@@ -424,8 +424,17 @@ export function ContribWiring({ children }: { children: ReactNode }) {
           await new Promise(resolve => window.setTimeout(resolve, 250))
         }
       }
+
+      return false
     },
     [activeSessionIdRef, selectedStoredSessionIdRef, updateSessionState]
+  )
+
+  const hydrateFromStoredSession = useCallback(
+    async (attempts?: number, storedSessionId?: string | null, runtimeSessionId?: string | null) => {
+      await tryHydrateFromStoredSession(attempts, storedSessionId, runtimeSessionId)
+    },
+    [tryHydrateFromStoredSession]
   )
 
   // Refresh any active transcript changed by another process. Signature-gated
@@ -796,7 +805,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     resyncReplaySession: runtimeSessionId => {
       const state = sessionStateByRuntimeIdRef.current.get(runtimeSessionId)
 
-      return hydrateFromStoredSession(3, state?.storedSessionId, runtimeSessionId)
+      return tryHydrateFromStoredSession(3, state?.storedSessionId, runtimeSessionId)
     },
     onConnectionReady: c => {
       connectionRef.current = c

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -793,6 +793,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
       closeAllTerminals()
     },
     handleGatewayEvent: handleGatewayEventWithPlugins,
+    resyncReplaySession: runtimeSessionId => {
+      const state = sessionStateByRuntimeIdRef.current.get(runtimeSessionId)
+
+      return hydrateFromStoredSession(3, state?.storedSessionId, runtimeSessionId)
+    },
     onConnectionReady: c => {
       connectionRef.current = c
     },

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -31,6 +31,7 @@ import {
   liveSecondaryConnectionIds,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
+  type ReplayGapSource,
   reportPrimaryGatewayState,
   setPrimaryGateway,
   setPrimaryGatewayConnection,
@@ -138,7 +139,7 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
   handleGatewayEvent: (event: RpcEvent) => void
-  resyncReplaySession?: (sessionId: string) => Promise<boolean> | boolean
+  resyncReplaySession?: (sessionId: string, source: ReplayGapSource) => Promise<boolean> | boolean
   onConnectionReady: (
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
@@ -778,7 +779,7 @@ export function useGatewayBoot({
         recordSessionEventScope(event)
         callbacksRef.current.handleGatewayEvent(event)
       },
-      onReplayGap: sessionId => callbacksRef.current.resyncReplaySession(sessionId),
+      onReplayGap: (sessionId, source) => callbacksRef.current.resyncReplaySession(sessionId, source),
       onActiveConnectionInvalidated: (fallbackProfile, invalidationEpoch) => {
         $activeGatewayProfile.set(fallbackProfile)
         // Bounded like every other getConnection() call in this file (#93454):
@@ -847,7 +848,13 @@ export function useGatewayBoot({
       callbacksRef.current.handleGatewayEvent(scopedEvent)
     })
 
-    const offReplayGap = gateway.onReplayGap?.(sessionId => callbacksRef.current.resyncReplaySession(sessionId)) ?? (() => {})
+    const offReplayGap =
+      gateway.onReplayGap?.(sessionId =>
+        callbacksRef.current.resyncReplaySession(sessionId, {
+          connectionId: activeGatewayConnectionId(),
+          profile: sourceProfile
+        })
+      ) ?? (() => {})
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -138,6 +138,7 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
   handleGatewayEvent: (event: RpcEvent) => void
+  resyncReplaySession?: (sessionId: string) => Promise<void> | void
   onConnectionReady: (
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
@@ -149,6 +150,7 @@ interface GatewayBootOptions {
 export function useGatewayBoot({
   beforeConnectionSwitch,
   handleGatewayEvent,
+  resyncReplaySession = () => undefined,
   onConnectionReady,
   onGatewayReady,
   refreshHermesConfig,
@@ -157,6 +159,7 @@ export function useGatewayBoot({
   const callbacksRef = useRef({
     beforeConnectionSwitch,
     handleGatewayEvent,
+    resyncReplaySession,
     onConnectionReady,
     onGatewayReady,
     refreshHermesConfig,
@@ -166,6 +169,7 @@ export function useGatewayBoot({
   callbacksRef.current = {
     beforeConnectionSwitch,
     handleGatewayEvent,
+    resyncReplaySession,
     onConnectionReady,
     onGatewayReady,
     refreshHermesConfig,
@@ -774,6 +778,7 @@ export function useGatewayBoot({
         recordSessionEventScope(event)
         callbacksRef.current.handleGatewayEvent(event)
       },
+      onReplayGap: sessionId => callbacksRef.current.resyncReplaySession(sessionId),
       onActiveConnectionInvalidated: (fallbackProfile, invalidationEpoch) => {
         $activeGatewayProfile.set(fallbackProfile)
         // Bounded like every other getConnection() call in this file (#93454):
@@ -841,6 +846,7 @@ export function useGatewayBoot({
       recordSessionEventScope(scopedEvent)
       callbacksRef.current.handleGatewayEvent(scopedEvent)
     })
+    const offReplayGap = gateway.onReplayGap?.(sessionId => callbacksRef.current.resyncReplaySession(sessionId)) ?? (() => {})
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the
     // window regaining focus/visibility. Each nudges an immediate reconnect.
@@ -1158,6 +1164,7 @@ export function useGatewayBoot({
       offGatewayReconnect()
       offState()
       offEvent()
+      offReplayGap()
       offExit()
       offWindowState?.()
       offBootProgress()

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -138,7 +138,7 @@ export function primaryRuntimeConnectionId(connection: Pick<HermesConnection, 'c
 interface GatewayBootOptions {
   beforeConnectionSwitch: () => void
   handleGatewayEvent: (event: RpcEvent) => void
-  resyncReplaySession?: (sessionId: string) => Promise<void> | void
+  resyncReplaySession?: (sessionId: string) => Promise<boolean> | boolean
   onConnectionReady: (
     connection: Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>> | null
   ) => void
@@ -150,7 +150,7 @@ interface GatewayBootOptions {
 export function useGatewayBoot({
   beforeConnectionSwitch,
   handleGatewayEvent,
-  resyncReplaySession = () => undefined,
+  resyncReplaySession = () => false,
   onConnectionReady,
   onGatewayReady,
   refreshHermesConfig,
@@ -846,6 +846,7 @@ export function useGatewayBoot({
       recordSessionEventScope(scopedEvent)
       callbacksRef.current.handleGatewayEvent(scopedEvent)
     })
+
     const offReplayGap = gateway.onReplayGap?.(sessionId => callbacksRef.current.resyncReplaySession(sessionId)) ?? (() => {})
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -20,7 +20,6 @@ import {
 import { resetBackgroundPollingGuard } from '@/store/composer-status'
 import {
   $gateway,
-  activeGatewayConnectionId,
   closeLegacySecondaryGateways,
   closeSecondaryGateways,
   configureGatewayRegistry,
@@ -29,6 +28,7 @@ import {
   gatewayActivationEpoch,
   isActivePrimary,
   liveSecondaryConnectionIds,
+  primaryGatewaySource,
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   type ReplayGapSource,
@@ -833,15 +833,13 @@ export function useGatewayBoot({
       }
     })
 
-    const sourceProfile = normalizeProfileKey($activeGatewayProfile.get())
-
     const offEvent = gateway.onEvent(event => {
-      const connectionId = activeGatewayConnectionId()
+      const source = primaryGatewaySource()
 
       const scopedEvent = {
         ...event,
-        profile: sourceProfile,
-        ...(connectionId ? { connectionId } : {})
+        profile: source.profile,
+        ...(source.connectionId ? { connectionId: source.connectionId } : {})
       }
 
       recordSessionEventScope(scopedEvent)
@@ -850,10 +848,7 @@ export function useGatewayBoot({
 
     const offReplayGap =
       gateway.onReplayGap?.(sessionId =>
-        callbacksRef.current.resyncReplaySession(sessionId, {
-          connectionId: activeGatewayConnectionId(),
-          profile: sourceProfile
-        })
+        callbacksRef.current.resyncReplaySession(sessionId, primaryGatewaySource())
       ) ?? (() => {})
 
     // Wake signals: power resume (macOS/Windows), network coming back, and the

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -13,7 +13,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 //     the entry instead of retrying forever.
 
 const gatewayMocks = vi.hoisted(() => {
-  const instances: { close: ReturnType<typeof vi.fn>; connectionState: string }[] = []
+  const instances: {
+    close: ReturnType<typeof vi.fn>
+    connectionState: string
+    replayGapHandler?: (sessionId: string) => Promise<boolean> | boolean
+  }[] = []
 
   return {
     connect: vi.fn(async (_wsUrl: string): Promise<void> => undefined),
@@ -38,7 +42,13 @@ vi.mock('@/hermes', () => ({
       this.connectionState = 'open'
     }
     onEvent = vi.fn(() => () => {})
+    onReplayGap = vi.fn((handler: (sessionId: string) => Promise<boolean> | boolean) => {
+      this.replayGapHandler = handler
+
+      return () => void (this.replayGapHandler = undefined)
+    })
     onState = vi.fn(() => () => {})
+    replayGapHandler?: (sessionId: string) => Promise<boolean> | boolean
     constructor() {
       gatewayMocks.instances.push(this as never)
     }
@@ -98,6 +108,27 @@ afterEach(() => {
 })
 
 describe('disposeSecondariesForConnection', () => {
+  it('preserves the exact secondary source when reporting a replay gap', async () => {
+    const onReplayGap = vi.fn(async () => true)
+
+    const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+      descriptorFor(connectionId, profile)
+    )
+
+    configureGatewayRegistry({ onEvent: vi.fn(), onReplayGap } as never)
+    installDesktop({ getConnectionFor })
+
+    await ensureGatewayForAgent('background-b', 'default')
+
+    const recovered = await gatewayMocks.instances[0].replayGapHandler?.('runtime-b')
+
+    expect(recovered).toBe(true)
+    expect(onReplayGap).toHaveBeenCalledWith('runtime-b', {
+      connectionId: 'background-b',
+      profile: 'default'
+    })
+  })
+
   it('keeps the previous source socket alive when another source becomes foreground', async () => {
     const getConnectionFor = vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
       descriptorFor(connectionId, profile)

--- a/apps/desktop/src/store/gateway-connection-scope.test.ts
+++ b/apps/desktop/src/store/gateway-connection-scope.test.ts
@@ -47,6 +47,7 @@ const {
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForAgent,
+  primaryGatewaySource,
   pruneSecondaryGateways,
   setPrimaryGateway,
   setPrimaryGatewayConnectionId
@@ -125,6 +126,23 @@ describe('primary gateway registry scope', () => {
 
     expect(activeGatewayConnectionId()).toBe('primary-vps')
     expect(setApiRequestConnection).toHaveBeenLastCalledWith('primary-vps')
+  })
+
+  it('reports the adopted non-default profile as the primary socket source', () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'writer')
+    setPrimaryGatewayConnectionId('primary-vps')
+
+    expect(primaryGatewaySource()).toEqual({ connectionId: 'primary-vps', profile: 'writer' })
+  })
+
+  it('keeps reporting the primary socket source while a secondary is active', async () => {
+    setPrimaryGateway({ connectionState: 'open' } as never, 'writer')
+    setPrimaryGatewayConnectionId('primary-vps')
+
+    await expect(ensureGatewayForAgent('homelab', 'default')).resolves.toBe(true)
+
+    expect(activeGatewayConnectionId()).toBe('homelab')
+    expect(primaryGatewaySource()).toEqual({ connectionId: 'primary-vps', profile: 'writer' })
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -30,7 +30,7 @@ interface RegistryConfig {
    * the connection store. */
   activeConnectionId?: () => null | string
   onEvent: (event: GatewayEvent) => void
-  onReplayGap?: (sessionId: string) => Promise<void> | void
+  onReplayGap?: (sessionId: string) => Promise<boolean> | boolean
   onActiveConnectionInvalidated?: (fallbackProfile: string, activationEpoch: number) => void
   onActiveConnectionChanged?: (connection: HermesConnection) => void
   /**
@@ -734,7 +734,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     g.config?.onEvent({ ...event, profile, ...(connectionId ? { connectionId } : {}) })
     releaseTerminalTurnLease(entry.scope, event)
   })
-  gateway.onReplayGap?.(sessionId => g.config?.onReplayGap?.(sessionId))
+  gateway.onReplayGap?.(sessionId => g.config?.onReplayGap?.(sessionId) ?? false)
   entry.offState = gateway.onState(state => {
     reportGatewayState(scope, state)
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -30,7 +30,7 @@ interface RegistryConfig {
    * the connection store. */
   activeConnectionId?: () => null | string
   onEvent: (event: GatewayEvent) => void
-  onReplayGap?: (sessionId: string) => Promise<boolean> | boolean
+  onReplayGap?: (sessionId: string, source: ReplayGapSource) => Promise<boolean> | boolean
   onActiveConnectionInvalidated?: (fallbackProfile: string, activationEpoch: number) => void
   onActiveConnectionChanged?: (connection: HermesConnection) => void
   /**
@@ -55,6 +55,11 @@ interface RegistryConfig {
    * follows the tile set, so closing the tile releases the socket.
    */
   foregroundScopes?: () => ReadonlySet<string>
+}
+
+export interface ReplayGapSource {
+  connectionId: null | string
+  profile: string
 }
 
 // ── Secondary (pool) backends ──────────────────────────────────────────────
@@ -734,7 +739,13 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     g.config?.onEvent({ ...event, profile, ...(connectionId ? { connectionId } : {}) })
     releaseTerminalTurnLease(entry.scope, event)
   })
-  gateway.onReplayGap?.(sessionId => g.config?.onReplayGap?.(sessionId) ?? false)
+  gateway.onReplayGap?.(
+    sessionId =>
+      g.config?.onReplayGap?.(sessionId, {
+        connectionId,
+        profile
+      }) ?? false
+  )
   entry.offState = gateway.onState(state => {
     reportGatewayState(scope, state)
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -400,6 +400,14 @@ export function activeGatewayConnectionId(): null | string {
   return g.secondaries.get(g.activeKey)?.connectionId ?? null
 }
 
+/** Exact registry source served by the window-owned primary socket. */
+export function primaryGatewaySource(): ReplayGapSource {
+  return {
+    connectionId: g.primaryConnectionId,
+    profile: g.primaryProfile
+  }
+}
+
 /**
  * Registry connections currently served by a live (open-socket) secondary.
  * Used by the reconnect path when the restarted primary's own registry

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -30,6 +30,7 @@ interface RegistryConfig {
    * the connection store. */
   activeConnectionId?: () => null | string
   onEvent: (event: GatewayEvent) => void
+  onReplayGap?: (sessionId: string) => Promise<void> | void
   onActiveConnectionInvalidated?: (fallbackProfile: string, activationEpoch: number) => void
   onActiveConnectionChanged?: (connection: HermesConnection) => void
   /**
@@ -733,6 +734,7 @@ function createSecondary(profile: string, connectionId: null | string = null): S
     g.config?.onEvent({ ...event, profile, ...(connectionId ? { connectionId } : {}) })
     releaseTerminalTurnLease(entry.scope, event)
   })
+  gateway.onReplayGap?.(sessionId => g.config?.onReplayGap?.(sessionId))
   entry.offState = gateway.onState(state => {
     reportGatewayState(scope, state)
 

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -56,6 +56,7 @@ export {
   type JsonRpcFrame,
   JsonRpcGatewayClient,
   JsonRpcGatewayError,
+  type ReplayGapHandler,
   type WebSocketLike
 } from './json-rpc-gateway'
 export { skillInvocationText } from './skill-scaffold'

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -306,6 +306,7 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     client.onReplayGap(async sid => {
       gaps.push(sid)
       await resync
+      return true
     })
 
     const first = client.connect('ws://x')
@@ -390,6 +391,124 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
         truncated: false,
         generation: 'gen-B'
       }
+    })
+
+    await vi.waitFor(() => expect(seen).toEqual([10, 1]))
+    expect(client.getSeqWatermarks().s1).toBe(1)
+    client.close()
+  })
+
+  it('retries without releasing parked frames when truncated history recovery fails', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+    client.onReplayGap(async () => false)
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 6 } })
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [], latest_seq: 5, truncated: true }
+    })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(seen).toEqual([2])
+    expect(client.getSeqWatermarks().s1).toBe(2)
+    client.close()
+  })
+
+  it('keeps the old watermark when truncated replay has no history handler', async () => {
+    const client = makeClient()
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [], latest_seq: 5, truncated: true }
+    })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(client.getSeqWatermarks().s1).toBe(2)
+    client.close()
+  })
+
+  it('keeps the old watermark when truncated history recovery rejects', async () => {
+    const client = makeClient()
+    client.onReplayGap(async () => {
+      throw new Error('history unavailable')
+    })
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [], latest_seq: 5, truncated: true }
+    })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(client.getSeqWatermarks().s1).toBe(2)
+    client.close()
+  })
+
+  it('accepts reset seqs from a generation-less older backend', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 10 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 1 } })
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [], latest_seq: 1, truncated: false }
     })
 
     await vi.waitFor(() => expect(seen).toEqual([10, 1]))

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -394,8 +394,122 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
       }
     })
 
+    await vi.waitFor(() => expect(sock.lastRequest().params.last_seen).toBe(0))
+    const freshRequest = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: freshRequest.id,
+      result: {
+        events: [{ type: 'message.delta', session_id: 's1', seq: 1, replay_generation: 'gen-B' }],
+        latest_seq: 1,
+        truncated: false,
+        generation: 'gen-B'
+      }
+    })
+
     await vi.waitFor(() => expect(seen).toEqual([10, 1]))
     expect(client.getSeqWatermarks().s1).toBe(1)
+    client.close()
+  })
+
+  it('refetches a changed generation from zero before releasing later live frames', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', event => seen.push((event as unknown as { seq: number }).seq))
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 10, replay_generation: 'gen-A' }
+    })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().params).toMatchObject({ session_id: 's1', last_seen: 10 }))
+
+    const staleRequest = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: staleRequest.id,
+      result: { events: [], latest_seq: 2, truncated: false, generation: 'gen-B' }
+    })
+
+    await vi.waitFor(() => expect(sock.lastRequest().params).toMatchObject({ session_id: 's1', last_seen: 0 }))
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 3, replay_generation: 'gen-B' }
+    })
+
+    const freshRequest = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: freshRequest.id,
+      result: {
+        events: [
+          { type: 'message.delta', session_id: 's1', seq: 1, replay_generation: 'gen-B' },
+          { type: 'message.delta', session_id: 's1', seq: 2, replay_generation: 'gen-B' }
+        ],
+        latest_seq: 2,
+        truncated: false,
+        generation: 'gen-B'
+      }
+    })
+
+    await vi.waitFor(() => expect(seen).toEqual([10, 1, 2, 3]))
+    expect(client.getSeqWatermarks().s1).toBe(3)
+    client.close()
+  })
+
+  it('preserves the old generation checkpoint when zero-based recovery fails', async () => {
+    const client = makeClient()
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 10, replay_generation: 'gen-A' }
+    })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().params.last_seen).toBe(10))
+
+    const staleRequest = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: staleRequest.id,
+      result: { events: [], latest_seq: 2, truncated: true, generation: 'gen-B' }
+    })
+    await vi.waitFor(() => expect(sock.lastRequest().params.last_seen).toBe(0))
+
+    const freshRequest = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: freshRequest.id,
+      error: { code: -32000, message: 'replay unavailable' }
+    })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(client.getSeqWatermarks().s1).toBe(10)
+
+    const third = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await third
+    await vi.waitFor(() => expect(sock.lastRequest().params).toMatchObject({ session_id: 's1', last_seen: 10 }))
     client.close()
   })
 

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -1,3 +1,5 @@
+// @vitest-environment jsdom
+
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { JsonRpcGatewayClient } from './json-rpc-gateway'
@@ -286,6 +288,112 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
       expect(seen).toEqual([2, 3, 4, 5, 6])
     })
     expect(client.getSeqWatermarks().s1).toBe(6)
+    client.close()
+  })
+
+  it('resyncs authoritative history instead of dispatching a truncated tail', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    let finishResync!: () => void
+
+    const resync = new Promise<void>(resolve => {
+      finishResync = resolve
+    })
+
+    const gaps: string[] = []
+
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+    client.onReplayGap(async sid => {
+      gaps.push(sid)
+      await resync
+    })
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 2, replay_generation: 'gen-A' }
+    })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 6, replay_generation: 'gen-A' }
+    })
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        events: [
+          { type: 'message.delta', session_id: 's1', seq: 4, replay_generation: 'gen-A' },
+          { type: 'message.delta', session_id: 's1', seq: 5, replay_generation: 'gen-A' }
+        ],
+        latest_seq: 5,
+        truncated: true,
+        generation: 'gen-A'
+      }
+    })
+
+    await vi.waitFor(() => expect(gaps).toEqual(['s1']))
+    expect(seen).toEqual([2])
+    finishResync()
+    await vi.waitFor(() => expect(seen).toEqual([2, 6]))
+    expect(client.getSeqWatermarks().s1).toBe(6)
+    client.close()
+  })
+
+  it('accepts reset seqs after a session replay generation changes', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 10, replay_generation: 'gen-A' }
+    })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      method: 'event',
+      params: { type: 'message.delta', session_id: 's1', seq: 1, replay_generation: 'gen-B' }
+    })
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: {
+        events: [{ type: 'message.delta', session_id: 's1', seq: 1, replay_generation: 'gen-B' }],
+        latest_seq: 1,
+        truncated: false,
+        generation: 'gen-B'
+      }
+    })
+
+    await vi.waitFor(() => expect(seen).toEqual([10, 1]))
+    expect(client.getSeqWatermarks().s1).toBe(1)
     client.close()
   })
 

--- a/apps/shared/src/json-rpc-gateway-replay.test.ts
+++ b/apps/shared/src/json-rpc-gateway-replay.test.ts
@@ -306,6 +306,7 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     client.onReplayGap(async sid => {
       gaps.push(sid)
       await resync
+
       return true
     })
 
@@ -482,6 +483,67 @@ describe('JsonRpcGatewayClient event-seq tracking + replay resume', () => {
     })
 
     await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(client.getSeqWatermarks().s1).toBe(2)
+    client.close()
+  })
+
+  it('retries without releasing parked frames when the replay request rejects', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 6 } })
+    const req = sock.lastRequest()
+    sock.serverFrame({ jsonrpc: '2.0', id: req.id, error: { code: -32000, message: 'replay unavailable' } })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(seen).toEqual([2])
+    expect(client.getSeqWatermarks().s1).toBe(2)
+    client.close()
+  })
+
+  it('retries without releasing parked frames when a history handler throws synchronously', async () => {
+    const client = makeClient()
+    const seen: number[] = []
+    client.on('message.delta', e => seen.push((e as unknown as { seq: number }).seq))
+    client.onReplayGap(() => {
+      throw new Error('history unavailable')
+    })
+
+    const first = client.connect('ws://x')
+    let sock = sockets[sockets.length - 1]
+    sock.open()
+    await first
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 2 } })
+
+    client.invalidate('drop')
+    const second = client.connect('ws://x')
+    sock = sockets[sockets.length - 1]
+    sock.open()
+    await second
+    await vi.waitFor(() => expect(sock.lastRequest().method).toBe('session.events.since'))
+    sock.serverFrame({ jsonrpc: '2.0', method: 'event', params: { type: 'message.delta', session_id: 's1', seq: 6 } })
+    const req = sock.lastRequest()
+    sock.serverFrame({
+      jsonrpc: '2.0',
+      id: req.id,
+      result: { events: [], latest_seq: 5, truncated: true }
+    })
+
+    await vi.waitFor(() => expect(sock.readyState).toBe(3))
+    expect(seen).toEqual([2])
     expect(client.getSeqWatermarks().s1).toBe(2)
     client.close()
   })

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -622,8 +622,42 @@ export class JsonRpcGatewayClient {
           this.replayEpoch = epoch
         }
 
-        const generation = result.value.generation
-        const latest = result.value.latest_seq
+        const previousGeneration = this.lastSeenGeneration.get(sid)
+        let replay = result.value
+        let generation = replay.generation
+
+        if (
+          previousGeneration &&
+          typeof generation === 'string' &&
+          generation &&
+          generation !== previousGeneration
+        ) {
+          // The first response was filtered with a watermark from a different
+          // generation. It cannot establish continuity for the recreated ring,
+          // so keep the old checkpoint intact until a zero-based snapshot has
+          // been fetched and (when truncated) authoritatively hydrated.
+          try {
+            const fresh = await this.request<typeof replay>(
+              'session.events.since',
+              { session_id: sid, last_seen: 0 },
+              REPLAY_REQUEST_TIMEOUT_MS
+            )
+
+            if (!Array.isArray(fresh?.events) || fresh.generation !== generation) {
+              throw new Error('Replay generation changed during recovery')
+            }
+
+            replay = fresh
+            generation = fresh.generation
+          } catch {
+            hold.delete(sid)
+            replayRecoveryFailed = true
+
+            continue
+          }
+        }
+
+        const latest = replay.latest_seq
 
         if (
           (typeof generation !== 'string' || !generation) &&
@@ -636,9 +670,9 @@ export class JsonRpcGatewayClient {
           this.lastSeenSeq.delete(sid)
         }
 
-        this.adoptReplayGeneration(sid, generation)
+        const generationChanged = Boolean(previousGeneration && generation !== previousGeneration)
 
-        if (result.value.truncated === true) {
+        if (replay.truncated === true) {
           // A retained tail is not a valid transcript. Rebuild from the
           // authoritative history before releasing live frames that raced the
           // request, then advance to the server snapshot that history covers.
@@ -659,6 +693,10 @@ export class JsonRpcGatewayClient {
             continue
           }
 
+          if (typeof generation === 'string' && generation) {
+            this.lastSeenGeneration.set(sid, generation)
+          }
+
           if (typeof latest === 'number' && Number.isFinite(latest)) {
             this.lastSeenSeq.set(sid, latest)
           }
@@ -666,12 +704,26 @@ export class JsonRpcGatewayClient {
           continue
         }
 
-        for (const event of result.value.events) {
+        if (generationChanged && typeof generation === 'string') {
+          // Commit the new namespace only after its zero-based snapshot is in
+          // hand. This lets its seqs start at one without destroying the old
+          // checkpoint on any request or recovery failure above.
+          this.lastSeenGeneration.set(sid, generation)
+          this.lastSeenSeq.set(sid, 0)
+        } else {
+          this.adoptReplayGeneration(sid, generation)
+        }
+
+        for (const event of replay.events ?? []) {
           if (!event?.type) {
             continue
           }
 
           this.dispatchIfNewer(event as GatewayEvent)
+        }
+
+        if (generationChanged && typeof latest === 'number' && Number.isFinite(latest)) {
+          this.lastSeenSeq.set(sid, Math.max(this.lastSeenSeq.get(sid) ?? 0, latest))
         }
       }
     } catch {

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -588,13 +588,22 @@ export class JsonRpcGatewayClient {
       )
 
       for (const [index, result] of results.entries()) {
-        if (result.status !== 'fulfilled' || !Array.isArray(result.value?.events)) {
-          continue
-        }
-
         const sid = entries[index]?.[0]
 
         if (!sid) {
+          hold.clear()
+          replayRecoveryFailed = true
+
+          continue
+        }
+
+        if (result.status !== 'fulfilled' || !Array.isArray(result.value?.events)) {
+          // A rejected, timed-out, or malformed replay response leaves the
+          // requested gap unresolved. Discard raced frames for this session
+          // and preserve its watermark so the reconnect owner can retry it.
+          hold.delete(sid)
+          replayRecoveryFailed = true
+
           continue
         }
 
@@ -633,7 +642,10 @@ export class JsonRpcGatewayClient {
           // A retained tail is not a valid transcript. Rebuild from the
           // authoritative history before releasing live frames that raced the
           // request, then advance to the server snapshot that history covers.
-          const recoveries = await Promise.allSettled([...this.replayGapHandlers].map(handler => handler(sid)))
+          const recoveries = await Promise.allSettled(
+            [...this.replayGapHandlers].map(handler => Promise.resolve().then(() => handler(sid)))
+          )
+
           const recovered =
             recoveries.length > 0 &&
             recoveries.every(recovery => recovery.status === 'fulfilled' && recovery.value === true)
@@ -663,10 +675,16 @@ export class JsonRpcGatewayClient {
         }
       }
     } catch {
-      // Replay is an optimization over lossy-reconnect; never surface errors.
+      // A synchronous recovery failure must not release frames parked above
+      // an unresolved gap. Invalidate the socket so reconnect can retry.
+
+      hold.clear()
+
+      replayRecoveryFailed = true
     } finally {
       this.flushReplayHold()
       this.replayInFlight = false
+
       if (replayRecoveryFailed) {
         this.invalidate('Replay history recovery failed')
       }

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -37,7 +37,7 @@ export interface GatewayEvent<P = unknown> {
   type: GatewayEventName
 }
 
-export type ReplayGapHandler = (sessionId: string) => Promise<void> | void
+export type ReplayGapHandler = (sessionId: string) => Promise<boolean> | boolean
 
 export type ConnectionState = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
 export type GatewayRequestId = number | string
@@ -553,6 +553,7 @@ export class JsonRpcGatewayClient {
     // racing the replay response can't dispatch ahead of (or duplicate) the
     // gap events. Sessions without watermarks are unaffected.
     const hold = new Map<string, GatewayEvent[]>()
+    let replayRecoveryFailed = false
 
     for (const sid of this.lastSeenSeq.keys()) {
       hold.set(sid, [])
@@ -612,14 +613,39 @@ export class JsonRpcGatewayClient {
           this.replayEpoch = epoch
         }
 
-        this.adoptReplayGeneration(sid, result.value.generation)
+        const generation = result.value.generation
+        const latest = result.value.latest_seq
+
+        if (
+          (typeof generation !== 'string' || !generation) &&
+          typeof latest === 'number' &&
+          Number.isFinite(latest) &&
+          latest < (this.lastSeenSeq.get(sid) ?? 0)
+        ) {
+          // Older backends have no per-session generation. A regressed server
+          // watermark is the only reset signal they can provide.
+          this.lastSeenSeq.delete(sid)
+        }
+
+        this.adoptReplayGeneration(sid, generation)
 
         if (result.value.truncated === true) {
           // A retained tail is not a valid transcript. Rebuild from the
           // authoritative history before releasing live frames that raced the
           // request, then advance to the server snapshot that history covers.
-          await Promise.allSettled([...this.replayGapHandlers].map(handler => handler(sid)))
-          const latest = result.value.latest_seq
+          const recoveries = await Promise.allSettled([...this.replayGapHandlers].map(handler => handler(sid)))
+          const recovered =
+            recoveries.length > 0 &&
+            recoveries.every(recovery => recovery.status === 'fulfilled' && recovery.value === true)
+
+          if (!recovered) {
+            // Do not let raced live frames advance across an unresolved gap.
+            // The reconnect owner will retry from the unchanged watermark.
+            hold.delete(sid)
+            replayRecoveryFailed = true
+
+            continue
+          }
 
           if (typeof latest === 'number' && Number.isFinite(latest)) {
             this.lastSeenSeq.set(sid, latest)
@@ -641,6 +667,9 @@ export class JsonRpcGatewayClient {
     } finally {
       this.flushReplayHold()
       this.replayInFlight = false
+      if (replayRecoveryFailed) {
+        this.invalidate('Replay history recovery failed')
+      }
     }
   }
 

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -32,8 +32,12 @@ export interface GatewayEvent<P = unknown> {
    * absent for the local/legacy primary path). */
   connectionId?: string
   session_id?: string
+  /** Changes if this session's bounded replay ring is evicted and recreated. */
+  replay_generation?: string
   type: GatewayEventName
 }
+
+export type ReplayGapHandler = (sessionId: string) => Promise<void> | void
 
 export type ConnectionState = 'idle' | 'connecting' | 'open' | 'closed' | 'error'
 export type GatewayRequestId = number | string
@@ -128,6 +132,10 @@ export class JsonRpcGatewayClient {
    * silently believe nothing was missed.
    */
   private replayEpoch: string | null = null
+  /** Generation paired with each session watermark. */
+  private lastSeenGeneration = new Map<string, string>()
+  /** Authoritative-history refresh hooks run before parked live frames resume. */
+  private readonly replayGapHandlers = new Set<ReplayGapHandler>()
   private readonly eventHandlers = new Map<string, Set<(event: GatewayEvent) => void>>()
   private readonly stateHandlers = new Set<(state: ConnectionState) => void>()
   private readonly options: Required<Omit<GatewayClientOptions, 'socketFactory'>> &
@@ -341,6 +349,13 @@ export class JsonRpcGatewayClient {
     return () => this.stateHandlers.delete(handler)
   }
 
+  /** Register an authoritative session-history refresh for truncated replay. */
+  onReplayGap(handler: ReplayGapHandler): () => void {
+    this.replayGapHandlers.add(handler)
+
+    return () => this.replayGapHandlers.delete(handler)
+  }
+
   request<T>(
     method: string,
     params: Record<string, unknown> = {},
@@ -507,6 +522,8 @@ export class JsonRpcGatewayClient {
       return
     }
 
+    this.adoptReplayGeneration(sid, event.replay_generation)
+
     const prev = this.lastSeenSeq.get(sid) ?? 0
 
     if (seq > prev) {
@@ -549,7 +566,19 @@ export class JsonRpcGatewayClient {
       // One RPC per known session keeps params flat; sessions are few (<20).
       const results = await Promise.allSettled(
         entries.map(([sid, lastSeen]) =>
-          this.request<{ events?: Array<{ type: string; session_id?: string; seq?: number; payload?: unknown }> }>(
+          this.request<{
+            events?: Array<{
+              type: string
+              session_id?: string
+              seq?: number
+              replay_generation?: string
+              payload?: unknown
+            }>
+            epoch?: string
+            generation?: string | null
+            latest_seq?: number
+            truncated?: boolean
+          }>(
             'session.events.since',
             { session_id: sid, last_seen: lastSeen },
             REPLAY_REQUEST_TIMEOUT_MS
@@ -557,8 +586,14 @@ export class JsonRpcGatewayClient {
         )
       )
 
-      for (const result of results) {
+      for (const [index, result] of results.entries()) {
         if (result.status !== 'fulfilled' || !Array.isArray(result.value?.events)) {
+          continue
+        }
+
+        const sid = entries[index]?.[0]
+
+        if (!sid) {
           continue
         }
 
@@ -575,6 +610,22 @@ export class JsonRpcGatewayClient {
 
         if (typeof epoch === 'string' && epoch && !this.replayEpoch) {
           this.replayEpoch = epoch
+        }
+
+        this.adoptReplayGeneration(sid, result.value.generation)
+
+        if (result.value.truncated === true) {
+          // A retained tail is not a valid transcript. Rebuild from the
+          // authoritative history before releasing live frames that raced the
+          // request, then advance to the server snapshot that history covers.
+          await Promise.allSettled([...this.replayGapHandlers].map(handler => handler(sid)))
+          const latest = result.value.latest_seq
+
+          if (typeof latest === 'number' && Number.isFinite(latest)) {
+            this.lastSeenSeq.set(sid, latest)
+          }
+
+          continue
         }
 
         for (const event of result.value.events) {
@@ -602,6 +653,7 @@ export class JsonRpcGatewayClient {
     const seq = (event as { seq?: unknown }).seq
 
     if (sid && typeof seq === 'number' && Number.isFinite(seq)) {
+      this.adoptReplayGeneration(sid, event.replay_generation)
       const prev = this.lastSeenSeq.get(sid) ?? 0
 
       if (seq <= prev) {
@@ -626,9 +678,25 @@ export class JsonRpcGatewayClient {
 
     if (this.replayEpoch !== null) {
       this.lastSeenSeq.clear()
+      this.lastSeenGeneration.clear()
     }
 
     this.replayEpoch = epoch
+  }
+
+  /** Reset one session's watermark when its bounded replay ring is recreated. */
+  private adoptReplayGeneration(sid: string, generation: unknown): void {
+    if (typeof generation !== 'string' || !generation) {
+      return
+    }
+
+    const previous = this.lastSeenGeneration.get(sid)
+
+    if (previous && previous !== generation) {
+      this.lastSeenSeq.delete(sid)
+    }
+
+    this.lastSeenGeneration.set(sid, generation)
   }
 
   /** Release frames parked during a replay fetch, seq-gated against dupes. */

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -168,3 +168,32 @@ def test_truncation_detection_semantics():
     assert event_replay.is_truncated("s1", 5)
     # Unknown session: nothing evicted, nothing truncated.
     assert not event_replay.is_truncated("nope", 0)
+
+
+def test_replay_snapshot_is_atomic_and_detached_during_concurrent_stamping():
+    for _ in range(event_replay._REPLAY_BUFFER_MAX + 10):
+        event_replay._stamp_event(_frame("s1"))
+
+    stop = threading.Event()
+
+    def stamp():
+        while not stop.is_set():
+            event_replay._stamp_event(_frame("s1"))
+
+    writer = threading.Thread(target=stamp)
+    writer.start()
+    try:
+        for _ in range(100):
+            snapshot = event_replay.replay_snapshot("s1", 0)
+            assert snapshot.truncated
+            assert snapshot.events[-1]["seq"] == snapshot.latest_seq
+            assert all(
+                left["seq"] + 1 == right["seq"]
+                for left, right in zip(snapshot.events, snapshot.events[1:])
+            )
+
+        snapshot.events[-1]["seq"] = -1
+        assert event_replay.replay_snapshot("s1", 0).events[-1]["seq"] > 0
+    finally:
+        stop.set()
+        writer.join()

--- a/tests/test_tui_gateway_event_replay.py
+++ b/tests/test_tui_gateway_event_replay.py
@@ -110,6 +110,22 @@ def test_session_count_bounded_with_fifo_eviction():
     assert latest_seq(f"s{event_replay._REPLAY_SESSIONS_MAX + 9}") == 1
 
 
+def test_evicted_session_restarts_in_a_new_generation():
+    first = _frame("s0")
+    event_replay._stamp_event(first)
+    old_generation = first["params"]["replay_generation"]
+
+    for i in range(1, event_replay._REPLAY_SESSIONS_MAX + 1):
+        event_replay._stamp_event(_frame(f"s{i}"))
+
+    revisited = _frame("s0")
+    event_replay._stamp_event(revisited)
+
+    assert revisited["params"]["seq"] == 1
+    assert revisited["params"]["replay_generation"] != old_generation
+    assert event_replay.replay_generation("s0") == revisited["params"]["replay_generation"]
+
+
 def test_concurrent_stamping_never_drops_or_duplicates_seq():
     errors = []
 

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -42,6 +42,7 @@ _replay_lock = threading.Lock()
 # the client's dispatch path consumes.
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
 _replay_next_seq: dict[str, int] = {}
+_replay_generations: dict[str, str] = {}
 
 
 def replay_epoch() -> str:
@@ -69,9 +70,12 @@ def _stamp_event(obj: dict) -> None:
         if buf is None:
             buf = deque(maxlen=_REPLAY_BUFFER_MAX)
             _replay_buffers[sid] = buf
+            _replay_generations[sid] = uuid.uuid4().hex
             while len(_replay_buffers) > _REPLAY_SESSIONS_MAX:
                 _oldest_sid, _oldest_buf = _replay_buffers.popitem(last=False)
                 _replay_next_seq.pop(_oldest_sid, None)
+                _replay_generations.pop(_oldest_sid, None)
+        params["replay_generation"] = _replay_generations[sid]
         buf.append((seq, params))
 
 
@@ -108,11 +112,18 @@ def latest_seq(sid: str) -> int:
         return _replay_next_seq.get(sid or "", 0)
 
 
+def replay_generation(sid: str) -> str | None:
+    """Current generation for *sid* (changes whenever its ring is recreated)."""
+    with _replay_lock:
+        return _replay_generations.get(sid or "")
+
+
 def reset_replay_state() -> None:
     """Test hook."""
     with _replay_lock:
         _replay_buffers.clear()
         _replay_next_seq.clear()
+        _replay_generations.clear()
 
 
 def replay_stats() -> dict:

--- a/tui_gateway/event_replay.py
+++ b/tui_gateway/event_replay.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import threading
 import uuid
 from collections import OrderedDict, deque
+from typing import NamedTuple
 
 # Process identity for the replay contract. Seq counters live in-process, so
 # a gateway restart silently resets them to 1 while clients still hold high
@@ -43,6 +44,15 @@ _replay_lock = threading.Lock()
 _replay_buffers: "OrderedDict[str, deque]" = OrderedDict()
 _replay_next_seq: dict[str, int] = {}
 _replay_generations: dict[str, str] = {}
+
+
+class ReplaySnapshot(NamedTuple):
+    """One lock-consistent view of a session's replay state."""
+
+    events: list[dict]
+    latest_seq: int
+    generation: str | None
+    truncated: bool
 
 
 def replay_epoch() -> str:
@@ -93,6 +103,20 @@ def events_since(sid: str, last_seen: int) -> list[dict]:
         if not buf:
             return []
         return [event for seq, event in buf if seq > last_seen]
+
+
+def replay_snapshot(sid: str, last_seen: int) -> ReplaySnapshot:
+    """Return one atomic, detached replay response snapshot for *sid*."""
+    key = sid or ""
+    with _replay_lock:
+        buf = _replay_buffers.get(key)
+        events = [event.copy() for seq, event in buf or () if seq > last_seen]
+        return ReplaySnapshot(
+            events=events,
+            latest_seq=_replay_next_seq.get(key, 0),
+            generation=_replay_generations.get(key),
+            truncated=bool(buf and last_seen + 1 < buf[0][0]),
+        )
 
 
 def is_truncated(sid: str, last_seen: int) -> bool:

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3733,6 +3733,7 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {
         "events": frames,
         "latest_seq": event_replay.latest_seq(sid),
+        "generation": event_replay.replay_generation(sid),
         "truncated": event_replay.is_truncated(sid, last_seen),
         "count": len(frames),
         # Restart detection: seq counters are in-process, so after a gateway

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3729,13 +3729,13 @@ def _(rid, params: dict) -> dict:
         return _err(rid, -32602, "invalid params: last_seen must be an integer")
     from tui_gateway import event_replay
 
-    frames = event_replay.events_since(sid, last_seen)
+    snapshot = event_replay.replay_snapshot(sid, last_seen)
     return _ok(rid, {
-        "events": frames,
-        "latest_seq": event_replay.latest_seq(sid),
-        "generation": event_replay.replay_generation(sid),
-        "truncated": event_replay.is_truncated(sid, last_seen),
-        "count": len(frames),
+        "events": snapshot.events,
+        "latest_seq": snapshot.latest_seq,
+        "generation": snapshot.generation,
+        "truncated": snapshot.truncated,
+        "count": len(snapshot.events),
         # Restart detection: seq counters are in-process, so after a gateway
         # restart a client's old high watermark would silently match nothing.
         # Clients compare this against the epoch they learned at gateway.ready


### PR DESCRIPTION
## What does this PR do?

Reconnects no longer accept an incomplete replay tail as a complete session transcript, and replayed session events can no longer become permanently invisible after the server evicts and recreates a session ring. The client now refreshes authoritative stored history before releasing parked live frames, while a bounded per-session generation lets it safely reset stale sequence watermarks.

### Symptom

After a WebSocket reconnect, a long session could resume with a missing assistant prefix, tool state, or terminal event when the replay ring had truncated older frames. A session revisited after FIFO replay eviction could also stop receiving replayed or parked live events because its server sequence restarted at 1 while the client retained a higher watermark.

### Impact

Desktop sessions at these bounded replay edges could silently show incomplete or stale conversation state rather than reporting a transport error.

### Bug Cause

**Trigger:** `apps/shared/src/json-rpc-gateway.ts:fetchReplay` receiving `truncated: true`, or `tui_gateway/event_replay.py:_stamp_event` recreating an evicted session ring.

**Causal chain:**
1. The server either returns only the retained replay tail or recreates an evicted session counter at 1.
2. The shared client ignores truncation and has no per-session generation to invalidate its old watermark.
3. Partial tails are dispatched as complete, or reset-sequence events are rejected as stale.

**Why it is wrong:** A process replay epoch only distinguishes server restarts. It cannot describe a single replay ring being recreated within the same process, and a truncated ring is explicitly not authoritative history.

**Working sibling / contrast:** A process restart already changes `replay_epoch`, which clears every client watermark. Non-truncated rings replay the complete gap in sequence order.

**Ruled out:** The server replay element shape is already correct and covered by the existing bare-event contract test; the loss occurs after a valid response reaches `fetchReplay()`.

### Fix

- Stamp each bounded session ring with a generation and return it from `session.events.since`.
- Reset only the affected client watermark when that generation changes.
- Add an awaited replay-gap callback; Desktop wires it to its existing authoritative transcript hydration path before parked live frames are released.
- Add regression tests for truncation resync ordering and same-epoch session eviction.

## Related Issue

Closes #100122

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/event_replay.py` and `tui_gateway/methods_session.py` - publish bounded per-session replay generations.
- `apps/shared/src/json-rpc-gateway.ts` - handle truncation through awaited resync and generation-aware watermarks.
- `apps/desktop/src/app/contrib/wiring.tsx` and gateway registry/boot hooks - hydrate stored history for primary and secondary sockets.
- Replay tests - cover truncated tails and eviction generation changes.

## How to Test

1. Run the Python replay-ring regression tests.
2. Run the shared replay client and Desktop gateway tests.
3. Run shared and Desktop typecheck/lint.

```bash
scripts/run_tests.sh tests/test_tui_gateway_event_replay.py -q
npm exec vitest -- run apps/shared/src/json-rpc-gateway-replay.test.ts
cd apps/desktop && npx vitest run --project ui src/app/gateway/hooks/use-gateway-boot.test.tsx src/store/gateway.test.ts
npm run typecheck --workspace apps/shared
npm run typecheck --workspace apps/desktop
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant Python tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; protocol comments and tests document the behavior
- [x] Config example update is N/A; no config keys changed
- [x] CONTRIBUTING.md and AGENTS.md updates are N/A; no workflow changed
- [x] I've considered cross-platform impact; the replay protocol is platform-independent
- [x] Tool schema updates are N/A; no model tool behavior changed

## Screenshots / Logs

N/A - automated replay contract tests cover both failure modes.
