### PR TITLE
fix(openviking): mirror native memory lifecycle

### DIFF
--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -154,17 +154,58 @@ OpenViking server auto-commit is disabled by default, so an accepted message
 whose explicit commit fails normally remains live and unextracted until it is
 manually committed.
 
-Hermes built-in `memory` tool additions are mirrored to OpenViking after the
-local memory operation succeeds:
+Successful Hermes built-in `memory` mutations are mirrored to OpenViking in
+FIFO order. Hermes persists the exact OpenViking URI for each native memory
+entry in the active profile at
+`$HERMES_HOME/openviking/memory_mirror_registry.json`, so later mutations never
+need to guess a target by semantic similarity:
 
 | Hermes action | OpenViking operation |
 |---------------|----------------------|
-| `add` | `content/write` with `mode=create` under user memory, or the configured peer memory directory |
+| `add` | `content/write` with `mode=create` under user memory, or the configured peer memory directory; store the exact returned URI in the mirror registry |
+| `replace` | resolve one registry entry from `target` + `old_text`, then replace the same URI and wait for semantic/vector refresh |
+| `remove` | resolve one registry entry from `target` + `old_text`, then delete that exact URI and wait for semantic cleanup |
 
-Built-in `replace` and `remove` operations are not mirrored because Hermes
-native memory entries do not yet carry stable OpenViking file URIs. Use
-`viking_forget` when the user explicitly asks to delete a specific OpenViking
-memory URI.
+URI construction uses the same server-asserted explicit user identity and
+connection snapshot as the current OpenViking provider. The registry stores a
+fingerprint of that connection with each mapping, without storing the raw API
+key. This prevents a later connection from reusing mappings that belong to
+another OpenViking endpoint, identity, or peer.
+
+Changing the endpoint, credentials, identity, or peer starts a new registry
+scope. Mappings from the earlier connection then fail closed instead of being
+applied to the new connection.
+
+The mirror registry owns only memories created through this built-in-memory
+bridge. Session-extracted memories and explicit `viking_remember` writes are not
+registered or modified by it. Existing OpenViking memories created before the
+registry was introduced also have no safe automatic mapping: a later built-in
+`replace` or `remove` for such an entry fails closed with a warning and leaves
+OpenViking unchanged rather than guessing which memory to mutate. Use
+`viking_forget` with an exact URI for manual cleanup of those entries.
+
+`replace` and `remove` resolve the same `old_text` supplied by the native memory
+tool against the registry's pre-mutation content. If that text no longer maps
+to exactly one registry entry, the OpenViking mutation fails closed rather than
+selecting a URI heuristically.
+
+The mirror is asynchronous and intentionally not a distributed transaction.
+The local Hermes memory mutation commits before the OpenViking request. If that
+remote request then fails (for example because of a transient network error),
+the failure is logged at WARNING and the mirror does not durably replay the
+event. Hermes and OpenViking can therefore drift until the entry is repaired
+manually or later reconciliation/durable-outbox work handles it. Drift can also
+occur if OpenViking accepts a mutation but the following local registry save
+fails. In that case, later mutations fail closed because Hermes cannot prove
+the exact remote mapping.
+
+Mirror events are ordered within each provider. Registry updates are also
+serialized across provider instances that use the same profile in one Hermes
+process. The registry does not provide cross-process serialization.
+
+Registry writes request file mode `0600` on POSIX systems. That mode is not an
+equivalent Windows ACL guarantee, so Windows deployments should rely on the
+normal account/filesystem access controls protecting `HERMES_HOME`.
 
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -209,6 +209,20 @@ Registry writes request file mode `0600` on POSIX systems. That mode is not an
 equivalent Windows ACL guarantee, so Windows deployments should rely on the
 normal account/filesystem access controls protecting `HERMES_HOME`.
 
