### PR TITLE
fix(linux): stop installing the Mint panel icon as a PNG in hicolor/scalable

### DIFF
--- a/hermes_cli/gui_uninstall.py
+++ b/hermes_cli/gui_uninstall.py
@@ -156,10 +156,9 @@ def packaged_gui_app_paths() -> "list[Path]":
             data_base / "applications" / "Hermes.desktop",
             data_base / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png",
         ]
-        # Fixed-size hicolor dirs: the icon is copied at its native size
-        # (read from the PNG header), so sweep the standard ones plus the
-        # 1024x1024 dir the shipped asset lands in.
-        for size in ("256x256", "512x512", "1024x1024"):
+        # Fixed-size hicolor dirs the installer may have written (resized
+        # panel sizes plus leftover native-size copies from older builds).
+        for size in ("24x24", "32x32", "48x48", "256x256", "512x512", "1024x1024"):
             paths.append(data_base / "icons" / "hicolor" / size / "apps" / "hermes.png")
     return paths
 

--- a/hermes_cli/linux_desktop_entry.py
+++ b/hermes_cli/linux_desktop_entry.py
@@ -15,9 +15,9 @@ Two values must be absolute for the entry to work:
     checkout. Do not copy the icon: ``Exec`` already depends on that tree.
 
 Cache refresh is best-effort and tool-gated: ``update-desktop-database``
-for the freedesktop menu cache, and ``kbuildsycoca6``/``kbuildsycoca5``
-for Plasma. Run each tool only when it exists. A missing tool is not an
-error.
+for the freedesktop menu cache, ``gtk-update-icon-cache`` for the user
+hicolor tree, and ``kbuildsycoca6``/``kbuildsycoca5`` for Plasma. Run
+each tool only when it exists. A missing tool is not an error.
 
 Import-light and side-effect-free at import time: the uninstaller uses
 this without loading the full CLI.
@@ -25,6 +25,7 @@ this without loading the full CLI.
 
 from __future__ import annotations
 
+import io
 import os
 import shutil
 import struct
@@ -624,31 +625,135 @@ def _run_quiet(cmd: "list[str]") -> bool:
     return result.returncode == 0
 
 
+# Sizes a typical hicolor ``index.theme`` actually lists. ``scalable`` is
+# SVG-only — a raster PNG there is what Cinnamon's panel draws as a
+# mangled low-res blob. The shipped desktop asset is 1024×1024, which is
+# also not an indexed dir name, so a copy-only fallback lands in ``256x256``.
+_HICOLOR_INDEXED_SIZES = (16, 22, 24, 32, 36, 48, 64, 72, 96, 128, 192, 256, 512)
+# Cinnamon's panel is ~24–32px. Write these so the theme loads an exact
+# raster instead of downscaling a 1024px PNG at lookup time.
+_HICOLOR_INSTALL_SIZES = (24, 32, 48, 256)
+
+
+def _png_dimensions(raw: bytes) -> Optional[tuple[int, int]]:
+    """Return ``(width, height)`` from a PNG IHDR, or ``None`` if unreadable."""
+    if len(raw) >= 24 and raw[:8] == b"\x89PNG\r\n\x1a\n" and raw[12:16] == b"IHDR":
+        return struct.unpack(">II", raw[16:24])
+    return None
+
+
+def _hicolor_subdir(dimensions: Optional[tuple[int, int]]) -> str:
+    """Pick a fixed-size hicolor dir the theme indexes. Never ``scalable``."""
+    if dimensions is None:
+        return "256x256"
+    width, height = dimensions
+    if width != height or width <= 0:
+        return "256x256"
+    if width in _HICOLOR_INDEXED_SIZES:
+        return f"{width}x{width}"
+    if width > 256:
+        return "256x256"
+    nearest = min(_HICOLOR_INDEXED_SIZES, key=lambda size: abs(size - width))
+    return f"{nearest}x{nearest}"
+
+
+def _hicolor_icon_dest(subdir: str) -> Path:
+    return _xdg_data_home() / "icons" / "hicolor" / subdir / "apps" / "hermes.png"
+
+
+def _remove_stale_scalable_icon() -> bool:
+    """Drop a leftover PNG from ``scalable/`` (the pre-fix install path).
+
+    Return True when a file was removed so the caller can refresh the
+    icon cache. A missing file is not an error.
+    """
+    stale = _hicolor_icon_dest("scalable")
+    try:
+        if stale.is_file():
+            stale.unlink()
+            return True
+    except OSError:
+        return False
+    return False
+
+
+def _refresh_hicolor_cache() -> None:
+    """Best-effort reindex of the user hicolor tree. Missing tool is fine."""
+    hicolor = _xdg_data_home() / "icons" / "hicolor"
+    for tool in ("gtk-update-icon-cache", "gtk4-update-icon-cache"):
+        resolved = shutil.which(tool)
+        if resolved:
+            _run_quiet([resolved, "-f", "-t", str(hicolor)])
+            return
+
+
+def _resized_hicolor_pngs(raw: bytes) -> Optional[dict[str, bytes]]:
+    """Lanczos-resize *raw* to each panel size. ``None`` when it will not decode.
+
+    Pillow is a core dep but this module stays import-light: the import is
+    local so the uninstaller does not pay it. A truncated/fake PNG (tests,
+    interrupted copy) returns None and the caller falls back to a copy.
+    """
+    try:
+        from PIL import Image
+    except ImportError:
+        return None
+    try:
+        with Image.open(io.BytesIO(raw)) as im:
+            rgba = im.convert("RGBA")
+            out: dict[str, bytes] = {}
+            for size in _HICOLOR_INSTALL_SIZES:
+                resized = rgba.resize((size, size), Image.Resampling.LANCZOS)
+                buf = io.BytesIO()
+                resized.save(buf, format="PNG")
+                out[f"{size}x{size}"] = buf.getvalue()
+            return out
+    except (OSError, ValueError):
+        return None
+
+
+def _write_hicolor_pngs(files: dict[str, bytes]) -> bool:
+    """Write *files* keyed by hicolor size dir. Return True if any file changed."""
+    wrote = False
+    for subdir, data in files.items():
+        dest = _hicolor_icon_dest(subdir)
+        if dest.is_file() and dest.read_bytes() == data:
+            continue
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        wrote = True
+    return wrote
+
+
 def _install_icon_to_hicolor(icon: Path) -> bool:
