### PR TITLE
fix(gateway): keep post-reset deliveries in the live conversation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15132,11 +15132,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         self._clear_conversation_scope(
                             key, reason="expiry_finalized"
                         )
-                        # Persist the finalized flag to sessions.json AND
-                        # state.db (single write-path, #9006) — also drops
-                        # the persisted /model override, since finalization
-                        # is a conversation boundary.
-                        await self.async_session_store.set_expiry_finalized(entry)
+                        # Persist the finalization boundary and immediately
+                        # publish the successor routing row. Otherwise cron /
+                        # send_message mirrors keep targeting the ended row
+                        # until a later inbound message lazily rotates it.
+                        await self.async_session_store.finalize_expired_session(entry)
                         logger.debug(
                             "Session expiry finalized for %s",
                             entry.session_id,
@@ -15151,7 +15151,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 "Marking as finalized to prevent infinite retry loop.",
                                 failures, entry.session_id, e,
                             )
-                            await self.async_session_store.set_expiry_finalized(
+                            await self.async_session_store.finalize_expired_session(
                                 entry, clear_model_override=False
                             )
                             _finalize_failures.pop(entry.session_id, None)
@@ -20682,11 +20682,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 context_note = "[System note: The previous gateway session could not be recovered after a restart (API recovery timed out). This is a fresh conversation — use /resume to restore history if needed.]"
             else:
                 context_note = "[System note: The user's previous session expired due to inactivity. This is a fresh conversation with no prior context.]"
-            # Slack/Discord channels/threads are long-lived: point the agent at
-            # the specific prior same-channel session so it recalls that context
-            # via session_search instead of an unrelated recent session.  Returns
-            # None (appends nothing) for other platforms or when there's no prior
-            # activity to recall.  Deterministic — no extra API/DB calls (#36220).
+            # Messaging surfaces outlive their backing Hermes sessions. Point
+            # the agent at the specific prior conversation so it can recover
+            # referenced context via session_search. Deterministic — no extra
+            # API/DB calls (#36220).
             try:
                 continuity_note = build_channel_continuity_note(session_entry, source)
             except Exception:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -817,10 +817,10 @@ class SessionEntry:
     reset_had_activity: bool = False  # whether the expired session had any messages
 
     # When this session was created by an auto-reset, the session_id of the
-    # session it replaced.  Used to give Slack/Discord channels/threads a
-    # lightweight continuity hint (see build_channel_continuity_note) so the
-    # agent recalls the prior same-channel session via session_search instead
-    # of binding the request to an unrelated recent session.
+    # session it replaced. Used to give messaging conversations a lightweight
+    # continuity hint (see build_channel_continuity_note) so the agent recalls
+    # the prior same-origin session via session_search instead of binding the
+    # request to an unrelated recent session.
     prev_session_id: Optional[str] = None
 
     # Set by reset_session() when the user explicitly sends /new or /reset.
@@ -1010,32 +1010,32 @@ def build_channel_continuity_note(
     entry: "SessionEntry",
     source: SessionSource,
 ) -> Optional[str]:
-    """Build a lightweight session-continuity hint for Slack/Discord channels.
+    """Build a lightweight continuity hint after an automatic session reset.
 
-    Slack and Discord channels/threads are long-lived: when the daily/idle
-    reset policy starts a fresh session, the agent loses the thread's prior
-    context and can mistakenly bind a new request to an unrelated recent
-    session.  This deterministic one-line hint points the agent at the
-    specific prior session in *this* channel/thread so it recalls that
-    context via ``session_search`` before acting.
+    Messaging conversations are long-lived even when their backing Hermes
+    sessions rotate.  This deterministic one-line hint points the agent at
+    the specific prior session for the same conversation so it can recall
+    that context via ``session_search`` before acting.
 
     Returns ``None`` (and the caller adds nothing) unless **all** hold:
-      - the source platform is Slack or Discord,
       - this session was created by an auto-reset that had real activity,
       - the previous session_id was recorded on the entry.
 
     No LLM calls, no extra API/DB lookups — the previous session id is
     already known from :meth:`SessionStore.get_or_create_session`.
     """
-    if source.platform not in (Platform.SLACK, Platform.DISCORD):
-        return None
     if not getattr(entry, "reset_had_activity", False):
         return None
     prev = getattr(entry, "prev_session_id", None)
     if not prev:
         return None
 
-    where = "thread" if source.thread_id else "channel"
+    if source.thread_id:
+        where = "thread"
+    elif source.chat_type == "dm":
+        where = "conversation"
+    else:
+        where = "channel"
     return (
         f"[System note: This {where} had an earlier Hermes session "
         f"(session_id: {prev}) that was auto-reset. If the user refers to "
@@ -2608,6 +2608,25 @@ class SessionStore:
                     "Session DB promote_to_session_reset failed for %s: %s",
                     entry.session_id, exc,
                 )
+
+    def finalize_expired_session(
+        self, entry: SessionEntry, *, clear_model_override: bool = True
+    ) -> Optional[SessionEntry]:
+        """Finalize *entry* and publish its live routing successor.
+
+        The expiry watcher previously ended the SQLite row but left the
+        routing entry pointing at it.  Out-of-band deliveries then fell back
+        to that stale sessions.json entry until the next inbound message
+        lazily created a successor.  Rotate immediately so delivery mirrors
+        resolve to a live row during that gap.  Legacy entries without an
+        origin cannot be recreated safely and retain the old behavior.
+        """
+        self.set_expiry_finalized(
+            entry, clear_model_override=clear_model_override
+        )
+        if entry.origin is None:
+            return None
+        return self.get_or_create_session(entry.origin, touch_activity=False)
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.

--- a/tests/gateway/test_channel_continuity_hint.py
+++ b/tests/gateway/test_channel_continuity_hint.py
@@ -1,12 +1,13 @@
-"""Tests for the lightweight Slack/Discord channel session-continuity hint.
+"""Tests for automatic-reset routing and session-continuity hints.
 
 Salvaged from PR #36220 (metamon-p), ported onto the current SessionStore.
 
 Covers:
 - SessionStore records the previous session_id on auto-reset (and only then).
 - prev_session_id survives a to_dict() → from_dict() roundtrip (gateway restart).
-- build_channel_continuity_note() emits a hint only for Slack/Discord sessions
-  that were auto-reset with real prior activity, and stays silent otherwise.
+- Expiry finalization immediately publishes a live routing successor.
+- build_channel_continuity_note() covers messaging surfaces that were
+  auto-reset with real prior activity, and stays silent otherwise.
 """
 
 from datetime import datetime, timedelta
@@ -48,6 +49,15 @@ def _slack_source(thread_id=None):
     )
 
 
