### PR TITLE
fix(cron): a zero-inference run is a failure, not a successful run

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -743,6 +743,36 @@ SILENT_MARKER = "[SILENT]"
 # autonomous lanes cannot drift apart.
 
 
+def _zero_inference_failure_reason(result: dict) -> str:
+    """Return a failure reason when a cron run never reached the model.
+
+    A run that made ZERO inference calls did none of its advertised work:
+    the transcript stops before the first tool result (or before any tool
+    call at all) and yet lands on the success path. Recording that as
+    ``ok`` is a false positive that defeats monitoring — an operator
+    watching ``last_status`` sees green while scheduled maintenance
+    silently never ran (#100180). This is the inverse of #70427, where
+    empty *successful* runs were mis-recorded as failures.
+
+    Returns ``""`` when the run is fine. ``api_calls`` is authoritative
+    and cheap: the conversation loop sets it to the provider round-trip
+    count on every return path, so an explicit 0 means the model was never
+    reached. A missing key (older result shapes, test doubles) is NOT
+    treated as zero — the guard only fires on an explicit 0, so it can
+    never fail a run whose call count simply wasn't reported.
+    """
+    api_calls = result.get("api_calls")
+    if isinstance(api_calls, bool) or not isinstance(api_calls, int):
+        return ""
+    if api_calls > 0:
+        return ""
+    return (
+        "cron run made zero inference calls (api_calls=0) — the run was "
+        "interrupted before reaching the model, so none of the job's work "
+        "was performed; refusing to record it as a successful run"
+    )
+
+
 def _is_cron_silence_response(text: str) -> bool:
     """Return True when a cron final response should suppress delivery.
 
@@ -6714,6 +6744,26 @@ def run_job(
                 )
                 final_response = ""
         # Use a separate variable for log display; keep final_response clean
+        # A run that made ZERO inference calls did none of the advertised
+        # work: the transcript stops before the first tool result (or before
+        # any tool call at all) and yet reached this success path. Recording
+        # it as `ok` is a false-positive that defeats monitoring — an
+        # operator watching `last_status` sees green while scheduled
+        # maintenance silently never ran (#100180). This is the inverse of
+        # #70427 (empty SUCCESSFUL runs mis-recorded as failures): here an
+        # UNFINISHED run is mis-recorded as success. Fail it so the except
+        # handler below builds the proper failure tuple.
+        #
+        # `api_calls` is authoritative and cheap: the conversation loop
+        # sets it to the provider round-trip count on every return path
+        # (agent/conversation_loop.py), so 0 means the model was never
+        # reached. A genuinely-silent job that DID run inference has
+        # api_calls >= 1 and stays on the success path (the cron silence
+        # handling above already covers its empty response).
+        _zero_inference = _zero_inference_failure_reason(result)
+        if _zero_inference:
+            raise RuntimeError(_zero_inference)
+
         # for delivery logic (empty response = no delivery).
         logged_response = final_response if final_response else "(No response generated)"
         

--- a/tests/cron/test_cron_zero_inference_run.py
+++ b/tests/cron/test_cron_zero_inference_run.py
@@ -1,0 +1,107 @@
+"""Zero-inference cron runs must not be recorded as successes (#100180).
+
+A manual `cronjob(action=run)` fire that was interrupted before reaching the
+model returned `result: ok` / `last_status: ok` with `API calls: 0` and a
+transcript truncated mid-first-tool-call. Operators monitoring `last_status`
+saw green while the scheduled maintenance silently never ran — the inverse of
+#70427 (empty *successful* runs mis-recorded as failures).
+
+These tests exercise the guard helper directly: `run_job` cannot be driven
+end-to-end in a bare test HERMES_HOME (no provider, real retry/backoff), so
+the classification logic is what's pinned.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from cron.scheduler import _zero_inference_failure_reason
+
+
+def test_zero_api_calls_is_a_failure():
+    """api_calls=0 means the model was never reached: must fail the run."""
+    reason = _zero_inference_failure_reason({
+        "final_response": "Starting weekly Mnemosyne maintenance. Step 1 —",
+        "api_calls": 0,
+        "completed": True,
+        "failed": False,
+    })
+    assert reason, "a zero-inference run must not be reported as success"
+    assert "zero inference calls" in reason.lower()
+
+
+@pytest.mark.parametrize("api_calls", [1, 2, 17])
+def test_nonzero_api_calls_is_a_success(api_calls):
+    """A run that reached the model stays on the success path."""
+    assert _zero_inference_failure_reason({
+        "final_response": "Full report body",
+        "api_calls": api_calls,
+        "completed": True,
+        "failed": False,
+    }) == ""
+
+
+def test_missing_api_calls_field_is_not_treated_as_zero():
+    """Absent api_calls (older result shapes / test doubles) must not fail
+    the run — the guard fires only on an explicit 0."""
+    assert _zero_inference_failure_reason({
+        "final_response": "ok",
+        "completed": True,
+        "failed": False,
+    }) == ""
+
+
+@pytest.mark.parametrize("value", [None, "0", "", 1.5, True, False])
+def test_non_integer_api_calls_is_not_treated_as_zero(value):
+    """Only a real int 0 counts. A bool is rejected explicitly: True/False
+    are ints in Python and would otherwise classify False as zero."""
+    assert _zero_inference_failure_reason({
+        "final_response": "ok",
+        "api_calls": value,
+        "completed": True,
+        "failed": False,
+    }) == ""
+
+
+def test_negative_api_calls_is_a_failure():
+    """A negative count is as impossible as zero — treat it as unreached."""
+    assert _zero_inference_failure_reason({"api_calls": -1}) != ""
+
+
+def test_run_job_fails_when_api_calls_is_zero(tmp_path):
+    """run_job must fail the run and record failure when api_calls is 0."""
+    from unittest.mock import MagicMock, patch
+
+    from cron.scheduler import run_job
+
+    job = {"id": "test-job", "name": "test", "prompt": "hello"}
+    fake_db = MagicMock()
+    fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+
+    with patch("cron.scheduler._hermes_home", tmp_path), \
+         patch("cron.scheduler._resolve_origin", return_value=None), \
+         patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+         patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+         patch("hermes_state.SessionDB", return_value=fake_db), \
+         patch(
+             "hermes_cli.runtime_provider.resolve_runtime_provider",
+             return_value={
+                 "api_key": "test-key",
+                 "base_url": "https://example.invalid/v1",
+                 "provider": "openrouter",
+                 "api_mode": "chat_completions",
+             },
+         ), \
+         patch("run_agent.AIAgent") as mock_agent_cls:
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {
+            "final_response": "interrupted mid-turn",
+            "api_calls": 0,
+        }
+        mock_agent_cls.return_value = mock_agent
+
+        success, output, final_response, error = run_job(job)
+
+    assert success is False
+    assert error is not None
+    assert "zero inference calls" in str(error).lower()


### PR DESCRIPTION
Fixes #100180

## Problem

A manual `cronjob(action=run)` fire that was interrupted before reaching the model recorded **`result: ok` / `last_status: ok` with `API calls: 0`** and a transcript truncated mid-first-tool-call. An operator monitoring `last_status` saw green while the scheduled maintenance silently never ran.

The reporter verified against the store: neither of two "ok" fires performed the job's consolidation step — the working/episodic split was unchanged and a follow-up `mnemosyne_sleep(dry_run=true)` returned `no_op`. Both async-delegation blocks reported `Status: completed | API calls: 0`.

This is the **inverse of #70427** (empty *successful* runs mis-recorded as failures) and more dangerous: an unfinished run recorded as clean success defeats monitoring entirely.

## Fix

`run_job`'s success path now consults `_zero_inference_failure_reason(result)` **before** building the success tuple. An explicit `api_calls == 0` (or negative) raises, so the existing `except` handler produces the proper failure tuple and `last_status`.

Deliberately conservative:

- `api_calls` is authoritative — `agent/conversation_loop.py` sets it to the provider round-trip count on **every** return path, so `0` means the model was never reached
- a **missing** or **non-int** `api_calls` is *not* treated as zero, so older result shapes and test doubles can never be failed by the guard
- `bool` is rejected explicitly (`True`/`False` are `int`s in Python, and `False` would otherwise classify as zero)
- a genuinely-silent job that *did* run inference has `api_calls >= 1` and stays on the success path — the existing cron-silence handling still covers its empty response

## Verification

New `tests/cron/test_cron_zero_inference_run.py`: **13/13 pass** — zero fails, 1/2/17 succeed, missing key succeeds, `None`/`"0"`/`""`/`1.5`/`True`/`False` all succeed, negative fails, plus a wiring test asserting the guard is called in `run_job` *before* the success return so a refactor can't silently drop it.

The 3 failures in the wider `tests/cron` cluster (`test_run_job_no_agent_reloads_dotenv_before_script`, `test_run_job_does_not_block_a_valid_no_agent_job`) are pre-existing on this Windows host — reproduced with the change stashed.