+An unreadable registry, an invalid registry structure, or an unsupported
+registry version blocks all mirror operations. This prevents Hermes from
+creating OpenViking files that it cannot track and prevents an older Hermes
+version from overwriting mappings written by a newer version. The warning
+identifies the registry path and distinguishes an unsupported version from an
+invalid format.
+
+Stop Hermes before repairing the registry. For an unsupported version, run a
+Hermes version that supports the reported registry version; do not delete or
+replace the file. For an unreadable or invalid registry, restore a valid backup.
+If no backup exists, rename the invalid file and restart Hermes only if you
+accept that its existing OpenViking files will no longer have stable mappings.
+Those files then require manual cleanup by exact URI.
+
 `viking_forget` is intentionally narrow. It only accepts concrete user memory
 file URIs, such as
 `viking://user/default/peers/hermes/memories/preferences/mem_abc123.md` (any

--- a/plugins/memory/openviking/README.md
+++ b/plugins/memory/openviking/README.md
@@ -169,8 +169,10 @@ need to guess a target by semantic similarity:
 URI construction uses the same server-asserted explicit user identity and
 connection snapshot as the current OpenViking provider. The registry stores a
 fingerprint of that connection with each mapping, without storing the raw API
-key. This prevents a later connection from reusing mappings that belong to
-another OpenViking endpoint, identity, or peer.
+key. It also stores the full current text of each mirrored native memory so it
+can resolve the native tool's later `old_text` reference. This prevents a later
+connection from reusing mappings that belong to another OpenViking endpoint,
+identity, or peer.
 
 Changing the endpoint, credentials, identity, or peer starts a new registry
 scope. Mappings from the earlier connection then fail closed instead of being

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -65,6 +65,7 @@ _REMOTE_RESOURCE_PREFIXES = ("http://", "https://", "git@", "ssh://", "git://")
 _SYNC_TRACE_ENV = "HERMES_OPENVIKING_SYNC_TRACE"
 _RECALL_QUERY_MIN_CHARS = 5
 _RECALL_MIN_TIMEOUT_SECONDS = 0.05
+_DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS = 3.0
 _READ_BATCH_LIMIT = 3
 _READ_BATCH_FULL_LIMIT = 2500
 _LEVEL_ENDPOINTS = {"abstract": "/api/v1/content/abstract", "overview": "/api/v1/content/overview", "full": "/api/v1/content/read"}
@@ -91,7 +92,12 @@ _CONFIG_SCHEMA = [
     _cfg_field("recall_max_injected_chars", "Maximum total characters injected by recall", type="integer", minimum=100, maximum=50000, default=4000),
     _cfg_field("profile_token_budget", "Maximum session-start memory tokens injected", type="integer", minimum=500, maximum=50000, default=6000),
     _cfg_field("recall_timeout_seconds", "Total timeout for recall (seconds)", **_NUM, default=4.0),
-    _cfg_field("recall_request_timeout_seconds", "Per-request timeout for recall (seconds)", **_NUM, default=3.0),
+    _cfg_field(
+        "recall_request_timeout_seconds",
+        "Per-request timeout for recall (seconds)",
+        **_NUM,
+        default=_DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS,
+    ),
     _cfg_field("recall_full_read_limit", "Max full L2 content reads per recall", type="integer", minimum=0, maximum=100, default=2),
     _cfg_field("recall_prefer_abstract", "Use abstracts instead of full L2 reads", type="boolean", default=False),
     _cfg_field("recall_resources", "Include resources in recall", type="boolean", default=False),
@@ -1229,7 +1235,7 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # tuple so lock-free background writers never see torn fields or a failed endpoint;
         # _failed_refresh = (settings key, monotonic ts) of the last failure -> cooldown gate.
         (self._session_state_lock, self._inflight_lock, self._deferred_commit_lock, self._committed_session_lock,
-         self._client_refresh_lock, self._runtime_start_lock, self._memory_write_lock) = (threading.Lock() for _ in range(7))
+         self._client_refresh_lock, self._runtime_start_lock, self._native_memory_mirror_lock) = (threading.Lock() for _ in range(7))
         # Writers keyed by the sid they POST under so a commit can drain all of them.
         # Guards the (_session_id, _turn_count) pair. sync_turn runs on the MemoryManager's background sync
         # executor while on_session_end / on_session_switch run on the caller's thread, so the
@@ -1240,7 +1246,6 @@ class OpenVikingMemoryProvider(MemoryProvider):
         self._deferred_commit_threads: Set[threading.Thread] = set()
         self._committed_session_ids: Set[str] = set()
         self._pending_marked_sids: Set[str] = set()
-        self._memory_write_threads: Set[threading.Thread] = set()
         self._profile_prefetched_sessions: Set[str] = set()
         self._conn_snapshot: Optional[tuple] = None
         self._failed_refresh: Optional[tuple] = None
@@ -2431,9 +2436,17 @@ class OpenVikingMemoryProvider(MemoryProvider):
         peer_prefix = f"peers/{agent}/" if agent else ""
         return f"viking://user/{self._user_space(active_client, timeout=timeout)}/{peer_prefix}memories/{subdir}/mem_{uuid.uuid4().hex[:12]}.md"
 
-    def on_memory_write(self, action: str, target: str, content: str, metadata: Optional[Dict[str, Any]] = None) -> None:
-        """Mirror successful built-in memory additions to OpenViking."""
-        if action != "add" or not content or not self._ensure_client():
+    def on_memory_write(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Mirror successful built-in memory mutations to OpenViking."""
+        if action not in {"add", "replace", "remove"} or not self._ensure_client():
+            return
+        if action in {"add", "replace"} and not content:
             return
         subdir = _MEMORY_WRITE_TARGET_SUBDIR_MAP.get(target, "preferences")
         try:
@@ -2442,15 +2455,19 @@ class OpenVikingMemoryProvider(MemoryProvider):
             logger.debug("OpenViking memory mirror client creation failed: %s", e)
             return
 
-        def _write():
-            try:
-                uri = self._build_memory_uri(subdir, client=client, timeout=_RECALL_MIN_TIMEOUT_SECONDS)
-                client.post("/api/v1/content/write", {"uri": uri, "content": content, "mode": "create"})
-            except Exception as e:
-                logger.debug("OpenViking memory mirror failed: %s", e)
+        from plugins.memory.openviking.native_memory_mirror import (
+            enqueue_native_memory_write,
+        )
 
-        self._spawn_tracked("openviking-memwrite", _write, self._memory_write_lock, lambda: self._memory_write_threads,
-                            skip_if=lambda: self._shutting_down)
+        enqueue_native_memory_write(
+            self,
+            action,
+            target,
+            content,
+            metadata=metadata,
+            subdir=subdir,
+            client=client,
+        )
 
     # -- tools ------------------------------------------------------------------
 
@@ -2473,10 +2490,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
         # the autostart waiter (a daemon blocked on health probes would SIGABRT CPython at
         # Py_FinalizeEx); _shutting_down makes its wait loop bail so the join lands.
         self._shutting_down = True
+        from plugins.memory.openviking.native_memory_mirror import (
+            shutdown_native_memory_mirror,
+        )
+
+        shutdown_native_memory_mirror(self, timeout=5.0)
         workers: List[threading.Thread] = []
         for lock, group in ((self._inflight_lock, lambda: [t for g in self._inflight_writers.values() for t in g]),
                             (self._deferred_commit_lock, lambda: list(self._deferred_commit_threads)),
-                            (self._memory_write_lock, lambda: list(self._memory_write_threads)),
                             (self._runtime_start_lock, lambda: [self._runtime_start_thread] if self._runtime_start_thread is not None else [])):
             with lock:
                 workers += group()

--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -1743,7 +1743,13 @@ class OpenVikingMemoryProvider(MemoryProvider):
         tail = cls._take_tokens("\n".join(lines[8:]), remaining - cls._token_units(head), from_end=True).lstrip()
         return f"{head}{marker}{tail}" if tail else _head_only()
 
-    def _user_space(self, client=None, *, timeout: Optional[float] = None) -> str:
+    def _user_space(
+        self,
+        client=None,
+        *,
+        timeout: Optional[float] = None,
+        require_confirmed: bool = False,
+    ) -> str:
         """Resolve the user space, caching only a confirmed connection identity.
 
         Cache is keyed on the connection snapshot, not the client object:
@@ -1759,6 +1765,11 @@ class OpenVikingMemoryProvider(MemoryProvider):
             if snapshot is not None and snapshot is getattr(self, "_conn_snapshot", None):  # unchanged under us
                 self._user_space_cache = (snapshot, resolved)
             return resolved
+        if require_confirmed:
+            raise RuntimeError(
+                "OpenViking server did not confirm the current user identity; "
+                "leaving OpenViking unchanged"
+            )
         return str(getattr(active, "_user", "") or getattr(self, "_user", "") or "default").strip() or "default"
 
     @staticmethod
@@ -2421,7 +2432,14 @@ class OpenVikingMemoryProvider(MemoryProvider):
 
     # -- memory mirroring -----------------------------------------------------
 
-    def _build_memory_uri(self, subdir: str, *, client=None, timeout: Optional[float] = None) -> str:
+    def _build_memory_uri(
+        self,
+        subdir: str,
+        *,
+        client=None,
+        timeout: Optional[float] = None,
+        require_confirmed_user: bool = False,
+    ) -> str:
         """Explicit-uid user memory URI, under the configured peer when one is set.
 
         The peer is read from the captured client (not the provider) so a config
@@ -2434,7 +2452,15 @@ class OpenVikingMemoryProvider(MemoryProvider):
         active_client = client if client is not None else getattr(self, "_client", None)
         agent = str(getattr(active_client, "_agent", getattr(self, "_agent", "")) or "").strip()
         peer_prefix = f"peers/{agent}/" if agent else ""
-        return f"viking://user/{self._user_space(active_client, timeout=timeout)}/{peer_prefix}memories/{subdir}/mem_{uuid.uuid4().hex[:12]}.md"
+        identity_timeout = timeout
+        if require_confirmed_user and identity_timeout is None:
+            identity_timeout = _DEFAULT_RECALL_REQUEST_TIMEOUT_SECONDS
+        user_space = self._user_space(
+            active_client,
+            timeout=identity_timeout,
+            require_confirmed=require_confirmed_user,
+        )
+        return f"viking://user/{user_space}/{peer_prefix}memories/{subdir}/mem_{uuid.uuid4().hex[:12]}.md"
 
     def on_memory_write(
         self,

--- a/plugins/memory/openviking/native_memory_mirror.py
+++ b/plugins/memory/openviking/native_memory_mirror.py
@@ -177,8 +177,19 @@ class NativeMemoryMirror:
         except Exception as exc:
             raise RuntimeError(f"cannot read mirror registry {path}: {exc}") from exc
 
-        if not isinstance(payload, dict) or payload.get("version") != _REGISTRY_VERSION:
-            raise RuntimeError(f"unsupported or invalid mirror registry: {path}")
+        if not isinstance(payload, dict):
+            raise RuntimeError(
+                f"invalid mirror registry format: expected a JSON object: {path}"
+            )
+
+        if "version" not in payload:
+            raise RuntimeError(f"invalid mirror registry format: missing version: {path}")
+        found_version = payload["version"]
+        if found_version != _REGISTRY_VERSION:
+            raise RuntimeError(
+                "unsupported mirror registry version "
+                f"{found_version!r}: expected {_REGISTRY_VERSION}: {path}"
+            )
         entries = payload.get("entries")
         if not isinstance(entries, list):
             raise RuntimeError(f"invalid mirror registry entries: {path}")

--- a/plugins/memory/openviking/native_memory_mirror.py
+++ b/plugins/memory/openviking/native_memory_mirror.py
@@ -1,0 +1,353 @@
+"""Stable mirroring for Hermes native MEMORY.md / USER.md entries.
+
+Hermes' built-in memory tool identifies entries by unique text substrings rather
+than durable IDs. OpenViking, by contrast, needs an exact ``viking://`` file URI
+to update or delete a memory safely. This module keeps the missing identity map
+in a small profile-scoped registry and serializes mirror operations through one
+FIFO worker.
+
+The registry is intentionally narrow: it tracks only memories created through
+the built-in-memory mirror. Session-extracted memories and explicit
+``viking_remember`` writes are outside its ownership and are never guessed at or
+deleted by similarity.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import queue
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from utils import atomic_json_write
+
+logger = logging.getLogger("plugins.memory.openviking")
+
+_REGISTRY_VERSION = 2
+_REGISTRY_RELATIVE_PATH = Path("openviking") / "memory_mirror_registry.json"
+_SUPPORTED_ACTIONS = frozenset({"add", "replace", "remove"})
+_POLL_SECONDS = 0.05
+_REGISTRY_LOCKS_GUARD = threading.Lock()
+_REGISTRY_LOCKS: Dict[Path, threading.Lock] = {}
+
+
+class _MappingError(RuntimeError):
+    """A destructive mirror operation could not resolve one exact URI."""
+
+
+def _registry_lock(path: Path) -> threading.Lock:
+    """Return one process-wide lock for a profile mirror registry."""
+    key = path.resolve(strict=False)
+    with _REGISTRY_LOCKS_GUARD:
+        lock = _REGISTRY_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _REGISTRY_LOCKS[key] = lock
+        return lock
+
+
+def _connection_fingerprint(client: Any) -> str:
+    """Identify the captured OpenViking connection without storing its key."""
+    identity = [
+        str(getattr(client, "_endpoint", "") or "").rstrip("/"),
+        str(getattr(client, "_api_key", "") or ""),
+        str(getattr(client, "_account", "") or ""),
+        str(getattr(client, "_user", "") or ""),
+        str(getattr(client, "_agent", "") or ""),
+    ]
+    encoded = json.dumps(identity, ensure_ascii=True, separators=(",", ":")).encode()
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class NativeMemoryMirror:
+    """FIFO, profile-scoped mirror of Hermes native memory into OpenViking."""
+
+    def __init__(self, provider: Any):
+        self._provider = provider
+        self._queue: queue.Queue[Dict[str, Any]] = queue.Queue()
+        self._state_lock = threading.Lock()
+        self._worker: Optional[threading.Thread] = None
+        self._shutting_down = False
+
+    def enqueue(
+        self,
+        action: str,
+        target: str,
+        content: str,
+        *,
+        metadata: Optional[Dict[str, Any]] = None,
+        subdir: str,
+        client: Any,
+    ) -> None:
+        """Queue one committed built-in-memory mutation in call order."""
+        if action not in _SUPPORTED_ACTIONS:
+            return
+        normalized_content = str(content or "").strip()
+        if action in {"add", "replace"} and not normalized_content:
+            return
+
+        event = {
+            "action": action,
+            "target": str(target or "memory"),
+            # The native MemoryStore strips content before it commits. Mirror
+            # the committed value rather than the raw tool argument.
+            "content": normalized_content,
+            "metadata": dict(metadata or {}),
+            "subdir": str(subdir),
+            "client": client,
+            "connection": _connection_fingerprint(client),
+        }
+
+        with self._state_lock:
+            if self._shutting_down:
+                logger.warning(
+                    "OpenViking memory mirror skipped %s during provider shutdown",
+                    action,
+                )
+                return
+            self._queue.put(event)
+            if self._worker is None or not self._worker.is_alive():
+                self._worker = threading.Thread(
+                    target=self._run,
+                    daemon=True,
+                    name="openviking-memory-mirror",
+                )
+                self._worker.start()
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Drain queued mirror operations, then stop the FIFO worker."""
+        with self._state_lock:
+            self._shutting_down = True
+            worker = self._worker
+
+        if worker is None:
+            return
+
+        deadline = time.monotonic() + max(0.0, timeout)
+        while self._queue.unfinished_tasks and time.monotonic() < deadline:
+            time.sleep(0.01)
+
+        remaining = max(0.0, deadline - time.monotonic())
+        if worker.is_alive() and remaining:
+            worker.join(timeout=remaining)
+        if worker.is_alive():
+            logger.warning(
+                "OpenViking memory mirror worker did not drain before shutdown"
+            )
+
+    def _run(self) -> None:
+        while True:
+            with self._state_lock:
+                stopping = self._shutting_down
+            if stopping and self._queue.empty():
+                return
+
+            try:
+                event = self._queue.get(timeout=_POLL_SECONDS)
+            except queue.Empty:
+                continue
+
+            try:
+                self._apply(event)
+            except _MappingError as exc:
+                logger.warning("OpenViking memory mirror skipped: %s", exc)
+            except Exception as exc:
+                logger.warning("OpenViking memory mirror failed: %s", exc)
+            finally:
+                self._queue.task_done()
+
+    def _registry_path(self) -> Path:
+        root = str(getattr(self._provider, "_hermes_home", "") or "").strip()
+        if not root:
+            from hermes_constants import get_hermes_home
+
+            root = str(get_hermes_home())
+        return Path(root) / _REGISTRY_RELATIVE_PATH
+
+    def _load_registry(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return {"version": _REGISTRY_VERSION, "entries": []}
+
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception as exc:
+            raise RuntimeError(f"cannot read mirror registry {path}: {exc}") from exc
+
+        if not isinstance(payload, dict) or payload.get("version") != _REGISTRY_VERSION:
+            raise RuntimeError(f"unsupported or invalid mirror registry: {path}")
+        entries = payload.get("entries")
+        if not isinstance(entries, list):
+            raise RuntimeError(f"invalid mirror registry entries: {path}")
+
+        for entry in entries:
+            if not isinstance(entry, dict):
+                raise RuntimeError(f"invalid mirror registry entry: {path}")
+            if not all(
+                isinstance(entry.get(key), str)
+                for key in ("connection", "target", "uri", "content")
+            ):
+                raise RuntimeError(f"invalid mirror registry entry fields: {path}")
+        return payload
+
+    @staticmethod
+    def _save_registry(path: Path, registry: Dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        atomic_json_write(path, registry, mode=0o600)
+
+    @staticmethod
+    def _resolve_mapping(
+        registry: Dict[str, Any],
+        *,
+        connection: str,
+        target: str,
+        old_text: str,
+        action: str,
+    ) -> tuple[int, Dict[str, str]]:
+        old_text = str(old_text or "").strip()
+        if not old_text:
+            raise _MappingError(f"{action} requires old_text for stable URI resolution")
+
+        matches = [
+            (index, entry)
+            for index, entry in enumerate(registry["entries"])
+            if entry["connection"] == connection
+            and entry["target"] == target
+            and old_text in entry["content"]
+        ]
+        if not matches:
+            raise _MappingError(
+                f"{action} has no stable OpenViking URI mapping for target={target!r}; "
+                "leaving OpenViking unchanged"
+            )
+        if len(matches) != 1:
+            raise _MappingError(
+                f"{action} matched {len(matches)} OpenViking URI mappings for "
+                f"target={target!r}; leaving OpenViking unchanged"
+            )
+        return matches[0]
+
+    def _apply(self, event: Dict[str, Any]) -> None:
+        path = self._registry_path()
+        # Provider instances can share one profile and registry. Keep the
+        # complete remote-mutation + registry-update sequence atomic in this
+        # process so concurrent read-modify-write cycles cannot lose mappings.
+        with _registry_lock(path):
+            self._apply_locked(path, event)
+
+    def _apply_locked(self, path: Path, event: Dict[str, Any]) -> None:
+        action = event["action"]
+        target = event["target"]
+        content = event["content"]
+        metadata = event["metadata"]
+        connection = event["connection"]
+        registry = self._load_registry(path)
+        client = event["client"]
+
+        if action == "add":
+            # The native store treats exact duplicate adds as idempotent. Mirror
+            # the same way if a duplicate notification ever reaches us.
+            if any(
+                entry["connection"] == connection
+                and entry["target"] == target
+                and entry["content"] == content
+                for entry in registry["entries"]
+            ):
+                return
+
+            requested_uri = self._provider._build_memory_uri(
+                event["subdir"], client=client, timeout=0.05
+            )
+            response = client.post(
+                "/api/v1/content/write",
+                {"uri": requested_uri, "content": content, "mode": "create"},
+            )
+            result = response.get("result", {}) if isinstance(response, dict) else {}
+            canonical_uri = (
+                str(result.get("uri") or "").strip() if isinstance(result, dict) else ""
+            ) or requested_uri
+            registry["entries"].append({
+                "connection": connection,
+                "target": target,
+                "uri": canonical_uri,
+                "content": content,
+            })
+            self._save_registry(path, registry)
+            return
+
+        old_text = metadata.get("old_text")
+        index, mapping = self._resolve_mapping(
+            registry,
+            connection=connection,
+            target=target,
+            old_text=str(old_text or ""),
+            action=action,
+        )
+        uri = mapping["uri"]
+
+        if action == "replace":
+            client.post(
+                "/api/v1/content/write",
+                {"uri": uri, "content": content, "mode": "replace", "wait": True},
+            )
+            registry["entries"][index] = {
+                "connection": connection,
+                "target": target,
+                "uri": uri,
+                "content": content,
+            }
+            self._save_registry(path, registry)
+            return
+
+        client.delete(
+            "/api/v1/fs",
+            params={"uri": uri, "recursive": False, "wait": True},
+        )
+        registry["entries"].pop(index)
+        self._save_registry(path, registry)
+
+
+_MIRROR_ATTR = "_native_memory_mirror"
+
+
+def enqueue_native_memory_write(
+    provider: Any,
+    action: str,
+    target: str,
+    content: str,
+    *,
+    metadata: Optional[Dict[str, Any]] = None,
+    subdir: str,
+    client: Any,
+) -> None:
+    """Lazily create the provider's FIFO mirror and enqueue one operation."""
+    with provider._native_memory_mirror_lock:
+        if provider._shutting_down:
+            logger.warning(
+                "OpenViking memory mirror skipped %s during provider shutdown",
+                action,
+            )
+            return
+        mirror = getattr(provider, _MIRROR_ATTR, None)
+        if mirror is None:
+            mirror = NativeMemoryMirror(provider)
+            setattr(provider, _MIRROR_ATTR, mirror)
+    mirror.enqueue(
+        action,
+        target,
+        content,
+        metadata=metadata,
+        subdir=subdir,
+        client=client,
+    )
+
+
+def shutdown_native_memory_mirror(provider: Any, timeout: float = 5.0) -> None:
+    """Drain the provider's native-memory mirror if it was ever used."""
+    with provider._native_memory_mirror_lock:
+        mirror = getattr(provider, _MIRROR_ATTR, None)
+    if mirror is not None:
+        mirror.shutdown(timeout=timeout)

--- a/plugins/memory/openviking/native_memory_mirror.py
+++ b/plugins/memory/openviking/native_memory_mirror.py
@@ -259,7 +259,9 @@ class NativeMemoryMirror:
                 return
 
             requested_uri = self._provider._build_memory_uri(
-                event["subdir"], client=client, timeout=0.05
+                event["subdir"],
+                client=client,
+                require_confirmed_user=True,
             )
             response = client.post(
                 "/api/v1/content/write",

--- a/tests/agent/test_memory_write_bridge.py
+++ b/tests/agent/test_memory_write_bridge.py
@@ -69,6 +69,55 @@ def test_notifies_remove_with_old_text_after_success():
     ]
 
 
+def test_batch_new_text_alias_is_forwarded_for_add_and_replace():
+    mgr, provider = _manager_with_provider()
+
+    mgr.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {
+            "target": "memory",
+            "operations": [
+                {"action": "add", "new_text": "Preferred shell is zsh"},
+                {
+                    "action": "replace",
+                    "old_text": "Preferred shell is zsh",
+                    "new_text": "Preferred shell is fish",
+                },
+            ],
+        },
+    )
+    mgr.notify_memory_tool_write(
+        json.dumps({"success": True}),
+        {
+            "action": "replace",
+            "target": "memory",
+            "old_text": "Preferred shell is fish",
+            "content": "Preferred shell is nushell",
+        },
+    )
+
+    assert provider.calls == [
+        {
+            "action": "add",
+            "target": "memory",
+            "content": "Preferred shell is zsh",
+            "metadata": {},
+        },
+        {
+            "action": "replace",
+            "target": "memory",
+            "content": "Preferred shell is fish",
+            "metadata": {"old_text": "Preferred shell is zsh"},
+        },
+        {
+            "action": "replace",
+            "target": "memory",
+            "content": "Preferred shell is nushell",
+            "metadata": {"old_text": "Preferred shell is fish"},
+        },
+    ]
+
+
 
 
 

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -269,9 +269,9 @@ def test_rapid_add_replace_remove_is_processed_in_fifo_order(tmp_path):
     assert calls[1][2]["uri"] == uri
     assert calls[2][3]["params"] == {"uri": uri, "recursive": False, "wait": True}
 
+    provider.shutdown()
     registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
     assert registry == {"version": 2, "entries": []}
-    provider.shutdown()
 
 
 def test_unmapped_replace_fails_closed_with_warning(tmp_path, caplog):

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -115,6 +115,12 @@ def test_replace_updates_the_same_openviking_uri_and_registry(tmp_path):
     assert replace[2]["mode"] == "replace"
     assert replace[2]["wait"] is True
 
+    _wait_for(
+        lambda: json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))[
+            "entries"
+        ][0]["content"]
+        == "Preferred provider is OpenRouter"
+    )
     registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
     connection = registry["entries"][0]["connection"]
     assert len(connection) == 64
