### PR TITLE
fix(dashboard): route-scoped exclusive shell for full product-home overrides

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18532,6 +18532,14 @@ def _discover_dashboard_plugins() -> list:
                     tab_info["override"] = override_path
                 if bool(raw_tab.get("hidden")):
                     tab_info["hidden"] = True
+                # Route-scoped exclusive shell: when the active route equals
+                # the overridden route and shell is "exclusive", the plugin
+                # owns the full product shell for that route only (no built-in
+                # sidebar/header chrome). Preserved exactly like override/hidden
+                # — generic, no per-plugin special cases. See #100149.
+                raw_shell = raw_tab.get("shell")
+                if isinstance(raw_shell, str) and raw_shell == "exclusive":
+                    tab_info["shell"] = "exclusive"
                 # Slots: list of named slot locations this plugin populates.
                 # The frontend exposes ``registerSlot(pluginName, slotName, Component)``
                 # on window; plugins with non-empty slots call it from their JS bundle.

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -100,7 +100,7 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
 import type { Translations } from "@/i18n/types";
-import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
+import { PluginPage, PluginSlot, usePlugins, getExclusiveShellManifest, getCachedManifests } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
@@ -400,6 +400,15 @@ export default function App() {
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
+  // Route-scoped exclusive shell: when a plugin's tab.shell === "exclusive"
+  // and its tab.override equals the active normalized route, that plugin
+  // owns the full product shell for that route only — no built-in sidebar/
+  // header/nav chrome. Generic, no per-plugin special cases (#100149).
+  const exclusiveManifest = useMemo(
+    () => getExclusiveShellManifest(manifests, normalizedPath),
+    [manifests, normalizedPath],
+  );
+  const isExclusiveShell = !!exclusiveManifest;
   const embeddedChat = isDashboardEmbeddedChatEnabled();
   // Defer mounting the persistent chat host (and its xterm chunk) until the
   // user has actually opened /chat at least once. Sticky after that so the
@@ -508,6 +517,79 @@ export default function App() {
     mql.addEventListener("change", onChange);
     return () => mql.removeEventListener("change", onChange);
   }, []);
+
+  // Avoid flash of built-in shell when "/" exclusivity is still unknown on
+  // first visit with empty cache (manifests not yet fetched). In that window
+  // we can't know if "/" is exclusive, so render a neutral loading state
+  // without sidebar/header chrome. For subsequent visits the cache seeds
+  // manifests synchronously and this branch is never taken — normal users
+  // with empty cache after first fetch get loading=false immediately.
+  const isExclusivePendingForRoot =
+    pluginsLoading &&
+    manifests.length === 0 &&
+    normalizedPath === "/" &&
+    getCachedManifests() === null;
+
+  if (isExclusivePendingForRoot) {
+    return (
+      <ProfileProvider>
+        <div
+          data-layout-variant={layoutVariant}
+          className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
+        >
+          <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center" aria-busy="true" aria-live="polite">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner />
+              <span>Loading…</span>
+            </div>
+          </div>
+        </div>
+      </ProfileProvider>
+    );
+  }
+
+  // Route-scoped exclusive shell: render plugin page as full product shell
+  // without built-in sidebar/header/navigation, still inside Profile/Auth/
+  // Theme providers. Native routes automatically restore standard shell.
+  if (isExclusiveShell) {
+    return (
+      <ProfileProvider>
+        <div
+          data-layout-variant={layoutVariant}
+          className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
+          data-exclusive-shell={exclusiveManifest?.name ?? "true"}
+        >
+          <SelectionSwitcher />
+          <div aria-hidden className="pointer-events-none fixed inset-0 z-0">
+            <PluginSlot name="backdrop" />
+          </div>
+          <PageHeaderProvider pluginTabs={pluginTabMeta}>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+              {/* No mobile header, no sidebar, no banners — plugin owns chrome */}
+              <div className="flex min-h-0 min-w-0 flex-1">
+                <div className="relative z-2 flex min-w-0 min-h-0 flex-1 flex-col">
+                  <ProfileKeyedRoutes>
+                    <Suspense fallback={<RouteFallback />}>
+                      <Routes>
+                        {routes.map(({ key, path, element }) => (
+                          <Route key={key} path={path} element={element} />
+                        ))}
+                        <Route
+                          path="*"
+                          element={<UnknownRouteFallback pluginsLoading={pluginsLoading} />}
+                        />
+                      </Routes>
+                    </Suspense>
+                  </ProfileKeyedRoutes>
+                </div>
+              </div>
+            </div>
+          </PageHeaderProvider>
+          <PluginSlot name="overlay" />
+        </div>
+      </ProfileProvider>
+    );
+  }
 
   return (
     <ProfileProvider>

--- a/web/src/plugins/index.ts
+++ b/web/src/plugins/index.ts
@@ -1,6 +1,6 @@
 export { exposePluginSDK, getPluginComponent, onPluginRegistered, getRegisteredCount } from "./registry";
 export { PluginPage } from "./PluginPage";
-export { usePlugins } from "./usePlugins";
+export { usePlugins, getExclusiveShellManifest, isExclusiveShellRoute, getCachedManifests, cacheManifests, canSeedLoadedFromCache, MANIFEST_CACHE_KEY } from "./usePlugins";
 export { PluginSlot, KNOWN_SLOT_NAMES, registerSlot, getSlotEntries, onSlotRegistered, unregisterPluginSlots } from "./slots";
 export type { KnownSlotName } from "./slots";
 export type { PluginManifest, RegisteredPlugin } from "./types";

--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -16,6 +16,13 @@ export interface PluginManifest {
     override?: string;
     /** When true, the plugin may register without a sidebar tab (slot-only, etc.). */
     hidden?: boolean;
+    /**
+     * Shell mode for an overridden route.
+     * - "standard" (default): plugin content renders inside the normal Hermes sidebar/header chrome.
+     * - "exclusive": when the active route equals `override`, the plugin owns the full product shell for that route only — built-in sidebar/header navigation is not rendered. Navigating to any other native route restores the standard shell.
+     * Only meaningful together with `override`. Ignored otherwise.
+     */
+    shell?: "standard" | "exclusive";
   };
   /** Declared for discovery; actual slots use registerSlot in the plugin bundle. */
   slots?: string[];

--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -142,3 +142,101 @@ describe("canSeedLoadedFromCache (loading seed gate)", () => {
     expect(canSeedLoadedFromCache(malformed)).toBe(true);
   });
 });
