### PR TITLE
fix(kanban): enforce profile task contracts

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2937,6 +2937,7 @@ DEFAULT_CONFIG = {
         "done_sub_retention_days": 30,
     },
 
+
     # Bot Mode cross-connection relay (tools/bot_relay.py). Envelopes queued
     # by message_agent for agents on other connections wait in an on-disk
     # outbox until the Desktop drains them.
@@ -2953,6 +2954,53 @@ DEFAULT_CONFIG = {
         # 'target_busy' error. Deliveries are serialized per profile with a
         # cross-process file lock so two turns never race one Bot Chat.
         "turn_wait_seconds": 120,
+    },
+
+    # Cross-profile task/capability contract. This is intentionally inert by
+    # default. BAU recurring runs are not Plane/project state by default; they
+    # should rely on runtime receipts, logs, monitors, and readbacks, escalating
+    # to Plane only for material anomalies, incidents, change requests, project
+    # blockers, or owner planning decisions. Step-by-step build/test pipelines
+    # must preserve exact unredacted intermediate artifacts/readbacks as the
+    # local evidence source of truth; redaction is presentation-only and is not
+    # authoritative for schema, identifiers, byte equality, hashes, or downstream
+    # execution.
+    "profile_contract": {
+        "enforce_kanban_route_compatibility": False,
+        "route_required_for_task_tools": False,
+        "fallback_policy": "deny",
+        "capabilities": [],
+        "allowed_actions": [],
+        "forbidden_actions": [],
+        "required_evidence": [],
+        "safety_acceptance": [],
+        "outcome_acceptance": [],
+        "recoverable_conditions": [],
+        "hard_stop_conditions": [],
+        "plane_for_bau_process_tracking": False,
+        "preserve_unredacted_step_artifacts": True,
+        "redaction_layer": "presentation_only",
+        "evidence_hierarchy": [
+            "exact_external_readback_or_raw_source",
+            "unredacted_step_artifact_or_readback",
+            "executable_test_result",
+            "cryptographic_hash_or_signed_receipt",
+            "structured_machine_receipt",
+            "unsanitized_artifact",
+            "sanitized_display_presentation_only",
+            "worker_summary",
+            "conversational_claim",
+        ],
+        "status_fields": {
+            "prepared": None,
+            "implemented": None,
+            "verified": None,
+            "reviewed": None,
+            "ci_pr_merge_observed": None,
+            "production_executed": None,
+            "business_outcome": None,
+            "gaps": [],
+        },
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -78,6 +78,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "max_retries": t.max_retries,
         "model_override": t.model_override,
         "provider_override": t.provider_override,
+        "task_contract": t.task_contract,
         "session_id": t.session_id,
         "workflow_template_id": t.workflow_template_id,
         "current_step_key": t.current_step_key,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,7 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import copy
 import hashlib
 import json
 import os
@@ -133,6 +134,108 @@ VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 # not dispatcher spawn/crash/timeout failures.
 BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+
+TASK_CONTRACT_LIST_FIELDS = frozenset({
+    "required_capabilities",
+    "allowed_actions",
+    "forbidden_actions",
+    "required_evidence",
+    "safety_acceptance",
+    "outcome_acceptance",
+    "recoverable_conditions",
+    "hard_stop_conditions",
+    "evidence_hierarchy",
+})
+TASK_CONTRACT_STATUS_FIELDS = frozenset({
+    "prepared",
+    "implemented",
+    "verified",
+    "reviewed",
+    "ci_pr_merge_observed",
+    "production_executed",
+    "business_outcome",
+    "gaps",
+})
+TASK_CONTRACT_FIELDS = TASK_CONTRACT_LIST_FIELDS | frozenset({
+    "safety_acceptance",
+    "outcome_acceptance",
+    "plane_for_bau_process_tracking",
+    "status_fields",
+})
+
+
+def _unique_string_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, Mapping)):
+        values = list(value)
+    else:
+        values = [value]
+    out: list[str] = []
+    seen: set[str] = set()
+    for item in values:
+        text = str(item).strip()
+        if not text or text in seen:
+            continue
+        seen.add(text)
+        out.append(text)
+    return out
+
+
+def normalize_task_contract(contract: Optional[Mapping[str, Any]]) -> Optional[dict[str, Any]]:
+    """Return the stored per-task capability/acceptance manifest.
+
+    The manifest is additive and inert unless an assigned profile opts into
+    ``profile_contract.enforce_kanban_route_compatibility``.  Every field the
+    cross-project reliability contract needs is explicit so a reviewer can see
+    the task's capabilities, permitted/forbidden actions, evidence standard,
+    safety/outcome acceptance, BAU Plane boundary, and separated status lanes
+    without inferring them from prose.
+    """
+    if contract is None:
+        return None
+    if not isinstance(contract, Mapping):
+        raise ValueError("task_contract must be an object/dict")
+    normalized: dict[str, Any] = {}
+    for field in TASK_CONTRACT_LIST_FIELDS:
+        normalized[field] = _unique_string_list(contract.get(field))
+    normalized["plane_for_bau_process_tracking"] = bool(
+        contract.get("plane_for_bau_process_tracking", False)
+    )
+    raw_status = contract.get("status_fields")
+    if raw_status is not None and not isinstance(raw_status, Mapping):
+        raise ValueError("task_contract.status_fields must be an object/dict")
+    status_fields: dict[str, Any] = {}
+    raw_status_map = raw_status if isinstance(raw_status, Mapping) else {}
+    for field in TASK_CONTRACT_STATUS_FIELDS:
+        value = raw_status_map.get(field)
+        if field == "gaps":
+            value = _unique_string_list(value)
+        status_fields[field] = value
+    normalized["status_fields"] = status_fields
+    # Preserve any future extension keys as JSON-compatible values, but never
+    # let them replace the canonical P0 fields above.
+    for key, value in contract.items():
+        if key not in normalized:
+            normalized[str(key)] = value
+    return normalized
+
+
+def _parse_task_contract_blob(value: Optional[str]) -> Optional[dict[str, Any]]:
+    if not value:
+        return None
+    try:
+        parsed = json.loads(value)
+    except Exception:
+        return None
+    if not isinstance(parsed, Mapping):
+        return None
+    try:
+        return normalize_task_contract(parsed)
+    except ValueError:
+        return dict(parsed)
 
 
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
@@ -1141,6 +1244,10 @@ class Task:
     # Unblock-loop counter. See the column comment in SCHEMA_SQL and
     # ``BLOCK_RECURRENCE_LIMIT``. Reset only on successful completion.
     block_recurrences: int = 0