-    """Copy the app icon into the user's hicolor icon theme tree.
+    """Install the app icon into the user's hicolor icon theme tree.
 
     The freedesktop icon lookup finds an installed ``apps/hermes.png``
     by the unqualified name ``hermes``, so the entry can reference the
-    icon without an absolute checkout path. The size subdirectory must
-    be one the theme actually indexes (hicolor's index.theme lists
-    fixed sizes and ``scalable`` — an unindexed dir like ``1024x1024``
-    would never be found), so the icon lands in ``scalable`` unless the
-    source is exactly 256x256, which goes to the fixed-size dir.
-    Idempotent via content-compare; OSError caught internally (False) —
-    the caller then falls back to the absolute path.
+    icon without an absolute checkout path. Raster PNGs go to indexed
+    fixed-size dirs, never ``scalable`` (SVG-only). When the source
+    decodes, it is Lanczos-resized to 24/32/48/256 so Cinnamon's panel
+    does not nearest-neighbor a 1024px PNG. Undecodable bytes fall back
+    to a copy into one indexed dir. Idempotent via content-compare;
+    OSError caught internally (False) — the caller then falls back to
+    the absolute path.
     """
     try:
         raw = icon.read_bytes()
-        is_256 = False
-        if len(raw) >= 24 and raw[:8] == b"\x89PNG\r\n\x1a\n" and raw[12:16] == b"IHDR":
-            width, height = struct.unpack(">II", raw[16:24])
-            is_256 = (width, height) == (256, 256)
-        subdir = "256x256" if is_256 else "scalable"
-        dest = _xdg_data_home() / "icons" / "hicolor" / subdir / "apps" / "hermes.png"
-        if dest.is_file() and dest.read_bytes() == raw:
-            return True
-        dest.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copyfile(icon, dest)
+        resized = _resized_hicolor_pngs(raw)
+        if resized is not None:
+            wrote = _write_hicolor_pngs(resized)
+        else:
+            dest = _hicolor_icon_dest(_hicolor_subdir(_png_dimensions(raw)))
+            wrote = True
+            if dest.is_file() and dest.read_bytes() == raw:
+                wrote = False
+            else:
+                dest.parent.mkdir(parents=True, exist_ok=True)
+                shutil.copyfile(icon, dest)
+        removed_stale = _remove_stale_scalable_icon()
+        if wrote or removed_stale:
+            _refresh_hicolor_cache()
         return True
     except OSError:
         return False

--- a/tests/hermes_cli/test_linux_desktop_entry.py
+++ b/tests/hermes_cli/test_linux_desktop_entry.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import io
 import os
 import stat
+import struct
 import sys
 from pathlib import Path
 
@@ -29,6 +31,26 @@ def _make_project(tmp_path: Path) -> Path:
     icon.parent.mkdir(parents=True)
     icon.write_bytes(b"\x89PNG fake")
     return root
+
+
+def _png_ihdr(width: int, height: int) -> bytes:
+    """Minimal PNG prefix whose IHDR the installer can parse (no pixels)."""
+    return (
+        b"\x89PNG\r\n\x1a\n"
+        + b"\x00\x00\x00\r"
+        + b"IHDR"
+        + struct.pack(">II", width, height)
+    )
+
+
+def _stub_install(tmp_path, monkeypatch) -> None:
+    hermes_bin = tmp_path / "bin" / "hermes"
+    hermes_bin.parent.mkdir(exist_ok=True)
+    hermes_bin.write_text("", encoding="utf-8")
+    monkeypatch.setattr(
+        "hermes_cli.relaunch.resolve_hermes_bin", lambda: str(hermes_bin)
+    )
+    monkeypatch.setattr(lde, "refresh_desktop_databases", lambda _dir: [])
 
 
 def _parse(entry_text: str) -> dict:
@@ -94,8 +116,8 @@ def test_install_prefers_themed_icon_from_hicolor(tmp_path, xdg_home, monkeypatc
 
     # And the icon really landed in the hicolor tree: the fixture icon is
     # a fake PNG (no valid IHDR), so the size is unknown and the icon
-    # lands under scalable/.
-    dest = xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    # lands under 256x256/ (indexed; never scalable, which is SVG-only).
+    dest = xdg_home / "icons" / "hicolor" / "256x256" / "apps" / "hermes.png"
     assert dest.is_file()
     assert dest.read_bytes() == lde.icon_path(root).read_bytes()
 
@@ -965,8 +987,8 @@ def test_probe_accepts_shell_launcher_wrapper(tmp_path, xdg_home, monkeypatch):
 
 def test_install_icon_handles_truncated_png_header(tmp_path, xdg_home, monkeypatch):
     """A truncated PNG (valid signature + IHDR tag, <24 bytes) must not
