### PR TITLE
fix(model): authenticate bare custom picker probes

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -268,6 +268,28 @@ def _bare_custom_provider_def(current_base_url: str) -> Optional[ProviderDef]:
     )
 
 
+def _bare_custom_model_api_key(current_base_url: str) -> str:
+    """Return the key only when config owns the current bare-custom endpoint."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        model_cfg = load_config_readonly().get("model", {})
+        if not isinstance(model_cfg, dict):
+            return ""
+        configured_provider = str(model_cfg.get("provider") or "").strip().lower()
+        configured_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        current_url = str(current_base_url or "").strip().rstrip("/")
+        if configured_provider != "custom" or not configured_url or configured_url != current_url:
+            return ""
+        for key in ("api_key", "api"):
+            value = model_cfg.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    except (OSError, TypeError, KeyError, AttributeError):
+        pass
+    return ""
+
+
 _MODEL_DISCOVERY_ERRORS = (
     ImportError,
     OSError,
@@ -3748,6 +3770,7 @@ def list_authenticated_providers(
         )
     ):
         _models = [current_model] if current_model else []
+        _api_key = _bare_custom_model_api_key(current_base_url)
         # With live probing suppressed, use the shared stale/cache path;
         # otherwise probe through the native-aware picker helper.
         native_catalog_empty = False
@@ -3755,7 +3778,7 @@ def list_authenticated_providers(
         try:
             if _probe_live:
                 _live_models = _fetch_picker_live_models(
-                    "",
+                    _api_key,
                     str(current_base_url).strip().rstrip("/"),
                     "custom",
                     False,
@@ -3765,7 +3788,7 @@ def list_authenticated_providers(
                 from hermes_cli.models import cached_fetch_api_models
 
                 _live_models = cached_fetch_api_models(
-                    "",
+                    _api_key,
                     str(current_base_url).strip().rstrip("/"),
                     cache_only=True,
                     timeout=(1.5 if for_picker else 5.0),

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -364,6 +364,122 @@ def test_list_authenticated_providers_can_probe_active_bare_custom_endpoint(monk
     assert bare_custom["models"] == ["gpt-4o", "gpt-4o-mini"]
 
 
+@pytest.mark.parametrize(
+    ("model_key", "configured_key"),
+    [("api_key", "sk-custom-test"), ("api", "sk-legacy-test")],
+)
+def test_bare_custom_picker_probe_uses_configured_api_key(
+    monkeypatch, model_key, configured_key
+):
+    """Authenticated bare custom endpoints must receive the model config key."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://custom.example.test/v1",
+                model_key: configured_key,
+            }
+        },
+    )
+    captured = {}
+
+    def _fake_fetch(api_key, api_url, *_args, **_kwargs):
+        captured.update(api_key=api_key, api_url=api_url)
+        return ["model-a", "model-b"]
+
+    monkeypatch.setattr("hermes_cli.model_switch._fetch_picker_live_models", _fake_fetch)
+
+    rows = list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://custom.example.test/v1",
+        current_model="model-a",
+        user_providers={},
+        custom_providers=[],
+        probe_current_custom_provider=True,
+    )
+
+    row = next(p for p in rows if p["slug"] == "custom")
+    assert captured == {
+        "api_key": configured_key,
+        "api_url": "https://custom.example.test/v1",
+    }
+    assert row["models"] == ["model-a", "model-b"]
+
+
+def test_bare_custom_picker_does_not_send_config_key_to_different_endpoint(monkeypatch):
+    """A session URL override must not receive the persisted endpoint's key."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://configured.example.test/v1",
+                "api_key": "sk-configured-test",
+            }
+        },
+    )
+    captured = {}
+
+    def _fake_fetch(api_key, api_url, *_args, **_kwargs):
+        captured.update(api_key=api_key, api_url=api_url)
+        return ["model-a"]
+
+    monkeypatch.setattr("hermes_cli.model_switch._fetch_picker_live_models", _fake_fetch)
+
+    list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://session.example.test/v1",
+        current_model="model-a",
+        user_providers={},
+        custom_providers=[],
+        probe_current_custom_provider=True,
+    )
+
+    assert captured == {
+        "api_key": "",
+        "api_url": "https://session.example.test/v1",
+    }
+
+
+def test_bare_custom_picker_url_match_preserves_path_case(monkeypatch):
+    """Case-distinct URL paths must not share an inline credential."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr(providers_mod, "HERMES_OVERLAYS", {})
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://custom.example.test/Tenant/v1",
+                "api_key": "sk-tenant-test",
+            }
+        },
+    )
+    captured = {}
+
+    def _fake_fetch(api_key, *_args, **_kwargs):
+        captured["api_key"] = api_key
+        return ["model-a"]
+
+    monkeypatch.setattr("hermes_cli.model_switch._fetch_picker_live_models", _fake_fetch)
+
+    list_authenticated_providers(
+        current_provider="custom",
+        current_base_url="https://custom.example.test/tenant/v1",
+        current_model="model-a",
+        user_providers={},
+        custom_providers=[],
+        probe_current_custom_provider=True,
+    )
+
+    assert captured["api_key"] == ""
+
+
 def test_switch_model_accepts_explicit_bare_custom_current_endpoint(monkeypatch):
     """Picker selections for bare custom endpoints should route to current base_url."""
     monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)


### PR DESCRIPTION
## Summary
- authenticate live and cached model-catalog probes for bare `model.provider: custom` endpoints
- resolve the legacy `model.api_key` / `model.api` fields only when the configured endpoint exactly owns the current URL
- keep session URL overrides from receiving a persisted endpoint's credential

## Why a new PR

Salvages the core fix from #83930 by @thatssoheil onto current `main`. The original patch was correct for the old `cached_fetch_api_models()` call site, but the picker discovery path has since moved behind `_fetch_picker_live_models()` and the PR is over 5,000 commits behind.

This version preserves Soheil Fakour's credit in the commit and adds endpoint-ownership guards discovered during independent review.

Fixes #83837. Supersedes #83930 and #83850.

## Reproduction on current main

With:

```yaml
model:
  provider: custom
  base_url: https://authenticated.example/v1
  api_key: sk-...
  default: model-a
```

section 3b of `list_authenticated_providers()` passed `api_key=""` into `_fetch_picker_live_models()`. Authenticated `/v1/models` endpoints returned 401, the exception was swallowed, and the picker collapsed to the single current model.

## Security boundary

The key is used only when:

- persisted `model.provider` is exactly `custom`, and
- persisted `model.base_url` exactly matches the current endpoint after whitespace and trailing-slash normalization.

URL path case is preserved. A session/runtime URL override receives no persisted key.

## Tests

- Regression test was confirmed **RED** before the production change: configured key observed as empty
- `scripts/run_tests.sh tests/hermes_cli/test_model_switch_custom_providers.py -q` — **74 passed**
- `.venv/bin/ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py` — passed
- `git diff --check` — clean
- Live validation against the reporter endpoint — **14 models discovered**, including `gpt-5.6-sol`, `gpt-5.6-luna`, and `gpt-5.6-terra`
- Independent final review — passed with no security or logic findings
