### PR TITLE
fix(gateway): suppress the automatic anti-growth compression refusal on chat surfaces

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -134,6 +134,15 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|resumed\s+after\s+\d+s\s+idle\s+[—-]\s+compacting"
     r"|preflight\s+compression"
     r"|pre[- ]api\s+compression"
+    # Automatic anti-growth refusal: the summary would have GROWN the
+    # transcript, so nothing was dropped and the conversation continues
+    # unchanged — a no-op diagnostic that must not leak internal
+    # compression mechanics into shared group chats (#100171).  The anchor
+    # "the generated summary would have GROWN" deliberately does NOT match
+    # manual /compress feedback, which reads "Compression refused (summary
+    # would grow the conversation): N messages preserved" (different
+    # wording, parenthesized, carries a count).
+    r"|compression\s+refused[:\s]+the\s+generated\s+summary\s+would\s+have\s+GROWN"
     # Buffered attempt/overflow retry chatter replayed through _emit_status
     # when a turn exhausts retries. The ", retrying"/"— compressing" anchors
     # keep manual /compress feedback ("Compressed: 30 → 12 messages") and

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -120,6 +120,32 @@ def test_telegram_status_suppresses_auxiliary_and_retry_noise():
         assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", message) is None
 
 
+def test_telegram_suppresses_anti_growth_compression_refusal():
+    """The automatic anti-growth refusal is a no-op diagnostic (no messages
+    dropped, conversation unchanged) that leaked internal compression
+    mechanics into shared group chats where the agent runs in observe mode
+    (#100171). It must be suppressed like the other automatic statuses."""
+    # Exact wording emitted by conversation_compression._emit_warning.
+    refusal = (
+        "⚠️ Compression refused: the generated summary "
+        "would have GROWN the conversation instead of "
+        "shrinking it. No messages were dropped — "
+        "conversation continues unchanged."
+    )
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", refusal) is None
+
+
+def test_manual_compress_refusal_feedback_stays_visible():
+    """Manual /compress feedback uses the parenthesized '(summary would
+    grow the conversation): N messages preserved' wording and carries a
+    count — the anti-growth noise anchor must NOT swallow it (#100171)."""
+    feedback = (
+        "Compression refused (summary would grow the conversation): "
+        "30 messages preserved"
+    )
+    assert _prepare_gateway_status_message(Platform.TELEGRAM, "warn", feedback) is not None
+
+
 def test_programmatic_surfaces_keep_raw_status():
     """Programmatic surfaces (local/api/webhook) must keep raw diagnostics.
 


### PR DESCRIPTION
Fixes #100171

## Problem

When automatic compression refuses to commit because the generated summary would **grow** the transcript, `conversation_compression._emit_warning` sends the full technical notice through `_prepare_gateway_status_message` — which only suppresses strings matching `_TELEGRAM_NOISY_STATUS_RE`. "Compression refused" wasn't covered, so it was delivered verbatim to every chat surface.

In shared group chats where the agent runs in observe/@mention mode, that leaks internal compression mechanics and framework jargon to users who never invoked anything — confusing at best, and the wording is searchable enough to identify the underlying framework.

The refusal is a **no-op diagnostic**: no messages were dropped and the conversation continues unchanged, so nothing actionable is lost by suppressing it.

## Fix

Added a surgical anchor to `_TELEGRAM_NOISY_STATUS_RE`, taking the issue's first (surgical) option:

```
compression\s+refused[:\s]+the\s+generated\s+summary\s+would\s+have\s+GROWN
```

The `the generated summary would have GROWN` anchor is deliberately specific so it does **not** swallow:

- **manual `/compress` feedback** — different wording: `Compression refused (summary would grow the conversation): N messages preserved` (parenthesized, carries a count)
- **failure-class notices** that must stay visible per the existing `VISIBLE_COMPRESSION_MESSAGES` carve-out (auth abort, empty transcript, blocked-overflow warning)

Programmatic surfaces (local/api/webhook) keep raw diagnostics, unchanged.

## Verification

`tests/gateway/test_telegram_noise_filter.py`: **138/138 pass**, including two new tests — the automatic refusal (exact `_emit_warning` wording) is suppressed, and the manual `/compress` refusal feedback still reaches the user.