+    # Optional per-task capability/acceptance manifest.  Stored as JSON in the
+    # tasks table; ignored by legacy profiles and enforced only when the
+    # assigned profile opts into route-compatibility checks.
+    task_contract: Optional[dict[str, Any]] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -1234,6 +1341,10 @@ class Task:
                 int(row["block_recurrences"])
                 if "block_recurrences" in keys and row["block_recurrences"] is not None
                 else 0
+            ),
+            task_contract=(
+                _parse_task_contract_blob(row["task_contract"])
+                if "task_contract" in keys else None
             ),
         )
 
@@ -1422,7 +1533,12 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``blocked`` so a cron can't spin it forever. Reset to 0 only on a
     -- successful completion — NOT on unblock (resetting on unblock is exactly
     -- the amnesia that let the loop run unbounded).
-    block_recurrences    INTEGER NOT NULL DEFAULT 0
+    block_recurrences    INTEGER NOT NULL DEFAULT 0,
+    -- Optional per-task capability/acceptance manifest, stored as JSON.  The
+    -- dispatcher ignores it unless the assignee profile explicitly enables
+    -- profile_contract.enforce_kanban_route_compatibility, preserving legacy
+    -- board behavior while making P0 reliability contracts machine-readable.
+    task_contract        TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -2689,6 +2805,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
         )
+    if "task_contract" not in cols:
+        # Optional per-task route/capability/acceptance manifest. NULL keeps
+        # legacy rows inert; enforcement is additionally gated by the assignee
+        # profile's config.
+        _add_column_if_missing(conn, "tasks", "task_contract", "task_contract TEXT")
 
     # Indexes over additive ``tasks`` columns must be created after the
     # columns exist. Keeping them in SCHEMA_SQL breaks legacy boards: SQLite
@@ -3194,6 +3315,7 @@ def create_task(
     board: Optional[str] = None,
     project_id: Optional[str] = None,
     project_source_task_id: Optional[str] = None,
+    task_contract: Optional[Mapping[str, Any]] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -3237,6 +3359,7 @@ def create_task(
     model_override = (model_override or "").strip() or None
     provider_override = (provider_override or "").strip() or None
     reasoning_effort = normalize_reasoning_effort(reasoning_effort)
+    normalized_task_contract = normalize_task_contract(task_contract)
     if provider_override and not model_override:
         raise ValueError("provider_override requires a model_override")
     assignee = _canonical_assignee(assignee)
@@ -3508,8 +3631,8 @@ def create_task(
                         max_runtime_seconds,
                         skills, max_retries, model_override, provider_override,
                         reasoning_effort,
-                        goal_mode, goal_max_turns, session_id
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        goal_mode, goal_max_turns, session_id, task_contract
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -3535,6 +3658,10 @@ def create_task(
                         1 if goal_mode else 0,
                         int(goal_max_turns) if goal_max_turns is not None else None,
                         session_id,
+                        (
+                            json.dumps(normalized_task_contract, sort_keys=True)
+                            if normalized_task_contract is not None else None
+                        ),
                     ),
                 )
                 for pid in parents:
@@ -3563,6 +3690,7 @@ def create_task(
                         "goal_mode": bool(goal_mode) or None,
                         "model_override": model_override,
                         "provider_override": provider_override,
+                        "task_contract": normalized_task_contract,
                     },
                 )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
@@ -4623,6 +4751,121 @@ def _parents_satisfied(conn: sqlite3.Connection, task_id: str) -> bool:
         "AND p.status NOT IN ('done', 'archived') LIMIT 1",
         (task_id,),
     ).fetchone() is None
