### PR TITLE
fix(desktop): render clarify choice buttons for one-entry questions[]

### DIFF
--- a/apps/desktop/src/components/assistant-ui/clarify-tool-one-entry.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool-one-entry.test.tsx
@@ -1,0 +1,144 @@
+import type { ToolCallMessagePartProps } from '@assistant-ui/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import { clearClarifyRequest, setClarifyRequest } from '@/store/clarify'
+import { $gateway } from '@/store/gateway'
+import { $activeSessionId } from '@/store/session'
+
+import { ClarifyTool } from './clarify-tool'
+
+// One-entry questions[] (the advertised single-question shape) must render
+// choice buttons, not an infinite loading spinner.
+
+vi.mock('@assistant-ui/react', () => ({
+  useAuiState: () => true
+}))
+
+afterEach(() => {
+  cleanup()
+  clearClarifyRequest()
+  $activeSessionId.set(null)
+  $gateway.set(null)
+  vi.clearAllMocks()
+})
+
+function renderClarify(ui: ReactNode) {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      {ui}
+    </I18nProvider>
+  )
+}
+
+const REPORTER_QUESTION = 'Approve storing the two Google credential JSONs into BWS secrets?'
+const REPORTER_CHOICES = ['Store credentials in BWS now', 'Not yet']
+
+function oneEntryQuestionsArgs() {
+  return {
+    questions: [{ choices: REPORTER_CHOICES, question: REPORTER_QUESTION }]
+  }
+}
+
+function liveProps(args: Record<string, unknown>): ToolCallMessagePartProps {
+  return {
+    addResult: vi.fn(),
+    args,
+    argsText: JSON.stringify(args),
+    isError: false,
+    respondToApproval: vi.fn(),
+    result: undefined,
+    resume: vi.fn(),
+    status: { type: 'running' },
+    toolCallId: 'clarify-one-entry',
+    toolName: 'clarify',
+    type: 'tool-call'
+  }
+}
+
+describe('one-entry questions[] must not spin forever', () => {
+  it('renders choice buttons from a one-entry questions[] tool.start before clarify.request', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+
+    renderClarify(<ClarifyTool {...liveProps(oneEntryQuestionsArgs())} />)
+
+    expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
+    expect(screen.getByRole('button', { name: /Store credentials in BWS now/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Not yet/ })).toBeTruthy()
+    expect(document.querySelector('[data-clarify-batch]')).toBeNull()
+    expect(document.querySelector('[data-clarify-choices]')).toBeTruthy()
+  })
+
+  it('answers a one-entry questions[] card when the gateway request is still single-shaped', async () => {
+    const request = vi.fn().mockResolvedValue({ ok: true })
+
+    $activeSessionId.set('session-1')
+    $gateway.set({ request } as never)
+    setClarifyRequest({
+      choices: REPORTER_CHOICES,
+      multiSelect: false,
+      question: REPORTER_QUESTION,
+      requestId: 'request-1',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveProps(oneEntryQuestionsArgs())} />)
+
+    expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
+    fireEvent.click(screen.getByRole('button', { name: /Not yet/ }))
+    fireEvent.click(screen.getByRole('button', { name: /Continue/ }))
+
+    await waitFor(() => {
+      expect(request).toHaveBeenCalledWith('clarify.respond', {
+        answer: 'Not yet',
+        request_id: 'request-1'
+      })
+    })
+  })
+
+  it('keeps a real one-item batch request on the batch card', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+    setClarifyRequest({
+      choices: null,
+      multiSelect: false,
+      question: '',
+      questions: [
+        { choices: REPORTER_CHOICES, multiSelect: false, qid: 'q0', question: REPORTER_QUESTION }
+      ],
+      requestId: 'request-batch',
+      sessionId: 'session-1'
+    })
+
+    renderClarify(<ClarifyTool {...liveProps(oneEntryQuestionsArgs())} />)
+
+    expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
+    expect(document.querySelector('[data-clarify-batch]')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Store credentials in BWS now/ })).toBeTruthy()
+    expect(screen.getByRole('button', { name: /Not yet/ })).toBeTruthy()
+  })
+
+  it('paints a multi-question card from args instead of spinning when the request is late', () => {
+    $activeSessionId.set('session-1')
+    $gateway.set({ request: vi.fn().mockResolvedValue({ ok: true }) } as never)
+
+    renderClarify(
+      <ClarifyTool
+        {...liveProps({
+          questions: [
+            { choices: ['red', 'blue'], question: 'Color?' },
+            { question: 'Name?' }
+          ]
+        })}
+      />
+    )
+
+    expect(screen.queryByRole('status', { name: /loading question/i })).toBeNull()
+    expect(screen.getByText('Color?')).toBeTruthy()
+    expect(screen.getByText('Name?')).toBeTruthy()
+    expect(screen.getByRole('button', { name: /red/ })).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/clarify-tool-one-entry.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool-one-entry.test.tsx
@@ -42,7 +42,7 @@ function oneEntryQuestionsArgs() {
   }
 }
 
-function liveProps(args: Record<string, unknown>): ToolCallMessagePartProps {
+function liveProps(args: ToolCallMessagePartProps['args']): ToolCallMessagePartProps {
   return {
     addResult: vi.fn(),
     args,

--- a/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
+++ b/apps/desktop/src/components/assistant-ui/clarify-tool.tsx
@@ -114,6 +114,27 @@ function readClarifyArgs(args: unknown): ClarifyArgs {
   }
 }
 
+/** Lift a one-entry `questions[]` payload onto the single-question fields.
+ *
+ * After the advertised schema became `questions[]`, an ordinary two-choice
+ * clarify arrives as `{ questions: [{ question, choices }] }` with no
+ * top-level `question`. The single card already paints from those fields
+ * without waiting for qids; leaving the entry nested routes to the batch
+ * card, which spins until `request.questions` arrives. */
+function unwrapOneEntryArgs(fromArgs: ClarifyArgs): ClarifyArgs {
+  if (!fromArgs.questions || fromArgs.questions.length !== 1) {
+    return fromArgs
+  }
+
+  const only = fromArgs.questions[0]
+
+  return {
+    choices: fromArgs.choices ?? only.choices,
+    multiSelect: fromArgs.multiSelect || Boolean(only.multiSelect),
+    question: fromArgs.question || only.question
+  }
+}
+
 interface ClarifyBatchResponse {
   id?: string
   question?: string
@@ -389,13 +410,21 @@ function ClarifyToolPending(props: ToolCallMessagePartProps) {
     return <ToolFallback {...props} />
   }
 
-  // Batch: the gateway request carries qid-keyed questions. Args alone can't
-  // drive the form (no qids to respond with), so batch waits for the request.
-  if (request?.questions?.length || fromArgs.questions) {
-    return <ClarifyToolBatchPending onAnswered={() => setAnswered(true)} request={request} />
+  // Batch only when the gateway sent qid-keyed questions, or the model
+  // emitted 2+ questions. A one-entry `questions[]` is the advertised
+  // single-question shape — routing it to the batch card left an infinite
+  // spinner whenever `clarify.request` was missing or still single-shaped.
+  if (request?.questions?.length || (fromArgs.questions?.length ?? 0) > 1) {
+    return <ClarifyToolBatchPending fromArgs={fromArgs} onAnswered={() => setAnswered(true)} request={request} />
   }
 
-  return <ClarifyToolSinglePending fromArgs={fromArgs} onAnswered={() => setAnswered(true)} request={request} />
+  return (
+    <ClarifyToolSinglePending
+      fromArgs={unwrapOneEntryArgs(fromArgs)}
+      onAnswered={() => setAnswered(true)}
+      request={request}
+    />
+  )
 }
 
 function ClarifyToolSinglePending({
@@ -949,15 +978,35 @@ const emptyStage = { choices: [] as string[], draft: '' }
  * back-to-back and completes the batch. Staged answers stay editable up to
  * that moment. The per-question wire protocol is unchanged (the TUI/CLI
  * still lock incrementally); this card just batches its locks at the end. */
-function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => void; request: ClarifyRequest | null }) {
+function ClarifyToolBatchPending({
+  fromArgs,
+  onAnswered,
+  request
+}: {
+  fromArgs: ClarifyArgs
+  onAnswered: () => void
+  request: ClarifyRequest | null
+}) {
   const { t } = useI18n()
   const copy = t.assistant.clarify
   const gateway = useStore($gateway)
 
-  // qids only exist on the gateway request — args are a hydration-race
-  // fallback for display, never answerable (no ids to respond with).
-  const questions = request?.questions ?? []
-  const ready = Boolean(request?.requestId) && questions.length > 0
+  // qids live on the gateway request. Args can still paint the questions
+  // (synthetic q0..qN, same index scheme the tool assigns) so a missed or
+  // late clarify.request does not leave an empty spinner.
+  const questions = useMemo(() => {
+    if (request?.questions?.length) {
+      return request.questions
+    }
+
+    return (fromArgs.questions ?? []).map((entry, index) => ({
+      choices: entry.choices ?? null,
+      multiSelect: Boolean(entry.multiSelect),
+      qid: `q${index}`,
+      question: entry.question
+    }))
+  }, [fromArgs.questions, request?.questions])
+  const ready = Boolean(request?.requestId) && Boolean(request?.questions?.length)
 
   const [staged, setStaged] = useState<Record<string, { choices: string[]; draft: string }>>({})
   const [submitting, setSubmitting] = useState(false)
@@ -1123,7 +1172,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
     [allStaged, confirmAll]
   )
 
-  if (!ready) {
+  if (questions.length === 0) {
     return (
       <ClarifyShell aria-label={copy.loadingQuestion} className="my-1.5 grid min-h-12 place-items-center" role="status">
         <Loader2 aria-hidden className="size-4 animate-spin text-(--ui-text-tertiary)" />
@@ -1142,7 +1191,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
         </div>
         {questions.map(question => (
           <BatchQuestionBlock
-            disabled={submitting}
+            disabled={submitting || !ready}
             key={question.qid}
             locked={false}
             onDraft={value => draftFor(question, value)}
@@ -1157,7 +1206,7 @@ function ClarifyToolBatchPending({ onAnswered, request }: { onAnswered: () => vo
         <Button disabled={submitting} onClick={() => void cancelAll()} size="xs" type="button" variant="text">
           {copy.skip}
         </Button>
-        <Button disabled={submitting || !allStaged} size="xs" type="submit">
+        <Button disabled={submitting || !ready || !allStaged} size="xs" type="submit">
           {submitting ? (
             <Loader2 className="size-3 animate-spin" />
           ) : (


### PR DESCRIPTION
## What does this PR do?

When `clarify` is called with a one-entry `questions[]` payload (the advertised single-question shape), the desktop chat card routed that tool row to the batch renderer. The batch card waits for a qid-keyed `clarify.request` before it will paint choices. If that event is late, missing, or still single-shaped (`question` + `choices` only), the card stays on an infinite "Loading question…" spinner and the user cannot click either option.

This unwraps a one-entry `questions[]` onto the existing single-question card so choice buttons render from `tool.start` args immediately. A real multi-question batch, or a gateway request that already carries qids, still uses the batch card. Multi-question args without a request now paint from the args (synthetic `q0..qN`) instead of spinning on an empty panel.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/100132

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/assistant-ui/clarify-tool.tsx`: unwrap one-entry `questions[]` onto the single-question card; keep batch routing for qid-keyed requests and 2+ questions; paint batch questions from args when the request has not arrived yet; disable batch controls until the request is wired.
- `apps/desktop/src/components/assistant-ui/clarify-tool-one-entry.test.tsx`: regression coverage for the reporter's two-choice prompt (buttons without a request, answer a single-shape request, keep a one-item batch request on the batch card, paint multi-question args instead of spinning).

## How to Test

1. From `apps/desktop`, run `npx vitest run --project ui src/components/assistant-ui/clarify-tool-one-entry.test.tsx src/components/assistant-ui/clarify-tool.test.tsx`.
2. Confirm the one-entry `questions[]` cases render the two choice buttons (no `role="status"` "Loading question…" spinner) and that clicking a choice + Continue sends `clarify.respond`.
3. In the desktop app, start a conversation that calls `clarify` with two choices (for example "Store credentials in BWS now" / "Not yet"). The choice rows should appear immediately; picking one and continuing should resume the turn.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
npx vitest run --project ui \
  src/components/assistant-ui/clarify-tool-one-entry.test.tsx \
  src/components/assistant-ui/clarify-tool.test.tsx \
  src/app/session/hooks/use-message-stream/clarify-hydration.test.tsx \
  src/store/clarify.test.ts \
  src/lib/keybinds/composer-focus-keys.test.ts

 Test Files  5 passed (5)
      Tests  95 passed (95)
```

Before the change, the one-entry cases rendered:

```
<div aria-label="Loading question…" role="status">…animate-spin…</div>
```

and no choice buttons.
