### PR TITLE
fix(agent): checkpoint/rollback for partial file mutations in long-running sessions

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -611,6 +611,7 @@ def init_agent(
     checkpoint_max_snapshots: int = 20,
     checkpoint_max_total_size_mb: int = 500,
     checkpoint_max_file_size_mb: int = 10,
+    checkpoint_interval: int = 10,
     pass_session_id: bool = False,
     requested_provider: str = None,
     capabilities: Optional[Dict[str, bool]] = None,
@@ -1755,6 +1756,7 @@ def init_agent(
         max_snapshots=checkpoint_max_snapshots,
         max_total_size_mb=checkpoint_max_total_size_mb,
         max_file_size_mb=checkpoint_max_file_size_mb,
+        checkpoint_interval=checkpoint_interval,
     )
     
     # SQLite session store (optional -- provided by CLI or gateway)

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -40,6 +40,37 @@ from agent.conversation_compression import (
 )
 from agent.context_engine import automatic_compaction_status_message
 from agent.display import KawaiiSpinner
+
+# Session-terminate marker for long-running sessions (#99869).
+def _record_session_interruption(agent, reason: str, last_action: str = "") -> None:
+    """Best-effort: write <hermes-home>/sessions/<id>.interrupted marker.
+
+    Called when a turn ends via kill/timeout/auth-error/context-exhaustion
+    so the next session can triage instead of trusting stale state.
+    Overwrites the "in_flight" marker written at turn start (see the
+    session-start block below) with the specific failure reason.
+    """
+    try:
+        sid = getattr(agent, "session_id", "") or ""
+        if not sid:
+            return
+        last_action = (last_action or "")[:2000]
+        reason = (reason or "interrupted")[:500]
+        if not last_action:
+            try:
+                # Assigned on every tool dispatch in _begin_tool_execution;
+                # _current_tool is the live fallback while a tool runs.
+                acted = getattr(agent, "_last_tool_action", "") or getattr(
+                    agent, "_current_tool", ""
+                ) or ""
+                if acted:
+                    last_action = str(acted)[:2000]
+            except Exception as exc:
+                logger.debug("interruption last-action probe failed: %s", exc)
+        from tools.checkpoint_manager import write_interrupted_marker
+        write_interrupted_marker(sid, last_action=last_action, reason=reason)
+    except Exception as exc:
+        logger.debug("session interruption record failed: %s", exc)
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.fast_mode import begin_turn as begin_fast_mode_turn
 from agent.message_metadata import append_message
@@ -2271,6 +2302,74 @@ def run_conversation(
     # (early failure / interrupt) so the hook receives None rather than a
     # stale prior turn's usage.
     agent._last_turn_usage = None
+
+    # Session-terminate markers for long-running sessions (#99869):
+    # write this session's in-flight marker FIRST, so a SIGKILL / process
+    # crash / watchdog exit-124 still leaves a record — no in-process
+    # handler can run on those paths, but an up-front marker needs none.
+    # Failure sites below overwrite the reason; clean completion clears it.
+    # The model-facing half of the signal is injected into the continuation
+    # prompt in build_turn_context (user-message channel), not here.
+    try:
+        from tools.checkpoint_manager import (
+            install_termination_handlers,
+            list_interrupted_markers,
+            write_interrupted_marker,
+        )
+        _own_sid = getattr(agent, "session_id", "") or ""
+        if _own_sid:
+            try:
+                install_termination_handlers(
+                    _own_sid,
+                    last_action_fn=lambda: (
+                        getattr(agent, "_last_tool_action", "")
+                        or getattr(agent, "_current_tool", "")
+                    ),
+                )
+            except Exception as exc:
+                logger.debug("termination handler install failed: %s", exc)
+            try:
+                _inflight_action = (
+                    getattr(agent, "_last_tool_action", "")
+                    or getattr(agent, "_current_tool", "")
+                    or (str(user_message)[:160] if isinstance(user_message, str) else "")
+                )
+                write_interrupted_marker(
+                    _own_sid, last_action=str(_inflight_action)[:500], reason="in_flight"
+                )
+            except Exception as exc:
+                logger.debug("in-flight marker write failed: %s", exc)
+        _recent_markers = list_interrupted_markers()
+        if _recent_markers:
+            _now = __import__("time").time()
+            # Only surface markers from the last 24h to avoid stale noise,
+            # and never our own in-flight marker — it just says we're running.
+            _recent = [
+                m for m in _recent_markers
+                if _now - m.get("timestamp", 0) < 86400
+                and m.get("session_id", "") != _own_sid
+            ]
+            if _recent:
+                agent._vprint(
+                    "⚠️  Previous long-running session was interrupted before completing its task.",
+                    force=True,
+                )
+                for _m in _recent[:3]:
+                    _sid = _m.get("session_id", "?")[:12]
+                    _when = _m.get("iso_time", "")
+                    _reason = _m.get("reason", "")
+                    _act = (_m.get("last_action", "") or "")[:80]
+                    agent._vprint(
+                        f"   • session {_sid} at {_when} — {_reason} last_action={_act}",
+                        force=True,
+                    )
+                agent._vprint(
+                    "   Partial file mutations may have been left on disk. "
+                    "Check `hermes checkpoints` / `/rollback` before trusting state.",
+                    force=True,
+                )
+    except Exception as exc:
+        logger.debug("interrupted-marker session-start handling failed: %s", exc)
 
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
@@ -4973,6 +5072,7 @@ def run_conversation(
                 api_elapsed = time.time() - api_start_time
                 agent._vprint(f"{agent.log_prefix}⚡ Interrupted during API call.", force=True)
                 interrupted = True
+                _record_session_interruption(agent, "interrupted_during_api_call", last_action="api_call")
                 # Preserve any assistant text already streamed to the user
                 # before the stop landed. Dropping it leaves history with no
                 # record of the half-finished reply on screen, so the next turn
@@ -5797,6 +5897,7 @@ def run_conversation(
                         _retry.restart_with_redirected_messages = True
                         break
                     agent._vprint(f"{agent.log_prefix}⚡ Interrupt detected during error handling, aborting retries.", force=True)
+                    _record_session_interruption(agent, f"interrupted_during_error:{error_type}", last_action=str(api_error)[:500])
                     _interrupt_text = f"Operation interrupted: handling API error ({error_type}: {agent._clean_error_message(str(api_error))})."
                     close_interrupted_tool_sequence(messages, _interrupt_text)
                     agent._persist_session(messages, conversation_history)
@@ -5870,6 +5971,7 @@ def run_conversation(
                         "(compression.enabled: false). Run /compress to compact manually, "
                         "/new to start fresh, or switch to a larger-context model."
                     )
+                    _record_session_interruption(agent, "context_overflow_compaction_disabled", last_action=_final_response[:500])
                     return {
                         "final_response": _final_response,
                         "messages": messages,
@@ -9260,6 +9362,29 @@ def run_conversation(
                 # break sites that set final_response without appending.
                 break
     
+    # Session-terminate marker for long-running sessions (#99869):
+    # if the turn ended via interruption / failure / context-exhaustion,
+    # record a marker so the next session can triage.
+    try:
+        _failure_reason = ""
+        if interrupted:
+            _failure_reason = f"interrupted:{_turn_exit_reason}"
+        elif failed:
+            _failure_reason = f"failed:{_turn_exit_reason}:{str(final_response)[:300]}"
+        elif _compression_timeout_exhausted:
+            _failure_reason = "compression_exhausted"
+        _resp_text = str(final_response or "")
+        if "AuthenticationError" in _resp_text or " 401" in _resp_text or ("auth" in _resp_text.lower() and "error" in _resp_text.lower()):
+            _failure_reason = _failure_reason or f"auth_error:{_resp_text[:300]}"
+        elif "exit 124" in _resp_text or "timeout" in _resp_text.lower() and "124" in _resp_text:
+            _failure_reason = _failure_reason or f"timeout_124:{_resp_text[:300]}"
+        elif "context" in _resp_text.lower() and ("exhaust" in _resp_text.lower() or "overflow" in _resp_text.lower()):
+            _failure_reason = _failure_reason or f"context_exhausted:{_resp_text[:300]}"
+        if _failure_reason:
+            _record_session_interruption(agent, _failure_reason, last_action=_turn_exit_reason)
+    except Exception as exc:
+        logger.debug("turn-end interruption record failed: %s", exc)
+
     # Post-loop turn finalization extracted to agent/turn_finalizer.finalize_turn
     # (god-file decomposition Phase 1 step 4). Behavior-neutral: the assembled
     # result dict is returned exactly as before.
@@ -9280,6 +9405,17 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
+    # On clean completion, clear this session's interrupted marker if any
+    # (it was triaged successfully). Best-effort.
+    try:
+        if not interrupted and not failed and not _compression_timeout_exhausted:
+            from tools.checkpoint_manager import clear_interrupted_marker
+            _sid = getattr(agent, "session_id", "") or ""
+            if _sid:
+                clear_interrupted_marker(_sid)
+    except Exception as exc:
+        logger.debug("interrupted-marker clear failed: %s", exc)
+
     if _compression_timeout_exhausted:
         # Reuse the gateway's existing context-recovery contract (#98722,
         # salvaged from #98741). The bloated transcript remains intact while

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -99,6 +99,33 @@ def _ensure_file_checkpoint(
     resolved_path = _resolve_path_for_task(file_path, effective_task_id or "default")
     work_dir = agent._checkpoint_mgr.get_working_dir_for_path(str(resolved_path))
     agent._checkpoint_mgr.ensure_checkpoint(work_dir, f"before {function_name}")
+    # Stash the pre-write hash for the mutation journal even when snapshots
+    # are disabled — the journal is the always-on triage record (#99869).
+    try:
+        agent._checkpoint_mgr.note_pending_mutation(str(resolved_path), tool=function_name)
+    except Exception as exc:
+        logger.debug("pending-mutation note failed for %s: %s", file_path, exc)
+    # Periodic checkpoint hook for long-running sessions (#99869):
+    # fires every checkpoint_interval file mutations regardless of the
+    # per-turn dedup, so a multi-hour sweep still persists progress.
+    try:
+        agent._checkpoint_mgr.maybe_periodic_checkpoint(
+            work_dir, f"periodic before {function_name}"
+        )
+    except Exception as exc:
+        logger.debug("periodic checkpoint hook failed: %s", exc)
+
+
+def _maybe_periodic_terminal_checkpoint(
+    agent, working_dir: str, command: str
+) -> None:
+    """Periodic checkpoint for destructive terminal commands (#99869)."""
+    try:
+        agent._checkpoint_mgr.maybe_periodic_checkpoint(
+            working_dir, f"periodic before terminal: {command[:60]}"
+        )
+    except Exception as exc:
+        logger.debug("periodic terminal checkpoint hook failed: %s", exc)
 
 
 def _budget_for_agent(agent) -> BudgetConfig:
@@ -1038,6 +1065,15 @@ def _begin_tool_execution(
             )
 
     agent._current_tool = function_name
+    # Compact last-action for session-interruption markers (#99869).
+    # Read by _record_session_interruption when a turn dies mid-task.
+    try:
+        _action_target = function_args.get("path") or function_args.get("command", "")
+        agent._last_tool_action = (
+            f"{function_name}:{str(_action_target)[:160]}" if _action_target else function_name
+        )
+    except Exception as exc:
+        logger.debug("last-tool-action record failed: %s", exc)
     agent._touch_activity(f"executing tool: {function_name}")
     try:
         from tools.environments.base import set_activity_callback
@@ -1071,7 +1107,10 @@ def _begin_tool_execution(
         except Exception as callback_error:
             logging.debug("Tool start callback error: %s", callback_error)
 
-    if function_name in {"write_file", "patch"} and agent._checkpoint_mgr.enabled:
+    # Snapshot calls self-gate on checkpoints.enabled; the pending-mutation
+    # note inside runs regardless so the journal records even for default
+    # sessions (#99869).
+    if function_name in {"write_file", "patch"}:
         try:
             _ensure_file_checkpoint(
                 agent,
@@ -1079,10 +1118,10 @@ def _begin_tool_execution(
                 function_args,
                 effective_task_id,
             )
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.debug("file checkpoint preflight failed: %s", exc)
 
-    if function_name == "terminal" and agent._checkpoint_mgr.enabled:
+    if function_name == "terminal":
         try:
             command = function_args.get("command", "")
             if _is_destructive_command(command):
@@ -1092,8 +1131,9 @@ def _begin_tool_execution(
                 agent._checkpoint_mgr.ensure_checkpoint(
                     cwd, f"before terminal: {command[:60]}"
                 )
-        except Exception:
-            pass
+                _maybe_periodic_terminal_checkpoint(agent, cwd, command)
+        except Exception as exc:
+            logger.debug("terminal checkpoint preflight failed: %s", exc)
 
 
 def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effective_task_id: str, api_call_count: int = 0, *, finalize: bool = True) -> None:

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -25,6 +25,7 @@ move-and-name refactor with no semantic change.
 from __future__ import annotations
 
 import logging
+import os
 import threading
 import time
 import uuid
@@ -1540,6 +1541,38 @@ def build_turn_context(
                 if plugin_user_context
                 else _gateway_notes
             )
+
+    # Interrupted-session note (#99869): when a PRIOR session died mid-task,
+    # the model must not trust stale tree state. Rides the same user-message
+    # injection channel as plugin/gateway context (API copy only — stored
+    # content stays clean, system prompt stays byte-stable). First turn per
+    # session only: the sidecar replays verbatim afterwards, and repeating it
+    # every turn would nag forever while untriaged markers exist. The human
+    # half (_vprint) lives in run_conversation and repeats while markers do.
+    try:
+        if (
+            not getattr(agent, "_interruption_note_injected", False)
+            and not bool(conversation_history)
+        ):
+            from tools.checkpoint_manager import build_interruption_note
+
+            try:
+                _note_cwd = os.getcwd()
+            except OSError:
+                _note_cwd = ""
+            _interruption_note = build_interruption_note(
+                working_dir=_note_cwd or None,
+                exclude_session_id=getattr(agent, "session_id", "") or "",
+            )
+            if _interruption_note:
+                plugin_user_context = (
+                    plugin_user_context + "\n\n" + _interruption_note
+                    if plugin_user_context
+                    else _interruption_note
+                )
+            agent._interruption_note_injected = True
+    except Exception as exc:
+        logger.debug("interruption-note injection failed: %s", exc)
 
     # Per-turn file-mutation verifier state.
     agent._turn_failed_file_mutations = {}

--- a/cli.py
+++ b/cli.py
@@ -5538,6 +5538,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         if isinstance(cp_cfg, bool):
             cp_cfg = {"enabled": cp_cfg}
         self.checkpoints_enabled = checkpoints or cp_cfg.get("enabled", False)
+        # Periodic checkpoint interval for long-running sessions (#99869).
+        try:
+            self.checkpoint_interval = int(cp_cfg.get("checkpoint_interval", 10))
+        except Exception:
+            self.checkpoint_interval = 10
+        if self.checkpoint_interval < 1:
+            self.checkpoint_interval = 1
         self.checkpoint_max_snapshots = cp_cfg.get("max_snapshots", 20)
         self.checkpoint_max_total_size_mb = cp_cfg.get("max_total_size_mb", 500)
         self.checkpoint_max_file_size_mb = cp_cfg.get("max_file_size_mb", 10)

--- a/cron/monitor.py
+++ b/cron/monitor.py
@@ -134,7 +134,8 @@ def _run_monitor_source(job: dict) -> tuple[bool, str]:
         from cron.scheduler import _run_job_script
 
         workdir = (job.get("workdir") or "").strip() or None
-        return _run_job_script(monitor_script, workdir=workdir)
+        return _run_job_script(monitor_script, workdir=workdir,
+                               job_id=str(job.get("id") or ""))
     monitor_url = (job.get("monitor_url") or "").strip()
     if monitor_url:
         return _fetch_monitor_url(monitor_url)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4520,10 +4520,35 @@ def _windows_cron_bootstrap_argv(
     return [python_exe, "-c", bootstrap, script_path]
 
 
+def _note_cron_script_interruption(
+    job_id: str, script_path: str, reason: str, detail: str = ""
+) -> None:
+    """Leave an interrupted-session marker when a cron script dies abnormally.
+
+    This is the parent-side half of #99869: the scheduler survives the
+    timeout/cancel kill (or a plain crash) and records it, so the next
+    session — agent or human — can triage instead of trusting whatever the
+    script half-wrote. Best-effort; never raises.
+    """
+    try:
+        from tools.checkpoint_manager import write_interrupted_marker
+
+        sid = f"cron-script:{job_id}" if job_id else f"cron-script:{Path(script_path).name}"
+        write_interrupted_marker(
+            sid,
+            last_action=f"{script_path} {detail}"[:2000],
+            reason=reason,
+            base=_get_hermes_home(),
+        )
+    except Exception as exc:
+        logger.debug("cron script interruption marker failed: %s", exc)
+
+
 def _run_job_script(
     script_path: str,
     workdir: Optional[str] = None,
     cancel_event: Optional[_CancelEventLike] = None,
+    job_id: str = "",
 ) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -4675,6 +4700,9 @@ def _run_job_script(
                 # must not orphan own-session grandchildren either.
                 _terminate_cron_script_tree(proc)
                 _drain_script_pipes(proc)
+                _note_cron_script_interruption(
+                    job_id, str(path), "cron_script_cancelled"
+                )
                 return False, "Script cancelled because cron fire ownership was lost"
             remaining = deadline - time.monotonic()
             if remaining <= 0:
@@ -4689,6 +4717,9 @@ def _run_job_script(
                 # layer's tree-kill (#85147, d6a5cb9725).
                 _terminate_cron_script_tree(proc)
                 _drain_script_pipes(proc)
+                _note_cron_script_interruption(
+                    job_id, str(path), "cron_script_timeout_killed"
+                )
                 return False, f"Script timed out after {script_timeout}s: {path}"
             try:
                 stdout_raw, stderr_raw = proc.communicate(timeout=min(0.1, remaining))
@@ -4715,11 +4746,17 @@ def _run_job_script(
                 parts.append(f"stderr:\n{stderr}")
             if stdout:
                 parts.append(f"stdout:\n{stdout}")
+            _note_cron_script_interruption(
+                job_id, str(path),
+                f"cron_script_exit_{proc.returncode}",
+                detail=(stderr or stdout)[-300:],
+            )
             return False, "\n".join(parts)
 
         return True, stdout
 
     except Exception as exc:
+        _note_cron_script_interruption(job_id, str(script_path), "cron_script_error")
         return False, f"Script execution failed: {exc}"
 
 
@@ -4744,14 +4781,15 @@ def _run_job_script_with_claim_heartbeat(
     schedule = job.get("schedule")
     claim = job.get("run_claim")
     owner = str(claim.get("by") or "") if isinstance(claim, dict) else ""
+    job_id = str(job.get("id") or "")
     if not (
         isinstance(schedule, dict)
         and schedule.get("kind") == "once"
         and owner
     ):
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event,
+                               job_id=job_id)
 
-    job_id = str(job.get("id") or "")
     stop = threading.Event()
     heartbeat_context = contextvars.copy_context()
 
@@ -4780,10 +4818,12 @@ def _run_job_script_with_claim_heartbeat(
             job_id,
             exc_info=True,
         )
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event,
+                               job_id=job_id)
 
     try:
-        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event)
+        return _run_job_script(script_path, workdir=workdir, cancel_event=cancel_event,
+                               job_id=job_id)
     finally:
         stop.set()
         # Event.wait() wakes immediately.  Keep completion bounded if the
@@ -4854,7 +4894,9 @@ def _build_job_prompt(
         if prerun_script is not None:
             success, script_output = prerun_script
         else:
-            success, script_output = _run_job_script(script_path)
+            success, script_output = _run_job_script(
+                script_path, job_id=str(job.get("id") or "")
+            )
         if success:
             if script_output:
                 prompt = (

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4277,6 +4277,7 @@ def _checkpoint_agent_kwargs(config: dict | None) -> dict:
         "checkpoint_max_file_size_mb": cp_cfg.get(
             "max_file_size_mb", defaults["max_file_size_mb"],
         ),
+        "checkpoint_interval": int(cp_cfg.get("checkpoint_interval", defaults.get("checkpoint_interval", 10))),
     }
 
 

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -569,6 +569,7 @@ class CLIAgentSetupMixin:
                 fallback_model=self._fallback_model,
                 thinking_callback=self._on_thinking,
                 checkpoints_enabled=self.checkpoints_enabled,
+                checkpoint_interval=getattr(self, "checkpoint_interval", 10),
                 checkpoint_max_snapshots=self.checkpoint_max_snapshots,
                 checkpoint_max_total_size_mb=self.checkpoint_max_total_size_mb,
                 checkpoint_max_file_size_mb=self.checkpoint_max_file_size_mb,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -744,6 +744,11 @@ DEFAULT_CONFIG = {
         "auto_prune": True,
         "retention_days": 7,
         "min_interval_hours": 24,
+        # Periodic checkpoint interval (tool calls) for long-running sessions
+        # (#99869). Every N file-mutating tool calls the checkpoint manager
+        # bypasses the per-turn dedup and persists an extra snapshot so a
+        # kill mid-loop does not lose all progress.
+        "checkpoint_interval": 10,
     },
 
     # Hard cap (chars) for a single automatic context file such as SOUL.md,

--- a/run_agent.py
+++ b/run_agent.py
@@ -566,6 +566,7 @@ class AIAgent:
         checkpoint_max_snapshots: int = 20,
         checkpoint_max_total_size_mb: int = 500,
         checkpoint_max_file_size_mb: int = 10,
+        checkpoint_interval: int = 10,
         pass_session_id: bool = False,
         requested_provider: str = None,
         capabilities: Dict[str, bool] | None = None,
@@ -659,6 +660,7 @@ class AIAgent:
             checkpoint_max_snapshots=checkpoint_max_snapshots,
             checkpoint_max_total_size_mb=checkpoint_max_total_size_mb,
             checkpoint_max_file_size_mb=checkpoint_max_file_size_mb,
+            checkpoint_interval=checkpoint_interval,
             pass_session_id=pass_session_id,
         )
 
@@ -4100,13 +4102,21 @@ class AIAgent:
                 changed.update(landed_paths)
             # Feed the checkpoint agent-write ledger so /rollback's safe mode
             # can tell Hermes-authored content from later user hand-edits.
+            # The mutation journal records regardless of checkpoints.enabled
+            # so a later session can triage without forensics (#99869).
             mgr = getattr(self, "_checkpoint_mgr", None)
+            if mgr is not None:
+                for _p in landed_paths:
+                    try:
+                        mgr.record_mutation(_p, tool=tool_name)
+                    except Exception as exc:
+                        logger.debug("mutation journal record failed for %s: %s", _p, exc)
             if mgr is not None and getattr(mgr, "enabled", False):
                 for _p in landed_paths:
                     try:
                         mgr.record_agent_write(_p)
-                    except Exception:
-                        pass
+                    except Exception as exc:
+                        logger.debug("agent-write ledger record failed for %s: %s", _p, exc)
         if is_error and not landed:
             preview = _extract_error_preview(result)
             for path in targets:

--- a/tests/cron/test_cron_script.py
+++ b/tests/cron/test_cron_script.py
@@ -807,3 +807,61 @@ class TestScriptTimeoutTreeKill:
                     psutil.Process(gpid).kill()
                 except psutil.NoSuchProcess:
                     pass
+
+
+class TestCronScriptInterruptionMarker:
+    """The scheduler (which survives the kill) must leave an interrupted
+    marker when a cron script times out or crashes (#99869 review)."""
+
+    def test_timeout_kill_leaves_marker(self, cron_env, monkeypatch):
+        from cron import scheduler as sched
+        from tools.checkpoint_manager import list_interrupted_markers
+
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "slow.py").write_text(
+            "import time; time.sleep(30)\n", encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_CRON_SCRIPT_TIMEOUT", "1")
+        monkeypatch.setattr(sched, "_SCRIPT_TIMEOUT", sched._DEFAULT_SCRIPT_TIMEOUT)
+
+        ok, _out = sched._run_job_script(
+            str(scripts_dir / "slow.py"), workdir=str(cron_env), job_id="job-1"
+        )
+        assert not ok
+        markers = [
+            m for m in list_interrupted_markers(base=cron_env)
+            if m.get("session_id") == "cron-script:job-1"
+        ]
+        assert len(markers) == 1
+        assert markers[0]["reason"] == "cron_script_timeout_killed"
+
+    def test_nonzero_exit_leaves_marker(self, cron_env):
+        from cron import scheduler as sched
+        from tools.checkpoint_manager import list_interrupted_markers
+
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "boom.py").write_text(
+            "import sys; print('half-written'); sys.exit(3)\n", encoding="utf-8"
+        )
+        ok, _out = sched._run_job_script(
+            str(scripts_dir / "boom.py"), workdir=str(cron_env), job_id="job-2"
+        )
+        assert not ok
+        markers = [
+            m for m in list_interrupted_markers(base=cron_env)
+            if m.get("session_id") == "cron-script:job-2"
+        ]
+        assert len(markers) == 1
+        assert markers[0]["reason"] == "cron_script_exit_3"
+
+    def test_success_leaves_no_marker(self, cron_env):
+        from cron import scheduler as sched
+        from tools.checkpoint_manager import list_interrupted_markers
+
+        scripts_dir = cron_env / "scripts"
+        (scripts_dir / "fine.py").write_text('print("ok")\n', encoding="utf-8")
+        ok, _out = sched._run_job_script(
+            str(scripts_dir / "fine.py"), workdir=str(cron_env), job_id="job-3"
+        )
+        assert ok
+        assert list_interrupted_markers(base=cron_env) == []

--- a/tests/tools/test_checkpoint_99869.py
+++ b/tests/tools/test_checkpoint_99869.py
@@ -1,0 +1,218 @@
+"""Tests for the #99869 review rework: markers, journal, periodic, durable writes."""
+
+import json
+import os
+import signal as _signal
+import time
+
+import pytest
+
+import tools.checkpoint_manager as cm
+from tools.checkpoint_manager import (
+    CheckpointManager,
+    build_interruption_note,
+    clear_interrupted_marker,
+    durable_atomic_write,
+    install_termination_handlers,
+    list_interrupted_markers,
+    read_interrupted_marker,
+    write_interrupted_marker,
+)
+
+
+@pytest.fixture()
+def ckpt_base(tmp_path, monkeypatch):
+    base = tmp_path / "cps"
+    monkeypatch.setattr(cm, "CHECKPOINT_BASE", base)
+    return base
+
+
+@pytest.fixture()
+def proj(tmp_path):
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "f.txt").write_text("one\n")
+    # Project-root marker so get_working_dir_for_path stops here instead of
+    # climbing into the real filesystem above tmp_path.
+    (d / "pyproject.toml").write_text("[project]\n")
+    return d
+
+
+# =========================================================================
+# Session-terminate markers
+# =========================================================================
+
+class TestInterruptedMarkers:
+    def test_write_read_clear_roundtrip(self, tmp_path):
+        assert read_interrupted_marker("sess-1", base=tmp_path) is None
+        marker = write_interrupted_marker(
+            "sess-1", last_action="write_file:x", reason="auth_error", base=tmp_path
+        )
+        assert marker is not None and marker.exists()
+        data = read_interrupted_marker("sess-1", base=tmp_path)
+        assert data["session_id"] == "sess-1"
+        assert data["last_action"] == "write_file:x"
+        assert data["reason"] == "auth_error"
+        assert data["timestamp"] > 0
+        assert clear_interrupted_marker("sess-1", base=tmp_path) is True
+        assert read_interrupted_marker("sess-1", base=tmp_path) is None
+        assert clear_interrupted_marker("sess-1", base=tmp_path) is False
+
+    def test_list_orders_newest_first(self, tmp_path):
+        write_interrupted_marker("old", reason="a", base=tmp_path)
+        time.sleep(0.02)
+        write_interrupted_marker("new", reason="b", base=tmp_path)
+        ids = [m["session_id"] for m in list_interrupted_markers(base=tmp_path)]
+        assert ids == ["new", "old"]
+
+    def test_session_id_sanitized_to_safe_filename(self, tmp_path):
+        marker = write_interrupted_marker("cron-script:../../evil", base=tmp_path)
+        assert marker is not None
+        assert "/" not in marker.name and "\\" not in marker.name
+        assert marker.resolve().parent == (tmp_path / "sessions").resolve()
+
+    def test_write_prunes_markers_older_than_7d(self, tmp_path):
+        stale = tmp_path / "sessions"
+        stale.mkdir(parents=True)
+        old_file = stale / "ancient.interrupted"
+        old_file.write_text(
+            '{"session_id": "ancient", "timestamp": 1}', encoding="utf-8"
+        )
+        ancient = time.time() - 8 * 86400
+        os.utime(old_file, (ancient, ancient))
+        write_interrupted_marker("fresh", base=tmp_path)
+        ids = [m["session_id"] for m in list_interrupted_markers(base=tmp_path)]
+        assert "ancient" not in ids
+        assert "fresh" in ids
+
+
+# =========================================================================
+# Periodic checkpoints
+# =========================================================================
+
+class TestMaybePeriodicCheckpoint:
+    def test_disabled_manager_never_fires(self, tmp_path, ckpt_base):
+        m = CheckpointManager(enabled=False)
+        assert m.maybe_periodic_checkpoint(str(tmp_path)) is False
+        assert m.maybe_periodic_checkpoint(str(tmp_path)) is False
+        assert m._periodic_counter == 0
+
+    def test_fires_every_interval(self, proj, ckpt_base):
+        m = CheckpointManager(enabled=True, checkpoint_interval=2)
+        assert m.maybe_periodic_checkpoint(str(proj)) is False
+        assert m.maybe_periodic_checkpoint(str(proj)) is True
+
+    def test_rate_limited_by_last_periodic_ts(self, proj, ckpt_base):
+        m = CheckpointManager(enabled=True, checkpoint_interval=1)
+        assert m.maybe_periodic_checkpoint(str(proj)) is True
+        # Counter gate passes (interval=1) but the fresh timestamp blocks.
+        assert m.maybe_periodic_checkpoint(str(proj)) is False
+        # Backdate the clock -> fires again (with fresh content to snapshot).
+        key = str(cm._normalize_path(str(proj)))
+        m._last_periodic_ts[key] = time.time() - cm._PERIODIC_MIN_INTERVAL_S - 1
+        (proj / "f.txt").write_text("changed\n")
+        assert m.maybe_periodic_checkpoint(str(proj)) is True
+
+
+# =========================================================================
+# Mutation journal (always on, even when snapshots are disabled)
+# =========================================================================
+
+class TestMutationJournal:
+    def test_records_when_snapshots_disabled(self, proj, ckpt_base):
+        import hashlib as _hashlib
+        target = proj / "notes.md"
+        target.write_text("v1\n")
+        v1bytes = target.read_bytes()
+        m = CheckpointManager(enabled=False)
+        m.note_pending_mutation(str(target), tool="write_file")
+        target.write_text("v2\n")
+        v2bytes = target.read_bytes()
+        assert m.record_mutation(str(target), tool="write_file") is True
+        entries = m.read_journal(str(proj))
+        assert len(entries) == 1
+        assert entries[0]["tool"] == "write_file"
+        assert entries[0]["before"] == _hashlib.sha256(v1bytes).hexdigest()
+        assert entries[0]["after"] == _hashlib.sha256(v2bytes).hexdigest()
+        assert entries[0]["path"].endswith("notes.md")
+
+    def test_before_is_none_without_preflight(self, proj, ckpt_base):
+        m = CheckpointManager(enabled=False)
+        assert m.record_mutation(str(proj / "f.txt"), tool="patch") is True
+        entries = m.read_journal(str(proj))
+        assert entries[0]["before"] is None
+        assert entries[0]["after"] is not None
+
+    def test_trims_to_cap(self, proj, ckpt_base, monkeypatch):
+        monkeypatch.setattr(cm, "_JOURNAL_MAX_LINES", 4)
+        m = CheckpointManager(enabled=False)
+        # Enough entries to trip the size-gated trim (~200B each).
+        for _ in range(20):
+            assert m.record_mutation(str(proj / "f.txt"), tool="write_file") is True
+        assert len(m.read_journal(str(proj), limit=100)) == 4
+
+
+# =========================================================================
+# Interruption note (continuation-prompt injection)
+# =========================================================================
+
+class TestInterruptionNote:
+    def test_none_without_markers(self, tmp_path):
+        assert build_interruption_note(base=tmp_path) is None
+
+    def test_none_when_only_own_marker(self, tmp_path):
+        write_interrupted_marker("mine", reason="in_flight", base=tmp_path)
+        assert build_interruption_note(base=tmp_path, exclude_session_id="mine") is None
+
+    def test_note_carries_reason_checkpoint_and_journal(self, tmp_path, proj, ckpt_base):
+        mgr = CheckpointManager(enabled=True)
+        assert mgr.ensure_checkpoint(str(proj), "baseline") is True
+        mgr.note_pending_mutation(str(proj / "f.txt"), tool="write_file")
+        (proj / "f.txt").write_text("two\n")
+        assert mgr.record_mutation(str(proj / "f.txt"), tool="write_file") is True
+        write_interrupted_marker(
+            "dead-beef", reason="sigterm", last_action="write_file:f.txt", base=tmp_path
+        )
+        note = build_interruption_note(
+            working_dir=str(proj), exclude_session_id="live", base=tmp_path
+        )
+        assert note is not None
+        assert "dead-beef" in note
+        assert "sigterm" in note
+        assert "f.txt" in note
+        assert "Last checkpoint" in note
+
+    def test_stale_markers_ignored(self, tmp_path):
+        marker = write_interrupted_marker("old", reason="sigterm", base=tmp_path)
+        data = json.loads(marker.read_text(encoding="utf-8"))
+        data["timestamp"] = time.time() - 2 * 86400
+        marker.write_text(json.dumps(data), encoding="utf-8")
+        assert build_interruption_note(base=tmp_path) is None
+
+
+# =========================================================================
+# Durable atomic writes + termination handlers
+# =========================================================================
+
+class TestDurableAtomicWrite:
+    def test_str_and_bytes_roundtrip(self, tmp_path):
+        p = tmp_path / "sub" / "out.txt"
+        durable_atomic_write(str(p), "hello\n")
+        assert p.read_text(encoding="utf-8") == "hello\n"
+        durable_atomic_write(str(p), "hi\n".encode("utf-8"))
+        assert p.read_text(encoding="utf-8") == "hi\n"
+        assert list(tmp_path.rglob("*.tmp.*")) == []
+
+
+class TestTerminationHandlers:
+    def test_install_once_per_session(self):
+        sid = "test-handler-session-xyz"
+        old_term = _signal.getsignal(_signal.SIGTERM)
+        old_int = _signal.getsignal(_signal.SIGINT)
+        try:
+            assert install_termination_handlers(sid) is True
+            assert install_termination_handlers(sid) is False
+        finally:
+            _signal.signal(_signal.SIGTERM, old_term)
+            _signal.signal(_signal.SIGINT, old_int)
+            cm._installed_termination_sessions.discard(sid)

--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -922,3 +922,41 @@ class TestEscapeNativeToolArg:
         assert node_cmds, f"no node command captured in: {commands}"
         assert "'C:/Users/alice/app/main.js'" in node_cmds[0]
         assert "/c/Users" not in node_cmds[0]
+
+
+# =========================================================================
+# Atomic write durability: real fsync, not bare `sync FILE` (#99869 review)
+# =========================================================================
+
+class TestAtomicWriteDurability:
+    """`sync FILE` is a no-op on Windows Git Bash/MSYS (the issue's repro
+    env). The generated script must fsync via fsync(2) instead."""
+
+    def test_script_fsyncs_temp_target_and_parent_dir(self, mock_env):
+        seen = {}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            seen["script"] = command
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        ops._atomic_write("/tmp/test/a.txt", "hello\n")
+        script = seen["script"]
+        assert "fsync" in script
+        # The old no-op chain must be gone (matched with surrounding context
+        # so the _fsync helper calls don't trip the substring).
+        assert 'sync "$tmp" 2>/dev/null || sync' not in script
+        assert 'sync "$t" 2>/dev/null || sync' not in script
+        assert '_fsync "$tmp"' in script
+        assert '_fsync "$t"' in script
+        assert '_fsync "$d"' in script
+
+    def test_real_write_roundtrips_with_fsync_script(self, tmp_path):
+        """End-to-end guard against shell syntax errors in the new lines."""
+        ops = ShellFileOperations(make_real_subprocess_env(str(tmp_path)))
+        dest = tmp_path / "durable.txt"
+        result = ops.write_file(str(dest), "durable content\n")
+        assert result.error is None, f"write failed: {result.error}"
+        assert dest.read_text() == "durable content\n"
+        assert list(tmp_path.glob(".hermes-tmp.*")) == []

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -54,7 +54,9 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
+import threading
 import time
 from pathlib import Path
 from hermes_constants import get_hermes_home
@@ -71,6 +73,12 @@ logger = logging.getLogger(__name__)
 
 CHECKPOINT_BASE = get_hermes_home() / "checkpoints"
 
+# Session-terminate marker directory — ~/.hermes/sessions/<id>.interrupted
+# Used by #99869: long-running sessions that die mid-task (auth error,
+# timeout 124, context exhaustion) record a marker so the next session can
+# triage instead of trusting stale in-memory state.
+_SESSION_MARKER_DIRNAME = "sessions"
+
 # Single shared store directory under CHECKPOINT_BASE.
 _STORE_DIRNAME = "store"
 _REFS_PREFIX = "refs/hermes"
@@ -81,6 +89,25 @@ _LEGACY_PREFIX = "legacy-"
 
 # Agent-write ledger cap: newest entries retained per project.
 _LEDGER_MAX_ENTRIES = 2000
+
+# Mutation-journal cap: newest JSONL lines retained per project. The journal
+# is deliberately tiny (one line per landed write_file/patch: path,
+# before/after hashes, tool, timestamp) so the next session can triage
+# without forensics even when snapshots are disabled.
+_JOURNALS_DIRNAME = "journals"
+_JOURNAL_MAX_LINES = 2000
+# Pending pre-write hashes: bounded so a pathological loop can't grow it.
+_PENDING_MUTATIONS_MAX = 500
+
+# Minimum gap between two periodic snapshots of the same directory.
+# _last_periodic_ts is the rate-limit clock: without it checkpoint_interval=1
+# plus a 500-file sweep would take 500 back-to-back git snapshots.
+_PERIODIC_MIN_INTERVAL_S = 60.0
+
+# Marker freshness: surfaced to humans/models within this window; pruned
+# from disk after _MARKER_PRUNE_AGE_S so dead sessions can't accumulate.
+_MARKER_FRESH_S = 86400
+_MARKER_PRUNE_AGE_S = 7 * 86400
 
 DEFAULT_EXCLUDES = [
     # Dependency / build output
@@ -259,6 +286,94 @@ def _load_ledger(store: Path, dir_hash: str) -> Dict[str, Dict]:
         return {}
 
 
+def _fsync_file(path: Path) -> None:
+    """Best-effort fsync of a single file's data to stable storage."""
+    try:
+        fd = os.open(str(path), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(fd)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+
+
+def _fsync_parent_dir(path: Path) -> None:
+    """Best-effort fsync of a file's parent directory (dirent durability).
+
+    Without this, a crash between ``os.replace`` and the directory entry
+    hitting disk can still lose the new inode. No-op where the platform
+    cannot open directories (e.g. Windows raises OSError — ignored).
+    """
+    try:
+        dir_fd = os.open(str(path.parent), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(dir_fd)
+    except OSError:
+        pass
+    finally:
+        try:
+            os.close(dir_fd)
+        except OSError:
+            pass
+
+
+def _durable_replace(tmp: Path, target: Path) -> None:
+    """Atomically swap ``tmp`` onto ``target`` with durability.
+
+    fsyncs the temp file's data, renames (atomic on POSIX and on every
+    backend FS we run on — same-directory temp is the caller's contract),
+    then fsyncs the parent dir. Same shape as the ``tools/mcp_oauth.py``
+    token-store write, plus the post-rename dir fsync.
+    """
+    _fsync_file(tmp)
+    os.replace(tmp, target)
+    _fsync_parent_dir(target)
+
+
+def durable_atomic_write(path_value: str, data) -> Path:
+    """Atomic + durable write for out-of-band scripts (no_agent cron jobs).
+
+    Canonical pattern for anything that mutates files outside
+    ``write_file`` / ``_atomic_write`` (e.g. a ``no_agent=True`` watchdog
+    like ``scripts/ci-sweep-cap.py``): temp file in the SAME directory,
+    flush + fsync, atomic rename, parent-dir fsync.
+
+    ``data`` is ``str`` (UTF-8) or ``bytes``. Returns the target path.
+
+    Caveat (issue #99869): atomic rename only protects against TORN
+    writes. A *completed* write of logically-wrong content (a buggy
+    transform that emits 70 bytes) still lands 70 bytes. Validate content
+    BEFORE calling — the in-process ``write_file`` path additionally has a
+    fail-closed syntax gate and post-write hash verification; scripts
+    using this helper should do their own sanity checks (e.g. refuse to
+    shrink a file by >90% without an explicit flag).
+    """
+    target = Path(path_value).expanduser()
+    target.parent.mkdir(parents=True, exist_ok=True)
+    tmp = target.with_name(f".{target.name}.tmp.{os.getpid()}.{time.monotonic_ns()}")
+    try:
+        if isinstance(data, bytes):
+            tmp.write_bytes(data)
+        else:
+            tmp.write_text(data, encoding="utf-8")
+        _durable_replace(tmp, target)
+    except BaseException:
+        try:
+            tmp.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+    return target
+
+
 def _save_ledger(store: Path, dir_hash: str, ledger: Dict[str, Dict]) -> None:
     """Persist the agent-write ledger, capped to the newest entries."""
     try:
@@ -273,9 +388,74 @@ def _save_ledger(store: Path, dir_hash: str, ledger: Dict[str, Dict]) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         tmp = path.with_suffix(".json.tmp")
         tmp.write_text(json.dumps(ledger), encoding="utf-8")
-        tmp.replace(path)
+        _durable_replace(tmp, path)
     except OSError:
         logger.debug("Failed to save agent-write ledger for %s", dir_hash, exc_info=True)
+
+
+def _journal_path(store: Path, dir_hash: str) -> Path:
+    return store / _JOURNALS_DIRNAME / f"{dir_hash}.jsonl"
+
+
+def _append_journal(store: Path, dir_hash: str, entry: Dict) -> None:
+    """Append one JSONL line, trimming to the newest _JOURNAL_MAX_LINES."""
+    path = _journal_path(store, dir_hash)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(entry)
+    try:
+        with open(path, "a", encoding="utf-8") as fh:
+            fh.write(line + "\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError:
+                pass
+    except OSError:
+        logger.debug("Failed to append journal for %s", dir_hash, exc_info=True)
+        return
+    try:
+        # Size-gated trim: only pay for a full read when the file is plausibly
+        # over budget (entries average well under 512B).
+        try:
+            oversized = path.stat().st_size > _JOURNAL_MAX_LINES * 512
+        except OSError:
+            oversized = False
+        if oversized:
+            with open(path, "r", encoding="utf-8") as fh:
+                lines = fh.readlines()
+            if len(lines) > _JOURNAL_MAX_LINES:
+                tmp = path.with_suffix(".jsonl.tmp")
+                tmp.write_text("".join(lines[-_JOURNAL_MAX_LINES:]), encoding="utf-8")
+                _durable_replace(tmp, path)
+            else:
+                _fsync_parent_dir(path)
+        else:
+            _fsync_parent_dir(path)
+    except OSError:
+        logger.debug("Failed to trim journal for %s", dir_hash, exc_info=True)
+
+
+def _read_journal(store: Path, dir_hash: str, limit: int = 20) -> List[Dict]:
+    """Newest-first journal entries (tolerates torn trailing lines)."""
+    try:
+        raw = _journal_path(store, dir_hash).read_text(encoding="utf-8")
+    except OSError:
+        return []
+    out: List[Dict] = []
+    for line in raw.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            data = json.loads(line)
+        except ValueError:
+            continue
+        if isinstance(data, dict):
+            out.append(data)
+    out.sort(key=lambda e: e.get("ts", 0), reverse=True)
+    # Cap semantic: never surface more than the newest _JOURNAL_MAX_LINES,
+    # even when the size-gated write-side trim has not tripped yet.
+    return out[: min(max(0, int(limit)), _JOURNAL_MAX_LINES)]
 
 
 def _ref_name(dir_hash: str) -> str:
@@ -780,13 +960,24 @@ class CheckpointManager:
         max_snapshots: int = 20,
         max_total_size_mb: int = 500,
         max_file_size_mb: int = 10,
+        checkpoint_interval: int = 10,
     ):
         self.enabled = enabled
         self.max_snapshots = max(1, int(max_snapshots))
         self.max_total_size_mb = max(0, int(max_total_size_mb))
         self.max_file_size_mb = max(0, int(max_file_size_mb))
+        self.checkpoint_interval = max(1, int(checkpoint_interval))
         self._checkpointed_dirs: Set[str] = set()
         self._git_available: Optional[bool] = None  # lazy probe
+        # Periodic checkpoint counter for long-running sessions (#99869).
+        self._periodic_counter: int = 0
+        # Last periodic checkpoint timestamp per working_dir — rate-limit
+        # clock for maybe_periodic_checkpoint (see _PERIODIC_MIN_INTERVAL_S).
+        self._last_periodic_ts: Dict[str, float] = {}
+        # Pre-write content hashes keyed by normalized path, stashed by
+        # note_pending_mutation before a file tool runs and consumed by
+        # record_mutation after it lands. Bounded (_PENDING_MUTATIONS_MAX).
+        self._pending_mutations: Dict[str, Dict] = {}
 
     # ------------------------------------------------------------------
     # Turn lifecycle
@@ -825,6 +1016,68 @@ class CheckpointManager:
             _save_ledger(store, dir_hash, ledger)
         except Exception as exc:
             logger.debug("record_agent_write failed for %s: %s", file_path, exc)
+
+    # ------------------------------------------------------------------
+    # Mutation journal (#99869 proposal 3)
+    # ------------------------------------------------------------------
+    # Snapshots stay opt-in (``checkpoints.enabled``, default False — git
+    # snapshots are heavyweight). The journal is the always-on half: one
+    # JSONL line per landed write_file/patch (path, before/after hashes,
+    # tool, timestamp), recorded regardless of ``enabled``, so the next
+    # session can triage what changed even when no snapshot exists.
+
+    def note_pending_mutation(self, file_path: str, tool: str = "") -> None:
+        """Stash the pre-write content hash for a file about to be mutated.
+
+        Called BEFORE the file tool runs (from the checkpoint preflight).
+        Never raises.
+        """
+        try:
+            path = _normalize_path(file_path)
+            if len(self._pending_mutations) >= _PENDING_MUTATIONS_MAX:
+                self._pending_mutations.pop(next(iter(self._pending_mutations)))
+            self._pending_mutations[str(path)] = {
+                "before_sha": _hash_file(path),
+                "tool": tool or "",
+                "ts": time.time(),
+            }
+        except Exception as exc:
+            logger.debug("note_pending_mutation failed for %s: %s", file_path, exc)
+
+    def record_mutation(self, file_path: str, tool: str = "") -> bool:
+        """Append one journal line for a landed file mutation. Never raises.
+
+        Consumes the pre-write hash stashed by :meth:`note_pending_mutation`
+        (None when the write bypassed the preflight). Works regardless of
+        ``enabled`` — the journal is bookkeeping, not snapshotting.
+        """
+        try:
+            path = _normalize_path(file_path)
+            key = str(path)
+            pending = self._pending_mutations.pop(key, {}) or {}
+            entry = {
+                "ts": time.time(),
+                "path": key,
+                "tool": tool or pending.get("tool", ""),
+                "before": pending.get("before_sha"),
+                "after": _hash_file(path),
+            }
+            working_dir = self.get_working_dir_for_path(key)
+            store = _store_path(CHECKPOINT_BASE)
+            _append_journal(store, _project_hash(working_dir), entry)
+            return True
+        except Exception as exc:
+            logger.debug("record_mutation failed for %s: %s", file_path, exc)
+            return False
+
+    def read_journal(self, working_dir: str, limit: int = 20) -> List[Dict]:
+        """Newest-first journal entries for a working directory."""
+        try:
+            store = _store_path(CHECKPOINT_BASE)
+            return _read_journal(store, _project_hash(str(_normalize_path(working_dir))), limit)
+        except Exception as exc:
+            logger.debug("read_journal failed for %s: %s", working_dir, exc)
+            return []
 
     def safe_restore_plan(self, working_dir: str, commit_hash: str) -> Dict:
         """Classify files changed since ``commit_hash`` for a safe restore.
@@ -925,6 +1178,42 @@ class CheckpointManager:
             return self._take(abs_dir, reason)
         except Exception as e:
             logger.debug("Checkpoint failed (non-fatal): %s", e)
+            return False
+
+    def maybe_periodic_checkpoint(self, working_dir: str, reason: str = "periodic") -> bool:
+        """Periodic checkpoint hook for long-running sessions (#99869).
+
+        Fires every ``checkpoint_interval`` tool calls regardless of the
+        per-turn dedup, so a multi-hour sweep that stays within one turn
+        or loops over many files still persists progress incrementally.
+        Bypasses the per-turn dedup by clearing the dir from the set
+        before delegating to :meth:`ensure_checkpoint`.
+
+        Returns True if a checkpoint was taken.
+        Never raises.
+        """
+        if not self.enabled:
+            return False
+        try:
+            self._periodic_counter += 1
+            if self._periodic_counter % self.checkpoint_interval != 0:
+                return False
+            abs_dir = str(_normalize_path(working_dir))
+            # Rate-limit: a sweep with checkpoint_interval=1 would otherwise
+            # take back-to-back git snapshots of the same dir.
+            now = time.time()
+            if now - self._last_periodic_ts.get(abs_dir, 0.0) < _PERIODIC_MIN_INTERVAL_S:
+                return False
+            # Bypass per-turn dedup for the periodic tick — long loops often
+            # mutate many files within one turn and would otherwise keep only
+            # the first snapshot.
+            self._checkpointed_dirs.discard(abs_dir)
+            took = self.ensure_checkpoint(working_dir, reason)
+            if took:
+                self._last_periodic_ts[abs_dir] = now
+            return took
+        except Exception as exc:
+            logger.debug("Periodic checkpoint failed: %s", exc)
             return False
 
     def list_checkpoints(self, working_dir: str) -> List[Dict]:
@@ -1648,6 +1937,276 @@ def format_checkpoint_list(checkpoints: List[Dict], directory: str) -> str:
     lines.append("  /rollback diff <N>        preview changes since checkpoint N")
     lines.append("  /rollback <N> <file>      restore a single file from checkpoint N")
     return "\n".join(lines)
+
+
+
+# ---------------------------------------------------------------------------
+# Session-terminate markers — #99869
+# ---------------------------------------------------------------------------
+# When a long-running session dies mid-task (AuthenticationError, terminal
+# exit 124, context exhaustion, SIGKILL, process crash), the next session
+# has no way to know the prior session died partway through a write. These
+# markers give that signal: a small JSON file under
+# <hermes-home>/sessions/<id>.interrupted with timestamp + last_action +
+# reason. The next session surfaces a warning AND injects the record into
+# its continuation prompt (see build_interruption_note) instead of trusting
+# stale state.
+#
+# Crash-safety design (review #100220): no in-process handler can run on
+# SIGKILL, so the marker is written UP FRONT — reason "in_flight" at turn
+# start — and CLEARED on clean completion. A kill/crash between the two
+# leaves the in-flight marker behind with zero handler involvement; the
+# failure-path call sites then only OVERWRITE the reason with something
+# more specific. Signal handlers (SIGTERM/SIGINT) and the cron script
+# watchdog add specificity on paths where a parent survives.
+#
+# Path note: the issue suggested ~/.local/share/hermes/sessions/.interrupted.
+# We use get_hermes_home()/sessions/<id>.interrupted instead — the same
+# profile-aware, platform-correct root as checkpoints (Windows:
+# %LOCALAPPDATA%/hermes, POSIX: ~/.hermes, $HERMES_HOME override honored) —
+# so markers follow the active profile like every other session artifact.
+
+def _session_marker_dir(base=None):
+    return (base or get_hermes_home()) / _SESSION_MARKER_DIRNAME
+
+
+def _session_marker_path(session_id, base=None):
+    safe_id = re.sub(r"[^a-zA-Z0-9._-]", "_", str(session_id).strip())[:128]
+    if not safe_id:
+        safe_id = "unknown"
+    return _session_marker_dir(base) / f"{safe_id}.interrupted"
+
+
+def _prune_old_markers(base=None):
+    """Best-effort removal of markers older than _MARKER_PRUNE_AGE_S."""
+    try:
+        now = time.time()
+        d = _session_marker_dir(base)
+        if not d.exists():
+            return
+        for p in d.glob("*.interrupted"):
+            try:
+                if now - p.stat().st_mtime > _MARKER_PRUNE_AGE_S:
+                    p.unlink()
+            except OSError:
+                continue
+    except Exception as exc:
+        logger.debug("marker prune failed: %s", exc)
+
+
+def write_interrupted_marker(session_id, last_action="", reason="interrupted",
+                             base=None, last_checkpoint=None):
+    """Write a marker for a terminated (or in-flight) session. Best-effort.
+
+    ``reason="in_flight"`` marks a session that STARTED work and has not
+    cleanly finished — the SIGKILL-proof half of the protocol. Failure
+    paths overwrite it with a specific reason; clean completion clears it
+    via :func:`clear_interrupted_marker`.
+    """
+    try:
+        marker = _session_marker_path(session_id, base)
+        marker.parent.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "session_id": session_id,
+            "timestamp": time.time(),
+            "iso_time": time.strftime("%Y-%m-%dT%H:%M:%S%z"),
+            "last_action": (last_action or "")[:2000],
+            "reason": (reason or "interrupted")[:500],
+        }
+        if last_checkpoint:
+            payload["last_checkpoint"] = str(last_checkpoint)[:500]
+        tmp = marker.with_suffix(".tmp")
+        tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        _durable_replace(tmp, marker)
+        _prune_old_markers(base)
+        return marker
+    except Exception as exc:
+        logger.debug("write_interrupted_marker failed for %s: %s", session_id, exc)
+        return None
+
+
+def read_interrupted_marker(session_id, base=None):
+    """Read an interrupted marker, or None if absent/unreadable."""
+    try:
+        marker = _session_marker_path(session_id, base)
+        if not marker.exists():
+            return None
+        return json.loads(marker.read_text(encoding="utf-8"))
+    except Exception as exc:
+        logger.debug("read_interrupted_marker failed for %s: %s", session_id, exc)
+        return None
+
+
+def clear_interrupted_marker(session_id, base=None):
+    """Remove a marker after it has been triaged. Returns True if removed."""
+    try:
+        marker = _session_marker_path(session_id, base)
+        if marker.exists():
+            marker.unlink()
+            return True
+        return False
+    except Exception as exc:
+        logger.debug("clear_interrupted_marker failed for %s: %s", session_id, exc)
+        return False
+
+
+def list_interrupted_markers(base=None):
+    """List all interrupted markers (newest first)."""
+    try:
+        d = _session_marker_dir(base)
+        if not d.exists():
+            return []
+        out = []
+        for p in d.glob("*.interrupted"):
+            try:
+                data = json.loads(p.read_text(encoding="utf-8"))
+                data["_path"] = str(p)
+                out.append(data)
+            except (OSError, ValueError) as exc:
+                logger.debug("skipping unreadable marker %s: %s", p, exc)
+                continue
+        out.sort(key=lambda x: x.get("timestamp", 0), reverse=True)
+        return out
+    except Exception as exc:
+        logger.debug("list_interrupted_markers failed: %s", exc)
+        return []
+
+
+# Terminating-signal handlers: SIGTERM/SIGINT get a chance to record a
+# specific reason before the process dies. SIGKILL is uncatchable by design —
+# the in-flight marker (written at turn start) is what covers that path.
+_installed_termination_sessions = set()
+
+
+def install_termination_handlers(session_id, last_action_fn=None, base=None):
+    """Record a marker when SIGTERM/SIGINT lands. Best-effort, idempotent.
+
+    Main-thread only (signal.signal requires it — gateway worker threads
+    skip silently) and once per session id. The handler overwrites the
+    in-flight marker with the signal reason, then re-raises with the
+    default disposition so the exit status still reflects the signal.
+    ``last_action_fn`` is a zero-arg callable returning the latest tool
+    action for the marker (may be None).
+    """
+    try:
+        if not session_id or session_id in _installed_termination_sessions:
+            return False
+        if threading.current_thread() is not threading.main_thread():
+            return False
+        _installed_termination_sessions.add(session_id)
+
+        def _handle(signum, _frame):
+            try:
+                last_action = ""
+                if last_action_fn is not None:
+                    try:
+                        last_action = str(last_action_fn() or "")
+                    except Exception as exc:
+                        logger.debug("termination last-action probe failed: %s", exc)
+                write_interrupted_marker(
+                    session_id,
+                    last_action=last_action,
+                    reason="sigterm" if signum == signal.SIGTERM else "sigint",
+                    base=base,
+                )
+            except Exception as exc:
+                logger.debug("termination marker write failed: %s", exc)
+            finally:
+                try:
+                    signal.signal(signum, signal.SIG_DFL)
+                    signal.raise_signal(signum)
+                except Exception as exc:
+                    logger.debug("termination re-raise failed: %s", exc)
+                    raise SystemExit(128 + int(signum))
+
+        for _sig in (signal.SIGTERM, signal.SIGINT):
+            try:
+                signal.signal(_sig, _handle)
+            except (OSError, ValueError, RuntimeError) as exc:
+                logger.debug("cannot install handler for signal %s: %s", _sig, exc)
+        return True
+    except Exception as exc:
+        logger.debug("install_termination_handlers failed: %s", exc)
+        return False
+
+
+def build_interruption_note(working_dir=None, exclude_session_id="", base=None):
+    """Build the model-facing interruption note for the continuation prompt.
+
+    Returns None when no recent (24h) foreign markers exist. Includes the
+    newest markers (reason + last action), the last checkpoint pointer for
+    ``working_dir`` when one exists, and the tail of the mutation journal
+    so the model can triage instead of trusting stale tree state.
+    """
+    try:
+        now = time.time()
+        markers = [
+            m for m in list_interrupted_markers(base=base)
+            if now - m.get("timestamp", 0) < _MARKER_FRESH_S
+            and m.get("session_id", "") != (exclude_session_id or "")
+        ]
+        if not markers:
+            return None
+        lines = [
+            "[System note: one or more previous sessions were interrupted "
+            "before completing their task. Do NOT trust in-memory/file-tree "
+            "state from before the interruption — verify against disk and "
+            "the checkpoints below.]",
+        ]
+        for m in markers[:3]:
+            sid = str(m.get("session_id", "?"))[:24]
+            reason = m.get("reason", "interrupted")
+            when = m.get("iso_time", "")
+            act = (m.get("last_action", "") or "")[:160]
+            ckpt = m.get("last_checkpoint", "")
+            detail = f"session {sid} at {when} — reason={reason} last_action={act}"
+            if ckpt:
+                detail += f" last_checkpoint={ckpt}"
+            lines.append("- " + detail)
+        if working_dir:
+            try:
+                mgr = CheckpointManager()
+                cps = mgr.list_checkpoints(str(working_dir))
+                if cps:
+                    latest = cps[0]
+                    lines.append(
+                        "Last checkpoint for %s: %s (%s — %s). Prefer "
+                        "`hermes checkpoints` / `/rollback` over manual "
+                        "forensics." % (
+                            working_dir,
+                            latest.get("short_hash", latest.get("hash", "?")),
+                            latest.get("date", latest.get("timestamp", "")),
+                            latest.get("reason", ""),
+                        )
+                    )
+                else:
+                    lines.append(
+                        "No checkpoint exists for %s — journal entries below "
+                        "are the only record." % working_dir
+                    )
+                store = _store_path(CHECKPOINT_BASE)
+                journal = _read_journal(
+                    store, _project_hash(str(_normalize_path(str(working_dir)))), 5
+                )
+                for e in journal:
+                    lines.append(
+                        "- mutated %s via %s (before=%.8s after=%.8s)" % (
+                            e.get("path", "?"),
+                            e.get("tool", "?"),
+                            str(e.get("before") or "-"),
+                            str(e.get("after") or "-"),
+                        )
+                    )
+            except Exception as exc:
+                logger.debug("interruption checkpoint/journal lookup failed: %s", exc)
+        lines.append(
+            "Triage before continuing: re-read the files above, diff against "
+            "the checkpoint when present, and re-apply only verified work."
+        )
+        return "\n".join(lines)
+    except Exception as exc:
+        logger.debug("build_interruption_note failed: %s", exc)
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -1478,6 +1478,17 @@ class ShellFileOperations(FileOperations):
         script = (
             "set -e; "
             f"d={q_parent}; t={q_path}; "
+            # Durable-write fsync helper (#99869 review): a bare
+            # `sync FILE` is a no-op on Windows Git Bash / MSYS (the repro
+            # env) and sync(1) without an operand only schedules a global
+            # flush. Do a real fsync(2) via python when available, keep
+            # `sync` as fallback for python-less backends, `true` as the
+            # final fallback so behavior never regresses. Always returns 0
+            # (best-effort — durability must not fail the write itself).
+            '_fsync() { '
+            'command -v python3 >/dev/null 2>&1 && python3 -c "import os,sys; f=os.open(sys.argv[1], os.O_RDONLY); os.fsync(f); os.close(f)" "$1" 2>/dev/null && return 0; '
+            'command -v python >/dev/null 2>&1 && python -c "import os,sys; f=os.open(sys.argv[1], os.O_RDONLY); os.fsync(f); os.close(f)" "$1" 2>/dev/null && return 0; '
+            'sync "$1" 2>/dev/null && return 0; sync 2>/dev/null; return 0; }; '
             # Follow a symlink target so we edit the file the link points at,
             # rather than replacing the symlink itself with a plain file (which
             # orphans the real target and destroys the link). Recompute the
@@ -1504,11 +1515,16 @@ class ShellFileOperations(FileOperations):
             '[ -n "$m" ] && chmod "$m" "$tmp" 2>/dev/null || true; '
             "fi; "
             'cat > "$tmp"; '
+            # fsync the temp file's data before the atomic rename (#99869).
+            '_fsync "$tmp"; '
             # new file: umask-default perms instead of mktemp's 0600 (#70856).
             # Runs AFTER cat so a write-masking umask can't EACCES the stream;
             # quoted "=rw" so zsh doesn't =word-expand it.
             'if [ ! -e "$t" ]; then chmod "=rw" "$tmp" 2>/dev/null || true; fi; '
             'mv -f "$tmp" "$t"; '
+            # fsync the target and the parent dir after rename so a crash
+            # between mv and the dirent hitting disk can't lose the inode.
+            '_fsync "$t"; _fsync "$d"; '
             "trap - EXIT"
         )
         return self._exec(script, stdin_data=content)


### PR DESCRIPTION
fix(agent): checkpoint/rollback for partial file mutations in long-running sessions

Reworked per @YangKangSung review on the first version (which only added sync FILE lines, in-process-only markers, and a gated periodic hook):

- Durable atomic writes: shell path fsyncs temp/target/parent-dir via real fsync(2) (python3/python, sync fallback, never fatal — bare sync FILE is a no-op on MSYS); Python paths use flush+fsync+replace+dir-fsync; new durable_atomic_write() helper for out-of-band no_agent scripts that bypass write_file.
- Markers survive SIGKILL/crash/exit-124: in-flight marker written at turn start (needs no handler) and cleared on clean completion; failure paths overwrite it with the specific reason; SIGTERM/SIGINT handlers add signal specificity; the cron watchdog leaves markers on script timeout/cancel/crash.
- Next session gets the record in its continuation prompt (user-message channel, first turn) with the last-checkpoint pointer and mutation-journal tail — not just a human-visible warning.
- Always-on mutation journal (path/before-hash/after-hash/tool/ts) independent of checkpoints.enabled (snapshots stay opt-in); periodic snapshots rate-limited via _last_periodic_ts.

Review notes: markers live under get_hermes_home()/sessions (profile-aware, platform-correct), not the literal ~/.local/share path from the issue. Atomic rename guards torn writes only — a completed wrong-content write (the 70-byte regex case) needs content validation, not durability; write_file keeps its fail-closed gate plus post-write hash verification for that.

Tests: tests/tools/test_checkpoint_99869.py (16 new), TestAtomicWriteDurability (2 new), TestCronScriptInterruptionMarker (3 new) pass; neighboring suites green (tool_executor checkpoint paths, turn_context, file_mutation_verifier, cron script/heartbeat).

Related to #99869