### PR TITLE
fix(cron): mark zero-inference manual runs as failure and preserve full trace

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6732,6 +6732,70 @@ def run_job(
 {logged_response}
 """
         
+        # #100180 false-positive guard: zero inference must not be recorded as ok.
+        # A turn that completed with zero LLM API calls (and zero tokens) made no
+        # progress — the model was never invoked or the response was truncated
+        # before any tool result. Marking it ok silently skips maintenance.
+        _result_api_calls = result.get("api_calls")
+        _result_total = result.get("total_tokens")
+        _result_prompt = result.get("prompt_tokens")
+        _is_zero_inference = False
+        if _result_api_calls == 0:
+            # api_calls == 0 is definitive when the field is present (turn_finalizer always sets it)
+            if _result_total is None or _result_total == 0:
+                _is_zero_inference = True
+            elif _result_prompt is None or _result_prompt == 0:
+                _is_zero_inference = True
+        # Also detect truncated trace where transcript ends inside a tool_calls block
+        _is_truncated_tool = False
+        if final_response and "<tool_calls>" in final_response and "</tool_calls>" not in final_response:
+            _is_truncated_tool = True
+        if _is_zero_inference and not job.get("no_agent"):
+            logger.warning(
+                "Job '%s' completed with zero inference calls (api_calls=%s, total_tokens=%s) — marking as failure (#100180)",
+                job_name, _result_api_calls, _result_total,
+            )
+            error_msg = "Agent completed with zero inference calls (no LLM API call was made) — treating as failure (#100180)"
+            if _is_truncated_tool:
+                error_msg += " — transcript appears truncated mid-tool-call"
+            _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
+            _audit_response_silent = _is_cron_silence_response(final_response or "")
+            _write_usage_audit({
+                "ts": _utcnow_iso_ms(),
+                "job_id": job_id,
+                "fire_id": _audit_fire_id,
+                "prompt_tokens": result.get("prompt_tokens"),
+                "completion_tokens": result.get("completion_tokens"),
+                "total_tokens": result.get("total_tokens"),
+                "api_calls": _result_api_calls,
+                "response_silent": _audit_response_silent,
+                "deliver_target": job.get("deliver"),
+                "model": model or None,
+                "duration_ms": _audit_duration_ms,
+                "error": error_msg,
+            })
+            output_failed = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Prompt
+
+{prompt}
+
+## Error
+
+```
+{error_msg}
+```
+
+## Partial Response
+
+{final_response}
+"""
+            return False, output_failed, "", error_msg
+
         logger.info("Job '%s' completed successfully", job_name)
 
         # Emit one JSONL line per fire for usage audit.
@@ -6744,6 +6808,7 @@ def run_job(
             "prompt_tokens": result.get("prompt_tokens"),
             "completion_tokens": result.get("completion_tokens"),
             "total_tokens": result.get("total_tokens"),
+            "api_calls": result.get("api_calls"),
             "response_silent": _audit_response_silent,
             "deliver_target": job.get("deliver"),
             "model": model or None,
@@ -6767,6 +6832,7 @@ def run_job(
                 "prompt_tokens": None,
                 "completion_tokens": None,
                 "total_tokens": None,
+                "api_calls": 0,
                 "response_silent": False,
                 "deliver_target": job.get("deliver"),
                 "model": model or None,

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1136,7 +1136,7 @@ def _run_claimed_job(
         }
 
 
-def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
+def _latest_job_output_excerpt(job_id: str, max_chars: int = 20000) -> Optional[str]:
     """Best-effort excerpt of the job's most recent saved output file.
 
     Included in the background-run completion block so the parent agent sees
@@ -1340,6 +1340,89 @@ def _try_dispatch_background_run(
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
+        # Derive real api_calls from usage audit instead of hardcoded 0 (#100180).
+        # The audit is written by cron/scheduler.run_job with the turn's
+        # prompt/completion/total tokens and api_calls. Using it here makes the
+        # completion block's "API calls" honest and gives us a zero-inference
+        # signal to flip false-positive ok to error.
+        real_api_calls = 0
+        real_total_tokens = 0
+        audit_record_found = False
+        try:
+            from cron.scheduler import _usage_audit_path
+            audit_path = _usage_audit_path()
+            if audit_path.exists():
+                # read last matching record for this job
+                latest = None
+                try:
+                    text = audit_path.read_text(encoding="utf-8", errors="ignore")
+                except Exception:
+                    text = ""
+                for line in text.splitlines():
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    if rec.get("job_id") == job_id:
+                        latest = rec
+                if latest is not None:
+                    audit_record_found = True
+                    try:
+                        real_api_calls = int(latest.get("api_calls") or 0)
+                    except Exception:
+                        real_api_calls = 0
+                    # Fallback for audits written before api_calls existed (or mocked records): tokens>0 implies >=1 call
+                    if real_api_calls == 0:
+                        try:
+                            if int(latest.get("total_tokens") or 0) > 0:
+                                real_api_calls = 1
+                            elif int(latest.get("prompt_tokens") or 0) > 0:
+                                real_api_calls = 1
+                        except Exception:
+                            pass
+                    try:
+                        real_total_tokens = int(latest.get("total_tokens") or 0)
+                    except Exception:
+                        real_total_tokens = 0
+        except Exception:
+            pass
+        # Zero-inference guard: if the scheduler still recorded ok but audit shows no tokens/calls, correct it here
+        # (defense-in-depth alongside scheduler's own guard). Don't flip no_agent jobs — they intentionally have 0 calls.
+        # Only flip when an audit record was found and confirms zero inference; mocked tests with no audit stay as-is.
+        try:
+            job_for_guard = refreshed or claimed_job or {}
+            if res.get("success") and audit_record_found and real_api_calls == 0 and real_total_tokens == 0 and not job_for_guard.get("no_agent"):
+                # Confirm via output excerpt whether transcript looks truncated (dangling tool_calls)
+                _excerpt_for_check = None
+                try:
+                    _excerpt_for_check = _latest_job_output_excerpt(job_id, max_chars=5000)
+                except Exception:
+                    pass
+                _is_trunc = False
+                if _excerpt_for_check and "<tool_calls>" in _excerpt_for_check and "</tool_calls>" not in _excerpt_for_check:
+                    _is_trunc = True
+                err_msg = "Zero inference calls (no LLM API call was made) — treating as failure (#100180)"
+                if _is_trunc:
+                    err_msg += " — transcript appears truncated mid-tool-call"
+                # Best-effort correction of persisted status so last_status reflects failure
+                try:
+                    from cron.jobs import mark_job_run
+                    _fire_owner = None
+                    _claim = claimed_job.get("fire_claim") if isinstance(claimed_job, dict) else None
+                    if isinstance(_claim, dict):
+                        _fire_owner = str(_claim.get("by") or "") or None
+                    mark_kwargs = {}
+                    if _fire_owner:
+                        mark_kwargs["expected_fire_owner"] = _fire_owner
+                    # Only correct if the persisted status is still ok (avoid overwriting a newer run)
+                    if refreshed.get("last_status") == "ok":
+                        mark_job_run(job_id, False, err_msg, **mark_kwargs)
+                        refreshed = get_job(job_id) or refreshed
+                except Exception:
+                    pass
+                res = {"success": False, "error": err_msg}
+        except Exception:
+            pass
         lines = [
             f"Cron job '{job_name}' ({job_id}) finished its manual run.",
             f"Result: {'ok' if res.get('success') else 'FAILED'}"
@@ -1361,7 +1444,7 @@ def _try_dispatch_background_run(
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
             "error": res.get("error"),
-            "api_calls": 0,
+            "api_calls": real_api_calls,
             "duration_seconds": duration,
         }
 


### PR DESCRIPTION
fix(cron): mark zero-inference manual runs as failure and preserve full trace

Manual cron runs via cronjob(action=run) background dispatch previously
reported ok with api_calls hardcoded to 0, so zero-inference fires were
recorded as success and the completion block's output excerpt was
truncated at 2000 chars mid-tool-call. This silently skipped maintenance.

- cron/scheduler.py: add zero-inference guard in run_job — if api_calls==0
  and tokens==0 (LLM path, not no_agent) return failure with audit
  api_calls, distinct FAILED doc and error; audit now records api_calls
  honestly for wrapper consumption.
- tools/cronjob_tools.py: raise excerpt limit to 20000 to keep full trace,
  plumb real api_calls from usage audit instead of 0, and add defense-
  in-depth zero-inference guard in _runner that flips false-positive ok
  to error and corrects last_status when audit confirms no inference.

Closes #100180

diff --git a/cron/scheduler.py b/cron/scheduler.py
index 6580427a6..256c349d5 100644
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6732,6 +6732,70 @@ def run_job(
 {logged_response}
 """

+        # #100180 false-positive guard: zero inference must not be recorded as ok.
+        # A turn that completed with zero LLM API calls (and zero tokens) made no
+        # progress — the model was never invoked or the response was truncated
+        # before any tool result. Marking it ok silently skips maintenance.
+        _result_api_calls = result.get("api_calls")
+        _result_total = result.get("total_tokens")
+        _result_prompt = result.get("prompt_tokens")
+        _is_zero_inference = False
+        if _result_api_calls == 0:
+            # api_calls == 0 is definitive when the field is present (turn_finalizer always sets it)
+            if _result_total is None or _result_total == 0:
+                _is_zero_inference = True
+            elif _result_prompt is None or _result_prompt == 0:
+                _is_zero_inference = True
+        # Also detect truncated trace where transcript ends inside a tool_calls block
+        _is_truncated_tool = False
+        if final_response and "<tool_calls>" in final_response and "</tool_calls>" not in final_response:
+            _is_truncated_tool = True
+        if _is_zero_inference and not job.get("no_agent"):
+            logger.warning(
+                "Job '%s' completed with zero inference calls (api_calls=%s, total_tokens=%s) — marking as failure (#100180)",
+                job_name, _result_api_calls, _result_total,
+            )
+            error_msg = "Agent completed with zero inference calls (no LLM API call was made) — treating as failure (#100180)"
+            if _is_truncated_tool:
+                error_msg += " — transcript appears truncated mid-tool-call"
+            _audit_duration_ms = int((time.monotonic() - _audit_t_start) * 1000)
+            _audit_response_silent = _is_cron_silence_response(final_response or "")
+            _write_usage_audit({
+                "ts": _utcnow_iso_ms(),
+                "job_id": job_id,
+                "fire_id": _audit_fire_id,
+                "prompt_tokens": result.get("prompt_tokens"),
+                "completion_tokens": result.get("completion_tokens"),
+                "total_tokens": result.get("total_tokens"),
+                "api_calls": _result_api_calls,
+                "response_silent": _audit_response_silent,
+                "deliver_target": job.get("deliver"),
+                "model": model or None,
+                "duration_ms": _audit_duration_ms,
+                "error": error_msg,
+            })
+            output_failed = f"""# Cron Job: {job_name} (FAILED)
+
+**Job ID:** {job_id}
+**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}
+**Schedule:** {job.get('schedule_display', 'N/A')}
+
+## Prompt
+
+{prompt}
+
+## Error
+
+```
+{error_msg}
+```
+
+## Partial Response
+
+{final_response}
+"""
+            return False, output_failed, "", error_msg
+
         logger.info("Job '%s' completed successfully", job_name)

         # Emit one JSONL line per fire for usage audit.
@@ -6744,6 +6808,7 @@ def run_job(
             "prompt_tokens": result.get("prompt_tokens"),
             "completion_tokens": result.get("completion_tokens"),
             "total_tokens": result.get("total_tokens"),
+            "api_calls": result.get("api_calls"),
             "response_silent": _audit_response_silent,
             "deliver_target": job.get("deliver"),
             "model": model or None,
@@ -6767,6 +6832,7 @@ def run_job(
                 "prompt_tokens": None,
                 "completion_tokens": None,
                 "total_tokens": None,
+                "api_calls": 0,
                 "response_silent": False,
                 "deliver_target": job.get("deliver"),
                 "model": model or None,
diff --git a/tools/cronjob_tools.py b/tools/cronjob_tools.py
index bc9df41bb..032476c2f 100644
--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1136,7 +1136,7 @@ def _run_claimed_job(
         }

-def _latest_job_output_excerpt(job_id: str, max_chars: int = 2000) -> Optional[str]:
+def _latest_job_output_excerpt(job_id: str, max_chars: int = 20000) -> Optional[str]:
     """Best-effort excerpt of the job's most recent saved output file.

     Included in the background-run completion block so the parent agent sees
@@ -1340,6 +1340,89 @@ def _try_dispatch_background_run(
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
+        # Derive real api_calls from usage audit instead of hardcoded 0 (#100180).
+        # The audit is written by cron/scheduler.run_job with the turn's
+        # prompt/completion/total tokens and api_calls. Using it here makes the
+        # completion block's "API calls" honest and gives us a zero-inference
+        # signal to flip false-positive ok to error.
+        real_api_calls = 0
+        real_total_tokens = 0
+        audit_record_found = False
+        try:
+            from cron.scheduler import _usage_audit_path
+            audit_path = _usage_audit_path()
+            if audit_path.exists():
+                # read last matching record for this job
+                latest = None
+                try:
+                    text = audit_path.read_text(encoding="utf-8", errors="ignore")
+                except Exception:
+                    text = ""
+                for line in text.splitlines():
+                    try:
+                        rec = json.loads(line)
+                    except Exception:
+                        continue
+                    if rec.get("job_id") == job_id:
+                        latest = rec
+                if latest is not None:
+                    audit_record_found = True
+                    try:
+                        real_api_calls = int(latest.get("api_calls") or 0)
+                    except Exception:
+                        real_api_calls = 0
+                    # Fallback for audits written before api_calls existed (or mocked records): tokens>0 implies >=1 call
+                    if real_api_calls == 0:
+                        try:
+                            if int(latest.get("total_tokens") or 0) > 0:
+                                real_api_calls = 1
+                            elif int(latest.get("prompt_tokens") or 0) > 0:
+                                real_api_calls = 1
+                        except Exception:
+                            pass
+                    try:
+                        real_total_tokens = int(latest.get("total_tokens") or 0)
+                    except Exception:
+                        real_total_tokens = 0
+        except Exception:
+            pass
+        # Zero-inference guard: if the scheduler still recorded ok but audit shows no tokens/calls, correct it here
+        # (defense-in-depth alongside scheduler's own guard). Don't flip no_agent jobs — they intentionally have 0 calls.
+        # Only flip when an audit record was found and confirms zero inference; mocked tests with no audit stay as-is.
+        try:
+            job_for_guard = refreshed or claimed_job or {}
+            if res.get("success") and audit_record_found and real_api_calls == 0 and real_total_tokens == 0 and not job_for_guard.get("no_agent"):
+                # Confirm via output excerpt whether transcript looks truncated (dangling tool_calls)
+                _excerpt_for_check = None
+                try:
+                    _excerpt_for_check = _latest_job_output_excerpt(job_id, max_chars=5000)
+                except Exception:
+                    pass
+                _is_trunc = False
+                if _excerpt_for_check and "<tool_calls>" in _excerpt_for_check and "</tool_calls>" not in _excerpt_for_check:
+                    _is_trunc = True
+                err_msg = "Zero inference calls (no LLM API call was made) — treating as failure (#100180)"
+                if _is_trunc:
+                    err_msg += " — transcript appears truncated mid-tool-call"
+                # Best-effort correction of persisted status so last_status reflects failure
+                try:
+                    from cron.jobs import mark_job_run
+                    _fire_owner = None
+                    _claim = claimed_job.get("fire_claim") if isinstance(claimed_job, dict) else None
+                    if isinstance(_claim, dict):
+                        _fire_owner = str(_claim.get("by") or "") or None
+                    mark_kwargs = {}
+                    if _fire_owner:
+                        mark_kwargs["expected_fire_owner"] = _fire_owner
+                    # Only correct if the persisted status is still ok (avoid overwriting a newer run)
+                    if refreshed.get("last_status") == "ok":
+                        mark_job_run(job_id, False, err_msg, **mark_kwargs)
+                        refreshed = get_job(job_id) or refreshed
+                except Exception:
+                    pass
+                res = {"success": False, "error": err_msg}
+        except Exception:
+            pass
         lines = [
             f"Cron job '{job_name}' ({job_id}) finished its manual run.",
             f"Result: {'ok' if res.get('success') else 'FAILED'}"
@@ -1361,7 +1444,7 @@ def _try_dispatch_background_run(
             "status": "completed" if res.get("success") else "error",
             "summary": "\n".join(lines),
             "error": res.get("error"),
-            "api_calls": 0,
+            "api_calls": real_api_calls,
             "duration_seconds": duration,
         }