### PR TITLE
fix(memory): surface discovery/load errors instead of silent empty list (#98920)

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -206,10 +206,14 @@ def _get_available_providers() -> list:
 
     Returns list of (name, description, provider_instance) tuples.
     """
+    import logging
+    _logger = logging.getLogger(__name__)
     try:
         from plugins.memory import discover_memory_providers, load_memory_provider
         raw = discover_memory_providers()
-    except Exception:
+    except Exception as e:
+        _logger.warning("memory provider discovery failed: %s", e, exc_info=True)
+        print(f"\n  Warning: memory provider discovery failed: {e}", file=sys.stderr)
         raw = []
 
     results = []
@@ -217,8 +221,11 @@ def _get_available_providers() -> list:
         try:
             provider = load_memory_provider(name)
             if not provider:
+                _logger.debug("memory provider %r returned None, skipping", name)
                 continue
-        except Exception:
+        except Exception as e:
+            _logger.warning("memory provider %r failed to load: %s", name, e, exc_info=True)
+            print(f"  Warning: memory provider '{name}' failed to load: {e}", file=sys.stderr)
             continue
 
         schema = provider.get_config_schema() if hasattr(provider, "get_config_schema") else []


### PR DESCRIPTION
Fixes #98920

**Problem:** `_get_available_providers()` in `hermes_cli/memory_setup.py:209-222` collapsed every failure into `[]` via bare `except Exception: raw=[]` / `continue`. The caller then reports "No memory provider plugins detected. Install a plugin to ~/.hermes/plugins/" — wrong for broken imports, missing deps, or any provider that fails to load, and the real exception is never logged.

**Fix:** Capture the exception, log via `logger.warning(..., exc_info=True)` and print a `Warning: ... failed: <error>` to stderr so the user sees the real cause. Covers both discovery failure and per-provider load failure. No behavior change when discovery genuinely finds zero providers.

**Tests:** Verified with mocked failures: `discover_memory_providers` raising and `load_memory_provider` raising now emit warnings and return `[]` instead of silently returning `[]`. `py_compile` and import checks pass.

Closes #98920