### PR TITLE
fix(desktop): restore gateways when a bootstrap-recovery hand-off fails (Windows)

### DIFF
--- a/apps/desktop/electron/bootstrap-recovery-gateway-restore.test.ts
+++ b/apps/desktop/electron/bootstrap-recovery-gateway-restore.test.ts
@@ -1,0 +1,49 @@
+// handOffWindowsBootstrapRecovery() is entangled with real Electron app init
+// (app.quit, process spawning, module-load side effects), so — following the
+// same convention as backend-dial-claim.test.ts — this reads main.ts's own
+// source and asserts the expected call pattern in a windowed slice, rather
+// than importing and invoking the function directly.
+
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+describe('handOffWindowsBootstrapRecovery gateway restore on failed hand-off (#70337 sibling gap)', () => {
+  it('restores the gateways stopped by releaseBackendLockForUpdate when the hand-off is not viable', () => {
+    const anchor = mainSource.indexOf(
+      '[bootstrap] recovery hand-off not viable, staying alive:'
+    )
+
+    expect(anchor).toBeGreaterThan(-1)
+
+    const body = mainSource.slice(anchor, anchor + 500)
+
+    // releaseBackendLockForUpdate() (called earlier in this function) took
+    // every profile's gateway down via `gateway stop --all` on Windows.
+    // applyUpdates()'s four abort paths all restore via
+    // startGatewaysAfterUpdateAbort() — this sibling branch must too, or a
+    // failed recovery hand-off strands every profile's gateway stopped.
+    expect(body).toContain('IS_WINDOWS')
+    expect(body).toContain('startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))')
+    expect(body).toContain('return false')
+  })
+
+  it('the restore call sits inside handOffWindowsBootstrapRecovery, not a different function', () => {
+    const fnStart = mainSource.indexOf('async function handOffWindowsBootstrapRecovery(reason) {')
+    const anchor = mainSource.indexOf(
+      '[bootstrap] recovery hand-off not viable, staying alive:'
+    )
+
+    expect(fnStart).toBeGreaterThan(-1)
+    expect(anchor).toBeGreaterThan(fnStart)
+    // Sanity bound: the failure branch must be well within this one function
+    // (it's the last branch before the success path, ~90 lines in), not
+    // accidentally matched inside some unrelated function far down the file.
+    expect(anchor - fnStart).toBeLessThan(4500)
+  })
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4145,6 +4145,14 @@ async function handOffWindowsBootstrapRecovery(reason) {
   if (!handoffOutcome.ok) {
     rememberLog(`[bootstrap] recovery hand-off not viable, staying alive: ${handoffOutcome.message}`)
 
+    if (IS_WINDOWS) {
+      // Same drain-semantics restore as applyUpdates's abort paths (#70337):
+      // releaseBackendLockForUpdate above already ran `gateway stop --all`
+      // for every profile; a failed hand-off means nothing else will bring
+      // them back.
+      startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
+    }
+
     return false
   }
 


### PR DESCRIPTION
## Summary
- `handOffWindowsBootstrapRecovery()` calls `releaseBackendLockForUpdate()`, which on Windows runs `hermes gateway stop --all` for every profile before spawning the recovery updater (#70337 drain semantics).
- Its sibling `applyUpdates()` restores those gateways via `startGatewaysAfterUpdateAbort()` on all four of its own abort paths (lock-held, venv-blocked, probe-failed, updater-spawn-failed).
- `handOffWindowsBootstrapRecovery()`'s own "hand-off not viable" failure branch — structurally the same shape as `applyUpdates()`'s `updater-spawn-failed` branch — never got the same restore call.

## Impact
If a bootstrap-recovery hand-off is attempted (`ensureRuntime()` → `backend.kind === 'bootstrap-needed'`, i.e. no runnable install was resolved) while a Hermes-owned gateway from a broken/partial install is still running, and the recovery updater then fails to spawn or dies early during the hand-off dwell, every profile's messaging gateway is left stopped with nothing to restart them — the app otherwise keeps running normally.

## Fix
Added the same `startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))` call, Windows-gated to match the style of the other three call sites. `startGatewaysAfterUpdateAbort()` is already a safe, best-effort no-op off Windows / when the CLI shim is missing (see `gateway-stop-before-update.ts`), so this cannot introduce a new failure mode.

## Test plan
- [x] Added `apps/desktop/electron/bootstrap-recovery-gateway-restore.test.ts`, following the existing `backend-dial-claim.test.ts` convention (source-read + windowed substring assertions) since this function is too entangled with real Electron app-init side effects to import and invoke directly
- [x] Mutation-verify: reverting the `main.ts` change makes the new regression test fail as expected; the structural-bound test is unaffected
- [x] `npx vitest run` on the touched + adjacent update/bootstrap test files: 72 passed
- [x] `npx tsc -p tsconfig.electron.json --noEmit`: clean