### PR TITLE
fix(cli): treat herdr panes as Ghostty for the extended-keys push

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4364,7 +4364,7 @@ _BACKSLASH_LINE_CONTINUATION_RE = re.compile(r"\\[ \t]*$")
 
 
 def _is_ghostty_terminal(env: Optional[Mapping[str, str]] = None) -> bool:
-    """Whether the terminal is Ghostty (either detection path).
+    """Whether the terminal must be treated as Ghostty for the extended-keys push.
 
     Ghostty must be pushed ONLY modifyOtherKeys, not the Kitty keyboard
     protocol: its Kitty disambiguate-mode implementation strips the Alt
@@ -4374,14 +4374,23 @@ def _is_ghostty_terminal(env: Optional[Mapping[str, str]] = None) -> bool:
     regression).  Ghostty implements modifyOtherKeys correctly (it then
     emits ``\\x1b[27;3;127~``, which the alias table also maps).
 
-    Matches exactly the two conditions that admit Ghostty through
-    ``_terminal_supports_extended_enter_keys``.
+    The TERM_PROGRAM/TERM conditions match exactly the two paths that
+    admit Ghostty through ``_terminal_supports_extended_enter_keys``.
+    herdr panes embed a Ghostty core but scrub those markers, and the
+    WT_SESSION they inherit from the outer Windows Terminal describes
+    that outer terminal, not the pane hermes talks to — pushing Kitty
+    there re-encodes shifted punctuation as CSI-u sequences the alias
+    table doesn't map, leaking them as literal text on non-US layouts
+    (#100169).  herdr sets HERDR_ENV in every pane, so a pane marker
+    means the same Ghostty core and the same modifyOtherKeys-only
+    exception applies.
     """
     if env is None:
         env = os.environ
     return (
         (env.get("TERM_PROGRAM") or "").strip() == "ghostty"
         or (env.get("TERM") or "").strip().lower() == "xterm-ghostty"
+        or bool((env.get("HERDR_ENV") or "").strip())
     )
 
 

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -211,6 +211,43 @@ def test_non_ghostty_terminals_still_push_kitty_protocol():
     assert b"\x1b[>4;2m" in out.written
 
 
+def test_herdr_pane_skips_kitty_push_despite_inherited_wt_session():
+    """herdr panes embed a Ghostty core, so an inherited WT_SESSION must
+    not earn the Kitty push: on non-US layouts (e.g. `/` = Shift+7 on
+    Slovenian) disambiguate mode re-encodes shifted punctuation as CSI-u
+    sequences the alias table doesn't map, and they leak as literal text
+    (#100169).  modifyOtherKeys stays on — Ghostty cores implement it
+    correctly."""
+    import cli as cli_mod
+
+    herdr_env = {
+        "HERDR_ENV": "1",
+        "HERDR_PANE_ID": "w1:p1",
+        "WT_SESSION": "f34fca49-0000-0000-0000-000000000000",
+        "TERM": "xterm-256color",
+    }
+    assert cli_mod._is_ghostty_terminal(herdr_env) is True
+
+    out = _FakeOutput()
+    result = cli_mod._enable_extended_enter_keys(output=out, env=herdr_env)
+    assert result is True
+    assert b"\x1b[>4;2m" in out.written
+    assert b"\x1b[>1u" not in out.written
+
+
+def test_herdr_env_alone_does_not_allowlist_the_push():
+    """A herdr pane without the inherited WT_SESSION stays outside the
+    allowlist entirely — no push of either protocol (#100169)."""
+    import cli as cli_mod
+
+    assert (
+        cli_mod._terminal_supports_extended_enter_keys(
+            {"HERDR_ENV": "1", "TERM": "xterm-256color"}
+        )
+        is False
+    )
+
+
 @pytest.mark.linux_only
 def test_proc_version_microsoft_marker_preserves_newline():
     """WSL detection via /proc when env vars are scrubbed (sudo etc.).
@@ -238,11 +275,13 @@ def test_proc_version_microsoft_marker_preserves_newline():
 
 
 def test_is_ghostty_terminal_detection_paths():
-    """_is_ghostty_terminal matches exactly the two allowlist conditions."""
+    """_is_ghostty_terminal matches the TERM_PROGRAM/TERM allowlist paths
+    plus the herdr pane marker (Ghostty core, markers scrubbed)."""
     import cli as cli_mod
 
     assert cli_mod._is_ghostty_terminal({"TERM_PROGRAM": "ghostty"}) is True
     assert cli_mod._is_ghostty_terminal({"TERM": "xterm-ghostty"}) is True
     assert cli_mod._is_ghostty_terminal({"TERM": "XTERM-GHOSTTY"}) is True
+    assert cli_mod._is_ghostty_terminal({"HERDR_ENV": "1"}) is True
     assert cli_mod._is_ghostty_terminal({"TERM_PROGRAM": "iTerm.app"}) is False
     assert cli_mod._is_ghostty_terminal({}) is False


### PR DESCRIPTION
## What does this PR do?

Stops the classic CLI from pushing the Kitty keyboard protocol (`CSI >1u`) to a herdr pane. herdr panes embed a Ghostty core but present no ghostty TERM markers (`TERM=xterm-256color`, `TERM_PROGRAM` empty); the `WT_SESSION` they inherit from the outer Windows Terminal describes that *outer* terminal, not the pane hermes is talking to. Trusting it made `_terminal_supports_extended_enter_keys` (cli.py) return True, so `_enable_extended_enter_keys` pushed the Kitty protocol — the exact push the code deliberately withholds from Ghostty (#87390/#87630).

Inside herdr, disambiguate mode re-encodes shifted punctuation with the *shifted* codepoint (`ESC[47;2u` for Shift+7 = `/` on the Slovenian layout), and the CSI-u alias table from #87390/#92343 doesn't map shifted punctuation, so the sequence leaked into the prompt as literal text (`[47;2u`).

The fix follows the issue's suggested cheapest option: herdr sets `HERDR_ENV` in every pane, so a pane marker now routes through the existing Ghostty exception in `_is_ghostty_terminal` — modifyOtherKeys only (Ghostty cores implement it correctly), no Kitty push. A herdr pane without the inherited `WT_SESSION` was already outside the allowlist and stays there.

## Related Issue

Fixes #100169

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `cli.py` — `_is_ghostty_terminal()` also returns True when `HERDR_ENV` is set (herdr pane = Ghostty core with scrubbed markers), so `_enable_extended_enter_keys()` pushes only modifyOtherKeys there; docstring updated with the rationale.
- `tests/cli/test_ctrl_enter_newline.py` — regression tests: a herdr pane with an inherited `WT_SESSION` gets modifyOtherKeys but not `CSI >1u`; `HERDR_ENV` alone does not allowlist the push; `HERDR_ENV` added to the detection-path test.

## How to Test

1. `pytest tests/cli/test_ctrl_enter_newline.py tests/cli/test_modify_other_keys_aliases.py -q` — Observed result: 238 passed, 2 skipped (linux_only) on macOS 15.
2. Unit-level repro of the report (no Windows needed): `HERDR_ENV=1 WT_SESSION=x TERM=xterm-256color` now selects `_MODIFY_OTHER_KEYS_SEQ` (no `\x1b[>1u`), asserted by `test_herdr_pane_skips_kitty_push_despite_inherited_wt_session`.
3. On Windows Terminal → herdr → `hermes` with a Slovenian layout, typing `/` should insert `/` (per the reporter's confirmed workaround behavior, which this change makes automatic).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); scenario is Windows Terminal→herdr as reported

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