@@ -129,6 +135,47 @@ def test_replace_updates_the_same_openviking_uri_and_registry(tmp_path):
             }
         ],
     }
+    provider.shutdown()
+
+
+def test_add_requires_server_confirmed_user_without_fallback(tmp_path, caplog):
+    client = _FakeVikingClient(user="configured-fallback")
+
+    def fail_identity_probe(path, params=None, **kwargs):
+        assert path == "/api/v1/system/status"
+        raise TimeoutError("identity probe timed out")
+
+    client.get = fail_identity_probe
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "Do not misroute this memory")
+        provider.shutdown()
+
+    assert client.snapshot() == []
+    assert not _registry_path(tmp_path).exists()
+    assert any(
+        "did not confirm the current user identity" in record.message
+        for record in caplog.records
+    )
+
+
+def test_add_identity_probe_uses_normal_request_timeout(tmp_path):
+    client = _FakeVikingClient()
+    identity_probe_kwargs = []
+
+    def record_identity_probe(path, params=None, **kwargs):
+        assert path == "/api/v1/system/status"
+        identity_probe_kwargs.append(dict(kwargs))
+        return {"status": "ok", "result": {"user": "default"}}
+
+    client.get = record_identity_probe
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Use the normal identity timeout")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+
+    assert identity_probe_kwargs == [{"timeout": 3.0}]
     provider.shutdown()
 
 
