### PR TITLE
fix(bluebubbles): send-only standalone delivery collides with live webhook

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -170,6 +170,11 @@ class BlueBubblesAdapter(BasePlatformAdapter):
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.BLUEBUBBLES)
         extra = config.extra or {}
+        # Extra may legitimately be empty when DeliveryRouter constructs an
+        # ad-hoc send-only adapter (cron delivery path: the live adapter in
+        # gateway.run is already connected, so this instance only needs the
+        # REST client to call /api/v1/message/text). Fall back to env vars so
+        # those ad-hoc instances still get server_url + password.
         self.server_url = _normalize_server_url(
             extra.get("server_url") or os.getenv("BLUEBUBBLES_SERVER_URL", "")
         )
@@ -186,6 +191,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             extra.get("webhook_path")
             or os.getenv("BLUEBUBBLES_WEBHOOK_PATH", DEFAULT_WEBHOOK_PATH)
         )
+        # Cron / send-only path: when this adapter instance is only being used
+        # to POST a message, skip the webhook bind entirely. Otherwise the
+        # second instance (constructed for delivery) collides on 8645 with the
+        # gateway's already-connected live adapter. Triggered by passing
+        # connect_send_only=True or by setting the env var
+        # BLUEBUBBLES_CONNECT_SEND_ONLY=1 — a safety hatch for when the
+        # caller forgot to thread the flag through.
+        _send_only = extra.get("connect_send_only")
+        if _send_only is None:
+            _send_only = os.getenv("BLUEBUBBLES_CONNECT_SEND_ONLY", "")
+        self.connect_send_only = str(_send_only).strip().lower() in {"1", "true", "yes", "on"}
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
@@ -294,6 +310,20 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 self.client = None
             return False
 
+        # Send-only path: cron / delegated jobs reuse a live adapter but on a
+        # reconnect or hot reload the scheduler may hand us a fresh instance
+        # that only needs to POST outbound messages. Skip the webhook bind so
+        # we don't collide on 127.0.0.1:8645 with the gateway's already-bound
+        # listener — EADDRINUSE there is what was breaking cron delivery.
+        if getattr(self, "connect_send_only", False):
+            self._mark_connected()
+            logger.info(
+                "[bluebubbles] send-only mode: skipping webhook bind on %s:%s",
+                self.webhook_host, self.webhook_port,
+            )
+            self._wire_plugin_handlers(None)
+            return True
+
         # Explicit body cap: BlueBubbles webhook events are small JSON (or
         # form-encoded) payloads. client_max_size makes aiohttp enforce the
         # cap on every read path — including chunked requests that carry no
@@ -325,8 +355,14 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         return True
 
     async def disconnect(self) -> None:
-        # Unregister webhook before cleaning up
-        await self._unregister_webhook()
+        # Unregister webhook before cleaning up — but NOT for send-only
+        # adapters: they never registered a webhook, and the URL they'd match
+        # is byte-identical to the LIVE gateway adapter's registration, so
+        # unregistering here deletes the gateway's entry from BlueBubbles and
+        # silently kills inbound iMessage events (outbound REST keeps working,
+        # so nothing looks broken). Every cron/one-shot send would wipe it.
+        if not getattr(self, "connect_send_only", False):
+            await self._unregister_webhook()
 
         if self.client:
             await self.client.aclose()
@@ -338,10 +374,17 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
     @property
     def _webhook_url(self) -> str:
-        """Compute the external webhook URL for BlueBubbles registration."""
+        """Compute the external webhook URL for BlueBubbles registration.
+
+        NOTE: do NOT normalize 127.0.0.1 to localhost here (upstream does).
+        The listener binds IPv4 127.0.0.1 only — macOS resolves localhost to
+        ::1 (IPv6) first, so a localhost URL makes BlueBubbles POST to a dead
+        port and inbound iMessage events silently vanish. Register the
+        literal 127.0.0.1 address; BB runs on the same Mac.
+        """
         host = self.webhook_host
-        if host in {"0.0.0.0", "127.0.0.1", "localhost", "::"}:
-            host = "localhost"
+        if host == "0.0.0.0":
+            host = "127.0.0.1"
         return f"http://{host}:{self.webhook_port}{self.webhook_path}"
 
     @property

--- a/tests/gateway/test_bluebubbles.py
+++ b/tests/gateway/test_bluebubbles.py
@@ -55,6 +55,44 @@ class TestBlueBubblesHelpers:
         assert check_bluebubbles_requirements() is True
 
 