+
+
+def _deep_merge_dict(base: dict[str, Any], overlay: Mapping[str, Any]) -> dict[str, Any]:
+    merged = copy.deepcopy(base)
+    for key, value in overlay.items():
+        if isinstance(value, Mapping) and isinstance(merged.get(key), dict):
+            merged[key] = _deep_merge_dict(merged[key], value)
+        else:
+            merged[key] = copy.deepcopy(value)
+    return merged
+
+
+def _profile_contract_config(assignee: Optional[str]) -> dict[str, Any]:
+    """Read the assignee's profile contract config without mutating globals."""
+    try:
+        from hermes_cli.config import DEFAULT_CONFIG, read_user_config_raw
+        from hermes_cli.profiles import get_profile_dir
+    except Exception:
+        return {}
+    base = copy.deepcopy(DEFAULT_CONFIG.get("profile_contract", {}))
+    if not assignee:
+        return base
+    try:
+        raw = read_user_config_raw(get_profile_dir(assignee) / "config.yaml")
+    except Exception:
+        raw = {}
+    overlay = raw.get("profile_contract") if isinstance(raw, Mapping) else None
+    if isinstance(overlay, Mapping):
+        return _deep_merge_dict(base, overlay)
+    return base
+
+
+def _route_compatibility_issue(
+    task: Optional[Task],
+    assignee: Optional[str],
+) -> Optional[dict[str, Any]]:
+    """Return a compatibility blocker for this task/profile, or None.
+
+    The check is intentionally opt-in at the *profile* level so old boards and
+    ordinary profiles preserve behavior.  Once enabled, a task's
+    ``required_capabilities`` and ``allowed_actions`` are compared against the
+    assignee profile's declared typed capabilities/actions before a worker is
+    claimed.  Sanitized displays are explicitly non-authoritative for exact
+    source identity when they appear in the task contract's evidence list.
+    """
+    if task is None or not assignee:
+        return None
+    contract = task.task_contract or {}
+    profile_contract = _profile_contract_config(assignee)
+    if not profile_contract.get("enforce_kanban_route_compatibility", False):
+        return None
+    required = set(_unique_string_list(contract.get("required_capabilities")))
+    profile_caps = set(_unique_string_list(profile_contract.get("capabilities")))
+    missing_caps = sorted(required - profile_caps)
+    task_allowed = set(_unique_string_list(contract.get("allowed_actions")))
+    profile_allowed = set(_unique_string_list(profile_contract.get("allowed_actions")))
+    # Empty profile allowed_actions means no typed action manifest was declared;
+    # if the task requires explicit actions under an enforcing profile, block
+    # rather than silently treating an undeclared action set as universal.
+    missing_actions = sorted(task_allowed - profile_allowed) if task_allowed else []
+    evidence = _unique_string_list(contract.get("required_evidence"))
+    if "sanitized_display" in evidence and not any(
+        item in evidence
+        for item in (
+            "exact_external_readback_or_raw_source",
+            "raw_source",
+            "executable_test_result",
+            "cryptographic_hash_or_signed_receipt",
+            "structured_machine_receipt",
+            "unsanitized_artifact",
+        )
+    ):
+        missing_caps.append("authoritative_non_sanitized_evidence")
+    if not missing_caps and not missing_actions:
+        return None
+    return {
+        "assignee": assignee,
+        "missing_capabilities": missing_caps,
+        "missing_allowed_actions": missing_actions,
+        "plane_for_bau_process_tracking": bool(
+            profile_contract.get("plane_for_bau_process_tracking", False)
+        ),
+    }
+
+
+def _block_route_incompatible_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    issue: Mapping[str, Any],
+) -> None:
+    reason = (
+        "route capability mismatch: missing capabilities="
+        f"{issue.get('missing_capabilities') or []}; missing allowed_actions="
+        f"{issue.get('missing_allowed_actions') or []}"
+    )
+    with write_txn(conn):
+        cur = conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'blocked',
+                   block_kind = 'capability',
+                   last_failure_error = ?
+             WHERE id = ?
+               AND status IN ('ready', 'review')
+               AND claim_lock IS NULL
+            """,
+            (reason[:1000], task_id),
+        )
+        if cur.rowcount == 1:
+            _append_event(
+                conn,
+                task_id,
+                "route_compatibility_blocked",
+                {"reason": reason, **dict(issue)},
+            )
 
 
 def claim_task(
@@ -8093,6 +8336,10 @@ class DispatchResult:
     spawned. ``None`` when memory was fine/unknown and the guard imposed
     no restriction. Reclaim/promotion bookkeeping still ran either way;
     deferred tasks stay queued for the next tick."""
+    skipped_incompatible: list[tuple[str, str, dict[str, Any]]] = field(default_factory=list)
+    """Tasks blocked before claim because the assignee profile opted into
+    route-compatibility enforcement and lacks the task's required typed
+    capabilities/actions.  Each entry is ``(task_id, assignee, issue)``."""
 
 
 # Bounded registry of recently-reaped worker child exits, populated by the
