### PR TITLE
fix(agent): fill empty non-final wire turns in the max-iterations summary path

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3048,9 +3048,12 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     try:
         # Build API messages, stripping internal-only fields
         # (finish_reason, reasoning) that strict APIs like Mistral reject with 422
+        from agent.agent_runtime_helpers import fill_empty_non_final_wire_payload
+
         _needs_sanitize = agent._should_sanitize_tool_calls()
         api_messages = []
-        for msg in messages:
+        _last_msg_idx = len(messages) - 1
+        for idx, msg in enumerate(messages):
             api_msg = msg.copy()
             agent._copy_reasoning_content_for_api(msg, api_msg)
             for internal_field in ("reasoning", "finish_reason"):
@@ -3076,6 +3079,19 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
             # sidecar-carrying message and re-prefilling the whole transcript
             # at exactly the moment the context is largest.
             substitute_api_content(api_msg)
+            # Empty non-final user/assistant turns (#88955 hidden placeholders
+            # and #96870 stream-death / host-fed empties): without this, the
+            # unconditional repair pass inside _sanitize_api_messages() below
+            # re-heals (and re-logs via _log_empty_non_final_heal) the same
+            # poisoned row on every single max-iterations summary call for
+            # this session. The main loop already fills the wire copy here
+            # for the identical reason (agent/conversation_loop.py) so the
+            # sanitizer has nothing left to do; this path hand-builds its own
+            # api_messages instead of going through the main loop and was
+            # missing the same guard. Durable history is not mutated. After
+            # substitute_api_content so a message carrying real sidecar bytes
+            # is never mistaken for empty.
+            fill_empty_non_final_wire_payload(api_msg, is_final=(idx == _last_msg_idx))
             if _needs_sanitize:
                 # In MoA mode, agent.model is the virtual preset name,
                 # not the actual aggregator model.  Resolve the real

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -892,6 +892,76 @@ class TestMaxIterationsSummaryReplay:
         assert messages[0]["content"] == "q1"
         assert messages[0]["api_content"] == "q1\n\nPLUGIN-CTX"
 
