### PR TITLE
fix(gateway): skip loop tick socket on Windows without warning traceback (#99895)

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -535,50 +535,57 @@ async def loop_heartbeat_forever(
     # #90502 incident environment — is Linux and arms the socket normally.)
     tick_server = None
     tick_socket_path = None
-    try:
-        tick_socket_path = get_loop_tick_socket_path(home)
-        tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
-        # Re-bind over a leftover node from a dead process (os._exit(75) /
-        # SIGKILL skip the finally-unlink; PID reuse re-lands on this
-        # PID-suffixed path) is handled by asyncio itself:
-        # create_unix_server os.remove()s an existing socket node before
-        # binding — guarded by test_producer_rebinds_over_stale_socket_node.
-        # What asyncio does NOT do is clean up SIBLING nodes from other
-        # dead PIDs, so sweep those to keep state/ from accumulating
-        # gateway.loop-tick.*.sock nodes across crash-restart cycles.
-        # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
-        # Windows os.kill calls TerminateProcess for non-CTRL signals —
-        # and AF_UNIX server nodes are never created there anyway.
-        if os.name == "posix":
-            try:
-                for _stale in tick_socket_path.parent.glob(
-                    "gateway.loop-tick.*.sock"
-                ):
-                    if _stale == tick_socket_path:
-                        continue
-                    try:
-                        _stale_pid = int(_stale.name.split(".")[-2])
-                    except (ValueError, IndexError):
-                        _stale.unlink(missing_ok=True)
-                        continue
-                    try:
-                        os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
-                    except OSError:
-                        _stale.unlink(missing_ok=True)
-            except Exception:
-                logger.debug(
-                    "stale loop-tick socket sweep failed", exc_info=True
-                )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
-    except Exception:
-        tick_server = None
-        logger.warning(
-            "Loop tick socket unavailable — liveness probes will have no "
-            "loop-scheduling witness and will not escalate on a stale heartbeat",
-            exc_info=True,
-        )
+    # Windows has no AF_UNIX / start_unix_server — skip the witness
+    # entirely without raising or logging a warning traceback. The payload
+    # will record loop_tick_socket=False (fail-safe: stale file never
+    # escalates to WEDGED on Windows).
+    if not hasattr(asyncio, "start_unix_server"):
+        logger.debug("Loop tick socket unavailable on this platform — witness disabled")
+    else:
+        try:
+            tick_socket_path = get_loop_tick_socket_path(home)
+            tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
+            # Re-bind over a leftover node from a dead process (os._exit(75) /
+            # SIGKILL skip the finally-unlink; PID reuse re-lands on this
+            # PID-suffixed path) is handled by asyncio itself:
+            # create_unix_server os.remove()s an existing socket node before
+            # binding — guarded by test_producer_rebinds_over_stale_socket_node.
+            # What asyncio does NOT do is clean up SIBLING nodes from other
+            # dead PIDs, so sweep those to keep state/ from accumulating
+            # gateway.loop-tick.*.sock nodes across crash-restart cycles.
+            # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
+            # Windows os.kill calls TerminateProcess for non-CTRL signals —
+            # and AF_UNIX server nodes are never created there anyway.
+            if os.name == "posix":
+                try:
+                    for _stale in tick_socket_path.parent.glob(
+                        "gateway.loop-tick.*.sock"
+                    ):
+                        if _stale == tick_socket_path:
+                            continue
+                        try:
+                            _stale_pid = int(_stale.name.split(".")[-2])
+                        except (ValueError, IndexError):
+                            _stale.unlink(missing_ok=True)
+                            continue
+                        try:
+                            os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
+                        except OSError:
+                            _stale.unlink(missing_ok=True)
+                except Exception:
+                    logger.debug(
+                        "stale loop-tick socket sweep failed", exc_info=True
+                    )
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        except Exception:
+            tick_server = None
+            logger.warning(
+                "Loop tick socket unavailable — liveness probes will have no "
+                "loop-scheduling witness and will not escalate on a stale heartbeat",
+                exc_info=True,
+            )
 
     async def _write_off_loop() -> None:
         # write_loop_heartbeat never raises, so a failure here is an executor


### PR DESCRIPTION
Fixes #99895

**Problem:** On native Windows `asyncio.start_unix_server` does not exist. `loop_heartbeat_forever` already caught the `AttributeError` via `except Exception` and fell back to witness-disabled mode, but it logged a WARNING with `exc_info=True` — surfacing as a traceback that looks like a crash and repeats on every gateway startup.

**Fix:** Early-exit with `if not hasattr(asyncio, "start_unix_server"): logger.debug(...)` before attempting the bind. Same fail-safe semantics (`loop_tick_socket=False`, probes never escalate to WEDGED on Windows, graceful-drain backstop preserved), no warning noise.

**Tests:** `pytest tests/gateway/test_loop_liveness_watchdog.py` — 11 passed. Import and py_compile pass.

Closes #99895