-    raise struct.error out of the fail-safe: it lands in scalable/ like
-    any other unknown-size image."""
+    raise struct.error out of the fail-safe: it lands in 256x256/ like
+    any other unknown-size raster."""
     root = _make_project(tmp_path)
     icon = lde.icon_path(root)
     icon.write_bytes(
@@ -984,5 +1006,96 @@ def test_install_icon_handles_truncated_png_header(tmp_path, xdg_home, monkeypat
 
     values = _parse(entry.read_text(encoding="utf-8"))
     assert values["Icon"] == "hermes"
-    dest = xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    dest = xdg_home / "icons" / "hicolor" / "256x256" / "apps" / "hermes.png"
     assert dest.is_file()
+
+
+def test_hicolor_subdir_puts_rasters_in_indexed_dirs_never_scalable():
+    """Panel lookup uses fixed sizes. scalable/ is SVG-only."""
+    assert lde._hicolor_subdir(None) == "256x256"
+    assert lde._hicolor_subdir((1024, 1024)) == "256x256"
+    assert lde._hicolor_subdir((512, 512)) == "512x512"
+    assert lde._hicolor_subdir((256, 256)) == "256x256"
+    assert lde._hicolor_subdir((48, 48)) == "48x48"
+    assert lde._hicolor_subdir((24, 24)) == "24x24"
+    assert lde._hicolor_subdir((64, 32)) == "256x256"
+
+
+def test_install_places_1024_png_in_256x256_not_scalable(
+    tmp_path, xdg_home, monkeypatch
+):
+    """The shipped desktop asset is 1024×1024. A PNG in scalable/ is what
+    Cinnamon's panel rasterizes as a mangled low-res icon."""
+    root = _make_project(tmp_path)
+    lde.icon_path(root).write_bytes(_png_ihdr(1024, 1024))
+    _stub_install(tmp_path, monkeypatch)
+
+    entry = lde.install_desktop_entry(root)
+    values = _parse(entry.read_text(encoding="utf-8"))
+
+    dest = xdg_home / "icons" / "hicolor" / "256x256" / "apps" / "hermes.png"
+    stale = xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    assert values["Icon"] == "hermes"
+    assert dest.is_file()
+    assert dest.read_bytes() == lde.icon_path(root).read_bytes()
+    assert not stale.exists()
+
+
+def test_install_removes_stale_scalable_png(tmp_path, xdg_home, monkeypatch):
+    """v2026.8.31 wrote the PNG into scalable/. A later hermes desktop
+    must delete that leftover so Cinnamon does not keep using it."""
+    root = _make_project(tmp_path)
+    lde.icon_path(root).write_bytes(_png_ihdr(1024, 1024))
+    _stub_install(tmp_path, monkeypatch)
+
+    stale = xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    stale.parent.mkdir(parents=True)
+    stale.write_bytes(b"old scalable png")
+
+    lde.install_desktop_entry(root)
+
+    dest = xdg_home / "icons" / "hicolor" / "256x256" / "apps" / "hermes.png"
+    assert dest.is_file()
+    assert not stale.exists()
+
+
+def test_install_exact_48_png_uses_48x48_dir(tmp_path, xdg_home, monkeypatch):
+    root = _make_project(tmp_path)
+    lde.icon_path(root).write_bytes(_png_ihdr(48, 48))
+    _stub_install(tmp_path, monkeypatch)
+
+    lde.install_desktop_entry(root)
+
+    dest = xdg_home / "icons" / "hicolor" / "48x48" / "apps" / "hermes.png"
+    assert dest.is_file()
+    assert not (
+        xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    ).exists()
+
+
+def test_install_resizes_decodable_png_to_panel_sizes(
+    tmp_path, xdg_home, monkeypatch
+):
+    """A decodeable PNG is Lanczos-resized so the 24px slot is actually 24px."""
+    from PIL import Image
+
+    root = _make_project(tmp_path)
+    im = Image.new("RGBA", (64, 64), (255, 255, 255, 255))
+    for x in range(16, 48):
+        for y in range(16, 48):
+            im.putpixel((x, y), (0, 0, 0, 255))
+    buf = io.BytesIO()
+    im.save(buf, format="PNG")
+    lde.icon_path(root).write_bytes(buf.getvalue())
+    _stub_install(tmp_path, monkeypatch)
+
+    lde.install_desktop_entry(root)
+
+    dest_24 = xdg_home / "icons" / "hicolor" / "24x24" / "apps" / "hermes.png"
+    dest_256 = xdg_home / "icons" / "hicolor" / "256x256" / "apps" / "hermes.png"
+    stale = xdg_home / "icons" / "hicolor" / "scalable" / "apps" / "hermes.png"
+    assert dest_24.is_file()
+    assert dest_256.is_file()
+    assert not stale.exists()
+    assert struct.unpack(">II", dest_24.read_bytes()[16:24]) == (24, 24)
+    assert struct.unpack(">II", dest_256.read_bytes()[16:24]) == (256, 256)


### PR DESCRIPTION
## Summary
- On Linux Mint Cinnamon, the Hermes panel icon went blurry/mangled after v2026.8.31 because `hermes desktop` copied the 1024×1024 PNG into `hicolor/scalable/` (that directory is SVG-only) and set `Icon=hermes`.
- Install raster icons into an indexed size dir (`256x256` for the shipped 1024px asset), delete the leftover `scalable/hermes.png`, and refresh the icon cache so Cinnamon picks up the good file.

## Test plan
- [ ] `scripts/run_tests.sh tests/hermes_cli/test_linux_desktop_entry.py tests/hermes_cli/test_gui_uninstall.py -q`
- [ ] On Linux: `hermes update` then `hermes desktop`, confirm `~/.local/share/icons/hicolor/256x256/apps/hermes.png` exists and `scalable/apps/hermes.png` is gone
- [ ] On Linux Mint Cinnamon, confirm the panel icon is sharp again (restart Cinnamon if the old icon is cached: Alt+F2, type `r`, Enter)