@@ -10192,6 +10439,16 @@ def _dispatch_once_locked(
             # of human-pulled work.
             result.skipped_nonspawnable.append(row["id"])
             continue
+        compatibility_issue = _route_compatibility_issue(
+            get_task(conn, row["id"]), row_assignee,
+        )
+        if compatibility_issue is not None:
+            result.skipped_incompatible.append(
+                (row["id"], row_assignee, compatibility_issue)
+            )
+            if not dry_run:
+                _block_route_incompatible_task(conn, row["id"], compatibility_issue)
+            continue
         # Per-profile concurrency cap (#21582): even if there's global
         # headroom, refuse to spawn for an assignee that's already at
         # its in-flight cap. Prevents one profile's local model / API
@@ -10339,6 +10596,16 @@ def _dispatch_once_locked(
             profile_exists = None  # type: ignore[assignment]
         if profile_exists is not None and not profile_exists(row["assignee"]):
             result.skipped_nonspawnable.append(row["id"])
+            continue
+        compatibility_issue = _route_compatibility_issue(
+            get_task(conn, row["id"]), row["assignee"],
+        )
+        if compatibility_issue is not None:
+            result.skipped_incompatible.append(
+                (row["id"], row["assignee"], compatibility_issue)
+            )
+            if not dry_run:
+                _block_route_incompatible_task(conn, row["id"], compatibility_issue)
             continue
         if _per_profile_cap is not None:
             current = _per_profile_running.get(row["assignee"], 0)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -613,6 +613,7 @@ class CreateTaskBody(BaseModel):
     goal_max_turns: Optional[int] = None
     model_override: Optional[str] = None
     provider_override: Optional[str] = None
+    task_contract: Optional[dict[str, Any]] = None
     # Per-task thinking depth (none|minimal|…|ultra). None = inherit the
     # assigned profile's own agent.reasoning_effort.
     reasoning_effort: Optional[str] = None
@@ -645,6 +646,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             goal_max_turns=payload.goal_max_turns,
             model_override=payload.model_override,
             provider_override=payload.provider_override,
+            task_contract=payload.task_contract,
             reasoning_effort=payload.reasoning_effort,
             project_id=payload.project_id,
             board=board,

--- a/tests/hermes_cli/test_kanban_profile_contract.py
+++ b/tests/hermes_cli/test_kanban_profile_contract.py
@@ -1,0 +1,386 @@
+"""P0 profile/task capability contract checks for Kanban routing."""
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def contract_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "profiles" / "worker").mkdir(parents=True)
+    (home / "profiles" / "reviewer").mkdir(parents=True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    for name in list(sys.modules):
+        if name == "hermes_constants" or name.startswith("hermes_cli"):
+            del sys.modules[name]
+    from hermes_cli import kanban_db
+
+    yield home, kanban_db
+
+
+def _write_profile_contract(home: Path, profile: str, body: str) -> None:
+    profile_dir = home / "profiles" / profile
+    profile_dir.mkdir(parents=True, exist_ok=True)
+    (profile_dir / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def _spawn(*args, **kwargs) -> int:
+    return 12345
+
+
+def test_task_contract_normalizes_explicit_p0_fields_and_bau_plane_default(contract_home):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  enforce_kanban_route_compatibility: true
+  capabilities: [provider.read, github.write]
+  allowed_actions: [provider.read, github.write]
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(
+            conn,
+            title="contracted",
+            assignee="worker",
+            task_contract={
+                "required_capabilities": ["provider.read", "provider.read"],
+                "allowed_actions": ["provider.read"],
+                "forbidden_actions": ["email.send"],
+                "required_evidence": ["exact_external_readback_or_raw_source"],
+                "safety_acceptance": ["no customer-visible mutation"],
+                "outcome_acceptance": ["readback reconciled"],
+                "recoverable_conditions": ["transient provider failure"],
+                "hard_stop_conditions": ["ambiguous write target"],
+                "evidence_hierarchy": ["exact_external_readback_or_raw_source"],
+                "status_fields": {
+                    "prepared": "route selected",
+                    "implemented": "code changed",
+                    "verified": "tests pass",
+                    "reviewed": None,
+                    "ci_pr_merge_observed": None,
+                    "production_executed": None,
+                    "business_outcome": "SAFE_BUT_NO_OUTCOME",
+                    "gaps": ["review pending"],
+                },
+            },
+        )
+        task = kb.get_task(conn, tid)
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert task is not None
+    assert DEFAULT_CONFIG["profile_contract"]["plane_for_bau_process_tracking"] is False
+    contract = task.task_contract
+    assert contract["required_capabilities"] == ["provider.read"]
+    assert contract["allowed_actions"] == ["provider.read"]
+    assert contract["forbidden_actions"] == ["email.send"]
+    assert contract["required_evidence"] == ["exact_external_readback_or_raw_source"]
+    assert contract["safety_acceptance"] == ["no customer-visible mutation"]
+    assert contract["outcome_acceptance"] == ["readback reconciled"]
+    assert contract["recoverable_conditions"] == ["transient provider failure"]
+    assert contract["hard_stop_conditions"] == ["ambiguous write target"]
+    assert contract["status_fields"]["prepared"] == "route selected"
+    assert contract["status_fields"]["business_outcome"] == "SAFE_BUT_NO_OUTCOME"
+    assert contract["status_fields"]["gaps"] == ["review pending"]
+    assert contract["plane_for_bau_process_tracking"] is False
+    assert task.project_id is None
+
+
+def test_dispatch_spawns_when_profile_satisfies_task_contract(contract_home):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  enforce_kanban_route_compatibility: true
+  capabilities: [provider.read]
+  allowed_actions: [provider.read]
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(
+            conn,
+            title="compatible",
+            assignee="worker",
+            task_contract={
+                "required_capabilities": ["provider.read"],
+                "allowed_actions": ["provider.read"],
+                "required_evidence": ["exact_external_readback_or_raw_source"],
+            },
+        )
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=False, max_spawn=1)
+        task = kb.get_task(conn, tid)
+
+    assert result.spawned and result.spawned[0][0] == tid
+    assert result.skipped_incompatible == []
+    assert task.status == "running"
+
+
+def test_dispatch_blocks_missing_capability_before_claim(contract_home):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  enforce_kanban_route_compatibility: true
+  capabilities: [provider.read]
+  allowed_actions: [provider.read]
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(
+            conn,
+            title="needs send",
+            assignee="worker",
+            task_contract={
+                "required_capabilities": ["email.send"],
+                "allowed_actions": ["email.send"],
+                "required_evidence": ["exact_external_readback_or_raw_source"],
+            },
+        )
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=False, max_spawn=1)
+        task = kb.get_task(conn, tid)
+
+    assert result.spawned == []
+    assert result.skipped_incompatible[0][0] == tid
+    assert result.skipped_incompatible[0][2]["missing_capabilities"] == ["email.send"]
+    assert result.skipped_incompatible[0][2]["missing_allowed_actions"] == ["email.send"]
+    assert task.status == "blocked"
+    assert task.block_kind == "capability"
+    assert task.claim_lock is None
+
+
+def test_sanitized_display_alone_is_not_authoritative_evidence(contract_home):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  enforce_kanban_route_compatibility: true
+  capabilities: [provider.read]
+  allowed_actions: [provider.read]
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(
+            conn,
+            title="sanitized only",
+            assignee="worker",
+            task_contract={
+                "required_capabilities": ["provider.read"],
+                "allowed_actions": ["provider.read"],
+                "required_evidence": ["sanitized_display"],
+            },
+        )
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=False, max_spawn=1)
+        task = kb.get_task(conn, tid)
+
+    assert result.spawned == []
+    assert result.skipped_incompatible[0][0] == tid
+    assert result.skipped_incompatible[0][2]["missing_capabilities"] == [
+        "authoritative_non_sanitized_evidence"
+    ]
+    assert task.status == "blocked"
+    assert task.claim_lock is None
+
+
+def test_legacy_profiles_ignore_task_contract_until_enabled(contract_home):
+    home, kb = contract_home
+    _write_profile_contract(home, "worker", "profile_contract: {}\n")
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(
+            conn,
+            title="legacy",
+            assignee="worker",
+            task_contract={"required_capabilities": ["unavailable.capability"]},
+        )
+        result = kb.dispatch_once(conn, spawn_fn=_spawn, dry_run=False, max_spawn=1)
+        task = kb.get_task(conn, tid)
+
+    assert result.spawned and result.spawned[0][0] == tid
+    assert result.skipped_incompatible == []
+    assert task.status == "running"
+
+
+def test_route_required_refuses_task_tool_without_selected_route(contract_home, monkeypatch):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  route_required_for_task_tools: true
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(conn, title="route gated", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker-test") is not None
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        run_id = str(run.id)
+    db_path = kb.kanban_db_path()
+
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    monkeypatch.setenv("HERMES_HOME", str(home / "profiles" / "worker"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", run_id)
+    monkeypatch.delenv("HERMES_ROUTE_SELECTED", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_TASK", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_SESSION_ID", raising=False)
+    for name in ["tools.kanban_tools", "hermes_cli.config"]:
+        sys.modules.pop(name, None)
+    kt = importlib.import_module("tools.kanban_tools")
+
+    blocked = json.loads(kt._handle_block({"reason": "should not write"}))
+    assert blocked["error"]
+    assert "route_required_for_task_tools" in blocked["error"]
+
+    monkeypatch.setenv("HERMES_ROUTE_TASK", tid)
+    assert kt._reject_missing_route("kanban_block") is None
+
+    allowed = json.loads(kt._handle_block({"reason": "selected route bound"}))
+    assert allowed["ok"] is True
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+
+
+def test_route_required_accepts_route_governor_runtime_state(contract_home, monkeypatch):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  route_required_for_task_tools: true
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(conn, title="route gated via db", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker-test") is not None
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        run_id = str(run.id)
+    db_path = kb.kanban_db_path()
+
+    runtime_db = home / "unified-control" / "runtime.db"
+    runtime_db.parent.mkdir(parents=True, exist_ok=True)
+    import sqlite3
+
+    with sqlite3.connect(runtime_db) as conn:
+        conn.execute(
+            """CREATE TABLE route_state(
+                profile TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                session_id TEXT,
+                selected_at REAL NOT NULL,
+                PRIMARY KEY(profile, task_id)
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO route_state(profile, task_id, session_id, selected_at) VALUES(?,?,?,?)",
+            ("worker", tid, "session-1", 1.0),
+        )
+
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    monkeypatch.setenv("HERMES_HOME", str(home / "profiles" / "worker"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", run_id)
+    monkeypatch.setenv("HERMES_SESSION_ID", "session-1")
+    monkeypatch.delenv("HERMES_ROUTE_SELECTED", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_TASK", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_SESSION_ID", raising=False)
+    for name in ["tools.kanban_tools", "hermes_cli.config"]:
+        sys.modules.pop(name, None)
+    kt = importlib.import_module("tools.kanban_tools")
+
+    assert kt._reject_missing_route("kanban_block") is None
+    allowed = json.loads(kt._handle_block({"reason": "selected route in runtime db"}))
+    assert allowed["ok"] is True
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"
+
+
+def test_route_required_accepts_recent_route_when_session_env_unavailable(contract_home, monkeypatch):
+    home, kb = contract_home
+    _write_profile_contract(
+        home,
+        "worker",
+        """
+profile_contract:
+  route_required_for_task_tools: true
+""",
+    )
+    with kb.connect_closing() as conn:
+        kb.create_board(slug="default", name="Default")
+        tid = kb.create_task(conn, title="route gated via recent db", assignee="worker")
+        assert kb.claim_task(conn, tid, claimer="worker-test") is not None
+        run = kb.latest_run(conn, tid)
+        assert run is not None
+        run_id = str(run.id)
+    db_path = kb.kanban_db_path()
+
+    runtime_db = home / "unified-control" / "runtime.db"
+    runtime_db.parent.mkdir(parents=True, exist_ok=True)
+    import sqlite3
+    import time
+
+    with sqlite3.connect(runtime_db) as conn:
+        conn.execute(
+            """CREATE TABLE route_state(
+                profile TEXT NOT NULL,
+                task_id TEXT NOT NULL,
+                session_id TEXT,
+                selected_at REAL NOT NULL,
+                PRIMARY KEY(profile, task_id)
+            )"""
+        )
+        conn.execute(
+            "INSERT INTO route_state(profile, task_id, session_id, selected_at) VALUES(?,?,?,?)",
+            ("worker", "session-key-only", "session-key-only", time.time()),
+        )
+
+    monkeypatch.setenv("HERMES_PROFILE", "worker")
+    monkeypatch.setenv("HERMES_HOME", str(home / "profiles" / "worker"))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", run_id)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_SELECTED", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_TASK", raising=False)
+    monkeypatch.delenv("HERMES_ROUTE_SESSION_ID", raising=False)
+    for name in ["tools.kanban_tools", "hermes_cli.config"]:
+        sys.modules.pop(name, None)
+    kt = importlib.import_module("tools.kanban_tools")
+
+    assert kt._reject_missing_route("kanban_block") is None
+    allowed = json.loads(kt._handle_block({"reason": "recent selected route in runtime db"}))
+    assert allowed["ok"] is True
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, tid)
+    assert task.status == "blocked"

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -31,6 +31,8 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sqlite3
+from pathlib import Path
 from typing import Any, Optional
 
 from agent.redact import redact_sensitive_text
@@ -60,6 +62,121 @@ def _profile_has_kanban_toolset() -> bool:
         return "kanban" in toolsets
     except Exception:
         return False
+
+
+def _route_required_for_task_tools() -> bool:
+    try:
+        cfg = load_config()
+        contract = cfg.get("profile_contract") or {}
+        return bool(contract.get("route_required_for_task_tools", False))
+    except Exception:
+        return False
+
+
+def _profile_name_for_route_lookup() -> str:
+    explicit = (os.environ.get("HERMES_PROFILE") or "").strip()
+    if explicit:
+        return explicit
+    home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser().resolve()
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def _route_runtime_db_path() -> Path:
+    home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))).expanduser().resolve()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    return root / "unified-control" / "runtime.db"
+
+
+def _route_governor_has_selected_route() -> bool:
+    """Return whether the route-governor DB has a route for this task/session.
+
+    ``hermes_route_select`` persists the authoritative selected route in the
+    route-governor runtime DB. Worker processes do not necessarily receive an
+    extra environment marker after selecting a route, so the Kanban lifecycle
+    gate must also consult that host-owned state before refusing a mutation.
+    """
+    db_path = _route_runtime_db_path()
+    if not db_path.exists():
+        return False
+    profile = _profile_name_for_route_lookup()
+    task_id = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
+    session_id = (os.environ.get("HERMES_SESSION_ID") or "").strip()
+    clauses: list[str] = []
+    params: list[str] = [profile]
+    if task_id:
+        clauses.append("task_id=?")
+        params.append(task_id)
+    if session_id:
+        clauses.append("session_id=?")
+        params.append(session_id)
+        clauses.append("task_id=?")
+        params.append(session_id)
+    if not clauses:
+        return False
+    try:
+        with sqlite3.connect(str(db_path), timeout=1.0) as conn:
+            row = conn.execute(
+                "SELECT 1 FROM route_state "
+                f"WHERE profile=? AND ({' OR '.join(clauses)}) "
+                "ORDER BY selected_at DESC LIMIT 1",
+                params,
+            ).fetchone()
+            if row is not None:
+                return True
+            # Some route providers receive the Hermes session id only through
+            # tool-call kwargs, not as an environment variable visible to this
+            # module. In that host path the route is still authoritative but is
+            # keyed by the session id in route_state.task_id/session_id. Accept
+            # a fresh route for the same profile as a bounded fallback so the
+            # worker can perform its required terminal Kanban lifecycle write.
+            recent = conn.execute(
+                "SELECT 1 FROM route_state "
+                "WHERE profile=? AND selected_at >= strftime('%s','now') - 3600 "
+                "ORDER BY selected_at DESC LIMIT 1",
+                (profile,),
+            ).fetchone()
+        return recent is not None
+    except Exception:
+        logger.exception("failed to inspect route governor state for Kanban gate")
+        return False
+
+
+def _route_selected_for_this_worker() -> bool:
+    """Best-effort process/session hook for route-required task tools.
+
+    Host integrations may bind a selected route through env markers. When they
+    do not, fall back to the route-governor runtime DB, which is what
+    ``hermes_route_select`` updates.
+    """
+    selected = (os.environ.get("HERMES_ROUTE_SELECTED") or "").strip().lower()
+    if selected in {"1", "true", "yes", "ok", "selected"}:
+        return True
+    selected_task = (os.environ.get("HERMES_ROUTE_TASK") or "").strip()
+    if selected_task and selected_task == (os.environ.get("HERMES_KANBAN_TASK") or ""):
+        return True
+    selected_session = (os.environ.get("HERMES_ROUTE_SESSION_ID") or "").strip()
+    if (
+        selected_session
+        and selected_session == (os.environ.get("HERMES_SESSION_ID") or "")
+    ):
+        return True
+    return _route_governor_has_selected_route()
+
+
+def _reject_missing_route(tool_name: str) -> Optional[str]:
+    if not _route_required_for_task_tools():
+        return None
+    if not (os.environ.get("HERMES_KANBAN_TASK") and _is_dispatcher_owned_worker()):
+        return None
+    if _route_selected_for_this_worker():
+        return None
+    return tool_error(
+        f"{tool_name} refused: profile_contract.route_required_for_task_tools "
+        "is enabled, but no selected route marker is bound to this worker task "
+        "or session. Call hermes_route_select before mutating Kanban task state."
+    )
 
 
 def _is_delegated_child_context() -> bool:
@@ -98,6 +215,10 @@ def _reject_delegated_child_mutation(tool_name: str) -> Optional[str]:
         "worker or an explicitly configured Kanban orchestrator must perform "
         "board mutations."
     )
+
+
+def _reject_disallowed_task_tool(tool_name: str) -> Optional[str]:
+    return _reject_delegated_child_mutation(tool_name) or _reject_missing_route(tool_name)
 
 
 def _check_kanban_mode() -> bool:
@@ -503,6 +624,7 @@ def _task_summary_dict(kb, conn, task) -> dict[str, Any]:
         "current_run_id": task.current_run_id,
         "model_override": task.model_override,
         "provider_override": task.provider_override,
+        "task_contract": task.task_contract,
         "parents": parents,
         "children": children,
         "parent_count": len(parents),
@@ -549,6 +671,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "current_run_id": t.current_run_id,
                     "model_override": t.model_override,
                     "provider_override": t.provider_override,
+                    "task_contract": t.task_contract,
                 }
 
             def _run_dict(r):
@@ -654,7 +777,7 @@ def _handle_list(args: dict, **kw) -> str:
 
 def _handle_complete(args: dict, **kw) -> str:
     """Mark the current task done with a structured handoff."""
-    delegated_err = _reject_delegated_child_mutation("kanban_complete")
+    delegated_err = _reject_disallowed_task_tool("kanban_complete")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -816,7 +939,7 @@ def _handle_complete(args: dict, **kw) -> str:
 
 def _handle_block(args: dict, **kw) -> str:
     """Transition the task to blocked with a reason a human will read."""
-    delegated_err = _reject_delegated_child_mutation("kanban_block")
+    delegated_err = _reject_disallowed_task_tool("kanban_block")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -897,7 +1020,7 @@ def _handle_block(args: dict, **kw) -> str:
 
 def _handle_request_review(args: dict, **kw) -> str:
     """Move implementation into the first-class review phase."""
-    delegated_err = _reject_delegated_child_mutation("kanban_request_review")
+    delegated_err = _reject_disallowed_task_tool("kanban_request_review")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -975,7 +1098,7 @@ def _handle_request_review(args: dict, **kw) -> str:
 
 def _handle_request_changes(args: dict, **kw) -> str:
     """Return a reviewer-owned running task to its implementer."""
-    delegated_err = _reject_delegated_child_mutation("kanban_request_changes")
+    delegated_err = _reject_disallowed_task_tool("kanban_request_changes")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -1031,7 +1154,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
     by ``release_stale_claims`` — which is exactly the trap that
     ``heartbeat_claim``'s docstring warns against.
     """
-    delegated_err = _reject_delegated_child_mutation("kanban_heartbeat")
+    delegated_err = _reject_disallowed_task_tool("kanban_heartbeat")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -1077,7 +1200,7 @@ def _handle_heartbeat(args: dict, **kw) -> str:
 
 def _handle_comment(args: dict, **kw) -> str:
     """Append a comment to a task's thread."""
-    delegated_err = _reject_delegated_child_mutation("kanban_comment")
+    delegated_err = _reject_disallowed_task_tool("kanban_comment")
     if delegated_err:
         return delegated_err
     tid = args.get("task_id")
@@ -1125,7 +1248,7 @@ def _handle_attach(args: dict, **kw) -> str:
     """
     from hermes_cli import kanban_db as kb
 
-    delegated_err = _reject_delegated_child_mutation("kanban_attach")
+    delegated_err = _reject_disallowed_task_tool("kanban_attach")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -1247,7 +1370,7 @@ def _handle_attach_url(args: dict, **kw) -> str:
     """
     from hermes_cli import kanban_db as kb
 
-    delegated_err = _reject_delegated_child_mutation("kanban_attach_url")
+    delegated_err = _reject_disallowed_task_tool("kanban_attach_url")
     if delegated_err:
         return delegated_err
     tid = _default_task_id(args.get("task_id"))
@@ -1346,7 +1469,7 @@ def _handle_create(args: dict, **kw) -> str:
     ``parents`` can be a list of task ids; dependency-gated promotion
     works as usual.
     """
-    delegated_err = _reject_delegated_child_mutation("kanban_create")
+    delegated_err = _reject_disallowed_task_tool("kanban_create")
     if delegated_err:
         return delegated_err
     title = args.get("title")
@@ -1411,8 +1534,13 @@ def _handle_create(args: dict, **kw) -> str:
     goal_max_turns = args.get("goal_max_turns")
     model_override = args.get("model")
     provider_override = args.get("provider")
+    task_contract = args.get("task_contract")
     if provider_override and not model_override:
         return tool_error("'provider' requires 'model' to be set as well")
+    if task_contract is not None and not isinstance(task_contract, dict):
+        return tool_error(
+            f"task_contract must be an object/dict, got {type(task_contract).__name__}"
+        )
     if isinstance(parents, str):
         parents = [parents]
     if not isinstance(parents, (list, tuple)):
@@ -1454,6 +1582,7 @@ def _handle_create(args: dict, **kw) -> str:
                 skills=skills,
                 model_override=model_override,
                 provider_override=provider_override,
+                task_contract=task_contract,
                 goal_mode=goal_mode,
                 goal_max_turns=(
                     int(goal_max_turns) if goal_max_turns is not None else None
@@ -1611,7 +1740,7 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
 
 def _handle_unblock(args: dict, **kw) -> str:
     """Transition a blocked task to ready, or todo while parents remain open."""
-    delegated_err = _reject_delegated_child_mutation("kanban_unblock")
+    delegated_err = _reject_disallowed_task_tool("kanban_unblock")
     if delegated_err:
         return delegated_err
     guard = _require_orchestrator_tool("kanban_unblock")
@@ -1643,7 +1772,7 @@ def _handle_unblock(args: dict, **kw) -> str:
 
 def _handle_link(args: dict, **kw) -> str:
     """Add a parent→child dependency edge after the fact."""
-    delegated_err = _reject_delegated_child_mutation("kanban_link")
+    delegated_err = _reject_disallowed_task_tool("kanban_link")
     if delegated_err:
         return delegated_err
     parent_id = args.get("parent_id")
@@ -2301,6 +2430,22 @@ KANBAN_CREATE_SCHEMA = {
                     "provider — a model name alone is resolved against "
                     "the profile's provider and will fail if it belongs "
                     "to a different one. Requires 'model'."
+                ),
+            },
+            "task_contract": {
+                "type": "object",
+                "description": (
+                    "Optional machine-readable capability/acceptance manifest. "
+                    "When the assignee profile enables route-compatibility "
+                    "checks, the dispatcher validates required_capabilities and "
+                    "allowed_actions before claim. Include explicit fields for "
+                    "required_capabilities, allowed_actions, forbidden_actions, "
+                    "required_evidence, safety_acceptance, outcome_acceptance, "
+                    "recoverable_conditions, hard_stop_conditions, "
+                    "evidence_hierarchy, status_fields (prepared, implemented, "
+                    "verified, reviewed, ci_pr_merge_observed, "
+                    "production_executed, business_outcome, gaps), and "
+                    "plane_for_bau_process_tracking=false for ordinary BAU runs."
                 ),
             },
             "board": _board_schema_prop(),


### PR DESCRIPTION
## Summary
- add config-gated profile capability/task contract defaults for Kanban routing
- block incompatible worker/reviewer assignments before claim/spawn when task contracts require unavailable capabilities/actions
- add route-required guard for mutating Kanban task tools
- preserve BAU boundary: Plane/Kanban are project-state/evidence pointers, not BAU process tracking
- add unredacted step-evidence policy: raw intermediate artifacts/readbacks remain the local source of truth; redaction is presentation-only

## Verification
- HERMES_PYTHON=/home/hl-metabase/.hermes/hermes-agent/venv/bin/python scripts/run_tests.sh tests/hermes_cli/test_kanban_profile_contract.py
- uvx ruff check hermes_cli/config_defaults.py hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py tools/kanban_tools.py tests/hermes_cli/test_kanban_profile_contract.py
- /home/hl-metabase/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/config_defaults.py hermes_cli/kanban.py hermes_cli/kanban_db.py plugins/kanban/dashboard/plugin_api.py tools/kanban_tools.py tests/hermes_cli/test_kanban_profile_contract.py

## Operational rollout already applied locally
- profile_contract enforcement enabled across default/business/forge/pd-ops workers/reviewers/routers
- reviewer terminal verification enabled while code_execution remains disabled
- route-governor profile plugin copies compiled after the narrow allowlist change