+def _telegram_source():
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="12345",
+    )
+
+
 # ---------------------------------------------------------------------------
 # SessionStore records prev_session_id on auto-reset
 # ---------------------------------------------------------------------------
@@ -68,6 +78,30 @@ class TestPrevSessionIdCapture:
         assert entry2.was_auto_reset is True
         assert entry2.reset_had_activity is True
         assert entry2.prev_session_id == entry1.session_id
+
+    def test_expiry_finalization_rotates_to_live_successor(
+        self, _isolated_db, tmp_path
+    ):
+        from gateway.mirror import _find_session_id
+
+        store = _make_store(
+            tmp_path, SessionResetPolicy(mode="idle", idle_minutes=1)
+        )
+        source = _telegram_source()
+        expired = store.get_or_create_session(source)
+        expired.last_prompt_tokens = 4000
+        expired.updated_at = datetime.now() - timedelta(minutes=5)
+        store._save()
+
+        successor = store.finalize_expired_session(expired)
+
+        assert successor is not None
+        assert successor.session_id != expired.session_id
+        assert successor.prev_session_id == expired.session_id
+        assert successor.was_auto_reset is True
+        assert store._db.get_session(expired.session_id)["ended_at"] is not None
+        assert store._db.get_session(successor.session_id)["ended_at"] is None
+        assert _find_session_id("telegram", "12345") == successor.session_id
 
 
 # ---------------------------------------------------------------------------
