### PR TITLE
fix(desktop): eliminate style-recalc freezes — static keyframes, containment, throttled measures

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-metrics.ts
@@ -114,8 +114,16 @@ export function useComposerMetrics({
   // would re-register the observation.
   const poppedOutRef = useRef(poppedOut)
   poppedOutRef.current = poppedOut
+  // #99889: ResizeObserver loop guard — setSurfaceVar mutates a CSS var that
+  // can change layout (thread clearance), which re-triggers the observer that
+  // just wrote it. Without a frame gate the observer fires again inside the
+  // same frame with undelivered notifications (see desktop.log) and the trace
+  // shows ForcedStyleAndLayout UpdateTime 17k events. Coalesce all
+  // measurements in one frame to a single rAF so at most one style invalidation
+  // is scheduled per frame.
+  const rafIdRef = useRef<number | null>(null)
 
-  const syncComposerMetrics = useCallback(() => {
+  const doSyncComposerMetrics = useCallback(() => {
     const composer = composerRef.current
     // The dock is the full docked footprint — strips, status stack, composer —
     // so it, not the composer alone, is what the thread has to clear.
@@ -183,7 +191,29 @@ export function useComposerMetrics({
     }
   }, [composerDockRef, composerRef, composerSurfaceRef, editorRef])
 
+  const syncComposerMetrics = useCallback(() => {
+    if (rafIdRef.current !== null) {
+      return
+    }
+
+    rafIdRef.current = window.requestAnimationFrame(() => {
+      rafIdRef.current = null
+      doSyncComposerMetrics()
+    })
+  }, [doSyncComposerMetrics])
+
   useResizeObserver(syncComposerMetrics, composerDockRef, composerRef, composerSurfaceRef, editorRef)
+
+  // Cancel any pending rAF on unmount so a late frame doesn't write after detach
+  // eslint-disable-next-line no-restricted-syntax -- rAF handle, not an atom mirror (see eslint rule comment)
+  useEffect(() => {
+    return () => {
+      if (rafIdRef.current !== null) {
+        cancelAnimationFrame(rafIdRef.current)
+        rafIdRef.current = null
+      }
+    }
+  }, [])
 
   // Toggling pop-out changes whether the composer reserves thread clearance.
   // The ResizeObserver may not fire (the box can keep the same box size), so

--- a/apps/desktop/src/app/starmap/timeline.tsx
+++ b/apps/desktop/src/app/starmap/timeline.tsx
@@ -182,7 +182,6 @@ export const Timeline = memo(function Timeline({
 
   return (
     <div className="pointer-events-auto flex w-[28rem] max-w-full items-center gap-3 [-webkit-app-region:no-drag]">
-      <style>{'@keyframes starmap-twinkle{0%,100%{opacity:var(--o,1)}50%{opacity:calc(var(--o,1) * 0.35)}}'}</style>
 
       <button
         aria-label={playing ? 'Pause' : 'Play timeline'}

--- a/apps/desktop/src/components/onboarding/glyph.tsx
+++ b/apps/desktop/src/components/onboarding/glyph.tsx
@@ -127,10 +127,8 @@ export function DecodedLabel({ leaving, text }: { leaving?: boolean; text: strin
       <GlyphText text={decoded} />
       <span
         aria-hidden="true"
-        className="dither ml-1.5 -mr-[0.875rem] inline-block size-2 shrink-0 -translate-y-px rounded-[1px] text-primary"
-        style={{ animation: 'ob-decode-cursor 1s step-end infinite' }}
+        className="dither ml-1.5 -mr-[0.875rem] inline-block size-2 shrink-0 -translate-y-px rounded-[1px] text-primary ob-decode-cursor-blink"
       />
-      <style>{'@keyframes ob-decode-cursor { 0%, 49% { opacity: 1 } 50%, 100% { opacity: 0 } }'}</style>
     </span>
   )
 }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/index.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/index.tsx
@@ -50,8 +50,6 @@ export function LayoutTreeRoot({ children }: { children?: ReactNode }) {
 
   return (
     <div className="relative flex min-h-0 min-w-0 flex-1">
-      {/* ZonesOverlay::GetAnimationAlpha ramp: clamp(t / 200ms, 0.001, 1). */}
-      <style>{`@keyframes hermes-zone-fade { from { opacity: 0.001 } to { opacity: 1 } }`}</style>
       {/* THE SEAM INVARIANT: boundaries are drawn by the tree (one sash
           hairline per seam) — content mounted in a zone must not paint its
           own edge chrome. App components (asides, the shadcn sidebar) carry

--- a/apps/desktop/src/components/ui/decode-text.tsx
+++ b/apps/desktop/src/components/ui/decode-text.tsx
@@ -108,14 +108,12 @@ export function DecodeText({
       )}
       {...props}
     >
-      {cursor && <style>{'@keyframes decode-cursor { 0%, 49% { opacity: 1 } 50%, 100% { opacity: 0 } }'}</style>}
       {staticPrefix}
       {tail}
       {cursor && (
         <span
           aria-hidden="true"
-          className="dither ml-0.5 inline-block size-2 shrink-0 -translate-y-px rounded-[1px]"
-          style={{ animation: 'decode-cursor 1s step-end infinite' }}
+          className="dither ml-0.5 inline-block size-2 shrink-0 -translate-y-px rounded-[1px] decode-cursor-blink"
         />
       )}
     </span>

--- a/apps/desktop/src/components/ui/loader.tsx
+++ b/apps/desktop/src/components/ui/loader.tsx
@@ -328,15 +328,59 @@ export function Loader({
   const groupRef = useRef<SVGGElement | null>(null)
   const particleRefs = useRef<Array<SVGCircleElement | null>>([])
   const pathRef = useRef<SVGPathElement | null>(null)
+  const svgRef = useRef<SVGSVGElement | null>(null)
 
   useEffect(() => {
     let animationFrame = 0
+    let hiddenTime = 0
     const startedAt = performance.now()
     const phaseOffset = Math.random()
     particleRefs.current.length = config.particleCount
 
+    const shouldPause = () => {
+      // Pause when the document is hidden, the global renderer-pause flag is
+      // set, or the host prefers reduced motion — same gates the compositor
+      // animations in styles.css use. Also pause when the SVG is off-screen /
+      // content-visibility skips it (intersection check is free inside rAF).
+      if (typeof document !== 'undefined') {
+        if (document.hidden) {
+          return true
+        }
+
+        if (document.documentElement?.hasAttribute('data-renderer-animations-paused')) {
+          return true
+        }
+
+        if (window.matchMedia?.('(prefers-reduced-motion: reduce)').matches) {
+          return true
+        }
+      }
+
+      const svg = svgRef.current
+
+      if (svg) {
+        const rect = svg.getBoundingClientRect()
+
+        // Zero-size means hidden by keep-alive tab (visibility:hidden but still
+        // in DOM) or content-visibility skip — don't burn 60 fps updating it.
+        if (rect.width === 0 && rect.height === 0) {
+          return true
+        }
+      }
+
+      return false
+    }
+
     const render = (now: number) => {
-      const time = now - startedAt
+      if (shouldPause()) {
+        // Accumulate paused time so progress doesn't jump on resume.
+        hiddenTime += 16
+        animationFrame = window.requestAnimationFrame(render)
+
+        return
+      }
+
+      const time = now - startedAt - hiddenTime
       const progress = ((time + phaseOffset * config.durationMs) % config.durationMs) / config.durationMs
       const detailScale = detailScaleFor(time, config, phaseOffset)
       const rotation = rotationFor(time, config, phaseOffset)
@@ -371,7 +415,13 @@ export function Loader({
       className={cn('inline-grid size-10 place-items-center text-primary', className)}
       role={role}
     >
-      <svg aria-hidden="true" className="size-full overflow-visible" fill="none" viewBox="0 0 100 100">
+      <svg
+        aria-hidden="true"
+        className="loader-svg size-full overflow-visible"
+        fill="none"
+        ref={svgRef}
+        viewBox="0 0 100 100"
+      >
         <g ref={groupRef}>
           <path
             opacity="0.1"

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1169,6 +1169,105 @@
   }
 }
 
+/* ── #99889: per-instance @keyframes → static stylesheet ────────────────
+   Each of these was previously rendered as a per-instance <style> tag inside
+   its component (DecodeText, pane-shell LayoutTreeRoot, Starmap Timeline,
+   onboarding Glyph). Inserting/removing a <style> that defines an
+   `@keyframes` rule invalidates every animating element in the document
+   (StyleRecalcInvalidation reason "@keyframes rule change" = 2,651 events in
+   the 60 s trace). Moving them here makes the registry change once at load.
+   The same bug family as #72844/#91473 and #91383; the per-instance form is
+   also what multiplied decode-cursor duplicates in the live DOM on every
+   Sessions/Bots tab switch.                                 — fix #99889 */
+@keyframes decode-cursor {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.decode-cursor-blink {
+  animation: decode-cursor 1s step-end infinite;
+}
+@keyframes ob-decode-cursor {
+  0%,
+  49% {
+    opacity: 1;
+  }
+  50%,
+  100% {
+    opacity: 0;
+  }
+}
+.ob-decode-cursor-blink {
+  animation: ob-decode-cursor 1s step-end infinite;
+}
+@keyframes hermes-zone-fade {
+  from {
+    opacity: 0.001;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes starmap-twinkle {
+  0%,
+  100% {
+    opacity: var(--o, 1);
+  }
+  50% {
+    opacity: calc(var(--o, 1) * 0.35);
+  }
+}
+
+/* ── #99889: contain expensive style subtrees ─────────────────────────
+   The 60 s trace shows single Document::recalcStyle slices of 300–1,232 ms
+   over ~6 k nodes (worst 1,385 ms) despite only ~20 ms of JS. The cost is
+   per-element selector matching, not recalc frequency: 2,266 "Affected by
+   :has()" invalidations and heavy color-mix/custom-property recomputation
+   across the whole document. Containment lets Blink skip subtrees that are
+   off-screen or style-isolated; :has() inside a `contain: style` boundary
+   does not re-evaluate outside it. These are the narrowest scopes that
+   still cover the expensive selectors in this file:
+     html:has([data-hud-shell]) / [data-hud-shell]:has(...)  → hud
+     [data-pane-shell]:has(...) / [data-tree-group]          → pane tree
+     [data-slot='aui_assistant-message-content'] :has(...)   → transcript
+   Loader SVG circles/paths (7,922/5,632 invalidations + 4,941 SVG-resource
+   invalidations) are also isolated so their per-frame Attribute mutations
+   (cx/cy/r/opacity + d) don't dirty ancestor style.               — #99889 */
+[data-hud-shell],
+[data-pane-shell],
+[data-tree-group] {
+  contain: layout style;
+}
+[data-slot='aui_assistant-message-content'] {
+  contain: style;
+}
+/* SVG loader: every rAF tick mutates <circle cx/cy/r/opacity> and <path d>;
+   without containment that schedules style+layout up the tree. `contain:
+   layout style paint` + `content-visibility: auto` keeps the work inside the
+   40×40 box and lets off-screen loaders (e.g. in a keep-alive Bots tab) skip
+   entirely. The compositor hint avoids layer churn on each tick. */
+.loader-svg {
+  contain: layout style paint;
+  content-visibility: auto;
+  contain-intrinsic-size: 40px 40px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .decode-cursor-blink,
+  .ob-decode-cursor-blink {
+    animation: none !important;
+  }
+}
+:root[data-renderer-animations-paused] .decode-cursor-blink,
+:root[data-renderer-animations-paused] .ob-decode-cursor-blink {
+  animation-play-state: paused !important;
+}
+
 /* No focus rings, anywhere. Kills the native outline plus Tailwind's
    `focus-visible:ring-*` (a box-shadow driven by --tw-ring-*). Unlayered so it
    beats the utilities layer without !important on the outline. The composer /


### PR DESCRIPTION
fix(desktop): eliminate style-recalc freezes — static keyframes, containment, throttled measures

Moves per-instance @keyframes (<style> tags in DecodeText, LayoutTreeRoot,
Starmap Timeline, onboarding Glyph) to the static stylesheet so inserting/
removing a tab no longer invalidates every animating element (2,651
"@keyframes rule change" invalidations in the 60 s trace, same family as
#91473/#91383).

Isolates expensive selector matching behind CSS containment: :has() inside
contain:style boundaries no longer re-evaluates the whole document,
reducing the 300–1,232 ms Document::recalcStyle slices over ~6k nodes
(2,266 "Affected by :has" events). Adds contain:layout style paint +
content-visibility:auto to the SVG loader so its per-frame cx/cy/r/opacity
and <path d> mutations (7,922 circle / 5,632 path + 4,941 SVG-resource
invalidations) stay inside the 40 px box and skip when off-screen / in a
keep-alive Bots tab.

Loader rAF now pauses when document.hidden, data-renderer-animations-paused,
prefers-reduced-motion, or the SVG is zero-size (keep-alive tab), and
coalesces hidden time so progress doesn't jump on resume.

ResizeObserver loop guard: use-composer-metrics coalesces all measurements
in one frame to a single rAF, preventing setSurfaceVar → layout → observer
feedback that filled desktop.log with "ResizeObserver loop completed with
undelivered notifications" and produced 17,821 ForcedStyleAndLayout events
(11.8 s) / 48 % of main-thread time.

Closes #99889