### PR TITLE
fix(desktop): scope composer reasoning-effort/fast-mode by connection+profile

### DIFF
--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -22,8 +22,10 @@ import {
   $activeSessionId,
   $connection,
   $currentCwd,
+  $currentFastMode,
   $currentModel,
   $currentProvider,
+  $currentReasoningEffort,
   $selectedStoredSessionId,
   $sessions,
   $unreadFinishedSessionIds,
@@ -52,9 +54,11 @@ import {
   setConnection,
   setCurrentCwd,
   setCurrentCwdTransient,
+  setCurrentFastMode,
   setCurrentModel,
   setCurrentModelSource,
   setCurrentProvider,
+  setCurrentReasoningEffort,
   setRememberedRoute,
   setRememberedSessionId,
   setSelectedStoredSessionId,
@@ -82,6 +86,8 @@ describe('composer model persistence scope', () => {
     setCurrentModel('')
     setCurrentProvider('')
     setCurrentModelSource('')
+    setCurrentReasoningEffort('')
+    setCurrentFastMode(false)
   })
 
   afterEach(() => {
@@ -97,31 +103,46 @@ describe('composer model persistence scope', () => {
     setCurrentModel('grok-4')
     setCurrentProvider('xai-oauth')
     setCurrentModelSource('manual')
+    setCurrentReasoningEffort('high')
+    setCurrentFastMode(true)
 
     setConnection(remote('fred-work'))
     expect($currentModel.get()).toBe('')
     expect($currentProvider.get()).toBe('')
+    expect($currentReasoningEffort.get()).toBe('')
+    expect($currentFastMode.get()).toBe(false)
 
     setCurrentModel('local/model')
     setCurrentProvider('custom:local')
+    setCurrentReasoningEffort('low')
+    setCurrentFastMode(false)
     setConnection(remote('fred'))
 
     expect($currentModel.get()).toBe('grok-4')
     expect($currentProvider.get()).toBe('xai-oauth')
+    expect($currentReasoningEffort.get()).toBe('high')
+    expect($currentFastMode.get()).toBe(true)
   })
 
   it('keeps inferred local-primary connections on the historical bare keys', () => {
     setComposerSelectionOwner('remote', 'default')
     window.localStorage.setItem('hermes.desktop.composer.model', 'legacy-model')
     window.localStorage.setItem('hermes.desktop.composer.provider', 'legacy-provider')
+    window.localStorage.setItem('hermes.desktop.composer.reasoning-effort', 'medium')
+    window.localStorage.setItem('hermes.desktop.composer.fast', 'true')
 
     setConnection({ baseUrl: '', connectionId: 'local', mode: 'local', profile: 'default' } as never)
 
     expect($currentModel.get()).toBe('legacy-model')
     expect($currentProvider.get()).toBe('legacy-provider')
+    expect($currentReasoningEffort.get()).toBe('medium')
+    expect($currentFastMode.get()).toBe(true)
     setCurrentModel('next-model')
+    setCurrentReasoningEffort('next-effort')
     expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('next-model')
     expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBeNull()
+    expect(window.localStorage.getItem('hermes.desktop.composer.reasoning-effort')).toBe('next-effort')
+    expect(window.localStorage.getItem('hermes.desktop.composer.reasoning-effort.registry.local.default')).toBeNull()
   })
 
   it('uses the live registry owner when the connection descriptor is stale', () => {
@@ -132,6 +153,8 @@ describe('composer model persistence scope', () => {
     setCurrentModel('grok-4')
     setCurrentProvider('xai-oauth')
     setCurrentModelSource('manual')
+    setCurrentReasoningEffort('high')
+    setCurrentFastMode(true)
 
     // ensureGatewayAgent publishes this coordinate even if getConnectionFor
     // fails and $connection therefore still describes fred.
@@ -139,14 +162,20 @@ describe('composer model persistence scope', () => {
     setCurrentModel('local/model')
     setCurrentProvider('custom:local')
     setCurrentModelSource('default')
+    setCurrentReasoningEffort('low')
+    setCurrentFastMode(false)
 
     setComposerSelectionOwner('aibox', 'fred')
     expect($currentModel.get()).toBe('grok-4')
     expect($currentProvider.get()).toBe('xai-oauth')
+    expect($currentReasoningEffort.get()).toBe('high')
+    expect($currentFastMode.get()).toBe(true)
 
     setComposerSelectionOwner('aibox', 'fred-work')
     expect($currentModel.get()).toBe('local/model')
     expect($currentProvider.get()).toBe('custom:local')
+    expect($currentReasoningEffort.get()).toBe('low')
+    expect($currentFastMode.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -69,6 +69,12 @@ function storedComposerString(base: string): string | null {
   return key === null ? null : storedString(key)
 }
 
+function storedComposerBoolean(base: string, fallback: boolean): boolean {
+  const key = composerSelectionKey(base)
+
+  return key === null ? fallback : storedBoolean(key, fallback)
+}
+
 // The last chat the user had open, so a relaunch lands back on it instead of an
 // empty new-chat. Stored (not runtime) id — the route is keyed by stored id.
 //
@@ -990,9 +996,9 @@ export function getSessionOwnerHint(
 export const $resumeExhaustedSessionId = atom<string | null>(null)
 export const $currentModel = atom(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
 export const $currentProvider = atom(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
-export const $currentReasoningEffort = atom(storedString(COMPOSER_EFFORT_KEY) ?? '')
+export const $currentReasoningEffort = atom(storedComposerString(COMPOSER_EFFORT_KEY) ?? '')
 export const $currentServiceTier = atom('')
-export const $currentFastMode = atom(storedBoolean(COMPOSER_FAST_KEY, false))
+export const $currentFastMode = atom(storedComposerBoolean(COMPOSER_FAST_KEY, false))
 // Effective approval-bypass state mirrored from the gateway (session.info).
 // Persistence lives in the backend config (approvals.mode), so this is a plain
 // reflection of the truth the gateway reports rather than its own store.
@@ -1054,6 +1060,11 @@ function rescopeComposerSelection(nextScope: string | null): void {
   $currentModel.set(storedComposerString(COMPOSER_MODEL_KEY) ?? '')
   $currentProvider.set(storedComposerString(COMPOSER_PROVIDER_KEY) ?? '')
   $currentModelSource.set(getCurrentModelSource())
+  // Same cross-connection leak model/provider/source were scoped against:
+  // a reasoning-effort or fast-mode pick on one remote connection+profile
+  // must not ride into a brand-new chat on a different one.
+  $currentReasoningEffort.set(storedComposerString(COMPOSER_EFFORT_KEY) ?? '')
+  $currentFastMode.set(storedComposerBoolean(COMPOSER_FAST_KEY, false))
 }
 
 /** Publish an exact registry route before active-profile effects can persist a
@@ -1255,7 +1266,11 @@ export const markComposerSelectionManual = (): void => {
 
 export const setCurrentReasoningEffort = (next: Updater<string>) => {
   updateAtom($currentReasoningEffort, next)
-  persistString(COMPOSER_EFFORT_KEY, $currentReasoningEffort.get() || null)
+  const key = composerSelectionKey(COMPOSER_EFFORT_KEY)
+
+  if (key !== null) {
+    persistString(key, $currentReasoningEffort.get() || null)
+  }
 }
 
 // The profile's `agent.reasoning_effort`, mirrored from config so surfaces that
@@ -1270,7 +1285,11 @@ export const setCurrentServiceTier = (next: Updater<string>) => updateAtom($curr
 
 export const setCurrentFastMode = (next: Updater<boolean>) => {
   updateAtom($currentFastMode, next)
-  persistBoolean(COMPOSER_FAST_KEY, $currentFastMode.get())
+  const key = composerSelectionKey(COMPOSER_FAST_KEY)
+
+  if (key !== null) {
+    persistBoolean(key, $currentFastMode.get())
+  }
 }
 
 export const setYoloActive = (next: Updater<boolean>) => updateAtom($yoloActive, next)


### PR DESCRIPTION
## Summary
`$currentModel`/`$currentProvider`/`$currentModelSource` are scoped to the remote (connection, profile) owner via `composerSelectionKey()` so a pick on one profile cannot contaminate another's `session.create`. `$currentReasoningEffort`/`$currentFastMode` are seeded and persisted identically as sticky composer defaults — `session-view.tsx`'s `PRIMARY_SESSION_VIEW` and `use-session-actions/index.ts`'s new-session `selection` treat all four fields the same way — but they were left on the historical bare, unscoped localStorage keys (`storedString`/`persistString`/`storedBoolean`/`persistBoolean` instead of the scoped `storedComposerString`/`composerSelectionKey` helpers). `rescopeComposerSelection()` also never reseeded either atom on a connection/profile switch — only model/provider/source were re-read from the new scope.

**Net effect:** a reasoning-effort or fast-mode pick made on one remote connection+profile rides into a brand-new chat on a different connection+profile, while model/provider correctly reset to empty.

## Related PR (complementary, not overlapping)
#98002 (open) addresses a different mechanism in the same area: whether a *non-manual* mirrored `reasoning_effort` should be sent as a `session.create` override at all, gated on `getCurrentModelSource() === 'manual'`. It explicitly does not touch `fast` ("a deliberate contract... worth a separate look") and doesn't touch the persistence-scoping mechanism in `store/session.ts` — this PR's diff has zero file overlap with it. Even after #98002 lands, a *manually* picked effort/fast value on connection A can still leak into connection B's composer state under the current bare-key persistence, since `modelSource` correctly resets per-scope while the effort/fast *value* itself does not. This PR fixes the underlying value-scoping for both fields; #98002 remains a useful, independent fix for the "never manually picked" send-time case.

## Fix
- Added `storedComposerBoolean()`, the boolean counterpart to the existing `storedComposerString()`.
- Scoped `$currentReasoningEffort`/`$currentFastMode`'s initial seed, their setters (`setCurrentReasoningEffort`/`setCurrentFastMode`), and their reseed in `rescopeComposerSelection()` through `composerSelectionKey()` — mirroring `$currentModel`/`$currentProvider` exactly, including the "local/single-backend users keep the historical bare keys" fallback (`composerSelectionKey()` returns the base key unchanged when scope is `''`).

## Test plan
- [x] Extended the existing `composer model persistence scope` suite in `session.test.ts` (all 3 tests) with reasoning-effort/fast-mode assertions alongside the existing model/provider ones, covering: cross-connection isolation, the legacy bare-key fallback for local/single-backend connections, and the stale-descriptor registry-owner path
- [x] Mutation-verify: reverting `session.ts` makes exactly the 3 new assertion blocks fail (91/94 tests still pass) as expected
- [x] `npx vitest run` on `session.test.ts`, `profile-agent-activation.test.ts`, `session-view.test.ts`, `use-session-actions.test.tsx`: 200 passed
- [x] `npx tsc --noEmit -p tsconfig.json`: clean