### PR TITLE
fix: fail closed on corrupt config.yaml in non-interactive runs (salvage #81988, extended to gateway/serve/cron)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5509,6 +5509,24 @@ def run_job(
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
 
+    # Fail closed on a corrupt config.yaml before any agent-driven work
+    # (issue #81952): a cron fire is fully non-interactive, and continuing
+    # on built-in defaults lets provider auto-detection adopt .env
+    # credentials the config never named, billing a provider the user did
+    # not choose. no_agent script jobs are exempt — they never construct an
+    # AIAgent or spend tokens. Escape hatch: HERMES_IGNORE_USER_CONFIG=1.
+    if not job.get("no_agent"):
+        from hermes_cli.config import (
+            InvalidUserConfigError,
+            require_parseable_user_config,
+        )
+
+        try:
+            require_parseable_user_config()
+        except InvalidUserConfigError as exc:
+            logger.error("Job '%s': refusing to run — %s", job_id, exc)
+            return (False, f"# Cron Job: {job_name}\n\nError: {exc}\n", "", str(exc))
+
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
     # ---------------------------------------------------------------

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -33429,8 +33429,34 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     return True
 
 
+def _guard_corrupt_user_config() -> None:
+    """Fail closed when the active profile's config.yaml cannot be parsed.
+
+    The gateway is a fully non-interactive surface: nobody is present to
+    repair a corrupt ``config.yaml``, and silently continuing on built-in
+    defaults lets provider auto-detection adopt credentials from ``.env``
+    that the config never named (issue #81952). Same policy and escape
+    hatch (``HERMES_IGNORE_USER_CONFIG=1``) as the non-interactive CLI
+    guard in ``hermes_cli/main.py``.
+    """
+    from hermes_cli.config import (
+        InvalidUserConfigError,
+        require_parseable_user_config,
+    )
+
+    try:
+        require_parseable_user_config()
+    except InvalidUserConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+
 def main():
     """CLI entry point for the gateway."""
+    # Refuse to start on a corrupt config.yaml — before any config-dependent
+    # startup (watchdog, DB opens, provider resolution). See _guard docstring.
+    _guard_corrupt_user_config()
+
     # Advertise the agent harness to child processes (AI_AGENT is the
     # cross-agent standard; HERMES_AGENT the Hermes-specific marker — see
     # _advertise_agent_env in hermes_cli/main.py, kept inline here to avoid

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -45,6 +45,10 @@ logger = logging.getLogger(__name__)
 _CONFIG_PARSE_WARNED: set = set()
 
 
+class InvalidUserConfigError(RuntimeError):
+    """Raised when a run that cannot repair config finds invalid user YAML."""
+
+
 def _backup_corrupt_config(config_path: Path) -> Optional[Path]:
     """Preserve a corrupted ``config.yaml`` by copying it to a timestamped ``.bak``.
 
@@ -770,6 +774,48 @@ from utils import atomic_replace, fast_safe_load
 def get_config_path() -> Path:
     """Get the main config file path."""
     return get_hermes_home() / "config.yaml"
+
+
+def require_parseable_user_config(*, ignore_user_config: bool = False) -> None:
+    """Reject an existing invalid config before a non-interactive agent run.
+
+    Interactive surfaces retain ``load_config()``'s recovery behavior so the
+    operator can repair their configuration. A one-shot or single-query run
+    has no such repair opportunity: allowing defaults there can silently pick
+    a hosted provider/model and spend against credentials loaded from ``.env``.
+
+    Missing and empty files remain valid first-run states. The explicit
+    ``--ignore-user-config``/safe-mode escape hatch also remains authoritative.
+    """
+    if ignore_user_config or os.environ.get("HERMES_IGNORE_USER_CONFIG") == "1":
+        return
+
+    config_path = get_config_path()
+    try:
+        with open(config_path, encoding="utf-8") as f:
+            data = fast_safe_load(f)
+    except FileNotFoundError:
+        return
+    except Exception as exc:
+        parse_error = exc
+    else:
+        if data is None or isinstance(data, dict):
+            return
+        parse_error = TypeError(
+            f"top-level YAML value must be a mapping, got {type(data).__name__}"
+        )
+
+    backup_path = _backup_corrupt_config(config_path)
+    message = (
+        f"Refusing non-interactive startup because {config_path} is invalid: "
+        f"{parse_error}. Repair the file or pass --ignore-user-config to "
+        "intentionally run with built-in defaults."
+    )
+    if backup_path is not None:
+        message += f" A copy was saved to {backup_path}."
+    logger.error(message)
+    raise InvalidUserConfigError(message) from parse_error
+
 
 def get_env_path() -> Path:
     """Get the .env file path (for API keys)."""

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3190,9 +3190,10 @@ def _resolve_use_tui(args) -> bool:
 
 def cmd_chat(args):
     """Run interactive chat CLI."""
-    use_tui = _resolve_use_tui(args)
-
     _apply_safe_mode(args)
+    _apply_user_config_bypass(args)
+    _guard_noninteractive_user_config(args)
+    use_tui = _resolve_use_tui(args)
 
     # --in DIR: run in DIR. Must happen before any session resolution so the
     # workspace-scoped "latest"/-c lookups key off DIR, and it pins the
@@ -3424,14 +3425,6 @@ def cmd_chat(args):
     # that invoke cmd_chat directly (e.g. subcommand dispatch).
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
-
-    # --ignore-user-config: make load_cli_config() / load_config() skip the
-    # user's ~/.hermes/config.yaml and return built-in defaults. Set BEFORE
-    # importing cli (which runs `CLI_CONFIG = load_cli_config()` at module
-    # import time). Credentials in .env are still loaded — this flag only
-    # ignores behavioral/config settings.
-    if getattr(args, "ignore_user_config", False):
-        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
 
     # --ignore-rules: skip auto-injection of AGENTS.md/SOUL.md/.cursorrules
     # (rules), memory entries, and any preloaded skills coming from user config.
@@ -12584,6 +12577,8 @@ def _prepare_agent_startup(args) -> None:
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
     _apply_safe_mode(args)
+    _apply_user_config_bypass(args)
+    _guard_noninteractive_user_config(args)
 
     _sub_attr, _sub_set = _AGENT_SUBCOMMANDS.get(args.command, (None, None))
     if not (
@@ -12673,6 +12668,44 @@ def _apply_safe_mode(args) -> None:
     os.environ["HERMES_SAFE_MODE"] = "1"
     os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
     os.environ["HERMES_IGNORE_RULES"] = "1"
+
+
+def _apply_user_config_bypass(args) -> None:
+    """Apply the explicit config bypass before any startup config reads."""
+    if getattr(args, "ignore_user_config", False):
+        os.environ["HERMES_IGNORE_USER_CONFIG"] = "1"
+
+
+def _guard_noninteractive_user_config(args) -> None:
+    """Fail closed before a non-interactive invocation initializes providers."""
+    if getattr(args, "_noninteractive_config_validated", False):
+        return
+
+    is_noninteractive = (
+        bool(getattr(args, "oneshot", None))
+        or getattr(args, "query", None) is not None
+        or bool(getattr(args, "quiet", False))
+    )
+    if not is_noninteractive:
+        return
+
+    from hermes_cli.config import (
+        InvalidUserConfigError,
+        require_parseable_user_config,
+    )
+
+    try:
+        require_parseable_user_config(
+            ignore_user_config=bool(
+                getattr(args, "ignore_user_config", False)
+                or getattr(args, "safe_mode", False)
+            )
+        )
+    except InvalidUserConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc
+
+    setattr(args, "_noninteractive_config_validated", True)
 
 
 def _set_chat_arg_defaults(args) -> None:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12683,7 +12683,7 @@ def _guard_noninteractive_user_config(args) -> None:
 
     is_noninteractive = (
         bool(getattr(args, "oneshot", None))
-        or getattr(args, "query", None) is not None
+        or bool(getattr(args, "query", None))
         or bool(getattr(args, "quiet", False))
     )
     if not is_noninteractive:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12043,6 +12043,23 @@ def cmd_dashboard(args):
     # ready sentinel. Resolved once and threaded through the re-exec, the
     # build gate, and start_server.
     _headless_backend = getattr(args, "headless_backend", False)
+    # `hermes serve` is headless/non-interactive: fail closed on a corrupt
+    # config.yaml instead of silently starting on defaults where provider
+    # auto-detection can adopt unnamed .env credentials (issue #81952).
+    # Same policy + escape hatch as _guard_noninteractive_user_config.
+    if _headless_backend:
+        from hermes_cli.config import (
+            InvalidUserConfigError,
+            require_parseable_user_config,
+        )
+
+        try:
+            require_parseable_user_config(
+                ignore_user_config=bool(getattr(args, "ignore_user_config", False))
+            )
+        except InvalidUserConfigError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            raise SystemExit(2) from exc
     _ssh_owner_nonce = getattr(args, "ssh_owner_nonce", None)
     if _ssh_owner_nonce and not re.fullmatch(r"[0-9a-f]{16}", _ssh_owner_nonce):
         raise SystemExit("--ssh-owner-nonce must be 16 lowercase hex characters")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12684,7 +12684,6 @@ def _guard_noninteractive_user_config(args) -> None:
     is_noninteractive = (
         bool(getattr(args, "oneshot", None))
         or bool(getattr(args, "query", None))
-        or bool(getattr(args, "quiet", False))
     )
     if not is_noninteractive:
         return

--- a/tests/hermes_cli/test_config_guard_surfaces.py
+++ b/tests/hermes_cli/test_config_guard_surfaces.py
@@ -1,0 +1,155 @@
+"""Fail-closed corrupt-config guards on gateway, serve, and cron surfaces.
+
+Companion to test_noninteractive_config_guard.py (PR #81988): issue #81952
+extended to every non-interactive startup surface.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    yield
+    os.environ.pop("HERMES_IGNORE_USER_CONFIG", None)
+
+
+def _write_corrupt_config(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text("model: [unterminated\n", encoding="utf-8")
+    return path
+
+
+class TestGatewayGuard:
+    def test_gateway_refuses_corrupt_config(self, tmp_path, capsys):
+        from gateway.run import _guard_corrupt_user_config
+
+        _write_corrupt_config(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _guard_corrupt_user_config()
+
+        assert exc_info.value.code == 2
+        assert "Refusing non-interactive startup" in capsys.readouterr().err
+
+    def test_gateway_allows_valid_config(self, tmp_path):
+        from gateway.run import _guard_corrupt_user_config
+
+        (tmp_path / "config.yaml").write_text("model:\n  default: local/test\n")
+        _guard_corrupt_user_config()  # must not raise
+
+    def test_gateway_allows_missing_config(self, tmp_path):
+        from gateway.run import _guard_corrupt_user_config
+
+        _guard_corrupt_user_config()  # first-run state: must not raise
+
+    def test_gateway_escape_hatch(self, monkeypatch, tmp_path):
+        from gateway.run import _guard_corrupt_user_config
+
+        _write_corrupt_config(tmp_path)
+        monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+        _guard_corrupt_user_config()  # must not raise
+
+
+class TestCronRunJobGuard:
+    def _job(self, **overrides):
+        job = {"id": "job-test-1", "name": "guard test", "prompt": "hi"}
+        job.update(overrides)
+        return job
+
+    def test_run_job_fails_closed_on_corrupt_config(self, tmp_path):
+        from cron.scheduler import run_job
+
+        _write_corrupt_config(tmp_path)
+
+        success, output_doc, final_response, error = run_job(self._job())
+
+        assert success is False
+        assert error is not None
+        assert "Refusing non-interactive startup" in error
+        assert "config.yaml" in error
+        assert final_response == ""
+
+    def test_run_job_escape_hatch(self, monkeypatch, tmp_path):
+        from cron.scheduler import run_job
+
+        _write_corrupt_config(tmp_path)
+        monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+
+        # With the escape hatch active the guard must not trip. The job then
+        # proceeds into normal execution; a missing provider/model in the
+        # empty temp HERMES_HOME may fail later, but never with the guard's
+        # refusal message.
+        success, output_doc, final_response, error = run_job(
+            self._job(no_agent=True, script="true", deliver="none")
+        )
+        assert "Refusing non-interactive startup" not in (error or "")
+
+    def test_run_job_no_agent_exempt(self, tmp_path):
+        from cron.scheduler import run_job
+
+        _write_corrupt_config(tmp_path)
+
+        success, output_doc, final_response, error = run_job(
+            self._job(no_agent=True, script="true", deliver="none")
+        )
+        assert "Refusing non-interactive startup" not in (error or "")
+
+
+class TestServeGuard:
+    def test_serve_headless_refuses_corrupt_config(self, tmp_path, capsys):
+        """The `hermes serve` headless path fails closed before startup."""
+        from argparse import Namespace
+
+        from hermes_cli import main as main_mod
+
+        _write_corrupt_config(tmp_path)
+        args = Namespace(
+            headless_backend=True,
+            ignore_user_config=False,
+            ssh_session_token_file=None,
+            ssh_owner_nonce=None,
+            status=False,
+            stop=False,
+        )
+
+        with pytest.raises(SystemExit) as exc_info:
+            main_mod.cmd_dashboard(args)
+
+        assert exc_info.value.code == 2
+        assert "Refusing non-interactive startup" in capsys.readouterr().err
+
+    def test_serve_escape_hatch_passes_guard(self, tmp_path, monkeypatch):
+        """--ignore-user-config lets serve get past the corrupt-config guard."""
+        from argparse import Namespace
+
+        from hermes_cli import main as main_mod
+
+        _write_corrupt_config(tmp_path)
+        args = Namespace(
+            headless_backend=True,
+            ignore_user_config=True,
+            ssh_session_token_file=None,
+            ssh_owner_nonce=None,
+            status=False,
+            stop=False,
+        )
+
+        # Stop execution right after the guard: the next thing cmd_dashboard
+        # touches on the headless path is the nonce regex via `re`.
+        sentinel = RuntimeError("passed-guard")
+
+        class _ReStop:
+            def fullmatch(self, *a, **k):
+                raise sentinel
+
+        monkeypatch.setattr(main_mod, "re", _ReStop())
+        args.ssh_owner_nonce = "0123456789abcdef"
+
+        with pytest.raises(RuntimeError, match="passed-guard"):
+            main_mod.cmd_dashboard(args)

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -38,9 +38,9 @@ def _isolated_config_env(monkeypatch, tmp_path):
     [
         _args(query="hello"),
         _args(command=None, query=None, oneshot="hello"),
-        _args(query=None, quiet=True),
+        _args(query="hello", quiet=True),
     ],
-    ids=["single-query", "oneshot", "quiet"],
+    ids=["single-query", "oneshot", "quiet-query"],
 )
 def test_noninteractive_guard_rejects_malformed_yaml(args, tmp_path, caplog, capsys):
     from hermes_cli import main as main_mod
@@ -146,11 +146,19 @@ def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
     assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
 
 
-def test_empty_query_keeps_interactive_repair_behavior(tmp_path):
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(query=""),
+        _args(query=None, quiet=True),
+        _args(query="", quiet=True),
+    ],
+    ids=["empty-query", "quiet", "quiet-empty-query"],
+)
+def test_queryless_chat_keeps_interactive_repair_behavior(args, tmp_path):
     from hermes_cli import main as main_mod
 
     (tmp_path / "config.yaml").write_text("model: [unterminated\n")
-    args = _args(query="")
 
     main_mod._guard_noninteractive_user_config(args)
 

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -1,0 +1,156 @@
+"""Regression coverage for fail-closed non-interactive config startup."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+import types
+from argparse import Namespace
+
+import pytest
+
+
+def _args(**overrides) -> Namespace:
+    values = {
+        "command": "chat",
+        "ignore_user_config": False,
+        "oneshot": None,
+        "query": "hello",
+        "quiet": False,
+        "safe_mode": False,
+        "yolo": False,
+    }
+    values.update(overrides)
+    return Namespace(**values)
+
+
+@pytest.fixture(autouse=True)
+def _isolated_config_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+    yield
+    os.environ.pop("HERMES_IGNORE_USER_CONFIG", None)
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(query="hello"),
+        _args(command=None, query=None, oneshot="hello"),
+        _args(query=None, quiet=True),
+    ],
+    ids=["single-query", "oneshot", "quiet"],
+)
+def test_noninteractive_guard_rejects_malformed_yaml(args, tmp_path, caplog, capsys):
+    from hermes_cli import main as main_mod
+
+    broken = "model: [unterminated\n"
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(broken, encoding="utf-8")
+
+    with caplog.at_level(logging.ERROR, logger="hermes_cli.config"):
+        with pytest.raises(SystemExit) as exc_info:
+            main_mod._guard_noninteractive_user_config(args)
+
+    assert exc_info.value.code == 2
+    assert "Refusing non-interactive startup" in capsys.readouterr().err
+    assert any(
+        record.levelno == logging.ERROR
+        and "Refusing non-interactive startup" in record.getMessage()
+        for record in caplog.records
+    )
+    assert config_path.read_text(encoding="utf-8") == broken
+    backups = list(tmp_path.glob("config.yaml.corrupt.*.bak"))
+    assert len(backups) == 1
+    assert backups[0].read_text(encoding="utf-8") == broken
+
+
+def test_prepare_rejects_bad_config_before_plugin_discovery(monkeypatch, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    discovery_calls = []
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.plugins",
+        types.SimpleNamespace(
+            discover_plugins=lambda: discovery_calls.append("plugins")
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod._prepare_agent_startup(_args())
+
+    assert exc_info.value.code == 2
+    assert discovery_calls == []
+
+
+@pytest.mark.parametrize(
+    "content", [None, "", "{}\n", "model:\n  default: local/test\n"]
+)
+def test_noninteractive_guard_accepts_missing_empty_and_mapping_configs(
+    content, tmp_path
+):
+    from hermes_cli import main as main_mod
+
+    if content is not None:
+        (tmp_path / "config.yaml").write_text(content, encoding="utf-8")
+    args = _args()
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+
+
+def test_noninteractive_guard_rejects_non_mapping_yaml(tmp_path, capsys):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("- model\n- provider\n")
+
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod._guard_noninteractive_user_config(_args())
+
+    assert exc_info.value.code == 2
+    assert "top-level YAML value must be a mapping" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "args",
+    [
+        _args(ignore_user_config=True),
+        _args(safe_mode=True),
+    ],
+    ids=["ignore-user-config", "safe-mode"],
+)
+def test_explicit_config_bypasses_allow_noninteractive_recovery(args, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    args = _args(query=None)
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert not hasattr(args, "_noninteractive_config_validated")
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_ignore_user_config_is_applied_before_oneshot_startup(monkeypatch):
+    from hermes_cli import main as main_mod
+
+    monkeypatch.delenv("HERMES_IGNORE_USER_CONFIG", raising=False)
+
+    main_mod._apply_user_config_bypass(_args(ignore_user_config=True))
+
+    assert os.environ["HERMES_IGNORE_USER_CONFIG"] == "1"

--- a/tests/hermes_cli/test_noninteractive_config_guard.py
+++ b/tests/hermes_cli/test_noninteractive_config_guard.py
@@ -146,6 +146,47 @@ def test_interactive_chat_keeps_existing_repair_behavior(tmp_path):
     assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
 
 
+def test_empty_query_keeps_interactive_repair_behavior(tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    args = _args(query="")
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert not hasattr(args, "_noninteractive_config_validated")
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_env_only_config_bypass_allows_noninteractive_recovery(monkeypatch, tmp_path):
+    from hermes_cli import main as main_mod
+
+    (tmp_path / "config.yaml").write_text("model: [unterminated\n")
+    monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+    args = _args()
+
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+    assert list(tmp_path.glob("config.yaml.corrupt.*.bak")) == []
+
+
+def test_reused_args_can_retry_after_config_repair(tmp_path):
+    from hermes_cli import main as main_mod
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("model: [unterminated\n")
+    args = _args()
+
+    with pytest.raises(SystemExit):
+        main_mod._guard_noninteractive_user_config(args)
+
+    config_path.write_text("model:\n  default: local/test\n")
+    main_mod._guard_noninteractive_user_config(args)
+
+    assert args._noninteractive_config_validated is True
+
+
 def test_ignore_user_config_is_applied_before_oneshot_startup(monkeypatch):
     from hermes_cli import main as main_mod
 


### PR DESCRIPTION
Salvage of #81988 by @embwl0x — corrupt-config **fail-closed** for non-interactive runs, extended to every headless surface.

Fixes #81952 (partial — the fail-closed half; interactive recovery UX unchanged).

## What this does

When a profile's `config.yaml` fails to parse, non-interactive runs used to silently continue on `DEFAULT_CONFIG`; provider auto-detection (tier-3 env sniff in `hermes_cli/auth.py::resolve_provider`) then adopts `OPENROUTER_API_KEY` from `.env` and the run bills real money to a provider the config never named. Per Teknium's ruling on #81952: corrupt config must **fail closed** in non-interactive runs with an ERROR naming the corrupt file and the fix.

### Salvaged from #81988 (@embwl0x, all 3 commits cherry-picked with authorship preserved)

- `hermes_cli/config.py::require_parseable_user_config()` + `InvalidUserConfigError` — missing/empty config stays a valid first-run state; corrupt file is backed up to a timestamped `.bak`, ERROR logged, error names the file and the fix.
- `_guard_noninteractive_user_config` wired into `cmd_chat` and `_prepare_agent_startup` — covers `-Q <query>` and `-z` oneshot; exit 2. Quiet interactive prompts stay interactive (commit 3).
- `tests/hermes_cli/test_noninteractive_config_guard.py` (205 lines).

### Our follow-up (extension to remaining non-interactive surfaces)

| Surface | Guard | Behavior on corrupt config |
|---|---|---|
| `hermes chat -Q` / `-z` oneshot | salvaged #81988 | exit 2 + ERROR |
| gateway (`gateway/run.py::main()`) | new `_guard_corrupt_user_config()` before any config-dependent startup | exit 2 + ERROR |
| `hermes serve` (headless path in `cmd_dashboard`) | same guard, gated on `headless_backend` | exit 2 + ERROR |
| cron in-process fires (`cron/scheduler.py::run_job`) | guard before AIAgent construction; `no_agent` script jobs exempt (no token spend) | job fails with the guard error, no agent constructed |
| cron → subprocess `hermes chat -Q --query-file` (bot-chat delivery path, scheduler.py:2688) | covered transitively by the CLI guard | subprocess exits 2 |
| interactive `hermes chat` (tty, no -Q/-z) | **not guarded** — keeps existing recovery/repair behavior | unchanged |

Escape hatch `--ignore-user-config` / `HERMES_IGNORE_USER_CONFIG=1` honored on every surface.

**Live repro:** real CLI + temp `HERMES_HOME` with `model: [unterminated` config.yaml and `OPENROUTER_API_KEY=sk-or-FAKE…` in `.env` — before (origin/main 29d4c0ebfd): `hermes chat -Q -q hi` proceeded past config load ("Falling back to default config"), `resolve_provider('auto')` returned `openrouter`, and the run reached a real API call (HTTP 401 on the fake key = money would have been spent with a real key); after (this branch): same command exits 2 with "Refusing non-interactive startup because …/config.yaml is invalid … Repair the file or pass --ignore-user-config". Gateway A/B: `_guard_corrupt_user_config()` exits 2 on the corrupt home, passes with `HERMES_IGNORE_USER_CONFIG=1`.

## Tests

- `tests/hermes_cli/test_noninteractive_config_guard.py` + new `tests/hermes_cli/test_config_guard_surfaces.py` (gateway/serve/cron): **27 passed**.
- Regression sweep `tests/hermes_cli/test_config*.py`: **197 passed, 4 skipped**.

Credit: @embwl0x — commits cherry-picked with original authorship; contributor mapping already present in `contributors/emails/`.

⚠️ Do not merge without Teknium's explicit approval.

## Infographic

![corrupt-config-fail-closed](https://v3b.fal.media/files/b/0aa8a8b2/OagrdnQte-ZFs3uOMMIYE_PlgFZ9lh.png)
