### PR TITLE
feat(agent): absolute wall-clock cap on streaming calls (HERMES_STREAM_MAX_SECONDS)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -5268,139 +5268,204 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
     t.start()
     _last_heartbeat = time.time()
     _HEARTBEAT_INTERVAL = 30.0  # seconds between gateway activity touches
-    while t.is_alive():
-        t.join(timeout=0.3)
+    # F2 (#gwfix-F2): absolute per-call wall-clock cap, independent of chunk
+    # timing.  The 180s stale detector only measures the gap since the LAST
+    # chunk, so a socket that returns headers then blocks forever, or a stream
+    # that dribbles one chunk every ~170s, never trips it and the call can run
+    # unbounded (the incident).  _call_start is the true call start and is
+    # NEVER reset (unlike last_chunk_time, which the stale branch resets on
+    # each kill).  When the cap is hit we force-close the client EXACTLY like
+    # the stale branch — we do NOT raise here.  This is the caller thread; a
+    # raise would bypass the worker's retry/fallback and the partial-stream
+    # recovery below.  Force-close makes the blocked worker's `for chunk in
+    # stream` raise; the worker records it in result["error"] and exits, the
+    # loop ends, and `raise result["error"]` / the length-stub recovery below
+    # handle it — landing in the existing retry/fallback path.
+    _call_start = time.time()
+    _stream_abs_timeout = env_float("HERMES_STREAM_MAX_SECONDS", 900.0)
+    _abs_cap_fired = False
+    logger.info(
+        "stream watchdog armed: stale=%.0fs abs=%.0fs model=%s",
+        _stream_stale_timeout, _stream_abs_timeout,
+        api_kwargs.get("model", "unknown"),
+    )
+    try:
+        while t.is_alive():
+            t.join(timeout=0.3)
 
-        # Periodic heartbeat: touch the agent's activity tracker so the
-        # gateway's inactivity monitor knows we're alive while waiting
-        # for stream chunks.  Without this, long thinking pauses (e.g.
-        # reasoning models) or slow prefill on local providers (Ollama)
-        # trigger false inactivity timeouts.  The _call thread touches
-        # activity on each chunk, but the gap between API call start
-        # and first chunk can exceed the gateway timeout — especially
-        # when the stale-stream timeout is disabled (local providers).
-        _hb_now = time.time()
-        if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
-            _last_heartbeat = _hb_now
-            _waiting_secs = int(_hb_now - last_chunk_time["t"])
-            if _waiting_secs >= _HEARTBEAT_INTERVAL:
-                # No chunks for 30s+ — rewrite the live spinner/status line
-                # so CLI/TUI/Desktop users see WHAT the wait is (slow or
-                # overloaded provider / long thinking pause) instead of an
-                # unexplained generic spinner, and WHEN recovery kicks in.
-                if (
-                    _stream_stale_timeout is not None
-                    and _stream_stale_timeout != float("inf")
-                ):
-                    _recovery = f"; auto-reconnect at {int(_stream_stale_timeout)}s"
+            # Periodic heartbeat: touch the agent's activity tracker so the
+            # gateway's inactivity monitor knows we're alive while waiting
+            # for stream chunks.  Without this, long thinking pauses (e.g.
+            # reasoning models) or slow prefill on local providers (Ollama)
+            # trigger false inactivity timeouts.  The _call thread touches
+            # activity on each chunk, but the gap between API call start
+            # and first chunk can exceed the gateway timeout — especially
+            # when the stale-stream timeout is disabled (local providers).
+            _hb_now = time.time()
+            if _hb_now - _last_heartbeat >= _HEARTBEAT_INTERVAL:
+                _last_heartbeat = _hb_now
+                _waiting_secs = int(_hb_now - last_chunk_time["t"])
+                if _waiting_secs >= _HEARTBEAT_INTERVAL:
+                    # No chunks for 30s+ — rewrite the live spinner/status line
+                    # so CLI/TUI/Desktop users see WHAT the wait is (slow or
+                    # overloaded provider / long thinking pause) instead of an
+                    # unexplained generic spinner, and WHEN recovery kicks in.
+                    if (
+                        _stream_stale_timeout is not None
+                        and _stream_stale_timeout != float("inf")
+                    ):
+                        _recovery = f"; auto-reconnect at {int(_stream_stale_timeout)}s"
+                    else:
+                        _recovery = ""
+                    agent._emit_wait_notice(
+                        f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
+                        f"{_waiting_secs}s with no output yet (provider may be "
+                        f"slow or overloaded, or the model is thinking{_recovery})"
+                    )
                 else:
