### PR TITLE
feat: add safe Kanban backlog updates

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3710,7 +3710,13 @@ def list_tasks(
     return [Task.from_row(r) for r in rows]
 
 
-def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) -> bool:
+def assign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    reason: Optional[str] = None,
+) -> bool:
     """Assign or reassign a task.  Returns True on success.
 
     Refuses to reassign a task that's currently running (claim_lock set).
@@ -3719,14 +3725,23 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
     profile = _canonical_assignee(profile)
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status, claim_lock, assignee FROM tasks WHERE id = ?", (task_id,)
+            "SELECT status, claim_lock, assignee, block_kind FROM tasks WHERE id = ?",
+            (task_id,),
         ).fetchone()
         if not row:
             return False
-        if row["claim_lock"] is not None and row["status"] == "running":
+        if row["status"] in {"done", "archived"}:
+            raise RuntimeError(
+                f"cannot reassign {task_id}: status is {row['status']}"
+            )
+        if row["status"] == "running" or row["claim_lock"] is not None:
             raise RuntimeError(
                 f"cannot reassign {task_id}: currently running (claimed). "
-                "Wait for completion or reclaim the stale lock first."
+                "Reclaim or stop the worker first."
+            )
+        if row["status"] == "blocked" and row["block_kind"] == "needs_input":
+            raise RuntimeError(
+                f"cannot reassign {task_id}: blocked on a real human action"
             )
         if row["assignee"] != profile:
             # The retry guard is scoped to the task/profile combination. A
@@ -3739,7 +3754,10 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
             )
         else:
             conn.execute("UPDATE tasks SET assignee = ? WHERE id = ?", (profile, task_id))
-        _append_event(conn, task_id, "assigned", {"assignee": profile})
+        payload = {"assignee": profile}
+        if reason:
+            payload["reason"] = reason
+        _append_event(conn, task_id, "assigned", payload)
     # Task-mutation observer (RFC #58548), fired AFTER the assignment txn
     # has committed so subscribers always observe durable board state.
     notify_task_updated(conn, task_id, ("assignee",))
@@ -7547,6 +7565,195 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     # Reap the workspace on archive too — tasks archived without ever
     # completing previously kept their scratch dir / worktree forever.
     _cleanup_workspace(conn, task_id)
+    return True
+
+
+def supersede_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: str,
+    replacement_task_id: Optional[str] = None,
+) -> dict:
+    """Archive obsolete work without accidentally releasing its children."""
+    reason = (reason or "").strip()
+    if not reason:
+        raise ValueError("reason is required")
+    replacement_task_id = (replacement_task_id or "").strip() or None
+
+    with write_txn(conn):
+        task = conn.execute(
+            "SELECT status, claim_lock, block_kind FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not task:
+            raise ValueError(f"unknown task: {task_id}")
+        if task["status"] in {"done", "archived"}:
+            raise RuntimeError(
+                f"cannot supersede {task_id}: status is {task['status']}"
+            )
+        if task["status"] == "running" or task["claim_lock"] is not None:
+            raise RuntimeError(f"cannot supersede {task_id}: task is running")
+        if task["status"] == "blocked" and task["block_kind"] == "needs_input":
+            raise RuntimeError(
+                f"cannot supersede {task_id}: blocked on a real human action"
+            )
+
+        children = child_ids(conn, task_id)
+        open_parents = [
+            row["parent_id"]
+            for row in conn.execute(
+                "SELECT l.parent_id FROM task_links l "
+                "JOIN tasks p ON p.id = l.parent_id "
+                "WHERE l.child_id = ? AND p.status NOT IN ('done', 'archived') "
+                "ORDER BY l.parent_id",
+                (task_id,),
+            ).fetchall()
+        ]
+        if children and not replacement_task_id:
+            raise RuntimeError(
+                f"cannot supersede {task_id}: {len(children)} child task(s) "
+                "require an active replacement"
+            )
+
+        if replacement_task_id:
+            if replacement_task_id == task_id:
+                raise RuntimeError(f"task {task_id} cannot replace itself")
+            replacement = conn.execute(
+                "SELECT status, claim_lock FROM tasks WHERE id = ?",
+                (replacement_task_id,),
+            ).fetchone()
+            if not replacement:
+                raise ValueError(f"unknown replacement task: {replacement_task_id}")
+            if replacement["status"] in {"done", "archived"}:
+                raise RuntimeError(
+                    "replacement task must be active so it continues blocking children"
+                )
+            if replacement["status"] == "running" or replacement["claim_lock"] is not None:
+                raise RuntimeError("replacement task is running; stop or reclaim it first")
+            for child_id in children:
+                if replacement_task_id == child_id or _would_cycle(
+                    conn, replacement_task_id, child_id
+                ):
+                    raise RuntimeError(
+                        f"replacement {replacement_task_id} cannot safely parent {child_id}"
+                    )
+
+            relinked_parent_ids = []
+            for parent_id in open_parents:
+                if parent_id == replacement_task_id:
+                    continue
+                if _would_cycle(conn, parent_id, replacement_task_id):
+                    raise RuntimeError(
+                        f"parent {parent_id} cannot safely parent replacement "
+                        f"{replacement_task_id}"
+                    )
+                inserted = conn.execute(
+                    "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                    (parent_id, replacement_task_id),
+                )
+                if inserted.rowcount != 1:
+                    continue
+                relinked_parent_ids.append(parent_id)
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                    (replacement_task_id,),
+                )
+                _append_event(
+                    conn,
+                    replacement_task_id,
+                    "linked",
+                    {"parent": parent_id, "child": replacement_task_id},
+                )
+                _inherit_notify_subs(conn, replacement_task_id, (parent_id,))
+
+            relinked_children = []
+            for child_id in children:
+                inserted = conn.execute(
+                    "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
+                    (replacement_task_id, child_id),
+                )
+                if inserted.rowcount != 1:
+                    continue
+                relinked_children.append(child_id)
+                conn.execute(
+                    "UPDATE tasks SET status = 'todo' WHERE id = ? AND status = 'ready'",
+                    (child_id,),
+                )
+                _append_event(
+                    conn,
+                    child_id,
+                    "linked",
+                    {"parent": replacement_task_id, "child": child_id},
+                )
+                _inherit_notify_subs(conn, child_id, (replacement_task_id,))
+        else:
+            relinked_parent_ids = []
+            relinked_children = []
+
+        conn.execute(
+            "UPDATE tasks SET status = 'archived', claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL WHERE id = ?",
+            (task_id,),
+        )
+        _append_event(
+            conn,
+            task_id,
+            "superseded",
+            {
+                "reason": reason,
+                "replacement_task_id": replacement_task_id,
+                "relinked_parent_ids": relinked_parent_ids,
+                "relinked_children": relinked_children,
+                "open_parent_ids": open_parents,
+            },
+        )
+
+    recompute_ready(conn)
+    _cleanup_workspace(conn, task_id)
+    notify_task_updated(conn, task_id, ("status",))
+    if relinked_parent_ids:
+        notify_task_updated(conn, replacement_task_id, ("parents", "status"))
+    for child_id in relinked_children:
+        notify_task_updated(conn, child_id, ("parents", "status"))
+    return {
+        "replacement_task_id": replacement_task_id,
+        "relinked_parent_ids": relinked_parent_ids,
+        "relinked_children": relinked_children,
+        "open_parent_ids": open_parents,
+    }
+
+
+def move_task_to_triage(
+    conn: sqlite3.Connection, task_id: str, *, reason: str
+) -> bool:
+    """Park deferred work without masking blockers or terminating live runs."""
+    reason = (reason or "").strip()
+    if not reason:
+        raise ValueError("reason is required")
+    changed = False
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if not row:
+            return False
+        old_status = row["status"]
+        if old_status not in {"todo", "ready", "scheduled", "triage"}:
+            raise RuntimeError(
+                f"cannot move {task_id} to triage from {old_status}; "
+                "resolve active runs, reviews, or blocked human actions first"
+            )
+        if old_status != "triage":
+            conn.execute("UPDATE tasks SET status = 'triage' WHERE id = ?", (task_id,))
+            changed = True
+        _append_event(
+            conn,
+            task_id,
+            "moved_to_triage",
+            {"from_status": old_status, "reason": reason},
+        )
+    if changed:
+        notify_task_updated(conn, task_id, ("status",))
     return True
 
 

--- a/tests/hermes_cli/test_kanban_safe_updates.py
+++ b/tests/hermes_cli/test_kanban_safe_updates.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    with kb.connect() as conn:
+        yield conn
+
+
+def test_supersede_refuses_to_release_unhandled_children(board):
+    obsolete = kb.create_task(board, title="obsolete", assignee="default")
+    child = kb.create_task(
+        board, title="child", assignee="worker", parents=[obsolete]
+    )
+
+    with pytest.raises(RuntimeError, match="replacement"):
+        kb.supersede_task(board, obsolete, reason="duplicate")
+
+    assert kb.get_task(board, obsolete).status == "ready"
+    assert kb.get_task(board, child).status == "todo"
+
+
+def test_supersede_relinks_children_and_records_audit_event(board):
+    obsolete = kb.create_task(board, title="obsolete", assignee="default")
+    replacement = kb.create_task(board, title="replacement", assignee="worker")
+    child = kb.create_task(
+        board, title="child", assignee="worker", parents=[obsolete]
+    )
+
+    result = kb.supersede_task(
+        board,
+        obsolete,
+        replacement_task_id=replacement,
+        reason="deduplicated backlog",
+    )
+
+    assert result["replacement_task_id"] == replacement
+    assert result["relinked_children"] == [child]
+    assert kb.get_task(board, obsolete).status == "archived"
+    assert kb.get_task(board, child).status == "todo"
+    assert replacement in kb.parent_ids(board, child)
+    event = kb.list_events(board, obsolete)[-1]
+    assert event.kind == "superseded"
+    assert event.payload == {
+        "reason": "deduplicated backlog",
+        "replacement_task_id": replacement,
+        "relinked_parent_ids": [],
+        "relinked_children": [child],
+        "open_parent_ids": [],
+    }
+
+
+def test_supersede_reports_open_parents(board):
+    upstream = kb.create_task(board, title="upstream", assignee="worker")
+    obsolete = kb.create_task(
+        board, title="obsolete", assignee="default", parents=[upstream]
+    )
+
+    result = kb.supersede_task(board, obsolete, reason="duplicate")
+
+    assert result["open_parent_ids"] == [upstream]
+
+
+def test_supersede_preserves_open_parents_on_replacement(board):
+    upstream = kb.create_task(board, title="upstream", assignee="worker")
+    obsolete = kb.create_task(
+        board, title="obsolete", assignee="default", parents=[upstream]
+    )
+    replacement = kb.create_task(board, title="replacement", assignee="worker")
+
+    result = kb.supersede_task(
+        board,
+        obsolete,
+        reason="duplicate",
+        replacement_task_id=replacement,
+    )
+
+    assert result["relinked_parent_ids"] == [upstream]
+    assert upstream in kb.parent_ids(board, replacement)
+    assert kb.get_task(board, replacement).status == "todo"
+
+
+def test_supersede_refuses_running_replacement_without_changing_graph(board):
+    upstream = kb.create_task(board, title="upstream", assignee="worker")
+    obsolete = kb.create_task(
+        board, title="obsolete", assignee="default", parents=[upstream]
+    )
+    replacement = kb.create_task(board, title="replacement", assignee="worker")
+    child = kb.create_task(
+        board, title="child", assignee="worker", parents=[obsolete]
+    )
+    assert kb.claim_task(board, replacement) is not None
+
+    with pytest.raises(RuntimeError, match="replacement task is running"):
+        kb.supersede_task(
+            board,
+            obsolete,
+            reason="duplicate",
+            replacement_task_id=replacement,
+        )
+
+    assert kb.get_task(board, obsolete).status == "todo"
+    assert kb.parent_ids(board, replacement) == []
+    assert kb.parent_ids(board, child) == [obsolete]
+
+
+def test_supersede_handles_unmaterialized_worktree(board):
+    task_id = kb.create_task(
+        board,
+        title="never dispatched",
+        assignee="default",
+        workspace_kind="worktree",
+        workspace_path=None,
+    )
+
+    kb.supersede_task(board, task_id, reason="obsolete")
+
+    assert kb.get_task(board, task_id).status == "archived"
+
+
+def test_move_to_triage_records_reason_without_releasing_children(board):
+    parent = kb.create_task(board, title="deferred", assignee="default")
+    child = kb.create_task(board, title="child", assignee="worker", parents=[parent])
+
+    assert kb.move_task_to_triage(board, parent, reason="defer until Q4") is True
+
+    assert kb.get_task(board, parent).status == "triage"
+    assert kb.get_task(board, child).status == "todo"
+    event = kb.list_events(board, parent)[-1]
+    assert event.kind == "moved_to_triage"
+    assert event.payload == {"from_status": "ready", "reason": "defer until Q4"}
+
+
+def test_move_to_triage_preserves_real_human_blockers(board):
+    task_id = kb.create_task(board, title="needs approval", assignee="default")
+    kb.block_task(board, task_id, reason="human approval", kind="needs_input")
+
+    with pytest.raises(RuntimeError, match="blocked"):
+        kb.move_task_to_triage(board, task_id, reason="defer")
+
+    assert kb.get_task(board, task_id).status == "blocked"
+
+
+def test_move_to_triage_audits_repeated_request(board):
+    task_id = kb.create_task(board, title="later", assignee="default")
+    kb.move_task_to_triage(board, task_id, reason="first deferral")
+
+    kb.move_task_to_triage(board, task_id, reason="still deferred")
+
+    event = kb.list_events(board, task_id)[-1]
+    assert event.kind == "moved_to_triage"
+    assert event.payload == {"from_status": "triage", "reason": "still deferred"}
+
+
+def test_move_to_triage_does_not_report_unchanged_status(board, monkeypatch):
+    task_id = kb.create_task(board, title="later", assignee="default")
+    kb.move_task_to_triage(board, task_id, reason="first deferral")
+    updates = []
+    monkeypatch.setattr(
+        kb,
+        "notify_task_updated",
+        lambda _conn, tid, fields: updates.append((tid, fields)),
+    )
+
+    kb.move_task_to_triage(board, task_id, reason="still deferred")
+
+    assert updates == []
+
+
+def test_supersede_preserves_real_human_blockers(board):
+    task_id = kb.create_task(board, title="needs approval", assignee="default")
+    kb.block_task(board, task_id, reason="human approval", kind="needs_input")
+
+    with pytest.raises(RuntimeError, match="human action"):
+        kb.supersede_task(board, task_id, reason="cleanup")
+
+    assert kb.get_task(board, task_id).status == "blocked"
+
+
+def test_supersede_rejects_self_replacement(board):
+    obsolete = kb.create_task(board, title="obsolete", assignee="default")
+    kb.create_task(board, title="child", assignee="worker", parents=[obsolete])
+
+    with pytest.raises(RuntimeError, match="replace itself"):
+        kb.supersede_task(
+            board,
+            obsolete,
+            reason="duplicate",
+            replacement_task_id=obsolete,
+        )
+
+    assert kb.get_task(board, obsolete).status == "ready"
+
+
+def test_supersede_does_not_audit_an_existing_replacement_link(board):
+    obsolete = kb.create_task(board, title="obsolete", assignee="default")
+    replacement = kb.create_task(board, title="replacement", assignee="worker")
+    child = kb.create_task(
+        board, title="child", assignee="worker", parents=[obsolete, replacement]
+    )
+    linked_before = len(
+        [event for event in kb.list_events(board, child) if event.kind == "linked"]
+    )
+
+    result = kb.supersede_task(
+        board,
+        obsolete,
+        reason="duplicate",
+        replacement_task_id=replacement,
+    )
+
+    assert result["relinked_children"] == []
+    linked_after = len(
+        [event for event in kb.list_events(board, child) if event.kind == "linked"]
+    )
+    assert linked_after == linked_before
+
+
+def test_assign_refuses_terminal_task_inside_db_transaction(board):
+    task_id = kb.create_task(board, title="finished", assignee="default")
+    kb.complete_task(board, task_id, result="done")
+
+    with pytest.raises(RuntimeError, match="done"):
+        kb.assign_task(board, task_id, "reviewer", reason="too late")
+
+    assert kb.get_task(board, task_id).assignee == "default"
+
+
+def test_assign_preserves_real_human_blocker(board):
+    task_id = kb.create_task(board, title="approval", assignee="default")
+    kb.block_task(board, task_id, reason="approval", kind="needs_input")
+
+    with pytest.raises(RuntimeError, match="human action"):
+        kb.assign_task(board, task_id, "reviewer", reason="route")
+
+    assert kb.get_task(board, task_id).assignee == "default"

--- a/tests/tools/test_kanban_safe_updates.py
+++ b/tests/tools/test_kanban_safe_updates.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from tools import kanban_tools as kt
+
+
+@pytest.fixture
+def orchestrator_board(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HERMES_PROFILE", "coordinator")
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(kt, "_profile_has_kanban_toolset", lambda: True)
+    monkeypatch.setattr(kt, "_kanban_profile_exists", lambda _name: True)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb._INITIALIZED_PATHS.clear()
+    kb.init_db()
+    return home
+
+
+def test_update_reassigns_default_card_with_audit_event(orchestrator_board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route me", assignee="default")
+
+    result = json.loads(
+        kt._handle_update(
+            {
+                "action": "reassign",
+                "task_id": task_id,
+                "assignee": "reviewer",
+                "reason": "route to real profile",
+            }
+        )
+    )
+
+    assert result["ok"] is True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).assignee == "reviewer"
+        event = kb.list_events(conn, task_id)[-1]
+        assert event.kind == "assigned"
+        assert event.payload == {
+            "assignee": "reviewer",
+            "reason": "route to real profile",
+        }
+
+
+def test_update_returns_canonical_reassigned_profile(orchestrator_board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route me", assignee="default")
+
+    result = json.loads(
+        kt._handle_update(
+            {
+                "action": "reassign",
+                "task_id": task_id,
+                "assignee": " Reviewer ",
+                "reason": "route",
+            }
+        )
+    )
+
+    assert result["assignee"] == "reviewer"
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).assignee == result["assignee"]
+
+
+def test_update_moves_deferred_card_to_triage(orchestrator_board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="later", assignee="default")
+
+    result = json.loads(
+        kt._handle_update(
+            {"action": "triage", "task_id": task_id, "reason": "deferred"}
+        )
+    )
+
+    assert result == {"ok": True, "task_id": task_id, "status": "triage"}
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "triage"
+
+
+def test_update_refuses_to_hide_human_blocker(orchestrator_board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="approval", assignee="default")
+        kb.block_task(conn, task_id, reason="approval", kind="needs_input")
+
+    result = json.loads(
+        kt._handle_update(
+            {"action": "triage", "task_id": task_id, "reason": "cleanup"}
+        )
+    )
+
+    assert "blocked" in result["error"]
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
+def test_update_supersede_readback_is_archived_not_done(orchestrator_board):
+    with kb.connect() as conn:
+        obsolete = kb.create_task(conn, title="duplicate", assignee="default")
+
+    result = json.loads(
+        kt._handle_update(
+            {"action": "supersede", "task_id": obsolete, "reason": "duplicate"}
+        )
+    )
+
+    assert result["ok"] is True
+    assert result["status"] == "archived"
+    with kb.connect() as conn:
+        assert kb.get_task(conn, obsolete).status == "archived"
+        assert kb.list_events(conn, obsolete)[-1].kind == "superseded"
+
+
+def test_update_schema_is_orchestrator_only():
+    assert kt.KANBAN_UPDATE_SCHEMA["name"] == "kanban_update"
+    assert "orchestrator-only" in kt.KANBAN_UPDATE_SCHEMA["description"].lower()
+
+
+def test_update_runtime_guard_rejects_ordinary_profile(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(kt, "_profile_has_kanban_toolset", lambda: False)
+
+    result = json.loads(
+        kt._handle_update(
+            {"action": "triage", "task_id": "t_any", "reason": "defer"}
+        )
+    )
+
+    assert "orchestrator-only" in result["error"]
+
+
+def test_update_runtime_guard_rejects_delegated_child(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+    monkeypatch.setattr(kt, "_profile_has_kanban_toolset", lambda: True)
+    monkeypatch.setattr(kt, "_is_delegated_child_context", lambda: True)
+
+    result = json.loads(
+        kt._handle_update(
+            {"action": "triage", "task_id": "t_any", "reason": "defer"}
+        )
+    )
+
+    assert "orchestrator-only" in result["error"]
+
+
+def test_update_reassign_rejects_unknown_profile(orchestrator_board, monkeypatch):
+    monkeypatch.setattr(kt, "_kanban_profile_exists", lambda _name: False)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route me", assignee="default")
+
+    result = json.loads(
+        kt._handle_update(
+            {
+                "action": "reassign",
+                "task_id": task_id,
+                "assignee": "ghost",
+                "reason": "route",
+            }
+        )
+    )
+
+    assert "unknown profile" in result["error"]
+
+
+def test_update_reassign_rejects_default_alias(orchestrator_board):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="route me", assignee="reviewer")
+
+    result = json.loads(
+        kt._handle_update(
+            {
+                "action": "reassign",
+                "task_id": task_id,
+                "assignee": " Default ",
+                "reason": "route",
+            }
+        )
+    )
+
+    assert "real profile" in result["error"]
+
+
+def test_update_notifies_relinked_child(orchestrator_board, monkeypatch):
+    updates = []
+    monkeypatch.setattr(
+        kb,
+        "notify_task_updated",
+        lambda _conn, tid, fields: updates.append((tid, fields)),
+    )
+    with kb.connect() as conn:
+        obsolete = kb.create_task(conn, title="obsolete", assignee="default")
+        replacement = kb.create_task(conn, title="replacement", assignee="worker")
+        child = kb.create_task(
+            conn, title="child", assignee="worker", parents=[obsolete]
+        )
+    updates.clear()
+
+    result = json.loads(
+        kt._handle_update(
+            {
+                "action": "supersede",
+                "task_id": obsolete,
+                "replacement_task_id": replacement,
+                "reason": "duplicate",
+            }
+        )
+    )
+
+    assert result["ok"] is True
+    assert (child, ("parents", "status")) in updates

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -62,6 +62,18 @@ def _profile_has_kanban_toolset() -> bool:
         return False
 
 
+def _kanban_profile_exists(name: str) -> bool:
+    from hermes_cli.profiles import profile_exists
+
+    return profile_exists(name)
+
+
+def _canonical_kanban_profile(name: str) -> str:
+    from hermes_cli.profiles import normalize_profile_name
+
+    return normalize_profile_name(name)
+
+
 def _is_delegated_child_context() -> bool:
     try:
         from agent.delegation_context import is_delegated_child_context
@@ -1609,6 +1621,75 @@ def _maybe_auto_subscribe(conn: Any, task_id: str) -> bool:
         return False
 
 
+def _handle_update(args: dict, **kw) -> str:
+    """Apply graph-safe backlog maintenance from an orchestrator session."""
+    if not _check_kanban_orchestrator_mode():
+        return tool_error(
+            "kanban_update is orchestrator-only; enable the kanban toolset in "
+            "a non-worker, non-delegated profile session."
+        )
+    guard = _require_orchestrator_tool("kanban_update")
+    if guard:
+        return guard
+    action = str(args.get("action") or "").strip().lower()
+    tid = str(args.get("task_id") or "").strip()
+    reason = str(args.get("reason") or "").strip()
+    if action not in {"reassign", "triage", "supersede"}:
+        return tool_error("action must be one of: reassign, triage, supersede")
+    if not tid:
+        return tool_error("task_id is required")
+    if not reason:
+        return tool_error("reason is required for the audit trail")
+
+    try:
+        kb, conn = _connect(board=args.get("board"))
+        try:
+            task = kb.get_task(conn, tid)
+            if not task:
+                return tool_error(f"unknown task: {tid}")
+
+            if action == "reassign":
+                assignee = str(args.get("assignee") or "").strip()
+                if not assignee or assignee.casefold() == "default":
+                    return tool_error("assignee must name a real profile, not default")
+                assignee = _canonical_kanban_profile(assignee)
+                if not _kanban_profile_exists(assignee):
+                    return tool_error(f"unknown profile: {assignee}")
+                if task.status in {"done", "archived"}:
+                    return tool_error(
+                        f"cannot reassign {tid}: status is {task.status}"
+                    )
+                if not kb.assign_task(conn, tid, assignee, reason=reason):
+                    return tool_error(f"unknown task: {tid}")
+                return json.dumps(
+                    {"ok": True, "task_id": tid, "assignee": assignee}
+                )
+
+            if action == "triage":
+                if not kb.move_task_to_triage(conn, tid, reason=reason):
+                    return tool_error(f"unknown task: {tid}")
+                return json.dumps(
+                    {"ok": True, "task_id": tid, "status": "triage"}
+                )
+
+            result = kb.supersede_task(
+                conn,
+                tid,
+                reason=reason,
+                replacement_task_id=args.get("replacement_task_id"),
+            )
+            return json.dumps(
+                {"ok": True, "task_id": tid, "status": "archived", **result}
+            )
+        finally:
+            conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_update: {e}")
+    except Exception as e:
+        logger.exception("kanban_update failed")
+        return tool_error(f"kanban_update: {e}")
+
+
 def _handle_unblock(args: dict, **kw) -> str:
     """Transition a blocked task to ready, or todo while parents remain open."""
     delegated_err = _reject_delegated_child_mutation("kanban_unblock")
@@ -2309,6 +2390,44 @@ KANBAN_CREATE_SCHEMA = {
     },
 }
 
+KANBAN_UPDATE_SCHEMA = {
+    "name": "kanban_update",
+    "description": (
+        "Orchestrator-only safe backlog maintenance: reassign active work, park "
+        "deferred work in triage, or supersede obsolete work without marking it "
+        "done. Superseding a task with children requires an active replacement; "
+        "the children are atomically linked to it. Blocked human actions and "
+        "running tasks are never silently moved or closed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["reassign", "triage", "supersede"],
+            },
+            "task_id": {"type": "string", "description": "Task to update."},
+            "reason": {
+                "type": "string",
+                "description": "Required explanation stored in the audit event.",
+            },
+            "assignee": {
+                "type": "string",
+                "description": "Real profile name; required for reassign.",
+            },
+            "replacement_task_id": {
+                "type": "string",
+                "description": (
+                    "Active replacement; required when superseding a task with children."
+                ),
+            },
+            "board": _board_schema_prop(),
+        },
+        "required": ["action", "task_id", "reason"],
+    },
+}
+
+
 KANBAN_UNBLOCK_SCHEMA = {
     "name": "kanban_unblock",
     "description": (
@@ -2459,6 +2578,15 @@ registry.register(
     handler=_handle_create,
     check_fn=_check_kanban_mode,
     emoji="➕",
+)
+
+registry.register(
+    name="kanban_update",
+    toolset="kanban",
+    schema=KANBAN_UPDATE_SCHEMA,
+    handler=_handle_update,
+    check_fn=_check_kanban_orchestrator_mode,
+    emoji="🧹",
 )
 
 registry.register(

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -14,10 +14,12 @@ Hermes Kanban is a durable task board, shared across all your Hermes profiles, t
 
 The board has two front doors, both backed by the same `~/.hermes/kanban.db`:
 
-- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_complete`, `kanban_request_review`, `kanban_request_changes`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
+- **Agents drive the board through a dedicated `kanban_*` toolset** — `kanban_show`, `kanban_list`, `kanban_update`, `kanban_complete`, `kanban_request_review`, `kanban_request_changes`, `kanban_block`, `kanban_heartbeat`, `kanban_comment`, `kanban_attach`, `kanban_attach_url`, `kanban_attachments`, `kanban_create`, `kanban_link`, `kanban_unblock`. The dispatcher spawns each worker with these tools already in its schema; orchestrator profiles can also enable the `kanban` toolset explicitly. The model reads and routes tasks by calling tools directly, *not* by shelling out to `hermes kanban`. See [How workers interact with the board](#how-workers-interact-with-the-board) below.
 - **You (and scripts, and cron) drive the board through `hermes kanban …`** on the CLI, `/kanban …` as a slash command, or the dashboard. These are for humans and automation — the places without a tool-calling model behind them.
 
-Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The rest of this page shows CLI examples because they're easy to copy-paste, but every CLI verb has a tool-call equivalent the model uses.
+Both surfaces route through the same `kanban_db` layer, so reads see a consistent view and writes can't drift. The examples below use the CLI where a matching human-facing verb exists.
+
+`kanban_update` is an orchestrator-only maintenance tool with three actions: `reassign` routes an active card to a real profile, `triage` parks deferred `todo`/`ready`/`scheduled` work, and `supersede` archives obsolete work with an explicit event instead of marking it `done`. A superseded task with children must name an active `replacement_task_id`; Hermes links every child to that replacement atomically before archiving the old card. Any active upstream parents are also linked to the replacement so their dependency remains effective. Running cards, terminal cards, and blocked human actions are refused rather than silently rewritten.
 
 This is the shape that covers the workloads `delegate_task` can't:
 


### PR DESCRIPTION
## Summary
- add orchestrator-only `kanban_update` actions for reassign, triage, and supersede
- preserve upstream/downstream graph gating and explicit audit events
- refuse terminal, human-blocked, running, claimed, or unsafe graph transitions
- document the new worker-tool surface

## Test plan
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py tests/tools/test_kanban_tools.py tests/hermes_cli/test_kanban_task_updated_hook.py tests/hermes_cli/test_kanban_safe_updates.py tests/tools/test_kanban_safe_updates.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_block_kinds.py tests/hermes_cli/test_kanban_default_assignee.py tests/tools/test_delegate_kanban_isolation.py tests/hermes_cli/test_kanban_worktree_teardown.py`
- Result: 137 passed, 1 Windows-only skipped