### PR TITLE
fix(cron): surface delivery_failed instead of last_status ok

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3010,7 +3010,13 @@ def _mark_job_run_locked(
     ``delivery_error`` is tracked separately from the agent error — a job
     can succeed (agent produced output) but fail delivery (platform down).
 
-    ``status`` overrides the derived ``last_status`` ("ok"/"error") with a
+    A run that succeeded but failed delivery records
+    ``last_status = "delivery_failed"`` (never "ok") so the failure is
+    visible to every reader, while ``failure_streak`` stays untouched —
+    the agent did its job.
+
+    ``status`` overrides the derived ``last_status`` ("ok"/"error"/
+    "delivery_failed") with a
     specific terminal status for this run — e.g. ``"blocked_config"`` when
     the pre-dispatch configuration validation refused to run the agent
     (T1-26), so `cronjob list` distinguishes "your config is broken" from
@@ -3035,7 +3041,21 @@ def _mark_job_run_locked(
                 # The transient manual-run context is single-fire: whatever
                 # run just completed consumed it (or superseded it).
                 job.pop("manual_run_prompt", None)
-                job["last_status"] = status or ("ok" if success else "error")
+                # A run whose agent succeeded but whose delivery failed is NOT
+                # "ok": recording it as such hid last_delivery_error behind a
+                # green status in `cron list`/the UI and made a job that never
+                # reached the user look like a quiet success (#83993). It gets
+                # its own status so every reader that keys off "ok" (CLI list,
+                # doctor, cronjob_tools) sees the failure. An explicit
+                # ``status`` override (e.g. "blocked_config") still wins.
+                if status:
+                    job["last_status"] = status
+                elif not success:
+                    job["last_status"] = "error"
+                elif isinstance(delivery_error, str) and delivery_error.strip():
+                    job["last_status"] = "delivery_failed"
+                else:
+                    job["last_status"] = "ok"
                 job["last_error"] = error if not success else None
                 # A healthy run means the configuration validates again — drop
                 # the preflight alert-dedup marker so a FUTURE config break

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -217,6 +217,12 @@ def cron_list(show_all: bool = False):
             last_run = job.get("last_run_at", "?")
             if last_status == "ok":
                 status_display = color("ok", Colors.GREEN)
+            elif last_status == "delivery_failed":
+                # The agent succeeded but the result never reached the user —
+                # not green, and the detail lives in last_delivery_error
+                # (last_error is None for these runs).
+                detail = job.get("last_delivery_error") or "?"
+                status_display = color(f"delivery_failed: {detail}", Colors.YELLOW)
             else:
                 status_display = color(f"{last_status}: {job.get('last_error', '?')}", Colors.RED)
                 streak = int(job.get("failure_streak") or 0)
@@ -612,7 +618,10 @@ def _cron_doctor_issues_for_job(job: Dict[str, Any]) -> List[str]:
     issues: List[str] = []
 
     last_status = str(job.get("last_status") or "").strip().lower()
-    if last_status and last_status != "ok":
+    # "delivery_failed" means the agent run itself succeeded, so it is not a
+    # failed last run — the dedicated delivery issue below reports it (and
+    # last_error is None, which would render as "unknown error" here).
+    if last_status and last_status not in {"ok", "delivery_failed"}:
         err = str(job.get("last_error") or "unknown error").strip()
         issues.append(f"last run failed: {err}")
 

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -645,6 +645,8 @@ class TestMarkJobRun:
         assert updated is not None
         assert updated["state"] == "completed"
         assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        # A terminal completion that never reached the user is not a success.
+        assert updated["last_status"] == "delivery_failed"
 
     def test_completed_oneshot_visible_in_list(self, tmp_cron_dir):
         """list_jobs(include_disabled=True) surfaces the completed record."""
@@ -654,6 +656,7 @@ class TestMarkJobRun:
         assert job["id"] in listed
         assert listed[job["id"]]["state"] == "completed"
         assert listed[job["id"]]["last_delivery_error"] == "send failed: 502"
+        assert listed[job["id"]]["last_status"] == "delivery_failed"
         # Default (enabled-only) listing hides it, matching paused/disabled jobs.
         assert job["id"] not in {j["id"] for j in list_jobs()}
 
@@ -672,13 +675,53 @@ class TestMarkJobRun:
         assert updated["last_error"] == "timeout"
 
     def test_delivery_error_tracked_separately(self, tmp_cron_dir):
-        """Agent succeeds but delivery fails — both tracked independently."""
+        """Agent succeeds but delivery fails — surfaced, not hidden behind ok.
+
+        Regression guard for #83993: recording ``last_status="ok"`` made a run
+        the user never received look like a quiet success everywhere that keys
+        off "ok". The agent error stays independent of the delivery error, and
+        the delivery failure is not an agent failure (no streak).
+        """
         job = create_job(prompt="Report", schedule="every 1h")
-        mark_job_run(job["id"], success=True, delivery_error="platform 'telegram' not configured")
+        mark_job_run(job["id"], success=True, delivery_error="send failed: 502")
         updated = get_job(job["id"])
-        assert updated["last_status"] == "ok"
+        assert updated["last_status"] == "delivery_failed"
         assert updated["last_error"] is None
-        assert updated["last_delivery_error"] == "platform 'telegram' not configured"
+        assert updated["last_delivery_error"] == "send failed: 502"
+        assert updated["failure_streak"] == 0
+
+    def test_success_without_delivery_error_stays_ok(self, tmp_cron_dir):
+        """A fully successful run is still plain "ok"."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(job["id"], success=True)
+        assert get_job(job["id"])["last_status"] == "ok"
+        # An empty delivery error is no error at all.
+        mark_job_run(job["id"], success=True, delivery_error="")
+        assert get_job(job["id"])["last_status"] == "ok"
+
+    def test_agent_failure_still_error_with_delivery_error(self, tmp_cron_dir):
+        """An agent failure outranks delivery: still "error", still a streak."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=False, error="timeout",
+            delivery_error="send failed: 502",
+        )
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "error"
+        assert updated["last_error"] == "timeout"
+        assert updated["failure_streak"] == 1
+
+    def test_explicit_status_override_wins_over_delivery_failed(self, tmp_cron_dir):
+        """An explicit terminal status (T1-26 blocked_config) still wins."""
+        job = create_job(prompt="Report", schedule="every 1h")
+        mark_job_run(
+            job["id"], success=True,
+            delivery_error="send failed: 502",
+            status="blocked_config",
+        )
+        updated = get_job(job["id"])
+        assert updated["last_status"] == "blocked_config"
+        assert updated["last_delivery_error"] == "send failed: 502"
 
     def test_failure_streak_increments_and_resets(self, tmp_cron_dir):
         """failure_streak counts consecutive agent failures; success resets."""

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -160,6 +160,28 @@ class TestCronDoctor:
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
 
+    def test_doctor_reports_delivery_failure_once(self, tmp_cron_dir, capsys):
+        """A delivery_failed run is a delivery issue, not a failed agent run.
+
+        The agent succeeded (last_error is None), so the generic last-run-failed
+        line would only ever say "unknown error" — double-reporting the same
+        incident (#83993).
+        """
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_status"] = "delivery_failed"
+        jobs[0]["last_error"] = None
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        rc = cron_command(Namespace(cron_command="doctor"))
+
+        out = capsys.readouterr().out
+        assert rc == 1
+        assert "last delivery failed: telegram timeout" in out
+        assert "last run failed" not in out
+        assert "unknown error" not in out
+
     def test_doctor_flags_overdue_next_run(self, tmp_cron_dir, capsys):
         from datetime import datetime, timedelta, timezone
 
@@ -191,6 +213,48 @@ class TestCronDoctor:
         out = capsys.readouterr().out
         assert rc == 0
         assert "✓ Cron doctor found no issues" in out
+
+
+class TestCronListStatusRendering:
+    """`cron list` must never paint an undelivered run as a success (#83993)."""
+
+    def test_delivery_failed_is_not_green_ok(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1])
+        # capsys is not a tty, so force colors on to check the paint itself.
+        monkeypatch.setattr("hermes_cli.colors.should_use_color", lambda: True)
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T09:00:00+00:00"
+        jobs[0]["last_status"] = "delivery_failed"
+        jobs[0]["last_error"] = None
+        jobs[0]["last_delivery_error"] = "telegram timeout"
+        save_jobs(jobs)
+
+        cron_command(Namespace(cron_command="list", all=True))
+
+        out = capsys.readouterr().out
+        last_run_line = next(l for l in out.splitlines() if "Last run:" in l)
+        assert "delivery_failed" in last_run_line
+        assert "telegram timeout" in last_run_line, (
+            "the delivery detail lives in last_delivery_error, not last_error"
+        )
+        assert cron_cli.Colors.GREEN not in last_run_line
+
+    def test_ok_run_still_green(self, tmp_cron_dir, capsys, monkeypatch):
+        monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [1])
+        monkeypatch.setattr("hermes_cli.colors.should_use_color", lambda: True)
+        create_job(prompt="Daily digest", schedule="every 1h")
+        jobs = load_jobs()
+        jobs[0]["last_run_at"] = "2026-09-01T09:00:00+00:00"
+        jobs[0]["last_status"] = "ok"
+        save_jobs(jobs)
+
+        cron_command(Namespace(cron_command="list", all=True))
+
+        out = capsys.readouterr().out
+        last_run_line = next(l for l in out.splitlines() if "Last run:" in l)
+        assert f"{cron_cli.Colors.GREEN}ok" in last_run_line
+        assert "delivery_failed" not in last_run_line
 
 
 class TestGatewayNotRunningWarning:


### PR DESCRIPTION
## Summary

When a cron job's agent run succeeded but delivery failed, `_mark_job_run_locked` still persisted `last_status: ok` and buried the failure in `last_delivery_error`. `hermes cron list` painted that as green. It looked identical to a quiet success.

This records `last_status: delivery_failed` instead, keeps `last_delivery_error`, and does not increment `failure_streak` (the agent did its job). Explicit `status=` overrides still win.

CLI list shows `delivery_failed` in yellow with the delivery error. `hermes cron doctor` still reports the delivery issue and no longer double-reports it as `last run failed: unknown error`.

Does not change the live-adapter send path or the scheduler.

## Test plan

- [x] `scripts/run_tests.sh tests/cron/test_jobs.py tests/hermes_cli/test_cron.py` — 134 passed
- [x] Sabotage: restore `last_status = status or ("ok" if success else "error")`; the three new/updated delivery-status assertions fail (`ok` vs `delivery_failed`); restore the fix and they pass
- [ ] CI on this PR

## Platforms

Linux (tested). Status field is platform-agnostic (CLI/cron store).

Fixes #83993