-                    _recovery = ""
+                    # Chunks are flowing — keep the activity tracker fresh but
+                    # leave the live display alone.
+                    agent._touch_activity(
+                        f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+                    )
+
+            # Detect stale streams: connections kept alive by SSE pings
+            # but delivering no real chunks.  Kill the client so the
+            # inner retry loop can start a fresh connection.
+            _stale_elapsed = time.time() - last_chunk_time["t"]
+            if _stale_elapsed > _stream_stale_timeout:
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                logger.warning(
+                    "Stream stale for %.0fs (threshold %.0fs) — no chunks received. "
+                    "model=%s context=~%s tokens. Killing connection.",
+                    _stale_elapsed, _stream_stale_timeout,
+                    api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
+                )
+                agent._buffer_status(
+                    f"⚠️ No response from provider for {int(_stale_elapsed)}s "
+                    f"(model: {api_kwargs.get('model', 'unknown')}, "
+                    f"context: ~{_est_ctx:,} tokens). "
+                    f"Reconnecting..."
+                )
+                try:
+                    _cancel_current_stream_attempt("stale_stream_kill")
+                    _close_request_client_once("stale_stream_kill")
+                except Exception:
+                    pass
+                # Circuit breaker (#58962): count the stale kill.  See the
+                # canonical comment block above ``_stale_streak()``.
+                _bump_stale_streak(agent)
+                # Rebuild the primary client too — its connection pool
+                # may hold dead sockets from the same provider outage.
+                if agent.api_mode == "anthropic_messages":
+                    # #67142: the stale stream ran on a request-local anthropic
+                    # client, already socket-aborted above via
+                    # _close_request_client_once (which unblocks the worker and
+                    # preserves the #28161 no-hang guarantee). The shared
+                    # _anthropic_client is NOT the in-flight transport, so we must
+                    # not close it from this poll (stranger) thread — that was the
+                    # FD-recycle corruption vector. Nothing further is needed.
+                    pass
+                else:
+                    # #70773: same FD-recycle corruption vector as #67142.
+                    # The shared OpenAI client's connection pool must NOT be
+                    # closed from this watchdog/poll thread — worker threads
+                    # from previous stale-killed attempts may still be
+                    # unwinding their SSL BIOs.  The request-local client is
+                    # already closed above via _close_request_client_once.
+                    # The shared client will be replaced lazily by
+                    # _ensure_primary_openai_client on the next request.
+                    pass
+                # Reset the timer so we don't kill repeatedly while
+                # the inner thread processes the closure.
+                last_chunk_time["t"] = time.time()
                 agent._emit_wait_notice(
-                    f"⏳ waiting on {api_kwargs.get('model', 'the provider')} — "
-                    f"{_waiting_secs}s with no output yet (provider may be "
-                    f"slow or overloaded, or the model is thinking{_recovery})"
+                    f"⚠ no output from provider for {int(_stale_elapsed)}s — "
+                    f"reconnecting..."
                 )
-            else:
-                # Chunks are flowing — keep the activity tracker fresh but
-                # leave the live display alone.
                 agent._touch_activity(
-                    f"waiting for stream response ({_waiting_secs}s, no chunks yet)"
+                    f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
                 )
 
