### PR TITLE
feat(security): gate docker escape verbs, s6 primitives, and bare kill 1

### DIFF
--- a/tests/tools/test_container_escape_patterns.py
+++ b/tests/tools/test_container_escape_patterns.py
@@ -45,9 +45,42 @@ class TestDockerEscapeVerbs:
             is_dangerous, _key, _description = detect_dangerous_command(cmd)
             assert is_dangerous is True, cmd
 
+    def test_compose_spellings_detected(self):
+        # `docker compose exec` / legacy `docker-compose exec` reach the same
+        # root shell in another container as the plain `docker exec`.
+        for cmd in (
+            "docker compose exec forge sh",
+            "docker-compose exec forge sh",
+            "docker compose run --rm x",
+            "docker-compose cp forge:/etc/shadow /tmp/shadow",
+        ):
+            is_dangerous, _key, description = detect_dangerous_command(cmd)
+            assert is_dangerous is True, cmd
+            assert ESCAPE_KEY in description, cmd
+
+    def test_global_flags_before_verb_detected(self):
+        # Global flags between `docker`/`compose` and the verb must not let
+        # the verb slip past (same shape the lifecycle rules tolerate).
+        for cmd in (
+            "docker --log-level debug exec forge sh",
+            "docker compose -f prod.yml run --rm x",
+            "docker compose --project-name p -f prod.yml exec forge sh",
+            "docker --config /tmp/cfg cp forge:/etc/shadow /tmp/shadow",
+        ):
+            is_dangerous, _key, description = detect_dangerous_command(cmd)
+            assert is_dangerous is True, cmd
+            assert ESCAPE_KEY in description, cmd
+
     def test_readonly_docker_verbs_not_detected(self):
         for cmd in ("docker ps", "docker logs web", "docker inspect web",
-                    "docker images"):
+                    "docker images", "docker logs x"):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is False, cmd
+
+    def test_readonly_compose_verbs_not_detected(self):
+        for cmd in ("docker compose ps", "docker compose logs",
+                    "docker-compose ps", "docker compose -f prod.yml ps",
+                    "docker --log-level debug ps"):
             is_dangerous, _key, _description = detect_dangerous_command(cmd)
             assert is_dangerous is False, cmd
 
@@ -59,8 +92,16 @@ class TestS6Primitives:
         assert is_dangerous is True
         assert "s6-svc" in description
 
+    def test_s6_svc_once_down_flag_detected(self):
+        # `-o` (once-down: bring up, don't restart when it exits) is a down
+        # flag too and must not slip through the class.
+        is_dangerous, _key, description = detect_dangerous_command(
+            "s6-svc -o /run/service/main-hermes")
+        assert is_dangerous is True
+        assert "s6-svc" in description
+
     def test_s6_svc_signal_flags_detected(self):
-        for flag in ("-t", "-k", "-h", "-i", "-q", "-p", "-r"):
+        for flag in ("-o", "-t", "-k", "-h", "-i", "-q", "-p", "-r"):
             is_dangerous, _key, _description = detect_dangerous_command(
                 f"s6-svc {flag} /run/service/main-hermes")
             assert is_dangerous is True, flag
@@ -80,7 +121,11 @@ class TestS6Primitives:
 
     def test_readonly_s6_siblings_not_detected(self):
         for cmd in ("s6-svstat /run/service/main-hermes",
-                    "s6-svwait -u /run/service/main-hermes"):
+                    "s6-svwait -u /run/service/main-hermes",
+                    "s6-svstat /run/service/x",
+                    "s6-svwait -u /run/service/x",
+                    # -d/-o only count as s6-svc flags, not on the siblings
+                    "s6-svwait -d /run/service/x"):
             is_dangerous, _key, _description = detect_dangerous_command(cmd)
             assert is_dangerous is False, cmd
 
@@ -97,6 +142,6 @@ class TestKillPidOne:
             assert is_dangerous is True, cmd
 
     def test_kill_of_ordinary_pids_not_detected(self):
-        for cmd in ("kill 1234", "kill -9 4321", "kill 12"):
+        for cmd in ("kill 1234", "kill -9 4321", "kill 12", "killall foo"):
             is_dangerous, _key, _description = detect_dangerous_command(cmd)
             assert is_dangerous is False, cmd

