### PR TITLE
fix(desktop): converge macOS installs on one stable app

### DIFF
--- a/apps/bootstrap-installer/src-tauri/src/update.rs
+++ b/apps/bootstrap-installer/src-tauri/src/update.rs
@@ -1092,9 +1092,16 @@ where
     I: IntoIterator<Item = S>,
     S: AsRef<str>,
 {
+    // The argument is an install request, not authority to choose a product
+    // location. Older Desktop builds passed their currently-running bundle,
+    // which made release/worktree artifacts become permanent installations.
+    // Accept only a syntactically valid app request, then converge it on the
+    // one stable per-user target.
     arg_value_from_args(args, "--target-app")
         .map(PathBuf::from)
         .filter(|p| p.extension().and_then(|e| e.to_str()) == Some("app"))
+        .and_then(|_| dirs::home_dir())
+        .map(|home| home.join("Applications").join("Hermes.app"))
 }
 
 fn arg_value_from_args<I, S>(args: I, name: &str) -> Option<String>
@@ -1802,9 +1809,21 @@ mod tests {
 
     #[test]
     fn parses_only_app_targets() {
+        let canonical = dirs::home_dir()
+            .unwrap()
+            .join("Applications")
+            .join("Hermes.app");
         assert_eq!(
             target_app_from_args(["--update", "--target-app", "/Applications/Hermes.app"]),
-            Some(PathBuf::from("/Applications/Hermes.app"))
+            Some(canonical.clone())
+        );
+        assert_eq!(
+            target_app_from_args([
+                "--update",
+                "--target-app",
+                "/tmp/worktree/release/mac-arm64/Hermes.app",
+            ]),
+            Some(canonical)
         );
         assert_eq!(target_app_from_args(["--target-app", "/tmp/not-an-app"]), None);
     }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -380,6 +380,7 @@ import { isOfficialSshRemote, OFFICIAL_REPO_HTTPS_URL } from './update-remote'
 import {
   collectRelaunchArgs,
   observeUpdaterHandoff,
+  resolveMacUpdateTarget,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -3797,7 +3798,22 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
     const { branch: configuredBranch } = readDesktopUpdateConfig()
     const branch = await resolveHealedBranch(updateRoot, configuredBranch || DEFAULT_UPDATE_BRANCH)
     const updaterArgs = ['--update', '--branch', branch]
-    const targetApp = IS_MAC ? runningAppBundle() : null
+    let targetApp: string | null = null
+
+    if (IS_MAC) {
+      const resolution = resolveMacUpdateTarget(runningAppBundle(), app.getPath('home'))
+
+      if (resolution.ok === false) {
+        const message = 'Update refused because the macOS home directory could not be resolved safely.'
+
+        rememberLog(`[updates] ${message} (${resolution.reason})`)
+        emitUpdateProgress({ stage: 'error', message, percent: null })
+
+        return { ok: false, error: 'invalid-home-directory', message }
+      }
+
+      targetApp = resolution.target
+    }
 
     if (targetApp) {
       updaterArgs.push('--target-app', targetApp)
@@ -4309,17 +4325,27 @@ async function applyUpdatesPosixHandoff(opts: any) {
   const args = [...handoff.args, '--install-root', updateRoot, '--branch', branch, '--desktop-pid', String(process.pid)]
   const updateStartedAt = Math.floor(Date.now() / 1000)
 
-  // Relaunch target: the running .app bundle on mac (script swaps the
-  // rebuilt bundle over it), the running binary elsewhere. The script's gate
-  // (an exact port of update-relaunch.ts's decideRelaunchOutcome) relaunches
-  // only a binary the rebuild replaced with a launchable sandbox helper —
-  // replaying the original launch context (filtered args, cwd, sandbox
-  // opt-out) so a deep-link or --no-sandbox launch survives the update.
-  const targetApp = IS_MAC ? runningAppBundle() : process.execPath
+  // macOS has one installed product path. Build/release/worktree bundles are
+  // artifacts and must never become update targets just because they happen to
+  // be running. Old artifact launches migrate into the stable per-user app.
+  let targetApp = process.execPath
 
-  if (targetApp) {
-    args.push('--relaunch-target', targetApp)
+  if (IS_MAC) {
+    const resolution = resolveMacUpdateTarget(runningAppBundle(), app.getPath('home'))
+
+    if (resolution.ok === false) {
+      const message = 'Update refused because the macOS home directory could not be resolved safely.'
+
+      rememberLog(`[updates] ${message} (${resolution.reason})`)
+      emitUpdateProgress({ stage: 'error', message, percent: null })
+
+      return { ok: false, error: 'invalid-home-directory', message }
+    }
+
+    targetApp = resolution.target
   }
+
+  args.push('--relaunch-target', targetApp)
 
   const relaunchArgs = collectRelaunchArgs(process.argv.slice(1))
 

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -8,6 +8,7 @@ import {
   collectRelaunchArgs,
   MARKER_SELF_ADOPT_EPOCH_MS,
   observeUpdaterHandoff,
+  resolveMacUpdateTarget,
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
@@ -18,6 +19,41 @@ import {
 } from './updater-process'
 
 const DAY_MS = 24 * 60 * 60 * 1000
+
+test('resolveMacUpdateTarget always selects the stable per-user Applications install', () => {
+  const home = '/Users/rohit'
+  const canonical = path.join(home, 'Applications', 'Hermes.app')
+
+  assert.deepEqual(resolveMacUpdateTarget(canonical, home), {
+    ok: true,
+    target: canonical
+  })
+})
+
+test('resolveMacUpdateTarget migrates release, artifact, worktree, and hidden-home copies', () => {
+  const home = '/Users/rohit'
+  const canonical = path.join(home, 'Applications', 'Hermes.app')
+  const unstable = [
+    path.join(home, '.hermes', 'hermes-agent', 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app'),
+    path.join(home, '.claude', 'orchestrate', 'incident', 'artifacts', 'Hermes.app'),
+    path.join(home, 'worktree', 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app')
+  ]
+
+  for (const candidate of unstable) {
+    assert.deepEqual(resolveMacUpdateTarget(candidate, home), { ok: true, target: canonical })
+  }
+})
+
+test('resolveMacUpdateTarget allows first install and rejects a root home', () => {
+  assert.deepEqual(resolveMacUpdateTarget('/tmp/Hermes.app', '/Users/rohit'), {
+    ok: true,
+    target: '/Users/rohit/Applications/Hermes.app'
+  })
+  assert.deepEqual(resolveMacUpdateTarget('/tmp/Hermes.app', '/'), {
+    ok: false,
+    reason: 'invalid-home-directory'
+  })
+})
 
 test('stagedUpdaterSupportsPrewrittenMarker rejects installers predating the self-adopt fix', () => {
   // The real-world trap: an installer staged at first install months ago, never

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -14,6 +14,30 @@ export interface ResolveUpdateScriptHandoffDeps {
   fileExists?: (candidate: string) => boolean
 }
 
+export type MacUpdateTargetResolution =
+  | { ok: true; target: string }
+  | { ok: false; reason: 'invalid-home-directory' }
+
+/**
+ * Resolve the only macOS app bundle the updater may replace.
+ *
+ * Build outputs are artifacts, never installations. A Desktop started from a
+ * checkout, release directory, worktree, or copied artifact still updates into
+ * the stable per-user contract: ~/Applications/Hermes.app. This migration is
+ * what repairs old installs without teaching the updater another transient
+ * path.
+ */
+export function resolveMacUpdateTarget(
+  _runningBundle: string | null,
+  homeDir: string
+): MacUpdateTargetResolution {
+  const resolvedHome = path.resolve(homeDir)
+  if (!resolvedHome || resolvedHome === path.parse(resolvedHome).root) {
+    return { ok: false, reason: 'invalid-home-directory' }
+  }
+  return { ok: true, target: path.join(resolvedHome, 'Applications', 'Hermes.app') }
+}
+
 export interface UpdateScriptHandoff {
   command: string
   args: string[]

--- a/hermes_cli/desktop_install.py
+++ b/hermes_cli/desktop_install.py
@@ -75,7 +75,14 @@ def _production_copy(source: Path, destination: Path) -> None:
 def _remove_owned_bundle(path: Path) -> None:
     if not path.exists() and not path.is_symlink():
         return
-    if path.is_symlink() or not path.is_dir():
+    # These are exact transaction-owned names (installing / rollback, or the
+    # canonical target after a failed final rename). Removing a symlink here
+    # unlinks only the directory entry; it never follows or deletes its target.
+    # This is also how a legacy versioned-app symlink is migrated safely.
+    if path.is_symlink():
+        path.unlink()
+        return
+    if not path.is_dir():
         raise DesktopInstallError(f"refusing to remove unexpected updater path: {path}")
     shutil.rmtree(path)
 
@@ -111,7 +118,7 @@ def install_macos_app(
 
     # Recover a transaction interrupted after the old app moved aside.
     if rollback.exists() and not canonical.exists():
-        if rollback.is_symlink() or not rollback.is_dir():
+        if not rollback.is_symlink() and not rollback.is_dir():
             raise DesktopInstallError(f"refusing unexpected rollback path: {rollback}")
         move(rollback, canonical)
     elif rollback.exists() or rollback.is_symlink():
@@ -131,11 +138,12 @@ def install_macos_app(
         raise DesktopInstallError(f"could not stage Hermes app from {source}") from exc
 
     replaced_existing = canonical.exists()
-    if replaced_existing:
-        if canonical.is_symlink() or not canonical.is_dir():
+    if replaced_existing or canonical.is_symlink():
+        if not canonical.is_symlink() and not canonical.is_dir():
             _remove_owned_bundle(stage)
             raise DesktopInstallError(f"canonical Hermes install is not a real app directory: {canonical}")
         move(canonical, rollback)
+        replaced_existing = True
 
     try:
         move(stage, canonical)

--- a/hermes_cli/desktop_install.py
+++ b/hermes_cli/desktop_install.py
@@ -1,0 +1,196 @@
+"""Stable macOS Hermes Desktop installation contract.
+
+Builds remain disposable artifacts under the source checkout.  The only
+launchable/updateable product install is ``~/Applications/Hermes.app``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import plistlib
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Callable
+
+BUNDLE_ID = "com.nousresearch.hermes"
+
+
+class DesktopInstallError(RuntimeError):
+    """Raised when the stable install cannot be proven safe and complete."""
+
+
+@dataclass(frozen=True)
+class DesktopInstallResult:
+    source: Path
+    target: Path
+    executable: Path
+    replaced_existing: bool
+
+
+def canonical_macos_app(home: Path | None = None) -> Path:
+    """Return the one supported per-user macOS installation path."""
+    resolved_home = Path.home() if home is None else Path(home)
+    return resolved_home.expanduser() / "Applications" / "Hermes.app"
+
+
+def macos_app_executable(app: Path) -> Path:
+    return Path(app) / "Contents" / "MacOS" / "Hermes"
+
+
+def _validate_bundle(app: Path) -> Path:
+    app = Path(app)
+    if app.is_symlink() or not app.is_dir():
+        raise DesktopInstallError(f"Hermes app bundle is missing or is a symlink: {app}")
+    info_path = app / "Contents" / "Info.plist"
+    try:
+        with info_path.open("rb") as stream:
+            info = plistlib.load(stream)
+    except (OSError, plistlib.InvalidFileException) as exc:
+        raise DesktopInstallError(f"Hermes app Info.plist is unreadable: {info_path}") from exc
+    if info.get("CFBundleIdentifier") != BUNDLE_ID:
+        raise DesktopInstallError(
+            f"unexpected bundle identifier in {info_path}: {info.get('CFBundleIdentifier')!r}"
+        )
+    executable_name = info.get("CFBundleExecutable")
+    if executable_name != "Hermes":
+        raise DesktopInstallError(f"unexpected Hermes executable name: {executable_name!r}")
+    executable = macos_app_executable(app)
+    if not executable.is_file() or not os.access(executable, os.X_OK):
+        raise DesktopInstallError(f"Hermes app executable is missing or not executable: {executable}")
+    return executable
+
+
+def _production_copy(source: Path, destination: Path) -> None:
+    ditto = Path("/usr/bin/ditto")
+    if ditto.is_file():
+        subprocess.run([str(ditto), str(source), str(destination)], check=True)
+    else:
+        shutil.copytree(source, destination, copy_function=shutil.copy2)
+
+
+def _remove_owned_bundle(path: Path) -> None:
+    if not path.exists() and not path.is_symlink():
+        return
+    if path.is_symlink() or not path.is_dir():
+        raise DesktopInstallError(f"refusing to remove unexpected updater path: {path}")
+    shutil.rmtree(path)
+
+
+def install_macos_app(
+    source: Path,
+    *,
+    home: Path | None = None,
+    target: Path | None = None,
+    copy_bundle: Callable[[Path, Path], None] = _production_copy,
+    move: Callable[[Path, Path], None] = lambda source, destination: source.rename(destination),
+) -> DesktopInstallResult:
+    """Atomically replace the canonical app bundle, rolling back on failure."""
+    source = Path(source).expanduser()
+    canonical = canonical_macos_app(home)
+    requested_target = canonical if target is None else Path(target).expanduser()
+    if requested_target != canonical:
+        raise DesktopInstallError(f"refusing noncanonical Hermes install target: {requested_target}; expected {canonical}")
+    if canonical.parent.is_symlink():
+        raise DesktopInstallError(f"canonical Applications directory must not be a symlink: {canonical.parent}")
+
+    source_executable = _validate_bundle(source)
+    del source_executable
+    try:
+        if source.resolve(strict=True) == canonical.resolve(strict=False):
+            raise DesktopInstallError("the canonical installed app cannot be used as its own artifact source")
+    except OSError as exc:
+        raise DesktopInstallError(f"cannot resolve Hermes artifact source: {source}") from exc
+
+    canonical.parent.mkdir(parents=True, exist_ok=True)
+    stage = canonical.with_name("Hermes.app.installing")
+    rollback = canonical.with_name("Hermes.app.rollback")
+
+    # Recover a transaction interrupted after the old app moved aside.
+    if rollback.exists() and not canonical.exists():
+        if rollback.is_symlink() or not rollback.is_dir():
+            raise DesktopInstallError(f"refusing unexpected rollback path: {rollback}")
+        move(rollback, canonical)
+    elif rollback.exists() or rollback.is_symlink():
+        _remove_owned_bundle(rollback)
+    _remove_owned_bundle(stage)
+
+    try:
+        copy_bundle(source, stage)
+        _validate_bundle(stage)
+    except Exception as exc:
+        try:
+            _remove_owned_bundle(stage)
+        except Exception:
+            pass
+        if isinstance(exc, DesktopInstallError):
+            raise
+        raise DesktopInstallError(f"could not stage Hermes app from {source}") from exc
+
+    replaced_existing = canonical.exists()
+    if replaced_existing:
+        if canonical.is_symlink() or not canonical.is_dir():
+            _remove_owned_bundle(stage)
+            raise DesktopInstallError(f"canonical Hermes install is not a real app directory: {canonical}")
+        move(canonical, rollback)
+
+    try:
+        move(stage, canonical)
+        executable = _validate_bundle(canonical)
+    except Exception as exc:
+        try:
+            if canonical.exists() or canonical.is_symlink():
+                _remove_owned_bundle(canonical)
+            if replaced_existing and rollback.exists():
+                move(rollback, canonical)
+                _validate_bundle(canonical)
+        except Exception as rollback_exc:
+            raise DesktopInstallError(
+                f"install failed and rollback failed; staged artifact remains at {stage}"
+            ) from rollback_exc
+        try:
+            _remove_owned_bundle(stage)
+        except Exception:
+            pass
+        if replaced_existing:
+            raise DesktopInstallError("install failed; the previous app was restored") from exc
+        raise DesktopInstallError("install failed before the canonical app could be created") from exc
+
+    _remove_owned_bundle(rollback)
+    return DesktopInstallResult(
+        source=source,
+        target=canonical,
+        executable=executable,
+        replaced_existing=replaced_existing,
+    )
+
+
+def _main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Install a Hermes.app artifact at its stable per-user path")
+    parser.add_argument("--source", required=True, type=Path)
+    args = parser.parse_args(argv)
+    try:
+        result = install_macos_app(args.source)
+    except DesktopInstallError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, sort_keys=True))
+        return 1
+    print(
+        json.dumps(
+            {
+                "ok": True,
+                "source": str(result.source),
+                "target": str(result.target),
+                "executable": str(result.executable),
+                "replaced_existing": result.replaced_existing,
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main())

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6995,6 +6995,22 @@ def _write_desktop_build_stamp(project_root: Path, *, source_mode: bool) -> None
         logger.debug("Failed to write desktop build stamp: %s", exc)
 
 
+def _desktop_macos_install_artifact(packaged_executable: Path) -> Path:
+    """Install a built macOS artifact at the one stable per-user app path."""
+    if sys.platform != "darwin":
+        return packaged_executable
+    from hermes_cli.desktop_install import DesktopInstallError, install_macos_app
+
+    artifact_app = packaged_executable.parents[2]
+    try:
+        result = install_macos_app(artifact_app)
+    except DesktopInstallError as exc:
+        print(f"✗ Could not install Hermes Desktop at ~/Applications/Hermes.app: {exc}")
+        raise SystemExit(1) from exc
+    print(f"✓ Hermes Desktop installed: {result.target}")
+    return result.executable
+
+
 def _desktop_packaged_executable(desktop_dir: Path) -> Optional[Path]:
     """Return the current platform's unpacked Electron app executable."""
     release_dir = desktop_dir / "release"
@@ -8612,6 +8628,7 @@ def cmd_gui(args: argparse.Namespace):
         print("  Expected an unpacked Electron app for the current OS.")
         sys.exit(1)
 
+    packaged_executable = _desktop_macos_install_artifact(packaged_executable)
     launch_command = [str(packaged_executable)]
     if not _desktop_linux_sandbox_fixup(packaged_executable):
         if _desktop_linux_needs_no_sandbox() and _desktop_linux_sandbox_helper_is_regular_file(packaged_executable):

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -625,16 +625,21 @@ if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
 fi
 trap 'on_signal TERM' TERM
 
-# Truthful completion: `hermes update` calls a GUI build failure non-fatal
-# (exit 0). For a Desktop-driven update that would relaunch the OLD build
-# and call it success -- retry the build once, propagate honestly.
-if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -q "Desktop build failed"; then
-  log "desktop build failed inside hermes update; retrying build"
+# A successful code update does not prove the release/ app matches the checked
+# out source. In particular, the "Already up to date" path skips the Desktop
+# build check entirely, yet mac_swap would still install whatever stale bundle
+# happened to be under release/. Always drive the content-stamp gate before the
+# install. It is fast when current and rebuilds when stale; one forced retry
+# covers a corrupt/partial artifact without ever shipping it.
+if [ "$CODE" -eq 0 ]; then
   publish_stage "Rebuilding Desktop"
-  "$HERMES_BIN" desktop --force-build --build-only >> "$LOG" 2>&1 || {
-    FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - you are running the previous build. Run hermes desktop --force-build from a terminal to retry."
-    exit 6
-  }
+  if ! "$HERMES_BIN" desktop --build-only >> "$LOG" 2>&1; then
+    log "desktop artifact check/build failed; retrying forced build"
+    "$HERMES_BIN" desktop --force-build --build-only >> "$LOG" 2>&1 || {
+      FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - the installed app was kept. Run hermes desktop --force-build from a terminal to retry."
+      exit 6
+    }
+  fi
 fi
 
 if [ "$CODE" -eq 0 ]; then FINAL_CODE=0 FINAL_MSG="Update complete."

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -327,39 +327,45 @@ linux_gate() {
 }
 
 mac_swap() {
-  local rebuilt="" c
+  local rebuilt="" c canonical="$HOME/Applications/Hermes.app"
   for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
            "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
     [ -d "$c" ] && { rebuilt="$c"; break; }
   done
 
-  # Transactional swap: stage a full copy, move the old bundle aside, move
-  # the copy in. Every step checked; a failed final move ROLLS BACK so the
-  # user always has a launchable app, and the result file tells the truth.
-  if [ "$FINAL_CODE" -eq 0 ] && [ -n "$rebuilt" ] && [ -d "$RELAUNCH_TARGET" ] && [ "$rebuilt" != "$RELAUNCH_TARGET" ]; then
-    publish_stage "Installing the new app"
-    rm -rf "$RELAUNCH_TARGET.new" "$RELAUNCH_TARGET.old" 2>/dev/null || true
-    if ! /usr/bin/ditto "$rebuilt" "$RELAUNCH_TARGET.new"; then
-      rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-      DONE_NOTE="Update complete, but the new app could not be staged; the previous version was kept. Run the update again."
-      log "WARNING: bundle copy failed; keeping existing app"
-    elif ! mv "$RELAUNCH_TARGET" "$RELAUNCH_TARGET.old"; then
-      rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-      DONE_NOTE="Update complete, but the new app could not replace the old one; the previous version was kept. Run the update again."
-      log "WARNING: could not move old bundle aside; keeping existing app"
-    elif ! mv "$RELAUNCH_TARGET.new" "$RELAUNCH_TARGET"; then
-      if mv "$RELAUNCH_TARGET.old" "$RELAUNCH_TARGET"; then
-        rm -rf "$RELAUNCH_TARGET.new" 2>/dev/null || true
-        DONE_NOTE="Update complete, but the new app could not be installed; the previous version was restored. Run the update again."
-        log "WARNING: bundle install failed; rolled back to the previous app"
-      else
-        FINAL_CODE=7 FINAL_MSG="The update finished but installing the new app failed and the previous app could not be restored. Reinstall Hermes (the rebuilt app is at $rebuilt)."
-        log "ERROR: bundle install failed AND rollback failed"
-      fi
-    else
-      rm -rf "$RELAUNCH_TARGET.old" 2>/dev/null || true
-      log "swapped app bundle"
-    fi
+  [ "$FINAL_CODE" -eq 0 ] || return 0
+  if [ "$RELAUNCH_TARGET" != "$canonical" ]; then
+    FINAL_CODE=8
+    FINAL_MSG="Update refused: Hermes must run from the stable install at $canonical; build and artifact copies cannot self-update."
+    log "ERROR: unstable macOS relaunch target refused: $RELAUNCH_TARGET"
+    return 0
+  fi
+  if [ -L "$canonical" ]; then
+    FINAL_CODE=8
+    FINAL_MSG="Update refused: the stable Hermes install is a symlink at $canonical. Run 'hermes desktop' to repair it."
+    log "ERROR: canonical macOS install is symlinked: $canonical"
+    return 0
+  fi
+  if [ -z "$rebuilt" ]; then
+    FINAL_CODE=7
+    FINAL_MSG="The update built no macOS Hermes.app artifact; the installed app was kept."
+    log "ERROR: rebuilt macOS app artifact missing"
+    return 0
+  fi
+  if [ ! -x "$INSTALL_ROOT/venv/bin/python" ]; then
+    FINAL_CODE=7
+    FINAL_MSG="The update could not install the new app because the managed Python runtime is missing; the installed app was kept."
+    log "ERROR: managed Python missing for stable app install"
+    return 0
+  fi
+
+  publish_stage "Installing the new app"
+  if HERMES_HOME="$HERMES_HOME" "$INSTALL_ROOT/venv/bin/python" -m hermes_cli.desktop_install --source "$rebuilt" >>"$LOG" 2>&1; then
+    log "atomically replaced stable app bundle: $canonical"
+  else
+    FINAL_CODE=7
+    FINAL_MSG="The update finished building, but the stable app install failed. The previous app was kept or restored. Run the update again."
+    log "ERROR: stable macOS app install failed"
   fi
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -3629,6 +3629,23 @@ PYEOF
         fi
     fi
 
+    # macOS build output is an artifact, not an application install. First
+    # install and repair atomically publish that artifact to the single stable
+    # per-user product path used by Finder, Dock, `hermes desktop`, and updates.
+    if [ "$OS" = "macos" ]; then
+        local install_python="$INSTALL_DIR/venv/bin/python"
+        if [ ! -x "$install_python" ]; then
+            log_error "Cannot install Hermes Desktop: managed Python is missing at $install_python"
+            return 1
+        fi
+        if ! HERMES_HOME="$HERMES_HOME" "$install_python" -m hermes_cli.desktop_install --source "$app"; then
+            log_error "Could not atomically install Hermes Desktop at ~/Applications/Hermes.app"
+            return 1
+        fi
+        app="$HOME/Applications/Hermes.app"
+        log_success "Desktop app installed: $app"
+    fi
+
     # `npm install` + `npm run pack` rewrite lockfiles; restore them so the
     # checkout stays clean for the next `hermes update`.
     restore_dirty_lockfiles "$INSTALL_DIR"

--- a/tests/hermes_cli/test_desktop_install.py
+++ b/tests/hermes_cli/test_desktop_install.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import plistlib
+import shutil
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from hermes_cli.desktop_install import (
+    DesktopInstallError,
+    canonical_macos_app,
+    install_macos_app,
+    macos_app_executable,
+)
+
+
+def _bundle(root: Path, version: str) -> Path:
+    app = root / "Hermes.app"
+    contents = app / "Contents"
+    executable = contents / "MacOS" / "Hermes"
+    executable.parent.mkdir(parents=True)
+    executable.write_text(version, encoding="utf-8")
+    executable.chmod(0o755)
+    with (contents / "Info.plist").open("wb") as stream:
+        plistlib.dump(
+            {
+                "CFBundleIdentifier": "com.nousresearch.hermes",
+                "CFBundleExecutable": "Hermes",
+                "CFBundleShortVersionString": version,
+            },
+            stream,
+        )
+    return app
+
+
+def _copytree(source: Path, target: Path) -> None:
+    shutil.copytree(source, target)
+
+
+class DesktopInstallContractTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def test_canonical_install_contract_is_per_user_applications(self) -> None:
+        target = canonical_macos_app(self.root)
+        self.assertEqual(target, self.root / "Applications" / "Hermes.app")
+        self.assertEqual(macos_app_executable(target), target / "Contents" / "MacOS" / "Hermes")
+
+    def test_two_updates_replace_one_stable_install_in_place(self) -> None:
+        first = _bundle(self.root / "build-v1", "1")
+        second = _bundle(self.root / "build-v2", "2")
+        target = canonical_macos_app(self.root / "user")
+        dock_url = target.as_uri()
+
+        one = install_macos_app(first, home=self.root / "user", copy_bundle=_copytree)
+        two = install_macos_app(second, home=self.root / "user", copy_bundle=_copytree)
+
+        self.assertEqual(one.target, target)
+        self.assertEqual(two.target, target)
+        self.assertEqual(two.executable.read_text(encoding="utf-8"), "2")
+        self.assertEqual(target.as_uri(), dock_url)
+        self.assertFalse(target.with_name("Hermes.app.installing").exists())
+        self.assertFalse(target.with_name("Hermes.app.rollback").exists())
+
+    def test_failed_second_update_restores_previous_bundle(self) -> None:
+        first = _bundle(self.root / "build-v1", "1")
+        second = _bundle(self.root / "build-v2", "2")
+        home = self.root / "user"
+        target = canonical_macos_app(home)
+        install_macos_app(first, home=home, copy_bundle=_copytree)
+        calls = 0
+
+        def fail_new_bundle(source: Path, destination: Path) -> None:
+            nonlocal calls
+            calls += 1
+            if calls == 2:
+                raise OSError("simulated final rename failure")
+            source.rename(destination)
+
+        with self.assertRaisesRegex(DesktopInstallError, "previous app was restored"):
+            install_macos_app(second, home=home, copy_bundle=_copytree, move=fail_new_bundle)
+
+        self.assertEqual(macos_app_executable(target).read_text(encoding="utf-8"), "1")
+
+    def test_refuses_noncanonical_target_and_source_alias(self) -> None:
+        source = _bundle(self.root / "release", "1")
+        home = self.root / "user"
+
+        with self.assertRaisesRegex(DesktopInstallError, "canonical"):
+            install_macos_app(
+                source,
+                home=home,
+                target=self.root / ".hermes" / "Hermes.app",
+                copy_bundle=_copytree,
+            )
+
+        canonical = canonical_macos_app(home)
+        canonical.parent.mkdir(parents=True)
+        shutil.copytree(source, canonical)
+        with self.assertRaisesRegex(DesktopInstallError, "artifact source"):
+            install_macos_app(canonical, home=home, copy_bundle=_copytree)
+
+    def test_refuses_wrong_bundle_identity(self) -> None:
+        source = _bundle(self.root / "release", "1")
+        info = source / "Contents" / "Info.plist"
+        with info.open("wb") as stream:
+            plistlib.dump(
+                {"CFBundleIdentifier": "example.not-hermes", "CFBundleExecutable": "Hermes"},
+                stream,
+            )
+
+        with self.assertRaisesRegex(DesktopInstallError, "bundle identifier"):
+            install_macos_app(source, home=self.root / "user", copy_bundle=_copytree)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_desktop_install.py
+++ b/tests/hermes_cli/test_desktop_install.py
@@ -104,6 +104,23 @@ class DesktopInstallContractTests(unittest.TestCase):
         with self.assertRaisesRegex(DesktopInstallError, "artifact source"):
             install_macos_app(canonical, home=home, copy_bundle=_copytree)
 
+    def test_migrates_legacy_versioned_app_symlink_without_deleting_target(self) -> None:
+        source = _bundle(self.root / "release", "2")
+        home = self.root / "user"
+        applications = home / "Applications"
+        legacy_staged = _bundle(self.root / "legacy", "1")
+        applications.mkdir(parents=True)
+        legacy = applications / "Hermes-0.17.0-old.app"
+        legacy_staged.rename(legacy)
+        canonical = canonical_macos_app(home)
+        canonical.symlink_to(legacy.name)
+
+        result = install_macos_app(source, home=home, copy_bundle=_copytree)
+
+        self.assertFalse(canonical.is_symlink())
+        self.assertEqual(result.executable.read_text(encoding="utf-8"), "2")
+        self.assertEqual(macos_app_executable(legacy).read_text(encoding="utf-8"), "1")
+
     def test_refuses_wrong_bundle_identity(self) -> None:
         source = _bundle(self.root / "release", "1")
         info = source / "Contents" / "Info.plist"

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -32,6 +32,12 @@ def _isolate_xdg_data_home(tmp_path, monkeypatch):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_macos_product_install(monkeypatch):
+    """Unit tests exercise launch wiring without writing ~/Applications."""
+    monkeypatch.setattr(cli_main, "_desktop_macos_install_artifact", lambda executable: executable)
+
+
+@pytest.fixture(autouse=True)
 def _stable_keychain_detection(monkeypatch):
     """Pin Linux keychain detection to the fast GNOME env path.
 

--- a/tests/test_desktop_update_posix_build_gate.py
+++ b/tests/test_desktop_update_posix_build_gate.py
@@ -1,0 +1,17 @@
+"""Ordering contract for the POSIX Desktop self-update handoff."""
+
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "desktop-update" / "posix.sh"
+
+
+def test_success_always_proves_desktop_artifact_before_install() -> None:
+    """Even an already-current checkout must not install a stale release app."""
+    source = SCRIPT.read_text(encoding="utf-8")
+    update = source.index('OUT="$("$HERMES_BIN" update')
+    build_gate = source.index('"$HERMES_BIN" desktop --build-only', update)
+    finish_trigger = source.index('exit "$FINAL_CODE"', build_gate)
+
+    assert update < build_gate < finish_trigger
+    assert '"$HERMES_BIN" desktop --force-build --build-only' in source[build_gate:finish_trigger]


### PR DESCRIPTION
## Summary
- install macOS Desktop builds atomically at `~/Applications/Hermes.app`
- make CLI install, repair, Desktop self-update, and Setup updater converge on that path
- keep release/worktree bundles as build artifacts only
- preserve the installed path across repeated updates with rollback on failed replacement

## Verification
- Electron updater target tests: 29 passed
- Python desktop install and launcher tests: 47 passed, 8 skipped
- Rust Setup updater target test: passed
- Desktop TypeScript typecheck: passed
- shell syntax and diff checks: passed