### PR TITLE
feat(desktop): add toggle to show/hide hidden files in project sidebar

### DIFF
--- a/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
+++ b/apps/desktop/src/app/right-sidebar/files/use-project-tree.ts
@@ -3,6 +3,7 @@ import { atom } from 'nanostores'
 import { useCallback, useEffect, useMemo } from 'react'
 
 import { desktopFsCacheKey } from '@/lib/desktop-fs'
+import { $showHiddenFiles } from '@/store/layout'
 import { $connection } from '@/store/session'
 import { $workspaceChangeTick, consumeWorkspaceChange } from '@/store/workspace-events'
 
@@ -29,6 +30,15 @@ const ERROR_PLACEHOLDER_ID = '__error__'
 
 function makeNode(path: string, name: string, isDirectory: boolean): TreeNode {
   return { id: path, isDirectory, name }
+}
+
+/** Filter out dotfiles (names starting with '.') when the hidden-files toggle is off. */
+function filterHiddenFiles(entries: ProjectTreeEntry[]): ProjectTreeEntry[] {
+  if ($showHiddenFiles.get()) {
+    return entries
+  }
+
+  return entries.filter(entry => !entry.name.startsWith('.'))
 }
 
 function patchNode(nodes: TreeNode[] | undefined | null, id: string, patch: (n: TreeNode) => TreeNode): TreeNode[] {
@@ -72,8 +82,9 @@ function findNode(nodes: TreeNode[], id: string): null | TreeNode {
 // dir only re-reads when it's itself in the change set.
 function mergeChildren(existing: TreeNode[], entries: ProjectTreeEntry[]): TreeNode[] {
   const byId = new Map(existing.filter(node => !node.placeholder).map(node => [node.id, node]))
+  const filtered = filterHiddenFiles(entries)
 
-  return entries.map(entry => byId.get(entry.path) ?? makeNode(entry.path, entry.name, entry.isDirectory))
+  return filtered.map(entry => byId.get(entry.path) ?? makeNode(entry.path, entry.name, entry.isDirectory))
 }
 
 function placeholderChild(parentId: string): TreeNode {
@@ -262,7 +273,7 @@ async function loadRoot(
 
     return {
       ...latest,
-      data: error ? [] : entries.map(e => makeNode(e.path, e.name, e.isDirectory)),
+      data: error ? [] : filterHiddenFiles(entries).map(e => makeNode(e.path, e.name, e.isDirectory)),
       loaded: true,
       resolvedCwd,
       rootError: error || null,
@@ -343,9 +354,10 @@ async function revalidateTree(
     }
 
     const byId = new Map(existing.filter(node => !node.placeholder).map(node => [node.id, node]))
+    const filtered = filterHiddenFiles(entries)
 
     return Promise.all(
-      entries.map(async entry => {
+      filtered.map(async entry => {
         const prev = byId.get(entry.path)
 
         if (prev?.isDirectory && prev.children) {
@@ -457,7 +469,7 @@ export function useProjectTree(cwd: string): UseProjectTreeResult {
             ...n,
             loading: false,
             error: error || undefined,
-            children: error ? [errorChild(n.id, error)] : entries.map(e => makeNode(e.path, e.name, e.isDirectory))
+            children: error ? [errorChild(n.id, error)] : filterHiddenFiles(entries).map(e => makeNode(e.path, e.name, e.isDirectory))
           }))
         }
       })

--- a/apps/desktop/src/app/right-sidebar/index.tsx
+++ b/apps/desktop/src/app/right-sidebar/index.tsx
@@ -5,12 +5,13 @@ import { TreeSkeleton } from '@/components/chat/skeletons'
 import { ErrorBoundary } from '@/components/error-boundary'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
+import { Switch } from '@/components/ui/switch'
 import { Tip } from '@/components/ui/tooltip'
 import { useDelayedTrue } from '@/hooks/use-delayed-true'
 import { useI18n } from '@/i18n'
 import { normalizeOrLocalPreviewTarget } from '@/lib/local-preview'
 import { cn } from '@/lib/utils'
-import { $panesFlipped } from '@/store/layout'
+import { $panesFlipped, $showHiddenFiles } from '@/store/layout'
 import { notifyError } from '@/store/notifications'
 import { openPreview } from '@/store/preview'
 import { $currentCwd, $selectedStoredSessionId, $workspaceCwdOwner } from '@/store/session'
@@ -140,6 +141,7 @@ function FilesystemTab({
 }: FilesystemTabProps) {
   const { t } = useI18n()
   const r = t.rightSidebar
+  const showHiddenFiles = useStore($showHiddenFiles)
 
   // No working directory (a bare/detached chat) → no tree, just a terse hint.
   // Switching workspace is a project/worktree action, never a raw folder picker.
@@ -176,6 +178,16 @@ function FilesystemTab({
           >
             <Codicon name="collapse-all" size="0.8125rem" />
           </Button>
+        </Tip>
+      <Tip label={r.showHiddenFiles}>
+          <div className={HEADER_ACTION_CLASS}>
+            <Switch
+              checked={showHiddenFiles}
+              onCheckedChange={next => $showHiddenFiles.set(next)}
+              aria-label={r.showHiddenFiles}
+              className="my-1"
+            />
+          </div>
         </Tip>
       </RightSidebarSectionHeader>
       <FileTreeBody

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2333,7 +2333,8 @@ export const ar = defineLocale({
     loadingTree: 'جار تحميل الشجرة...',
     loadingFiles: 'جار تحميل الملفات...',
     terminalHide: 'إخفاء الطرفية',
-    addToChat: 'إضافة للمحادثة'
+    addToChat: 'إضافة للمحادثة',
+    showHiddenFiles: 'إظهار الملفات المخفية'
   },
   preview: {
     tab: 'معاينة',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3023,7 +3023,8 @@ export const en: Translations = {
     terminalNew: 'New terminal',
     terminalCloseOthers: 'Close others',
     terminalCloseAll: 'Close all',
-    addToChat: 'Add to chat'
+    addToChat: 'Add to chat',
+    showHiddenFiles: 'Show hidden files'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2653,7 +2653,8 @@ export const ja = defineLocale({
     terminalNew: '新しいターミナル',
     terminalCloseOthers: '他を閉じる',
     terminalCloseAll: 'すべて閉じる',
-    addToChat: 'チャットに追加'
+    addToChat: 'チャットに追加',
+    showHiddenFiles: '隠しファイルを表示'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2590,6 +2590,7 @@ export interface Translations {
     terminalCloseOthers: string
     terminalCloseAll: string
     addToChat: string
+    showHiddenFiles: string
   }
 
   preview: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2561,7 +2561,8 @@ export const zhHant = defineLocale({
     terminalNew: '新增終端機',
     terminalCloseOthers: '關閉其他',
     terminalCloseAll: '全部關閉',
-    addToChat: '新增至聊天'
+    addToChat: '新增至聊天',
+    showHiddenFiles: '顯示隱藏檔案'
   },
 
   preview: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3186,7 +3186,8 @@ export const zh: Translations = {
     terminalNew: '新建终端',
     terminalCloseOthers: '关闭其他',
     terminalCloseAll: '关闭全部',
-    addToChat: '添加到对话'
+    addToChat: '添加到对话',
+    showHiddenFiles: '显示隐藏文件'
   },
 
   preview: {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -395,6 +395,10 @@ export const $sidebarViewCustomized: ReadableAtom<boolean> = computed(
 
 // When true, the sessions sidebar moves to the right and the file browser +
 // preview rail move to the left — a mirror of the default layout.
+/** Whether hidden files (dotfiles) are shown in the file browser tree.
+ *  Defaults to true for backward compatibility — the tree has always shown them. */
+export const $showHiddenFiles = persistentAtom('hermes.desktop.showHiddenFiles', true, Codecs.bool)
+
 export const $panesFlipped = persistentAtom(PANES_FLIPPED_STORAGE_KEY, false, Codecs.bool)
 export const $isSidebarResizing = atom(false)
 export const $sessionsLimit = atom(SIDEBAR_SESSIONS_PAGE_SIZE)


### PR DESCRIPTION
This PR adds a toggle switch in the project file browser sidebar that allows users to control whether hidden files (dotfiles, files starting with ) are displayed.

## Problem
The project sidebar shows *all* files by default, including many dotfiles (, , , , , etc.). When a project has many hidden files, it can make it harder for users to quickly find the source files and important project content they're looking for — this is what issue #64968 describes.

## Solution
- Add a  (toggle) to the file tree header, next to the collapse-all button
- Add a persistent  atom that defaults to  (backward compatible — existing users keep seeing what they saw before)
- When the toggle is off, filter out all entries whose name starts with  at every point the tree is built:
  - Root tree render
  - 
  -  (lazy loading)
  -  (opaque fallback)
- Added i18n translations to all existing languages: en, zh, zh-hant, ja, ar

## Behavior
- Default: ON (continue showing hidden files by default, same as before)
- Toggle OFF: hides all dotfiles
- Preference is persisted to localStorage via the existing persisted atom system
- The toggle fits naturally alongside the other header actions (refresh, collapse-all)

Closes #64968