### PR TITLE
Fix compression recovery across gateway turns

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -301,6 +301,9 @@ _DB_PERSISTED_MARKER = "_db_persisted"
 # only reads known columns.
 _COMPACTION_TAIL_MARKER = "_compaction_tail"
 PROACTIVE_PRUNE_REARM_MODEL_CONFIG_KEY = "_proactive_prune_rearm_tokens"
+ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY = "_compression_anti_thrash_recovery_at"
+ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY = "_compression_anti_thrash_probe_until"
+ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY = "_compression_anti_thrash_probe_token"
 
 _NO_USER_TASK_SENTINEL = "None. This session contains no user-authored turns."
 COMPRESSION_CONTINUATION_USER_CONTENT = (
@@ -2299,10 +2302,14 @@ class ContextCompressor(ContextEngine):
         self._last_aux_model_failure_model = None
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
+        self._fallback_compression_streak = 0
         self._anti_thrash_recovery_deadline = 0.0
+        self._anti_thrash_probe_until = 0.0
+        self._anti_thrash_probe_token = ""
+        self._owns_anti_thrash_probe = False
+        self._persist_anti_thrash_breaker_state()
         self._structural_no_op_backoff_until = 0.0
         self._prellm_skip_count = 0
-        self._fallback_compression_streak = 0
         self._verify_compaction_cleared_threshold = False
         self._last_compression_made_progress = False
         self._summary_failure_cooldown_until = 0.0  # transient errors must not block a fresh session
@@ -2604,6 +2611,9 @@ class ContextCompressor(ContextEngine):
         self._last_compression_savings_pct = 100.0
         self._ineffective_compression_count = 0
         self._anti_thrash_recovery_deadline = 0.0
+        self._anti_thrash_probe_until = 0.0
+        self._anti_thrash_probe_token = ""
+        self._owns_anti_thrash_probe = False
         self._structural_no_op_backoff_until = 0.0
         self._prellm_skip_count = 0
         self._fallback_compression_streak = 0
@@ -2637,11 +2647,16 @@ class ContextCompressor(ContextEngine):
         self._ineffective_compression_count = 0
         self._prellm_skip_count = 0
         self._anti_thrash_recovery_deadline = 0.0
+        self._anti_thrash_probe_until = 0.0
+        self._anti_thrash_probe_token = ""
+        self._owns_anti_thrash_probe = False
         self._structural_no_op_backoff_until = 0.0
         self._proactive_prune_rearm_tokens = 0
         self.get_active_compression_failure_cooldown()
-        self._load_fallback_compression_streak()
-        self._load_ineffective_compression_count()
+        if not self._load_anti_thrash_breaker_state():
+            self._load_fallback_compression_streak()
+            self._load_ineffective_compression_count()
+            self._load_anti_thrash_recovery_deadline()
         self._load_proactive_prune_rearm_tokens()
 
     def on_session_start(self, session_id: str, **kwargs) -> None:
@@ -2650,53 +2665,30 @@ class ContextCompressor(ContextEngine):
         boundary_reason = kwargs.get("boundary_reason")
         old_session_id = kwargs.get("old_session_id")
         session_db = kwargs.get("session_db", getattr(self, "_session_db", None))
-        previous_fallback_streak = self._fallback_compression_streak
-        previous_ineffective_count = self._ineffective_compression_count
+        owned_probe_token = (
+            self._anti_thrash_probe_token if self._owns_anti_thrash_probe else ""
+        )
         if boundary_reason == "compression" and old_session_id:
-            getter = getattr(session_db, "get_compression_fallback_streak", None)
-            if callable(getter):
+            copier = getattr(session_db, "copy_compression_breaker_state", None)
+            if callable(copier):
                 try:
-                    stored_streak = getter(old_session_id)
-                    if isinstance(stored_streak, (int, float, str)):
-                        previous_fallback_streak = max(0, int(stored_streak))
-                except (TypeError, ValueError, sqlite3.Error) as exc:
-                    logger.debug("compression parent fallback streak lookup failed: %s", exc)
+                    copier(old_session_id, session_id)
                 except Exception as exc:
-                    logger.debug(
-                        "compression parent fallback streak lookup failed (non-sqlite): %s",
-                        exc,
-                    )
-            count_getter = getattr(
-                session_db, "get_compression_ineffective_count", None,
-            )
-            if callable(count_getter):
-                try:
-                    stored_count = count_getter(old_session_id)
-                    if isinstance(stored_count, (int, float, str)):
-                        previous_ineffective_count = max(0, int(stored_count))
-                except (TypeError, ValueError, sqlite3.Error) as exc:
-                    logger.debug(
-                        "compression parent ineffective count lookup failed: %s", exc,
-                    )
-                except Exception as exc:
-                    logger.debug(
-                        "compression parent ineffective count lookup failed (non-sqlite): %s",
-                        exc,
-                    )
+                    logger.debug("compression breaker rotation copy failed: %s", exc)
         self.bind_session_state(session_db, session_id)
-        if boundary_reason == "compression":
-            # Rotation creates a fresh child row before this callback. Preserve
-            # the logical conversation's streak until boundary bookkeeping
-            # persists the updated value onto the child row.
-            self._fallback_compression_streak = previous_fallback_streak
-            # Same for the anti-thrash strike counter — but unlike the streak,
-            # no later boundary bookkeeping writes it, so persist the carried
-            # value onto the (fresh) child row now. Otherwise a restart between
-            # rotation and the next real-usage verdict would silently disarm
-            # an armed guard (#54923).
-            if self._ineffective_compression_count != previous_ineffective_count:
-                self._ineffective_compression_count = previous_ineffective_count
-                self._persist_ineffective_compression_count()
+        if (
+            boundary_reason == "compression"
+            and owned_probe_token
+            and self._anti_thrash_probe_token == owned_probe_token
+        ):
+            # The same in-process winner owns the copied claim on the child.
+            # Durable counters stay tripped so every sibling remains blocked;
+            # the winner's local one-strike mirrors make its verdict decisive.
+            self._owns_anti_thrash_probe = True
+            if self._ineffective_compression_count >= 2:
+                self._ineffective_compression_count = 1
+            if self._fallback_compression_streak >= 2:
+                self._fallback_compression_streak = 1
 
     def _load_fallback_compression_streak(self) -> None:
         session_db = getattr(self, "_session_db", None)
@@ -2765,6 +2757,64 @@ class ContextCompressor(ContextEngine):
         except Exception as exc:
             logger.debug("compression fallback streak persist failed (non-sqlite): %s", exc)
 
+    def _load_anti_thrash_breaker_state(self) -> bool:
+        """Load the complete durable breaker tuple when SessionDB supports it."""
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        getter = getattr(session_db, "get_compression_breaker_state", None)
+        if not session_id or not callable(getter):
+            return False
+        try:
+            state = getter(session_id)
+            self._ineffective_compression_count = max(
+                0, int(state.get("ineffective_count", 0) or 0)
+            )
+            self._fallback_compression_streak = max(
+                0, int(state.get("fallback_streak", 0) or 0)
+            )
+            self._anti_thrash_recovery_deadline = max(
+                0.0, float(state.get("recovery_at", 0) or 0)
+            )
+            self._anti_thrash_probe_until = max(
+                0.0, float(state.get("probe_until", 0) or 0)
+            )
+            self._anti_thrash_probe_token = str(state.get("probe_token", "") or "")
+            self._owns_anti_thrash_probe = False
+            return True
+        except (TypeError, ValueError, sqlite3.Error) as exc:
+            logger.debug("compression breaker-state lookup failed: %s", exc)
+        except Exception as exc:
+            logger.debug("compression breaker-state lookup failed (non-sqlite): %s", exc)
+        return False
+
+    def _persist_anti_thrash_breaker_state(self) -> bool:
+        """Persist counters, recovery deadline, and probe claim atomically."""
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        setter = getattr(session_db, "set_compression_breaker_state", None)
+        if not session_id:
+            return True
+        if not callable(setter):
+            return False
+        try:
+            return bool(
+                setter(
+                    session_id,
+                    ineffective_count=self._ineffective_compression_count,
+                    fallback_streak=self._fallback_compression_streak,
+                    recovery_at=self._anti_thrash_recovery_deadline,
+                    probe_until=self._anti_thrash_probe_until,
+                    probe_token=self._anti_thrash_probe_token,
+                )
+            )
+        except sqlite3.Error as exc:
+            logger.debug("compression breaker-state persist failed: %s", exc)
+        except Exception as exc:
+            logger.debug(
+                "compression breaker-state persist failed (non-sqlite): %s", exc
+            )
+        return False
+
     def _load_ineffective_compression_count(self) -> None:
         """Load the durable anti-thrash strike count for the bound session.
 
@@ -2807,6 +2857,103 @@ class ContextCompressor(ContextEngine):
         except Exception as exc:
             logger.debug("compression ineffective count persist failed (non-sqlite): %s", exc)
 
+    def _load_anti_thrash_recovery_deadline(self) -> None:
+        """Restore the wall-clock deadline for the breaker's half-open probe.
+
+        Gateway turns create a fresh ``AIAgent`` for every inbound message.
+        Keeping this deadline only in ``time.monotonic()`` state therefore
+        restarted the full recovery window on every message and could leave a
+        durable tripped counter blocked forever.  ``model_config`` already
+        owns session-scoped auxiliary compaction state, so store an epoch
+        deadline there without adding another schema migration.
+        """
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        getter = getattr(session_db, "get_session_model_config_value", None)
+        if not session_id or not callable(getter):
+            return
+        try:
+            value = getter(
+                session_id,
+                ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY,
+                0,
+            )
+            self._anti_thrash_recovery_deadline = max(
+                0.0,
+                float(value) if isinstance(value, (int, float, str)) else 0.0,
+            )
+        except (TypeError, ValueError, json.JSONDecodeError, sqlite3.Error) as exc:
+            logger.debug("compression recovery deadline lookup failed: %s", exc)
+        except Exception as exc:
+            logger.debug(
+                "compression recovery deadline lookup failed (non-sqlite): %s",
+                exc,
+            )
+
+    def _persist_anti_thrash_recovery_deadline(self) -> bool:
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "_session_id", "")
+        patcher = getattr(session_db, "patch_session_model_config", None)
+        if not session_id:
+            return True
+        if not callable(patcher):
+            return False
+        value = self._anti_thrash_recovery_deadline or None
+        try:
+            patcher(
+                session_id,
+                {ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY: value},
+            )
+            return True
+        except sqlite3.Error as exc:
+            logger.debug("compression recovery deadline persist failed: %s", exc)
+        except Exception as exc:
+            logger.debug(
+                "compression recovery deadline persist failed (non-sqlite): %s",
+                exc,
+            )
+        return False
+
+    def _arm_anti_thrash_recovery_deadline(self) -> bool:
+        if self._anti_thrash_recovery_deadline <= 0.0 or self._owns_anti_thrash_probe:
+            self._anti_thrash_recovery_deadline = (
+                time.time() + self._ANTI_THRASH_RECOVERY_SECONDS
+            )
+        self._anti_thrash_probe_until = 0.0
+        self._anti_thrash_probe_token = ""
+        self._owns_anti_thrash_probe = False
+        if callable(
+            getattr(
+                getattr(self, "_session_db", None),
+                "set_compression_breaker_state",
+                None,
+            )
+        ):
+            return self._persist_anti_thrash_breaker_state()
+        return self._persist_anti_thrash_recovery_deadline()
+
+    def _clear_anti_thrash_recovery_deadline(self) -> None:
+        if (
+            self._anti_thrash_recovery_deadline <= 0.0
+            and self._anti_thrash_probe_until <= 0.0
+            and not self._anti_thrash_probe_token
+        ):
+            return
+        self._anti_thrash_recovery_deadline = 0.0
+        self._anti_thrash_probe_until = 0.0
+        self._anti_thrash_probe_token = ""
+        self._owns_anti_thrash_probe = False
+        if callable(
+            getattr(
+                getattr(self, "_session_db", None),
+                "set_compression_breaker_state",
+                None,
+            )
+        ):
+            self._persist_anti_thrash_breaker_state()
+        else:
+            self._persist_anti_thrash_recovery_deadline()
+
     def _record_ineffective_compression_verdict(self, count: int) -> None:
         """Set the anti-thrash strike counter, keeping the durable copy in sync.
 
@@ -2816,7 +2963,30 @@ class ContextCompressor(ContextEngine):
         if count == self._ineffective_compression_count:
             return
         self._ineffective_compression_count = count
-        self._persist_ineffective_compression_count()
+        atomic_state = callable(
+            getattr(
+                getattr(self, "_session_db", None),
+                "set_compression_breaker_state",
+                None,
+            )
+        )
+        if count >= 2:
+            # One transaction owns counters + deadline + claim. A failed write
+            # leaves the previous durable tuple intact instead of persisting a
+            # permanent trip without its recovery clock.
+            if not self._arm_anti_thrash_recovery_deadline() and not atomic_state:
+                self._persist_ineffective_compression_count()
+        elif self._fallback_compression_streak < 2:
+            self._anti_thrash_recovery_deadline = 0.0
+            self._anti_thrash_probe_until = 0.0
+            self._anti_thrash_probe_token = ""
+            self._owns_anti_thrash_probe = False
+            if not self._persist_anti_thrash_breaker_state() and not atomic_state:
+                self._persist_ineffective_compression_count()
+                self._persist_anti_thrash_recovery_deadline()
+        else:
+            if not self._persist_anti_thrash_breaker_state() and not atomic_state:
+                self._persist_ineffective_compression_count()
 
     def _record_structural_no_op(self, reason: str) -> None:
         """Defer retries after a structural no-op WITHOUT striking the breaker.
@@ -2910,7 +3080,27 @@ class ContextCompressor(ContextEngine):
                 )
         elif self._fallback_compression_streak:
             self._fallback_compression_streak = 0
-        self._persist_fallback_compression_streak()
+        if self._fallback_compression_streak >= 2:
+            atomic_state = callable(
+                getattr(
+                    getattr(self, "_session_db", None),
+                    "set_compression_breaker_state",
+                    None,
+                )
+            )
+            if self._arm_anti_thrash_recovery_deadline() and not atomic_state:
+                self._persist_fallback_compression_streak()
+        elif self._ineffective_compression_count < 2:
+            self._anti_thrash_recovery_deadline = 0.0
+            self._anti_thrash_probe_until = 0.0
+            self._anti_thrash_probe_token = ""
+            self._owns_anti_thrash_probe = False
+            if not self._persist_anti_thrash_breaker_state():
+                self._persist_fallback_compression_streak()
+                self._persist_anti_thrash_recovery_deadline()
+        else:
+            if not self._persist_anti_thrash_breaker_state():
+                self._persist_fallback_compression_streak()
 
     def get_active_compression_failure_cooldown(
         self,
@@ -3225,12 +3415,12 @@ class ContextCompressor(ContextEngine):
 
     # Anti-thrash recovery window (#14694): once the ineffective/fallback
     # breaker trips, automatic compaction stays blocked for this long, then
-    # ONE probe attempt is allowed (counters drop to 1 strike, so another
-    # ineffective pass re-trips immediately). Long enough that a genuinely
+    # the breaker enters probation (counters drop to 1 strike, so another
+    # ineffective verdict re-trips immediately). Long enough that a genuinely
     # incompressible session isn't compacting in a loop; short enough that a
     # session which has since grown real compressible material recovers well
     # before it rides into the provider's hard context limit.
-    _ANTI_THRASH_RECOVERY_SECONDS = 300.0
+    _ANTI_THRASH_RECOVERY_SECONDS = 900.0
 
     # Structural no-op backoff (#93022): when a compression attempt finds
     # nothing eligible inside the protection window (too few messages, empty
@@ -3532,12 +3722,15 @@ class ContextCompressor(ContextEngine):
         # Anti-thrashing: track whether last compression was effective
         self._last_compression_savings_pct: float = 100.0
         self._ineffective_compression_count: int = 0
-        # Monotonic deadline after which a tripped anti-thrash guard grants
-        # one probation probe (#14694). 0.0 = clock not armed. Armed lazily on
-        # the first blocked evaluation; deliberately NOT durable, so a process
-        # restart with a persisted tripped counter (#69872) waits a full fresh
-        # window before probing (#54923: restart must never disarm a guard).
+        # Epoch deadline after which a tripped anti-thrash guard may claim one
+        # probation probe (#14694). Both the deadline and the bounded claim
+        # are durable because gateways create a fresh agent per inbound turn.
         self._anti_thrash_recovery_deadline: float = 0.0
+        self._anti_thrash_probe_until: float = 0.0
+        self._anti_thrash_probe_token: str = ""
+        # Process-local ownership is deliberately not restored on bind: only
+        # the SessionDB transaction that created the claim may set it True.
+        self._owns_anti_thrash_probe: bool = False
         # Pre-LLM feasibility skips (#60451). Observability only; NEVER feeds
         # the ineffectiveness strike latch or the fallback streak breaker.
         self._prellm_skip_count: int = 0
@@ -3892,13 +4085,12 @@ class ContextCompressor(ContextEngine):
         except Exception as exc:
             logger.debug("compression cooldown refresh failed: %s", exc)
         try:
-            self._load_fallback_compression_streak()
+            if not self._load_anti_thrash_breaker_state():
+                self._load_fallback_compression_streak()
+                self._load_ineffective_compression_count()
+                self._load_anti_thrash_recovery_deadline()
         except Exception as exc:
-            logger.debug("compression fallback-streak refresh failed: %s", exc)
-        try:
-            self._load_ineffective_compression_count()
-        except Exception as exc:
-            logger.debug("compression ineffective-count refresh failed: %s", exc)
+            logger.debug("compression breaker-state refresh failed: %s", exc)
 
     def _automatic_compression_blocked(self) -> bool:
         """Return whether automatic compaction is in cooldown or tripped."""
@@ -3958,32 +4150,87 @@ class ContextCompressor(ContextEngine):
         # recovery path the session never auto-compacts again and rides into
         # the provider's hard context limit. Recovery is a probation probe:
         # after _ANTI_THRASH_RECOVERY_SECONDS of continuous block, allow ONE
-        # attempt by dropping the tripped counter(s) to 1 strike (persisted,
-        # so sibling agents on the same session row unblock too). If the probe
-        # is ineffective again the very next verdict re-trips the guard, so
+        # period by dropping the tripped counter(s) to 1 strike (persisted).
+        # The existing per-session compression lease serializes actual
+        # concurrent attempts. If probation is ineffective, the very next
+        # verdict re-trips the guard, so
         # the worst case in the truly-incompressible state is one compaction
         # attempt per recovery window — bounded, not thrash.
         #
-        # The clock is armed lazily on the first BLOCKED evaluation rather
-        # than persisted at trip time: a fresh process that loads a durable
-        # tripped counter (#69872) therefore starts a full window blocked,
-        # preserving the restart-must-not-disarm contract (#54923).
+        # The deadline is armed when the breaker trips and persisted with the
+        # session.  Messaging gateways construct a fresh agent per inbound
+        # turn; a process-local monotonic deadline would restart the wait on
+        # every message and make the half-open probe unreachable.
         if (
             self._ineffective_compression_count >= 2
             or self._fallback_compression_streak >= 2
         ):
-            _now = time.monotonic()
-            if self._anti_thrash_recovery_deadline <= 0.0:
-                self._anti_thrash_recovery_deadline = (
-                    _now + self._ANTI_THRASH_RECOVERY_SECONDS
+            _now = time.time()
+            claimer = getattr(
+                getattr(self, "_session_db", None),
+                "claim_compression_recovery_probe",
+                None,
+            )
+            if getattr(self, "_session_id", "") and callable(claimer):
+                try:
+                    state = claimer(
+                        self._session_id,
+                        now=_now,
+                        recovery_seconds=self._ANTI_THRASH_RECOVERY_SECONDS,
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Compression recovery claim failed for session=%s: %s",
+                        self._session_id,
+                        exc,
+                    )
+                    return True
+                self._anti_thrash_recovery_deadline = max(
+                    0.0, float(state.get("recovery_at", 0) or 0)
                 )
-            elif _now >= self._anti_thrash_recovery_deadline:
-                self._anti_thrash_recovery_deadline = 0.0
+                self._anti_thrash_probe_until = max(
+                    0.0, float(state.get("probe_until", 0) or 0)
+                )
+                self._anti_thrash_probe_token = str(
+                    state.get("probe_token", "") or ""
+                )
+                if state.get("claimed"):
+                    self._owns_anti_thrash_probe = True
+                    if self._ineffective_compression_count >= 2:
+                        self._ineffective_compression_count = 1
+                    if self._fallback_compression_streak >= 2:
+                        self._fallback_compression_streak = 1
+                    if not self.quiet_mode:
+                        logger.info(
+                            "Anti-thrashing recovery: %.0fs elapsed — this "
+                            "agent atomically claimed the single compaction probe.",
+                            self._ANTI_THRASH_RECOVERY_SECONDS,
+                        )
+                    return False
+                self._owns_anti_thrash_probe = False
+                if not self.quiet_mode:
+                    remaining_until = max(
+                        self._anti_thrash_recovery_deadline,
+                        self._anti_thrash_probe_until,
+                    )
+                    logger.warning(
+                        "Compression skipped — anti-thrash recovery is blocked "
+                        "for %.0fs more (ineffective=%d fallback=%d).",
+                        max(0.0, remaining_until - _now),
+                        self._ineffective_compression_count,
+                        self._fallback_compression_streak,
+                    )
+                return True
+            if self._anti_thrash_recovery_deadline <= 0.0:
+                # Compatibility for a tripped row written by an older build.
+                self._arm_anti_thrash_recovery_deadline()
+            if _now >= self._anti_thrash_recovery_deadline:
                 if self._ineffective_compression_count >= 2:
                     self._record_ineffective_compression_verdict(1)
                 if self._fallback_compression_streak >= 2:
                     self._fallback_compression_streak = 1
                     self._persist_fallback_compression_streak()
+                self._clear_anti_thrash_recovery_deadline()
                 if not self.quiet_mode:
                     logger.info(
                         "Anti-thrashing recovery: %.0fs elapsed since the "
@@ -4009,7 +4256,32 @@ class ContextCompressor(ContextEngine):
         # Guard not tripped (counters were cleared by an effective compaction
         # or a fitting real-usage reading) — disarm any pending recovery clock
         # so a LATER trip starts its own full window.
-        self._anti_thrash_recovery_deadline = 0.0
+        if self._owns_anti_thrash_probe:
+            validator = getattr(
+                getattr(self, "_session_db", None),
+                "validate_compression_recovery_probe",
+                None,
+            )
+            if getattr(self, "_session_id", "") and callable(validator):
+                try:
+                    if validator(
+                        self._session_id,
+                        probe_token=self._anti_thrash_probe_token,
+                        now=time.time(),
+                    ):
+                        return False
+                except Exception as exc:
+                    logger.warning(
+                        "Compression recovery ownership validation failed for "
+                        "session=%s: %s",
+                        self._session_id,
+                        exc,
+                    )
+                self._owns_anti_thrash_probe = False
+                self._load_anti_thrash_breaker_state()
+                return True
+            return False
+        self._clear_anti_thrash_recovery_deadline()
         return False
 
     # ------------------------------------------------------------------

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -46,6 +46,9 @@ from agent.message_sanitization import _sanitize_surrogates
 # predating copy — hermes_state cannot import run_agent (circular) — guarded
 # by test_marker_constant_in_sync.
 from agent.context_compressor import (
+    ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY,
+    ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY,
+    ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY,
     _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY,
 )
 from agent.skill_commands import (
@@ -8434,6 +8437,279 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             )
 
         self._execute_write(_do)
+
+    def get_compression_breaker_state(self, session_id: str) -> Dict[str, Any]:
+        """Read the anti-thrash counters and recovery markers as one snapshot."""
+        empty = {
+            "ineffective_count": 0,
+            "fallback_streak": 0,
+            "recovery_at": 0.0,
+            "probe_until": 0.0,
+            "probe_token": "",
+        }
+        if not session_id:
+            return empty
+        with self._read_ctx() as conn:
+            if conn is None:
+                return empty
+            row = conn.execute(
+                "SELECT compression_ineffective_count, "
+                "compression_fallback_streak, model_config "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+        if row is None:
+            return empty
+        raw_config = row["model_config"] if isinstance(row, sqlite3.Row) else row[2]
+        config: Dict[str, Any] = {}
+        if isinstance(raw_config, str) and raw_config.strip():
+            try:
+                parsed = json.loads(raw_config)
+                if isinstance(parsed, dict):
+                    config = parsed
+            except (json.JSONDecodeError, TypeError):
+                pass
+
+        def _number(key: str) -> float:
+            try:
+                return max(0.0, float(config.get(key, 0) or 0))
+            except (TypeError, ValueError):
+                return 0.0
+
+        return {
+            "ineffective_count": max(0, int(row[0] or 0)),
+            "fallback_streak": max(0, int(row[1] or 0)),
+            "recovery_at": _number(ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY),
+            "probe_until": _number(ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY),
+            "probe_token": str(
+                config.get(ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY, "") or ""
+            ),
+        }
+
+    def set_compression_breaker_state(
+        self,
+        session_id: str,
+        *,
+        ineffective_count: int,
+        fallback_streak: int,
+        recovery_at: float = 0.0,
+        probe_until: float = 0.0,
+        probe_token: str = "",
+    ) -> bool:
+        """Persist the complete anti-thrash tuple in one transaction."""
+        if not session_id:
+            return False
+        ineffective_count = max(0, int(ineffective_count))
+        fallback_streak = max(0, int(fallback_streak))
+        recovery_at = max(0.0, float(recovery_at))
+        probe_until = max(0.0, float(probe_until))
+        probe_token = str(probe_token or "")
+
+        def _do(conn):
+            merged = self._merge_model_config_json(
+                conn,
+                session_id,
+                {
+                    ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY: recovery_at or None,
+                    ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY: probe_until or None,
+                    ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY: probe_token or None,
+                },
+            )
+            if merged is _MODEL_CONFIG_ROW_MISSING:
+                return False
+            conn.execute(
+                "UPDATE sessions SET compression_ineffective_count = ?, "
+                "compression_fallback_streak = ?, model_config = ? WHERE id = ?",
+                (ineffective_count, fallback_streak, merged, session_id),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def claim_compression_recovery_probe(
+        self,
+        session_id: str,
+        *,
+        now: float,
+        recovery_seconds: float,
+    ) -> Dict[str, Any]:
+        """Atomically grant at most one half-open probe for a tripped session.
+
+        Durable counters remain tripped while the winner is running.  The
+        winner uses one-strike local mirrors so its next verdict either clears
+        the tuple or re-arms a full recovery window.  If it dies before a
+        verdict, ``probe_until`` bounds the abandoned claim.
+        """
+        now = float(now)
+        recovery_seconds = max(1.0, float(recovery_seconds))
+
+        def _do(conn):
+            row = conn.execute(
+                "SELECT compression_ineffective_count, "
+                "compression_fallback_streak, model_config "
+                "FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if row is None:
+                return {"claimed": False, "missing": True}
+            ineffective = max(0, int(row[0] or 0))
+            fallback = max(0, int(row[1] or 0))
+            raw_config = row[2]
+            config: Dict[str, Any] = {}
+            if isinstance(raw_config, str) and raw_config.strip():
+                try:
+                    parsed = json.loads(raw_config)
+                    if isinstance(parsed, dict):
+                        config = parsed
+                except (json.JSONDecodeError, TypeError):
+                    pass
+
+            def _number(key: str) -> float:
+                try:
+                    return max(0.0, float(config.get(key, 0) or 0))
+                except (TypeError, ValueError):
+                    return 0.0
+
+            recovery_at = _number(ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY)
+            probe_until = _number(ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY)
+            probe_token = str(
+                config.get(ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY, "") or ""
+            )
+            original_recovery_at = recovery_at
+            original_probe_until = probe_until
+            original_probe_token = probe_token
+            # Epoch time is the only clock that survives a process restart.
+            # A backward wall-clock jump must not turn one recovery window
+            # into an unbounded latch, so clamp future markers to one window
+            # from the first post-jump observation. A forward jump deliberately
+            # fails open: an early bounded probe is safer than permanent block.
+            upper_bound = now + recovery_seconds
+            recovery_at = min(recovery_at, upper_bound)
+            probe_until = min(probe_until, upper_bound)
+            tripped = ineffective >= 2 or fallback >= 2
+            claimed = False
+            if not tripped:
+                recovery_at = 0.0
+                probe_until = 0.0
+                probe_token = ""
+            elif probe_until > now:
+                pass
+            elif probe_until > 0.0:
+                # The previous winner never produced a verdict. Its bounded
+                # claim has elapsed, so this transaction may replace it.
+                claimed = True
+                recovery_at = 0.0
+                probe_until = now + recovery_seconds
+                probe_token = uuid.uuid4().hex
+            elif recovery_at <= 0.0:
+                # Compatibility for rows written before the durable clock.
+                recovery_at = now + recovery_seconds
+                probe_until = 0.0
+                probe_token = ""
+            elif recovery_at <= now:
+                claimed = True
+                recovery_at = 0.0
+                probe_until = now + recovery_seconds
+                probe_token = uuid.uuid4().hex
+
+            if (
+                recovery_at != original_recovery_at
+                or probe_until != original_probe_until
+                or probe_token != original_probe_token
+            ):
+                merged = self._merge_model_config_json(
+                    conn,
+                    session_id,
+                    {
+                        ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY: recovery_at or None,
+                        ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY: probe_until or None,
+                        ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY: probe_token or None,
+                    },
+                    on_missing="raise",
+                )
+                conn.execute(
+                    "UPDATE sessions SET model_config = ? WHERE id = ?",
+                    (merged, session_id),
+                )
+            return {
+                "claimed": claimed,
+                "missing": False,
+                "ineffective_count": ineffective,
+                "fallback_streak": fallback,
+                "recovery_at": recovery_at,
+                "probe_until": probe_until,
+                "probe_token": probe_token,
+            }
+
+        return self._execute_write(_do)
+
+    def copy_compression_breaker_state(
+        self, parent_session_id: str, child_session_id: str,
+    ) -> bool:
+        """Copy the complete breaker tuple across rotation atomically."""
+        if not parent_session_id or not child_session_id:
+            return False
+
+        def _do(conn):
+            parent = conn.execute(
+                "SELECT compression_ineffective_count, "
+                "compression_fallback_streak, model_config "
+                "FROM sessions WHERE id = ?",
+                (parent_session_id,),
+            ).fetchone()
+            if parent is None:
+                return False
+            raw_config = parent[2]
+            config: Dict[str, Any] = {}
+            if isinstance(raw_config, str) and raw_config.strip():
+                try:
+                    parsed = json.loads(raw_config)
+                    if isinstance(parsed, dict):
+                        config = parsed
+                except (json.JSONDecodeError, TypeError):
+                    pass
+            merged = self._merge_model_config_json(
+                conn,
+                child_session_id,
+                {
+                    ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY: config.get(
+                        ANTI_THRASH_RECOVERY_AT_MODEL_CONFIG_KEY
+                    ),
+                    ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY: config.get(
+                        ANTI_THRASH_PROBE_UNTIL_MODEL_CONFIG_KEY
+                    ),
+                    ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY: config.get(
+                        ANTI_THRASH_PROBE_TOKEN_MODEL_CONFIG_KEY
+                    ),
+                },
+            )
+            if merged is _MODEL_CONFIG_ROW_MISSING:
+                return False
+            conn.execute(
+                "UPDATE sessions SET compression_ineffective_count = ?, "
+                "compression_fallback_streak = ?, model_config = ? WHERE id = ?",
+                (max(0, int(parent[0] or 0)), max(0, int(parent[1] or 0)), merged,
+                 child_session_id),
+            )
+            return True
+
+        return bool(self._execute_write(_do))
+
+    def validate_compression_recovery_probe(
+        self, session_id: str, *, probe_token: str, now: float,
+    ) -> bool:
+        """Return whether ``probe_token`` still owns the unexpired claim."""
+        if not session_id or not probe_token:
+            return False
+        state = self.get_compression_breaker_state(session_id)
+        return (
+            state["probe_token"] == probe_token
+            and float(state["probe_until"] or 0) > float(now)
+            and (
+                int(state["ineffective_count"] or 0) >= 2
+                or int(state["fallback_streak"] or 0) >= 2
+            )
+        )
 
     # ──────────────────────────────────────────────────────────────────────
     # Compression locks

--- a/tests/agent/test_compression_anti_thrash_persistence.py
+++ b/tests/agent/test_compression_anti_thrash_persistence.py
@@ -176,7 +176,7 @@ class TestStrikesPersistFromEveryVerdictSite:
 
         with patch.object(
             db,
-            "set_compression_ineffective_count",
+            "set_compression_breaker_state",
             side_effect=Exception("disk full"),
         ):
             cc._verify_compaction_cleared_threshold = True

--- a/tests/agent/test_compression_anti_thrash_recovery.py
+++ b/tests/agent/test_compression_anti_thrash_recovery.py
@@ -10,21 +10,23 @@ hard context limit, and only ``/new`` or ``/reset`` recovered it.
 
 The recovery contract pinned here:
 
-* After ``_ANTI_THRASH_RECOVERY_SECONDS`` of continuous block, the gate
-  grants exactly ONE probation probe: tripped counters drop to 1 strike
-  (persisted) and the gate reports unblocked once.
+* After ``_ANTI_THRASH_RECOVERY_SECONDS`` of continuous block, the gate enters
+  probation: tripped counters drop to 1 strike (persisted). The existing
+  per-session compression lease serializes actual concurrent attempts until
+  the next real-usage verdict either clears or re-trips the breaker.
 * An ineffective probe re-trips the guard on the very next verdict, and the
   next recovery waits a FULL fresh window (no immediate re-probe loop).
 * An effective probe (or any fitting real-usage reading) fully clears the
   counters through the existing ``update_from_response`` path.
-* The recovery clock is armed lazily on the first blocked evaluation and is
-  NOT durable: a process restart that loads a durable tripped counter
-  (#69872) starts a full fresh window blocked — a restart must never disarm
-  or shorten the guard (#54923).
+* The recovery deadline is persisted when the breaker trips. Gateway turns
+  create a new agent per inbound message, so a restart must preserve elapsed
+  recovery time instead of restarting the wait forever.
 * The protection itself is preserved: inside the window the gate stays
   blocked exactly as before.
 """
 
+from concurrent.futures import ThreadPoolExecutor
+from threading import Barrier
 from unittest.mock import patch
 
 from agent.context_compressor import ContextCompressor
@@ -51,16 +53,17 @@ def _trip(cc: ContextCompressor) -> None:
 
 
 class TestRecoveryWindow:
-
+    def test_recovery_window_is_fifteen_minutes(self):
+        assert _compressor()._ANTI_THRASH_RECOVERY_SECONDS == 900.0
 
     def test_effective_probe_clears_the_guard_completely(self):
         cc = _compressor()
-        _trip(cc)
         base = 1000.0
-        with patch("agent.context_compressor.time.monotonic", return_value=base):
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(cc)
             assert cc.should_compress(cc.threshold_tokens + 1) is False
         with patch(
-            "agent.context_compressor.time.monotonic",
+            "agent.context_compressor.time.time",
             return_value=base + cc._ANTI_THRASH_RECOVERY_SECONDS + 1,
         ):
             assert cc.should_compress(cc.threshold_tokens + 1) is True
@@ -71,51 +74,268 @@ class TestRecoveryWindow:
 
     def test_fallback_streak_breaker_recovers_too(self):
         cc = _compressor()
-        cc._fallback_compression_streak = 2
         base = 1000.0
-        with patch("agent.context_compressor.time.monotonic", return_value=base):
+        with patch("agent.context_compressor.time.time", return_value=base):
+            cc.record_completed_compaction(used_fallback=True)
+            cc.record_completed_compaction(used_fallback=True)
             assert cc.should_compress(cc.threshold_tokens + 1) is False
         with patch(
-            "agent.context_compressor.time.monotonic",
+            "agent.context_compressor.time.time",
             return_value=base + cc._ANTI_THRASH_RECOVERY_SECONDS + 1,
         ):
             assert cc.should_compress(cc.threshold_tokens + 1) is True
         assert cc._fallback_compression_streak == 1
 
-
-
-
-class TestRestartSemantics:
-    def test_restart_with_durable_tripped_counter_waits_a_full_window(self, tmp_path):
-        """#69872 x #14694: a restart must not disarm OR shorten the guard."""
+    def test_ineffective_probation_rearms_a_full_durable_window(self, tmp_path):
         db = SessionDB(db_path=tmp_path / "state.db")
         db.create_session(session_id="sess-1", source="cli")
-        db.set_compression_ineffective_count("sess-1", 2)
-
         cc = _compressor()
         cc.bind_session_state(session_db=db, session_id="sess-1")
-        assert cc._ineffective_compression_count == 2
-        # The recovery clock is process-local and must come up disarmed.
-        assert cc._anti_thrash_recovery_deadline == 0.0
-        base = 5000.0
-        with patch("agent.context_compressor.time.monotonic", return_value=base):
-            assert cc.should_compress(cc.threshold_tokens + 1) is False
+        base = 2000.0
+
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(cc)
         with patch(
-            "agent.context_compressor.time.monotonic",
+            "agent.context_compressor.time.time",
             return_value=base + cc._ANTI_THRASH_RECOVERY_SECONDS + 1,
         ):
             assert cc.should_compress(cc.threshold_tokens + 1) is True
-        # The probation reset is durable, so sibling agents on the same
-        # session row (gateway hygiene) unblock too.
-        assert db.get_compression_ineffective_count("sess-1") == 1
+            cc._record_ineffective_compression_verdict(2)
 
-    def test_session_reset_disarms_the_recovery_clock(self):
+        fresh = _compressor()
+        fresh.bind_session_state(session_db=db, session_id="sess-1")
+        assert fresh._ineffective_compression_count == 2
+        assert fresh._anti_thrash_recovery_deadline == (
+            base + (2 * cc._ANTI_THRASH_RECOVERY_SECONDS) + 1
+        )
+        with patch(
+            "agent.context_compressor.time.time",
+            return_value=base + (2 * cc._ANTI_THRASH_RECOVERY_SECONDS),
+        ):
+            assert fresh.should_compress(fresh.threshold_tokens + 1) is False
+
+    def test_deadline_write_failure_cannot_persist_a_permanent_trip(
+        self, tmp_path, monkeypatch,
+    ):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
         cc = _compressor()
+        cc.bind_session_state(session_db=db, session_id="sess-1")
+
+        def fail_deadline_write(*_args, **_kwargs):
+            raise RuntimeError("simulated deadline write failure")
+
+        monkeypatch.setattr(db, "set_compression_breaker_state", fail_deadline_write)
+
         _trip(cc)
+
+        assert cc._ineffective_compression_count == 2
+        assert db.get_compression_ineffective_count("sess-1") == 0
+
+        fresh = _compressor()
+        fresh.bind_session_state(session_db=db, session_id="sess-1")
+        assert fresh.should_compress(fresh.threshold_tokens + 1) is True
+
+class TestRestartSemantics:
+    def test_elapsed_recovery_window_survives_agent_restart(self, tmp_path):
+        """A later gateway turn must probe immediately after real elapsed time."""
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        base = 5000.0
+        first = _compressor()
+        first.bind_session_state(session_db=db, session_id="sess-1")
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(first)
+            assert first.should_compress(first.threshold_tokens + 1) is False
+
+        resumed = _compressor()
+        with patch(
+            "agent.context_compressor.time.time",
+            return_value=base + resumed._ANTI_THRASH_RECOVERY_SECONDS + 1,
+        ):
+            resumed.bind_session_state(session_db=db, session_id="sess-1")
+            assert resumed.should_compress(resumed.threshold_tokens + 1) is True
+        state = db.get_compression_breaker_state("sess-1")
+        assert state["ineffective_count"] == 2
+        assert state["probe_until"] > 0.0
+        sibling = _compressor()
+        with patch(
+            "agent.context_compressor.time.time",
+            return_value=base + resumed._ANTI_THRASH_RECOVERY_SECONDS + 2,
+        ):
+            sibling.bind_session_state(session_db=db, session_id="sess-1")
+            assert sibling.should_compress(sibling.threshold_tokens + 1) is False
+
+    def test_two_fresh_agents_get_exactly_one_probe(self, tmp_path):
+        db_path = tmp_path / "state.db"
+        setup_db = SessionDB(db_path=db_path)
+        setup_db.create_session(session_id="sess-1", source="cli")
+        first = _compressor()
+        first.bind_session_state(session_db=setup_db, session_id="sess-1")
+        base = 10_000.0
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(first)
+
+        barrier = Barrier(2)
+
+        def attempt() -> bool:
+            db = SessionDB(db_path=db_path)
+            cc = _compressor()
+            cc.bind_session_state(session_db=db, session_id="sess-1")
+            barrier.wait()
+            return cc.should_compress(cc.threshold_tokens + 1)
+
+        with patch(
+            "agent.context_compressor.time.time",
+            return_value=base + 901.0,
+        ), ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(lambda _index: attempt(), range(2)))
+
+        assert sorted(results) == [False, True]
+        state = setup_db.get_compression_breaker_state("sess-1")
+        assert state["ineffective_count"] == 2
+        assert state["probe_until"] == base + 1801.0
+        assert state["probe_token"]
+
+    def test_abandoned_probe_can_be_reclaimed_after_one_full_window(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        base = 20_000.0
+        first = _compressor()
+        first.bind_session_state(session_db=db, session_id="sess-1")
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(first)
+        with patch("agent.context_compressor.time.time", return_value=base + 901.0):
+            assert first.should_compress(first.threshold_tokens + 1) is True
+
+        replacement = _compressor()
+        with patch("agent.context_compressor.time.time", return_value=base + 1802.0):
+            replacement.bind_session_state(session_db=db, session_id="sess-1")
+            assert replacement.should_compress(replacement.threshold_tokens + 1) is True
+
+    def test_reclaimed_probe_fences_the_stale_owner(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        base = 40_000.0
+        old_owner = _compressor()
+        old_owner.bind_session_state(session_db=db, session_id="sess-1")
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(old_owner)
+        with patch("agent.context_compressor.time.time", return_value=base + 901.0):
+            assert old_owner.should_compress(old_owner.threshold_tokens + 1) is True
+        old_token = old_owner._anti_thrash_probe_token
+
+        new_owner = _compressor()
+        with patch("agent.context_compressor.time.time", return_value=base + 1802.0):
+            new_owner.bind_session_state(session_db=db, session_id="sess-1")
+            assert new_owner.should_compress(new_owner.threshold_tokens + 1) is True
+        assert new_owner._anti_thrash_probe_token != old_token
+
+        with patch("agent.context_compressor.time.time", return_value=base + 1803.0):
+            assert old_owner.should_compress(old_owner.threshold_tokens + 1) is False
+            assert new_owner.should_compress(new_owner.threshold_tokens + 1) is True
+
+    def test_backward_clock_jump_is_bounded_to_one_fresh_window(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        first = _compressor()
+        first.bind_session_state(session_db=db, session_id="sess-1")
+        with patch("agent.context_compressor.time.time", return_value=10_000.0):
+            _trip(first)
+
+        rewound = _compressor()
+        with patch("agent.context_compressor.time.time", return_value=1_000.0):
+            rewound.bind_session_state(session_db=db, session_id="sess-1")
+            assert rewound.should_compress(rewound.threshold_tokens + 1) is False
+        assert db.get_compression_breaker_state("sess-1")["recovery_at"] == 1_900.0
+
+        with patch("agent.context_compressor.time.time", return_value=1_901.0):
+            assert rewound.should_compress(rewound.threshold_tokens + 1) is True
+
+    def test_forward_clock_jump_fails_open_to_one_bounded_probe(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        first = _compressor()
+        first.bind_session_state(session_db=db, session_id="sess-1")
+        with patch("agent.context_compressor.time.time", return_value=1_000.0):
+            _trip(first)
+        with patch("agent.context_compressor.time.time", return_value=20_000.0):
+            assert first.should_compress(first.threshold_tokens + 1) is True
+
+    def test_compression_rotation_carries_the_original_deadline(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(session_id="child", source="cli")
+        cc = _compressor()
+        cc.bind_session_state(session_db=db, session_id="parent")
+        with patch("agent.context_compressor.time.time", return_value=7000.0):
+            _trip(cc)
+        parent_deadline = cc._anti_thrash_recovery_deadline
+
+        cc.on_session_start(
+            "child",
+            boundary_reason="compression",
+            old_session_id="parent",
+            session_db=db,
+        )
+
+        assert cc._anti_thrash_recovery_deadline == parent_deadline
+        assert db.get_session_model_config_value(
+            "child", "_compression_anti_thrash_recovery_at",
+        ) == parent_deadline
+
+    def test_compression_rotation_carries_claim_and_ownership(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="parent", source="cli")
+        db.create_session(session_id="child", source="cli")
+        cc = _compressor()
+        cc.bind_session_state(session_db=db, session_id="parent")
+        with patch("agent.context_compressor.time.time", return_value=30_000.0):
+            _trip(cc)
+        with patch("agent.context_compressor.time.time", return_value=30_901.0):
+            assert cc.should_compress(cc.threshold_tokens + 1) is True
+            cc.on_session_start(
+                "child",
+                boundary_reason="compression",
+                old_session_id="parent",
+                session_db=db,
+            )
+
+        child_state = db.get_compression_breaker_state("child")
+        assert child_state["ineffective_count"] == 2
+        assert child_state["probe_until"] == 31_801.0
+        assert child_state["probe_token"] == cc._anti_thrash_probe_token
+        assert cc._owns_anti_thrash_probe is True
+        assert cc._ineffective_compression_count == 1
+
+        sibling = _compressor()
+        with patch("agent.context_compressor.time.time", return_value=30_902.0):
+            sibling.bind_session_state(session_db=db, session_id="child")
+            assert sibling.should_compress(sibling.threshold_tokens + 1) is False
+
+    def test_session_reset_disarms_the_recovery_clock_durably(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session(session_id="sess-1", source="cli")
+        cc = _compressor()
+        cc.bind_session_state(session_db=db, session_id="sess-1")
         base = 1000.0
-        with patch("agent.context_compressor.time.monotonic", return_value=base):
+        with patch("agent.context_compressor.time.time", return_value=base):
+            _trip(cc)
             assert cc.should_compress(cc.threshold_tokens + 1) is False
-        assert cc._anti_thrash_recovery_deadline > 0.0
+            cc.record_completed_compaction(used_fallback=True)
+            cc.record_completed_compaction(used_fallback=True)
+        with patch("agent.context_compressor.time.time", return_value=base + 901.0):
+            assert cc.should_compress(cc.threshold_tokens + 1) is True
+        assert cc._anti_thrash_probe_until > 0.0
+        assert cc._anti_thrash_probe_token
         cc.on_session_reset()
         assert cc._anti_thrash_recovery_deadline == 0.0
         assert cc._ineffective_compression_count == 0
+        assert db.get_compression_ineffective_count("sess-1") == 0
+        assert db.get_session_model_config_value(
+            "sess-1", "_compression_anti_thrash_recovery_at",
+        ) is None
+        state = db.get_compression_breaker_state("sess-1")
+        assert state["fallback_streak"] == 0
+        assert state["probe_until"] == 0.0
+        assert state["probe_token"] == ""


### PR DESCRIPTION
## Summary

- persist the anti-thrash breaker as one durable session tuple: strike counters, recovery deadline, probe lease, and fencing token
- after 15 minutes, atomically grant exactly one half-open compression probe across fresh agents, concurrent turns, and gateway restarts
- carry an owned probe across compression-created child sessions and reject stale owners before re-entry
- fail closed on state-store errors and bound backward/forward wall-clock jumps

## Problem

The gateway constructs a fresh `ContextCompressor` for each inbound turn. The recovery deadline was process-local, so every new message restarted the wait while the durable strike counter remained tripped. A long messaging conversation could therefore stay permanently blocked above the compression threshold and eventually stop responding.

## Verification

- `pytest -q tests/agent/test_compression_anti_thrash_recovery.py tests/agent/test_compression_anti_thrash_persistence.py` — 22 passed
- `ruff check agent/context_compressor.py hermes_state.py tests/agent/test_compression_anti_thrash_recovery.py tests/agent/test_compression_anti_thrash_persistence.py` — passed
- `git diff --check origin/main...kom/persist-compaction-breaker-recovery` — passed

The broader compression glob currently has unrelated Python 3.14 failures in `DaemonThreadPoolExecutor` (`_initializer` is absent); the same representative failure reproduces on an untouched archive of `origin/main`.

## Safety

- truly incompressible sessions remain bounded to one probe per 15-minute window
- durable counters stay tripped while the winner holds a short probe lease
- stale or failed claim owners cannot mutate the breaker verdict
- state-store failures keep automatic compression blocked
