### PR TITLE
fix(state): converge cjk rebuild when a tokenizer-less open races optimize-storage

### DIFF
--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -856,12 +856,39 @@ class SessionSearchMixin:
 
         # Phase 1b: backfill the CJK-bigram index (its own marker pair; a
         # no-op when the tokenizer isn't loadable or nothing is pending).
-        while True:
-            _t0 = time.monotonic()
-            if not self.fts_cjk_rebuild_step():
+        # A tokenizer-less process that opens the DB mid-run self-heals:
+        # it drops the freshly-installed cjk triggers and re-stales the
+        # breadcrumb, throwing this run's rebuild away while it still
+        # reports success (#100204). Detect that and run one more
+        # reset+backfill pass so a single invocation converges instead of
+        # leaving the reset→rebuild→re-stale loop for every re-run.
+        cjk_stale_final = False
+        for cjk_pass in range(2):
+            if cjk_pass:
+                self._fts_cjk_reset_if_stale()
+            while True:
+                _t0 = time.monotonic()
+                if not self.fts_cjk_rebuild_step():
+                    break
+                _emit("backfill")
+                _pause(time.monotonic() - _t0)
+            if not self._fts_cjk_loaded:
                 break
-            _emit("backfill")
-            _pause(time.monotonic() - _t0)
+            with self._lock:
+                cjk_stale_final = self._conn.execute(
+                    "SELECT 1 FROM state_meta WHERE key = ?",
+                    (FTS_CJK_STALE_KEY,),
+                ).fetchone() is not None
+            if not cjk_stale_final:
+                break
+            logger.warning(
+                "CJK index re-staled mid-backfill by a tokenizer-less "
+                "process (%s)",
+                "retrying the rebuild once"
+                if cjk_pass == 0 else
+                "leaving it stale; run optimize-storage again on a host "
+                "where the resident process can load the tokenizer",
+            )
 
         # Phase 2: tear down the demoted legacy shadow tables in chunks.
         _emit("teardown")
@@ -973,7 +1000,14 @@ class SessionSearchMixin:
         logger.info(
             "FTS storage optimization complete (layout v%d).", FTS_STORAGE_VERSION
         )
