### PR TITLE
fix(gateway): suppress anti-growth compression refusal warning on chat surfaces (#100171)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -179,6 +179,21 @@ COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE = (
 COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE = (
     "🗜️ Context reduced to {new_ctx:,} tokens (was {old_ctx:,}), retrying..."
 )
+# No-op anti-growth refusal notice (#100171): automatic compression declined
+# to commit a summary that would have grown the transcript. A pure no-op
+# diagnostic — nothing was dropped and the conversation continues unchanged —
+# so chat surfaces should not receive it (opsec: shared group chats must not
+# leak framework internals). It is NOT routine compression progress and must
+# stay out of ROUTINE_COMPRESSION_STATUS_SAMPLES /
+# _COMPRESSION_PROGRESS_STATUS_RE (the #52995 opt-in gate must not release
+# it). Manual /compress feedback (manual_compression_feedback.py) uses a
+# different wording and is a deliberate carve-out that stays visible.
+COMPRESSION_REFUSED_WOULD_GROW_WARNING = (
+    "⚠️ Compression refused: the generated summary "
+    "would have GROWN the conversation instead of "
+    "shrinking it. No messages were dropped — "
+    "conversation continues unchanged."
+)
 
 # FAILURE-CLASS notice — a deliberate carve-out from routine-compression
 # silence (#16775 class): the context is over the compression threshold but
@@ -4623,12 +4638,7 @@ def compress_context(
                     except Exception:
                         pass
                     try:
-                        agent._emit_warning(
-                            "⚠️ Compression refused: the generated summary "
-                            "would have GROWN the conversation instead of "
-                            "shrinking it. No messages were dropped — "
-                            "conversation continues unchanged."
-                        )
+                        agent._emit_warning(COMPRESSION_REFUSED_WOULD_GROW_WARNING)
                     except Exception:
                         pass
                     _existing_sp = getattr(agent, "_cached_system_prompt", None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -51,6 +51,7 @@ from agent.async_utils import consume_detached_task_result, safe_schedule_thread
 from agent.conversation_compression import (
     COMPACTION_DONE_STATUS,
     COMPACTION_STATUS,
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
     COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE,
     COMPRESSION_RETRY_MESSAGES_STATUS_TEMPLATE,
     COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE,
@@ -143,6 +144,14 @@ _TELEGRAM_NOISY_STATUS_RE = re.compile(
     r"|compressed\s+~[\d,]+\s+(?:→|->)\s+~[\d,]+\s+tokens,\s+retrying"
     r"|context\s+reduced\s+to\s+[\d,]+\s+tokens\s+\(was\s+[\d,]+\),\s+retrying"
     r"|session\s+compressed\s+\d+\s+times"
+    # #100171: the anti-growth refusal warning is a no-op diagnostic (no
+    # messages dropped, conversation unchanged) — chat surfaces should not
+    # receive it. Anchored to the SAME constant the emit site uses, so a
+    # rewording there fails the noise-filter suite instead of silently
+    # re-leaking. Manual /compress feedback ("Compression refused (summary
+    # would grow the conversation): N messages preserved") does not match
+    # this full-literal alternative and stays visible.
+    rf"|{re.escape(COMPRESSION_REFUSED_WOULD_GROW_WARNING)}"
     r"|rate\s+limited\.\s+waiting\s+\d"
     r"|retrying\s+in\s+\d"
     r"|max\s+retries\s+\(\d+\).*(?:trying\s+fallback|exhausted|invalid\s+responses)"

--- a/tests/gateway/test_compression_progress_notices.py
+++ b/tests/gateway/test_compression_progress_notices.py
@@ -18,6 +18,7 @@ import pytest
 import gateway.run as gateway_run
 from agent.conversation_compression import (
     COMPACTION_DONE_STATUS,
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
     ROUTINE_COMPRESSION_STATUS_SAMPLES,
 )
 from gateway.run import _prepare_gateway_status_message
@@ -43,6 +44,10 @@ NON_COMPRESSION_NOISE = [
         "⚠ Skipping concurrent compression — another path is already "
         "compressing this session. Will retry after it finishes."
     ),
+    # #100171: the anti-growth refusal is a no-op diagnostic, not routine
+    # compression progress — the opt-in gate must not release it to chat
+    # surfaces.
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
 ]
 
 

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -3,6 +3,7 @@
 import pytest
 
 from agent.conversation_compression import (
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
     CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE,
     ROUTINE_COMPRESSION_STATUS_SAMPLES,
 )
@@ -57,6 +58,11 @@ NOISY_STATUS_MESSAGES = [
         "⚠ Skipping concurrent compression — another path is already "
         "compressing this session. Will retry after it finishes."
     ),
+    # #100171: the automatic anti-growth refusal warning is a no-op
+    # diagnostic (nothing dropped, conversation unchanged) — chat surfaces
+    # must not receive it. Pinned from the emit-site constant, not a
+    # hand-copied literal, so rewording drift fails here.
+    COMPRESSION_REFUSED_WOULD_GROW_WARNING,
 ]
 
 # Messages that must NEVER be swallowed by the compression-noise filter:
@@ -68,6 +74,12 @@ VISIBLE_COMPRESSION_MESSAGES = [
     "Compression aborted: 30 messages preserved",
     "Compressed with fallback: 30 → 12 messages",
     "No changes from compression: 30 messages",
+    # #100171: manual /compress refused-would-grow feedback uses this exact
+    # headline shape (manual_compression_feedback.py). The automatic no-op
+    # refusal warning is suppressed (NOISY_STATUS_MESSAGES above); this
+    # user-invoked feedback must stay visible — the two wordings must never
+    # be conflated by the noise regex.
+    "Compression refused (summary would grow the conversation): 30 messages preserved",
     (
         "⚠ Compression aborted: auth failure. No messages were dropped — "
         "conversation continues unchanged. Run /compress to retry, or /new "
@@ -124,13 +136,21 @@ def test_programmatic_surfaces_keep_raw_status():
     """Programmatic surfaces (local/api/webhook) must keep raw diagnostics.
 
     Negative case for the invariant: the chat-noise filter must not touch
-    CLI/TUI diagnostics, API JSON, or webhook payloads.
+    CLI/TUI diagnostics, API JSON, or webhook payloads. Includes the
+    #100171 anti-growth refusal warning — chat surfaces suppress it, but
+    local/API/webhook consumers keep the raw diagnostic stream.
     """
     message = "⏳ Retrying in 4.2s (attempt 1/3)..."
 
     for platform in ("local", "api_server", "webhook", "msgraph_webhook"):
         assert (
             _prepare_gateway_status_message(platform, "lifecycle", message) == message
+        )
+        assert (
+            _prepare_gateway_status_message(
+                platform, "warn", COMPRESSION_REFUSED_WOULD_GROW_WARNING
+            )
+            == COMPRESSION_REFUSED_WOULD_GROW_WARNING
         )
 
 


### PR DESCRIPTION
## What

Automatic compression can refuse to commit a generated summary when that summary would have **grown** the transcript instead of shrinking it. The refusal warning ("Compression refused: the generated summary would have GROWN the conversation instead of shrinking it. No messages were dropped — conversation continues unchanged.") was not covered by `_TELEGRAM_NOISY_STATUS_RE`, so it was delivered verbatim to every chat surface — including shared group chats where the agent runs in observe/@mention mode, leaking internal compression mechanics and framework jargon to users who never invoked anything.

The warning is a pure no-op diagnostic: no messages are dropped and the conversation continues unchanged, so nothing actionable is lost by suppressing it on chat surfaces.

## How

- `agent/conversation_compression.py`: the emit-site literal is extracted to a named constant `COMPRESSION_REFUSED_WOULD_GROW_WARNING` (#69550 constant-coupling convention); the emit call now uses the constant — emission itself is behavior-identical.
- `gateway/run.py`: `_TELEGRAM_NOISY_STATUS_RE` gains a full-literal alternative built from `re.escape(COMPRESSION_REFUSED_WOULD_GROW_WARNING)`. Because the regex is anchored to the same constant the emit site uses, a future rewording there fails the noise-filter suite instead of silently re-leaking the warning to chat surfaces.
- Manual `/compress` feedback (`manual_compression_feedback.py`) uses different wording — "Compression refused (summary would grow the conversation): N messages preserved" — and does not match the full-literal alternative; the deliberate carve-out stays visible (pinned by a new `VISIBLE_COMPRESSION_MESSAGES` entry).
- The refusal is NOT routine compression progress: the constant is kept out of `ROUTINE_COMPRESSION_STATUS_SAMPLES` / `_COMPRESSION_PROGRESS_STATUS_RE`, so the `compression.progress_notices: true` opt-in gate (#52995) cannot release it to chat surfaces (pinned in `NON_COMPRESSION_NOISE`).
- Programmatic surfaces (local/api/webhook) bypass the chat filter and keep the raw diagnostic — extended `test_programmatic_surfaces_keep_raw_status`.

## Verification

- RED without fix on pristine `origin/main`: standalone probe + stashed-regex repo tests produced exactly 7 failures (3x chat-suppression L1, 4x progress-notices L3); all carve-out tests green (fail-without-fix.txt in run artifacts).
- GREEN with fix (reviewer re-run after rebase onto current `origin/main` 5a8e8a6b87):
  - `tests/gateway/test_telegram_noise_filter.py` + `tests/gateway/test_compression_progress_notices.py`: **184 passed**
  - `tests/agent/test_manual_compression_feedback.py` + `test_manual_compression_refusal_feedback.py` + `test_turn_context_overflow_warning.py`: **14 passed**
  - compression neighborhood (anti_thrash_persistence, anti_thrash_recovery, attempt_lifecycle, compress_signal_leak): **23 passed**
  - `ruff check` on the 4 changed files: clean; `git diff --check`: clean; `git rev-list --left-right --count origin/main...HEAD` = `0 1`.

## Competing PRs

#100181 (pan-long) and #100188 (Sahilvishnaliya) fix the same leak with prefix regexes. Both miss the `compression.progress_notices` opt-in gate layer (the refusal could still be released to chat surfaces when the gate is open), and both hand-copy the warning literal into tests instead of pinning it from the emit-site constant, so an emit-site rewording would silently re-leak. This PR covers all four layers and is constant-coupled.

Closes #100171

Auto-published by Moonsong via Path B automated pipeline.