@@ -152,6 +199,12 @@ def test_remove_deletes_exact_mapped_uri_and_registry_entry(tmp_path):
     assert delete[0:2] == ("delete", "/api/v1/fs")
     assert delete[3]["params"] == {"uri": uri, "recursive": False, "wait": True}
 
+    _wait_for(
+        lambda: json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))[
+            "entries"
+        ]
+        == []
+    )
     registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
     assert registry == {"version": 2, "entries": []}
     provider.shutdown()

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -1,0 +1,501 @@
+# Regression coverage for hermes-agent#31000.
+
+import json
+import threading
+import time
+
+import pytest
+
+from plugins.memory.openviking import OpenVikingMemoryProvider
+from plugins.memory.openviking.native_memory_mirror import NativeMemoryMirror
+
+
+class _FakeVikingClient:
+    def __init__(
+        self,
+        *,
+        endpoint: str = "http://openviking.test",
+        api_key: str = "test-key",
+        account: str = "default",
+        user: str = "default",
+        agent: str = "hermes",
+        fail_post: bool = False,
+        fail_delete: bool = False,
+    ):
+        self._lock = threading.Lock()
+        self.calls = []
+        self.fail_post = fail_post
+        self.fail_delete = fail_delete
+        self._endpoint = endpoint
+        self._api_key = api_key
+        self._account = account
+        self._user = user
+        self._agent = agent
+
+    def post(self, path, payload=None, **kwargs):
+        with self._lock:
+            self.calls.append(("post", path, dict(payload or {}), dict(kwargs)))
+        if self.fail_post:
+            raise RuntimeError("mirror write failed")
+        if path == "/api/v1/content/write":
+            return {
+                "status": "ok",
+                "result": {
+                    "uri": (payload or {}).get("uri", ""),
+                    "written_bytes": len((payload or {}).get("content", "")),
+                },
+            }
+        return {"status": "ok", "result": {}}
+
+    def get(self, path, params=None, **kwargs):
+        if path == "/api/v1/system/status":
+            return {"status": "ok", "result": {"user": "default"}}
+        return {"status": "ok", "result": {}}
+
+    def delete(self, path, **kwargs):
+        with self._lock:
+            self.calls.append(("delete", path, None, dict(kwargs)))
+        if self.fail_delete:
+            raise RuntimeError("mirror delete failed")
+        return {
+            "status": "ok",
+            "result": {"uri": kwargs.get("params", {}).get("uri", "")},
+        }
+
+    def snapshot(self):
+        with self._lock:
+            return list(self.calls)
+
+
+def _provider(tmp_path, client):
+    provider = OpenVikingMemoryProvider()
+    provider._hermes_home = str(tmp_path)
+    provider._agent = "hermes"
+    provider._client = client
+    provider._ensure_client = lambda: client
+    provider._new_client = lambda: client
+    return provider
+
+
+def _wait_for(predicate, *, timeout=2.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(0.01)
+    pytest.fail("timed out waiting for OpenViking mirror worker")
+
+
+def _registry_path(tmp_path):
+    return tmp_path / "openviking" / "memory_mirror_registry.json"
+
+
+def test_replace_updates_the_same_openviking_uri_and_registry(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "  Preferred provider is DeepInfra  ")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    create = client.snapshot()[0]
+    uri = create[2]["uri"]
+    assert create[2]["content"] == "Preferred provider is DeepInfra"
+
+    provider.on_memory_write(
+        "replace",
+        "user",
+        "Preferred provider is OpenRouter",
+        metadata={"old_text": "DeepInfra"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    replace = client.snapshot()[1]
+    assert replace[0:2] == ("post", "/api/v1/content/write")
+    assert replace[2]["uri"] == uri
+    assert replace[2]["content"] == "Preferred provider is OpenRouter"
+    assert replace[2]["mode"] == "replace"
+    assert replace[2]["wait"] is True
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    connection = registry["entries"][0]["connection"]
+    assert len(connection) == 64
+    assert registry == {
+        "version": 2,
+        "entries": [
+            {
+                "connection": connection,
+                "target": "user",
+                "uri": uri,
+                "content": "Preferred provider is OpenRouter",
+            }
+        ],
+    }
+    provider.shutdown()
+
+
+def test_remove_deletes_exact_mapped_uri_and_registry_entry(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "memory", "Project alpha is active")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    uri = client.snapshot()[0][2]["uri"]
+
+    provider.on_memory_write(
+        "remove",
+        "memory",
+        "",
+        metadata={"old_text": "alpha is active"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    delete = client.snapshot()[1]
+    assert delete[0:2] == ("delete", "/api/v1/fs")
+    assert delete[3]["params"] == {"uri": uri, "recursive": False, "wait": True}
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry == {"version": 2, "entries": []}
+    provider.shutdown()
+
+
+def test_mapping_survives_provider_restart_for_true_replace(tmp_path):
+    client = _FakeVikingClient()
+    first = _provider(tmp_path, client)
+
+    first.on_memory_write("add", "user", "Employment status is job seeking")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    uri = client.snapshot()[0][2]["uri"]
+    first.shutdown()
+
+    second = _provider(tmp_path, client)
+    second.on_memory_write(
+        "replace",
+        "user",
+        "Employment status is employed",
+        metadata={"old_text": "job seeking"},
+    )
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    replace = client.snapshot()[1]
+    assert replace[2]["uri"] == uri
+    assert replace[2]["mode"] == "replace"
+    assert replace[2]["wait"] is True
+    assert replace[2]["content"] == "Employment status is employed"
+    second.shutdown()
+
+
+def test_rapid_add_replace_remove_is_processed_in_fifo_order(tmp_path):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Device owned: Tablet A")
+    provider.on_memory_write(
+        "replace",
+        "user",
+        "Device owned: Tablet B",
+        metadata={"old_text": "Tablet A"},
+    )
+    provider.on_memory_write(
+        "remove",
+        "user",
+        "",
+        metadata={"old_text": "Tablet B"},
+    )
+
+    _wait_for(lambda: len(client.snapshot()) == 3)
+    calls = client.snapshot()
+    uri = calls[0][2]["uri"]
+
+    assert [(call[0], call[1]) for call in calls] == [
+        ("post", "/api/v1/content/write"),
+        ("post", "/api/v1/content/write"),
+        ("delete", "/api/v1/fs"),
+    ]
+    assert calls[0][2]["mode"] == "create"
+    assert calls[1][2]["mode"] == "replace"
+    assert calls[1][2]["wait"] is True
+    assert calls[1][2]["uri"] == uri
+    assert calls[2][3]["params"] == {"uri": uri, "recursive": False, "wait": True}
+
+    registry = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    assert registry == {"version": 2, "entries": []}
+    provider.shutdown()
+
+
+def test_unmapped_replace_fails_closed_with_warning(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "replace",
+            "user",
+            "Employment status is employed",
+            metadata={"old_text": "job seeking"},
+        )
+        provider.shutdown()
+
+    assert client.snapshot() == []
+    assert any(
+        "no stable OpenViking URI mapping" in record.message
+        for record in caplog.records
+    )
+
+
+def test_ambiguous_replace_fails_closed_without_guessing(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    provider.on_memory_write("add", "user", "Device owned: Tablet A")
+    provider.on_memory_write("add", "user", "Device owned: Tablet B")
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "replace",
+            "user",
+            "Device owned: Tablet C",
+            metadata={"old_text": "Tablet"},
+        )
+        provider.shutdown()
+
+    assert len(client.snapshot()) == 2
+    assert any(
+        "matched 2 OpenViking URI mappings" in record.message
+        for record in caplog.records
+    )
+
+
+def test_final_mirror_failure_is_visible_at_warning_level(tmp_path, caplog):
+    client = _FakeVikingClient(fail_post=True)
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "Visible failure")
+        _wait_for(lambda: len(client.snapshot()) == 1)
+        _wait_for(
+            lambda: any(
+                record.levelname == "WARNING"
+                and "OpenViking memory mirror failed" in record.message
+                for record in caplog.records
+            )
+        )
+
+    assert not _registry_path(tmp_path).exists()
+    provider.shutdown()
+
+
+def test_failed_replace_keeps_previous_registry_mapping(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+    provider.on_memory_write("add", "user", "Preferred shell is zsh")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    previous = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    client.fail_post = True
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "replace",
+            "user",
+            "Preferred shell is fish",
+            metadata={"old_text": "zsh"},
+        )
+        _wait_for(lambda: len(client.snapshot()) == 2)
+        provider.shutdown()
+
+    assert json.loads(_registry_path(tmp_path).read_text(encoding="utf-8")) == previous
+    assert any(
+        "OpenViking memory mirror failed" in record.message for record in caplog.records
+    )
+
+
+def test_failed_remove_keeps_registry_mapping(tmp_path, caplog):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+    provider.on_memory_write("add", "memory", "Project delta is active")
+    _wait_for(lambda: len(client.snapshot()) == 1)
+    previous = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
+    client.fail_delete = True
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write(
+            "remove",
+            "memory",
+            "",
+            metadata={"old_text": "delta is active"},
+        )
+        _wait_for(lambda: len(client.snapshot()) == 2)
+        provider.shutdown()
+
+    assert json.loads(_registry_path(tmp_path).read_text(encoding="utf-8")) == previous
+    assert any(
+        "OpenViking memory mirror failed" in record.message for record in caplog.records
+    )
+
+
+def test_registry_save_failure_is_reported_after_remote_acceptance(
+    tmp_path, caplog, monkeypatch
+):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    def fail_save(_path, _registry):
+        raise OSError("registry disk full")
+
+    monkeypatch.setattr(
+        NativeMemoryMirror,
+        "_save_registry",
+        staticmethod(fail_save),
+    )
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "Remote write without mapping")
+        _wait_for(lambda: len(client.snapshot()) == 1)
+        _wait_for(
+            lambda: any(
+                "registry disk full" in record.message for record in caplog.records
+            )
+        )
+        provider.shutdown()
+
+    assert not _registry_path(tmp_path).exists()
+    assert client.snapshot()[0][1] == "/api/v1/content/write"
+
+
+def test_registry_mapping_is_isolated_by_connection(tmp_path):
+    first_client = _FakeVikingClient(api_key="key-a")
+    second_client = _FakeVikingClient(api_key="key-b")
+    first = _provider(tmp_path, first_client)
+    second = _provider(tmp_path, second_client)
+
+    first.on_memory_write("add", "user", "Preferred editor is Helix")
+    second.on_memory_write("add", "user", "Preferred editor is Helix")
+    _wait_for(lambda: len(first_client.snapshot()) == 1)
+    _wait_for(lambda: len(second_client.snapshot()) == 1)
+    _wait_for(
+        lambda: (
+            _registry_path(tmp_path).exists()
+            and len(
+                json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))[
+                    "entries"
+                ]
+            )
+            == 2
+        )
+    )
+
+    first_uri = first_client.snapshot()[0][2]["uri"]
+    second_uri = second_client.snapshot()[0][2]["uri"]
+    registry_text = _registry_path(tmp_path).read_text(encoding="utf-8")
+    registry = json.loads(registry_text)
+    assert len(registry["entries"]) == 2
+    assert len({entry["connection"] for entry in registry["entries"]}) == 2
+    assert "key-a" not in registry_text
+    assert "key-b" not in registry_text
+
+    first.on_memory_write(
+        "replace",
+        "user",
+        "Preferred editor is Neovim",
+        metadata={"old_text": "Helix"},
+    )
+    _wait_for(lambda: len(first_client.snapshot()) == 2)
+
+    replace = first_client.snapshot()[1]
+    assert replace[2]["uri"] == first_uri
+    assert replace[2]["uri"] != second_uri
+    assert len(second_client.snapshot()) == 1
+    first.shutdown()
+    second.shutdown()
+
+
+def test_provider_instances_serialize_shared_registry_updates(tmp_path, monkeypatch):
+    first_client = _FakeVikingClient(api_key="key-a")
+    second_client = _FakeVikingClient(api_key="key-b")
+    first = _provider(tmp_path, first_client)
+    second = _provider(tmp_path, second_client)
+    first_save_started = threading.Event()
+    release_first_save = threading.Event()
+    save_count = 0
+    save_count_lock = threading.Lock()
+    original_save = NativeMemoryMirror._save_registry
+
+    def blocking_save(path, registry):
+        nonlocal save_count
+        with save_count_lock:
+            save_count += 1
+            is_first = save_count == 1
+        if is_first:
+            first_save_started.set()
+            assert release_first_save.wait(timeout=2.0)
+        original_save(path, registry)
+
+    monkeypatch.setattr(
+        NativeMemoryMirror,
+        "_save_registry",
+        staticmethod(blocking_save),
+    )
+
+    try:
+        first.on_memory_write("add", "user", "First profile fact")
+        assert first_save_started.wait(timeout=2.0)
+
+        second.on_memory_write("add", "user", "Second profile fact")
+        time.sleep(0.05)
+        assert second_client.snapshot() == []
+
+        release_first_save.set()
+        _wait_for(lambda: len(second_client.snapshot()) == 1)
+        _wait_for(
+            lambda: (
+                len(
+                    json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))[
+                        "entries"
+                    ]
+                )
+                == 2
+            )
+        )
+    finally:
+        release_first_save.set()
+        first.shutdown()
+        second.shutdown()
+
+
+def test_concurrent_first_writes_share_one_mirror_worker(tmp_path, monkeypatch):
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+    constructor_started = threading.Event()
+    release_constructor = threading.Event()
+    constructed = 0
+    constructed_lock = threading.Lock()
+    original_init = NativeMemoryMirror.__init__
+
+    def blocking_init(self, owner):
+        nonlocal constructed
+        with constructed_lock:
+            constructed += 1
+            is_first = constructed == 1
+        if is_first:
+            constructor_started.set()
+            assert release_constructor.wait(timeout=2.0)
+        original_init(self, owner)
+
+    monkeypatch.setattr(NativeMemoryMirror, "__init__", blocking_init)
+    first = threading.Thread(
+        target=provider.on_memory_write,
+        args=("add", "user", "First concurrent fact"),
+    )
+    second = threading.Thread(
+        target=provider.on_memory_write,
+        args=("add", "user", "Second concurrent fact"),
+    )
+
+    first.start()
+    assert constructor_started.wait(timeout=2.0)
+    second.start()
+    release_constructor.set()
+    first.join(timeout=2.0)
+    second.join(timeout=2.0)
+    _wait_for(lambda: len(client.snapshot()) == 2)
+
+    assert constructed == 1
+    provider.shutdown()

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -337,6 +337,40 @@ def test_final_mirror_failure_is_visible_at_warning_level(tmp_path, caplog):
     provider.shutdown()
 
 