-        return {"ok": True, "vacuumed": vacuum_ok}
+        result = {"ok": True, "vacuumed": vacuum_ok}
+        if cjk_stale_final:
+            # Not a failure of the base index — the cjk surface stayed
+            # stale through the retry pass (a resident tokenizer-less
+            # process kept self-healing). Surface it so callers/CLI runs
+            # can tell a converged optimize from a still-looping one.
+            result["cjk_stale"] = True
+        return result
 
     def get_anchored_view(
         self,

--- a/tests/test_fts_cjk_bigram.py
+++ b/tests/test_fts_cjk_bigram.py
@@ -235,6 +235,65 @@ def test_fresh_db_index_counts_exclude_tool_rows(db):
     assert idx == non_tool
 
 
+def test_optimize_storage_converges_over_concurrent_tokenizerless_open(
+    cjk_so, tmp_path, monkeypatch
+):
+    """#100204: a tokenizer-less process opening the DB mid-backfill
+    self-heals — it drops the freshly installed cjk triggers and re-stales
+    the breadcrumb, throwing the in-flight rebuild away. optimize-storage
+    must converge within the same invocation (one reset+backfill retry)
+    instead of reporting success over a discarded index."""
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    db_path = tmp_path / "state.db"
+    d = SessionDB(db_path=db_path)
+    d.create_session(session_id="s1", source="cli", model="m")
+    d.append_message("s1", role="user", content="웅기가 프로필을 요청했다 일본 우선순위")
+    d.close()
+
+    # Historical stale state, exactly as it arises in production: a
+    # tokenizer-less open drops the triggers and leaves the breadcrumb
+    # (the self-heal branch of _ensure_fts_cjk_schema).
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", "/nonexistent/libfts5_cjk.so")
+    SessionDB(db_path=db_path).close()
+
+    monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+    d = SessionDB(db_path=db_path)
+    try:
+        assert d.get_meta("fts_cjk_stale") == "1"
+
+        raced = {"done": False}
+
+        def _resident_open(info):
+            # A resident tokenizer-less process opens the DB inside the
+            # first backfill pass (progress_cb fires between chunks).
+            if info.get("phase") == "backfill" and not raced["done"]:
+                raced["done"] = True
+                monkeypatch.setenv(
+                    "HERMES_FTS5_CJK_SO", "/nonexistent/libfts5_cjk.so"
+                )
+                SessionDB(db_path=db_path).close()
+                monkeypatch.setenv("HERMES_FTS5_CJK_SO", str(cjk_so))
+
+        result = d.optimize_fts_storage(progress_cb=_resident_open)
+        assert result["ok"]
+        assert "cjk_stale" not in result
+        assert d.get_meta("fts_cjk_stale") is None
+        assert d._fts_cjk_available
+    finally:
+        d.close()
+
+    # Reopen: the rebuild held and the cjk index is served again — the
+    # reset→rebuild→re-stale loop is broken.
+    d2 = SessionDB(db_path=db_path)
+    try:
+        assert d2.get_meta("fts_cjk_stale") is None
+        assert d2._fts_cjk_available
+        assert d2._describe_search_path("일본") == "fts_cjk"
+        assert d2.search_messages("일본", limit=10)
+    finally:
+        d2.close()
+
+
 def test_integrity_after_lifecycle(db):
     db.append_message("s1", role="user", content="무결성 검사")
     with db._lock:


### PR DESCRIPTION
## What does this PR do?

Fixes the #100204 loop where `sessions optimize-storage` rebuilds the stale CJK-bigram index, reports `{'ok': True, 'vacuumed': True}`, yet leaves `fts_cjk_stale=1` written back with all cjk triggers dropped — so every re-run repeats the same reset→rebuild→throw-away cycle and CJK search degrades permanently.

Root cause (reproduced deterministically, not the in-process reopen the issue suspected): a tokenizer-less process that opens the DB **while the optimize backfill is in flight** hits the self-heal branch of `_ensure_fts_cjk_schema`, which drops the freshly-installed cjk triggers and re-stales the breadcrumb (that drop is necessary — without it that process's message INSERTs die inside the cjk trigger). The backfill itself keeps running (it writes `messages_fts_cjk` directly, not through triggers), finishes, and clears its markers — so optimize reports success over a rebuild that was just discarded. In the reporter's environment the racing tokenizer-less open is a resident process sharing state.db; the write lands inside the optimize call, which is why the breadcrumb is already back when the same instance reads it right after `optimize_fts_storage()` returns.

Fix: after the cjk backfill pass, detect the re-staled breadcrumb and run one more reset+backfill pass **inside the same invocation**, so a single `optimize-storage` run converges over a one-shot resident open (the common case). If the breadcrumb is re-staled again, the result dict carries `cjk_stale: True` so callers can tell a converged run from a still-contended one instead of silently discarding the rebuild.

## Related Issue

Fixes #100204

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state_search.py` — `optimize_fts_storage()` Phase 1b: wrap the cjk backfill loop in a 2-pass loop; pass 2 re-runs `_fts_cjk_reset_if_stale()` + backfill when pass 1 ended with the breadcrumb re-staled by a concurrent tokenizer-less open. Both passes reuse the existing idempotent reset/backfill machinery; no locking or self-heal semantics change. On a clean run this adds one `state_meta` probe; on a tokenizer-less host the loop exits unchanged.
- `hermes_state_search.py` — return `cjk_stale: True` in the success dict when the breadcrumb survived the retry pass, so a still-contended DB is visible instead of silently looped.
- `tests/test_fts_cjk_bigram.py` — regression test that reproduces the race end-to-end: plants the historical stale state via a real tokenizer-less open, races a second tokenizer-less open inside the first backfill pass via `progress_cb`, and asserts the same invocation converges (breadcrumb cleared, triggers restored on reopen, CJK search served from `fts_cjk` again).

## How to Test

1. `pytest tests/test_fts_cjk_bigram.py -q` — Observed result: 10 passed, including the new `test_optimize_storage_converges_over_concurrent_tokenizerless_open`.
2. Red check on unpatched `main`: the new test fails at `assert d.get_meta("fts_cjk_stale") is None` (breadcrumb is `'1'` and reopen sees `_fts_cjk_available=False`) — observed `1 failed` before the fix, `10 passed` after.
3. Wider surface: `pytest tests/test_search_slow_query_log.py tests/test_wal_checkpoint_strategy.py tests/test_fts_update_of_narrowing.py tests/test_hermes_state.py tests/test_state_db_stats.py tests/hermes_state/ -q` — Observed result: 279 passed + 226 passed, 3 skipped, 0 failed.
4. `ruff check hermes_state_search.py tests/test_fts_cjk_bigram.py` — All checks passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5 (Apple Silicon, darwin 25.4)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — no skill changes.
