### PR TITLE
fix(desktop): open file HTML previews externally instead of a dead pop-out

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { normalizePreviewAddress, PreviewBrowserBar } from './preview-browser-bar'
+import { normalizePreviewAddress, PreviewBrowserBar, previewBrowserBarWindowAction } from './preview-browser-bar'
 
 const baseProps = {
   canGoBack: false,
@@ -371,5 +371,67 @@ describe('PreviewBrowserBar', () => {
     fireEvent.click(rendered.getByRole('button', { name: 'Pop in' }))
 
     expect(onPopIn).toHaveBeenCalledOnce()
+  })
+})
+
+describe('previewBrowserBarWindowAction', () => {
+  it.each([
+    {
+      expected: 'pop-in' as const,
+      input: {
+        canOpenBrowserWindow: true,
+        isBrowserWindow: true,
+        tabId: 'url:https://example.com',
+        targetKind: 'url' as const
+      },
+      name: 'already-popped Browser window'
+    },
+    {
+      expected: 'pop-out' as const,
+      input: {
+        canOpenBrowserWindow: true,
+        isBrowserWindow: false,
+        tabId: 'url:https://example.com',
+        targetKind: 'url' as const
+      },
+      name: 'docked URL tab that can leave the rail'
+    },
+    {
+      expected: 'open-external' as const,
+      input: {
+        canOpenBrowserWindow: false,
+        isBrowserWindow: false,
+        tabId: 'url:https://example.com',
+        targetKind: 'url' as const
+      },
+      name: 'URL tab when the shell cannot pop out'
+    },
+    {
+      expected: 'open-external' as const,
+      input: {
+        canOpenBrowserWindow: true,
+        isBrowserWindow: false,
+        tabId: 'file:file:///work/demo.html',
+        targetKind: 'file' as const
+      },
+      name: 'file HTML tab even when pop-out IPC exists'
+    },
+    {
+      expected: 'open-external' as const,
+      input: {
+        canOpenBrowserWindow: true,
+        isBrowserWindow: false,
+        tabId: 'artifact:card',
+        targetKind: 'artifact' as const
+      },
+      name: 'artifact tab'
+    },
+    {
+      expected: 'open-external' as const,
+      input: { canOpenBrowserWindow: true, isBrowserWindow: false, targetKind: 'url' as const },
+      name: 'URL tab with no tab id'
+    }
+  ])('chooses $expected for a $name', ({ expected, input }) => {
+    expect(previewBrowserBarWindowAction(input)).toBe(expected)
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx
@@ -93,6 +93,31 @@ export function normalizePreviewAddress(value: string): null | string {
   }
 }
 
+export type PreviewBrowserWindowAction = 'open-external' | 'pop-in' | 'pop-out'
+
+/**
+ * Which window glyph the bar should offer. Pop-out is a Browser-tab action
+ * (a URL vessel that can leave the rail). File and artifact previews have no
+ * such vessel — `popOutBrowserTab` no-ops for them — so they take the
+ * open-in-system-browser fallback instead of advertising a dead click.
+ */
+export function previewBrowserBarWindowAction(input: {
+  canOpenBrowserWindow: boolean
+  isBrowserWindow: boolean
+  tabId?: string
+  targetKind: 'artifact' | 'file' | 'url'
+}): PreviewBrowserWindowAction | undefined {
+  if (input.isBrowserWindow) {
+    return 'pop-in'
+  }
+
+  if (input.targetKind === 'url' && input.tabId && input.canOpenBrowserWindow) {
+    return 'pop-out'
+  }
+
+  return 'open-external'
+}
+
 export function PreviewBrowserBar({
   annotateMode = false,
   canGoBack,

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -2,6 +2,7 @@ import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerAttachImagesRequest } from '@/app/chat/composer/focus'
+import { $previewTabs, closeRightRail, openPreview } from '@/store/preview'
 import { $connection, $selectedStoredSessionId } from '@/store/session'
 
 import { forgetPreviewConsole, previewConsoleState } from './preview-console-store'
@@ -41,6 +42,7 @@ describe('PreviewPane console state', () => {
 
   afterEach(() => {
     cleanup()
+    closeRightRail()
     $connection.set(null)
     $selectedStoredSessionId.set(null)
     vi.unstubAllGlobals()
@@ -149,6 +151,68 @@ describe('PreviewPane console state', () => {
     })
 
     expect(rendered.queryByRole('textbox', { name: 'Address' })).toBeNull()
+  })
+
+  it('opens a file HTML preview in the system browser instead of a silent pop-out', async () => {
+    const openBrowserWindow = vi.fn(async () => ({ ok: true }))
+    const openExternal = vi.fn(async () => undefined)
+    const previousDesktop = window.hermesDesktop
+
+    window.hermesDesktop = {
+      ...previousDesktop,
+      openBrowserWindow,
+      openExternal
+    }
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(
+        <PreviewPane
+          tabId="file:file:///work/demo.html"
+          target={{
+            kind: 'file',
+            label: 'demo.html',
+            path: '/work/demo.html',
+            previewKind: 'html',
+            renderMode: 'preview',
+            source: '/work/demo.html',
+            url: 'file:///work/demo.html'
+          }}
+        />
+      )
+    })
+
+    expect(rendered.queryByRole('button', { name: 'Pop out' })).toBeNull()
+    fireEvent.click(rendered.getByRole('button', { name: 'Open in browser' }))
+
+    expect(openExternal).toHaveBeenCalledWith('file:///work/demo.html')
+    expect(openBrowserWindow).not.toHaveBeenCalled()
+
+    window.hermesDesktop = previousDesktop
+  })
+
+  it('still pops a URL tab into its own window', async () => {
+    const openBrowserWindow = vi.fn(async () => ({ ok: true }))
+    const previousDesktop = window.hermesDesktop
+    const target = { kind: 'url' as const, label: 'Example', source: 'https://example.com', url: 'https://example.com' }
+
+    window.hermesDesktop = {
+      ...previousDesktop,
+      openBrowserWindow
+    }
+    openPreview(target)
+    const tabId = $previewTabs.get()[0]!.id
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(<PreviewPane tabId={tabId} target={target} />)
+    })
+
+    fireEvent.click(rendered.getByRole('button', { name: 'Pop out' }))
+
+    expect(openBrowserWindow).toHaveBeenCalledWith(tabId)
+
+    window.hermesDesktop = previousDesktop
   })
 
   it('drives the webview from the bar and tracks its history', async () => {

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -54,7 +54,7 @@ import {
   waitAnnotateEvent
 } from './preview-annotate-host'
 import { ArtifactPreview } from './preview-artifact'
-import { PreviewBrowserBar } from './preview-browser-bar'
+import { PreviewBrowserBar, previewBrowserBarWindowAction } from './preview-browser-bar'
 import {
   clampConsoleHeight,
   compactUrl,
@@ -319,6 +319,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   // `about:blank` paints a white void that reads as broken next to the app's
   // dark chrome, so the pane says what it is instead.
   const isBlankPage = isWebPreview && !isRemoteHtml && (!currentUrl || /^about:blank\/?$/i.test(currentUrl))
+
+  const windowAction = previewBrowserBarWindowAction({
+    canOpenBrowserWindow: canOpenBrowserWindow(),
+    isBrowserWindow: isBrowserWindow(),
+    tabId,
+    targetKind: target.kind
+  })
 
   const previewLabel =
     target.label && target.label.replace(/\/$/, '') !== currentLabel.replace(/\/$/, '') ? target.label : currentLabel
@@ -1297,14 +1304,10 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
             onForward={goForward}
             onNavigate={navigateTo}
             onOpenExternal={
-              !isBrowserWindow() && !canOpenBrowserWindow()
-                ? () => void window.hermesDesktop?.openExternal(currentUrl)
-                : undefined
+              windowAction === 'open-external' ? () => void window.hermesDesktop?.openExternal(currentUrl) : undefined
             }
-            onPopIn={isBrowserWindow() ? () => window.close() : undefined}
-            onPopOut={
-              isBrowserWindow() || !tabId || !canOpenBrowserWindow() ? undefined : () => popOutBrowserTab(tabId)
-            }
+            onPopIn={windowAction === 'pop-in' ? () => window.close() : undefined}
+            onPopOut={windowAction === 'pop-out' && tabId ? () => popOutBrowserTab(tabId) : undefined}
             onReload={reloadPreview}
             onToggleAnnotate={toggleAnnotate}
             onToggleConsole={() => consoleState.setOpen(open => !open)}


### PR DESCRIPTION
## What does this PR do?

The preview browser bar showed a **Pop out** glyph for local HTML file tabs whenever the desktop shell could open a Browser window. Clicking it did nothing: `popOutBrowserTab` only pops `kind: 'url'` vessels, so file tabs returned silently with no window, toast, or log.

This wires the bar through `previewBrowserBarWindowAction`: pop-out stays for Browser (URL) tabs, and file/artifact tabs use the existing **Open in browser** (`openExternal`) path instead of advertising a dead click.

## Related Issue

Fixes #100184

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/right-rail/preview-browser-bar.tsx` — add `previewBrowserBarWindowAction` so pop-out is only chosen for URL tabs with a tab id and Browser-window IPC.
- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx` — pass `onPopOut` / `onOpenExternal` / `onPopIn` from that action instead of gating only on `canOpenBrowserWindow`.
- `apps/desktop/src/app/chat/right-rail/preview-browser-bar.test.tsx` — table-driven tests for the action helper.
- `apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx` — file HTML tabs show Open in browser and call `openExternal`; URL tabs still pop out.

## How to Test

1. Open a local HTML file in the desktop preview pane (tool-result / `previewKind: 'html'`, `renderMode: 'preview'`).
2. Confirm the bar shows **Open in browser**, not **Pop out**. Click it and the file opens in the system browser.
3. Open a Browser (URL) tab. Confirm **Pop out** still opens a standalone Browser window.

Renderer tests:

```
cd apps/desktop
npx vitest run --project ui src/app/chat/right-rail/preview-browser-bar.test.tsx src/app/chat/right-rail/preview-pane.test.tsx
```

Result: 2 files, 59 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (desktop renderer vitest / jsdom)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Test Files  2 passed (2)
     Tests  59 passed (59)
```
