### PR TITLE
fix(agent): stop treating TERMINAL_CWD as a local path on remote backends

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -22,6 +22,7 @@ from hermes_constants import (
 )
 from typing import List, Optional
 
+from agent.runtime_cwd import REMOTE_TERMINAL_BACKENDS as _REMOTE_TERMINAL_BACKENDS
 from agent.runtime_cwd import resolve_agent_cwd
 from agent.skill_utils import (
     EXCLUDED_SKILL_DIRS,
@@ -1071,10 +1072,8 @@ WSL_ENVIRONMENT_HINT = (
 # container / remote host rather than on the machine where Hermes itself
 # runs. For these backends, host info (Windows/Linux/macOS, $HOME, cwd) is
 # misleading — the agent should only see the machine it can actually touch.
-_REMOTE_TERMINAL_BACKENDS = frozenset({
-    "docker", "singularity", "modal", "daytona", "ssh",
-    "vercel_sandbox", "managed_modal",
-})
+# Canonical set lives in agent.runtime_cwd (imported above) so this module
+# and the local-cwd resolvers can't drift apart on which backends count.
 
 
 # Per-backend fallback descriptions — used when the live probe fails.

--- a/agent/runtime_cwd.py
+++ b/agent/runtime_cwd.py
@@ -29,6 +29,33 @@ _SESSION_CWD: ContextVar = ContextVar("HERMES_SESSION_CWD", default=_UNSET)
 # resolve here.
 _PACKAGE_ROOT = Path(__file__).resolve().parent.parent
 
+# Backends whose `terminal.cwd` names a path inside a *different* filesystem
+# (a container, a sandbox, or — for ssh — a different host entirely). For
+# these, `TERMINAL_CWD` carries no meaning as a local path: it can coincide
+# with a real local directory by accident (e.g. an ssh profile's remote
+# `~/.hermes` scoped small on purpose to keep session-sync fast, which also
+# happens to exist locally as this machine's OWN Hermes root) and silently
+# redirect local-only concerns — context-file discovery, git-workspace
+# snapshots — into the wrong directory (#confused-identity-leak). Kept as the
+# single source of truth here; `agent/prompt_builder.py`'s environment-hints
+# builder imports this instead of keeping its own copy.
+REMOTE_TERMINAL_BACKENDS = frozenset({
+    "docker", "singularity", "modal", "daytona", "ssh",
+    "vercel_sandbox", "managed_modal",
+})
+
+
+def _is_remote_terminal_backend() -> bool:
+    backend = (os.environ.get("TERMINAL_ENV") or "local").strip().lower()
+    if backend in REMOTE_TERMINAL_BACKENDS:
+        return True
+    try:
+        from agent.prompt_builder import _plugin_backend_is_remote
+
+        return _plugin_backend_is_remote(backend)
+    except Exception:
+        return False
+
 
 def _is_install_tree(p: Path) -> bool:
     # True only when p IS the package root or sits inside it. Ancestors of the
@@ -64,12 +91,13 @@ def resolve_agent_cwd() -> Path:
         if p.is_dir():
             return p
         logger.warning("configured working directory does not exist: %s", override)
-    raw = os.environ.get("TERMINAL_CWD", "").strip()
-    if raw:
-        p = Path(raw).expanduser()
-        if p.is_dir():
-            return p
-        logger.warning("TERMINAL_CWD does not exist: %s", raw)
+    if not _is_remote_terminal_backend():
+        raw = os.environ.get("TERMINAL_CWD", "").strip()
+        if raw:
+            p = Path(raw).expanduser()
+            if p.is_dir():
+                return p
+            logger.warning("TERMINAL_CWD does not exist: %s", raw)
     return Path(os.getcwd())
 
 
@@ -89,6 +117,8 @@ def resolve_context_cwd() -> Path | None:
             logger.warning("configured working directory does not exist: %s", override)
         else:
             return p
+        return None
+    if _is_remote_terminal_backend():
         return None
     raw = os.environ.get("TERMINAL_CWD", "").strip()
     if raw:


### PR DESCRIPTION
## Problem

`resolve_agent_cwd()` and `resolve_context_cwd()` in `agent/runtime_cwd.py` read `TERMINAL_CWD` from the environment and use it directly as a local filesystem path, with no check on which terminal backend is actually active.

For `ssh` / `docker` / `singularity` / `modal` / `daytona` / `vercel_sandbox` / `managed_modal` backends, `TERMINAL_CWD` names a path on a *different* filesystem — or, for `ssh`, a different host entirely. It has no meaning as a local path in that case.

This turns into a real bug when the remote path happens to coincide with a real local directory. For example, an ssh-backed profile with a small, generic remote `HERMES_HOME` (say, `~/.hermes`) that also happens to exist locally: `TERMINAL_CWD` then gets treated as valid and silently redirects local-only concerns — context-file discovery, git-workspace snapshotting — into the wrong directory. It's a quiet correctness bug, not a crash, so it's easy to miss.

## Fix

- Added `REMOTE_TERMINAL_BACKENDS` and `_is_remote_terminal_backend()` in `agent/runtime_cwd.py` as the single source of truth for which backends are non-local.
- Both `resolve_agent_cwd()` and `resolve_context_cwd()` now skip `TERMINAL_CWD` entirely when the active backend is remote, falling back to the real local cwd / `None` instead.
- `agent/prompt_builder.py` previously kept its own separate copy of the same backend list (for building environment hints) — it now imports the canonical set from `runtime_cwd` so the two can't drift apart again.

## Testing

Ran the existing test suite locally; no regressions from this change (pre-existing environment-specific failures unrelated to this diff).