### PR TITLE
fix(auxiliary): preserve Grok 4.6 priority service_tier in the Codex auxiliary adapter

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1660,14 +1660,24 @@ class _CodexCompletionsAdapter:
             # Auxiliary callers express provider controls through
             # auxiliary.<task>.extra_body, so project service_tier here just as
             # the main Codex transport projects request_overrides. xAI's
-            # Responses endpoint rejects this field; keep the same xAI-only
-            # guard as agent/transports/codex.py.
+            # Responses endpoint rejects this field on most models, but Grok
+            # 4.6 accepts Priority Processing — keep the same xAI guard AND
+            # Grok-4.6 carve-out as agent/transports/codex.py::build_kwargs().
             service_tier = extra_body.get("service_tier")
             client_base_url = str(getattr(self._client, "base_url", "") or "")
             is_xai_responses = (
                 base_url_host_matches(client_base_url, "x.ai")
                 or base_url_host_matches(client_base_url, "api.x.ai")
             )
+            if is_xai_responses:
+                from agent.model_metadata import is_grok_46_family
+
+                _tier_stripped = (
+                    service_tier.strip() if isinstance(service_tier, str) else None
+                )
+                is_xai_responses = not (
+                    is_grok_46_family(model) and _tier_stripped == "priority"
+                )
             if (
                 isinstance(service_tier, str)
                 and service_tier.strip()

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -3026,11 +3026,36 @@ class TestCodexAdapterPromptCacheKey:
     def test_xai_backend_drops_auxiliary_service_tier(self):
         adapter, captured = self._build_adapter(
             base_url="https://api.x.ai/v1",
+            model="grok-4",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"service_tier": "priority"},
+        )
+        assert "service_tier" not in captured
+
+    def test_xai_backend_preserves_grok46_priority_service_tier(self):
+        # Grok 4.6 accepts Priority Processing on the Responses endpoint,
+        # unlike older xAI models — mirrors agent/transports/codex.py's
+        # build_kwargs() carve-out for the main agent transport.
+        adapter, captured = self._build_adapter(
+            base_url="https://api.x.ai/v1",
             model="grok-4.6",
         )
         adapter.create(
             messages=[{"role": "user", "content": "hi"}],
             extra_body={"service_tier": "priority"},
+        )
+        assert captured["service_tier"] == "priority"
+
+    def test_xai_backend_drops_non_priority_service_tier_for_grok46(self):
+        adapter, captured = self._build_adapter(
+            base_url="https://api.x.ai/v1",
+            model="grok-4.6",
+        )
+        adapter.create(
+            messages=[{"role": "user", "content": "hi"}],
+            extra_body={"service_tier": "flex"},
         )
         assert "service_tier" not in captured
 


### PR DESCRIPTION
## Summary
- `_CodexCompletionsAdapter.create()` in `agent/auxiliary_client.py` (used by auxiliary calls: context compression, `flush_memories()`, MoA aggregation) strips `service_tier` for **all** xAI Responses requests unconditionally.
- Its own comment claims to "keep the same xAI-only guard as `agent/transports/codex.py`" — but that main transport's `build_kwargs()` carves out an exception for Grok 4.6 with `service_tier == "priority"` (landed in #85510). The auxiliary adapter never got the same carve-out.
- Net effect: an auxiliary task (e.g. context-compression summarization) routed to a Grok 4.6 xAI backend with `auxiliary.<task>.extra_body.service_tier = "priority"` silently loses Priority Processing, while the main agent transport forwards the identical setting correctly for the same model.

## Fix
Ports the identical `is_grok_46_family()` check from `agent/transports/codex.py::build_kwargs()` into the auxiliary adapter's xAI guard, so `service_tier="priority"` survives for Grok 4.6 and is still stripped for every other xAI model/tier.

## Test plan
- [x] Added `test_xai_backend_preserves_grok46_priority_service_tier` (Grok 4.6 + `priority` → forwarded)
- [x] Added `test_xai_backend_drops_non_priority_service_tier_for_grok46` (Grok 4.6 + non-priority tier → still stripped)
- [x] Updated `test_xai_backend_drops_auxiliary_service_tier` to use a non-4.6 xAI model (`grok-4`), since it now correctly encodes "not Grok 4.6" rather than "any xAI model"
- [x] Mutation-verify: reverting the fix makes the new Grok-4.6 test fail as expected; all other tests unaffected
- [x] Full `tests/agent/test_auxiliary_client.py` suite: 189 passed