+
+describe("exclusive shell (route-scoped)", () => {
+  it("returns undefined when no exclusive manifest matches", async () => {
+    const { getExclusiveShellManifest, isExclusiveShellRoute } = await import("./usePlugins");
+    const list: PluginManifest[] = [exampleManifest];
+    expect(getExclusiveShellManifest(list, "/")).toBeUndefined();
+    expect(isExclusiveShellRoute(list, "/")).toBe(false);
+  });
+
+  it("matches exclusive shell only when override equals active route", async () => {
+    const { getExclusiveShellManifest, isExclusiveShellRoute } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "worker-studio",
+      label: "Worker Studio",
+      tab: { path: "/worker-studio", override: "/", shell: "exclusive" },
+    };
+    const list: PluginManifest[] = [exclusive];
+    expect(getExclusiveShellManifest(list, "/")?.name).toBe("worker-studio");
+    expect(isExclusiveShellRoute(list, "/")).toBe(true);
+    // Not active on other routes
+    expect(getExclusiveShellManifest(list, "/sessions")).toBeUndefined();
+    expect(isExclusiveShellRoute(list, "/sessions")).toBe(false);
+    // Back to exclusive
+    expect(isExclusiveShellRoute(list, "/")).toBe(true);
+  });
+
+  it("normalizes trailing slashes", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "ws",
+      tab: { path: "/ws", override: "/", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([exclusive], "/")?.name).toBe("ws");
+    expect(getExclusiveShellManifest([exclusive], "/")?.name).toBe("ws");
+    // Manifest with trailing slash override still matches normalized "/"
+    const exclusive2: PluginManifest = {
+      ...exampleManifest,
+      name: "ws2",
+      tab: { path: "/ws2", override: "/sessions", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([exclusive2], "/sessions/")?.name).toBe("ws2");
+    expect(getExclusiveShellManifest([exclusive2], "/sessions")?.name).toBe("ws2");
+  });
+
+  it("ignores standard shell and manifests without override", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const standard: PluginManifest = {
+      ...exampleManifest,
+      name: "std",
+      tab: { path: "/std", override: "/", shell: "standard" },
+    };
+    const noShell: PluginManifest = {
+      ...exampleManifest,
+      name: "no-shell",
+      tab: { path: "/no-shell", override: "/" },
+    };
+    const exclusiveButNoOverride: PluginManifest = {
+      ...exampleManifest,
+      name: "orphan",
+      tab: { path: "/orphan", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([standard], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([noShell], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([exclusiveButNoOverride], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([exclusiveButNoOverride], "/orphan")).toBeUndefined();
+  });
+
+  it("picks the first exclusive manifest that matches active route", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const a: PluginManifest = {
+      ...exampleManifest,
+      name: "a",
+      tab: { path: "/a", override: "/", shell: "exclusive" },
+    };
+    const b: PluginManifest = {
+      ...exampleManifest,
+      name: "b",
+      tab: { path: "/b", override: "/", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([a, b], "/")?.name).toBe("a");
+  });
+
+  it("exclusive shell is route-scoped: native routes remain non-exclusive", async () => {
+    const { isExclusiveShellRoute } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "ws",
+      tab: { path: "/ws", override: "/", shell: "exclusive" },
+    };
+    const nativeRoutes = ["/sessions", "/cron", "/skills", "/plugins", "/mcp", "/config", "/channels", "/webhooks", "/system", "/profiles", "/docs", "/files", "/analytics", "/logs"];
+    for (const route of nativeRoutes) {
+      expect(isExclusiveShellRoute([exclusive], route)).toBe(false);
+    }
+    expect(isExclusiveShellRoute([exclusive], "/")).toBe(true);
+  });
+});

--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -57,6 +57,44 @@ export function canSeedLoadedFromCache(
   return !cached.some((m) => m.tab?.override === "/chat");
 }
 
+/**
+ * Normalize a route path for comparison (strip trailing slash, keep root as "/").
+ */
+function normalizeRoutePath(path: string): string {
+  if (!path) return "/";
+  const n = path.replace(/\/$/, "");
+  return n || "/";
+}
+
+/**
+ * Return the manifest that owns an exclusive shell for the given active route,
+ * if any. Exclusive shell is route-scoped: only when `tab.shell === "exclusive"`
+ * and `tab.override` exactly equals the active normalized route does the plugin
+ * take over the full product shell for that route.
+ * Exported for App.tsx and tests — pure, no side effects.
+ */
+export function getExclusiveShellManifest(
+  manifests: PluginManifest[],
+  activePath: string,
+): PluginManifest | undefined {
+  const normalizedActive = normalizeRoutePath(activePath);
+  return manifests.find((m) => {
+    const override = m.tab?.override;
+    if (!override || m.tab?.shell !== "exclusive") return false;
+    return normalizeRoutePath(override) === normalizedActive;
+  });
+}
+
+/**
+ * Whether the active route is an exclusive-shell route owned by a plugin.
+ */
+export function isExclusiveShellRoute(
+  manifests: PluginManifest[],
+  activePath: string,
+): boolean {
+  return !!getExclusiveShellManifest(manifests, activePath);
+}
+
 export function usePlugins() {
   // Lazy initialisers run once at mount — safe to read sessionStorage here.
   // This avoids the "cannot access ref during render" lint error that would

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -459,7 +459,8 @@ None of them are required; include only the layers you need.
     "path": "/my-plugin",
     "position": "after:skills",
     "override": "/",
-    "hidden": false
+    "hidden": false,
+    "shell": "exclusive"
   },
   "slots": ["sidebar", "header-left"],
   "entry": "dist/index.js",
@@ -479,6 +480,7 @@ None of them are required; include only the layers you need.
 | `tab.position` | No | Where to insert the tab. `"end"` (default), `"after:<path>"`, or `"before:<path>"` — value after the colon is the **path segment** of the target tab (no leading slash). Examples: `"after:skills"`, `"before:config"`. |
 | `tab.override` | No | Set to a built-in route path (`"/"`, `"/sessions"`, `"/config"`, ...) to **replace** that page instead of adding a new tab. See [Replacing built-in pages](#replacing-built-in-pages-taboverride). |
 | `tab.hidden` | No | When true, register the component and any slots without adding a tab to the nav. Used by slot-only plugins. See [Slot-only plugins](#slot-only-plugins-tabhidden). |
+| `tab.shell` | No | `"standard"` (default) or `"exclusive"` — when `override` is set and `shell: "exclusive"`, the plugin owns the full product shell for that overridden route only (no built-in sidebar/header navigation). Route-scoped: every other route renders the normal Hermes shell. See [Route-scoped exclusive shell](#route-scoped-exclusive-shell-tabshellexclusive). |
 | `slots` | No | Named shell slots this plugin populates. **Documentation aid only** — actual registration happens from the JS bundle via `registerSlot()`. Listing slots here makes discovery surfaces more informative. |
 | `entry` | Yes | Path to the JS bundle relative to `dashboard/`. Defaults to `dist/index.js`. |
 | `css` | No | Path to a CSS file to inject as a `<link>` tag. |
@@ -650,6 +652,34 @@ With `override` set:
 Only one plugin can override a given path. If two plugins claim the same override, the first wins and the second is ignored with a dev-mode warning.
 
 If you only need to add a card or toolbar to an existing page without taking it over, use [page-scoped slots](#augmenting-built-in-pages-page-scoped-slots) instead.
+
+### Route-scoped exclusive shell (`tab.shell: "exclusive"`)
+
+A product-shell plugin may want to fully own the dashboard shell for **one** route (e.g. `/`) while leaving every other native route (`/sessions`, `/cron`, `/skills`, `/plugins`, `/mcp`, `/config`, etc.) untouched. That is expressed as a route-scoped exclusive shell — a small generic extension to the `tab` contract, not global control over navigation.
+
+```json
+// ~/.hermes/plugins/worker-studio/dashboard/manifest.json
+{
+  "name": "worker-studio",
+  "label": "Worker Studio",
+  "tab": {
+    "path": "/worker-studio",
+    "override": "/",
+    "shell": "exclusive"
+  },
+  "entry": "dist/index.js"
+}
+```
+
+**Semantics (generic, no per-plugin special cases):**
+
+1. When the active route equals the plugin's `override` path **and** `shell: "exclusive"`, the plugin page renders as the dashboard product shell **without** built-in sidebar/header navigation chrome. The plugin provides its own navigation/header/composer.
+2. On every other route the normal Hermes dashboard shell (sidebar, header, banners) renders unchanged. Navigating from the plugin's menu to a native route (e.g. `/sessions`) automatically restores the standard shell; navigating back to `/` restores the exclusive plugin shell. No plugin-side cleanup is required.
+3. Native routes remain authoritative and reachable — the plugin does not delete or hide Hermes routes, it only controls chrome while its own overridden route is active.
+4. Deep-linking, browser history (back/forward), plugin loading gates, auth/theme/profile providers, and route ownership are preserved. No DOM/CSS monkey-patching is needed.
+5. Existing manifests without `tab.shell` keep current behavior (`"standard"` is the implicit default). Mobile sidebar and collapsed desktop sidebar do not leak onto an exclusive route. No flash of built-in navigation is shown while plugin manifests are still loading, especially for `/` overrides.
+
+Use `tab.shell: "exclusive"` only together with `tab.override`. When `override` is absent the field is ignored. Only one plugin can own a given overridden route; the first match wins for both standard and exclusive shells.
 
 ### Augmenting built-in pages (page-scoped slots)
 


### PR DESCRIPTION
fix(dashboard): route-scoped exclusive shell for full product-home overrides

Implements route-scoped tab.shell=exclusive for Dashboard Plugin SDK so a
plugin can own the full product shell for its overridden route only (e.g.
override / with exclusive) without built-in sidebar/header chrome, while
all native routes remain standard. Preserved server-side via dashboard
manifest discovery, typed in PluginManifest, and routed in App.tsx with
flash-free loading gate. Docs updated.

Closes #100149

diff --git a/hermes_cli/web_server.py b/hermes_cli/web_server.py
index d5ad2e9ab..f326ae87c 100644
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -18532,6 +18532,14 @@ def _discover_dashboard_plugins() -> list:
                     tab_info["override"] = override_path
                 if bool(raw_tab.get("hidden")):
                     tab_info["hidden"] = True
+                # Route-scoped exclusive shell: when the active route equals
+                # the overridden route and shell is "exclusive", the plugin
+                # owns the full product shell for that route only (no built-in
+                # sidebar/header chrome). Preserved exactly like override/hidden
+                # — generic, no per-plugin special cases. See #100149.
+                raw_shell = raw_tab.get("shell")
+                if isinstance(raw_shell, str) and raw_shell == "exclusive":
+                    tab_info["shell"] = "exclusive"
                 # Slots: list of named slot locations this plugin populates.
                 # The frontend exposes ``registerSlot(pluginName, slotName, Component)``
                 # on window; plugins with non-empty slots call it from their JS bundle.
diff --git a/web/src/App.tsx b/web/src/App.tsx
index bb79cb6a6..492f097b1 100644
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -100,7 +100,7 @@ import { LanguageSwitcher } from "@/components/LanguageSwitcher";
 import { ThemeSwitcher } from "@/components/ThemeSwitcher";
 import { useI18n } from "@/i18n";
 import type { Translations } from "@/i18n/types";
-import { PluginPage, PluginSlot, usePlugins } from "@/plugins";
+import { PluginPage, PluginSlot, usePlugins, getExclusiveShellManifest, getCachedManifests } from "@/plugins";
 import type { PluginManifest } from "@/plugins";
 import { useTheme } from "@/themes";
 import { isDashboardEmbeddedChatEnabled } from "@/lib/dashboard-flags";
@@ -400,6 +400,15 @@ export default function App() {
   const isDocsRoute = pathname === "/docs" || pathname === "/docs/";
   const normalizedPath = pathname.replace(/\/$/, "") || "/";
   const isChatRoute = normalizedPath === "/chat";
+  // Route-scoped exclusive shell: when a plugin's tab.shell === "exclusive"
+  // and its tab.override equals the active normalized route, that plugin
+  // owns the full product shell for that route only — no built-in sidebar/
+  // header/nav chrome. Generic, no per-plugin special cases (#100149).
+  const exclusiveManifest = useMemo(
+    () => getExclusiveShellManifest(manifests, normalizedPath),
+    [manifests, normalizedPath],
+  );
+  const isExclusiveShell = !!exclusiveManifest;
   const embeddedChat = isDashboardEmbeddedChatEnabled();
   // Defer mounting the persistent chat host (and its xterm chunk) until the
   // user has actually opened /chat at least once. Sticky after that so the
@@ -509,6 +518,79 @@ export default function App() {
     return () => mql.removeEventListener("change", onChange);
   }, []);

+  // Avoid flash of built-in shell when "/" exclusivity is still unknown on
+  // first visit with empty cache (manifests not yet fetched). In that window
+  // we can't know if "/" is exclusive, so render a neutral loading state
+  // without sidebar/header chrome. For subsequent visits the cache seeds
+  // manifests synchronously and this branch is never taken — normal users
+  // with empty cache after first fetch get loading=false immediately.
+  const isExclusivePendingForRoot =
+    pluginsLoading &&
+    manifests.length === 0 &&
+    normalizedPath === "/" &&
+    getCachedManifests() === null;
+
+  if (isExclusivePendingForRoot) {
+    return (
+      <ProfileProvider>
+        <div
+          data-layout-variant={layoutVariant}
+          className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
+        >
+          <div className="flex min-h-0 min-w-0 flex-1 items-center justify-center" aria-busy="true" aria-live="polite">
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Spinner />
+              <span>Loading…</span>
+            </div>
+          </div>
+        </div>
+      </ProfileProvider>
+    );
+  }
+
+  // Route-scoped exclusive shell: render plugin page as full product shell
+  // without built-in sidebar/header/navigation, still inside Profile/Auth/
+  // Theme providers. Native routes automatically restore standard shell.
+  if (isExclusiveShell) {
+    return (
+      <ProfileProvider>
+        <div
+          data-layout-variant={layoutVariant}
+          className="flex h-dvh max-h-dvh min-h-0 flex-col overflow-hidden bg-background-base text-text-primary antialiased"
+          data-exclusive-shell={exclusiveManifest?.name ?? "true"}
+        >
+          <SelectionSwitcher />
+          <div aria-hidden className="pointer-events-none fixed inset-0 z-0">
+            <PluginSlot name="backdrop" />
+          </div>
+          <PageHeaderProvider pluginTabs={pluginTabMeta}>
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col overflow-hidden">
+              {/* No mobile header, no sidebar, no banners — plugin owns chrome */}
+              <div className="flex min-h-0 min-w-0 flex-1">
+                <div className="relative z-2 flex min-w-0 min-h-0 flex-1 flex-col">
+                  <ProfileKeyedRoutes>
+                    <Suspense fallback={<RouteFallback />}>
+                      <Routes>
+                        {routes.map(({ key, path, element }) => (
+                          <Route key={key} path={path} element={element} />
+                        ))}
+                        <Route
+                          path="*"
+                          element={<UnknownRouteFallback pluginsLoading={pluginsLoading} />}
+                        />
+                      </Routes>
+                    </Suspense>
+                  </ProfileKeyedRoutes>
+                </div>
+              </div>
+            </div>
+          </PageHeaderProvider>
+          <PluginSlot name="overlay" />
+        </div>
+      </ProfileProvider>
+    );
+  }
+
   return (
     <ProfileProvider>
     <div
diff --git a/web/src/plugins/index.ts b/web/src/plugins/index.ts
index da9c1bdef..0af5e265d 100644
--- a/web/src/plugins/index.ts
+++ b/web/src/plugins/index.ts
@@ -1,6 +1,6 @@
 export { exposePluginSDK, getPluginComponent, onPluginRegistered, getRegisteredCount } from "./registry";
 export { PluginPage } from "./PluginPage";
-export { usePlugins } from "./usePlugins";
+export { usePlugins, getExclusiveShellManifest, isExclusiveShellRoute, getCachedManifests, cacheManifests, canSeedLoadedFromCache, MANIFEST_CACHE_KEY } from "./usePlugins";
 export { PluginSlot, KNOWN_SLOT_NAMES, registerSlot, getSlotEntries, onSlotRegistered, unregisterPluginSlots } from "./slots";
 export type { KnownSlotName } from "./slots";
 export type { PluginManifest, RegisteredPlugin } from "./types";
diff --git a/web/src/plugins/types.ts b/web/src/plugins/types.ts
index 51fecffbd..6066ecc53 100644
--- a/web/src/plugins/types.ts
+++ b/web/src/plugins/types.ts
@@ -16,6 +16,13 @@ export interface PluginManifest {
     override?: string;
     /** When true, the plugin may register without a sidebar tab (slot-only, etc.). */
     hidden?: boolean;
+    /**
+     * Shell mode for an overridden route.
+     * - "standard" (default): plugin content renders inside the normal Hermes sidebar/header chrome.
+     * - "exclusive": when the active route equals `override`, the plugin owns the full product shell for that route only — built-in sidebar/header navigation is not rendered. Navigating to any other native route restores the standard shell.
+     * Only meaningful together with `override`. Ignored otherwise.
+     */
+    shell?: "standard" | "exclusive";
   };
   /** Declared for discovery; actual slots use registerSlot in the plugin bundle. */
   slots?: string[];
diff --git a/web/src/plugins/usePlugins.test.ts b/web/src/plugins/usePlugins.test.ts
index 05d0cd40d..d28421585 100644
--- a/web/src/plugins/usePlugins.test.ts
+++ b/web/src/plugins/usePlugins.test.ts
@@ -142,3 +142,101 @@ describe("canSeedLoadedFromCache (loading seed gate)", () => {
     expect(canSeedLoadedFromCache(malformed)).toBe(true);
   });
 });
+
+describe("exclusive shell (route-scoped)", () => {
+  it("returns undefined when no exclusive manifest matches", async () => {
+    const { getExclusiveShellManifest, isExclusiveShellRoute } = await import("./usePlugins");
+    const list: PluginManifest[] = [exampleManifest];
+    expect(getExclusiveShellManifest(list, "/")).toBeUndefined();
+    expect(isExclusiveShellRoute(list, "/")).toBe(false);
+  });
+
+  it("matches exclusive shell only when override equals active route", async () => {
+    const { getExclusiveShellManifest, isExclusiveShellRoute } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "worker-studio",
+      label: "Worker Studio",
+      tab: { path: "/worker-studio", override: "/", shell: "exclusive" },
+    };
+    const list: PluginManifest[] = [exclusive];
+    expect(getExclusiveShellManifest(list, "/")?.name).toBe("worker-studio");
+    expect(isExclusiveShellRoute(list, "/")).toBe(true);
+    // Not active on other routes
+    expect(getExclusiveShellManifest(list, "/sessions")).toBeUndefined();
+    expect(isExclusiveShellRoute(list, "/sessions")).toBe(false);
+    // Back to exclusive
+    expect(isExclusiveShellRoute(list, "/")).toBe(true);
+  });
+
+  it("normalizes trailing slashes", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "ws",
+      tab: { path: "/ws", override: "/", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([exclusive], "/")?.name).toBe("ws");
+    expect(getExclusiveShellManifest([exclusive], "/")?.name).toBe("ws");
+    // Manifest with trailing slash override still matches normalized "/"
+    const exclusive2: PluginManifest = {
+      ...exampleManifest,
+      name: "ws2",
+      tab: { path: "/ws2", override: "/sessions", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([exclusive2], "/sessions/")?.name).toBe("ws2");
+    expect(getExclusiveShellManifest([exclusive2], "/sessions")?.name).toBe("ws2");
+  });
+
+  it("ignores standard shell and manifests without override", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const standard: PluginManifest = {
+      ...exampleManifest,
+      name: "std",
+      tab: { path: "/std", override: "/", shell: "standard" },
+    };
+    const noShell: PluginManifest = {
+      ...exampleManifest,
+      name: "no-shell",
+      tab: { path: "/no-shell", override: "/" },
+    };
+    const exclusiveButNoOverride: PluginManifest = {
+      ...exampleManifest,
+      name: "orphan",
+      tab: { path: "/orphan", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([standard], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([noShell], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([exclusiveButNoOverride], "/")).toBeUndefined();
+    expect(getExclusiveShellManifest([exclusiveButNoOverride], "/orphan")).toBeUndefined();
+  });
+
+  it("picks the first exclusive manifest that matches active route", async () => {
+    const { getExclusiveShellManifest } = await import("./usePlugins");
+    const a: PluginManifest = {
+      ...exampleManifest,
+      name: "a",
+      tab: { path: "/a", override: "/", shell: "exclusive" },
+    };
+    const b: PluginManifest = {
+      ...exampleManifest,
+      name: "b",
+      tab: { path: "/b", override: "/", shell: "exclusive" },
+    };
+    expect(getExclusiveShellManifest([a, b], "/")?.name).toBe("a");
+  });
+
+  it("exclusive shell is route-scoped: native routes remain non-exclusive", async () => {
+    const { isExclusiveShellRoute } = await import("./usePlugins");
+    const exclusive: PluginManifest = {
+      ...exampleManifest,
+      name: "ws",
+      tab: { path: "/ws", override: "/", shell: "exclusive" },
+    };
+    const nativeRoutes = ["/sessions", "/cron", "/skills", "/plugins", "/mcp", "/config", "/channels", "/webhooks", "/system", "/profiles", "/docs", "/files", "/analytics", "/logs"];
+    for (const route of nativeRoutes) {
+      expect(isExclusiveShellRoute([exclusive], route)).toBe(false);
+    }
+    expect(isExclusiveShellRoute([exclusive], "/")).toBe(true);
+  });
+});
diff --git a/web/src/plugins/usePlugins.ts b/web/src/plugins/usePlugins.ts
index f03a06983..135d8938c 100644
--- a/web/src/plugins/usePlugins.ts
+++ b/web/src/plugins/usePlugins.ts
@@ -57,6 +57,44 @@ export function canSeedLoadedFromCache(
   return !cached.some((m) => m.tab?.override === "/chat");
 }

+/**
+ * Normalize a route path for comparison (strip trailing slash, keep root as "/").
+ */
+function normalizeRoutePath(path: string): string {
+  if (!path) return "/";
+  const n = path.replace(/\/$/, "");
+  return n || "/";
+}
+
+/**
+ * Return the manifest that owns an exclusive shell for the given active route,
+ * if any. Exclusive shell is route-scoped: only when `tab.shell === "exclusive"`
+ * and `tab.override` exactly equals the active normalized route does the plugin
+ * take over the full product shell for that route.
+ * Exported for App.tsx and tests — pure, no side effects.
+ */
+export function getExclusiveShellManifest(
+  manifests: PluginManifest[],
+  activePath: string,
+): PluginManifest | undefined {
+  const normalizedActive = normalizeRoutePath(activePath);
+  return manifests.find((m) => {
+    const override = m.tab?.override;
+    if (!override || m.tab?.shell !== "exclusive") return false;
+    return normalizeRoutePath(override) === normalizedActive;
+  });
+}
+
+/**
+ * Whether the active route is an exclusive-shell route owned by a plugin.
+ */
+export function isExclusiveShellRoute(
+  manifests: PluginManifest[],
+  activePath: string,
+): boolean {
+  return !!getExclusiveShellManifest(manifests, activePath);
+}
+
 export function usePlugins() {
   // Lazy initialisers run once at mount — safe to read sessionStorage here.
   // This avoids the "cannot access ref during render" lint error that would
diff --git a/website/docs/user-guide/features/extending-the-dashboard.md b/website/docs/user-guide/features/extending-the-dashboard.md
index 50f4958b1..234c812dd 100644
--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -459,7 +459,8 @@ None of them are required; include only the layers you need.
     "path": "/my-plugin",
     "position": "after:skills",
     "override": "/",
-    "hidden": false
+    "hidden": false,
+    "shell": "exclusive"
   },
   "slots": ["sidebar", "header-left"],
   "entry": "dist/index.js",
@@ -479,6 +480,7 @@ None of them are required; include only the layers you need.
 | `tab.position` | No | Where to insert the tab. `"end"` (default), `"after:<path>"`, or `"before:<path>"` — value after the colon is the **path segment** of the target tab (no leading slash). Examples: `"after:skills"`, `"before:config"`. |
 | `tab.override` | No | Set to a built-in route path (`"/"`, `"/sessions"`, `"/config"`, ...) to **replace** that page instead of adding a new tab. See [Replacing built-in pages](#replacing-built-in-pages-taboverride). |
 | `tab.hidden` | No | When true, register the component and any slots without adding a tab to the nav. Used by slot-only plugins. See [Slot-only plugins](#slot-only-plugins-tabhidden). |
+| `tab.shell` | No | `"standard"` (default) or `"exclusive"` — when `override` is set and `shell: "exclusive"`, the plugin owns the full product shell for that overridden route only (no built-in sidebar/header navigation). Route-scoped: every other route renders the normal Hermes shell. See [Route-scoped exclusive shell](#route-scoped-exclusive-shell-tabshellexclusive). |
 | `slots` | No | Named shell slots this plugin populates. **Documentation aid only** — actual registration happens from the JS bundle via `registerSlot()`. Listing slots here makes discovery surfaces more informative. |
 | `entry` | Yes | Path to the JS bundle relative to `dashboard/`. Defaults to `dist/index.js`. |
 | `css` | No | Path to a CSS file to inject as a `<link>` tag. |
@@ -651,6 +653,34 @@ Only one plugin can override a given path. If two plugins claim the same overrid

 If you only need to add a card or toolbar to an existing page without taking it over, use [page-scoped slots](#augmenting-built-in-pages-page-scoped-slots) instead.

+### Route-scoped exclusive shell (`tab.shell: "exclusive"`)
+
+A product-shell plugin may want to fully own the dashboard shell for **one** route (e.g. `/`) while leaving every other native route (`/sessions`, `/cron`, `/skills`, `/plugins`, `/mcp`, `/config`, etc.) untouched. That is expressed as a route-scoped exclusive shell — a small generic extension to the `tab` contract, not global control over navigation.
+
+```json
+// ~/.hermes/plugins/worker-studio/dashboard/manifest.json
+{
+  "name": "worker-studio",
+  "label": "Worker Studio",
+  "tab": {
+    "path": "/worker-studio",
+    "override": "/",
+    "shell": "exclusive"
+  },
+  "entry": "dist/index.js"
+}
+```
+
+**Semantics (generic, no per-plugin special cases):**
+
+1. When the active route equals the plugin's `override` path **and** `shell: "exclusive"`, the plugin page renders as the dashboard product shell **without** built-in sidebar/header navigation chrome. The plugin provides its own navigation/header/composer.
+2. On every other route the normal Hermes dashboard shell (sidebar, header, banners) renders unchanged. Navigating from the plugin's menu to a native route (e.g. `/sessions`) automatically restores the standard shell; navigating back to `/` restores the exclusive plugin shell. No plugin-side cleanup is required.
+3. Native routes remain authoritative and reachable — the plugin does not delete or hide Hermes routes, it only controls chrome while its own overridden route is active.
+4. Deep-linking, browser history (back/forward), plugin loading gates, auth/theme/profile providers, and route ownership are preserved. No DOM/CSS monkey-patching is needed.
+5. Existing manifests without `tab.shell` keep current behavior (`"standard"` is the implicit default). Mobile sidebar and collapsed desktop sidebar do not leak onto an exclusive route. No flash of built-in navigation is shown while plugin manifests are still loading, especially for `/` overrides.
+
+Use `tab.shell: "exclusive"` only together with `tab.override`. When `override` is absent the field is ignored. Only one plugin can own a given overridden route; the first match wins for both standard and exclusive shells.
+
 ### Augmenting built-in pages (page-scoped slots)

 Full replacement via `tab.override` is heavy — your plugin now owns the entire page, including any future updates we ship to it. Most of the time you just want to add a banner, card, or toolbar to an existing page. That's what **page-scoped slots** are for.