-        # Detect stale streams: connections kept alive by SSE pings
-        # but delivering no real chunks.  Kill the client so the
-        # inner retry loop can start a fresh connection.
-        _stale_elapsed = time.time() - last_chunk_time["t"]
-        if _stale_elapsed > _stream_stale_timeout:
-            _est_ctx = estimate_request_context_tokens(api_kwargs)
-            logger.warning(
-                "Stream stale for %.0fs (threshold %.0fs) — no chunks received. "
-                "model=%s context=~%s tokens. Killing connection.",
-                _stale_elapsed, _stream_stale_timeout,
-                api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
-            )
-            agent._buffer_status(
-                f"⚠️ No response from provider for {int(_stale_elapsed)}s "
-                f"(model: {api_kwargs.get('model', 'unknown')}, "
-                f"context: ~{_est_ctx:,} tokens). "
-                f"Reconnecting..."
-            )
-            try:
-                _cancel_current_stream_attempt("stale_stream_kill")
-                _close_request_client_once("stale_stream_kill")
-            except Exception:
-                pass
-            # Circuit breaker (#58962): count the stale kill.  See the
-            # canonical comment block above ``_stale_streak()``.
-            _bump_stale_streak(agent)
-            # Rebuild the primary client too — its connection pool
-            # may hold dead sockets from the same provider outage.
-            if agent.api_mode == "anthropic_messages":
-                # #67142: the stale stream ran on a request-local anthropic
-                # client, already socket-aborted above via
-                # _close_request_client_once (which unblocks the worker and
-                # preserves the #28161 no-hang guarantee). The shared
-                # _anthropic_client is NOT the in-flight transport, so we must
-                # not close it from this poll (stranger) thread — that was the
-                # FD-recycle corruption vector. Nothing further is needed.
-                pass
-            else:
-                # #70773: same FD-recycle corruption vector as #67142.
-                # The shared OpenAI client's connection pool must NOT be
-                # closed from this watchdog/poll thread — worker threads
-                # from previous stale-killed attempts may still be
-                # unwinding their SSL BIOs.  The request-local client is
-                # already closed above via _close_request_client_once.
-                # The shared client will be replaced lazily by
-                # _ensure_primary_openai_client on the next request.
-                pass
-            # Reset the timer so we don't kill repeatedly while
-            # the inner thread processes the closure.
-            last_chunk_time["t"] = time.time()
-            agent._emit_wait_notice(
-                f"⚠ no output from provider for {int(_stale_elapsed)}s — "
-                f"reconnecting..."
-            )
-            agent._touch_activity(
-                f"stale stream detected after {int(_stale_elapsed)}s, reconnecting"
-            )
-
-        if agent._interrupt_requested:
-            # The stale branch above already counted this iteration when its
-            # deadline won the race; do not double-count a simultaneous stop.
-            if _stale_elapsed <= _stream_stale_timeout:
-                _record_interrupted_provider_wait(
-                    agent,
-                    _stale_elapsed,
-                    response_started=deltas_were_sent["yes"],
+            # F2 (#gwfix-F2): absolute wall-clock cap.  Fires ONCE
+            # (_abs_cap_fired guard) so we don't re-close every 0.3s poll —
+            # after the single force-close we keep polling `while t.is_alive()`
+            # until the blocked worker's read raises and the worker exits.
+            # Mirrors the stale branch (close-not-raise) so the error lands in
+            # the worker's own retry/fallback and result["error"], NOT here on
+            # the caller thread.  _call_start is never reset.
+            if not _abs_cap_fired and (time.time() - _call_start) > _stream_abs_timeout:
+                _abs_cap_fired = True
+                _abs_elapsed = time.time() - _call_start
+                _est_ctx = estimate_request_context_tokens(api_kwargs)
+                logger.error(
+                    "stream abs-cap hit after %.0fs (cap %.0fs) — no completion. "
+                    "model=%s context=~%s tokens. Force-closing so the worker's "
+                    "read raises into retry/fallback.",
+                    _abs_elapsed, _stream_abs_timeout,
+                    api_kwargs.get("model", "unknown"), f"{_est_ctx:,}",
                 )
-            # Mark THIS request cancelled before force-closing so the worker's
-            # exception handler recognizes the forced transport error as a
-            # cancel and exits without retrying or surfacing a network error.
-            # (#6600)
-            _request_cancelled["value"] = True
-            logger.debug(
-                "Force-closing streaming httpx client due to interrupt "
-                "(not a network error)."
-            )
-            try:
-                _cancel_current_stream_attempt("stream_interrupt_abort")
-                # #67142: kind-aware — anthropic aborts the request-local
-                # client's socket from this poll thread; the shared
-                # _anthropic_client is never closed here.
-                _close_request_client_once("stream_interrupt_abort")
-            except Exception:
-                pass
-            # Wait for the worker to unwind Relay-managed stream scopes
-            # (physical LLM + deferred logical) before surfacing
-            # InterruptedError. Raising immediately lets turn teardown
-            # (finish_logical_calls / end_turn / close_session) race a
-            # still-open physical scope and corrupt the LIFO stack —
-            # "scope handle is not at the top of the stack" → CLI EIO /
-            # redraw storm (#81521). No-op when Relay managed execution
-            # is not live.
-            _join_worker_for_relay_teardown(t, label="Streaming")
-            raise InterruptedError("Agent interrupted during streaming API call")
+                agent._buffer_status(
+                    f"⚠️ Provider call exceeded {int(_abs_elapsed)}s hard cap "
+                    f"(model: {api_kwargs.get('model', 'unknown')}). Aborting."
+                )
+                try:
+                    # Same rule as the stale branch above (#67142/#70773): only
+                    # the request-local transport is touched from this poll
+                    # thread; shared clients are replaced lazily, never closed
+                    # from here.
+                    _cancel_current_stream_attempt("stream_abs_cap")
+                    _close_request_client_once("stream_abs_cap")
+                except Exception:
+                    pass
+                continue
+            if agent._interrupt_requested:
+                # The stale branch above already counted this iteration when its
+                # deadline won the race; do not double-count a simultaneous stop.
+                if _stale_elapsed <= _stream_stale_timeout:
+                    _record_interrupted_provider_wait(
+                        agent,
+                        _stale_elapsed,
+                        response_started=deltas_were_sent["yes"],
+                    )
+                # Mark THIS request cancelled before force-closing so the worker's
+                # exception handler recognizes the forced transport error as a
+                # cancel and exits without retrying or surfacing a network error.
+                # (#6600)
+                _request_cancelled["value"] = True
+                logger.debug(
+                    "Force-closing streaming httpx client due to interrupt "
+                    "(not a network error)."
+                )
+                try:
+                    _cancel_current_stream_attempt("stream_interrupt_abort")
+                    # #67142: kind-aware — anthropic aborts the request-local
+                    # client's socket from this poll thread; the shared
+                    # _anthropic_client is never closed here.
+                    _close_request_client_once("stream_interrupt_abort")
+                except Exception:
+                    pass
+                # Wait for the worker to unwind Relay-managed stream scopes
+                # (physical LLM + deferred logical) before surfacing
+                # InterruptedError. Raising immediately lets turn teardown
+                # (finish_logical_calls / end_turn / close_session) race a
+                # still-open physical scope and corrupt the LIFO stack —
+                # "scope handle is not at the top of the stack" → CLI EIO /
+                # redraw storm (#81521). No-op when Relay managed execution
+                # is not live.
+                _join_worker_for_relay_teardown(t, label="Streaming")
+                raise InterruptedError("Agent interrupted during streaming API call")
+    except InterruptedError:
+        # Expected control-flow signal (interrupt path above / post-worker).
+        # Propagate unchanged — not a watchdog failure.
+        raise
+    except Exception:
+        # F2 (#gwfix-F2): a silent exception in this monitor loop previously
+        # ended monitoring with no trace — the observability gap this incident
+        # hit.  Log with stack, then re-raise so behavior is otherwise
+        # unchanged (the error still surfaces to the caller / retry path).
+        logger.error("stream watchdog monitor loop aborted abnormally", exc_info=True)
+        raise
     # Worker thread exited before the main thread's poll loop could check
     # the interrupt flag.  If the worker returned early due to an interrupt
     # (e.g. _call_anthropic() detected _interrupt_requested and returned

--- a/tests/run_agent/test_stream_absolute_cap.py
+++ b/tests/run_agent/test_stream_absolute_cap.py
@@ -1,0 +1,130 @@
+"""HERMES_STREAM_MAX_SECONDS: absolute wall-clock cap on a streaming call.
+
+The stale watchdog only measures the gap since the LAST chunk, so a socket
+that returns headers and then blocks forever (or dribbles a chunk just
+under the stale threshold) never trips it and the call runs unbounded.
+The absolute cap measures from call start, fires once, and force-closes
+the request-local client exactly like the stale branch — landing the
+worker in the existing retry/fallback path instead of raising from the
+poll thread.
+"""
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from tests.run_agent.test_streaming import _make_stream_chunk
+
+
+def _make_agent():
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://custom.example.com/v1",
+        provider="custom",
+        model="deepseek-v4-pro",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent
+
+
+class TestAbsoluteWallClockCap:
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_cap_fires_when_stale_detector_cannot(
+        self, mock_close, mock_create, mock_abort, mock_replace, monkeypatch,
+    ):
+        """Stale timeout far above test time + a stream that blocks after
+        connecting → only the absolute cap can end the call; the worker's
+        forced transport error then rides the normal retry to recovery."""
+        monkeypatch.setenv("HERMES_STREAM_STALE_TIMEOUT", "60")
+        monkeypatch.setenv("HERMES_STREAM_MAX_SECONDS", "0.3")
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "1")
+
+        unblock = threading.Event()
+
+        class BlockedStream:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                # Connected (headers back) but never a chunk: invisible to
+                # the stale detector inside this test's lifetime.
+                unblock.wait(timeout=5.0)
+                raise httpx.ConnectError("connection dropped after abort")
+                yield  # pragma: no cover — make this a generator
+
+        retry_chunks = [
+            _make_stream_chunk(content="recovered"),
+            _make_stream_chunk(finish_reason="stop", model="test/model"),
+        ]
+
+        class RetryStream:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                return iter(retry_chunks)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = [
+            BlockedStream(),
+            RetryStream(),
+        ]
+        mock_create.return_value = mock_client
+        mock_abort.side_effect = lambda *a, **k: unblock.set()
+
+        agent = _make_agent()
+        response = agent._interruptible_streaming_api_call({})
+
+        # The cap aborted the doomed first attempt and the retry recovered.
+        assert response.choices[0].message.content == "recovered"
+        assert mock_abort.call_count >= 1
+        # Same thread-ownership rule as the stale branch (#67142/#70773):
+        # the poll thread never replaces/closes the shared primary client.
+        mock_replace.assert_not_called()
+
+    @pytest.mark.filterwarnings(
+        "ignore::pytest.PytestUnhandledThreadExceptionWarning"
+    )
+    @patch("run_agent.AIAgent._replace_primary_openai_client")
+    @patch("run_agent.AIAgent._abort_request_openai_client")
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_default_cap_does_not_disturb_fast_streams(
+        self, mock_close, mock_create, mock_abort, mock_replace, monkeypatch,
+    ):
+        """With the 900s default cap, a normal fast stream completes with no
+        abort — the watchdog is inert on the happy path."""
+        monkeypatch.delenv("HERMES_STREAM_MAX_SECONDS", raising=False)
+
+        chunks = [
+            _make_stream_chunk(content="hello"),
+            _make_stream_chunk(finish_reason="stop", model="test/model"),
+        ]
+
+        class FastStream:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                return iter(chunks)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = FastStream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.choices[0].message.content == "hello"
+        assert mock_abort.call_count == 0