--- a/tests/tools/test_container_escape_patterns.py
+++ b/tests/tools/test_container_escape_patterns.py
@@ -1,0 +1,102 @@
+"""Tests for the container-escape / supervisor-primitive DANGEROUS_PATTERNS.
+
+Covers the three rule groups added for containerized gateway deployments
+that mount docker.sock read-write:
+
+- ``docker exec|run|cp|create|commit|start`` — cross-container escape verbs
+  (root in the target container); read-only verbs stay auto-approved.
+- ``s6-svc`` down/signal flags and ``s6-svscanctl`` — reaching past the
+  gated wrapper spellings (``hermes gateway stop``, ``docker compose
+  restart`` …) straight to the s6 supervision primitives.
+- bare ``kill 1`` — signaling the container's init/supervision tree; the
+  HARDLINE ``kill -1`` rule requires a leading dash and does not match it.
+"""
+
+from tools.approval import detect_dangerous_command
+
+
+ESCAPE_KEY = "cross-container / container escape"
+
+
+class TestDockerEscapeVerbs:
+    def test_docker_exec_detected(self):
+        is_dangerous, _key, description = detect_dangerous_command(
+            "docker exec other-container sh")
+        assert is_dangerous is True
+        assert ESCAPE_KEY in description
+
+    def test_docker_run_with_root_mount_detected(self):
+        is_dangerous, _key, description = detect_dangerous_command(
+            "docker run -v /:/host -it alpine sh")
+        assert is_dangerous is True
+        assert ESCAPE_KEY in description
+
+    def test_docker_cp_detected(self):
+        is_dangerous, _key, _description = detect_dangerous_command(
+            "docker cp web:/etc/shadow /tmp/shadow")
+        assert is_dangerous is True
+
+    def test_docker_create_commit_start_detected(self):
+        for cmd in (
+            "docker create --name x alpine",
+            "docker commit web evil:latest",
+            "docker start web",
+        ):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is True, cmd
+
+    def test_readonly_docker_verbs_not_detected(self):
+        for cmd in ("docker ps", "docker logs web", "docker inspect web",
+                    "docker images"):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is False, cmd
+
+
+class TestS6Primitives:
+    def test_s6_svc_down_flag_detected(self):
+        is_dangerous, _key, description = detect_dangerous_command(
+            "s6-svc -d /run/service/main-hermes")
+        assert is_dangerous is True
+        assert "s6-svc" in description
+
+    def test_s6_svc_signal_flags_detected(self):
+        for flag in ("-t", "-k", "-h", "-i", "-q", "-p", "-r"):
+            is_dangerous, _key, _description = detect_dangerous_command(
+                f"s6-svc {flag} /run/service/main-hermes")
+            assert is_dangerous is True, flag
+
+    def test_s6_svc_via_docker_exec_wrapper_detected(self):
+        # Detection runs over the full command string, so the wrapper
+        # spelling is covered without its own rule.
+        is_dangerous, _key, _description = detect_dangerous_command(
+            "docker exec hermes s6-svc -d /run/service/main-hermes")
+        assert is_dangerous is True
+
+    def test_s6_svscanctl_detected(self):
+        is_dangerous, _key, description = detect_dangerous_command(
+            "s6-svscanctl -h /run/service")
+        assert is_dangerous is True
+        assert "s6-svscanctl" in description
+
+    def test_readonly_s6_siblings_not_detected(self):
+        for cmd in ("s6-svstat /run/service/main-hermes",
+                    "s6-svwait -u /run/service/main-hermes"):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is False, cmd
+
+
+class TestKillPidOne:
+    def test_bare_kill_1_detected(self):
+        is_dangerous, _key, description = detect_dangerous_command("kill 1")
+        assert is_dangerous is True
+        assert "PID 1" in description
+
+    def test_kill_with_signal_flag_then_1_detected(self):
+        for cmd in ("kill -9 1", "kill -TERM 1", "kill -s KILL 1"):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is True, cmd
+
+    def test_kill_of_ordinary_pids_not_detected(self):
+        for cmd in ("kill 1234", "kill -9 4321", "kill 12"):
+            is_dangerous, _key, _description = detect_dangerous_command(cmd)
+            assert is_dangerous is False, cmd

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1140,7 +1140,13 @@ DANGEROUS_PATTERNS = [
     # the same escape shape (spin up or hijack a container, or move data
     # in/out of one). Read-only verbs (`ps`, `logs`, `inspect`, `images`,
     # ...) are not in this alternation and stay auto-approved.
-    (r'\bdocker\s+(exec|run|cp|create|commit|start)\b', "docker exec/run/cp/create/commit/start (cross-container / container escape — root in the target container)"),
+    # `docker compose exec <svc> sh` and legacy `docker-compose exec` are the
+    # same escape, and global flags may sit between `docker`/`compose` and
+    # the verb (`docker --log-level debug exec ...`, `docker compose -f
+    # prod.yml run ...`), so mirror the lifecycle rules above: optional
+    # compose spelling, the same interleaved-flag loop, then the verb.
+    (r'\bdocker(?:-compose|\s+compose)?\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(exec|run|cp|create|commit|start)\b',
+     "docker exec/run/cp/create/commit/start (cross-container / container escape — root in the target container)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
@@ -1190,7 +1196,7 @@ DANGEROUS_PATTERNS = [
     # combos). s6-svc is write-only by design, so gating the whole command
     # unconditionally is safe; the read-only s6-svstat/s6-svwait siblings do
     # not share the "s6-svc" token and are unaffected.
-    (r'\bs6-svc\b.*\s-[a-z0-9]*[dtkhiqrp]', "s6-svc down/signal flag (supervised service lifecycle)"),
+    (r'\bs6-svc\b.*\s-[a-z0-9]*[dtkhioqrp]', "s6-svc down/signal flag (supervised service lifecycle)"),
     # s6-svscanctl controls the whole supervision tree (rescan/halt/reload),
     # i.e. every supervised process at once — always gate it.
     (r'\bs6-svscanctl\b', "s6-svscanctl (supervision-tree control)"),

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1132,6 +1132,15 @@ DANGEROUS_PATTERNS = [
      "docker compose restart/stop/kill/down (container lifecycle)"),
     (r'\bdocker\s+(?:-{1,2}\S+(?:[=\s]\S+)?\s+)*(restart|stop|kill)\b',
      "docker restart/stop/kill (container lifecycle)"),
+
+    # Cross-container exec / container escape: any user with docker.sock
+    # mounted can `docker exec <other-container> ...` and land as root
+    # inside a container it doesn't own (e.g. the gateway execing into the
+    # separate Forge container). `run`/`cp`/`create`/`commit`/`start` carry
+    # the same escape shape (spin up or hijack a container, or move data
+    # in/out of one). Read-only verbs (`ps`, `logs`, `inspect`, `images`,
+    # ...) are not in this alternation and stay auto-approved.
+    (r'\bdocker\s+(exec|run|cp|create|commit|start)\b', "docker exec/run/cp/create/commit/start (cross-container / container escape — root in the target container)"),
     # Gateway protection: never start gateway outside systemd management
     (r'gateway\s+run\b.*(&\s*$|&\s*;|\bdisown\b|\bsetsid\b)', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
@@ -1165,6 +1174,30 @@ DANGEROUS_PATTERNS = [
     # that's the correct direction to err: an extra approval prompt is
     # cheap, a missed one took down the whole gateway fleet.
     (r'(?=[\s\S]*\blaunchctl\s+(?:stop|kickstart|bootout|unload|kill|disable|remove)\b)(?=[\s\S]*\b(?:hermes|ai\.hermes)\b)', "stop/restart hermes launchd service (kills running agents)"),
+    # Supervisor-primitive protection: the container gateway runs under an
+    # s6 supervision tree (PID 1 = s6 /init). The patterns above gate
+    # `hermes gateway stop|restart`, `docker compose restart/stop/kill/down`,
+    # and `pkill/killall hermes` — but the agent can reach straight past all
+    # of them to the underlying s6 primitives (or signal PID 1 directly) and
+    # produce the identical effect: the gateway dies and every in-flight
+    # agent turn is killed with it. Target the EFFECT/primitive rather than
+    # enumerating wrapper spellings, so this also covers a
+    # `docker exec hermes s6-svc ...` wrapper for free (detection runs over
+    # the full command string). See the 2026-07-12 crash-loop-guard audit.
+    #
+    # s6-svc's down/signal flags (-d down, -o once-down, -t SIGTERM,
+    # -k SIGKILL, -h SIGHUP, -i SIGINT, -q SIGQUIT, -p SIGSTOP, -r restart-ish
+    # combos). s6-svc is write-only by design, so gating the whole command
+    # unconditionally is safe; the read-only s6-svstat/s6-svwait siblings do
+    # not share the "s6-svc" token and are unaffected.
+    (r'\bs6-svc\b.*\s-[a-z0-9]*[dtkhiqrp]', "s6-svc down/signal flag (supervised service lifecycle)"),
+    # s6-svscanctl controls the whole supervision tree (rescan/halt/reload),
+    # i.e. every supervised process at once — always gate it.
+    (r'\bs6-svscanctl\b', "s6-svscanctl (supervision-tree control)"),
+    # Signaling PID 1 tears down the container's s6 /init and everything
+    # under it. The existing HARDLINE `kill -1` pattern requires a leading
+    # dash and does not match this bare-PID form, so it needs its own rule.
+    (r'\bkill\b\s+(-[^\s]+\s+)*1\b', "kill PID 1 (container init/supervision tree)"),
     # File copy/move/edit into sensitive system paths (/etc/ and macOS
     # /private/etc/ mirror).
     (rf'\b(cp|mv|install)\b.*\s{_SYSTEM_CONFIG_PATH}', "copy/move file into system config path"),


### PR DESCRIPTION
## What does this PR do?

Containerized gateway deployments commonly mount `docker.sock` read-write so the agent can manage sibling services. `DANGEROUS_PATTERNS` gates the docker lifecycle verbs (`restart`/`stop`/`kill`, `compose down`) but not the **escape shapes**: `docker exec <other-container> …` lands as root inside a container the agent doesn't own, and `run`/`cp`/`create`/`commit`/`start` carry the same shape (spin up or hijack a container, or move data in/out of one). Read-only verbs (`ps`, `logs`, `inspect`, `images`, …) are not in the alternation and stay auto-approved.

The same deployments run under an s6 supervision tree, where the agent can reach past the gated wrapper spellings (`hermes gateway stop`, `docker compose restart`, `pkill hermes`) straight to the primitives with the identical effect — the gateway dies and every in-flight turn dies with it:

- `s6-svc` with a down/signal flag (`-d`, `-t`, `-k`, …) — s6-svc is write-only by design, so gating it is safe; the read-only `s6-svstat`/`s6-svwait` siblings don't share the token and are unaffected.
- `s6-svscanctl` — controls the whole supervision tree, always gated.
- bare `kill 1` — the HARDLINE `kill -1` rule requires a leading dash and does not match the bare-PID form.

Detection runs over the full command string, so wrapper forms like `docker exec hermes s6-svc -d …` are covered without extra rules.

This has been running in a production containerized gateway deployment since July; the prompts fire on the escape verbs and stay quiet on read-only ones (`hermes approvals test` verified: `docker exec …` / `kill 1` → ask-approval, `docker ps` / `ls` → allow).

## Related Issue

No existing issue — found while hardening a self-hosted containerized deployment (docker.sock mounted rw). Searched open and closed PRs/issues for duplicates; none found.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `tools/approval.py` — three new `DANGEROUS_PATTERNS` groups: docker cross-container verbs, s6 primitives (`s6-svc` signal flags, `s6-svscanctl`), bare `kill 1`
- `tests/tools/test_container_escape_patterns.py` — new; covers every new pattern plus read-only negatives (`docker ps/logs/inspect/images`, `s6-svstat`, `s6-svwait`, `kill <ordinary pid>`)

## How to Test

1. `pytest tests/tools/test_container_escape_patterns.py -q` — 13 tests, all new patterns + negatives
2. `pytest tests/tools/ -q` (approval suite: `test_command_guards.py test_approval_deny_rules.py test_hardline_blocklist.py test_yolo_mode.py` + the new file) — 320 passed, no regressions
3. Live: `hermes approvals test "docker exec other sh"` → ask-approval; `hermes approvals test "docker ps"` → allow

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the approval-related test files (`tests/tools/`, 320 passed); 4 unrelated files in that dir fail collection on my machine for pre-existing reasons (`CreateMessageResultWithTools` import, Windows `PosixPath`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (test suite) + Debian 13 container (production deployment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (pattern descriptions are self-documenting in the approval prompt)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — patterns are platform-neutral regexes; docker/s6 shapes only occur where those tools exist
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A