### PR TITLE
fix(gateway): suppress the anti-growth 'Compression refused' warning on chat surfaces

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -122,6 +122,17 @@ CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE = (
     "session or /compress to retry immediately."
 )
 
+# NO-OP diagnostic, not a failure: the commit-site anti-growth guard refused a compression whose generated
+# summary was larger than what it would replace — nothing was dropped and no user action is needed, so it must
+# NOT reach chat surfaces. The gateway noise regex (_TELEGRAM_NOISY_STATUS_RE, gateway/run.py) derives its
+# suppressing pattern from THIS constant so a reword cannot drift past the filter. Manual /compress reports the
+# same refusal with its own headline (agent/manual_compression_feedback.py) and must stay visible; that
+# carve-out is pinned in tests/gateway/test_telegram_noise_filter.py.
+COMPRESSION_REFUSED_WOULD_GROW_WARNING = (
+    "⚠️ Compression refused: the generated summary would have GROWN the conversation instead of "
+    "shrinking it. No messages were dropped — conversation continues unchanged."
+)
+
 # Formatted from the same constants the emission sites use, so noise-filter tests exercise the ACTUAL wording.
 ROUTINE_COMPRESSION_STATUS_SAMPLES = (
     COMPACTION_STATUS, COMPACTION_HEARTBEAT_STATUS, COMPACTION_DONE_STATUS,
@@ -2880,10 +2891,7 @@ def _salvage_or_refuse_grown_transcript(
         with contextlib.suppress(Exception):
             agent.context_compressor._last_compress_refused_would_grow = True
         with contextlib.suppress(Exception):
-            agent._emit_warning(
-                "⚠️ Compression refused: the generated summary would have GROWN the conversation instead of "
-                "shrinking it. No messages were dropped — conversation continues unchanged."
-            )
+            agent._emit_warning(COMPRESSION_REFUSED_WOULD_GROW_WARNING)
         _existing_sp = _existing_system_prompt(agent, system_message)
         _emit_aborted_attempt_telemetry(agent, attempt_started_at, "would_grow")
         # Count the refusal as an ineffective-compaction strike so the anti-thrash

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -31,7 +31,8 @@ from typing import Callable, Dict, Optional, Any, List, Tuple, cast
 
 from agent.async_utils import safe_schedule_threadsafe
 from agent.conversation_compression import (
-    COMPACTION_DONE_STATUS, COMPACTION_HEARTBEAT_STATUS, COMPACTION_STATUS, COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
+    COMPACTION_DONE_STATUS, COMPACTION_HEARTBEAT_STATUS, COMPACTION_STATUS, COMPRESSION_REFUSED_WOULD_GROW_WARNING,
+    COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE, COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOO_LARGE_STATUS_TEMPLATE, IDLE_COMPACTION_STATUS_TEMPLATE,
     PRE_API_COMPRESSION_STATUS_TEMPLATE, PREFLIGHT_COMPRESSION_STATUS_TEMPLATE)
@@ -83,6 +84,11 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|resumed\s+after\s+\d+s\s+idle\s+[—-]\s+compacting"
     r"|preflight\s+compression"
     r"|pre[- ]api\s+compression"
+    # Anti-growth refusal warning (_emit_warning from the commit-site guard): a NO-OP diagnostic — nothing
+    # dropped, no user action needed — whose distinctive wording comes from the SAME constant the emit site
+    # formats, so a reword cannot drift past this filter. Manual /compress reports the refusal with its own
+    # headline instead and stays visible.
+    rf"|{re.escape(COMPRESSION_REFUSED_WOULD_GROW_WARNING)}"
     # Retry chatter via _emit_status; ", retrying"/"— compressing" anchors exclude manual /compress feedback.
     r"|context\s+too\s+large\s+\(~[\d,]+\s+tokens\)\s+[—-]+\s+compressing"
     r"|compressed\s+\d[\d,]*\s+(?:→|->)\s+\d[\d,]*\s+messages,\s+retrying"

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -3,14 +3,35 @@
 import pytest
 
 from agent.conversation_compression import (
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
     CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE,
     ROUTINE_COMPRESSION_STATUS_SAMPLES,
 )
+from agent.manual_compression_feedback import summarize_manual_compression
 from gateway.config import Platform
 from gateway.run import (
     _prepare_gateway_status_message,
     _sanitize_gateway_final_response,
 )
+
+
+class _RefusedWouldGrowState:
+    """Stand-in for a ContextCompressor carrying only the flag the summarizer reads."""
+
+    _last_compress_refused_would_grow = True
+
+
+# The manual /compress refusal headline, built by the SAME summarizer the CLI/gateway
+# surface it from (agent/manual_compression_feedback.py), so widening the noise regex
+# cannot quietly start eating it — the property this file exists to pin.
+MANUAL_COMPRESS_REFUSAL_HEADLINE = summarize_manual_compression(
+    [{"role": "user", "content": "hi"}] * 30,
+    [{"role": "user", "content": "hi"}] * 30,
+    1000,
+    1000,
+    compression_state=_RefusedWouldGrowState(),
+)["headline"]
+
 
 # Every human-facing chat surface that must receive noise-filtered,
 # secret-redacted, provider-error-sanitized output (not just Telegram).
@@ -34,6 +55,10 @@ NOISY_STATUS_MESSAGES = [
     "💤 Resumed after 3600s idle — compacting ~120,000 tokens before continuing.",
     "⚠️  Session compressed 12 times — accuracy may degrade. Consider /new to start fresh.",
     "⚠ Compression summary failed: upstream error. Inserted a fallback context marker.",
+    # Auto anti-growth refusal warning: a NO-OP diagnostic the commit-site guard emits via
+    # _emit_warning. Built from the emit site's own constant so a reword cannot drift past
+    # the noise regex while this list still passes.
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
     "⏱️ Rate limited. Waiting 30.0s (attempt 2/3)...",
     "⏳ Retrying in 4.2s (attempt 1/3)...",
     # Buffered overflow/attempt-cap retry chatter (replayed on retry exhaustion).
@@ -68,6 +93,9 @@ VISIBLE_COMPRESSION_MESSAGES = [
     "Compression aborted: 30 messages preserved",
     "Compressed with fallback: 30 → 12 messages",
     "No changes from compression: 30 messages",
+    # Manual /compress refusal feedback (#100171 sibling): shares the "Compression refused"
+    # head words with the suppressed auto warning but reports counts, so it must survive.
+    MANUAL_COMPRESS_REFUSAL_HEADLINE,
     (
         "⚠ Compression aborted: auth failure. No messages were dropped — "
         "conversation continues unchanged. Run /compress to retry, or /new "


### PR DESCRIPTION
## Problem

The in-place compaction commit guard emits a user-visible warning via `_emit_warning` when a generated summary would grow the transcript:

> ⚠️ Compression refused: the generated summary would have GROWN the conversation instead of shrinking it. No messages were dropped — conversation continues unchanged.

It flows through `_prepare_gateway_status_message`, but `Compression refused` is not covered by `_TELEGRAM_NOISY_STATUS_RE`, so this **no-op diagnostic** (nothing dropped, conversation unchanged, no user action needed) is delivered verbatim to chat surfaces — leaking compression internals to group chats running in observe/@mention mode.

## Fix

- Promote the warning wording to a named constant `COMPRESSION_REFUSED_WOULD_GROW_WARNING` in `agent/conversation_compression.py`, next to the other compression-status constants, and emit that from the refusal path.
- Add the warning to `_TELEGRAM_NOISY_STATUS_RE` as an alternative **derived from the constant** (`rf"|{re.escape(...)}"`, same pattern as `COMPACTION_STATUS`), so a future reword cannot silently drift past the filter.
- Deliberately narrower than manual `/compress` feedback (`Compression refused (summary would grow the conversation): N messages preserved`), which reports the same refusal to a user who explicitly asked and must stay visible. The manual headline is not covered by the regex and is additionally pinned as still-visible.
- Pin **both sides** in `tests/gateway/test_telegram_noise_filter.py`: the automatic warning is suppressed (added to `NOISY_STATUS_MESSAGES` via the imported constant), the manual feedback passes through (added to `VISIBLE_COMPRESSION_MESSAGES`, headline built by calling the real `summarize_manual_compression`).

Files: `agent/conversation_compression.py`, `gateway/run.py`, `tests/gateway/test_telegram_noise_filter.py` (+47/−5).

Local verification (`scripts/run_tests.sh`): focused set 201 passed, 0 failed; `tests/gateway/test_telegram_noise_filter.py` green. Base-red proof: on unmodified `main` the warning reaches chat delivery (`telegram delivery on base: True`) and the regex does not match it; on the branch the regex matches the warning and does not match the manual headline.

Closes #100171
