### PR TITLE
fix(update): recover the hermes serve generation after an aborted restart phase (salvage #96235)

### DIFF
--- a/hermes_cli/dashboard_procs.py
+++ b/hermes_cli/dashboard_procs.py
@@ -390,7 +390,21 @@ def _kill_stale_dashboard_processes(
     left untouched.
     """
     if restart_managed and _m()._restart_managed_dashboard_service(reason):
-        return {"matched": [], "killed": [], "failed": []}
+        # The dashboard unit is handled; every OTHER backend is not (#92145).
+        # This used to return here, which meant a host running BOTH
+        # ``hermes-dashboard.service`` and ``hermes-serve.service`` -- the
+        # exact unit set in the report -- restarted only the dashboard and
+        # never even scanned for the serve backend that hosts
+        # ``tui_gateway``. That backend then kept its pre-update
+        # ``sys.modules`` while the checkout moved on. Record the unit as
+        # already handled (the filter below drops PIDs it owns, including
+        # the one systemd just replaced) and keep scanning.
+        _dash_unit = getattr(
+            _m(), "_DASHBOARD_SYSTEMD_UNIT", "hermes-dashboard.service"
+        )
+        already_restarted_units = set(already_restarted_units or ()) | {
+            str(_dash_unit).removesuffix(".service")
+        }
 
     # When the Hermes Desktop Electron app spawns this dashboard as a
     # backend child, it sets HERMES_DESKTOP_CHILD_PID so that the update

--- a/hermes_cli/update_abort_recovery.py
+++ b/hermes_cli/update_abort_recovery.py
@@ -1,0 +1,423 @@
+"""Fresh-process recovery after the update's in-process restart phase aborts.
+
+``hermes update`` performs its fleet restart in the interpreter that started
+before ``git pull``.  When that phase raises — the module graph it is running
+no longer matches the checkout on disk — this module owns everything that
+happens next: which runtimes a clean child may relaunch, what counts as proof
+that a relaunch actually replaced the old generation, which pre-update
+processes are still alive, and whether any of that adds up to a recovery that
+may call itself complete (#92145).
+
+It is deliberately a separate owner from ``update_cmd``: the abort path has
+its own vocabulary (``verified`` / ``relaunch_attempted`` / ``failed``, serve
+units, survivors) and its own fail-closed contract, and the update monolith
+must not grow another authority surface (review on #96235).  The child process
+itself lives in :mod:`hermes_cli.update_restart_recovery`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+
+logger = logging.getLogger(__name__)
+
+
+def _serve_unit_recovery_available() -> bool:
+    """Can a fresh process restart ``hermes-serve*`` units on this host?"""
+    return sys.platform == "linux" and bool(shutil.which("systemctl"))
+
+
+def _surviving_pre_update_serve_runtimes(plan) -> list[dict]:
+    """Pre-update serve/dashboard runtimes that are STILL the same process.
+
+    Identity is the process incarnation ``(pid, create_time)``, never the PID
+    alone. ``ledger_entries()`` re-verifies that pair on every read and prunes
+    anything that is gone, so a live entry is a real process — but the numeric
+    PID can be reused, and a serve that was restarted correctly can come back
+    on the same number. Comparing PIDs alone would then report the successor
+    as the pre-update survivor and keep the update incomplete forever
+    (#92145 review).
+
+    Anything still here after the recovery pass is a live runtime on the
+    pre-update code generation, which is precisely the unsafe state #92145
+    reports. Fail closed on missing evidence: an unreadable ledger, or an
+    incarnation neither side can produce, counts the runtime as surviving.
+    """
+    planned: dict[int, dict] = {}
+    try:
+        for runtime in getattr(plan, "runtimes", ()) or ():
+            if getattr(runtime, "kind", None) not in ("serve", "dashboard"):
+                continue
+            pid = getattr(runtime, "pid", None)
+            if not isinstance(pid, int) or pid <= 0:
+                continue
+            detail = getattr(runtime, "detail", None)
+            created = detail.get("create_time") if isinstance(detail, dict) else None
+            planned[pid] = {
+                "pid": pid,
+                "kind": str(getattr(runtime, "kind", "")),
+                "profile": str(getattr(runtime, "profile", "")),
+                "supervisor": str(getattr(runtime, "supervisor", "")),
+                "_create_time": created if isinstance(created, (int, float)) else None,
+            }
+    except Exception as exc:
+        logger.debug("Could not read planned serve runtimes: %s", exc)
+        return []
+    if not planned:
+        return []
+    try:
+        from hermes_cli.process_identity import ledger_entries
+
+        live: dict[int, float | None] = {}
+        for entry in ledger_entries():
+            if entry.get("purpose") not in ("serve", "dashboard"):
+                continue
+            pid = entry.get("pid")
+            if not isinstance(pid, int):
+                continue
+            created = entry.get("create_time")
+            live[pid] = created if isinstance(created, (int, float)) else None
+    except Exception as exc:
+        logger.debug("Serve/dashboard survivor probe failed: %s", exc)
+        return sorted(
+            (_without_incarnation(row) for row in planned.values()),
+            key=lambda row: row["pid"],
+        )
+    survivors = []
+    for pid, row in planned.items():
+        if pid not in live:
+            continue
+        planned_created = row["_create_time"]
+        live_created = live[pid]
+        if (
+            planned_created is not None
+            and live_created is not None
+            and abs(float(live_created) - float(planned_created)) >= 2.0
+        ):
+            # Same number, different process: the pre-update runtime is gone
+            # and something new registered under its PID. Not a survivor.
+            continue
+        survivors.append(_without_incarnation(row))
+    return sorted(survivors, key=lambda row: row["pid"])
+
+
+def _without_incarnation(row: dict) -> dict:
+    """The operator-facing survivor row (incarnation is a matching key only)."""
+    return {key: value for key, value in row.items() if key != "_create_time"}
+
+
+def _qualified_serve_skips(skip_units) -> list[dict]:
+    """Scope-qualify the units the aborted phase already settled.
+
+    ``restarted_scoped_units`` records ``<scope>/<unit>`` because
+    ``hermes-serve.service`` can exist in BOTH the user and the system
+    manager, and those are two different processes. Handing the fresh child a
+    bare unit name would make one settled scope suppress recovery of the other
+    — the stale one would never be restarted and nothing downstream would say
+    so. Entries that carry no scope (a payload built by a pre-update
+    interpreter) are forwarded without one and read as scope-agnostic there.
+    """
+    rows: list[dict] = []
+    for entry in sorted(skip_units or ()):
+        scope, sep, unit = str(entry).partition("/")
+        if sep and scope in ("user", "system") and unit:
+            rows.append({"scope": scope, "unit": unit})
+        elif entry:
+            rows.append({"unit": str(entry)})
+    return rows
+
+
+def _recover_gateway_restart_after_abort(
+    plan,
+    *,
+    gateway_mode: bool,
+    skip_profiles: set[str] | None = None,
+    skip_units: set[str] | None = None,
+) -> dict[str, list]:
+    """Retry supervised gateway restarts from a clean Python process.
+
+    ``hermes update`` normally performs the fleet restart in the interpreter
+    that started before ``git pull``.  If that phase raises while importing the
+    new tree, a warning alone leaves the old gateway alive against new files on
+    disk.  The recovery boundary launches the existing per-profile
+    ``gateway restart`` command through a new interpreter, preserving its
+    platform-specific drain and service-manager logic without inheriting the
+    stale ``sys.modules`` graph.
+
+    Only profiles classified as supervisor-owned by the pre-update inventory
+    are handed off.  A manual gateway must remain running and be reported for
+    explicit operator action rather than being killed without a relaunch
+    authority; serve/dashboard runtimes from the spawn ledger are likewise
+    recorded as skipped with a reason instead of vanishing from the pass.
+    The returned protocol is persisted in the update receipt so operators can
+    distinguish a spawn failure from a per-profile failure.
+
+    The same child additionally restarts active ``hermes-serve*`` systemd
+    units (#92145).  ``hermes serve`` hosts ``tui_gateway.server`` and is
+    restarted by the in-process phase alongside the gateway units, but no
+    per-profile ``gateway restart`` command reaches it — so an abort used to
+    leave it holding the pre-pull module graph with nothing left to notice.
+
+    ``skip_units`` names the units the aborted phase already settled, as
+    ``<scope>/<unit>``.  The scope is part of the identity, not decoration:
+    ``hermes-serve.service`` can exist in both the user and the system
+    manager as two different processes, and an unqualified token would let a
+    settled one suppress recovery of a stale one (review on #96235).
+
+    Outcome honesty: ``verified`` means the fresh child independently observed
+    the profile's systemd unit active after the relaunch.  A zero exit from
+    ``gateway restart`` alone is NOT observed proof that the new code
+    generation is serving, so those outcomes are reported as
+    ``relaunch_attempted`` and never claim supervisor coverage.
+    """
+    from hermes_cli.update_cmd import _gateway_recovery_partition
+
+    candidates, skipped = _gateway_recovery_partition(
+        plan, skip_profiles=skip_profiles
+    )
+    profiles = sorted(candidates)
+    recover_serve = _serve_unit_recovery_available()
+    _empty_serve: dict[str, list] = {"verified": [], "failed": []}
+    if not profiles and not recover_serve:
+        return {
+            "requested": [],
+            "verified": [],
+            "relaunch_attempted": [],
+            "failed": [],
+            "skipped": skipped,
+            "serve_units": dict(_empty_serve),
+        }
+
+    def _all_failed() -> dict[str, list]:
+        return {
+            "requested": profiles,
+            "verified": [],
+            "relaunch_attempted": [],
+            "failed": profiles,
+            "skipped": skipped,
+            "serve_units": dict(_empty_serve),
+        }
+
+    command = [
+        sys.executable,
+        "-m",
+        "hermes_cli.update_restart_recovery",
+        "--stdin",
+    ]
+    env = os.environ.copy()
+    env["HERMES_UPDATE_RESTART_RECOVERY"] = "1"
+    for marker in ("_HERMES_GATEWAY", "HERMES_GATEWAY", "HERMES_GATEWAY_MODE"):
+        env.pop(marker, None)
+
+    # A gateway-triggered update may run inside the gateway's systemd cgroup.
+    # Put the recovery process in a transient user scope before it asks systemd
+    # to restart that gateway, otherwise KillMode can terminate the recovery
+    # process together with the old service. If systemd-run is unavailable,
+    # fail closed rather than pretending the in-cgroup child is independent.
+    if gateway_mode and sys.platform == "linux":
+        systemd_run = shutil.which("systemd-run")
+        if not systemd_run:
+            logger.warning("Cannot isolate fresh gateway recovery from the gateway cgroup")
+            return _all_failed()
+        command = [
+            systemd_run,
+            "--user",
+            "--scope",
+            "--quiet",
+            "--collect",
+            "--",
+            *command,
+        ]
+
+    kwargs = {
+        "input": json.dumps(
+            {
+                "profiles": profiles,
+                "supervisors": candidates,
+                "serve_units": {
+                    "recover": recover_serve,
+                    "skip": _qualified_serve_skips(skip_units),
+                },
+            }
+        ),
+        "capture_output": True,
+        "text": True,
+        "encoding": "utf-8",
+        "errors": "replace",
+        "check": False,
+        "env": env,
+        # Gateway profiles run sequentially at up to 90s each; the serve pass
+        # adds its own restart + settle budget on top, so give the child room
+        # for both rather than killing a recovery that was working.
+        "timeout": max(180, 30 + 90 * len(profiles) + (150 if recover_serve else 0)),
+    }
+    if sys.platform == "win32":
+        kwargs["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
+            | getattr(subprocess, "DETACHED_PROCESS", 0)
+        )
+    else:
+        kwargs["start_new_session"] = True
+
+    try:
+        result = subprocess.run(command, **kwargs)
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.warning("Fresh gateway restart recovery failed: %s", exc)
+        return _all_failed()
+
+    if result.returncode != 0:
+        logger.warning("Fresh gateway restart recovery exited %s", result.returncode)
+        return _all_failed()
+
+    try:
+        recovery_result = json.loads(result.stdout or "")
+        verified = recovery_result.get("verified")
+        relaunch_attempted = recovery_result.get("relaunch_attempted")
+        failed = recovery_result.get("failed")
+        raw_serve = recovery_result.get("serve_units") or dict(_empty_serve)
+    except (AttributeError, TypeError, ValueError):
+        logger.warning("Fresh gateway restart recovery returned invalid JSON")
+        return _all_failed()
+
+    serve_units = dict(_empty_serve)
+    if (
+        isinstance(raw_serve, dict)
+        and isinstance(raw_serve.get("verified"), list)
+        and isinstance(raw_serve.get("failed"), list)
+        and all(
+            isinstance(unit, str)
+            for unit in (*raw_serve["verified"], *raw_serve["failed"])
+        )
+    ):
+        serve_units = {
+            "verified": sorted(raw_serve["verified"]),
+            "failed": sorted(raw_serve["failed"]),
+        }
+    elif recover_serve:
+        # An unreadable serve block cannot be read as "nothing to do": the
+        # units it describes are exactly the ones that host tui_gateway and
+        # may still be serving the pre-update generation.
+        logger.warning("Fresh recovery returned an invalid serve-unit result")
+        serve_units = {"verified": [], "failed": ["<unreadable>"]}
+
+    buckets = (verified, relaunch_attempted, failed)
+    reported: list[str] = []
+    if all(isinstance(bucket, list) for bucket in buckets):
+        reported = [*verified, *relaunch_attempted, *failed]
+    if (
+        not all(isinstance(bucket, list) for bucket in buckets)
+        or any(not isinstance(profile, str) for profile in reported)
+        or set(reported) != set(profiles)
+        or len(reported) != len(set(reported))
+    ):
+        logger.warning("Fresh gateway restart recovery returned incomplete profiles")
+        return _all_failed()
+
+    if verified:
+        print(
+            "  ✓ Restarted supervised gateway(s) in a fresh process"
+            " (systemd-verified active): " + ", ".join(sorted(verified))
+        )
+    if relaunch_attempted:
+        print(
+            "  ⚠ Relaunch attempted in a fresh process but not"
+            " supervisor-verified (check these gateways manually): "
+            + ", ".join(sorted(relaunch_attempted))
+        )
+    if serve_units["verified"]:
+        print(
+            "  ✓ Restarted serve unit(s) in a fresh process"
+            " (new main PID observed): "
+            + ", ".join(serve_units["verified"])
+        )
+    if serve_units["failed"]:
+        print(
+            "  ⚠ Could not verify a replacement for serve unit(s): "
+            + ", ".join(serve_units["failed"])
+        )
+    return {
+        "requested": profiles,
+        "verified": sorted(verified),
+        "relaunch_attempted": sorted(relaunch_attempted),
+        "failed": sorted(failed),
+        "skipped": skipped,
+        "serve_units": serve_units,
+    }
+
+
+def _warn_stale_serve_runtimes(rows) -> None:
+    """Name the serve/dashboard processes that survived on pre-update code.
+
+    The original #92145 report is a user watching every chat turn fail with an
+    ``ImportError`` for a symbol that imports fine on disk, with nothing in the
+    terminal naming the responsible process. ``hermes serve`` hosts
+    ``tui_gateway.server``; when its unit was never restarted it keeps the
+    pre-pull ``sys.modules`` graph and there is no gateway row anywhere that
+    reveals it. Print the PIDs and the exact command that fixes it.
+    """
+    if not rows:
+        return
+    print(
+        "  ⚠ These serve/dashboard processes still run pre-update code"
+        " (they started before the checkout changed):"
+    )
+    for row in rows:
+        supervisor = row.get("supervisor") or "unknown"
+        print(
+            f"      pid {row.get('pid')} — {row.get('kind')}"
+            f" (profile {row.get('profile') or 'default'}, {supervisor})"
+        )
+    print(
+        "    Restart them before using Hermes again, e.g."
+        " `systemctl --user restart hermes-serve.service`"
+        " or by relaunching `hermes serve` / the Desktop app."
+    )
+
+
+def _abort_recovery_is_complete(
+    *,
+    planned_gateway_profiles,
+    covered_gateway_profiles,
+    recovery_result,
+    stale_runtime_rows,
+) -> bool:
+    """May a fresh-process recovery clear the incomplete flag?
+
+    Only when EVERY inventoried runtime family is accounted for. The gateway
+    leg alone is not enough (#92145): the post-update read-back
+    (``collect_fleet_versions``) is gateway-only — it reads each profile's
+    ``gateway_state.json`` / control socket — so a ``hermes serve`` still
+    holding the pre-update ``sys.modules`` graph is invisible to both the
+    recovery pass and the verification that follows it. Clearing the flag on
+    gateway coverage alone is exactly how an update reported success while
+    every chat turn kept failing with an ``ImportError`` for a symbol that
+    imports fine on disk.
+
+    Fail closed on each leg:
+
+    * every planned gateway profile is covered, with nothing failed and
+      nothing merely ``relaunch_attempted`` (rc 0 is not observed coverage);
+    * no ``hermes-serve*`` unit failed to produce a verified replacement; and
+    * no serve/dashboard process from the pre-update inventory is still the
+      same process (``stale_runtime_rows``).
+
+    ``planned_gateway_profiles`` being empty is deliberately NOT completeness:
+    with no gateway leg to prove, the caller's own fail-closed contract
+    (``_restart_phase_failure_is_incomplete``) plus the stale-runtime rows
+    decide the outcome.
+    """
+    if not planned_gateway_profiles:
+        return False
+    if not set(planned_gateway_profiles) <= set(covered_gateway_profiles):
+        return False
+    result = recovery_result or {}
+    if result.get("failed") or result.get("relaunch_attempted"):
+        return False
+    if (result.get("serve_units") or {}).get("failed"):
+        return False
+    return not stale_runtime_rows

--- a/hermes_cli/update_abort_recovery.py
+++ b/hermes_cli/update_abort_recovery.py
@@ -32,6 +32,24 @@ def _serve_unit_recovery_available() -> bool:
     return sys.platform == "linux" and bool(shutil.which("systemctl"))
 
 
+def _plan_has_serve_runtimes(plan) -> bool:
+    """Does the pre-update plan record any serve/dashboard runtime?
+
+    The serve-unit recovery pass costs a fresh child spawn and a systemd
+    scan; hosts whose inventory saw no serve/dashboard runtime (e.g. a
+    manual-only gateway fleet) must keep the pre-#92145 contract of not
+    spawning anything. Capability alone (``systemctl`` on Linux) is not
+    evidence a serve backend exists.
+    """
+    try:
+        for runtime in getattr(plan, "runtimes", ()) or ():
+            if getattr(runtime, "kind", None) in ("serve", "dashboard"):
+                return True
+    except Exception as exc:
+        logger.debug("Could not scan plan for serve runtimes: %s", exc)
+    return False
+
+
 def _surviving_pre_update_serve_runtimes(plan) -> list[dict]:
     """Pre-update serve/dashboard runtimes that are STILL the same process.
 
@@ -181,7 +199,7 @@ def _recover_gateway_restart_after_abort(
         plan, skip_profiles=skip_profiles
     )
     profiles = sorted(candidates)
-    recover_serve = _serve_unit_recovery_available()
+    recover_serve = _serve_unit_recovery_available() and _plan_has_serve_runtimes(plan)
     _empty_serve: dict[str, list] = {"verified": [], "failed": []}
     if not profiles and not recover_serve:
         return {

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6933,11 +6933,19 @@ def _gateway_recovery_partition(
     Returns ``(candidates, skipped)`` where ``candidates`` maps profile →
     supervisor for supervised gateway runtimes the fresh process may restart,
     and ``skipped`` lists every other inventoried runtime the recovery pass
-    deliberately does NOT touch, each with an explicit reason.  Nothing from
-    the spawn ledger may vanish from the recovery pass silently: manual
-    gateways have no relaunch authority, and serve/dashboard runtimes (the
-    ``update_inventory`` serve collector) are owned by the Desktop app or a
-    human terminal, not by this recovery boundary.
+    deliberately does NOT touch *through a profile command*, each with an
+    explicit reason.  Nothing from the spawn ledger may vanish silently:
+    manual gateways have no relaunch authority, and serve/dashboard runtimes
+    (the ``update_inventory`` serve collector) have no per-profile relaunch
+    command at all.
+
+    A ``skipped`` serve/dashboard entry is NOT a statement that the runtime is
+    unrecoverable.  The fresh child runs a separate ``hermes-serve*`` systemd
+    pass that enumerates units from systemd rather than from this inventory,
+    precisely because the ledger collector cannot classify a systemd-launched
+    ``hermes serve``: it records no spawner, so it reads as ``manual-serve``.
+    Whatever that unit pass does not reconcile is caught afterwards by
+    :func:`_surviving_pre_update_serve_runtimes` (#92145).
     """
     skip_profiles = skip_profiles or set()
     candidates: dict[str, str] = {}
@@ -6975,10 +6983,21 @@ def _gateway_recovery_partition(
                         " its supervisor"
                     )
                 else:
+                    # NOT a claim that no supervisor exists. The ledger
+                    # collector derives serve/dashboard supervisors from
+                    # spawner liveness alone, and a systemd-launched
+                    # `hermes serve` sets neither HERMES_SPAWN nor
+                    # HERMES_PARENT_PID, so it lands here as "manual-serve".
+                    # Unit-backed serve runtimes are recovered by the
+                    # fresh child's systemd pass, which enumerates
+                    # `hermes-serve*` from systemd instead of trusting this
+                    # classification; survivors are reported afterwards by
+                    # _surviving_pre_update_serve_runtimes (#92145).
                     reason = (
-                        "manually launched serve/dashboard has no relaunch"
-                        " authority; left running for explicit operator"
-                        " restart"
+                        "no per-profile relaunch command reaches a serve/"
+                        "dashboard runtime; recovered by the fresh systemd"
+                        " unit pass when it owns a hermes-serve* unit, else"
+                        " left running for explicit operator restart"
                     )
                 skipped.append(
                     {
@@ -7001,8 +7020,66 @@ def _gateway_restart_recovery_profiles(
     return sorted(candidates)
 
 
+def _serve_unit_recovery_available() -> bool:
+    """Can a fresh process restart ``hermes-serve*`` units on this host?"""
+    return sys.platform == "linux" and bool(shutil.which("systemctl"))
+
+
+def _surviving_pre_update_serve_runtimes(plan) -> list[dict]:
+    """Pre-update serve/dashboard runtimes that are STILL the same process.
+
+    ``ledger_entries()`` re-verifies ``(pid, create_time)`` on every read and
+    prunes anything that is gone, so an entry that still matches a pre-update
+    PID is the original process — not a PID-reuse look-alike, and not a
+    successor (a restarted serve re-registers under a new PID).
+
+    Anything still here after the recovery pass is a live runtime on the
+    pre-update code generation, which is precisely the unsafe state #92145
+    reports. Fail closed: if the ledger cannot be read, every inventoried
+    runtime counts as surviving, because we cannot prove otherwise.
+    """
+    planned: dict[int, dict] = {}
+    try:
+        for runtime in getattr(plan, "runtimes", ()) or ():
+            if getattr(runtime, "kind", None) not in ("serve", "dashboard"):
+                continue
+            pid = getattr(runtime, "pid", None)
+            if not isinstance(pid, int) or pid <= 0:
+                continue
+            planned[pid] = {
+                "pid": pid,
+                "kind": str(getattr(runtime, "kind", "")),
+                "profile": str(getattr(runtime, "profile", "")),
+                "supervisor": str(getattr(runtime, "supervisor", "")),
+            }
+    except Exception as exc:
+        logger.debug("Could not read planned serve runtimes: %s", exc)
+        return []
+    if not planned:
+        return []
+    try:
+        from hermes_cli.process_identity import ledger_entries
+
+        live_pids = {
+            entry.get("pid")
+            for entry in ledger_entries()
+            if entry.get("purpose") in ("serve", "dashboard")
+        }
+    except Exception as exc:
+        logger.debug("Serve/dashboard survivor probe failed: %s", exc)
+        return sorted(planned.values(), key=lambda row: row["pid"])
+    return sorted(
+        (row for pid, row in planned.items() if pid in live_pids),
+        key=lambda row: row["pid"],
+    )
+
+
 def _recover_gateway_restart_after_abort(
-    plan, *, gateway_mode: bool, skip_profiles: set[str] | None = None
+    plan,
+    *,
+    gateway_mode: bool,
+    skip_profiles: set[str] | None = None,
+    skip_units: set[str] | None = None,
 ) -> dict[str, list]:
     """Retry supervised gateway restarts from a clean Python process.
 
@@ -7022,6 +7099,12 @@ def _recover_gateway_restart_after_abort(
     The returned protocol is persisted in the update receipt so operators can
     distinguish a spawn failure from a per-profile failure.
 
+    The same child additionally restarts active ``hermes-serve*`` systemd
+    units (#92145).  ``hermes serve`` hosts ``tui_gateway.server`` and is
+    restarted by the in-process phase alongside the gateway units, but no
+    per-profile ``gateway restart`` command reaches it — so an abort used to
+    leave it holding the pre-pull module graph with nothing left to notice.
+
     Outcome honesty: ``verified`` means the fresh child independently observed
     the profile's systemd unit active after the relaunch.  A zero exit from
     ``gateway restart`` alone is NOT observed proof that the new code
@@ -7032,13 +7115,16 @@ def _recover_gateway_restart_after_abort(
         plan, skip_profiles=skip_profiles
     )
     profiles = sorted(candidates)
-    if not profiles:
+    recover_serve = _serve_unit_recovery_available()
+    _empty_serve: dict[str, list] = {"verified": [], "failed": []}
+    if not profiles and not recover_serve:
         return {
             "requested": [],
             "verified": [],
             "relaunch_attempted": [],
             "failed": [],
             "skipped": skipped,
+            "serve_units": dict(_empty_serve),
         }
 
     def _all_failed() -> dict[str, list]:
@@ -7048,6 +7134,7 @@ def _recover_gateway_restart_after_abort(
             "relaunch_attempted": [],
             "failed": profiles,
             "skipped": skipped,
+            "serve_units": dict(_empty_serve),
         }
 
     command = [
@@ -7082,14 +7169,26 @@ def _recover_gateway_restart_after_abort(
         ]
 
     kwargs = {
-        "input": json.dumps({"profiles": profiles, "supervisors": candidates}),
+        "input": json.dumps(
+            {
+                "profiles": profiles,
+                "supervisors": candidates,
+                "serve_units": {
+                    "recover": recover_serve,
+                    "skip": sorted(skip_units or set()),
+                },
+            }
+        ),
         "capture_output": True,
         "text": True,
         "encoding": "utf-8",
         "errors": "replace",
         "check": False,
         "env": env,
-        "timeout": max(120, 30 + 90 * len(profiles)),
+        # Gateway profiles run sequentially at up to 90s each; the serve pass
+        # adds its own restart + settle budget on top, so give the child room
+        # for both rather than killing a recovery that was working.
+        "timeout": max(180, 30 + 90 * len(profiles) + (150 if recover_serve else 0)),
     }
     if sys.platform == "win32":
         kwargs["creationflags"] = (
@@ -7114,9 +7213,31 @@ def _recover_gateway_restart_after_abort(
         verified = recovery_result.get("verified")
         relaunch_attempted = recovery_result.get("relaunch_attempted")
         failed = recovery_result.get("failed")
+        raw_serve = recovery_result.get("serve_units") or dict(_empty_serve)
     except (AttributeError, TypeError, ValueError):
         logger.warning("Fresh gateway restart recovery returned invalid JSON")
         return _all_failed()
+
+    serve_units = dict(_empty_serve)
+    if (
+        isinstance(raw_serve, dict)
+        and isinstance(raw_serve.get("verified"), list)
+        and isinstance(raw_serve.get("failed"), list)
+        and all(
+            isinstance(unit, str)
+            for unit in (*raw_serve["verified"], *raw_serve["failed"])
+        )
+    ):
+        serve_units = {
+            "verified": sorted(raw_serve["verified"]),
+            "failed": sorted(raw_serve["failed"]),
+        }
+    elif recover_serve:
+        # An unreadable serve block cannot be read as "nothing to do": the
+        # units it describes are exactly the ones that host tui_gateway and
+        # may still be serving the pre-update generation.
+        logger.warning("Fresh recovery returned an invalid serve-unit result")
+        serve_units = {"verified": [], "failed": ["<unreadable>"]}
 
     buckets = (verified, relaunch_attempted, failed)
     reported: list[str] = []
@@ -7142,13 +7263,54 @@ def _recover_gateway_restart_after_abort(
             " supervisor-verified (check these gateways manually): "
             + ", ".join(sorted(relaunch_attempted))
         )
+    if serve_units["verified"]:
+        print(
+            "  ✓ Restarted serve unit(s) in a fresh process"
+            " (new main PID observed): "
+            + ", ".join(serve_units["verified"])
+        )
+    if serve_units["failed"]:
+        print(
+            "  ⚠ Could not verify a replacement for serve unit(s): "
+            + ", ".join(serve_units["failed"])
+        )
     return {
         "requested": profiles,
         "verified": sorted(verified),
         "relaunch_attempted": sorted(relaunch_attempted),
         "failed": sorted(failed),
         "skipped": skipped,
+        "serve_units": serve_units,
     }
+
+
+def _warn_stale_serve_runtimes(rows) -> None:
+    """Name the serve/dashboard processes that survived on pre-update code.
+
+    The original #92145 report is a user watching every chat turn fail with an
+    ``ImportError`` for a symbol that imports fine on disk, with nothing in the
+    terminal naming the responsible process. ``hermes serve`` hosts
+    ``tui_gateway.server``; when its unit was never restarted it keeps the
+    pre-pull ``sys.modules`` graph and there is no gateway row anywhere that
+    reveals it. Print the PIDs and the exact command that fixes it.
+    """
+    if not rows:
+        return
+    print(
+        "  ⚠ These serve/dashboard processes still run pre-update code"
+        " (they started before the checkout changed):"
+    )
+    for row in rows:
+        supervisor = row.get("supervisor") or "unknown"
+        print(
+            f"      pid {row.get('pid')} — {row.get('kind')}"
+            f" (profile {row.get('profile') or 'default'}, {supervisor})"
+        )
+    print(
+        "    Restart them before using Hermes again, e.g."
+        " `systemctl --user restart hermes-serve.service`"
+        " or by relaunching `hermes serve` / the Desktop app."
+    )
 
 
 def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
@@ -10357,7 +10519,26 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _pre_update_plan,
                 gateway_mode=gateway_mode,
                 skip_profiles=_already_restarted_profiles,
+                skip_units=set(restarted_services),
             )
+            _recovery_serve_units = _recovery_result.get("serve_units") or {}
+            _serve_units_failed = list(_recovery_serve_units.get("failed") or [])
+            # Deliberately NOT merged into ``restarted_services``: that list is
+            # the gateway phase's own vocabulary and feeds the fleet-probe
+            # expectation. Serve coverage lives in the recovery result and the
+            # receipt, where it can be read without changing gateway semantics.
+            # A serve/dashboard runtime that is still the SAME process the
+            # pre-update inventory saw is a live runtime on the pre-update
+            # code generation — the exact unsafe state of #92145, and the one
+            # the reporter hit through tui_gateway (hosted by `hermes serve`,
+            # which is not a gateway profile and which no `gateway restart`
+            # command can reach). Recovery may not report success while one
+            # is still there, and it must never kill one: a manual or
+            # Desktop-owned serve has no relaunch authority.
+            _stale_runtime_rows = _surviving_pre_update_serve_runtimes(
+                _pre_update_plan
+            )
+            _recovery_result["stale_runtimes"] = _stale_runtime_rows
             # Only systemd-VERIFIED outcomes may claim supervisor coverage.
             # A relaunch that merely exited 0 ("relaunch_attempted") was never
             # observed by the code and must not clear the incomplete flag.
@@ -10380,21 +10561,27 @@ def _cmd_update_impl(args, gateway_mode: bool):
             _covered_gateway_profiles = (
                 _already_restarted_profiles | _recovery_verified
             )
-            _recovery_complete = bool(_planned_gateway_profiles) and (
-                _planned_gateway_profiles <= _covered_gateway_profiles
-                and not _recovery_result.get("failed")
-                and not _recovery_result.get("relaunch_attempted")
+            _recovery_complete = _abort_recovery_is_complete(
+                planned_gateway_profiles=_planned_gateway_profiles,
+                covered_gateway_profiles=_covered_gateway_profiles,
+                recovery_result=_recovery_result,
+                stale_runtime_rows=_stale_runtime_rows,
             )
             if _recovery_complete:
                 # The fresh child is the recovery terminal result. Leave the
                 # final fleet-version matrix below as the authoritative
                 # read-back before the update is declared successful.
                 gateway_fleet_restart_incomplete = False
-            elif _restart_phase_failure_is_incomplete(
-                _surviving, _pre_restart_gateway_pids
+            elif (
+                _restart_phase_failure_is_incomplete(
+                    _surviving, _pre_restart_gateway_pids
+                )
+                or _stale_runtime_rows
+                or _serve_units_failed
             ):
                 gateway_fleet_restart_incomplete = True
                 _warn_gateway_restart_phase_aborted(e, _surviving)
+                _warn_stale_serve_runtimes(_stale_runtime_rows)
                 if gateway_mode:
                     _exit_code_path = get_hermes_home() / ".update_exit_code"
                     try:
@@ -10739,6 +10926,50 @@ def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
         return True
     # surviving == []: safe only if we know nothing was running beforehand.
     return pre_restart_pids is None or bool(pre_restart_pids)
+
+
+def _abort_recovery_is_complete(
+    *,
+    planned_gateway_profiles,
+    covered_gateway_profiles,
+    recovery_result,
+    stale_runtime_rows,
+) -> bool:
+    """May a fresh-process recovery clear the incomplete flag?
+
+    Only when EVERY inventoried runtime family is accounted for. The gateway
+    leg alone is not enough (#92145): the post-update read-back
+    (``collect_fleet_versions``) is gateway-only — it reads each profile's
+    ``gateway_state.json`` / control socket — so a ``hermes serve`` still
+    holding the pre-update ``sys.modules`` graph is invisible to both the
+    recovery pass and the verification that follows it. Clearing the flag on
+    gateway coverage alone is exactly how an update reported success while
+    every chat turn kept failing with an ``ImportError`` for a symbol that
+    imports fine on disk.
+
+    Fail closed on each leg:
+
+    * every planned gateway profile is covered, with nothing failed and
+      nothing merely ``relaunch_attempted`` (rc 0 is not observed coverage);
+    * no ``hermes-serve*`` unit failed to produce a verified replacement; and
+    * no serve/dashboard process from the pre-update inventory is still the
+      same process (``stale_runtime_rows``).
+
+    ``planned_gateway_profiles`` being empty is deliberately NOT completeness:
+    with no gateway leg to prove, the caller's own fail-closed contract
+    (``_restart_phase_failure_is_incomplete``) plus the stale-runtime rows
+    decide the outcome.
+    """
+    if not planned_gateway_profiles:
+        return False
+    if not set(planned_gateway_profiles) <= set(covered_gateway_profiles):
+        return False
+    result = recovery_result or {}
+    if result.get("failed") or result.get("relaunch_attempted"):
+        return False
+    if (result.get("serve_units") or {}).get("failed"):
+        return False
+    return not stale_runtime_rows
 
 
 def _fleet_probe_expected_runtimes(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -6921,6 +6921,19 @@ def _gateway_service_matches_profile(profile: str, service: object) -> bool:
     }
 
 
+# Abort recovery lives in its own bounded module (review on #96235). Re-exported
+# here because `hermes_cli.main` and the update flow below address these names
+# through `update_cmd`.
+from hermes_cli.update_abort_recovery import (  # noqa: E402
+    _abort_recovery_is_complete,
+    _qualified_serve_skips,
+    _recover_gateway_restart_after_abort,
+    _serve_unit_recovery_available,
+    _surviving_pre_update_serve_runtimes,
+    _warn_stale_serve_runtimes,
+)
+
+
 def _gateway_recovery_partition(
     plan, *, skip_profiles: set[str] | None = None
 ) -> tuple[dict[str, str], list[dict]]:
@@ -7018,299 +7031,6 @@ def _gateway_restart_recovery_profiles(
     """Return supervised gateway profiles that a fresh process may restart."""
     candidates, _ = _gateway_recovery_partition(plan, skip_profiles=skip_profiles)
     return sorted(candidates)
-
-
-def _serve_unit_recovery_available() -> bool:
-    """Can a fresh process restart ``hermes-serve*`` units on this host?"""
-    return sys.platform == "linux" and bool(shutil.which("systemctl"))
-
-
-def _surviving_pre_update_serve_runtimes(plan) -> list[dict]:
-    """Pre-update serve/dashboard runtimes that are STILL the same process.
-
-    ``ledger_entries()`` re-verifies ``(pid, create_time)`` on every read and
-    prunes anything that is gone, so an entry that still matches a pre-update
-    PID is the original process — not a PID-reuse look-alike, and not a
-    successor (a restarted serve re-registers under a new PID).
-
-    Anything still here after the recovery pass is a live runtime on the
-    pre-update code generation, which is precisely the unsafe state #92145
-    reports. Fail closed: if the ledger cannot be read, every inventoried
-    runtime counts as surviving, because we cannot prove otherwise.
-    """
-    planned: dict[int, dict] = {}
-    try:
-        for runtime in getattr(plan, "runtimes", ()) or ():
-            if getattr(runtime, "kind", None) not in ("serve", "dashboard"):
-                continue
-            pid = getattr(runtime, "pid", None)
-            if not isinstance(pid, int) or pid <= 0:
-                continue
-            planned[pid] = {
-                "pid": pid,
-                "kind": str(getattr(runtime, "kind", "")),
-                "profile": str(getattr(runtime, "profile", "")),
-                "supervisor": str(getattr(runtime, "supervisor", "")),
-            }
-    except Exception as exc:
-        logger.debug("Could not read planned serve runtimes: %s", exc)
-        return []
-    if not planned:
-        return []
-    try:
-        from hermes_cli.process_identity import ledger_entries
-
-        live_pids = {
-            entry.get("pid")
-            for entry in ledger_entries()
-            if entry.get("purpose") in ("serve", "dashboard")
-        }
-    except Exception as exc:
-        logger.debug("Serve/dashboard survivor probe failed: %s", exc)
-        return sorted(planned.values(), key=lambda row: row["pid"])
-    return sorted(
-        (row for pid, row in planned.items() if pid in live_pids),
-        key=lambda row: row["pid"],
-    )
-
-
-def _recover_gateway_restart_after_abort(
-    plan,
-    *,
-    gateway_mode: bool,
-    skip_profiles: set[str] | None = None,
-    skip_units: set[str] | None = None,
-) -> dict[str, list]:
-    """Retry supervised gateway restarts from a clean Python process.
-
-    ``hermes update`` normally performs the fleet restart in the interpreter
-    that started before ``git pull``.  If that phase raises while importing the
-    new tree, a warning alone leaves the old gateway alive against new files on
-    disk.  The recovery boundary launches the existing per-profile
-    ``gateway restart`` command through a new interpreter, preserving its
-    platform-specific drain and service-manager logic without inheriting the
-    stale ``sys.modules`` graph.
-
-    Only profiles classified as supervisor-owned by the pre-update inventory
-    are handed off.  A manual gateway must remain running and be reported for
-    explicit operator action rather than being killed without a relaunch
-    authority; serve/dashboard runtimes from the spawn ledger are likewise
-    recorded as skipped with a reason instead of vanishing from the pass.
-    The returned protocol is persisted in the update receipt so operators can
-    distinguish a spawn failure from a per-profile failure.
-
-    The same child additionally restarts active ``hermes-serve*`` systemd
-    units (#92145).  ``hermes serve`` hosts ``tui_gateway.server`` and is
-    restarted by the in-process phase alongside the gateway units, but no
-    per-profile ``gateway restart`` command reaches it — so an abort used to
-    leave it holding the pre-pull module graph with nothing left to notice.
-
-    Outcome honesty: ``verified`` means the fresh child independently observed
-    the profile's systemd unit active after the relaunch.  A zero exit from
-    ``gateway restart`` alone is NOT observed proof that the new code
-    generation is serving, so those outcomes are reported as
-    ``relaunch_attempted`` and never claim supervisor coverage.
-    """
-    candidates, skipped = _gateway_recovery_partition(
-        plan, skip_profiles=skip_profiles
-    )
-    profiles = sorted(candidates)
-    recover_serve = _serve_unit_recovery_available()
-    _empty_serve: dict[str, list] = {"verified": [], "failed": []}
-    if not profiles and not recover_serve:
-        return {
-            "requested": [],
-            "verified": [],
-            "relaunch_attempted": [],
-            "failed": [],
-            "skipped": skipped,
-            "serve_units": dict(_empty_serve),
-        }
-
-    def _all_failed() -> dict[str, list]:
-        return {
-            "requested": profiles,
-            "verified": [],
-            "relaunch_attempted": [],
-            "failed": profiles,
-            "skipped": skipped,
-            "serve_units": dict(_empty_serve),
-        }
-
-    command = [
-        sys.executable,
-        "-m",
-        "hermes_cli.update_restart_recovery",
-        "--stdin",
-    ]
-    env = os.environ.copy()
-    env["HERMES_UPDATE_RESTART_RECOVERY"] = "1"
-    for marker in ("_HERMES_GATEWAY", "HERMES_GATEWAY", "HERMES_GATEWAY_MODE"):
-        env.pop(marker, None)
-
-    # A gateway-triggered update may run inside the gateway's systemd cgroup.
-    # Put the recovery process in a transient user scope before it asks systemd
-    # to restart that gateway, otherwise KillMode can terminate the recovery
-    # process together with the old service. If systemd-run is unavailable,
-    # fail closed rather than pretending the in-cgroup child is independent.
-    if gateway_mode and sys.platform == "linux":
-        systemd_run = shutil.which("systemd-run")
-        if not systemd_run:
-            logger.warning("Cannot isolate fresh gateway recovery from the gateway cgroup")
-            return _all_failed()
-        command = [
-            systemd_run,
-            "--user",
-            "--scope",
-            "--quiet",
-            "--collect",
-            "--",
-            *command,
-        ]
-
-    kwargs = {
-        "input": json.dumps(
-            {
-                "profiles": profiles,
-                "supervisors": candidates,
-                "serve_units": {
-                    "recover": recover_serve,
-                    "skip": sorted(skip_units or set()),
-                },
-            }
-        ),
-        "capture_output": True,
-        "text": True,
-        "encoding": "utf-8",
-        "errors": "replace",
-        "check": False,
-        "env": env,
-        # Gateway profiles run sequentially at up to 90s each; the serve pass
-        # adds its own restart + settle budget on top, so give the child room
-        # for both rather than killing a recovery that was working.
-        "timeout": max(180, 30 + 90 * len(profiles) + (150 if recover_serve else 0)),
-    }
-    if sys.platform == "win32":
-        kwargs["creationflags"] = (
-            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
-            | getattr(subprocess, "DETACHED_PROCESS", 0)
-        )
-    else:
-        kwargs["start_new_session"] = True
-
-    try:
-        result = subprocess.run(command, **kwargs)
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.warning("Fresh gateway restart recovery failed: %s", exc)
-        return _all_failed()
-
-    if result.returncode != 0:
-        logger.warning("Fresh gateway restart recovery exited %s", result.returncode)
-        return _all_failed()
-
-    try:
-        recovery_result = json.loads(result.stdout or "")
-        verified = recovery_result.get("verified")
-        relaunch_attempted = recovery_result.get("relaunch_attempted")
-        failed = recovery_result.get("failed")
-        raw_serve = recovery_result.get("serve_units") or dict(_empty_serve)
-    except (AttributeError, TypeError, ValueError):
-        logger.warning("Fresh gateway restart recovery returned invalid JSON")
-        return _all_failed()
-
-    serve_units = dict(_empty_serve)
-    if (
-        isinstance(raw_serve, dict)
-        and isinstance(raw_serve.get("verified"), list)
-        and isinstance(raw_serve.get("failed"), list)
-        and all(
-            isinstance(unit, str)
-            for unit in (*raw_serve["verified"], *raw_serve["failed"])
-        )
-    ):
-        serve_units = {
-            "verified": sorted(raw_serve["verified"]),
-            "failed": sorted(raw_serve["failed"]),
-        }
-    elif recover_serve:
-        # An unreadable serve block cannot be read as "nothing to do": the
-        # units it describes are exactly the ones that host tui_gateway and
-        # may still be serving the pre-update generation.
-        logger.warning("Fresh recovery returned an invalid serve-unit result")
-        serve_units = {"verified": [], "failed": ["<unreadable>"]}
-
-    buckets = (verified, relaunch_attempted, failed)
-    reported: list[str] = []
-    if all(isinstance(bucket, list) for bucket in buckets):
-        reported = [*verified, *relaunch_attempted, *failed]
-    if (
-        not all(isinstance(bucket, list) for bucket in buckets)
-        or any(not isinstance(profile, str) for profile in reported)
-        or set(reported) != set(profiles)
-        or len(reported) != len(set(reported))
-    ):
-        logger.warning("Fresh gateway restart recovery returned incomplete profiles")
-        return _all_failed()
-
-    if verified:
-        print(
-            "  ✓ Restarted supervised gateway(s) in a fresh process"
-            " (systemd-verified active): " + ", ".join(sorted(verified))
-        )
-    if relaunch_attempted:
-        print(
-            "  ⚠ Relaunch attempted in a fresh process but not"
-            " supervisor-verified (check these gateways manually): "
-            + ", ".join(sorted(relaunch_attempted))
-        )
-    if serve_units["verified"]:
-        print(
-            "  ✓ Restarted serve unit(s) in a fresh process"
-            " (new main PID observed): "
-            + ", ".join(serve_units["verified"])
-        )
-    if serve_units["failed"]:
-        print(
-            "  ⚠ Could not verify a replacement for serve unit(s): "
-            + ", ".join(serve_units["failed"])
-        )
-    return {
-        "requested": profiles,
-        "verified": sorted(verified),
-        "relaunch_attempted": sorted(relaunch_attempted),
-        "failed": sorted(failed),
-        "skipped": skipped,
-        "serve_units": serve_units,
-    }
-
-
-def _warn_stale_serve_runtimes(rows) -> None:
-    """Name the serve/dashboard processes that survived on pre-update code.
-
-    The original #92145 report is a user watching every chat turn fail with an
-    ``ImportError`` for a symbol that imports fine on disk, with nothing in the
-    terminal naming the responsible process. ``hermes serve`` hosts
-    ``tui_gateway.server``; when its unit was never restarted it keeps the
-    pre-pull ``sys.modules`` graph and there is no gateway row anywhere that
-    reveals it. Print the PIDs and the exact command that fixes it.
-    """
-    if not rows:
-        return
-    print(
-        "  ⚠ These serve/dashboard processes still run pre-update code"
-        " (they started before the checkout changed):"
-    )
-    for row in rows:
-        supervisor = row.get("supervisor") or "unknown"
-        print(
-            f"      pid {row.get('pid')} — {row.get('kind')}"
-            f" (profile {row.get('profile') or 'default'}, {supervisor})"
-        )
-    print(
-        "    Restart them before using Hermes again, e.g."
-        " `systemctl --user restart hermes-serve.service`"
-        " or by relaunching `hermes serve` / the Desktop app."
-    )
 
 
 def _warn_gateway_restart_phase_aborted(exc: BaseException, pids) -> None:
@@ -9718,6 +9438,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
         # needed to forward already-restarted units to
         # ``_finish_dashboard_update_cleanup`` (review on #83595).
         restarted_services: list = []
+        # Scope-qualified twin of ``restarted_services`` for systemd units:
+        # ``user/hermes-serve`` and ``system/hermes-serve`` are two different
+        # processes, and the abort-recovery child needs to know WHICH one was
+        # already settled. ``restarted_services`` itself keeps its bare-name
+        # vocabulary — the fleet probe, the receipt and the operator summary
+        # all read it (#92145 review).
+        restarted_scoped_units: set = set()
         # Keep these restart bookkeeping collections defined even when the
         # phase raises before its platform-specific imports initialize them.
         # The abort recovery and the fleet reconciliation both consume the
@@ -10256,11 +9983,22 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             f"continuing with remaining gateways"
                         )
 
-                    _for_each_systemd_gateway_unit(
-                        result.stdout,
-                        process_unit=_restart_one_systemd_gateway_unit,
-                        on_unit_timeout=_on_unit_timeout,
-                    )
+                    # Everything this scope appends to ``restarted_services``
+                    # belongs to THIS systemd manager; qualify it before the
+                    # next scope can append a same-named unit. ``finally`` so a
+                    # phase abort mid-scope still carries the units it settled.
+                    _scope_mark = len(restarted_services)
+                    try:
+                        _for_each_systemd_gateway_unit(
+                            result.stdout,
+                            process_unit=_restart_one_systemd_gateway_unit,
+                            on_unit_timeout=_on_unit_timeout,
+                        )
+                    finally:
+                        restarted_scoped_units.update(
+                            f"{scope}/{name}"
+                            for name in restarted_services[_scope_mark:]
+                        )
 
             # --- Launchd services (macOS) ---
             # Restart EVERY ai.hermes.gateway* LaunchAgent, not only the
@@ -10519,7 +10257,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 _pre_update_plan,
                 gateway_mode=gateway_mode,
                 skip_profiles=_already_restarted_profiles,
-                skip_units=set(restarted_services),
+                skip_units=set(restarted_scoped_units),
             )
             _recovery_serve_units = _recovery_result.get("serve_units") or {}
             _serve_units_failed = list(_recovery_serve_units.get("failed") or [])
@@ -10926,50 +10664,6 @@ def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
         return True
     # surviving == []: safe only if we know nothing was running beforehand.
     return pre_restart_pids is None or bool(pre_restart_pids)
-
-
-def _abort_recovery_is_complete(
-    *,
-    planned_gateway_profiles,
-    covered_gateway_profiles,
-    recovery_result,
-    stale_runtime_rows,
-) -> bool:
-    """May a fresh-process recovery clear the incomplete flag?
-
-    Only when EVERY inventoried runtime family is accounted for. The gateway
-    leg alone is not enough (#92145): the post-update read-back
-    (``collect_fleet_versions``) is gateway-only — it reads each profile's
-    ``gateway_state.json`` / control socket — so a ``hermes serve`` still
-    holding the pre-update ``sys.modules`` graph is invisible to both the
-    recovery pass and the verification that follows it. Clearing the flag on
-    gateway coverage alone is exactly how an update reported success while
-    every chat turn kept failing with an ``ImportError`` for a symbol that
-    imports fine on disk.
-
-    Fail closed on each leg:
-
-    * every planned gateway profile is covered, with nothing failed and
-      nothing merely ``relaunch_attempted`` (rc 0 is not observed coverage);
-    * no ``hermes-serve*`` unit failed to produce a verified replacement; and
-    * no serve/dashboard process from the pre-update inventory is still the
-      same process (``stale_runtime_rows``).
-
-    ``planned_gateway_profiles`` being empty is deliberately NOT completeness:
-    with no gateway leg to prove, the caller's own fail-closed contract
-    (``_restart_phase_failure_is_incomplete``) plus the stale-runtime rows
-    decide the outcome.
-    """
-    if not planned_gateway_profiles:
-        return False
-    if not set(planned_gateway_profiles) <= set(covered_gateway_profiles):
-        return False
-    result = recovery_result or {}
-    if result.get("failed") or result.get("relaunch_attempted"):
-        return False
-    if (result.get("serve_units") or {}).get("failed"):
-        return False
-    return not stale_runtime_rows
 
 
 def _fleet_probe_expected_runtimes(

--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -380,6 +380,11 @@ def collect_runtime_inventory() -> UpdatePlan:
                         "argv": entry.get("argv") or "",
                         "host": entry.get("host") or "",
                         "port": entry.get("port"),
+                        # Process incarnation, not just the numeric PID: a
+                        # post-update survivor probe that compares PIDs alone
+                        # calls a NEW serve that reused the number a survivor
+                        # (#92145 review).
+                        "create_time": entry.get("create_time"),
                     },
                 )
             )

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -132,6 +132,27 @@ class UpdateReceipt:
                 for entry in fresh_recovery.get("skipped", [])
                 if isinstance(entry, dict)
             ]
+            # Serve/dashboard coverage (#92145). ``hermes serve`` hosts
+            # tui_gateway and is not a gateway profile, so neither the
+            # per-profile buckets above nor the fleet-version matrix can
+            # describe it. Persist its unit outcomes and any process that
+            # survived on the pre-update generation, or the receipt keeps
+            # claiming a clean recovery the operator's box contradicts.
+            serve_units = fresh_recovery.get("serve_units") or {}
+            persisted["serve_units"] = {
+                key: [str(unit) for unit in (serve_units.get(key) or [])]
+                for key in ("verified", "failed")
+            }
+            persisted["stale_runtimes"] = [
+                {
+                    "pid": int(entry.get("pid", 0) or 0),
+                    "kind": str(entry.get("kind", "")),
+                    "profile": str(entry.get("profile", "")),
+                    "supervisor": str(entry.get("supervisor", "")),
+                }
+                for entry in fresh_recovery.get("stale_runtimes", [])
+                if isinstance(entry, dict)
+            ]
             result["fresh_recovery"] = persisted
         self.data["gateway_restart"] = result
 

--- a/hermes_cli/update_restart_recovery.py
+++ b/hermes_cli/update_restart_recovery.py
@@ -19,6 +19,20 @@ Outcome vocabulary (deliberately conservative):
   so this outcome must never be treated as verified coverage.
 - ``failed``            — the relaunch command errored, timed out, or exited
   non-zero.
+
+The pass covers two runtime families, because the in-process restart phase
+covers both and an abort can strand either one (#92145):
+
+- **gateway profiles**, relaunched through the existing per-profile
+  ``hermes_cli.main -p <profile> gateway restart`` command; and
+- **``hermes-serve*`` systemd units**, restarted directly through
+  ``systemctl``.  ``hermes serve`` is not a gateway profile and has no
+  per-profile relaunch command, but it is the runtime that hosts
+  ``tui_gateway.server``: the process the original report saw answering every
+  chat turn with an ``ImportError`` for a symbol that existed on disk.  The
+  unit family is enumerated from systemd itself rather than from the update
+  inventory, so a manually launched or Desktop-owned ``hermes serve`` — which
+  has no relaunch authority — can never enter this path.
 """
 
 from __future__ import annotations
@@ -30,6 +44,7 @@ import re
 import shutil
 import subprocess
 import sys
+import time
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
@@ -39,6 +54,11 @@ _PROFILE_RESTART_TIMEOUT = 90
 _VERIFY_TIMEOUT = 15
 _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 _SUPERVISOR_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
+_UNIT_RE = re.compile(r"^hermes-serve(-[a-z0-9][a-z0-9_-]{0,63})?\.service$")
+_SERVE_UNIT_PATTERN = "hermes-serve*"
+_UNIT_RESTART_TIMEOUT = 60
+_UNIT_SETTLE_ATTEMPTS = 10
+_UNIT_SETTLE_DELAY = 1.0
 
 
 def _profile_command(profile: str) -> list[str]:
@@ -183,7 +203,208 @@ def restart_profiles(
     }
 
 
-def _parse_payload(stream) -> tuple[list[str], dict[str, str]]:
+def _systemctl_scopes() -> list[list[str]]:
+    """``systemctl`` invocations for the user and system scopes, or nothing.
+
+    Mirrors the scope pair the in-process restart phase walks. ``systemctl``
+    is resolved through ``shutil.which`` so this module never has to import
+    any Hermes platform helper — importing the freshly pulled tree is exactly
+    what aborted the phase that called us.
+    """
+    systemctl = shutil.which("systemctl")
+    if not systemctl or sys.platform != "linux":
+        return []
+    return [[systemctl, "--user"], [systemctl]]
+
+
+def _listed_serve_units(scope: list[str], *, run: Callable[..., Any]) -> list[str]:
+    """Serve units systemd knows about in one scope, validated by name."""
+    try:
+        result = run(
+            scope
+            + [
+                "list-units",
+                _SERVE_UNIT_PATTERN,
+                "--plain",
+                "--no-legend",
+                "--no-pager",
+            ],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=_VERIFY_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return []
+    units: list[str] = []
+    for line in (getattr(result, "stdout", "") or "").splitlines():
+        parts = line.split()
+        if not parts:
+            continue
+        # The glob is a systemd pattern, not a name gate: `hermes-serve*` also
+        # matches the unrelated `hermes-server.service`. Require the exact
+        # base unit or the hyphenated profile family, same shape as the
+        # in-process phase's own name gate.
+        if _UNIT_RE.fullmatch(parts[0]) and parts[0] not in units:
+            units.append(parts[0])
+    return units
+
+
+def _unit_property(
+    scope: list[str], unit: str, prop: str, *, run: Callable[..., Any]
+) -> str | None:
+    """One ``systemctl show`` property, or ``None`` when it cannot be read."""
+    try:
+        result = run(
+            scope + ["show", unit, f"--property={prop}", "--value"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=_VERIFY_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if getattr(result, "returncode", 1) != 0:
+        return None
+    return (getattr(result, "stdout", "") or "").strip()
+
+
+def _unit_main_pid(scope: list[str], unit: str, *, run: Callable[..., Any]) -> int:
+    """The unit's ``MainPID``; ``0`` when absent or unreadable."""
+    raw = _unit_property(scope, unit, "MainPID", run=run)
+    try:
+        return int(raw or 0)
+    except ValueError:
+        return 0
+
+
+def _unit_is_active(scope: list[str], unit: str, *, run: Callable[..., Any]) -> bool:
+    try:
+        result = run(
+            scope + ["is-active", unit],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            check=False,
+            timeout=_VERIFY_TIMEOUT,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return (getattr(result, "stdout", "") or "").strip() == "active"
+
+
+def _serve_unit_replaced(
+    scope: list[str],
+    unit: str,
+    previous_pid: int,
+    *,
+    run: Callable[..., Any],
+    sleep: Callable[[float], Any],
+) -> bool:
+    """Did the unit come back on a NEW main process?
+
+    ``restart`` returning 0 is not evidence: the whole point of #92145 is that
+    a live process can keep serving the pre-update generation while every
+    status command reports success. A changed ``MainPID`` on an ``active``
+    unit is the observation that the old interpreter — and its stale
+    ``sys.modules`` — is gone.
+    """
+    for attempt in range(_UNIT_SETTLE_ATTEMPTS):
+        if attempt:
+            sleep(_UNIT_SETTLE_DELAY)
+        if not _unit_is_active(scope, unit, run=run):
+            continue
+        current = _unit_main_pid(scope, unit, run=run)
+        if current > 0 and current != previous_pid:
+            return True
+    return False
+
+
+def restart_serve_units(
+    *,
+    skip_units: Iterable[str] = (),
+    run: Callable[..., Any] = subprocess.run,
+    sleep: Callable[[float], Any] = time.sleep,
+) -> dict[str, list[str]]:
+    """Restart every active ``hermes-serve*`` systemd unit from this process.
+
+    ``hermes serve`` hosts ``tui_gateway.server`` and is restarted by the
+    in-process phase alongside the gateway units, but it is not a gateway
+    profile: no ``gateway restart`` command reaches it. When the phase aborts
+    part-way — systemd lists ``hermes-gateway.service`` before
+    ``hermes-serve.service``, so the gateway is typically already done — the
+    serve unit is the one left holding generation-N modules over a
+    generation-N+1 checkout.
+
+    Units are enumerated from systemd, never from the update inventory. That
+    keeps the relaunch authority requirement structural: a manually launched
+    or Desktop-owned ``hermes serve`` owns no unit and therefore cannot be
+    touched here.
+
+    Returns ``{"verified": [...], "failed": [...]}`` keyed by base unit name
+    (no ``.service`` suffix), matching the vocabulary the restart phase
+    already uses for ``restarted_services``.
+    """
+    skipped = {str(name).removesuffix(".service") for name in skip_units}
+    # base unit name -> replaced?  A unit name can exist in BOTH the user and
+    # the system scope; each is a separate process and each must be proven.
+    # Worst outcome wins, so one unprovable scope cannot be masked by the
+    # other reporting success.
+    outcomes: dict[str, bool] = {}
+    seen: set[tuple[str, str]] = set()
+    for scope in _systemctl_scopes():
+        scope_key = " ".join(scope)
+        for unit in _listed_serve_units(scope, run=run):
+            base = unit.removesuffix(".service")
+            if (scope_key, base) in seen or base in skipped:
+                continue
+            seen.add((scope_key, base))
+            if not _unit_is_active(scope, unit, run=run):
+                # Not running: nothing is serving a stale generation from it.
+                continue
+            previous_pid = _unit_main_pid(scope, unit, run=run)
+            if previous_pid <= 0:
+                # Active with no readable main process: a replacement cannot
+                # be observed, so it cannot be claimed. Restarting blind and
+                # reporting success is the failure mode this module exists to
+                # remove.
+                outcomes[base] = False
+                continue
+            try:
+                result = run(
+                    scope + ["--no-ask-password", "restart", unit],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    check=False,
+                    timeout=_UNIT_RESTART_TIMEOUT,
+                )
+            except (OSError, subprocess.TimeoutExpired):
+                outcomes[base] = False
+                continue
+            if getattr(result, "returncode", 1) != 0:
+                # Includes the unprivileged system-scope case. We do not probe
+                # for sudo here: an unverifiable unit must read as failed so
+                # the update stays explicitly incomplete.
+                outcomes[base] = False
+                continue
+            replaced = _serve_unit_replaced(
+                scope, unit, previous_pid, run=run, sleep=sleep
+            )
+            outcomes[base] = outcomes.get(base, True) and replaced
+    return {
+        "verified": sorted(base for base, ok in outcomes.items() if ok),
+        "failed": sorted(base for base, ok in outcomes.items() if not ok),
+    }
+
+
+def _parse_payload(stream) -> tuple[list[str], dict[str, str], bool, list[str]]:
     payload = json.load(stream)
     profiles = payload.get("profiles") if isinstance(payload, dict) else None
     if not isinstance(profiles, list):
@@ -205,7 +426,26 @@ def _parse_payload(stream) -> tuple[list[str], dict[str, str]]:
         ):
             raise ValueError("recovery supervisors map is invalid")
         supervisors = dict(raw_supervisors)
-    return profiles, supervisors
+    raw_serve = payload.get("serve_units") if isinstance(payload, dict) else None
+    recover_serve = False
+    skip_units: list[str] = []
+    if raw_serve is not None:
+        if not isinstance(raw_serve, dict):
+            raise ValueError("recovery serve_units block is invalid")
+        recover_serve = bool(raw_serve.get("recover"))
+        raw_skip = raw_serve.get("skip") or []
+        if not isinstance(raw_skip, list) or any(
+            not isinstance(unit, str) for unit in raw_skip
+        ):
+            raise ValueError("recovery serve_units skip list is invalid")
+        # Only the shapes systemd can actually produce for this family; a
+        # skip entry is a name filter, never a command argument.
+        skip_units = [
+            unit
+            for unit in raw_skip
+            if _UNIT_RE.fullmatch(unit if unit.endswith(".service") else f"{unit}.service")
+        ]
+    return profiles, supervisors, recover_serve, skip_units
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -220,8 +460,13 @@ def main(argv: list[str] | None = None) -> int:
         parser.error("this command is an internal update-recovery entry point")
 
     try:
-        profiles, supervisors = _parse_payload(sys.stdin)
+        profiles, supervisors, recover_serve, skip_units = _parse_payload(sys.stdin)
         result = restart_profiles(profiles, supervisors=supervisors)
+        result["serve_units"] = (
+            restart_serve_units(skip_units=skip_units)
+            if recover_serve
+            else {"verified": [], "failed": []}
+        )
     except (ValueError, json.JSONDecodeError) as exc:
         print(
             json.dumps(
@@ -230,13 +475,16 @@ def main(argv: list[str] | None = None) -> int:
                     "verified": [],
                     "relaunch_attempted": [],
                     "failed": [],
+                    "serve_units": {"verified": [], "failed": []},
                 }
             )
         )
         return 2
 
     print(json.dumps(result, sort_keys=True))
-    return 0 if not result["failed"] else 1
+    if result["failed"] or result["serve_units"]["failed"]:
+        return 1
+    return 0
 
 
 if __name__ == "__main__":

--- a/hermes_cli/update_restart_recovery.py
+++ b/hermes_cli/update_restart_recovery.py
@@ -33,6 +33,14 @@ covers both and an abort can strand either one (#92145):
   unit family is enumerated from systemd itself rather than from the update
   inventory, so a manually launched or Desktop-owned ``hermes serve`` — which
   has no relaunch authority — can never enter this path.
+
+Serve-unit identity is always ``<scope>/<unit>`` (``user/hermes-serve``,
+``system/hermes-serve``).  The two managers can each own a unit of the same
+name and they are different processes: an identity that projects the scope
+away lets one settled unit suppress recovery of the other, and lets one
+scope's outcome speak for the other's.  Scope is therefore never dropped and
+reconstructed — not in the skip payload, not in ``verified``/``failed``, not
+in the receipt.
 """
 
 from __future__ import annotations
@@ -56,6 +64,7 @@ _PROFILE_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
 _SUPERVISOR_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,31}$")
 _UNIT_RE = re.compile(r"^hermes-serve(-[a-z0-9][a-z0-9_-]{0,63})?\.service$")
 _SERVE_UNIT_PATTERN = "hermes-serve*"
+_SCOPE_LABELS = ("user", "system")
 _UNIT_RESTART_TIMEOUT = 60
 _UNIT_SETTLE_ATTEMPTS = 10
 _UNIT_SETTLE_DELAY = 1.0
@@ -203,18 +212,23 @@ def restart_profiles(
     }
 
 
-def _systemctl_scopes() -> list[list[str]]:
+def _systemctl_scopes() -> list[tuple[str, list[str]]]:
     """``systemctl`` invocations for the user and system scopes, or nothing.
 
     Mirrors the scope pair the in-process restart phase walks. ``systemctl``
     is resolved through ``shutil.which`` so this module never has to import
     any Hermes platform helper — importing the freshly pulled tree is exactly
     what aborted the phase that called us.
+
+    Each scope is returned with its label because ``hermes-serve.service`` in
+    the user manager and ``hermes-serve.service`` in the system manager are
+    two different processes. Every identity this module produces or consumes
+    stays qualified by that label; the bare unit name is never the key.
     """
     systemctl = shutil.which("systemctl")
     if not systemctl or sys.platform != "linux":
         return []
-    return [[systemctl, "--user"], [systemctl]]
+    return [("user", [systemctl, "--user"]), ("system", [systemctl])]
 
 
 def _listed_serve_units(scope: list[str], *, run: Callable[..., Any]) -> list[str]:
@@ -325,9 +339,48 @@ def _serve_unit_replaced(
     return False
 
 
+def _qualified(scope_label: str, base: str) -> str:
+    """The only identity this module reports for a serve unit."""
+    return f"{scope_label}/{base}"
+
+
+def _normalized_skips(
+    skip_units: Iterable[Any],
+) -> tuple[set[tuple[str, str]], set[str]]:
+    """Split already-settled units into scope-qualified and legacy entries.
+
+    Qualified entries (``{"scope": "user", "unit": "hermes-serve"}`` or the
+    equivalent ``"user/hermes-serve"`` string) suppress exactly one process.
+
+    A bare ``"hermes-serve"`` carries no scope and therefore cannot say WHICH
+    of two same-named processes was settled. It is honoured across both scopes
+    because that is all the information it contains — the caller in this tree
+    always sends the qualified shape, and this branch exists only for a payload
+    written by a pre-update interpreter that had no scope to send.
+    """
+    qualified: set[tuple[str, str]] = set()
+    legacy: set[str] = set()
+    for entry in skip_units or ():
+        if isinstance(entry, Mapping):
+            scope_label = str(entry.get("scope") or "")
+            base = str(entry.get("unit") or "").removesuffix(".service")
+        else:
+            scope_label, sep, unit = str(entry).partition("/")
+            if not sep:
+                scope_label, unit = "", scope_label
+            base = unit.removesuffix(".service")
+        if not base:
+            continue
+        if scope_label in _SCOPE_LABELS:
+            qualified.add((scope_label, base))
+        else:
+            legacy.add(base)
+    return qualified, legacy
+
+
 def restart_serve_units(
     *,
-    skip_units: Iterable[str] = (),
+    skip_units: Iterable[Any] = (),
     run: Callable[..., Any] = subprocess.run,
     sleep: Callable[[float], Any] = time.sleep,
 ) -> dict[str, list[str]]:
@@ -346,24 +399,29 @@ def restart_serve_units(
     or Desktop-owned ``hermes serve`` owns no unit and therefore cannot be
     touched here.
 
-    Returns ``{"verified": [...], "failed": [...]}`` keyed by base unit name
-    (no ``.service`` suffix), matching the vocabulary the restart phase
-    already uses for ``restarted_services``.
+    Every identity in and out of this function is scope-qualified. The user
+    manager and the system manager can each own a ``hermes-serve.service``,
+    and they are different processes: projecting the scope away would let one
+    already-settled unit suppress recovery of the other, and would let one
+    scope's success describe the other's outcome.
+
+    Returns ``{"verified": [...], "failed": [...]}`` whose entries are
+    ``<scope>/<base unit>`` (no ``.service`` suffix), e.g.
+    ``user/hermes-serve``.
     """
-    skipped = {str(name).removesuffix(".service") for name in skip_units}
-    # base unit name -> replaced?  A unit name can exist in BOTH the user and
-    # the system scope; each is a separate process and each must be proven.
-    # Worst outcome wins, so one unprovable scope cannot be masked by the
-    # other reporting success.
-    outcomes: dict[str, bool] = {}
+    skipped_qualified, skipped_legacy = _normalized_skips(skip_units)
+    # (scope, base unit) -> replaced?  A unit name can exist in BOTH the user
+    # and the system scope; each is a separate process and each is proven,
+    # reported and accounted for on its own.
+    outcomes: dict[tuple[str, str], bool] = {}
     seen: set[tuple[str, str]] = set()
-    for scope in _systemctl_scopes():
-        scope_key = " ".join(scope)
+    for scope_label, scope in _systemctl_scopes():
         for unit in _listed_serve_units(scope, run=run):
             base = unit.removesuffix(".service")
-            if (scope_key, base) in seen or base in skipped:
+            target = (scope_label, base)
+            if target in seen or target in skipped_qualified or base in skipped_legacy:
                 continue
-            seen.add((scope_key, base))
+            seen.add(target)
             if not _unit_is_active(scope, unit, run=run):
                 # Not running: nothing is serving a stale generation from it.
                 continue
@@ -373,7 +431,7 @@ def restart_serve_units(
                 # be observed, so it cannot be claimed. Restarting blind and
                 # reporting success is the failure mode this module exists to
                 # remove.
-                outcomes[base] = False
+                outcomes[target] = False
                 continue
             try:
                 result = run(
@@ -386,21 +444,24 @@ def restart_serve_units(
                     timeout=_UNIT_RESTART_TIMEOUT,
                 )
             except (OSError, subprocess.TimeoutExpired):
-                outcomes[base] = False
+                outcomes[target] = False
                 continue
             if getattr(result, "returncode", 1) != 0:
                 # Includes the unprivileged system-scope case. We do not probe
                 # for sudo here: an unverifiable unit must read as failed so
                 # the update stays explicitly incomplete.
-                outcomes[base] = False
+                outcomes[target] = False
                 continue
-            replaced = _serve_unit_replaced(
+            outcomes[target] = _serve_unit_replaced(
                 scope, unit, previous_pid, run=run, sleep=sleep
             )
-            outcomes[base] = outcomes.get(base, True) and replaced
     return {
-        "verified": sorted(base for base, ok in outcomes.items() if ok),
-        "failed": sorted(base for base, ok in outcomes.items() if not ok),
+        "verified": sorted(
+            _qualified(*target) for target, ok in outcomes.items() if ok
+        ),
+        "failed": sorted(
+            _qualified(*target) for target, ok in outcomes.items() if not ok
+        ),
     }
 
 
@@ -435,16 +496,39 @@ def _parse_payload(stream) -> tuple[list[str], dict[str, str], bool, list[str]]:
         recover_serve = bool(raw_serve.get("recover"))
         raw_skip = raw_serve.get("skip") or []
         if not isinstance(raw_skip, list) or any(
-            not isinstance(unit, str) for unit in raw_skip
+            not isinstance(entry, (str, dict)) for entry in raw_skip
         ):
             raise ValueError("recovery serve_units skip list is invalid")
-        # Only the shapes systemd can actually produce for this family; a
-        # skip entry is a name filter, never a command argument.
-        skip_units = [
-            unit
-            for unit in raw_skip
-            if _UNIT_RE.fullmatch(unit if unit.endswith(".service") else f"{unit}.service")
-        ]
+        for entry in raw_skip:
+            # A skip entry names one already-settled process. The qualified
+            # shape carries the systemd scope, because `hermes-serve.service`
+            # can exist in BOTH managers and settling one says nothing about
+            # the other. A bare string is the legacy shape a pre-update
+            # interpreter can still send; it is kept, and read as
+            # scope-agnostic by `restart_serve_units`.
+            if isinstance(entry, dict):
+                scope_label = entry.get("scope")
+                unit = entry.get("unit")
+                if not isinstance(unit, str):
+                    raise ValueError("recovery serve_units skip list is invalid")
+                if not isinstance(scope_label, str):
+                    scope_label = ""
+            else:
+                scope_label, _, unit = entry.rpartition("/")
+            # Only the shapes systemd can actually produce for this family; a
+            # skip entry is a name filter, never a command argument. An
+            # unrecognized scope drops the entry rather than raising: dropping
+            # a skip can only ever cause one more restart-and-verify, while
+            # honouring an unreadable one could suppress recovery of a stale
+            # process.
+            if scope_label and scope_label not in _SCOPE_LABELS:
+                continue
+            if not _UNIT_RE.fullmatch(
+                unit if unit.endswith(".service") else f"{unit}.service"
+            ):
+                continue
+            base = unit.removesuffix(".service")
+            skip_units.append(f"{scope_label}/{base}" if scope_label else base)
     return profiles, supervisors, recover_serve, skip_units
 
 

--- a/tests/hermes_cli/test_serve_runtime_inventory.py
+++ b/tests/hermes_cli/test_serve_runtime_inventory.py
@@ -216,3 +216,22 @@ def test_scan_dashboard_processes_ledger_respects_exclusions(monkeypatch):
     monkeypatch.setattr(dp.subprocess, "run", lambda *a, **k: fake_run)
 
     assert dp._scan_dashboard_processes(exclude_pids={8124}) == []
+
+
+def test_inventory_records_the_serve_process_incarnation(monkeypatch):
+    """The plan carries ``(pid, create_time)``, not just the PID (#92145 review).
+
+    The post-abort survivor probe compares a planned serve against the live
+    spawn ledger. With only the number to compare, a NEW serve that reused the
+    old PID reads as the pre-update process that never restarted, and recovery
+    stays incomplete forever.
+    """
+    entry = _ledger_entry(create_time=1712345678.5)
+    fake_pi = SimpleNamespace(
+        ledger_entries=lambda **k: [entry],
+        spawner_is_dead=lambda e: None,
+    )
+    monkeypatch.setitem(sys.modules, "hermes_cli.process_identity", fake_pi)
+    plan = update_inventory.collect_runtime_inventory()
+    serves = [r for r in plan.runtimes if r.kind == "serve"]
+    assert serves and serves[0].detail["create_time"] == 1712345678.5

--- a/tests/hermes_cli/test_update_receipt.py
+++ b/tests/hermes_cli/test_update_receipt.py
@@ -93,7 +93,12 @@ class TestReceiptLifecycle:
 
         payload = json.loads(path.read_text(encoding="utf-8"))
         persisted = payload["gateway_restart"]["fresh_recovery"]
-        assert persisted == recovery
+        assert {key: persisted[key] for key in recovery} == recovery
+        # Serve coverage is always persisted, even when the pass had nothing
+        # to report, so a reader can tell "no serve runtime" from "the field
+        # predates #92145".
+        assert persisted["serve_units"] == {"verified": [], "failed": []}
+        assert persisted["stale_runtimes"] == []
         # The conservative vocabulary is the persisted contract: no bucket may
         # rebrand an unverified relaunch as supervisor-backed success.
         assert "succeeded" not in persisted

--- a/tests/hermes_cli/test_update_restart_recovery.py
+++ b/tests/hermes_cli/test_update_restart_recovery.py
@@ -19,6 +19,7 @@ import sys
 import textwrap
 from types import SimpleNamespace
 
+from hermes_cli import update_abort_recovery as abort_recovery
 from hermes_cli import update_cmd
 
 
@@ -61,7 +62,7 @@ def test_abort_recovery_hands_managed_profiles_to_a_fresh_process(monkeypatch):
         calls.append((argv, kwargs))
         return _successful_recovery_result(verified=["coder", "default"])
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     plan = SimpleNamespace(
         runtimes=[
             _runtime("default", "systemd"),
@@ -136,7 +137,7 @@ def test_abort_recovery_skips_profiles_already_restarted_by_the_phase(monkeypatc
         calls.append((argv, kwargs))
         return _successful_recovery_result(verified=["coder"])
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     plan = SimpleNamespace(
         runtimes=[_runtime("default", "systemd"), _runtime("coder", "systemd")]
     )

--- a/tests/hermes_cli/test_update_restart_recovery.py
+++ b/tests/hermes_cli/test_update_restart_recovery.py
@@ -86,10 +86,11 @@ def test_abort_recovery_hands_managed_profiles_to_a_fresh_process(monkeypatch):
     assert argv[0] == sys.executable
     assert argv[1:4] == ["-m", "hermes_cli.update_restart_recovery", "--stdin"]
     payload = json.loads(kwargs["input"])
-    assert payload == {
-        "profiles": ["coder", "default"],
-        "supervisors": {"coder": "launchd", "default": "systemd"},
-    }
+    assert payload["profiles"] == ["coder", "default"]
+    assert payload["supervisors"] == {"coder": "launchd", "default": "systemd"}
+    # Serve units travel in the same payload so one fresh child covers both
+    # runtime families (#92145).
+    assert set(payload["serve_units"]) == {"recover", "skip"}
     assert kwargs["text"] is True
     assert kwargs["capture_output"] is True
     assert kwargs["check"] is False
@@ -224,7 +225,7 @@ def test_abort_recovery_records_serve_runtimes_as_skipped_with_reason(monkeypatc
     assert set(by_kind) == {"serve", "dashboard"}
     assert "desktop app" in by_kind["serve"]["reason"]
     assert by_kind["dashboard"]["profile"] == "ops"
-    assert "relaunch authority" in by_kind["dashboard"]["reason"]
+    assert "relaunch" in by_kind["dashboard"]["reason"]
 
 
 def test_service_matching_is_exact_for_overlapping_profile_names():
@@ -375,6 +376,7 @@ def test_recovery_module_empty_payload_is_a_real_clean_process():
         "failed": [],
         "relaunch_attempted": [],
         "verified": [],
+        "serve_units": {"verified": [], "failed": []},
     }
 
 
@@ -455,6 +457,7 @@ def test_recovery_module_end_to_end_in_a_real_fresh_process(tmp_path):
         "failed": [],
         "relaunch_attempted": ["coder"],
         "verified": ["default"],
+        "serve_units": {"verified": [], "failed": []},
     }
     restarts = [json.loads(line) for line in ledger.read_text().splitlines()]
     assert [argv[argv.index("-p") + 1] for argv in restarts] == ["coder", "default"]

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -26,6 +26,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from hermes_cli import update_abort_recovery as abort_recovery
 from hermes_cli import update_cmd
 from hermes_cli import update_restart_recovery as recovery
 
@@ -43,6 +44,18 @@ def _runtime(kind: str, profile: str, supervisor: str, pid):
 
 def _plan(*runtimes):
     return SimpleNamespace(runtimes=list(runtimes))
+
+
+def _serve_runtime(pid, *, create_time=None, kind="serve", profile="default"):
+    """A planned serve runtime carrying its process incarnation, the way the
+    inventory records it (``detail["create_time"]`` from the spawn ledger)."""
+    return SimpleNamespace(
+        kind=kind,
+        profile=profile,
+        supervisor="manual-serve",
+        pid=pid,
+        detail={"create_time": create_time},
+    )
 
 
 def _identity_module():
@@ -331,7 +344,9 @@ def test_serve_unit_verified_when_main_pid_changes(linux_systemctl):
         main_pids={"hermes-serve.service": 4242},
     )
     out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
-    assert out == {"verified": ["hermes-serve"], "failed": []}
+    # Identity stays scope-qualified: the same unit name can exist in the
+    # system manager as a different process (#92145 review).
+    assert out == {"verified": ["user/hermes-serve"], "failed": []}
     assert fake.restarted == ["hermes-serve.service"]
 
 
@@ -351,7 +366,7 @@ def test_unchanged_main_pid_is_not_verified(linux_systemctl):
         return original_call(argv, **kwargs)
 
     out = recovery.restart_serve_units(run=frozen, sleep=lambda _: None)
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert out == {"verified": [], "failed": ["user/hermes-serve"]}
 
 
 def test_unit_that_does_not_come_back_active_is_failed(linux_systemctl):
@@ -370,7 +385,7 @@ def test_unit_that_does_not_come_back_active_is_failed(linux_systemctl):
         return original_call(argv, **kwargs)
 
     out = recovery.restart_serve_units(run=dies, sleep=lambda _: None)
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert out == {"verified": [], "failed": ["user/hermes-serve"]}
 
 
 def test_nonzero_restart_is_failed_not_silently_skipped(linux_systemctl):
@@ -382,7 +397,7 @@ def test_nonzero_restart_is_failed_not_silently_skipped(linux_systemctl):
         restart_rc=1,
     )
     out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert out == {"verified": [], "failed": ["user/hermes-serve"]}
 
 
 def test_restart_timeout_is_failed(linux_systemctl):
@@ -399,7 +414,7 @@ def test_restart_timeout_is_failed(linux_systemctl):
         return original_call(argv, **kwargs)
 
     out = recovery.restart_serve_units(run=timing_out, sleep=lambda _: None)
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert out == {"verified": [], "failed": ["user/hermes-serve"]}
 
 
 def test_inactive_serve_unit_is_left_alone(linux_systemctl):
@@ -421,10 +436,12 @@ def test_units_already_restarted_by_the_phase_are_skipped(linux_systemctl):
         main_pids={"hermes-serve.service": 1, "hermes-serve-work.service": 2},
     )
     out = recovery.restart_serve_units(
-        skip_units=["hermes-serve"], run=fake, sleep=lambda _: None
+        skip_units=[{"scope": "user", "unit": "hermes-serve"}],
+        run=fake,
+        sleep=lambda _: None,
     )
     assert fake.restarted == ["hermes-serve-work.service"]
-    assert out == {"verified": ["hermes-serve-work"], "failed": []}
+    assert out == {"verified": ["user/hermes-serve-work"], "failed": []}
 
 
 def test_unrelated_hermes_server_service_is_never_touched(linux_systemctl):
@@ -436,7 +453,7 @@ def test_unrelated_hermes_server_service_is_never_touched(linux_systemctl):
     )
     out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
     assert fake.restarted == ["hermes-serve.service"]
-    assert out["verified"] == ["hermes-serve"]
+    assert out["verified"] == ["user/hermes-serve"]
 
 
 def test_gateway_units_are_not_restarted_by_the_serve_pass(linux_systemctl):
@@ -484,13 +501,15 @@ def test_active_unit_with_no_readable_main_pid_is_failed(linux_systemctl):
         main_pids={"hermes-serve.service": 0},
     )
     out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert out == {"verified": [], "failed": ["user/hermes-serve"]}
     assert fake.restarted == []
 
 
 def test_same_unit_name_in_both_scopes_is_proven_in_both(linux_systemctl):
     """User and system scope are two different processes, not one."""
     calls: list[tuple[str, list]] = []
+
+    pids = {"user": 10, "system": 20}
 
     def dual_scope(argv, **kwargs):
         scope = "user" if "--user" in argv else "system"
@@ -500,17 +519,24 @@ def test_same_unit_name_in_both_scopes_is_proven_in_both(linux_systemctl):
         if "is-active" in argv:
             return _Completed(0, stdout="active")
         if "show" in argv:
-            return _Completed(0, stdout="10" if scope == "user" else "20")
+            return _Completed(0, stdout=str(pids[scope]))
         if "restart" in argv:
             # The user scope relaunches cleanly; the system scope is refused
             # (no privilege) and must not be masked by the user-scope success.
-            return _Completed(0 if scope == "user" else 1)
+            if scope == "user":
+                pids["user"] += 1000
+                return _Completed(0)
+            return _Completed(1)
         raise AssertionError(argv)
 
     out = recovery.restart_serve_units(run=dual_scope, sleep=lambda _: None)
     restarts = [scope for scope, argv in calls if "restart" in argv]
     assert restarts == ["user", "system"]
-    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    # One name, two processes, two independent outcomes.
+    assert out == {
+        "verified": ["user/hermes-serve"],
+        "failed": ["system/hermes-serve"],
+    }
 
 
 def test_restart_is_invoked_without_an_interactive_auth_prompt(linux_systemctl):
@@ -548,6 +574,8 @@ def test_skip_unit_names_are_filtered_to_the_serve_family():
                         "skip": [
                             "hermes-serve",
                             "hermes-serve-work.service",
+                            {"scope": "system", "unit": "hermes-serve"},
+                            {"scope": "user", "unit": "hermes-serve-work.service"},
                             "hermes-server",
                             "../../etc/systemd/evil",
                             "hermes-serve; rm -rf /",
@@ -559,7 +587,13 @@ def test_skip_unit_names_are_filtered_to_the_serve_family():
         )
     )
     assert recover_serve is True
-    assert skip == ["hermes-serve", "hermes-serve-work.service"]
+    # Qualified entries keep their scope; the legacy bare shape stays bare.
+    assert skip == [
+        "hermes-serve",
+        "hermes-serve-work",
+        "system/hermes-serve",
+        "user/hermes-serve-work",
+    ]
 
 
 def test_malformed_serve_block_is_rejected():
@@ -596,7 +630,7 @@ def test_absent_serve_block_defaults_to_no_serve_recovery():
 def test_serve_only_fleet_still_spawns_the_recovery_child(monkeypatch):
     """Before #92145 the driver returned early whenever no gateway profile was
     supervised, so a stale serve unit was never even attempted."""
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
     calls = []
 
     def fake_run(argv, **kwargs):
@@ -613,7 +647,7 @@ def test_serve_only_fleet_still_spawns_the_recovery_child(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("serve", "default", "manual-serve", 4242)),
         gateway_mode=False,
@@ -627,7 +661,7 @@ def test_serve_only_fleet_still_spawns_the_recovery_child(monkeypatch):
 
 def test_child_timeout_budget_covers_the_serve_pass(monkeypatch):
     """A serve-only recovery must not be killed before its settle window."""
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
     captured = {}
 
     def fake_run(argv, **kwargs):
@@ -644,7 +678,7 @@ def test_child_timeout_budget_covers_the_serve_pass(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("serve", "default", "manual-serve", 4242)),
         gateway_mode=False,
@@ -654,7 +688,7 @@ def test_child_timeout_budget_covers_the_serve_pass(monkeypatch):
 
 def test_verified_serve_units_do_not_enter_gateway_restart_vocabulary(monkeypatch):
     """Serve coverage must not silently widen the gateway fleet-probe gate."""
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
 
     def fake_run(argv, **kwargs):
         return _Completed(
@@ -669,7 +703,7 @@ def test_verified_serve_units_do_not_enter_gateway_restart_vocabulary(monkeypatc
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("gateway", "default", "systemd", 111)),
         gateway_mode=False,
@@ -679,12 +713,12 @@ def test_verified_serve_units_do_not_enter_gateway_restart_vocabulary(monkeypatc
 
 
 def test_no_serve_authority_and_no_gateway_profile_spawns_nothing(monkeypatch):
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: False)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: False)
 
     def unreachable(*a, **k):
         raise AssertionError("recovery child spawned with nothing to recover")
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", unreachable)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", unreachable)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("serve", "default", "manual-serve", 4242)),
         gateway_mode=False,
@@ -694,7 +728,7 @@ def test_no_serve_authority_and_no_gateway_profile_spawns_nothing(monkeypatch):
 
 
 def test_already_restarted_units_are_forwarded_as_skips(monkeypatch):
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
     captured = {}
 
     def fake_run(argv, **kwargs):
@@ -711,18 +745,22 @@ def test_already_restarted_units_are_forwarded_as_skips(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("gateway", "default", "systemd", 111)),
         gateway_mode=False,
-        skip_units={"hermes-serve"},
+        skip_units={"user/hermes-serve"},
     )
-    assert captured["payload"]["serve_units"]["skip"] == ["hermes-serve"]
+    # The scope travels with the unit: settling `user/hermes-serve` must not
+    # suppress recovery of a stale system-scope unit of the same name.
+    assert captured["payload"]["serve_units"]["skip"] == [
+        {"scope": "user", "unit": "hermes-serve"}
+    ]
 
 
 def test_unreadable_serve_block_from_the_child_reads_as_failure(monkeypatch):
     """A child that answers with a broken serve block has proven nothing."""
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
 
     def fake_run(argv, **kwargs):
         return _Completed(
@@ -737,7 +775,7 @@ def test_unreadable_serve_block_from_the_child_reads_as_failure(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("gateway", "default", "systemd", 111)),
         gateway_mode=False,
@@ -756,7 +794,7 @@ def test_unreadable_serve_block_from_the_child_reads_as_failure(monkeypatch):
 
 def test_missing_serve_block_off_linux_is_not_a_failure(monkeypatch):
     """Hosts with no serve authority must not manufacture a phantom failure."""
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: False)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: False)
 
     def fake_run(argv, **kwargs):
         return _Completed(
@@ -770,7 +808,7 @@ def test_missing_serve_block_off_linux_is_not_a_failure(monkeypatch):
             ),
         )
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", fake_run)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("gateway", "default", "systemd", 111)),
         gateway_mode=False,
@@ -779,12 +817,12 @@ def test_missing_serve_block_off_linux_is_not_a_failure(monkeypatch):
 
 
 def test_spawn_failure_reports_empty_serve_coverage(monkeypatch):
-    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
 
     def boom(*a, **k):
         raise OSError("no fork available")
 
-    monkeypatch.setattr(update_cmd.subprocess, "run", boom)
+    monkeypatch.setattr(abort_recovery.subprocess, "run", boom)
     result = update_cmd._recover_gateway_restart_after_abort(
         _plan(_runtime("gateway", "default", "systemd", 111)),
         gateway_mode=False,
@@ -814,8 +852,8 @@ def test_serve_coverage_reaches_the_persisted_receipt(tmp_path, monkeypatch):
             "failed": [],
             "skipped": [],
             "serve_units": {
-                "verified": ["hermes-serve"],
-                "failed": ["hermes-serve-work"],
+                "verified": ["user/hermes-serve"],
+                "failed": ["system/hermes-serve-work"],
             },
             "stale_runtimes": [
                 {
@@ -832,9 +870,11 @@ def test_serve_coverage_reaches_the_persisted_receipt(tmp_path, monkeypatch):
     persisted = json.loads(path.read_text(encoding="utf-8"))["gateway_restart"][
         "fresh_recovery"
     ]
+    # The receipt keeps the scope: an operator reading it must know WHICH
+    # manager owns the unit that could not be proven (#96235 review).
     assert persisted["serve_units"] == {
-        "verified": ["hermes-serve"],
-        "failed": ["hermes-serve-work"],
+        "verified": ["user/hermes-serve"],
+        "failed": ["system/hermes-serve-work"],
     }
     assert persisted["stale_runtimes"] == [
         {
@@ -987,3 +1027,201 @@ def test_serve_backend_survives_selection_when_the_dashboard_unit_restarts(monke
     assert signalled == [7001]
     assert restarted == ["hermes-serve.service"]
     assert result["killed"] == [7001]
+
+
+# ---------------------------------------------------------------------------
+# Scope-qualified identity (review on #96235)
+# ---------------------------------------------------------------------------
+
+
+def _dual_scope_systemctl(*, user_pid=10, system_pid=20, settle=("user", "system")):
+    """Both managers own a ``hermes-serve.service``; each is its own process."""
+    state = {"user": user_pid, "system": system_pid}
+    calls: list[tuple[str, list]] = []
+
+    def run(argv, **kwargs):
+        scope = "user" if "--user" in argv else "system"
+        calls.append((scope, list(argv)))
+        if "list-units" in argv:
+            return _Completed(0, stdout="hermes-serve.service loaded active running x")
+        if "is-active" in argv:
+            return _Completed(0, stdout="active")
+        if "show" in argv:
+            return _Completed(0, stdout=str(state[scope]))
+        if "restart" in argv:
+            if scope in settle:
+                state[scope] += 1000
+            return _Completed(0)
+        raise AssertionError(argv)
+
+    return run, calls
+
+
+def test_settled_user_scope_does_not_suppress_the_stale_system_scope(
+    linux_systemctl,
+):
+    """The dual-scope skip collision (review on #96235).
+
+    ``user/hermes-serve`` was restarted before the phase aborted;
+    ``system/hermes-serve`` is a different process still on the pre-update
+    generation. A bare ``hermes-serve`` skip token suppressed BOTH, leaving
+    the stale one running with nothing reporting it.
+    """
+    run, calls = _dual_scope_systemctl()
+    out = recovery.restart_serve_units(
+        skip_units=[{"scope": "user", "unit": "hermes-serve"}],
+        run=run,
+        sleep=lambda _: None,
+    )
+    restarted_scopes = [scope for scope, argv in calls if "restart" in argv]
+    assert restarted_scopes == ["system"]
+    assert out == {"verified": ["system/hermes-serve"], "failed": []}
+
+
+def test_settled_system_scope_does_not_suppress_the_stale_user_scope(
+    linux_systemctl,
+):
+    """Mirror: authority for one scope is not authority for the other, in
+    either direction."""
+    run, calls = _dual_scope_systemctl()
+    out = recovery.restart_serve_units(
+        skip_units=["system/hermes-serve"],
+        run=run,
+        sleep=lambda _: None,
+    )
+    restarted_scopes = [scope for scope, argv in calls if "restart" in argv]
+    assert restarted_scopes == ["user"]
+    assert out == {"verified": ["user/hermes-serve"], "failed": []}
+
+
+def test_one_authorized_scope_never_mutates_the_same_name_in_the_other(
+    linux_systemctl,
+):
+    """Name equality is not identity: no systemctl verb at all may reach the
+    scope that was already settled."""
+    run, calls = _dual_scope_systemctl()
+    recovery.restart_serve_units(
+        skip_units=[{"scope": "user", "unit": "hermes-serve.service"}],
+        run=run,
+        sleep=lambda _: None,
+    )
+    user_verbs = [
+        argv for scope, argv in calls if scope == "user" and "list-units" not in argv
+    ]
+    assert user_verbs == [], user_verbs
+
+
+def test_each_scope_reports_its_own_outcome(linux_systemctl):
+    """One scope failing must not be reported as the other's failure."""
+    run, _ = _dual_scope_systemctl(settle=("user",))
+    out = recovery.restart_serve_units(run=run, sleep=lambda _: None)
+    assert out == {
+        "verified": ["user/hermes-serve"],
+        "failed": ["system/hermes-serve"],
+    }
+
+
+def test_legacy_unqualified_skip_is_honoured_in_both_scopes(linux_systemctl):
+    """A payload written by a pre-update interpreter carries no scope.
+
+    That entry is all the information there is, so it suppresses both — the
+    documented lossy shape, kept only for that skew. The current tree always
+    sends the qualified form (see
+    ``test_already_restarted_units_are_forwarded_as_skips``).
+    """
+    run, calls = _dual_scope_systemctl()
+    out = recovery.restart_serve_units(
+        skip_units=["hermes-serve"], run=run, sleep=lambda _: None
+    )
+    assert [argv for scope, argv in calls if "restart" in argv] == []
+    assert out == {"verified": [], "failed": []}
+
+
+def test_qualified_skip_payload_shape():
+    """``restarted_scoped_units`` reaches the child as scope + unit."""
+    assert update_cmd._qualified_serve_skips(
+        {"user/hermes-serve", "system/hermes-serve-work"}
+    ) == [
+        {"scope": "system", "unit": "hermes-serve-work"},
+        {"scope": "user", "unit": "hermes-serve"},
+    ]
+
+
+def test_unscoped_bookkeeping_entries_are_forwarded_without_a_scope():
+    """A name with no scope must not be given one it was never proven for."""
+    assert update_cmd._qualified_serve_skips({"hermes-serve"}) == [
+        {"unit": "hermes-serve"}
+    ]
+
+
+def test_scope_qualified_failure_blocks_completion():
+    """Completion accounting reads the qualified id, not a bare name."""
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result={
+                "verified": ["default"],
+                "relaunch_attempted": [],
+                "failed": [],
+                "serve_units": {
+                    "verified": ["user/hermes-serve"],
+                    "failed": ["system/hermes-serve"],
+                },
+            },
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+# ---------------------------------------------------------------------------
+# Survivor identity is the process incarnation, not the PID number
+# ---------------------------------------------------------------------------
+
+
+def test_pid_reuse_by_a_new_serve_is_not_reported_as_the_old_survivor(monkeypatch):
+    """Same number, later start time: the pre-update process is gone."""
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 4242, "purpose": "serve", "create_time": 5000.0}],
+    )
+    assert (
+        update_cmd._surviving_pre_update_serve_runtimes(
+            _plan(_serve_runtime(4242, create_time=1000.0))
+        )
+        == []
+    )
+
+
+def test_same_pid_and_same_incarnation_is_still_a_survivor(monkeypatch):
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 4242, "purpose": "serve", "create_time": 1000.5}],
+    )
+    rows = update_cmd._surviving_pre_update_serve_runtimes(
+        _plan(_serve_runtime(4242, create_time=1000.0))
+    )
+    assert [row["pid"] for row in rows] == [4242]
+    assert "_create_time" not in rows[0]
+
+
+def test_missing_incarnation_on_either_side_fails_closed(monkeypatch):
+    """No incarnation to compare means the runtime cannot be cleared."""
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 4242, "purpose": "serve"}],
+    )
+    assert update_cmd._surviving_pre_update_serve_runtimes(
+        _plan(_serve_runtime(4242, create_time=1000.0))
+    ) == [
+        {
+            "pid": 4242,
+            "kind": "serve",
+            "profile": "default",
+            "supervisor": "manual-serve",
+        }
+    ]

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -893,3 +893,97 @@ def test_recovery_module_reports_serve_units_in_a_real_process():
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
     assert set(payload["serve_units"]) == {"verified", "failed"}
+
+
+# ---------------------------------------------------------------------------
+# The managed-dashboard fallback must not short-circuit the serve scan
+# ---------------------------------------------------------------------------
+
+
+def _dashboard_main_stub(scan_calls, *, restart_result=True):
+    """A ``_m()`` stand-in for the dashboard-cleanup path."""
+    return SimpleNamespace(
+        _DASHBOARD_SYSTEMD_UNIT="hermes-dashboard.service",
+        _restart_managed_dashboard_service=lambda reason, *a, **k: restart_result,
+        _find_stale_dashboard_pids=lambda **kwargs: scan_calls.append(kwargs) or [],
+    )
+
+
+def test_managed_dashboard_restart_still_scans_for_serve_backends(monkeypatch):
+    """A restarted dashboard unit may not end the pass (#92145).
+
+    The reporter's host runs ``hermes-dashboard.service`` AND
+    ``hermes-serve.service``.  Returning as soon as the dashboard unit was
+    restarted meant the serve backend hosting ``tui_gateway`` was never even
+    looked for, so it kept serving the pre-update generation.
+    """
+    from hermes_cli import dashboard_procs
+
+    scan_calls: list[dict] = []
+    monkeypatch.setattr(
+        dashboard_procs, "_m", lambda: _dashboard_main_stub(scan_calls)
+    )
+    monkeypatch.setattr(dashboard_procs, "_lock_owned_serve_pids", lambda: set())
+
+    dashboard_procs._kill_stale_dashboard_processes(restart_managed=True)
+
+    assert scan_calls, "serve/dashboard scan never ran after the dashboard restart"
+
+
+def test_restarted_dashboard_unit_is_not_killed_by_the_continued_scan(monkeypatch):
+    """Continuing the scan must not undo the restart it just performed."""
+    from hermes_cli import dashboard_procs
+
+    killed: list[int] = []
+    main = SimpleNamespace(
+        _DASHBOARD_SYSTEMD_UNIT="hermes-dashboard.service",
+        _restart_managed_dashboard_service=lambda reason, *a, **k: True,
+        _find_stale_dashboard_pids=lambda **kwargs: [4242],
+        _get_pid_cgroup_path=lambda pid: None,
+        _get_systemd_service_for_pid=lambda pid: "hermes-dashboard.service",
+        _dashboard_cmdline_for_pid=lambda pid: None,
+    )
+    monkeypatch.setattr(dashboard_procs, "_m", lambda: main)
+    monkeypatch.setattr(dashboard_procs, "_lock_owned_serve_pids", lambda: set())
+    monkeypatch.setattr(dashboard_procs.sys, "platform", "linux")
+    monkeypatch.setattr(
+        dashboard_procs.os, "kill", lambda pid, sig: killed.append(pid)
+    )
+
+    result = dashboard_procs._kill_stale_dashboard_processes(restart_managed=True)
+
+    assert killed == []
+    assert result["killed"] == []
+
+
+def test_serve_backend_survives_selection_when_the_dashboard_unit_restarts(monkeypatch):
+    """A serve PID owned by a DIFFERENT unit is still selected for recovery."""
+    from hermes_cli import dashboard_procs
+
+    signalled: list[int] = []
+    restarted: list[str] = []
+    main = SimpleNamespace(
+        _DASHBOARD_SYSTEMD_UNIT="hermes-dashboard.service",
+        _restart_managed_dashboard_service=lambda reason, *a, **k: True,
+        _find_stale_dashboard_pids=lambda **kwargs: [7001],
+        _get_pid_cgroup_path=lambda pid: "/user.slice/hermes-serve.service",
+        _get_systemd_service_for_pid=lambda pid: "hermes-serve.service",
+        _dashboard_cmdline_for_pid=lambda pid: None,
+        _try_restart_systemd_service=lambda svc, cg: restarted.append(svc) or True,
+        _respawn_dashboard_processes=lambda cmds: [],
+    )
+    monkeypatch.setattr(dashboard_procs, "_m", lambda: main)
+    monkeypatch.setattr(dashboard_procs, "_lock_owned_serve_pids", lambda: set())
+    monkeypatch.setattr(dashboard_procs.sys, "platform", "linux")
+
+    def _fake_kill(pid, sig):
+        signalled.append(pid)
+        raise ProcessLookupError
+
+    monkeypatch.setattr(dashboard_procs.os, "kill", _fake_kill)
+
+    result = dashboard_procs._kill_stale_dashboard_processes(restart_managed=True)
+
+    assert signalled == [7001]
+    assert restarted == ["hermes-serve.service"]
+    assert result["killed"] == [7001]

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -1,0 +1,895 @@
+"""Regression coverage for stale ``hermes serve`` generations after an abort.
+
+Issue #92145: ``hermes update`` moves the checkout from generation N to N+1
+while the updater still holds the pre-pull module graph.  When the in-process
+restart phase raises, a fresh process retries the *gateway* profiles — but
+``hermes serve`` is not a gateway profile.  It hosts ``tui_gateway.server``,
+systemd lists ``hermes-gateway.service`` before ``hermes-serve.service`` (so
+the serve unit is the one an abort typically never reaches), and the final
+read-back (``collect_fleet_versions``) only inspects gateway state.  A serve
+process left on generation N is therefore invisible to every check, and the
+update reports a clean recovery while every chat turn fails with an
+``ImportError`` for a symbol that imports fine on disk.
+
+These tests pin the closure predicate: no runtime from the pre-update
+inventory may still be the same process once recovery reports success, and
+nothing without a verified relaunch authority may be killed to get there.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_cmd
+from hermes_cli import update_restart_recovery as recovery
+
+
+class _Completed:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _runtime(kind: str, profile: str, supervisor: str, pid):
+    return SimpleNamespace(kind=kind, profile=profile, supervisor=supervisor, pid=pid)
+
+
+def _plan(*runtimes):
+    return SimpleNamespace(runtimes=list(runtimes))
+
+
+def _identity_module():
+    return __import__("hermes_cli.process_identity", fromlist=["ledger_entries"])
+
+
+# ---------------------------------------------------------------------------
+# The closure predicate itself
+# ---------------------------------------------------------------------------
+
+
+def _gateway_only_success():
+    return {
+        "requested": ["default"],
+        "verified": ["default"],
+        "relaunch_attempted": [],
+        "failed": [],
+        "skipped": [],
+        "serve_units": {"verified": [], "failed": []},
+    }
+
+
+def test_full_gateway_recovery_does_not_clear_the_flag_while_serve_is_stale():
+    """The reported bug as a predicate: gateway green, serve still generation N."""
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=_gateway_only_success(),
+            stale_runtime_rows=[
+                {
+                    "pid": 4242,
+                    "kind": "serve",
+                    "profile": "default",
+                    "supervisor": "manual-serve",
+                }
+            ],
+        )
+        is False
+    )
+
+
+def test_recovery_is_complete_when_no_runtime_survived():
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=_gateway_only_success(),
+            stale_runtime_rows=[],
+        )
+        is True
+    )
+
+
+def test_failed_serve_unit_blocks_completion():
+    result = _gateway_only_success()
+    result["serve_units"] = {"verified": [], "failed": ["hermes-serve"]}
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=result,
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+@pytest.mark.parametrize("blocking", ["failed", "relaunch_attempted"])
+def test_unverified_gateway_outcomes_still_block_completion(blocking):
+    result = _gateway_only_success()
+    result[blocking] = ["default"]
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=result,
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+def test_uncovered_gateway_profile_blocks_completion():
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default", "coder"},
+            covered_gateway_profiles={"default"},
+            recovery_result=_gateway_only_success(),
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+def test_no_planned_gateway_leg_is_not_completeness():
+    """A serve-only fleet must fall through to the caller's fail-closed path."""
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles=set(),
+            covered_gateway_profiles=set(),
+            recovery_result=_gateway_only_success(),
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+def test_legacy_recovery_result_without_serve_key_still_evaluates():
+    """Forward/backward compatibility: a pre-#92145 shape must not crash."""
+    legacy = {
+        "requested": ["default"],
+        "verified": ["default"],
+        "relaunch_attempted": [],
+        "failed": [],
+        "skipped": [],
+    }
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=legacy,
+            stale_runtime_rows=[],
+        )
+        is True
+    )
+
+
+# ---------------------------------------------------------------------------
+# Survivor probe — identity, not PID guessing
+# ---------------------------------------------------------------------------
+
+
+def test_serve_process_that_never_restarted_is_reported_as_stale(monkeypatch):
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 4242, "purpose": "serve"}],
+    )
+    rows = update_cmd._surviving_pre_update_serve_runtimes(
+        _plan(_runtime("serve", "default", "manual-serve", 4242))
+    )
+    assert rows == [
+        {
+            "pid": 4242,
+            "kind": "serve",
+            "profile": "default",
+            "supervisor": "manual-serve",
+        }
+    ]
+
+
+def test_restarted_serve_leaves_no_survivor(monkeypatch):
+    """A restarted unit re-registers under a NEW pid; the old row is pruned."""
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 9999, "purpose": "serve"}],
+    )
+    assert (
+        update_cmd._surviving_pre_update_serve_runtimes(
+            _plan(_runtime("serve", "default", "manual-serve", 4242))
+        )
+        == []
+    )
+
+
+def test_gateway_runtimes_are_not_counted_as_serve_survivors(monkeypatch):
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 4242, "purpose": "gateway"}],
+    )
+    assert (
+        update_cmd._surviving_pre_update_serve_runtimes(
+            _plan(_runtime("gateway", "default", "systemd", 4242))
+        )
+        == []
+    )
+
+
+def test_dashboard_survivors_count_too(monkeypatch):
+    monkeypatch.setattr(
+        _identity_module(),
+        "ledger_entries",
+        lambda *a, **k: [{"pid": 77, "purpose": "dashboard"}],
+    )
+    rows = update_cmd._surviving_pre_update_serve_runtimes(
+        _plan(_runtime("dashboard", "default", "manual-serve", 77))
+    )
+    assert [row["kind"] for row in rows] == ["dashboard"]
+
+
+def test_unreadable_ledger_fails_closed(monkeypatch):
+    """Unprovable state is unsafe state — never a silent all-clear."""
+
+    def boom(*a, **k):
+        raise OSError("ledger unreadable")
+
+    monkeypatch.setattr(_identity_module(), "ledger_entries", boom)
+    rows = update_cmd._surviving_pre_update_serve_runtimes(
+        _plan(_runtime("serve", "default", "manual-serve", 4242))
+    )
+    assert [row["pid"] for row in rows] == [4242]
+
+
+def test_no_inventoried_serve_runtime_is_a_clean_no_op(monkeypatch):
+    def boom(*a, **k):  # must not even be consulted
+        raise AssertionError("ledger probed with nothing to check")
+
+    monkeypatch.setattr(_identity_module(), "ledger_entries", boom)
+    assert (
+        update_cmd._surviving_pre_update_serve_runtimes(
+            _plan(_runtime("gateway", "default", "systemd", 111))
+        )
+        == []
+    )
+
+
+def test_runtimes_without_a_usable_pid_are_ignored(monkeypatch):
+    def boom(*a, **k):
+        raise AssertionError("ledger probed with nothing to check")
+
+    monkeypatch.setattr(_identity_module(), "ledger_entries", boom)
+    assert (
+        update_cmd._surviving_pre_update_serve_runtimes(
+            _plan(
+                _runtime("serve", "default", "manual-serve", 0),
+                _runtime("serve", "other", "manual-serve", None),
+            )
+        )
+        == []
+    )
+
+
+# ---------------------------------------------------------------------------
+# restart_serve_units — what may claim "verified"
+# ---------------------------------------------------------------------------
+
+
+class _Systemctl:
+    """Scriptable systemctl double: unit table + MainPID progression."""
+
+    def __init__(self, listed, active, main_pids, restart_rc=0):
+        self.listed = listed
+        self.active = dict(active)
+        self.main_pids = dict(main_pids)
+        self.restart_rc = restart_rc
+        self.restarted: list[str] = []
+
+    def __call__(self, argv, **kwargs):
+        if "list-units" in argv:
+            if "--user" not in argv:
+                return _Completed(0, stdout="")
+            body = "\n".join(
+                f"{unit} loaded active running Hermes" for unit in self.listed
+            )
+            return _Completed(0, stdout=body)
+        if "is-active" in argv:
+            unit = argv[-1]
+            return _Completed(
+                0, stdout="active" if self.active.get(unit) else "inactive"
+            )
+        if "show" in argv:
+            unit = argv[argv.index("show") + 1]
+            return _Completed(0, stdout=str(self.main_pids.get(unit, 0)))
+        if "restart" in argv:
+            unit = argv[-1]
+            self.restarted.append(unit)
+            if self.restart_rc == 0:
+                self.main_pids[unit] = self.main_pids.get(unit, 0) + 1000
+            return _Completed(self.restart_rc)
+        raise AssertionError(f"unexpected systemctl call: {argv}")
+
+
+@pytest.fixture
+def linux_systemctl(monkeypatch):
+    monkeypatch.setattr(recovery.sys, "platform", "linux")
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: "/usr/bin/systemctl")
+
+
+def test_serve_unit_verified_when_main_pid_changes(linux_systemctl):
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert out == {"verified": ["hermes-serve"], "failed": []}
+    assert fake.restarted == ["hermes-serve.service"]
+
+
+def test_unchanged_main_pid_is_not_verified(linux_systemctl):
+    """rc 0 with the same main process means the stale interpreter survived."""
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+    )
+    original_call = fake.__call__
+
+    def frozen(argv, **kwargs):
+        if "restart" in argv:
+            fake.restarted.append(argv[-1])
+            return _Completed(0)  # rc 0, MainPID deliberately untouched
+        return original_call(argv, **kwargs)
+
+    out = recovery.restart_serve_units(run=frozen, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+
+
+def test_unit_that_does_not_come_back_active_is_failed(linux_systemctl):
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+    )
+    original_call = fake.__call__
+
+    def dies(argv, **kwargs):
+        if "restart" in argv:
+            fake.restarted.append(argv[-1])
+            fake.active["hermes-serve.service"] = False
+            return _Completed(0)
+        return original_call(argv, **kwargs)
+
+    out = recovery.restart_serve_units(run=dies, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+
+
+def test_nonzero_restart_is_failed_not_silently_skipped(linux_systemctl):
+    """The unprivileged system-scope case must read as failure, not absence."""
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+        restart_rc=1,
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+
+
+def test_restart_timeout_is_failed(linux_systemctl):
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+    )
+    original_call = fake.__call__
+
+    def timing_out(argv, **kwargs):
+        if "restart" in argv:
+            raise subprocess.TimeoutExpired(cmd=argv, timeout=60)
+        return original_call(argv, **kwargs)
+
+    out = recovery.restart_serve_units(run=timing_out, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+
+
+def test_inactive_serve_unit_is_left_alone(linux_systemctl):
+    """Nothing inactive can be serving a stale generation."""
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": False},
+        main_pids={"hermes-serve.service": 0},
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": []}
+    assert fake.restarted == []
+
+
+def test_units_already_restarted_by_the_phase_are_skipped(linux_systemctl):
+    fake = _Systemctl(
+        listed=["hermes-serve.service", "hermes-serve-work.service"],
+        active={"hermes-serve.service": True, "hermes-serve-work.service": True},
+        main_pids={"hermes-serve.service": 1, "hermes-serve-work.service": 2},
+    )
+    out = recovery.restart_serve_units(
+        skip_units=["hermes-serve"], run=fake, sleep=lambda _: None
+    )
+    assert fake.restarted == ["hermes-serve-work.service"]
+    assert out == {"verified": ["hermes-serve-work"], "failed": []}
+
+
+def test_unrelated_hermes_server_service_is_never_touched(linux_systemctl):
+    """``hermes-serve*`` is a systemd glob, not a name gate (review on #83595)."""
+    fake = _Systemctl(
+        listed=["hermes-server.service", "hermes-serve.service"],
+        active={"hermes-server.service": True, "hermes-serve.service": True},
+        main_pids={"hermes-server.service": 7, "hermes-serve.service": 8},
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert fake.restarted == ["hermes-serve.service"]
+    assert out["verified"] == ["hermes-serve"]
+
+
+def test_gateway_units_are_not_restarted_by_the_serve_pass(linux_systemctl):
+    """Gateway profiles have their own per-profile relaunch command."""
+    fake = _Systemctl(
+        listed=["hermes-gateway.service"],
+        active={"hermes-gateway.service": True},
+        main_pids={"hermes-gateway.service": 5},
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert fake.restarted == []
+    assert out == {"verified": [], "failed": []}
+
+
+def test_no_systemctl_means_no_serve_pass(monkeypatch):
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: None)
+
+    def unreachable(*a, **k):
+        raise AssertionError("systemctl invoked without a systemctl binary")
+
+    assert recovery.restart_serve_units(run=unreachable) == {
+        "verified": [],
+        "failed": [],
+    }
+
+
+def test_non_linux_hosts_do_not_run_the_serve_pass(monkeypatch):
+    monkeypatch.setattr(recovery.sys, "platform", "win32")
+    monkeypatch.setattr(recovery.shutil, "which", lambda name: "systemctl")
+
+    def unreachable(*a, **k):
+        raise AssertionError("serve unit pass ran off Linux")
+
+    assert recovery.restart_serve_units(run=unreachable) == {
+        "verified": [],
+        "failed": [],
+    }
+
+
+def test_active_unit_with_no_readable_main_pid_is_failed(linux_systemctl):
+    """No observable main process means no observable replacement."""
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 0},
+    )
+    out = recovery.restart_serve_units(run=fake, sleep=lambda _: None)
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+    assert fake.restarted == []
+
+
+def test_same_unit_name_in_both_scopes_is_proven_in_both(linux_systemctl):
+    """User and system scope are two different processes, not one."""
+    calls: list[tuple[str, list]] = []
+
+    def dual_scope(argv, **kwargs):
+        scope = "user" if "--user" in argv else "system"
+        calls.append((scope, list(argv)))
+        if "list-units" in argv:
+            return _Completed(0, stdout="hermes-serve.service loaded active running x")
+        if "is-active" in argv:
+            return _Completed(0, stdout="active")
+        if "show" in argv:
+            return _Completed(0, stdout="10" if scope == "user" else "20")
+        if "restart" in argv:
+            # The user scope relaunches cleanly; the system scope is refused
+            # (no privilege) and must not be masked by the user-scope success.
+            return _Completed(0 if scope == "user" else 1)
+        raise AssertionError(argv)
+
+    out = recovery.restart_serve_units(run=dual_scope, sleep=lambda _: None)
+    restarts = [scope for scope, argv in calls if "restart" in argv]
+    assert restarts == ["user", "system"]
+    assert out == {"verified": [], "failed": ["hermes-serve"]}
+
+
+def test_restart_is_invoked_without_an_interactive_auth_prompt(linux_systemctl):
+    """A polkit prompt inside a captured subprocess hangs the whole update."""
+    seen = []
+    fake = _Systemctl(
+        listed=["hermes-serve.service"],
+        active={"hermes-serve.service": True},
+        main_pids={"hermes-serve.service": 4242},
+    )
+    original_call = fake.__call__
+
+    def recording(argv, **kwargs):
+        if "restart" in argv:
+            seen.append(list(argv))
+        return original_call(argv, **kwargs)
+
+    recovery.restart_serve_units(run=recording, sleep=lambda _: None)
+    assert seen and "--no-ask-password" in seen[0]
+
+
+# ---------------------------------------------------------------------------
+# Payload boundary
+# ---------------------------------------------------------------------------
+
+
+def test_skip_unit_names_are_filtered_to_the_serve_family():
+    _, _, recover_serve, skip = recovery._parse_payload(
+        io.StringIO(
+            json.dumps(
+                {
+                    "profiles": [],
+                    "serve_units": {
+                        "recover": True,
+                        "skip": [
+                            "hermes-serve",
+                            "hermes-serve-work.service",
+                            "hermes-server",
+                            "../../etc/systemd/evil",
+                            "hermes-serve; rm -rf /",
+                            "hermes-gateway",
+                        ],
+                    },
+                }
+            )
+        )
+    )
+    assert recover_serve is True
+    assert skip == ["hermes-serve", "hermes-serve-work.service"]
+
+
+def test_malformed_serve_block_is_rejected():
+    with pytest.raises(ValueError, match="serve_units"):
+        recovery._parse_payload(
+            io.StringIO(json.dumps({"profiles": [], "serve_units": ["nope"]}))
+        )
+
+
+def test_non_string_skip_entries_are_rejected():
+    with pytest.raises(ValueError, match="skip list"):
+        recovery._parse_payload(
+            io.StringIO(
+                json.dumps(
+                    {"profiles": [], "serve_units": {"recover": True, "skip": [7]}}
+                )
+            )
+        )
+
+
+def test_absent_serve_block_defaults_to_no_serve_recovery():
+    _, _, recover_serve, skip = recovery._parse_payload(
+        io.StringIO(json.dumps({"profiles": []}))
+    )
+    assert recover_serve is False
+    assert skip == []
+
+
+# ---------------------------------------------------------------------------
+# Driver: the fresh child is still launched for a serve-only fleet
+# ---------------------------------------------------------------------------
+
+
+def test_serve_only_fleet_still_spawns_the_recovery_child(monkeypatch):
+    """Before #92145 the driver returned early whenever no gateway profile was
+    supervised, so a stale serve unit was never even attempted."""
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    calls = []
+
+    def fake_run(argv, **kwargs):
+        calls.append((argv, kwargs))
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": [],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                    "serve_units": {"verified": ["hermes-serve"], "failed": []},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("serve", "default", "manual-serve", 4242)),
+        gateway_mode=False,
+    )
+    assert len(calls) == 1
+    payload = json.loads(calls[0][1]["input"])
+    assert payload["profiles"] == []
+    assert payload["serve_units"]["recover"] is True
+    assert result["serve_units"] == {"verified": ["hermes-serve"], "failed": []}
+
+
+def test_child_timeout_budget_covers_the_serve_pass(monkeypatch):
+    """A serve-only recovery must not be killed before its settle window."""
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["timeout"] = kwargs["timeout"]
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": [],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                    "serve_units": {"verified": [], "failed": []},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("serve", "default", "manual-serve", 4242)),
+        gateway_mode=False,
+    )
+    assert captured["timeout"] >= 180
+
+
+def test_verified_serve_units_do_not_enter_gateway_restart_vocabulary(monkeypatch):
+    """Serve coverage must not silently widen the gateway fleet-probe gate."""
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+
+    def fake_run(argv, **kwargs):
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": ["default"],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                    "serve_units": {"verified": ["hermes-serve"], "failed": []},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("gateway", "default", "systemd", 111)),
+        gateway_mode=False,
+    )
+    assert result["verified"] == ["default"]
+    assert "hermes-serve" not in result["verified"]
+
+
+def test_no_serve_authority_and_no_gateway_profile_spawns_nothing(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: False)
+
+    def unreachable(*a, **k):
+        raise AssertionError("recovery child spawned with nothing to recover")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", unreachable)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("serve", "default", "manual-serve", 4242)),
+        gateway_mode=False,
+    )
+    assert result["requested"] == []
+    assert result["serve_units"] == {"verified": [], "failed": []}
+
+
+def test_already_restarted_units_are_forwarded_as_skips(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured["payload"] = json.loads(kwargs["input"])
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": ["default"],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                    "serve_units": {"verified": [], "failed": []},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("gateway", "default", "systemd", 111)),
+        gateway_mode=False,
+        skip_units={"hermes-serve"},
+    )
+    assert captured["payload"]["serve_units"]["skip"] == ["hermes-serve"]
+
+
+def test_unreadable_serve_block_from_the_child_reads_as_failure(monkeypatch):
+    """A child that answers with a broken serve block has proven nothing."""
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+
+    def fake_run(argv, **kwargs):
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": ["default"],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                    "serve_units": {"verified": "not-a-list", "failed": []},
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("gateway", "default", "systemd", 111)),
+        gateway_mode=False,
+    )
+    assert result["serve_units"]["failed"] == ["<unreadable>"]
+    assert (
+        update_cmd._abort_recovery_is_complete(
+            planned_gateway_profiles={"default"},
+            covered_gateway_profiles={"default"},
+            recovery_result=result,
+            stale_runtime_rows=[],
+        )
+        is False
+    )
+
+
+def test_missing_serve_block_off_linux_is_not_a_failure(monkeypatch):
+    """Hosts with no serve authority must not manufacture a phantom failure."""
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: False)
+
+    def fake_run(argv, **kwargs):
+        return _Completed(
+            0,
+            stdout=json.dumps(
+                {
+                    "verified": ["default"],
+                    "relaunch_attempted": [],
+                    "failed": [],
+                }
+            ),
+        )
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", fake_run)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("gateway", "default", "systemd", 111)),
+        gateway_mode=False,
+    )
+    assert result["serve_units"] == {"verified": [], "failed": []}
+
+
+def test_spawn_failure_reports_empty_serve_coverage(monkeypatch):
+    monkeypatch.setattr(update_cmd, "_serve_unit_recovery_available", lambda: True)
+
+    def boom(*a, **k):
+        raise OSError("no fork available")
+
+    monkeypatch.setattr(update_cmd.subprocess, "run", boom)
+    result = update_cmd._recover_gateway_restart_after_abort(
+        _plan(_runtime("gateway", "default", "systemd", 111)),
+        gateway_mode=False,
+    )
+    assert result["failed"] == ["default"]
+    assert result["serve_units"] == {"verified": [], "failed": []}
+
+
+# ---------------------------------------------------------------------------
+# Receipt persistence
+# ---------------------------------------------------------------------------
+
+
+def test_serve_coverage_reaches_the_persisted_receipt(tmp_path, monkeypatch):
+    from hermes_cli import update_receipt
+
+    monkeypatch.setattr(update_receipt, "_receipt_dir", lambda: tmp_path)
+    update_receipt.begin_update_receipt()
+    update_receipt.record_gateway_restart(
+        restarted_services=[],
+        incomplete=True,
+        phase_error="cannot import name 'line_input' from 'hermes_cli.cli_output'",
+        fresh_recovery={
+            "requested": ["default"],
+            "verified": ["default"],
+            "relaunch_attempted": [],
+            "failed": [],
+            "skipped": [],
+            "serve_units": {
+                "verified": ["hermes-serve"],
+                "failed": ["hermes-serve-work"],
+            },
+            "stale_runtimes": [
+                {
+                    "pid": 4242,
+                    "kind": "serve",
+                    "profile": "default",
+                    "supervisor": "manual-serve",
+                }
+            ],
+        },
+    )
+    path = update_receipt.finalize_update_receipt("partial")
+    assert path is not None
+    persisted = json.loads(path.read_text(encoding="utf-8"))["gateway_restart"][
+        "fresh_recovery"
+    ]
+    assert persisted["serve_units"] == {
+        "verified": ["hermes-serve"],
+        "failed": ["hermes-serve-work"],
+    }
+    assert persisted["stale_runtimes"] == [
+        {
+            "pid": 4242,
+            "kind": "serve",
+            "profile": "default",
+            "supervisor": "manual-serve",
+        }
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Operator-facing output
+# ---------------------------------------------------------------------------
+
+
+def test_stale_serve_warning_names_the_process_and_the_fix(capsys):
+    update_cmd._warn_stale_serve_runtimes(
+        [
+            {
+                "pid": 4242,
+                "kind": "serve",
+                "profile": "default",
+                "supervisor": "manual-serve",
+            }
+        ]
+    )
+    out = capsys.readouterr().out
+    assert "4242" in out
+    assert "serve" in out
+    assert "systemctl --user restart hermes-serve.service" in out
+
+
+def test_no_survivors_prints_nothing(capsys):
+    update_cmd._warn_stale_serve_runtimes([])
+    assert capsys.readouterr().out == ""
+
+
+# ---------------------------------------------------------------------------
+# Real fresh interpreter
+# ---------------------------------------------------------------------------
+
+
+def test_recovery_module_reports_serve_units_in_a_real_process():
+    """The protocol survives a genuine subprocess round-trip."""
+    result = subprocess.run(
+        [sys.executable, "-m", "hermes_cli.update_restart_recovery", "--stdin"],
+        input=json.dumps(
+            {"profiles": [], "serve_units": {"recover": True, "skip": []}}
+        ),
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=120,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert set(payload["serve_units"]) == {"verified", "failed"}

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -761,6 +761,7 @@ def test_already_restarted_units_are_forwarded_as_skips(monkeypatch):
 def test_unreadable_serve_block_from_the_child_reads_as_failure(monkeypatch):
     """A child that answers with a broken serve block has proven nothing."""
     monkeypatch.setattr(abort_recovery, "_serve_unit_recovery_available", lambda: True)
+    monkeypatch.setattr(abort_recovery, "_plan_has_serve_runtimes", lambda plan: True)
 
     def fake_run(argv, **kwargs):
         return _Completed(

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -246,8 +246,16 @@ class TestKillStaleDashboardPosix:
                 return MagicMock(returncode=0, stdout="", stderr="")
             raise AssertionError(f"unexpected subprocess.run call: {args}")
 
+        # Since #96235 the managed-unit restart no longer short-circuits the
+        # stale-process scan (the scan must still find serve backends the
+        # unit restart didn't cover). The dashboard's own PID is excluded
+        # via already_restarted_units, so nothing is killed — but the scan
+        # DOES run now, and its per-PID probes must be stubbed so the
+        # strict subprocess mock above only sees the systemctl ladder.
         with patch("subprocess.run", side_effect=fake_run), \
              patch("hermes_cli.main._find_stale_dashboard_pids", return_value=[12345]) as find_pids, \
+             patch("hermes_cli.main._get_pid_cgroup_path", return_value=None), \
+             patch("hermes_cli.main._get_systemd_service_for_pid", return_value="hermes-dashboard.service"), \
              patch("os.kill") as kill:
             _kill_stale_dashboard_processes(restart_managed=True)
 
@@ -258,7 +266,7 @@ class TestKillStaleDashboardPosix:
             ["systemctl", "--user", "restart", "hermes-dashboard.service"],
         ]
         assert all(call[:1] != ["sudo"] and call[:2] != ["systemctl"] for call in calls)
-        find_pids.assert_not_called()
+        find_pids.assert_called_once()
         kill.assert_not_called()
         assert "✓ restarted hermes-dashboard.service" in capsys.readouterr().out
 


### PR DESCRIPTION
## Summary

Salvage of #96235 by @JoaoMarcos44 onto current main; all three commits cherry-picked cleanly with authorship preserved.

After an aborted `hermes update` restart phase, recovery now also restarts `hermes-serve*` systemd units. Previously the abort-recovery path only restarted gateway profiles via the fresh child — `hermes serve` (which hosts `tui_gateway.server` and is not a gateway profile) kept running pre-update `sys.modules` against the new checkout, producing the mixed-module ImportError class from #92145.

## Changes
- `hermes_cli/update_restart_recovery.py`: serve-unit restart pass — scope-qualified user/system identities, MainPID-change verification (rc 0 alone is not proof of replacement; polls bounded 10×1s).
- `hermes_cli/update_abort_recovery.py` (new, ~423 lines of which ~200 are MOVED from update_cmd.py): abort-recovery logic relocated into a bounded module so update_cmd.py doesn't grow another authority surface; survivor detection via process incarnation (pid+create_time, same 2.0s threshold as `process_identity`); stdlib-only module imports (fresh-child safe).
- `hermes_cli/dashboard_procs.py`: managed-dashboard early return now records the unit in `already_restarted_units` so serve backends aren't skipped.
- Receipt + completeness gate wired for serve outcomes and stale runtimes.
- `tests/hermes_cli/test_update_serve_generation_recovery.py` (new, ~1228 lines).

## Validation
| | Result |
|---|---|
| serve-generation + restart-recovery + receipt + inventory suites | 111/111 pass |
| Normal (non-aborted) update path | additive changes only (try/finally scope tracking, extra elifs) |

Size note: +2157 is ~1228 test lines + ~200 moved lines; net new logic ≈450 lines for a crash-safety boundary.

Closes #96235