+    def test_empty_non_final_turn_is_filled_not_re_healed_every_call(self):
+        """A mid-transcript empty non-final assistant turn (dead-stream stub,
+        #88955/#96870) must be filled with the interrupted placeholder on the
+        summary path's own wire copy, the same way the main loop's
+        fill_empty_non_final_wire_payload() does — not left for
+        _sanitize_api_messages()'s repair_empty_non_final_messages() to heal
+        (and re-log via _log_empty_non_final_heal) on every single call."""
+        from agent import agent_runtime_helpers as arh
+        from run_agent import AIAgent
+        from agent.chat_completion_helpers import handle_max_iterations
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent._cached_system_prompt = "SYS"
+
+        captured = {}
+
+        class _Completions:
+            def create(self, **kwargs):
+                captured.update(kwargs)
+                return "RAW-RESPONSE"
+
+        client = types.SimpleNamespace(
+            chat=types.SimpleNamespace(completions=_Completions())
+        )
+        transport = types.SimpleNamespace(
+            normalize_response=lambda _r: types.SimpleNamespace(content="SUMMARY")
+        )
+
+        messages = [
+            {"role": "user", "content": "q1"},
+            # Dead-stream stub: no content, no tool_calls — mid-transcript,
+            # so it is a candidate for the empty-turn repair pass.
+            {"role": "assistant", "content": ""},
+            {"role": "user", "content": "q2"},
+        ]
+
+        arh._empty_heal_log_state.clear()
+        arh._empty_heal_user_notified.clear()
+        arh._empty_heal_pending_notice.clear()
+        try:
+            with patch.object(
+                agent, "_ensure_primary_openai_client", return_value=client
+            ), patch.object(agent, "_get_transport", return_value=transport):
+                out = handle_max_iterations(agent, messages, 5)
+
+            assert out == "SUMMARY"
+            sent = captured["messages"]
+            assistant_turns = [m for m in sent if m.get("role") == "assistant"]
+            assert len(assistant_turns) == 1
+            assert assistant_turns[0]["content"] == arh._INTERRUPTED_PLACEHOLDER
+
+            # The original stored message is untouched — only the wire copy
+            # sent to the provider was filled.
+            assert messages[1]["content"] == ""
+
+            # repair_empty_non_final_messages (inside _sanitize_api_messages)
+            # found nothing left to heal, so it never logged a heal for this
+            # call — the summary path's own fill already handled it.
+            assert arh._empty_heal_log_state == {}
+        finally:
+            arh._empty_heal_log_state.clear()
+            arh._empty_heal_user_notified.clear()
+            arh._empty_heal_pending_notice.clear()
+
 
 class TestSessionRowExistsBeforePreflightCompaction:
     """Moving the crash persist after prefetch/pre_llm_call (one write with


### PR DESCRIPTION
## Summary
`handle_max_iterations()`'s `_managed_summary_call` hand-builds its own `api_messages` and calls `agent._sanitize_api_messages()` (which unconditionally runs `repair_empty_non_final_messages()`) before every summary request. The main turn loop (`agent/conversation_loop.py`) already guards against this exact class of poisoned transcript: it fills an empty non-final user/assistant wire turn (#88955 hidden placeholders, #96870 stream-death / host-fed empties) via `fill_empty_non_final_wire_payload()` so the sanitizer's repair pass has nothing left to heal on the next send. The max-iterations summary path never got the same guard, since it builds `api_messages` independently of the main loop instead of going through it.

## Impact
Once a session carries one empty non-final turn, every single max-iterations summary call re-heals (and re-logs via `_log_empty_non_final_heal`) the identical row, spamming errors.log. `consume_pending_sanitizer_heal_notice()` — the one-time user-facing notice for repeated heals — is only ever drained by the main loop's own post-sanitize point (`agent/conversation_loop.py`), so a notice queued from a summary-only call site (e.g. a session that hits `max_iterations` as its last turn before rotation/close) can go permanently undelivered.

## Fix
Adds the same `fill_empty_non_final_wire_payload()` call to the summary path's own per-message loop, positioned right after `substitute_api_content()` — matching the main loop's own ordering requirement, so a message carrying real `api_content` sidecar bytes is never mistaken for empty and overwritten with the placeholder.

## Test plan
- [x] Added `test_empty_non_final_turn_is_filled_not_re_healed_every_call` to the existing `TestMaxIterationsSummaryReplay` class in `tests/agent/test_api_content_sidecar.py`, which drives `handle_max_iterations()` end-to-end and inspects the actual wire payload
- [x] Mutation-verify: reverting the `chat_completion_helpers.py` change makes the new test fail with the exact expected symptom (`_empty_heal_log_state` shows a logged heal; the WARNING-level "healed 1 empty non-final message(s)" log fires) — confirmed via a real (not simulated) `repair_empty_non_final_messages()` run
- [x] `tests/agent/test_api_content_sidecar.py` (28), `tests/run_agent/test_sanitiser_escalation.py` (19), `tests/agent/test_turn_finalizer_*.py` (3 files), `tests/run_agent/test_verification_continuation_budget.py`, `tests/run_agent/test_run_agent.py::TestHandleMaxIterations` (14): all pass
- [x] `python3 -c "import ast; ast.parse(...)"` syntax check on both changed files: clean

## Related PRs (different mechanism, no overlap)
Two older, stale (unrebased since early Aug) open PRs also touch `handle_max_iterations()` in `agent/chat_completion_helpers.py` but address unrelated concerns with zero insertion-point overlap:
- #67399 drops assistant rows whose *only* payload was an internal Codex-only field (`codex_message_items`) that gets stripped during `chat_completions`-mode conversion — a structurally different "internal field was the only content" case, inserted after `_drop_thinking_only_and_merge_users()`, not in the per-message loop this PR touches.
- #36246 hardens the summary request into a system-role stop instruction + `tool_choice="none"` enforcement — an unrelated tool-calling-budget concern.

Neither addresses the dead-stream/host-fed empty-turn re-heal-on-every-call issue this PR fixes.