### PR DESCRIPTION
## What does this PR do?

The stale-stream watchdog in `interruptible_streaming_api_call` only measures the gap since the **last chunk**. Two real stream shapes never trip it and run unbounded:

- a socket that returns headers and then blocks forever (the stale timer starts from connection, but a worker blocked in `for chunk in stream` with no data still resets on the kill-and-retry cycle), and
- a stream that dribbles one chunk just under the stale threshold — each dribble resets `last_chunk_time` and the call runs for hours with the 180s detector armed the whole time (the production incident that motivated this).

This adds `HERMES_STREAM_MAX_SECONDS` (default 900s): an absolute cap measured from call start and **never reset**. On expiry the poll loop force-closes the request-local client **exactly like the stale branch** — it does not raise from the poll thread (a raise would bypass the worker's retry/fallback and the partial-stream recovery), so the blocked worker's read raises into the existing retry/fallback path. The cap fires once per call (`_abs_cap_fired`) so it can't re-close on every 0.3s poll tick, and the same thread-ownership rule as #67142/#70773 holds: shared clients are never touched from the watchdog.

Two smaller hardening changes ride along in the same loop, both observability-only:

- the monitor loop is wrapped so an unexpected exception in the watchdog itself is logged with a stack trace before re-raising (previously a silent monitor death ended all supervision with no trace — the gap the incident exposed), and
- a one-line `stream watchdog armed: stale=… abs=… model=…` info log at arm time.

The existing hard timeout (`HERMES_CODEX_HARD_TIMEOUT_SECONDS`) is codex-only; this covers every provider on the chat-completions streaming path. Running in a production gateway deployment since July.

## Related Issue

No existing issue — incident-driven from a self-hosted deployment (local + OpenAI-compatible providers). Searched open and closed PRs/issues for duplicates; none found.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/chat_completion_helpers.py` — absolute-cap branch in the streaming poll loop; `try/except` wrap of the monitor loop with logged stack on abnormal exit; watchdog-armed log line. (The diff looks larger than it is: wrapping the loop re-indents the existing body; `git diff -w` shows the true delta.)
- `tests/run_agent/test_stream_absolute_cap.py` — new; proves the cap ends a blocked stream the stale detector can't see (stale=60s, cap=0.3s → retry recovers) and that the default cap is inert on a normal fast stream, reusing the #70773 harness idiom including the shared-client-never-replaced assertion

## How to Test

1. `pytest tests/run_agent/test_stream_absolute_cap.py -q` — 2 tests
2. `pytest tests/run_agent/test_70773_shared_client_fd_corruption.py -q` — the sibling stale-branch suite, still green (7 total with the new file)
3. `pytest tests/agent/test_local_stream_timeout.py tests/agent/test_reasoning_stale_timeout_floor.py tests/agent/test_stream_read_timeout_floor.py tests/agent/test_cascading_interrupt_6600.py tests/agent/test_bedrock_interrupt_post_worker.py -q` — 82 passed, the interrupt/stale suites that exercise this loop
4. Live: set `HERMES_STREAM_MAX_SECONDS=30`, point at a provider that stalls after headers, observe `stream abs-cap hit after 30s` + reconnect instead of an unbounded hang

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the streaming/interrupt-related suites listed above (82 + 7 passed); full `pytest tests/ -q` has pre-existing unrelated collection failures on my machine
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (test suite) + Debian 13 container (production deployment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (`HERMES_STREAM_STALE_TIMEOUT`/`HERMES_STREAM_RETRIES` are likewise env-only and undocumented; happy to add a docs entry if you'd like one)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (env var, not a config key)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — pure-Python timing logic, no platform-specific I/O
- [x] I've updated tool descriptions/schemas — N/A