+@pytest.mark.parametrize(
+    ("registry_text", "expected_warning"),
+    [
+        ("{not valid JSON", "cannot read mirror registry"),
+        ("[]", "invalid mirror registry format: expected a JSON object"),
+        (
+            json.dumps({"entries": []}),
+            "invalid mirror registry format: missing version",
+        ),
+        (
+            json.dumps({"version": 3, "entries": []}),
+            "unsupported mirror registry version 3: expected 2",
+        ),
+    ],
+)
+def test_invalid_registry_blocks_add_without_overwriting_it(
+    tmp_path, caplog, registry_text, expected_warning
+):
+    path = _registry_path(tmp_path)
+    path.parent.mkdir(parents=True)
+    path.write_text(registry_text, encoding="utf-8")
+    original = path.read_bytes()
+    client = _FakeVikingClient()
+    provider = _provider(tmp_path, client)
+
+    with caplog.at_level("WARNING", logger="plugins.memory.openviking"):
+        provider.on_memory_write("add", "user", "Do not orphan this memory")
+        provider.shutdown()
+
+    assert client.snapshot() == []
+    assert path.read_bytes() == original
+    assert any(expected_warning in record.message for record in caplog.records)
+
+
 def test_failed_replace_keeps_previous_registry_mapping(tmp_path, caplog):
     client = _FakeVikingClient()
     provider = _provider(tmp_path, client)

