### PR TITLE
fix(telegram): allow topic mention exceptions

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8961,6 +8961,22 @@ class TelegramAdapter(BasePlatformAdapter):
         topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
         return f"{chat_id}:{topic_id}" in topics
 
+    def _telegram_is_mention_required_topic(self, message: Message) -> bool:
+        """True when a topic requires an explicit bot trigger."""
+        raw = self.config.extra.get("mention_required_topics", "")
+        if isinstance(raw, list):
+            topics = {str(part).strip() for part in raw if str(part).strip()}
+        else:
+            topics = {part.strip() for part in str(raw).split(",") if part.strip()}
+        if not topics:
+            return False
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        if not chat_id:
+            return False
+        thread_id = self._effective_message_thread_id(message)
+        topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+        return f"{chat_id}:{topic_id}" in topics
+
     def _telegram_allowed_chats(self) -> set[str]:
         """Return the whitelist of group/supergroup chat IDs the bot will respond in.
 
@@ -9472,6 +9488,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # Only observe messages skipped by the require_mention gate.  If the
         # message would be processed normally, let the dispatcher handle it;
         # if require_mention is disabled, every group message is a request.
+        if self._telegram_is_mention_required_topic(message):
+            return False
         if chat_id_str in self._telegram_free_response_chats():
             return False
         if self._telegram_is_free_response_topic(message):
@@ -9856,11 +9874,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
         if guest_mention:
             return True
-        if chat_id_str in self._telegram_free_response_chats():
+        mention_required_topic = self._telegram_is_mention_required_topic(message)
+        if not mention_required_topic and chat_id_str in self._telegram_free_response_chats():
             return True
-        if self._telegram_is_free_response_topic(message):
+        if not mention_required_topic and self._telegram_is_free_response_topic(message):
             return True
-        if not self._telegram_require_mention():
+        if not mention_required_topic and not self._telegram_require_mention():
             return True
         if self._is_reply_to_bot(message):
             return True

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -12,6 +12,7 @@ def _make_adapter(
     require_mention=None,
     free_response_chats=None,
     free_response_topics=None,
+    mention_required_topics=None,
     mention_patterns=None,
     exclusive_bot_mentions=None,
     ignored_threads=None,
@@ -33,6 +34,8 @@ def _make_adapter(
         extra["free_response_chats"] = free_response_chats
     if free_response_topics is not None:
         extra["free_response_topics"] = free_response_topics
+    if mention_required_topics is not None:
+        extra["mention_required_topics"] = mention_required_topics
     if mention_patterns is not None:
         extra["mention_patterns"] = mention_patterns
     if exclusive_bot_mentions is not None:
@@ -407,6 +410,28 @@ def test_free_response_topic_messages_are_dispatched_not_observed():
     other_topic = _group_message("side chatter", chat_id=-200, thread_id=32)
     assert adapter._should_process_message(other_topic) is False
     assert adapter._should_observe_unmentioned_group_message(other_topic) is True
+
+
+def test_mention_required_topic_overrides_whole_chat_free_response():
+    adapter = _make_adapter(
+        require_mention=False,
+        free_response_chats=["-200"],
+        mention_required_topics=["-200:31"],
+    )
+
+    restricted = _group_message("hello", chat_id=-200, thread_id=31)
+    assert adapter._should_process_message(restricted) is False
+    assert adapter._should_process_message(
+        _group_message(
+            "hi @hermes_bot",
+            chat_id=-200,
+            thread_id=31,
+            entities=[_mention_entity("hi @hermes_bot")],
+        )
+    ) is True
+    assert adapter._should_process_message(
+        _group_message("hello", chat_id=-200, thread_id=32)
+    ) is True
 
 
 def test_guest_mode_allows_only_direct_mentions_outside_allowed_chats():


### PR DESCRIPTION
## Summary
- add a topic-scoped mention-required override
- let it override whole-chat and topic free-response settings
- cover restricted and unrestricted topics with focused tests

This supports groups that are free-response by default while keeping one forum topic mention-only.

## Tests
- `/tmp/hermes-topic-test/bin/python -m pytest -q tests/gateway/test_telegram_group_gating.py` (24 passed)
- `/tmp/hermes-topic-test/bin/ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_group_gating.py`
- `python -m compileall -q plugins/platforms/telegram/adapter.py`
- `git diff --check`
