### PR TITLE
fix(streaming): require terminal evidence for tool calls (salvage #95404)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4551,8 +4551,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 "(possible upstream error or malformed SSE response)."
             )
 
-        # A stream that delivered a tool call but only partial/unparseable
-        # JSON args splits into two very different cases:
+        # A stream that delivered a tool call without an explicit finish
+        # marker is not executable, even if its JSON parses or can be repaired.
+        # Iterator EOF proves only that transport consumption stopped; it does
+        # not authorize the tool-call boundary. The two terminal cases are:
         #
         #   1. Provider sent finish_reason="length" → a genuine output-cap
         #      truncation.  Boosting max_tokens on retry is the right move.
@@ -4570,17 +4572,19 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         #      due to output length limit" — the red herring this guards
         #      against.  Route it through the partial-stream-stub path
         #      instead so the loop reports an honest mid-tool-call stream
-        #      drop and fails fast rather than escalating output budget.
-        _tool_args_dropped_no_finish = has_truncated_tool_args and finish_reason is None
-        if _tool_args_dropped_no_finish:
+        #      drop and fails fast rather than escalating output budget. This
+        #      also covers complete-looking JSON: payload validity is not
+        #      terminal evidence or permission to execute.
+        _tool_call_dropped_no_finish = bool(tool_calls_acc) and finish_reason is None
+        if _tool_call_dropped_no_finish:
             _dropped_names = [
                 (tool_calls_acc[idx]["function"]["name"] or "?")
                 for idx in sorted(tool_calls_acc)
             ]
             logger.warning(
-                "Stream ended with no finish_reason while a tool call's "
-                "arguments were still incomplete (tools=%s); treating as a "
-                "mid-tool-call stream drop, not an output-length truncation.",
+                "Stream ended with no finish_reason after delivering tool-call "
+                "payload (tools=%s); treating as a mid-tool-call stream drop, "
+                "not permission to execute or an output-length truncation.",
                 _dropped_names,
             )
             return _build_partial_stream_stub(

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -207,6 +207,85 @@ class TestCleanStreamEndBeforeAnyToolArgs:
         assert getattr(response, "_dropped_tool_names", None) == ["write_file"]
 
 
+# ── Complete-looking payload without terminal evidence ────────────────────
+
+class TestToolCallsRequireTerminalEvidence:
+    """Valid JSON and iterator EOF do not authorize tool execution."""
+
+    @pytest.mark.parametrize(
+        "arguments",
+        [
+            '{"confirm":true}',
+            '{"confirm":true,}',
+        ],
+        ids=["valid-json", "repairable-json"],
+    )
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_tool_payload_without_finish_reason_routes_to_stub(
+        self, _mock_close, mock_create, monkeypatch, arguments,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _unterminated_stream():
+            yield _make_stream_chunk(tool_calls=[
+                _make_tool_call_delta(
+                    index=0,
+                    tc_id="call_unterminated",
+                    name="dangerous_tool",
+                    arguments=arguments,
+                ),
+            ])
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _unterminated_stream()
+        )
+        mock_create.return_value = mock_client
+
+        response = _make_agent()._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.tool_calls is None
+        assert response._dropped_tool_names == ["dangerous_tool"]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_explicit_tool_calls_terminal_preserves_payload(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _complete_stream():
+            yield _make_stream_chunk(
+                tool_calls=[
+                    _make_tool_call_delta(
+                        index=0,
+                        tc_id="call_complete",
+                        name="read_file",
+                        arguments='{"path":"README.md"}',
+                    ),
+                ],
+                finish_reason="tool_calls",
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _complete_stream()
+        )
+        mock_create.return_value = mock_client
+
+        response = _make_agent()._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "tool_calls"
+        tool_calls = response.choices[0].message.tool_calls
+        assert len(tool_calls) == 1
+        assert tool_calls[0].function.name == "read_file"
+        assert tool_calls[0].function.arguments == '{"path":"README.md"}'
+
+
 # ── Mixed response: one complete call, one dropped (#80498) ─────────────────
 
 class TestMixedToolCallsOneDroppedOneComplete:


### PR DESCRIPTION
## Summary

Salvage of #95404 by @YusenZhang0601 onto current main (authorship preserved via cherry-pick).

A streamed tool call whose provider iterator ends **without any `finish_reason`** is no longer executed. Previously, valid or repairable JSON arguments fell through `finish_reason or "stop"` and ran as a normal tool call even though the stream never terminally authorized it; only truncated/unparseable payloads were routed to the partial-stream recovery path.

This extends the codebase's established contract — "no finish_reason = the stream did not terminate normally" — already applied by the text-only drop guard (#32086) and the incomplete-JSON/empty-args guards (#42314, #80498) — to the one remaining case (complete-looking payload).

## Changes
- `agent/chat_completion_helpers.py`: any accumulated tool call without terminal evidence routes to the existing partial-stream stub; explicit `finish_reason="tool_calls"` preserves the payload.
- `tests/run_agent/test_partial_stream_finish_reason.py`: regression coverage for valid JSON, repairable JSON, and the explicit `tool_calls` terminal case.

## Validation
| | Before | After |
|---|---|---|
| valid-JSON tool call, stream drops before finish_reason | executes as `"stop"` | stubbed → recovery/retry |
| `finish_reason="tool_calls"` | executes | executes (unchanged) |
| tests | — | 20/20 pass |

False-positive cost for providers/proxies that legitimately omit finish_reason is bounded: one wasted retry (the model re-emits the call). Cherry-pick lands on top of `normalize_finish_reason` (e1df4c9553) without clobbering it — the guard checks `is None`, which normalization never affects.

Closes #95404
