### PR TITLE
fix(gateway): refuse to mirror deliveries into an already-ended session

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -208,11 +208,43 @@ def _find_session_id(
 
 
 def _append_to_sqlite(session_id: str, message: dict) -> None:
-    """Append a message to the SQLite session database."""
+    """Append a message to the SQLite session database.
+
+    Refuses to write into an ALREADY-ENDED session (#100177). After a
+    ``session_reset`` expiry the watcher finalizes the DB row but the
+    routing entry in ``sessions.json`` still points at it, so every
+    delivery between the expiry and the next inbound message (cron
+    briefs, ``hermes send``, ``send_message`` mirroring) was appended to
+    a dead session. The #54878 self-heal then drops the stale routing
+    entry and starts a fresh session, and those deliveries are gone from
+    the transcript the agent actually reads — it answers a reply to its
+    own message with "the previous session expired".
+
+    Writing into a dead session is never useful: nothing reads that
+    transcript again. Refusing surfaces the routing staleness at WARNING
+    so the delivery is visibly dropped instead of silently lost.
+    """
     db = None
     try:
         from hermes_state import SessionDB
         db = SessionDB()
+        row = None
+        try:
+            row = db.get_session(session_id)
+        except Exception:
+            # Lookup failure must not block the append — a mirror that
+            # can't verify the session is better than a lost delivery.
+            row = None
+        if row is not None and row.get("ended_at"):
+            logger.warning(
+                "Mirror: refusing to write into ended session %s "
+                "(end_reason=%s, ended_at=%s) — routing entry is stale; "
+                "delivery not mirrored",
+                session_id,
+                row.get("end_reason"),
+                row.get("ended_at"),
+            )
+            return
         db.append_message(
             session_id=session_id,
             role=message.get("role", "assistant"),

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -123,10 +123,55 @@ class TestAppendToSqlite:
         """Verify _append_to_sqlite closes the SessionDB connection."""
         from gateway.mirror import _append_to_sqlite
         mock_db = MagicMock()
+        mock_db.get_session.return_value = {"id": "sess_1", "ended_at": None}
 
         with patch("hermes_state.SessionDB", return_value=mock_db):
             _append_to_sqlite("sess_1", {"role": "assistant", "content": "hello"})
 
         mock_db.append_message.assert_called_once()
         mock_db.close.assert_called_once()
+
+    def test_refuses_to_write_into_ended_session(self):
+        """#100177: after a session_reset expiry the routing entry still
+        points at the ended session, so cron deliveries / hermes send were
+        appended to a dead transcript and lost when the #54878 self-heal
+        started a fresh session. The append must be refused, not silent."""
+        from gateway.mirror import _append_to_sqlite
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = {
+            "id": "sess_dead",
+            "ended_at": 1_756_000_000.0,
+            "end_reason": "session_reset",
+        }
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_sqlite("sess_dead", {"role": "user", "content": "brief"})
+
+        mock_db.append_message.assert_not_called()
+        mock_db.close.assert_called_once()
+
+    def test_writes_when_session_lookup_fails(self):
+        """A lookup failure must not block the delivery — a mirror that
+        can't verify the session is better than a lost message."""
+        from gateway.mirror import _append_to_sqlite
+        mock_db = MagicMock()
+        mock_db.get_session.side_effect = RuntimeError("db busy")
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_sqlite("sess_1", {"role": "user", "content": "brief"})
+
+        mock_db.append_message.assert_called_once()
+        mock_db.close.assert_called_once()
+
+    def test_writes_when_session_row_missing(self):
+        """No row (deterministic seed session not yet created) still writes —
+        append_message creates the row, which is the seeded-cron path."""
+        from gateway.mirror import _append_to_sqlite
+        mock_db = MagicMock()
+        mock_db.get_session.return_value = None
+
+        with patch("hermes_state.SessionDB", return_value=mock_db):
+            _append_to_sqlite("sess_new", {"role": "user", "content": "brief"})
+
+        mock_db.append_message.assert_called_once()
 


### PR DESCRIPTION
Fixes #100177

## Problem

After a `session_reset` (idle/daily) expiry, `_session_expiry_watcher` finalizes the DB row but the routing entry in `sessions.json` keeps pointing at it. Every outbound delivery made between the expiry and the next inbound message — cron briefs, `hermes send`, `send_message` mirroring — was appended to the **already-ended** session via `gateway/mirror.py`.

When the user finally replies, the #54878 self-heal drops the stale routing entry and starts a fresh session — and none of those deliveries are in it. The agent answers a reply to its own message with *"the previous session expired, what are you referring to?"*.

The reporter measured it directly: `SELECT count(*) ... WHERE m.timestamp > s.ended_at` returned **18 deliveries** landed in ended sessions over 14 days on one DM (every morning/evening brief, two reminders, one review alert).

## Fix

`_append_to_sqlite` checks `ended_at` before appending and refuses with a `WARNING` naming the session, `end_reason` and `ended_at` — so the stale routing entry becomes visible instead of the delivery vanishing silently into a transcript nothing will read again.

Deliberately **not** over-strict:

- a `get_session` **lookup failure** still appends (a mirror that can't verify beats a lost delivery)
- a **missing row** still appends — the seeded-cron path relies on `append_message` creating the row on first write

This is the narrow half of the issue: it stops the corruption of ended transcripts and makes the drop loud. The broader routing-invalidation half (evicting the `sessions.json` entry at expiry time so deliveries land in a fresh session, plus the missing Telegram continuity hint) is a separate change and left to the maintainers' preferred design.

## Verification

`tests/gateway/test_mirror.py` + `tests/cron/test_mirror_origin_fallback.py`: **24/24 pass**, with three new tests — ended session refuses the append, lookup failure still appends, missing row still appends.