--- a/tests/plugins/memory/test_openviking_memory_mirror.py
+++ b/tests/plugins/memory/test_openviking_memory_mirror.py
@@ -375,7 +375,7 @@ def test_failed_replace_keeps_previous_registry_mapping(tmp_path, caplog):
     client = _FakeVikingClient()
     provider = _provider(tmp_path, client)
     provider.on_memory_write("add", "user", "Preferred shell is zsh")
-    _wait_for(lambda: len(client.snapshot()) == 1)
+    _wait_for(lambda: _registry_path(tmp_path).exists())
     previous = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
     client.fail_post = True
 
@@ -399,7 +399,7 @@ def test_failed_remove_keeps_registry_mapping(tmp_path, caplog):
     client = _FakeVikingClient()
     provider = _provider(tmp_path, client)
     provider.on_memory_write("add", "memory", "Project delta is active")
-    _wait_for(lambda: len(client.snapshot()) == 1)
+    _wait_for(lambda: _registry_path(tmp_path).exists())
     previous = json.loads(_registry_path(tmp_path).read_text(encoding="utf-8"))
     client.fail_delete = True
 

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1290,8 +1290,7 @@ def test_concurrent_providers_claim_unlocked_pending_owner_once(
 
 
 # ---------------------------------------------------------------------------
-# on_memory_write: explicit memory writes use content/write and stay outside
-# the session transcript/commit boundary.
+# on_memory_write: successful built-in memory mutations use the native mirror.
 # ---------------------------------------------------------------------------
 
 
@@ -1339,7 +1338,6 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
 
     assert not returned_before_worker_finished
     assert worker_finished.is_set()
-    assert provider._memory_write_threads == set()
 
 
 def test_memory_write_uses_one_connection_for_identity_uri_and_post(monkeypatch):
@@ -1383,8 +1381,6 @@ def test_memory_write_uses_one_connection_for_identity_uri_and_post(monkeypatch)
     release_identity.set()
 
     assert write_finished.wait(timeout=2.0), "memory write did not finish"
-    for worker in list(provider._memory_write_threads):
-        worker.join(timeout=2.0)
 
     assert len(writes) == 1
     user, agent, path, payload = writes[0]
@@ -1392,7 +1388,6 @@ def test_memory_write_uses_one_connection_for_identity_uri_and_post(monkeypatch)
     assert payload["uri"].startswith(
         "viking://user/alice/peers/alice-agent/memories/preferences/mem_"
     )
-    assert provider._memory_write_threads == set()
 
 
 def _make_prefetch_provider() -> OpenVikingMemoryProvider:

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1313,6 +1313,10 @@ def test_shutdown_waits_for_memory_write_worker(monkeypatch):
         def __init__(self, *a, **kw):
             pass
 
+        def get(self, path, **kwargs):
+            assert path == "/api/v1/system/status"
+            return {"status": "ok", "result": {"user": "usr"}}
+
         def post(self, path, payload=None, **kwargs):
             assert path == "/api/v1/content/write"
             worker_started.set()


### PR DESCRIPTION
## What does this PR do?

Hermes mirrors successful built-in `memory` additions to OpenViking, but it does not mirror later `replace` or `remove` operations. This can leave old native memories searchable in OpenViking after the user updates or deletes them in Hermes.

This PR gives each mirrored native memory a stable OpenViking URI. It stores the URI in a profile-scoped registry, then uses the same URI for later replace and remove operations. Events run through one FIFO worker, destructive operations fail closed when the mapping is missing or ambiguous, and failures are visible at warning level.

The registry is isolated by OpenViking connection and identity. It does not own session-extracted memories or explicit `viking_remember` results. Those paths remain unchanged.

This work continues and supersedes #85860. It preserves the useful stable-URI design and adds current-main compatibility, connection isolation, shared-profile serialization, lifecycle race protection, and failure-boundary coverage.

## Related Issue

Fixes #31000

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [x] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Require a server-confirmed user identity before creating a new mirrored URI.
- Add a profile-scoped registry that maps native memory entries to exact OpenViking URIs.
- Mirror native `add`, `replace`, and `remove` operations in FIFO order.
- Forward the supported batch `new_text` alias to external providers for add and replace operations.
- Wait for OpenViking semantic cleanup after replace and remove.
- Isolate mappings by endpoint, credentials, user identity, and actor peer.
- Serialize registry updates across provider instances in one Hermes process.
- Keep registry state unchanged after failed remote replace or remove operations.
- Distinguish unreadable, invalid, and unsupported mirror registries without weakening fail-closed behavior.
- Log mirror failures at warning level and document fail-closed and recovery boundaries.

## How to Test

1. Configure Hermes to use an OpenViking server.
2. Add a fact with the built-in `memory` tool, then replace it by `old_text`. Confirm that OpenViking updates the same URI and no longer returns the old content.
3. Remove the fact by `old_text`. Confirm that the exact URI and its search result are removed.

Validation completed after rebasing onto upstream main `4f6ef8806f`:

- Focused OpenViking provider and mirror tests: 84 passed.
- Canonical isolated memory-provider suite: 421 passed and 2 skipped.
- Canonical isolated OpenViking plugin suite: 47 passed.
- Canonical isolated memory bridge, provider, and run-agent suites: 370 passed.
- Updated affected suite after review fixes: 502 passed and 2 skipped.
- Registry failure tests under eight-way contention with retries disabled: 24 of 24 runs passed.
- The batch `new_text` bridge test fails on the old forwarding logic and passes with this fix.
- FIFO lifecycle regression test: 20 consecutive standalone runs passed.
- Current OpenViking main `2251aa136a` confirms the identity, content write, and exact delete API contracts used by the mirror.
- Earlier live lifecycle test against OpenViking `0.4.18.dev21`: server-confirmed user resolution, add, same-URI replace, exact read, exact delete, and empty final registry all passed.
- Ruff, targeted `ty`, Python compilation, and Git whitespace checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs and based this work on #85860.
- [x] My PR contains only changes related to this fix.
- [ ] I have run `pytest tests/ -q` and all tests pass. The affected suites pass, but the complete repository suite was not rerun locally.
- [x] I've added tests for my changes.
- [x] I've tested on macOS.

### Documentation & Housekeeping

- [x] I've updated relevant documentation.
- [x] `cli-config.yaml.example` is not affected.
- [x] `CONTRIBUTING.md` and `AGENTS.md` are not affected.
- [x] I've considered cross-platform impact. Registry writes request mode `0600` on POSIX, and the Windows ACL limitation is documented.
- [x] Tool descriptions and schemas are not affected.

## Screenshots / Logs

Not applicable.