@@ -96,6 +130,14 @@ class TestBuildChannelContinuityNote:
         assert "session_search" in note
         assert entry.prev_session_id in note
         assert "channel" in note
+
+    def test_telegram_dm_emits_hint(self):
+        entry = _reset_entry(Platform.TELEGRAM)
+        note = build_channel_continuity_note(entry, _telegram_source())
+        assert note is not None
+        assert "session_search" in note
+        assert entry.prev_session_id in note
+        assert "conversation" in note
 
 
     def test_no_activity_returns_none(self):

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -148,6 +148,9 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
     )
+    runner.session_store.finalize_expired_session.assert_called_once_with(
+        expired_entry
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What does this PR do?

Outbound deliveries made after an idle or daily session reset now land in the live successor session instead of the finalized predecessor. The reset path also gives every messaging surface, including Telegram DMs, a deterministic pointer to the prior session when older context may be needed.

### Symptom

After the expiry watcher finalized a session, cron deliveries and `hermes send` mirrors could still be appended to that ended session. The next inbound message created a fresh session without those deliveries, so replies such as "Not done" arrived without the reminder they referenced.

### Impact

Users with automatic session resets could lose conversational continuity for every out-of-band delivery sent between expiry and their next inbound message. Non-Slack and non-Discord surfaces also lacked the prior-session hint needed to recover older same-conversation context.

### Bug Cause

**Trigger:** `gateway/run.py:15044` / `_session_expiry_watcher` finalizes a session before another delivery reaches the same chat.

**Causal chain:**
1. The expiry watcher marked the SQLite session row ended but kept its routing entry live.
2. `gateway.mirror` found no live SQLite origin match, fell back to the stale routing index, and appended the delivery to the ended row.
3. The next inbound message lazily rotated to a new session that did not contain those post-expiry deliveries.

**Why it is wrong:** Finalization created a period where the durable session state and routing index disagreed, so outbound delivery routing targeted a conversation that could no longer receive inbound turns.

**Working sibling / contrast:** A reset discovered during `SessionStore.get_or_create_session` already ends the predecessor and publishes a successor in one routing transition. The background expiry path stopped after finalization instead.

**Ruled out:** The delivery transport itself succeeds and the SQLite append is not dropped. The failure is the selected session id, demonstrated by the pre-fix regression tests and the live-only behavior of `find_session_by_origin`.

### Fix

`SessionStore.finalize_expired_session` now finalizes the predecessor and immediately runs the existing single-flight session transition without advancing user activity, publishing a live successor for the same origin. The expiry watcher uses that operation on both normal and retry-exhausted finalization paths. Automatic-reset continuity hints now describe DMs as conversations and apply across messaging platforms rather than only Slack and Discord.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py` - rotate expired sessions to a live successor and generalize the prior-session continuity hint.
- `gateway/run.py` - use the rotate-on-finalize operation from the expiry watcher.
- `tests/gateway/test_channel_continuity_hint.py` - verify the ended predecessor, live successor, mirror lookup, and Telegram DM hint.
- `tests/gateway/test_session_boundary_hooks.py` - verify the expiry watcher invokes the rotate-on-finalize path.

## How to Test

1. Run the automatic-reset routing and boundary tests.
2. Run the related mirror, reset notification, model reset, and pruning tests.

```bash
scripts/run_tests.sh tests/gateway/test_channel_continuity_hint.py tests/gateway/test_session_boundary_hooks.py -q
scripts/run_tests.sh tests/gateway/test_session_reset_notify.py tests/gateway/test_session_model_reset.py tests/gateway/test_mirror.py tests/gateway/test_session_store_prune.py -q
```

Result: 35 tests passed on Windows 11.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.).
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repo's test entry on the relevant tests and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: Windows 11.

### Documentation & Housekeeping

- [x] Relevant docstrings and code comments are updated.
- [x] Config examples are N/A because no config keys changed.
- [x] Contributor and agent guides are N/A because no workflow changed.
- [x] Cross-platform impact was considered; the routing and SQLite behavior is platform-independent.
- [x] Tool descriptions and schemas are N/A because no tool behavior changed.

