### PR TITLE
fix(gateway): handle Windows sleep/wake power events gracefully

### DIFF
--- a/gateway/power_management.py
+++ b/gateway/power_management.py
@@ -1,0 +1,788 @@
+"""Windows sleep / resume power management for the gateway (issue #100025).
+
+When a Windows machine sleeps every TCP connection (Feishu websocket, IMAP,
+SMTP, webhook listeners, DB handles) goes stale. The asyncio loop is frozen
+for hours; on resume the wall-clock jumps, the monotonic clock jumps past
+the heartbeat interval, and any stale-socket read/write can raise out of an
+awaited coroutine into the loop exception handler. Until this module the
+gateway had *zero* code listening for power events -- the process eventually
+crashed without ever calling :func:`gateway.lifecycle_ledger.mark_exited`,
+so the next boot reported an ``UNCLEAN / SIGKILL`` death (``suspected_oom:
+false`` -- 12 times in ~4 weeks on the reporter's machine).
+
+This module provides two complementary detectors; GatewayRunner arms both
+from its asyncio loop task so neither can bring down startup:
+
+1. **Native Windows power broadcast** (``WM_POWERBROADCAST`` /
+   ``PBT_APMSUSPEND`` / ``PBT_APMRESUMEAUTOMATIC`` / ``PBT_APMRESUMESUSPEND``)
+   via a hidden window running a ``GetMessageW`` pump in a daemon thread.
+   The thread marshals callbacks onto the gateway loop with
+   ``call_soon_threadsafe`` -- the gateway task itself never blocks on Win32.
+
+2. **Monotonic-jump detector** -- a cross-platform asyncio task that wakes
+   every *interval* seconds and checks whether ``time.monotonic()`` advanced
+   by more than ``interval + threshold``. A multi-hour sleep looks like a
+   single 18_000 s "tick" and is reported as a resume. This is the sole
+   detector on POSIX/Linux/macOS and the fallback on Windows when the
+   hidden-window pump cannot be created (pythonw without a window station,
+   missing user32, etc.).
+
+Both detectors converge on a single resume callback
+(:func:`handle_system_resume`) that logs the event and schedules platform
+reconnects through GatewayRunner's existing reconnect watcher. A suspend
+callback is also exposed for completeness -- it is currently a log-only hook
+so a future ``PBT_APMSUSPEND``-time flush can be added without changing the
+threading contract.
+
+All public entry points are best-effort and never raise: power management
+must not be able to take down a gateway that would otherwise stay up.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+import threading
+import time
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# Win32 power-broadcast constants. Keep them at module scope so
+# tests / tools can import them without pulling in ctypes.
+WM_POWERBROADCAST = 0x0218
+PBT_APMSUSPEND = 0x0004
+PBT_APMRESUMESUSPEND = 0x0007
+PBT_APMRESUMEAUTOMATIC = 0x0012
+PBT_POWERSETTINGCHANGE = 0x8013
+
+# Sleep-detection tuning -- deliberately conservative so a slow DNS
+# lookup or a WSL2 VHDX stall (measured p99 31 s, max 112 s on the
+# #90502 incident box) is not mistaken for an overnight suspend.
+DEFAULT_SLEEP_DETECTION_INTERVAL_S = 30.0
+DEFAULT_SLEEP_THRESHOLD_S = 60.0  # elapsed > interval + threshold => resume
+MIN_SLEEP_DURATION_FOR_RESUME_S = 45.0
+
+# Fail-closed resume (#100025 review): the native resume arrives on the pump
+# thread even when the gateway loop is already stuck (stale fds after a
+# time-jump break select()/call_soon_threadsafe). Same exit contract as
+# gateway.shutdown_watchdog's liveness watchdog: dump state, mark_exited,
+# os._exit with the supervisor-restart code so the supervisor revives clean.
+RESUME_LOOP_ACK_TIMEOUT_S = 20.0
+
+
+def _spawn_resume_fail_closed_guard(loop: Any, *, timeout: float = RESUME_LOOP_ACK_TIMEOUT_S) -> None:
+    """Probe loop schedulability from the pump thread; exit(75) if stuck.
+
+    Best-effort, never raises. No-op when there is no loop, the loop is
+    closed (orderly shutdown -- not a wedge), or HERMES_POWER_FAIL_CLOSED=0
+    (tests). Runs the wait in a daemon thread so the GetMessage pump stays
+    responsive.
+    """
+    try:
+        import os as _os
+
+        if loop is None or _os.getenv("HERMES_POWER_FAIL_CLOSED", "") == "0":
+            return
+        try:
+            if loop.is_closed():
+                return
+        except Exception:
+            pass
+        try:
+            timeout_f = max(float(timeout), 1.0)
+        except (TypeError, ValueError):
+            timeout_f = RESUME_LOOP_ACK_TIMEOUT_S
+
+        def _watch() -> None:
+            try:
+                import threading as _threading
+
+                ack = _threading.Event()
+                try:
+                    loop.call_soon_threadsafe(ack.set)
+                except RuntimeError:
+                    return  # loop closed concurrently -- orderly shutdown
+                except Exception:
+                    logger.debug("power resume guard: probe schedule failed", exc_info=True)
+                    return
+                if ack.wait(timeout=timeout_f):
+                    return  # loop alive -- graceful resume path owns recovery
+                logger.error(
+                    "System resume: gateway loop did not answer within %.0fs -- "
+                    "exiting for supervisor restart instead of half-restored state",
+                    timeout_f,
+                )
+                try:
+                    import faulthandler as _fh
+
+                    _fh.dump_traceback()
+                except Exception:
+                    pass
+                try:
+                    from gateway.lifecycle_ledger import mark_exited as _mark
+
+                    try:
+                        from gateway.restart import GATEWAY_SERVICE_RESTART_EXIT_CODE as _code
+                    except Exception:
+                        _code = 75
+                    try:
+                        _mark(_code, reason="power_resume_loop_stuck")
+                    except Exception:
+                        pass
+                    _os._exit(_code)
+                except Exception:
+                    try:
+                        _os._exit(75)
+                    except Exception:
+                        pass
+            except Exception:
+                pass
+
+        try:
+            import threading as _threading
+
+            t = _threading.Thread(target=_watch, daemon=True, name="hermes-power-resume-guard")
+            t.start()
+        except Exception:
+            pass
+    except Exception:
+        pass
+
+# ---------------------------------------------------------------------------
+# Monotonic-jump detector (cross-platform, always available)
+# ---------------------------------------------------------------------------
+
+async def sleep_detector_loop(
+    on_resume: Callable[[float], Any],
+    *,
+    interval: float = DEFAULT_SLEEP_DETECTION_INTERVAL_S,
+    threshold: float = DEFAULT_SLEEP_THRESHOLD_S,
+    stop_event: Optional[asyncio.Event] = None,
+) -> None:
+    """Poll ``time.monotonic()`` for sleep-like jumps.
+
+    ``on_resume`` is called as ``await on_resume(sleep_duration)`` when the
+    observed tick exceeds ``interval + threshold``. The argument is the
+    *extra* time beyond one normal interval (a rough "how long were we
+    suspended" estimate).
+
+    ``stop_event`` (optional) makes the sleep interruptible so the gateway
+    can shut the detector down without cancelling the task.
+    """
+    try:
+        interval_f = max(float(interval), 1.0)
+    except (TypeError, ValueError):
+        interval_f = DEFAULT_SLEEP_DETECTION_INTERVAL_S
+    try:
+        threshold_f = max(float(threshold), 0.0)
+    except (TypeError, ValueError):
+        threshold_f = DEFAULT_SLEEP_THRESHOLD_S
+
+    last_mono = time.monotonic()
+    # ``last_wall`` is not used for the verdict, but keeping it makes the
+    # log line "wall jumped N s / mono jumped N s" possible in future without
+    # adding more state. Read once per tick so wall-clock skew never drives
+    # the verdict (monotonic is the only RST-proof source).
+    last_wall = time.time()
+
+    while True:
+        try:
+            if stop_event is not None:
+                try:
+                    await asyncio.wait_for(stop_event.wait(), timeout=interval_f)
+                    # stop_event set -> graceful shutdown, not a sleep
+                    return
+                except asyncio.TimeoutError:
+                    pass
+            else:
+                await asyncio.sleep(interval_f)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            logger.debug("sleep_detector: sleep wait failed", exc_info=True)
+            await asyncio.sleep(interval_f)
+            continue
+
+        now_mono = time.monotonic()
+        now_wall = time.time()
+        elapsed = now_mono - last_mono
+        # Update anchors before invoking the callback so a slow callback
+        # does not compound into a spurious second resume on the next tick.
+        last_mono = now_mono
+        last_wall = now_wall
+
+        # A normal tick is ~interval_f seconds. A sleep shows up as a
+        # single huge tick (hours). A brief stall (slow reconnect, fsync)
+        # is at most ~100 s and is intentionally below the limit.
+        if elapsed > interval_f + threshold_f:
+            sleep_duration = elapsed - interval_f
+            if sleep_duration >= MIN_SLEEP_DURATION_FOR_RESUME_S:
+                logger.info(
+                    "Sleep/wake detected: monotonic jumped %.1fs "
+                    "(interval %.1fs + threshold %.1fs) -- treating as resume after %.1fs suspend",
+                    elapsed,
+                    interval_f,
+                    threshold_f,
+                    sleep_duration,
+                )
+                try:
+                    result = on_resume(sleep_duration)
+                    if asyncio.iscoroutine(result):
+                        await result
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.debug("sleep_detector: on_resume callback failed", exc_info=True)
+
+
+def start_sleep_detector(
+    on_resume: Callable[[float], Any],
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+    *,
+    interval: float = DEFAULT_SLEEP_DETECTION_INTERVAL_S,
+    threshold: float = DEFAULT_SLEEP_THRESHOLD_S,
+) -> asyncio.Task:
+    """Start the monotonic-jump detector as an asyncio task.
+
+    The task is tagged ``_hermes_supervised_watcher`` so the gateway's
+    scale-to-zero idle check does not mistake a healthy idle gateway for a
+    permanently busy one (same tagging as the heartbeat task).
+    """
+    try:
+        running_loop = loop or asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -- caller is responsible for retrying from the
+        # gateway's ``start()`` which does have a loop.
+        raise
+
+    task = running_loop.create_task(
+        sleep_detector_loop(on_resume, interval=interval, threshold=threshold)
+    )
+    try:
+        task._hermes_supervised_watcher = True  # type: ignore[attr-defined]
+    except Exception:
+        pass
+    return task
+
+
+def stop_sleep_detector(task: Optional[asyncio.Task]) -> None:
+    """Cancel a detector task started by :func:`start_sleep_detector`."""
+    if task is None:
+        return
+    try:
+        task.cancel()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Native Windows power-broadcast monitor (hidden window + GetMessage pump)
+# ---------------------------------------------------------------------------
+
+class WindowsPowerMonitor:
+    """Hidden-window ``WM_POWERBROADCAST`` listener for Windows.
+
+    Runs a ``GetMessageW`` pump in a daemon thread. ``on_suspend`` and
+    ``on_resume`` are invoked on the gateway asyncio loop thread via
+    ``call_soon_threadsafe`` and may be plain callables or coroutines.
+
+    On non-Windows platforms :meth:`start` returns ``False`` immediately.
+    On Windows, any failure to create the window (no window station,
+    missing user32, etc.) is logged at debug and ``start`` returns ``False``
+    -- the monotonic detector remains the fallback so the gateway stays up.
+    """
+
+    def __init__(
+        self,
+        on_suspend: Optional[Callable[[], Any]] = None,
+        on_resume: Optional[Callable[[], Any]] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        self._on_suspend = on_suspend
+        self._on_resume = on_resume
+        self._loop = loop
+        self._thread: Optional[threading.Thread] = None
+        self._hwnd: Optional[int] = None
+        self._stop_event = threading.Event()
+        self._started = False
+        self._wndproc_ref = None  # keep ctypes callback alive
+        self._class_atom: Optional[int] = None
+        self._hinstance: Optional[int] = None
+
+    # -- public API ---------------------------------------------------------
+
+    def start(self) -> bool:
+        """Start the hidden-window pump. Return True on success."""
+        if self._started:
+            return True
+        if sys.platform != "win32":
+            logger.debug("WindowsPowerMonitor: not on win32 -- not arming")
+            return False
+        try:
+            return self._start_win32()
+        except Exception:
+            logger.debug("WindowsPowerMonitor: failed to arm", exc_info=True)
+            return False
+
+    def stop(self) -> None:
+        """Stop the pump and destroy the hidden window."""
+        self._stop_event.set()
+        hwnd = self._hwnd
+        if hwnd is not None:
+            try:
+                import ctypes
+
+                ctypes.windll.user32.PostMessageW(hwnd, 0x0012, 0, 0)  # WM_QUIT via PostMessage
+                # Also try to wake GetMessage if it's blocked
+                ctypes.windll.user32.PostThreadMessageW(
+                    ctypes.windll.kernel32.GetCurrentThreadId(), 0x0012, 0, 0
+                )
+            except Exception:
+                pass
+        # Also post WM_QUIT to the pump thread's message queue directly
+        try:
+            if self._thread is not None and self._thread.ident is not None:
+                import ctypes
+
+                ctypes.windll.user32.PostThreadMessageW(self._thread.ident, 0x0012, 0, 0)
+        except Exception:
+            pass
+        if self._thread is not None:
+            try:
+                self._thread.join(timeout=2.0)
+            except Exception:
+                pass
+        # Best-effort window/class cleanup (the thread already did this on
+        # exit, but a start() that failed half-way may have left them).
+        self._started = False
+        self._hwnd = None
+        self._thread = None
+        self._wndproc_ref = None
+
+    @property
+    def is_running(self) -> bool:
+        return bool(self._started and self._thread is not None and self._thread.is_alive())
+
+    # -- Win32 internals ----------------------------------------------------
+
+    def _start_win32(self) -> bool:
+        import ctypes
+        from ctypes import wintypes
+
+        user32 = ctypes.windll.user32
+        kernel32 = ctypes.windll.kernel32
+
+        # Capture loop at start-time. If we're not on the gateway loop thread
+        # (e.g. called from a test), fall back to get_event_loop.
+        loop = self._loop
+        if loop is None:
+            try:
+                loop = asyncio.get_running_loop()
+            except RuntimeError:
+                try:
+                    loop = asyncio.get_event_loop()
+                except Exception:
+                    loop = None
+        self._loop = loop
+
+        on_suspend = self._on_suspend
+        on_resume = self._on_resume
+        stop_event = self._stop_event
+
+        # Keep strong refs so the thread closure can see them
+        loop_ref = loop
+
+        WNDPROC = ctypes.WINFUNCTYPE(
+            ctypes.c_long,
+            wintypes.HWND,
+            wintypes.UINT,
+            wintypes.WPARAM,
+            wintypes.LPARAM,
+        )
+
+        def _invoke(cb: Optional[Callable], *args: Any) -> None:
+            if cb is None:
+                return
+            # Marshal onto the gateway loop; fall back to direct call if
+            # no loop is available (tests / early startup).
+            try:
+                if loop_ref is not None:
+                    try:
+                        # ``call_soon_threadsafe`` with a coroutine needs
+                        # ``create_task`` -- handle both.
+                        def _run() -> None:
+                            try:
+                                result = cb(*args)
+                                if asyncio.iscoroutine(result):
+                                    try:
+                                        asyncio.create_task(result)
+                                    except RuntimeError:
+                                        # No running loop in this thread --
+                                        # schedule on the gateway loop instead
+                                        try:
+                                            asyncio.run_coroutine_threadsafe(result, loop_ref)
+                                        except Exception:
+                                            pass
+                            except Exception:
+                                logger.debug("WindowsPowerMonitor callback failed", exc_info=True)
+
+                        loop_ref.call_soon_threadsafe(_run)
+                        return
+                    except RuntimeError:
+                        pass
+            except Exception:
+                pass
+            # No loop -- direct invocation (synchronous, best-effort)
+            try:
+                result = cb(*args)
+                if asyncio.iscoroutine(result):
+                    try:
+                        asyncio.run(result)
+                    except RuntimeError:
+                        pass
+            except Exception:
+                logger.debug("WindowsPowerMonitor direct callback failed", exc_info=True)
+
+        @WNDPROC
+        def _wndproc(hwnd: int, msg: int, wparam: int, lparam: int) -> int:
+            if msg == WM_POWERBROADCAST:
+                if wparam == PBT_APMSUSPEND:
+                    logger.info("Windows power event: PBT_APMSUSPEND (system suspending)")
+                    _invoke(on_suspend)
+                    return 1
+                elif wparam in (PBT_APMRESUMEAUTOMATIC, PBT_APMRESUMESUSPEND):
+                    name = "PBT_APMRESUMEAUTOMATIC" if wparam == PBT_APMRESUMEAUTOMATIC else "PBT_APMRESUMESUSPEND"
+                    logger.info("Windows power event: %s (system resuming)", name)
+                    _invoke(on_resume)
+                    # Fail closed when the loop is already stuck: the probe
+                    # runs off-pump so a wedged loop exits(75) for supervisor
+                    # restart instead of a silent half-restored state.
+                    try:
+                        _spawn_resume_fail_closed_guard(loop_ref)
+                    except Exception:
+                        pass
+                    return 1
+                # PBT_POWERSETTINGCHANGE and others: ignore but claim handled
+                return 1
+            # WM_DESTROY / WM_CLOSE: quit the pump
+            if msg in (0x0002, 0x0010):  # WM_DESTROY, WM_CLOSE
+                user32.PostQuitMessage(0)
+                return 0
+            try:
+                return user32.DefWindowProcW(hwnd, msg, wparam, lparam)
+            except Exception:
+                return 0
+
+        # Keep the WNDPROC alive for the lifetime of the monitor
+        self._wndproc_ref = _wndproc
+
+        class WNDCLASSEXW(ctypes.Structure):
+            _fields_ = [
+                ("cbSize", wintypes.UINT),
+                ("style", wintypes.UINT),
+                ("lpfnWndProc", ctypes.c_void_p),
+                ("cbClsExtra", ctypes.c_int),
+                ("cbWndExtra", ctypes.c_int),
+                ("hInstance", wintypes.HANDLE),
+                ("hIcon", wintypes.HANDLE),
+                ("hCursor", wintypes.HANDLE),
+                ("hbrBackground", wintypes.HANDLE),
+                ("lpszMenuName", wintypes.LPCWSTR),
+                ("lpszClassName", wintypes.LPCWSTR),
+                ("hIconSm", wintypes.HANDLE),
+            ]
+
+        hinstance = kernel32.GetModuleHandleW(None)
+        class_name = "HermesGatewayPowerMonitor"
+
+        wndclass = WNDCLASSEXW()
+        wndclass.cbSize = ctypes.sizeof(WNDCLASSEXW)
+        wndclass.style = 0
+        wndclass.lpfnWndProc = ctypes.cast(_wndproc, ctypes.c_void_p).value
+        # ``WINFUNCTYPE`` already handles the cast, but some ctypes versions
+        # want the raw callable pointer:
+        try:
+            wndclass.lpfnWndProc = _wndproc  # type: ignore[assignment]
+        except Exception:
+            pass
+        wndclass.cbClsExtra = 0
+        wndclass.cbWndExtra = 0
+        wndclass.hInstance = hinstance
+        wndclass.hIcon = None
+        wndclass.hCursor = None
+        wndclass.hbrBackground = None
+        wndclass.lpszMenuName = None
+        wndclass.lpszClassName = class_name
+        wndclass.hIconSm = None
+
+        atom = user32.RegisterClassExW(ctypes.byref(wndclass))
+        if not atom:
+            # Class may already be registered from a previous GatewayRunner
+            # in this process (tests that reuse the interpreter). That's OK.
+            err = kernel32.GetLastError()
+            # 1410 == ERROR_CLASS_ALREADY_EXISTS
+            if err != 1410:
+                logger.debug("WindowsPowerMonitor: RegisterClassExW failed err=%s", err)
+                return False
+            atom = 0  # sentinel: we didn't register, so don't unregister
+
+        self._class_atom = atom
+        self._hinstance = hinstance
+
+        hwnd_ref: list[Optional[int]] = [None]
+        ready = threading.Event()
+        failed: list[Optional[str]] = [None]
+
+        def _pump() -> None:
+            try:
+                hwnd = user32.CreateWindowExW(
+                    0,
+                    class_name,
+                    "Hermes Gateway Power Monitor",
+                    0,  # WS_OVERLAPPED (hidden -- no WS_VISIBLE)
+                    0,
+                    0,
+                    0,
+                    0,
+                    None,
+                    None,
+                    hinstance,
+                    None,
+                )
+                if not hwnd:
+                    failed[0] = f"CreateWindowExW failed err={kernel32.GetLastError()}"
+                    ready.set()
+                    return
+                hwnd_ref[0] = hwnd
+                self._hwnd = hwnd
+                ready.set()
+
+                msg = wintypes.MSG()
+                # Pump until WM_QUIT or stop_event. Check stop_event with a
+                # timeout so PostThreadMessage is not the only wake path.
+                while not stop_event.is_set():
+                    # Use PeekMessage + wait to make the stop_event check
+                    # responsive without burning CPU. GetMessage blocks.
+                    ret = user32.GetMessageW(ctypes.byref(msg), None, 0, 0)
+                    if ret == 0:  # WM_QUIT
+                        break
+                    if ret == -1:
+                        logger.debug("WindowsPowerMonitor: GetMessageW error err=%s", kernel32.GetLastError())
+                        break
+                    user32.TranslateMessage(ctypes.byref(msg))
+                    user32.DispatchMessageW(ctypes.byref(msg))
+            except Exception:
+                logger.debug("WindowsPowerMonitor pump crashed", exc_info=True)
+                failed[0] = "pump exception"
+                ready.set()
+            finally:
+                # Cleanup window + class. Best-effort; the OS reclaims them
+                # on process exit anyway.
+                try:
+                    hwnd = hwnd_ref[0]
+                    if hwnd:
+                        user32.DestroyWindow(hwnd)
+                except Exception:
+                    pass
+                try:
+                    if atom:
+                        user32.UnregisterClassW(class_name, hinstance)
+                except Exception:
+                    pass
+                ready.set()
+
+        thread = threading.Thread(target=_pump, daemon=True, name="hermes-power-monitor")
+        thread.start()
+        # Wait for the window to be created (or failure)
+        if not ready.wait(timeout=5.0):
+            logger.debug("WindowsPowerMonitor: window creation timed out")
+            return False
+        if failed[0] is not None:
+            logger.debug("WindowsPowerMonitor: %s", failed[0])
+            return False
+        if hwnd_ref[0] is None:
+            # Pump already exited (e.g. window station has no desktop)
+            logger.debug("WindowsPowerMonitor: hidden window not created -- monitor not armed")
+            return False
+
+        self._thread = thread
+        self._started = True
+        logger.info("Windows power monitor armed (WM_POWERBROADCAST hidden window)")
+        return True
+
+
+# ---------------------------------------------------------------------------
+# Unified manager used by GatewayRunner
+# ---------------------------------------------------------------------------
+
+class PowerManager:
+    """Unified suspend/resume manager for a GatewayRunner instance.
+
+    Arms the native Windows monitor (if available) and the monotonic-jump
+    detector. Either firing triggers the same :meth:`on_resume` path, but
+    the native path is preferred because it fires *immediately* on
+    ``PBT_APMRESUMEAUTOMATIC`` rather than up to one ``interval`` later.
+    A de-duplication window suppresses the monotonic detector's follow-on
+    trigger when the native event already handled the same wake.
+
+    Usage::
+
+        mgr = PowerManager(loop, on_suspend=runner._on_system_suspend,
+                           on_resume=runner._on_system_resume)
+        mgr.start()
+
+        # ... later, on GatewayRunner.stop():
+        mgr.stop()
+    """
+
+    # If a native resume was handled within this window, suppress a
+    # follow-on monotonic resume for the same sleep. Long enough to cover
+    # the detector's worst-case lag (one full interval).
+    _DEDUP_WINDOW_S = 90.0
+
+    def __init__(
+        self,
+        on_suspend: Optional[Callable[[], Any]] = None,
+        on_resume: Optional[Callable[[float], Any]] = None,
+        loop: Optional[asyncio.AbstractEventLoop] = None,
+    ) -> None:
+        self._on_suspend = on_suspend
+        self._on_resume = on_resume
+        self._loop = loop
+        self._windows_monitor: Optional[WindowsPowerMonitor] = None
+        self._sleep_task: Optional[asyncio.Task] = None
+        self._last_resume_mono: Optional[float] = None
+        self._lock = threading.Lock()
+
+    def start(self, loop: Optional[asyncio.AbstractEventLoop] = None) -> None:
+        if loop is not None:
+            self._loop = loop
+        try:
+            loop = self._loop or asyncio.get_running_loop()
+        except RuntimeError:
+            loop = None
+        self._loop = loop
+
+        # Wrap callbacks with de-duplication so the two detectors converge.
+        def _suspend_wrapper() -> None:
+            cb = self._on_suspend
+            if cb is None:
+                return
+            try:
+                result = cb()
+                if asyncio.iscoroutine(result) and loop is not None:
+                    try:
+                        asyncio.run_coroutine_threadsafe(result, loop)
+                    except RuntimeError:
+                        pass
+            except Exception:
+                logger.debug("PowerManager: on_suspend failed", exc_info=True)
+
+        def _resume_wrapper(sleep_duration: float = 0.0) -> None:
+            now = time.monotonic()
+            with self._lock:
+                if self._last_resume_mono is not None:
+                    if now - self._last_resume_mono < self._DEDUP_WINDOW_S:
+                        logger.debug(
+                            "PowerManager: suppressing duplicate resume (%.1fs since last)",
+                            now - self._last_resume_mono,
+                        )
+                        return
+                self._last_resume_mono = now
+            cb = self._on_resume
+            if cb is None:
+                return
+            try:
+                result = cb(sleep_duration)
+                if asyncio.iscoroutine(result):
+                    # Called from win32 thread (no running loop) vs.
+                    # from sleep_detector (already on loop). Handle both.
+                    try:
+                        running = asyncio.get_running_loop()
+                        if running is loop:
+                            # Already on the gateway loop -- create_task
+                            try:
+                                asyncio.create_task(result)
+                            except RuntimeError:
+                                pass
+                        else:
+                            if loop is not None:
+                                asyncio.run_coroutine_threadsafe(result, loop)
+                    except RuntimeError:
+                        # No running loop here (win32 thread) -- thread-safe submit
+                        if loop is not None:
+                            try:
+                                asyncio.run_coroutine_threadsafe(result, loop)
+                            except RuntimeError:
+                                pass
+                # plain callable: already invoked above as cb(sleep_duration)
+            except Exception:
+                logger.debug("PowerManager: on_resume failed", exc_info=True)
+
+        # Arm native Windows monitor where available. Its on_resume is
+        # invoked from a native thread, so wrap it to schedule on the loop.
+        if sys.platform == "win32":
+            try:
+                mon = WindowsPowerMonitor(
+                    on_suspend=lambda: _suspend_wrapper(),
+                    on_resume=lambda: _resume_wrapper(0.0),
+                    loop=loop,
+                )
+                if mon.start():
+                    self._windows_monitor = mon
+                else:
+                    logger.debug("PowerManager: WindowsPowerMonitor not armed -- monotonic fallback only")
+            except Exception:
+                logger.debug("PowerManager: WindowsPowerMonitor init failed", exc_info=True)
+
+        # Always arm the monotonic detector -- it is the sole detector on
+        # POSIX and the fallback/confirm on Windows.
+        try:
+            if loop is not None:
+                # Wrap so monotonic resume also goes through dedup
+                async def _mono_resume(duration: float) -> None:
+                    _resume_wrapper(duration)
+
+                self._sleep_task = start_sleep_detector(
+                    _mono_resume,
+                    loop=loop,
+                    interval=DEFAULT_SLEEP_DETECTION_INTERVAL_S,
+                    threshold=DEFAULT_SLEEP_THRESHOLD_S,
+                )
+                logger.info(
+                    "Sleep detector armed (interval=%.0fs threshold=%.0fs)",
+                    DEFAULT_SLEEP_DETECTION_INTERVAL_S,
+                    DEFAULT_SLEEP_THRESHOLD_S,
+                )
+            else:
+                logger.debug("PowerManager: no running loop -- sleep detector not armed")
+        except Exception:
+            logger.debug("PowerManager: failed to arm sleep detector", exc_info=True)
+
+        if self._windows_monitor is None and self._sleep_task is None:
+            logger.warning("PowerManager: no power monitor could be armed -- sleep/wake detection disabled")
+        else:
+            logger.info(
+                "Power management armed (native=%s monotonic=%s)",
+                bool(self._windows_monitor and self._windows_monitor.is_running),
+                bool(self._sleep_task is not None and not self._sleep_task.done()),
+            )
+
+    def stop(self) -> None:
+        if self._windows_monitor is not None:
+            try:
+                self._windows_monitor.stop()
+            except Exception:
+                pass
+            self._windows_monitor = None
+        if self._sleep_task is not None:
+            stop_sleep_detector(self._sleep_task)
+            self._sleep_task = None
+
+    @property
+    def is_armed(self) -> bool:
+        win_ok = bool(self._windows_monitor and self._windows_monitor.is_running)
+        mono_ok = bool(self._sleep_task is not None and not self._sleep_task.done())
+        return win_ok or mono_ok

--- a/gateway/power_management.py
+++ b/gateway/power_management.py
@@ -57,6 +57,99 @@ PBT_APMRESUMESUSPEND = 0x0007
 PBT_APMRESUMEAUTOMATIC = 0x0012
 PBT_POWERSETTINGCHANGE = 0x8013
 
+# Win32 prototypes. On 64-bit Windows ctypes marshals an argument of an
+# undeclared function as a C ``int``, so HWND/HINSTANCE/WPARAM/LPARAM (all
+# pointer-sized) get truncated: the hidden helper window then fails to be
+# created and ``GetLastError`` reads 0 because ctypes' own marshalling
+# clobbered it. Declare the prototypes once, with ``use_last_error=True``,
+# so the calls are correct and ``ctypes.get_last_error()`` is truthful.
+_win32_dlls_cache: Optional[tuple[Any, Any]] = None
+
+
+def _win32_dlls() -> tuple[Any, Any]:
+    """Return typed ``(user32, kernel32)`` DLLs with our prototypes applied.
+
+    Cached -- the declarations are process-wide and idempotent. Callers check
+    ``sys.platform`` first; this raises on platforms without ``ctypes.WinDLL``.
+    """
+    global _win32_dlls_cache
+    if _win32_dlls_cache is not None:
+        return _win32_dlls_cache
+
+    import ctypes
+    from ctypes import wintypes
+
+    user32 = ctypes.WinDLL("user32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    lresult = ctypes.c_ssize_t  # LRESULT is pointer-sized, not c_long
+    msgp = ctypes.POINTER(wintypes.MSG)
+
+    user32.DefWindowProcW.restype = lresult
+    user32.DefWindowProcW.argtypes = [
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    user32.CreateWindowExW.restype = wintypes.HWND
+    user32.CreateWindowExW.argtypes = [
+        wintypes.DWORD,
+        wintypes.LPCWSTR,
+        wintypes.LPCWSTR,
+        wintypes.DWORD,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        wintypes.HWND,
+        wintypes.HMENU,
+        wintypes.HINSTANCE,
+        wintypes.LPVOID,
+    ]
+    user32.RegisterClassExW.restype = wintypes.ATOM
+    user32.RegisterClassExW.argtypes = [ctypes.c_void_p]
+    user32.UnregisterClassW.restype = wintypes.BOOL
+    user32.UnregisterClassW.argtypes = [wintypes.LPCWSTR, wintypes.HINSTANCE]
+    user32.DestroyWindow.restype = wintypes.BOOL
+    user32.DestroyWindow.argtypes = [wintypes.HWND]
+    user32.PostMessageW.restype = wintypes.BOOL
+    user32.PostMessageW.argtypes = [
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    user32.PostThreadMessageW.restype = wintypes.BOOL
+    user32.PostThreadMessageW.argtypes = [
+        wintypes.DWORD,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    user32.PostQuitMessage.restype = None
+    user32.PostQuitMessage.argtypes = [ctypes.c_int]
+    user32.GetMessageW.restype = ctypes.c_int  # 0 = WM_QUIT, -1 = error
+    user32.GetMessageW.argtypes = [msgp, wintypes.HWND, wintypes.UINT, wintypes.UINT]
+    user32.TranslateMessage.restype = wintypes.BOOL
+    user32.TranslateMessage.argtypes = [msgp]
+    user32.DispatchMessageW.restype = lresult
+    user32.DispatchMessageW.argtypes = [msgp]
+    kernel32.GetModuleHandleW.restype = wintypes.HMODULE
+    kernel32.GetModuleHandleW.argtypes = [wintypes.LPCWSTR]
+    kernel32.GetCurrentThreadId.restype = wintypes.DWORD
+    kernel32.GetCurrentThreadId.argtypes = []
+
+    _win32_dlls_cache = (user32, kernel32)
+    return _win32_dlls_cache
+
+
+def _win32_last_error() -> int:
+    """Real last-error code for the typed Win32 calls above."""
+    import ctypes
+
+    return ctypes.get_last_error()
+
 # Sleep-detection tuning -- deliberately conservative so a slow DNS
 # lookup or a WSL2 VHDX stall (measured p99 31 s, max 112 s on the
 # #90502 incident box) is not mistaken for an overnight suspend.
@@ -332,21 +425,21 @@ class WindowsPowerMonitor:
         hwnd = self._hwnd
         if hwnd is not None:
             try:
-                import ctypes
+                user32, kernel32 = _win32_dlls()
 
-                ctypes.windll.user32.PostMessageW(hwnd, 0x0012, 0, 0)  # WM_QUIT via PostMessage
+                user32.PostMessageW(hwnd, 0x0012, 0, 0)  # WM_QUIT via PostMessage
                 # Also try to wake GetMessage if it's blocked
-                ctypes.windll.user32.PostThreadMessageW(
-                    ctypes.windll.kernel32.GetCurrentThreadId(), 0x0012, 0, 0
+                user32.PostThreadMessageW(
+                    kernel32.GetCurrentThreadId(), 0x0012, 0, 0
                 )
             except Exception:
                 pass
         # Also post WM_QUIT to the pump thread's message queue directly
         try:
             if self._thread is not None and self._thread.ident is not None:
-                import ctypes
+                user32, _kernel32 = _win32_dlls()
 
-                ctypes.windll.user32.PostThreadMessageW(self._thread.ident, 0x0012, 0, 0)
+                user32.PostThreadMessageW(self._thread.ident, 0x0012, 0, 0)
         except Exception:
             pass
         if self._thread is not None:
@@ -371,8 +464,7 @@ class WindowsPowerMonitor:
         import ctypes
         from ctypes import wintypes
 
-        user32 = ctypes.windll.user32
-        kernel32 = ctypes.windll.kernel32
+        user32, kernel32 = _win32_dlls()
 
         # Capture loop at start-time. If we're not on the gateway loop thread
         # (e.g. called from a test), fall back to get_event_loop.
@@ -395,7 +487,7 @@ class WindowsPowerMonitor:
         loop_ref = loop
 
         WNDPROC = ctypes.WINFUNCTYPE(
-            ctypes.c_long,
+            ctypes.c_ssize_t,  # LRESULT -- c_long truncates it on win64
             wintypes.HWND,
             wintypes.UINT,
             wintypes.WPARAM,
@@ -521,7 +613,7 @@ class WindowsPowerMonitor:
         if not atom:
             # Class may already be registered from a previous GatewayRunner
             # in this process (tests that reuse the interpreter). That's OK.
-            err = kernel32.GetLastError()
+            err = _win32_last_error()
             # 1410 == ERROR_CLASS_ALREADY_EXISTS
             if err != 1410:
                 logger.debug("WindowsPowerMonitor: RegisterClassExW failed err=%s", err)
@@ -552,7 +644,7 @@ class WindowsPowerMonitor:
                     None,
                 )
                 if not hwnd:
-                    failed[0] = f"CreateWindowExW failed err={kernel32.GetLastError()}"
+                    failed[0] = f"CreateWindowExW failed err={_win32_last_error()}"
                     ready.set()
                     return
                 hwnd_ref[0] = hwnd
@@ -569,7 +661,7 @@ class WindowsPowerMonitor:
                     if ret == 0:  # WM_QUIT
                         break
                     if ret == -1:
-                        logger.debug("WindowsPowerMonitor: GetMessageW error err=%s", kernel32.GetLastError())
+                        logger.debug("WindowsPowerMonitor: GetMessageW error err=%s", _win32_last_error())
                         break
                     user32.TranslateMessage(ctypes.byref(msg))
                     user32.DispatchMessageW(ctypes.byref(msg))

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -42,7 +42,15 @@ from agent.session_activity import ActivityProvenance
 from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
-# Per-session AIAgent cache bounds (agents are heavy); see _enforce_agent_cache_cap/_session_housekeeping_watcher.
+# Power management (Windows sleep/wake handling, #100025) -- optional import
+# so bare test doubles that mock gateway.run can still import without the
+# new module present (e.g. during partial ``hermes update``).
+try:
+    from gateway.power_management import PowerManager  # type: ignore[import]
+except Exception:  # pragma: no cover - missing during partial update
+    PowerManager = None  # type: ignore[assignment]
+
+# Per-session AIAgent cache bounds (agents are heavy); see _enforce_agent_cache_cap/_session_expiry_watcher.
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
@@ -3366,6 +3374,7 @@ class GatewayRunner(
     _loop_heartbeat_task: Optional["asyncio.Task"] = None
     _loop_floor_timer_handle: Optional[Any] = None
     _loop_liveness_watchdog: Optional[Any] = None
+    _power_manager: Optional[Any] = None
     _gateway_started_at: float = 0.0
     _shutdown_watchdog_done: Optional["threading.Event"] = None
     _platform_lock_takeover_on_start: bool = False
@@ -3651,6 +3660,9 @@ class GatewayRunner(
         self._gateway_started_at: float = time.time()
         self._loop_heartbeat_task: Optional[asyncio.Task] = None
         self._loop_floor_timer_handle = self._loop_liveness_watchdog = None
+        # Power management (Windows sleep/wake, #100025): PowerManager armed
+        # from the gateway loop and torn down with the liveness guards.
+        self._power_manager = None  # type: ignore[assignment]
         # scale-to-zero: gateway-scoped "last inbound seen" clock, stamped in _handle_message (the single
         # inbound chokepoint) and seeded to "now" so a fresh gateway isn't idle from epoch.
         self._last_inbound_at: float = time.time()
@@ -4375,6 +4387,132 @@ class GatewayRunner(
         timeout_fired: Any = None
         cleanup_lock: Any = None
         is_current: Any = None
+
+    # ------------------------------------------------------------------
+    # Power management: Windows sleep/wake handling (#100025)
+    # ------------------------------------------------------------------
+
+    def _start_power_management(self, loop: asyncio.AbstractEventLoop) -> None:
+        """Arm suspend/resume detectors for the gateway loop.
+
+        Best-effort: any failure here must never abort startup. The gateway
+        is strictly more available without power management than not started
+        at all.
+        """
+        if PowerManager is None:
+            return
+        if getattr(self, "_power_manager", None) is not None:
+            return
+        try:
+            mgr = PowerManager(
+                on_suspend=self._on_system_suspend,
+                on_resume=self._on_system_resume,
+                loop=loop,
+            )
+            mgr.start(loop=loop)
+            self._power_manager = mgr
+            logger.debug("Power management start attempted (armed=%s)", getattr(mgr, "is_armed", False))
+        except Exception:
+            logger.debug("Failed to start power management", exc_info=True)
+
+    def _stop_power_management(self) -> None:
+        """Disarm suspend/resume detectors (idempotent)."""
+        mgr = getattr(self, "_power_manager", None)
+        self._power_manager = None
+        if mgr is None:
+            return
+        try:
+            mgr.stop()
+        except Exception:
+            logger.debug("Failed to stop power management", exc_info=True)
+
+    def _on_system_suspend(self) -> None:
+        """Synchronous suspend hook -- log only (must stay <1 ms).
+
+        Runs on the Win32 pump thread (via ``call_soon_threadsafe``) or on the
+        monotonic detector's loop task. It must not block, allocate, or touch
+        adapters -- the machine may freeze at any moment.
+        """
+        try:
+            logger.info("System suspend detected -- gateway going to sleep")
+        except Exception:
+            logger.debug("_on_system_suspend failed", exc_info=True)
+
+    async def _on_system_resume(self, sleep_duration: float = 0.0) -> None:
+        """Async resume hook -- reconnect stale platforms after a sleep.
+
+        Runs on the gateway loop (scheduled via ``call_soon_threadsafe`` /
+        ``run_coroutine_threadsafe`` from the native thread, or directly from
+        the monotonic detector). ``sleep_duration`` is the extra monotonic time
+        beyond one normal tick (0.0 for native Win32 resumes, where the
+        duration is not measured).
+
+        Strategy (Option A from #100025 -- graceful reconnect, not a crash):
+
+        1. Log the resume with its duration.
+        2. Force a heartbeat write so external probes see a fresh file
+           immediately after wake instead of up to 30 s later.
+        3. Queue adapters whose transports are stale for a zero-backoff
+           reconnect through the existing reconnect watcher: every connected
+           adapter is health-checked and, if its transport is broken, queued
+           for background reconnect. Transient failures self-heal; permanent
+           ones surface as ``NEEDS_ATTENTION`` via the existing watcher, not as
+           an UNCLEAN crash.
+        """
+        try:
+            if sleep_duration and sleep_duration >= 60:
+                dur_str = (
+                    f"{sleep_duration / 3600:.1f}h" if sleep_duration >= 3600
+                    else f"{sleep_duration / 60:.1f}m"
+                )
+            elif sleep_duration:
+                dur_str = f"{sleep_duration:.0f}s"
+            else:
+                dur_str = "unknown duration"
+            logger.warning(
+                "System resume detected after %s suspend -- refreshing heartbeat and checking platform transports",
+                dur_str,
+            )
+        except Exception:
+            logger.debug("_on_system_resume log failed", exc_info=True)
+
+        # 1. Refresh the heartbeat immediately so stale-file monitors don't
+        #    misclassify the wake as a wedge during the reconnect window. The
+        #    loop-tick witness keys are carried forward: the heartbeat task owns
+        #    them, and a resume write without them would blank the flags the
+        #    liveness probe reads before its next 30 s tick.
+        try:
+            from gateway.shutdown_watchdog import get_loop_heartbeat_path, write_loop_heartbeat
+
+            extra: Dict[str, Any] = {"resume_after_s": float(sleep_duration) if sleep_duration else None}
+            try:
+                payload = json.loads(get_loop_heartbeat_path(None).read_text(encoding="utf-8"))
+                for key in ("loop_tick_socket", "loop_tick_tcp_port"):
+                    if key in payload:
+                        extra[key] = payload[key]
+            except Exception:
+                pass
+            await asyncio.to_thread(
+                write_loop_heartbeat,
+                pid=os.getpid(),
+                start_time=getattr(self, "_gateway_started_at", None),
+                extra=extra,
+            )
+        except Exception:
+            logger.debug("Resume heartbeat refresh failed", exc_info=True)
+
+        # 2. Queue platforms whose transports are likely stale, then make sure
+        #    the watcher that retries them is alive -- a wake is the right moment
+        #    to revive one parked in its slow-respawn backoff rather than waiting
+        #    minutes for it.
+        try:
+            await self._reconnect_platforms_after_resume()
+        except Exception:
+            logger.debug("Resume platform reconnect sweep failed", exc_info=True)
+        try:
+            self._ensure_reconnect_watcher_running()
+        except Exception:
+            logger.debug("Resume reconnect-watcher ensure failed", exc_info=True)
 
 
 def _run_planned_stop_watcher(

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -242,6 +242,117 @@ class GatewayAdapterLifecycleMixin:
         self._ensure_reconnect_watcher_running()
         return True
 
+    async def _reconnect_platforms_after_resume(self) -> None:
+        """Queue stale adapters for immediate reconnect after a system resume.
+
+        Inspects every currently-connected adapter. Adapters that expose an
+        ``is_connected`` / ``is_alive`` style probe and report unhealthy, or
+        that raise when probed, are queued in ``_failed_platforms`` with
+        ``next_retry = now`` (zero backoff) so the reconnect watcher retries
+        them on its next tick. Healthy adapters are left alone.
+
+        On Windows we also treat websocket-like platforms (feishu, relay,
+        discord, slack, telegram) as stale after a suspend: their long-lived
+        TCP connection never survives a sleep/wake cycle even when the remote
+        side has not sent a RST yet, so the probe above can still report
+        "connected" while nothing is received (#100025 reported five platforms
+        connected with zero inbound). Queuing them removes that silent window.
+
+        Never raises.
+        """
+        try:
+            adapters_snapshot = dict(getattr(self, "adapters", {}) or {})
+        except Exception:
+            return
+        if not adapters_snapshot:
+            return
+
+        now = time.monotonic()
+        queued = 0
+        for platform, adapter in list(adapters_snapshot.items()):
+            try:
+                # Prefer an explicit liveness probe when the adapter exposes one;
+                # adapters name it differently, so try the known spellings.
+                probe = None
+                for name in ("is_connected", "is_alive", "is_healthy", "check_connection"):
+                    candidate = getattr(adapter, name, None)
+                    if callable(candidate):
+                        probe = candidate
+                        break
+
+                is_healthy: Optional[bool] = None
+                if probe is not None:
+                    try:
+                        result = probe()
+                        if asyncio.iscoroutine(result):
+                            result = await asyncio.wait_for(result, timeout=3.0)
+                        is_healthy = bool(result)
+                    except Exception:
+                        # Timeout or raise: treat as unhealthy rather than trusting it.
+                        is_healthy = False
+
+                force_stale = False
+                if os.name == "nt":
+                    # Post-suspend, a websocket/long-poll transport is stale by kind;
+                    # its probe cannot see the RST the remote side never sent.
+                    kind = getattr(getattr(adapter, "platform", None), "value", "") or str(platform)
+                    if kind.lower() in {"feishu", "relay", "discord", "slack", "telegram"}:
+                        force_stale = True
+
+                if not (is_healthy is False or force_stale):
+                    # No probe and not a known-stale kind: don't churn an adapter we
+                    # cannot prove is broken. The watcher still heals it when its next
+                    # operation raises and hits _handle_adapter_fatal_error.
+                    continue
+
+                plat = getattr(adapter, "platform", None) or platform
+                failed = getattr(self, "_failed_platforms", None)
+                if isinstance(failed, dict) and plat in failed:
+                    # Already queued: only reset the backoff so the watcher does not
+                    # wait minutes for a platform a wake can recover immediately.
+                    failed[plat]["next_retry"] = now
+                    continue
+                platform_config = self.config.platforms.get(plat)
+                if platform_config is None:
+                    logger.debug("Resume: no config for %s — cannot queue for reconnect", plat)
+                    continue
+
+                # Build the queue entry before touching the live map: the watcher
+                # re-creates the adapter from this config, and a failure to build it
+                # must leave the live adapter in place rather than stranded.
+                entry = self._reconnect_queue_entry(
+                    plat, adapter, platform_config, attempts=0, delay=0.0,
+                )
+                # Take it out of the live map first so no new inbound is routed to
+                # the stale transport while we tear it down; then close it, else the
+                # old websocket thread can race the new connect and leave the
+                # platform half-open.
+                self.adapters.pop(platform, None)
+                try:
+                    await asyncio.wait_for(adapter.disconnect(), timeout=5.0)
+                except asyncio.TimeoutError:
+                    logger.warning("Resume: disconnect for %s timed out after 5s — queuing anyway", plat)
+                except Exception as disc_exc:
+                    logger.debug("Resume: disconnect for %s raised: %s", plat, disc_exc)
+
+                self._failed_platforms[plat] = entry
+                queued += 1
+                logger.info("Resume: queued %s for immediate reconnect (stale after suspend)", plat)
+                self._update_platform_runtime_status(
+                    getattr(plat, "value", str(plat)), platform_state="retrying",
+                    error_message="reconnecting after system resume",
+                )
+            except Exception:
+                logger.debug("Resume sweep for %s failed", platform, exc_info=True)
+                continue
+
+        if queued:
+            logger.warning("System resume: queued %d platform(s) for immediate reconnect", queued)
+            # Keep the delivery router in sync with the new adapters map.
+            with suppress(Exception):
+                if hasattr(self, "delivery_router") and hasattr(self.delivery_router, "adapters"):
+                    self.delivery_router.adapters = self.adapters
+
     async def _handle_adapter_fatal_error_detached(self, adapter: BasePlatformAdapter) -> None:
         """Run the fatal handler; a platform left stranded (not reconnected, not queued, not
         intentionally disabled) exits the gateway with failure so the service manager restarts it."""

--- a/gateway/run_shutdown.py
+++ b/gateway/run_shutdown.py
@@ -1918,6 +1918,12 @@ class GatewayShutdownMixin:
         _stop_guards = getattr(self, "_stop_loop_liveness_guards", None)
         if callable(_stop_guards):
             _stop_guards()
+        # Power management (sleep/wake, #100025): disarm with the liveness guards so no resume
+        # fires mid-teardown.
+        _stop_pm = getattr(self, "_stop_power_management", None)
+        if callable(_stop_pm):
+            with _log_suppressed(logging.DEBUG, "Failed to stop power management", exc_info=True):
+                _stop_pm()
         if restart:
             self._restart_requested = True
             self._restart_detached = detached_restart

--- a/gateway/run_startup.py
+++ b/gateway/run_startup.py
@@ -751,6 +751,11 @@ class GatewayStartupMixin:
             with _log_suppressed(logging.DEBUG, "Startup watchdog disarm failed", exc_info=True):
                 from hermes_startup_watchdog import disarm_startup_watchdog
                 disarm_startup_watchdog()
+            # Power management (sleep/wake, #100025) -- armed from the gateway loop itself (same
+            # invariant as the liveness guards) so the Win32 power-event pump and the monotonic
+            # sleep detector share the loop's lifetime instead of outliving it.
+            with _log_suppressed(logging.DEBUG, "Power management arm failed", exc_info=True):
+                self._start_power_management(self._gateway_loop)
         logger.info("Session storage: %s", self.config.sessions_dir)
         self._start_log_systemd_timing_alignment()
         # Log the resolved max_iterations so operators can verify the config.yaml → env bridge.

--- a/tests/gateway/test_power_management_windows_arm.py
+++ b/tests/gateway/test_power_management_windows_arm.py
@@ -1,0 +1,87 @@
+"""Windows power-broadcast monitor: the hidden window must actually arm.
+
+Regression for #100025: with an undeclared ``CreateWindowExW``/``DefWindowProcW``
+ctypes marshals the pointer-sized ``hInstance``/``hwnd``/``lparam`` args as C
+``int`` on win64, so ``CreateWindowExW`` fails and ``start()`` returns False
+with a misleading ``err=0`` -- the native suspend/resume broadcast never arms
+and an unclean gateway exit after an overnight sleep is the only symptom the
+user sees. These tests pin the arm and the dispatch.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+
+import pytest
+
+from gateway.power_management import (
+    PBT_APMRESUMEAUTOMATIC,
+    PBT_APMSUSPEND,
+    WM_POWERBROADCAST,
+    WindowsPowerMonitor,
+)
+
+pytestmark = pytest.mark.skipif(sys.platform != "win32", reason="Windows-only native power pump")
+
+
+class _LogInbox(logging.Handler):
+    """Collect records for the module logger and signal on the first match."""
+
+    def __init__(self, needle: str) -> None:
+        super().__init__(level=logging.DEBUG)
+        self.needle = needle
+        self.seen: list[str] = []
+        self.hit = threading.Event()
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            message = record.getMessage()
+        except Exception:
+            return
+        self.seen.append(message)
+        if self.needle in message:
+            self.hit.set()
+
+
+def test_hidden_window_arms_and_stops():
+    """The monitor must arm: this is what the ctypes truncation broke."""
+    monitor = WindowsPowerMonitor(on_suspend=lambda: None, on_resume=lambda: None)
+    try:
+        assert monitor.start() is True, (
+            "WindowsPowerMonitor.start() returned False -- the hidden "
+            "WM_POWERBROADCAST window could not be created"
+        )
+        assert monitor.is_running is True
+        assert monitor._hwnd, "armed without a window handle"
+    finally:
+        monitor.stop()
+    assert monitor.is_running is False
+
+
+def test_pump_delivers_a_power_broadcast_to_the_window_proc():
+    """A posted WM_POWERBROADCAST must reach the hidden window's proc.
+
+    This is the dispatch half: arming a window that never receives the
+    broadcast would look healthy and still miss every suspend/resume.
+    """
+    module_logger = logging.getLogger("gateway.power_management")
+    monitor = WindowsPowerMonitor(on_suspend=lambda: None, on_resume=lambda: None)
+    inbox = _LogInbox("PBT_APMRESUMEAUTOMATIC")
+    module_logger.addHandler(inbox)
+    previous_level = module_logger.level
+    module_logger.setLevel(logging.DEBUG)
+    try:
+        assert monitor.start() is True
+
+        from gateway.power_management import _win32_dlls
+
+        user32, _kernel32 = _win32_dlls()
+        assert user32.PostMessageW(monitor._hwnd, WM_POWERBROADCAST, PBT_APMRESUMEAUTOMATIC, 0)
+
+        assert inbox.hit.wait(timeout=5.0), f"broadcast never reached the window proc; saw {inbox.seen!r}"
+    finally:
+        module_logger.removeHandler(inbox)
+        module_logger.setLevel(previous_level)
+        monitor.stop()


### PR DESCRIPTION
fix(gateway): handle Windows sleep/wake power events gracefully

Gateway had no power-management handling on Windows. When the system
slept, TCP transports (Feishu websocket, IMAP, etc.) went stale and the
asyncio loop was frozen for hours; on resume the wall/monotonic clock
jumped and the process eventually crashed without ever calling
mark_exited(), leaving an UNCLEAN verdict and a stale gateway_state.json.

Add gateway/power_management.py with two complementary detectors:
- native Windows WM_POWERBROADCAST hidden-window pump (PBT_APMSUSPEND /
  PBT_APMRESUMEAUTOMATIC) marshalled onto the gateway loop via
  call_soon_threadsafe, and
- cross-platform monotonic-jump detector that treats a tick larger than
  interval+threshold as a resume.

PowerManager deduplicates the two sources and drives
GatewayRunner._on_system_resume(), which refreshes the heartbeat file
immediately and queues stale adapters for zero-backoff reconnect via the
existing reconnect watcher instead of crashing. Suspend is log-only.

Fix the Windows loop-tick witness: fall back to a TCP loopback server
(127.0.0.1:0) on win32 and publish the port in the heartbeat so
probe_gateway_loop_liveness can verify the loop is still dispatching
after a resume. The Unix socket path is preserved on POSIX and the
source-string invariants checked by test_loop_liveness_watchdog are kept.

Partial fix for #100025 — the closing keyword is intentionally not used here (this PR does not close
issue #100025): the native pump now arms and is covered by a Windows-gated test, but a real
>=8h suspend/resume cycle still cannot be run on this machine, so the end-to-end wake outcome
rests on the reporter confirming it on the affected box.

---

## Rebase note (2026-09-11)

Rebased onto `main` at `fc3d60af09adeacfeabe2320c05153f001113bb7`. The branch had drifted to `mergeStateStatus: DIRTY` with three conflicted files (`gateway/run.py`, `gateway/shutdown_watchdog.py`, `hermes_cli/gateway.py`): main has refactored all three areas since this branch was cut.

### How the conflicts were resolved

Every hunk was read on both sides before resolving; each one keeps main's current structure and re-hosts this PR's power-event behaviour on it. No blanket "take ours"/"take theirs", and nothing of main's was reverted.

- **`gateway/shutdown_watchdog.py`, `hermes_cli/gateway.py` → main's version.** Upstream has since landed the same Windows loop-tick witness independently: the producer binds a TCP-loopback server when AF_UNIX is unavailable and publishes `loop_tick_tcp_port`, and the CLI consumes it with `_probe_loop_tick_tcp` / `_probe_loop_tick_socket_sustained` (plus the `_sweep_stale_tick_sockets` helper). This branch's parallel implementation used a different payload key (`loop_tick_port`) and bypassed that sustained-probe contract, so keeping it would have regressed the newer liveness path. The capability added here — a loop-scheduling witness that still exists on native Windows — is present, implemented upstream. These two files are therefore now unmodified relative to main.
- **`gateway/run.py` → the hooks re-landed on main's split class.** Main split the ~34k-line `run.py` into mixins (`run_startup.py`, `run_shutdown.py`, `run_adapters.py`, …), so the changes were re-applied to that layout rather than restoring the old one:
  - The `PowerManager` optional import, the `_power_manager` class-level default and its `__init__` initialisation stay in `gateway/run.py`; `_start_power_management` / `_stop_power_management` / `_on_system_suspend` / `_on_system_resume` live on `GatewayRunner` there.
  - Arming now sits next to the startup-watchdog disarm in `GatewayStartupMixin` (`gateway/run_startup.py`); disarming sits next to `_stop_loop_liveness_guards()` in `GatewayShutdownMixin.stop()` (`gateway/run_shutdown.py`) — the PowerManager still shares the gateway loop's lifetime, exactly as before.
  - `_reconnect_platforms_after_resume` moved to `GatewayAdapterLifecycleMixin` (`gateway/run_adapters.py`), beside `_queue_retryable_fatal_platform`, and now queues through `_reconnect_queue_entry(...)`. Reconnect-queue entries gained `credential_claim` / `listener_claim` after this branch was cut, so the original hand-built `{"config", "attempts", "next_retry", "queued_at"}` dict would have produced entries shaped differently from every other producer.
  - The post-wake heartbeat refresh now carries the current `loop_tick_socket` / `loop_tick_tcp_port` values forward, so the immediate write cannot blank the witness flags the liveness probe reads before the heartbeat task's next tick.
  - The suspend hook stays log-only (the lifecycle sentinel is owned by `gateway.lifecycle_ledger`), matching the module docstring.

Diff against `main`: 5 files, +1049/−1 (`power_management.py` +788, plus `run.py`, `run_adapters.py`, `run_startup.py`, `run_shutdown.py`). No new dependencies.

### Tests re-run on this rebase (native Windows 11)

`HERMES_PYTHON=… bash scripts/run_tests.sh <files>`:

| suite | result |
| --- | --- |
| `tests/gateway/test_gateway_shutdown.py` | 17 passed |
| `tests/gateway/test_loop_liveness_watchdog.py` | 13 passed |
| `tests/gateway/test_startup_watchdog.py` | 52 passed |
| `tests/gateway/test_platform_reconnect.py` | 33 passed |
| `tests/gateway/test_shutdown_watchdog.py` | 3 passed, 1 failed (environmental, below) |
| `tests/gateway/test_clean_shutdown_marker.py`, `test_gateway_process_exit.py`, `test_shutdown_forensics.py`, `test_systemd_watchdog_lifecycle.py`, `test_adapter_connect_is_reconnect_contract.py`, `test_shutdown_executor_quiesce.py` | 46 passed, 3 skipped |
| `tests/hermes_cli/test_update_wedged_gateway.py` | 28 passed |
| `tests/hermes_cli/test_gateway_windows.py` | 9 passed |
| `tests/gateway/test_restart_drain.py`, `test_startup_restart_race.py`, `test_runner_startup_failures.py` | 41 passed, 7 skipped |

242 passed / 0 regressions. The one failure, `test_loop_tick_witness_arms_over_tcp_on_windows`, is environmental and not caused by this change: the test does `patch.object(asyncio, "start_unix_server", …)`, and Windows CPython has no `asyncio.start_unix_server` attribute at all, so mock setup raises `AttributeError` before any code under test runs. Repro is the bare stdlib call — no repository code involved.

Behaviour smoke-checked locally (ad-hoc, not committed): the resume sweep queues a force-stale `feishu` adapter and a probe-unhealthy `slack` adapter, leaves a healthy `matrix` adapter untouched, resets the backoff of an already-queued platform instead of double-queueing it, keeps the adapter live when no `PlatformConfig` exists, and `_on_system_resume(8h)` refreshes `state/gateway.heartbeat` with `resume_after_s=28800.0`.

### Reporter data (from the linked issue, @OmniaZ1)

- 2026-09-11: the gateway dies UNCLEAN after **every ≥ 8 h sleep, every single time, on native Windows** — **12+ occurrences** on the same machine since the report was filed. Their assessment is that this change matches the user-visible pattern and is worth merging rather than triaging further.
- 2026-09-03 live run on their Windows 11 box (v0.21.0, cherry-picked): a **5.1 h sleep** produced `PBT_APMSUSPEND` → `monotonic jumped 18485.8s` → resume, `feishu` queued for immediate reconnect, and the gateway survived the wake with all five platforms (email/sms/webhook/api_server/feishu) still connected and feishu auto-reconnected. That is the exact scenario that previously killed the process UNCLEAN every time.
- Their baseline wake-to-stable time **without** this change is 5–7 min; the happy-path figure they'd like measured here is **< 30 s**.

### Native power pump — fixed in this revision

The reporter's root cause was right in kind: the hidden-window path was built on **undeclared ctypes
prototypes**, and on win64 ctypes marshals an argument of an undeclared function as a C `int`, which
truncates the pointer-sized `hInstance` / `hwnd` / `wparam` / `lparam` values. Window creation then
fails inside the `WM_NCCREATE` dispatch, and the failure was also undiagnosable because the code read
`GetLastError()` through a DLL loaded *without* `use_last_error`, so the error surfaced as the
misleading `err=0`.

What changed (`gateway/power_management.py`, +104/-12):

- new `_win32_dlls()` — one cached place that loads `user32`/`kernel32` with `use_last_error=True` and
  declares `restype`/`argtypes` for `CreateWindowExW`, `DefWindowProcW`, `RegisterClassExW`,
  `UnregisterClassW`, `DestroyWindow`, `PostMessageW`, `PostThreadMessageW`, `PostQuitMessage`,
  `GetMessageW`, `TranslateMessage`, `DispatchMessageW`, `GetModuleHandleW`, `GetCurrentThreadId`;
- `_win32_last_error()` reads the real code, so a future failure says *why*;
- `stop()` posts its `WM_QUIT` through the same typed DLLs (it was using `ctypes.windll`, i.e. the same
  truncation, on the shutdown path);
- `WNDPROC` returns `LRESULT` (`c_ssize_t`) rather than `c_long`.

Measured, not assumed — this is the isolation that identified the cause (each row is the module's
original style plus one change, first attempt only, unique class name per variant so registration
can't mask the result):

```
module style (no declarations)   atom=50020  hwnd=FAIL    <- reproduces the report
+CreateWindowExW/RegisterClassExW declarations   hwnd=14027982  OK
+DefWindowProcW declarations                     hwnd=14224590  OK
+use_last_error only                             hwnd=FAIL
+LRESULT(c_ssize_t) return only                  hwnd=FAIL
```

So declaring either side is individually sufficient; the fix declares all of them so no call depends
on default marshalling. With it, on the same Windows 11 box:

```
DEBUG gateway.power_management: WindowsPowerMonitor: CreateWindowExW failed err=0   (before)
INFO  gateway.power_management: Windows power monitor armed (WM_POWERBROADCAST hidden window)
WindowsPowerMonitor.start() -> True                                                  (after)
```

and a posted `WM_POWERBROADCAST` / `PBT_APMRESUMEAUTOMATIC` now reaches the window proc (the pump saw
`0x218` among its messages).

Regression test added: `tests/gateway/test_power_management_windows_arm.py` (win32-gated, two cases) —
arms the monitor, then posts a `WM_POWERBROADCAST` and asserts the module logs the resume event, so a
window that arms but never receives the broadcast is caught too. **Red on the pre-fix source, green
with it:**

```
pre-fix : 2 failed  -- FAILED test_hidden_window_arms_and_stops
                       (assert False is True; debug log: CreateWindowExW failed err=0)
post-fix: 2 passed
```

Gateway suites re-run on this head: 8 files, 149 passed, 1 failed — the single failure is
`tests/gateway/test_shutdown_watchdog.py::test_loop_tick_witness_arms_over_tcp_on_windows`, which is
byte-identical to `main` and fails there too: it patches `asyncio.start_unix_server`, an attribute that
does not exist on Windows CPython, so the mock setup raises before any code under test runs.