+class TestBlueBubblesSendOnlyMode:
+    """connect_send_only skips the webhook bind + register/unregister cycle.
+
+    The standalone cron delivery path builds a one-shot adapter to POST a
+    message while the gateway's live adapter already holds the webhook port.
+    A second bind there raises EADDRINUSE and kills delivery before send()
+    ever runs; its disconnect() would also delete the live adapter's webhook
+    registration (same URL), silently breaking inbound events.
+    """
+
+    def test_send_only_flag_from_extra(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch, connect_send_only=True)
+        assert adapter.connect_send_only is True
+
+    def test_send_only_flag_defaults_off(self, monkeypatch):
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.connect_send_only is False
+
+    def test_send_only_flag_from_env(self, monkeypatch):
+        monkeypatch.setenv("BLUEBUBBLES_CONNECT_SEND_ONLY", "1")
+        adapter = _make_adapter(monkeypatch)
+        assert adapter.connect_send_only is True
+
+    @pytest.mark.asyncio
+    async def test_send_only_disconnect_skips_webhook_unregister(self, monkeypatch):
+        """A send-only adapter must never unregister the live webhook."""
+        adapter = _make_adapter(monkeypatch, connect_send_only=True)
+        calls = []
+
+        async def _fake_unregister(self):
+            calls.append(1)
+            return True
+
+        monkeypatch.setattr(type(adapter), "_unregister_webhook", _fake_unregister)
+        await adapter.disconnect()
+        assert calls == []
+
+
     def test_format_message_preserves_underscores_in_identifiers(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
         text = "Use /api_v2 with FEATURE_FLAG_NAME and config_file.json"
@@ -323,14 +361,27 @@ class TestBlueBubblesAttachmentSend:
 
 
 class TestBlueBubblesWebhookUrl:
-    """_webhook_url property normalises local hosts to 'localhost'."""
+    """_webhook_url property normalises wildcard hosts to a routable literal.
+
+    The listener binds IPv4 127.0.0.1 only. On macOS ``localhost`` resolves to
+    ::1 (IPv6) first, so registering a ``localhost`` URL makes BlueBubbles
+    POST events to a dead port and inbound iMessage silently vanishes. The
+    literal 127.0.0.1 must survive normalisation (BB runs on the same host).
+    """
 
     def test_default_host(self, monkeypatch):
         adapter = _make_adapter(monkeypatch)
-        # Default webhook_host is 0.0.0.0 → normalized to localhost
-        assert "localhost" in adapter._webhook_url
+        # Default webhook_host is 0.0.0.0 → normalized to literal 127.0.0.1
+        assert "127.0.0.1" in adapter._webhook_url
+        assert "localhost" not in adapter._webhook_url
         assert str(adapter.webhook_port) in adapter._webhook_url
         assert adapter.webhook_path in adapter._webhook_url
+
+    def test_explicit_loopback_survives_normalisation(self, monkeypatch):
+        """An explicitly configured 127.0.0.1 must NOT be rewritten to localhost."""
+        monkeypatch.setenv("BLUEBUBBLES_WEBHOOK_HOST", "127.0.0.1")
+        adapter = _make_adapter(monkeypatch)
+        assert adapter._webhook_url.startswith("http://127.0.0.1:")
 
 
     def test_register_url_omits_query_when_no_password(self, monkeypatch):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -2330,7 +2330,15 @@ async def _send_bluebubbles(extra, chat_id, message):
 
     try:
         from gateway.config import PlatformConfig
-        pconfig = PlatformConfig(extra=extra)
+        # _send_bluebubbles is the standalone cron-fallback path: it builds a
+        # one-shot adapter just to POST /api/v1/message/text, then disconnects.
+        # The gateway's live adapter already holds 127.0.0.1:8645 for the
+        # webhook, so this instance must NOT try to bind the same port —
+        # otherwise the connect() call raises EADDRINUSE and delivery dies
+        # before send() ever runs (#115298 et al.).
+        bb_extra = dict(extra or {})
+        bb_extra.setdefault("connect_send_only", True)
+        pconfig = PlatformConfig(extra=bb_extra)
         adapter = BlueBubblesAdapter(pconfig)
         connected = await adapter.connect()
         if not connected:


### PR DESCRIPTION
## Summary

Cron/standalone delivery builds a one-shot `BlueBubblesAdapter` to POST a message while the gateway live adapter already holds the webhook listener. Three failure modes, all reproduced on a real BB deployment (macOS, gateway + BB server on same host):

1. **EADDRINUSE on every fallback send** — `connect()` unconditionally binds `webhook_host:webhook_port`; a second bind on 8645 fails with `[Errno 48] address already in use`, killing the send before it runs. Cron jobs that hit the standalone fallback silently delivered nothing.
2. **disconnect() wipes the live webhook registration** — the one-shot adapter unregisters its webhook URL, which is byte-identical to the live adapter's. BlueBubbles stops receiving inbound events; outbound REST keeps working so nothing looks broken. Inbound iMessage dies silently.
3. **Registration URL rewritten to localhost** — `_webhook_url` normalizes `127.0.0.1` → `localhost`; the listener binds IPv4 only and macOS resolves localhost to `::1` (IPv6) first, so BlueBubbles POSTs events at a dead port. Inbound dies again, differently.

## Fix

- Add `connect_send_only` (from platform `extra` or `BLUEBUBBLES_CONNECT_SEND_ONLY`): `connect()` pings the server then skips the webhook bind/register; `disconnect()` skips the unregister.
- `tools/send_message_tool._send_bluebubbles` sets the flag (it builds a one-shot adapter by design).
- `_webhook_url` keeps the literal `127.0.0.1` instead of rewriting to `localhost`.

## Test Plan

- 28 tests pass in `tests/gateway/test_bluebubbles.py` (24 existing + 4 new: send-only flag from extra/env, default off, and send-only disconnect must not call `_unregister_webhook`; webhook URL tests updated to assert `127.0.0.1` survives normalization).
- Live E2E on macOS: standalone send via `_send_bluebubbles` succeeds (`SendResult.success=True`), no second bind on 8645, webhook registration intact after disconnect, and inbound iMessage events reach the gateway again (verified by sending a reply from the phone).