### PR TITLE
fix(cli): keep single-query delegations inline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -22030,6 +22030,9 @@ def main(
         # takes the deterministic approvals.single_query_mode path instead of
         # waiting the full timeout. See #86878.
         os.environ["HERMES_SINGLE_QUERY_SESSION"] = "1"
+        from gateway.session_context import declare_stateless_channel
+
+        declare_stateless_channel()
         if not cli._claim_active_session("cli", stderr=bool(quiet)):
             sys.exit(1)
         try:

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -378,9 +378,9 @@ def build_top_level_parser():
         # prompt. `oneshot_exit` keeps the surfaces independent.
         default=False,
         help=(
-            "With -q/--query-file: answer the query and exit (legacy "
-            "single-query behavior) instead of seeding an interactive "
-            "session. Implied on non-TTY stdio and by -Q/--quiet."
+            "With -q: answer the query and exit (legacy single-query "
+            "behavior) instead of seeding an interactive session. Implied "
+            "by --query-file, non-TTY stdio, and -Q/--quiet."
         ),
     )
     chat_parser.add_argument(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3151,15 +3151,16 @@ def _resolve_use_tui(args) -> bool:
     Precedence (highest first):
       1. ``--cli`` flag         → always classic REPL
       2. ``--tui`` flag         → always TUI (explicit ask)
-      3. no TTY                 → always classic (ambient prefs don't apply)
-      4. ``HERMES_TUI=1`` env   → TUI
-      5. ``display.interface`` config value ("cli" | "tui")
-      6. default → classic REPL
+      3. ``--query-file``       → always classic single-query
+      4. no TTY                 → always classic (ambient prefs don't apply)
+      5. ``HERMES_TUI=1`` env   → TUI
+      6. ``display.interface`` config value ("cli" | "tui")
+      7. default → classic REPL
 
     Explicit flags always win over config so muscle memory and scripts keep
     working regardless of the configured default.
 
-    The TTY gate (3) is load-bearing: ambient TUI preferences (env var or
+    The TTY gate (4) is load-bearing: ambient TUI preferences (env var or
     config default) must never hijack a NON-interactive invocation. Kanban
     workers, cron jobs, and pipelines run ``hermes … chat -q`` with stdout
     on a pipe; booting the Ink TUI there hits its no-TTY bail-out, which
@@ -3172,6 +3173,8 @@ def _resolve_use_tui(args) -> bool:
         return False
     if getattr(args, "tui", False):
         return True
+    if getattr(args, "query_file", None):
+        return False
     try:
         if not (sys.stdin.isatty() and sys.stdout.isatty()):
             return False
@@ -3500,7 +3503,7 @@ def cmd_chat(args):
         "verbose": getattr(args, "verbose", None),
         "quiet": getattr(args, "quiet", False),
         "query": args.query,
-        "oneshot": bool(getattr(args, "oneshot_exit", False)),
+        "oneshot": bool(_qfile or getattr(args, "oneshot_exit", False)),
         "image": getattr(args, "image", None),
         "resume": getattr(args, "resume", None),
         "worktree": getattr(args, "worktree", False),

--- a/tests/cli/test_single_query_async_delivery.py
+++ b/tests/cli/test_single_query_async_delivery.py
@@ -1,0 +1,145 @@
+"""Single-query CLI sessions cannot receive detached completions."""
+
+from __future__ import annotations
+
+from argparse import Namespace
+import json
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("quiet", "oneshot", "stdin_tty"),
+    [
+        pytest.param(True, False, True, id="quiet"),
+        pytest.param(False, True, True, id="query-file"),
+        pytest.param(False, False, False, id="non-tty-query"),
+    ],
+)
+def test_single_query_cli_disables_async_delivery(
+    monkeypatch, quiet, oneshot, stdin_tty
+):
+    import cli as cli_mod
+    from gateway import session_context
+    import tools.delegate_tool as delegate_tool
+
+    results = []
+    dispatched = []
+
+    class Parent:
+        _delegate_depth = 0
+        _subagent_id = None
+
+    class FakeCLI:
+        def __init__(self, **_kwargs):
+            self.session_id = "single-query-test"
+
+        def _claim_active_session(self, _surface, *, stderr=False):
+            assert "HERMES_KANBAN_TASK" not in cli_mod.os.environ
+            results.append(
+                json.loads(
+                    delegate_tool.delegate_task(
+                        goal="review the spec",
+                        background=True,
+                        parent_agent=Parent(),
+                    )
+                )
+            )
+            return False
+
+    fake_child = SimpleNamespace(_subagent_id="subagent-0")
+    credentials = {
+        "model": "test-model",
+        "provider": None,
+        "base_url": None,
+        "api_key": None,
+        "api_mode": None,
+        "command": None,
+        "args": None,
+    }
+
+    session_context.reset_session_vars()
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(cli_mod, "HermesCLI", FakeCLI)
+    monkeypatch.setattr(cli_mod.atexit, "register", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(delegate_tool, "_build_child_agent", lambda **_kwargs: fake_child)
+    monkeypatch.setattr(
+        delegate_tool,
+        "_run_single_child",
+        lambda task_index, goal, *_args, **_kwargs: {
+            "task_index": task_index,
+            "status": "completed",
+            "summary": f"done: {goal}",
+            "api_calls": 1,
+            "duration_seconds": 0.1,
+            "model": "test-model",
+            "exit_reason": "completed",
+        },
+    )
+    monkeypatch.setattr(
+        delegate_tool,
+        "_resolve_delegation_credentials",
+        lambda *_args, **_kwargs: credentials,
+    )
+    monkeypatch.setattr(
+        "tools.async_delegation.dispatch_async_delegation_batch",
+        lambda *_args, **_kwargs: dispatched.append(True),
+    )
+    monkeypatch.setattr(cli_mod.sys, "stdin", SimpleNamespace(isatty=lambda: stdin_tty))
+
+    try:
+        with pytest.raises(SystemExit):
+            cli_mod.main(
+                query="review this",
+                quiet=quiet,
+                oneshot=oneshot,
+                toolsets="terminal",
+            )
+    finally:
+        session_context.reset_session_vars()
+
+    assert not dispatched
+    assert results[0]["results"][0]["summary"] == "done: review the spec"
+
+
+def test_query_file_is_single_query_without_extra_flag(tmp_path, monkeypatch):
+    import hermes_cli.main as main_mod
+
+    query_file = tmp_path / "query.txt"
+    query_file.write_text("review this", encoding="utf-8")
+    captured = {}
+    tui_launched = []
+
+    args = Namespace(
+        query=None,
+        query_file=str(query_file),
+        oneshot_exit=False,
+        model=None,
+        toolsets=None,
+        tui=False,
+        quiet=False,
+    )
+    monkeypatch.setenv("HERMES_TUI", "1")
+    monkeypatch.setattr(main_mod.sys.stdin, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(main_mod.sys.stdout, "isatty", lambda: True, raising=False)
+    monkeypatch.setattr(
+        main_mod, "_launch_tui", lambda *_args, **_kwargs: tui_launched.append(True)
+    )
+    monkeypatch.setattr(main_mod, "_apply_safe_mode", lambda _args: None)
+    monkeypatch.setattr(main_mod, "_resolve_continue_arg", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(
+        main_mod, "_confirm_startup_expensive_model_override", lambda _args: None
+    )
+    monkeypatch.setitem(sys.modules, "cli", SimpleNamespace(main=captured.update))
+
+    main_mod.cmd_chat(args)
+
+    assert not tui_launched
+    assert captured["query"] == "review this"
+    assert captured["oneshot"] is True


### PR DESCRIPTION
## Summary

- declare classic CLI single-query sessions stateless so `delegate_task(background=True)` returns child results inline instead of losing them during CLI shutdown
- keep bare `--query-file` on the single-query path, including when an ambient TUI preference is enabled; explicit `--tui` still wins
- cover `-Q`, bare `--query-file`, and non-TTY `-q` through the real CLI-to-`delegate_task` path

## Root cause

The classic single-query branch set `HERMES_SINGLE_QUERY_SESSION` but never declared that its response channel ends with the turn. `delegate_task` therefore accepted background delivery, while CLI shutdown cancelled the detached child before its result could be delivered.

## Test plan

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cli/test_single_query_async_delivery.py tests/hermes_cli/test_default_interface_resolution.py tests/hermes_cli/test_chat_query_file.py tests/gateway/test_async_delivery_capability.py` — 23 passed
- Python `compileall` for changed Python files — passed
- `git diff --check origin/main...HEAD` — passed
- `scripts/run_tests.sh` — 42,278 passed, 359 skipped, 94 failed across 27 files not touched by this diff; the focused regression slice is green and the full-suite failures are tracked separately
