### PR TITLE
feat(cli): add hermes group subcommand for Bot Mode group chat CRUD

### DIFF
--- a/hermes_cli/groups.py
+++ b/hermes_cli/groups.py
@@ -1,0 +1,364 @@
+"""Bot Mode group chat CRUD — the backend for the ``hermes group`` subcommand.
+
+Bot Mode group chats (the desktop Bots tab → group rooms) are backed by profile
+metadata, not a database. Two ``ui_meta`` keys under ``profile.yaml``:
+
+* each bot's own profile → ``ui_meta.hermes-bots.groups`` (its membership list)
+* the default profile   → ``ui_meta.hermes-bots-groups`` (the room projection:
+  durable roomId, members, cross-client mirror, rename/disband tombstones)
+
+This module writes the *same contract* the desktop's Bots plugin writes through
+the ``profiles.configure`` gateway RPC, so a group created here is
+indistinguishable from one created in the UI — the desktop rehydrates rooms
+from this projection on every cold start.
+"""
+
+from __future__ import annotations
+
+import random
+import string
+import time
+from typing import Dict, List, Optional, Set, Tuple
+
+from hermes_cli.profiles import (
+    get_profile_dir,
+    list_profile_names,
+    read_profile_ui_meta,
+    set_profile_ui_meta,
+)
+
+BOT_META_KEY = "hermes-bots"
+PROJECTION_KEY = "hermes-bots-groups"
+MAX_MEMBERS = 6  # desktop GROUP_CHAT_MAX_MEMBERS
+LOCAL_CONNECTION = {
+    "connectionId": "local",
+    "connectionKind": "local",
+    "connectionLabel": "This device",
+    "sourceScoped": True,
+}
+
+
+def _bot_meta(profile_dir) -> dict:
+    meta = read_profile_ui_meta(profile_dir, BOT_META_KEY)
+    return meta if isinstance(meta, dict) else {}
+
+
+def _bot_groups(meta: dict) -> List[str]:
+    """Group names a bot belongs to. ``groups`` is authoritative; the legacy
+    ``group`` scalar is the fallback (single value, no comma-split)."""
+    groups = meta.get("groups")
+    if isinstance(groups, list):
+        return [g for g in groups if isinstance(g, str) and g.strip()]
+    scalar = meta.get("group")
+    if isinstance(scalar, str) and scalar.strip():
+        return [scalar.strip()]
+    return []
+
+
+def _set_bot_groups(bot: str, group: str, enabled: bool) -> None:
+    """Add/remove one group from a bot's membership, preserving appearance."""
+    profile_dir = get_profile_dir(bot)
+    meta = dict(_bot_meta(profile_dir))
+    groups = _bot_groups(meta)
+    if enabled:
+        if group and group not in groups:
+            groups.append(group)
+    else:
+        groups = [g for g in groups if g != group]
+    meta["groups"] = groups
+    if groups:
+        meta["group"] = groups[0]
+    else:
+        meta.pop("group", None)
+    set_profile_ui_meta(profile_dir, BOT_META_KEY, meta)
+
+
+def _projection() -> dict:
+    proj = read_profile_ui_meta(get_profile_dir("default"), PROJECTION_KEY)
+    if not isinstance(proj, dict):
+        return {"version": 3, "updatedAt": 0, "rooms": {}, "deleted": {}}
+    proj = dict(proj)
+    proj.setdefault("version", 3)
+    proj.setdefault("updatedAt", 0)
+    proj.setdefault("rooms", {})
+    proj.setdefault("deleted", {})
+    return proj
+
+
+def _save_projection(proj: dict) -> None:
+    set_profile_ui_meta(get_profile_dir("default"), PROJECTION_KEY, proj)
+
+
+def _mint_room_id() -> str:
+    # Matches the desktop's mintGroupRoomId(): r<base36-ms>-<5 chars>.
+    suffix = "".join(random.choices(string.ascii_lowercase + string.digits, k=5))
+    return f"r{_base36(int(time.time() * 1000))}-{suffix}"
+
+
+def _base36(n: int) -> str:
+    chars = "0123456789abcdefghijklmnopqrstuvwxyz"
+    if n == 0:
+        return "0"
+    out = ""
+    while n:
+        n, r = divmod(n, 36)
+        out = chars[r] + out
+    return out
+
+
+def _member_descriptor(bot: str) -> dict:
+    return {"name": bot, "handle": bot, **LOCAL_CONNECTION}
+
+
+def _find_room(proj: dict, name: str) -> Tuple[Optional[str], Optional[dict]]:
+    for key, room in proj.get("rooms", {}).items():
+        if isinstance(room, dict) and room.get("name") == name:
+            return key, room
+    legacy = f"name:{name}"
+    if legacy in proj.get("rooms", {}):
+        return legacy, proj["rooms"][legacy]
+    return None, None
+
+
+def _next_revision(proj: dict) -> int:
+    latest = max(
+        [int(r.get("revision", 0) or 0) for r in proj.get("rooms", {}).values() if isinstance(r, dict)]
+        or [0]
+    )
+    return latest + 1
+
+
+def _touch(proj: dict) -> None:
+    proj["updatedAt"] = int(time.time() * 1000)
+    proj["version"] = 3
+
+
+def _unique_name(base: str, taken: Set[str]) -> str:
+    # Matches the desktop's uniqueGroupChatName(): truncate 64, " 2", " 3", …
+    if base not in taken:
+        return base
+    for n in range(2, 100):
+        suffix = f" {n}"
+        candidate = base[: 64 - len(suffix)] + suffix
+        if candidate not in taken:
+            return candidate
+    raise ValueError("no free name for the group")
+
+
+def _clean_bots(bots: List[str]) -> List[str]:
+    seen: List[str] = []
+    for b in bots:
+        b = b.strip()
+        if b and b not in seen:
+            seen.append(b)
+    return seen
+
+
+# ── public API ──────────────────────────────────────────────────────────────
+
+
+def list_bots() -> List[str]:
+    return list_profile_names()
+
+
+def list_groups() -> Dict[str, dict]:
+    """Union of bot-meta membership and the room projection.
+
+    Returns {name: {"members": [sorted], "roomId": str|None}}."""
+    groups: Dict[str, dict] = {}
+    for bot in list_profile_names():
+        for g in _bot_groups(_bot_meta(get_profile_dir(bot))):
+            groups.setdefault(g, {"members": set(), "roomId": None})
+            groups[g]["members"].add(bot)
+    for key, room in _projection().get("rooms", {}).items():
+        if not isinstance(room, dict) or room.get("tombstone"):
+            continue
+        name = room.get("name") or (key[5:] if key.startswith("name:") else key)
+        groups.setdefault(name, {"members": set(), "roomId": None})
+        rid = room.get("roomId")
+        if isinstance(rid, str) and rid:
+            groups[name]["roomId"] = rid
+        for m in room.get("members", []):
+            if isinstance(m, dict) and m.get("name"):
+                groups[name]["members"].add(m["name"])
+    return {
+        n: {"members": sorted(m["members"]), "roomId": m["roomId"]}
+        for n, m in sorted(groups.items())
+    }
+
+
+def create_group(name: str, bots: List[str]) -> dict:
+    bots = _clean_bots(bots)
+    if len(bots) < 2:
+        raise ValueError("a group chat needs at least 2 bots")
+    if len(bots) > MAX_MEMBERS:
+        raise ValueError(f"a group chat holds at most {MAX_MEMBERS} bots (got {len(bots)})")
+    name = _unique_name(name.strip()[:64], set(list_groups().keys()))
+    for bot in bots:
+        _set_bot_groups(bot, name, True)
+    proj = _projection()
+    room_id = _mint_room_id()
+    proj.setdefault("rooms", {})[f"id:{room_id}"] = {
+        "name": name,
+        "roomId": room_id,
+        "log": [],
+        "members": [_member_descriptor(b) for b in bots],
+        "revision": _next_revision(proj),
+    }
+    _touch(proj)
+    _save_projection(proj)
+    return {"name": name, "roomId": room_id, "members": bots}
+
+
+def _update_projection_members(name: str, members: List[str]) -> None:
+    proj = _projection()
+    _, room = _find_room(proj, name)
+    if room is not None:
+        room["members"] = [_member_descriptor(b) for b in members]
+        room["revision"] = _next_revision(proj)
+        _touch(proj)
+        _save_projection(proj)
+
+
+def add_members(name: str, bots: List[str]) -> dict:
+    bots = _clean_bots(bots)
+    groups = list_groups()
+    if name not in groups:
+        raise ValueError(f"group '{name}' does not exist")
+    current = set(groups[name]["members"])
+    added = [b for b in bots if b not in current]
+    if len(current | set(added)) > MAX_MEMBERS:
+        raise ValueError(f"a group chat holds at most {MAX_MEMBERS} bots")
+    for bot in added:
+        _set_bot_groups(bot, name, True)
+    if added:
+        _update_projection_members(name, sorted(current | set(added)))
+    return {"name": name, "added": added}
+
+
+def remove_members(name: str, bots: List[str]) -> dict:
+    bots = _clean_bots(bots)
+    groups = list_groups()
+    if name not in groups:
+        raise ValueError(f"group '{name}' does not exist")
+    current = set(groups[name]["members"])
+    removed = [b for b in bots if b in current]
+    for bot in removed:
+        _set_bot_groups(bot, name, False)
+    _update_projection_members(name, sorted(current - set(removed)))
+    return {"name": name, "removed": removed}
+
+
+def rename_group(old: str, new: str) -> dict:
+    old, new = old.strip(), new.strip()
+    if not new:
+        raise ValueError("new name is required")
+    groups = list_groups()
+    if old not in groups:
+        raise ValueError(f"group '{old}' does not exist")
+    if new in groups:
+        raise ValueError(f"group '{new}' already exists")
+    for bot in groups[old]["members"]:
+        _set_bot_groups(bot, old, False)
+        _set_bot_groups(bot, new, True)
+    proj = _projection()
+    key, room = _find_room(proj, old)
+    if room is not None:
+        room["name"] = new
+        room["revision"] = _next_revision(proj)
+        if key.startswith("name:"):
+            del proj["rooms"][key]
+            proj["rooms"][f"name:{new}"] = room
+        _touch(proj)
+        _save_projection(proj)
+    return {"old": old, "new": new}
+
+
+def disband_group(name: str) -> dict:
+    name = name.strip()
+    groups = list_groups()
+    if name not in groups:
+        raise ValueError(f"group '{name}' does not exist")
+    for bot in groups[name]["members"]:
+        _set_bot_groups(bot, name, False)
+    proj = _projection()
+    key, _ = _find_room(proj, name)
+    if key is not None:
+        proj.setdefault("deleted", {})[key] = _next_revision(proj)
+        proj.setdefault("rooms", {}).pop(key, None)
+        _touch(proj)
+        _save_projection(proj)
+    return {"name": name}
+
+
+def group_info(name: str) -> dict:
+    groups = list_groups()
+    if name not in groups:
+        return {"name": name, "exists": False}
+    info = {"name": name, "exists": True, **groups[name]}
+    return info
+
+
+# ── command handler ──────────────────────────────────────────────────────────
+
+
+def _split(csv: str) -> List[str]:
+    return _clean_bots(csv.split(","))
+
+
+def cmd_group(args) -> None:
+    """Dispatch ``hermes group <action>``."""
+    action = getattr(args, "group_action", None)
+
+    if action in (None, "list"):
+        groups = list_groups()
+        if not groups:
+            print("(no groups)")
+            return
+        for name, info in groups.items():
+            members = ", ".join(info["members"]) or "—"
+            tag = f"  (id:{info['roomId']})" if info.get("roomId") else ""
+            print(f"{name}  [{len(info['members'])}]{tag}\n    {members}")
+        return
+
+    if action == "bots":
+        for b in list_bots():
+            print(b)
+        return
+
+    if action == "create":
+        res = create_group(args.name, _split(args.bots))
+        print(f"created '{res['name']}' ({res['roomId']}) with {len(res['members'])} bots")
+        return
+
+    if action == "info":
+        info = group_info(args.name)
+        if not info["exists"]:
+            print(f"group '{args.name}' does not exist")
+            return
+        print(f"group:    {info['name']}")
+        print(f"roomId:   {info.get('roomId') or '(legacy, minted on first message)'}")
+        print(f"members:  {', '.join(info['members']) or '—'}")
+        return
+
+    if action == "add":
+        res = add_members(args.name, _split(args.bots))
+        print(f"added {len(res['added'])} to '{args.name}'")
+        return
+
+    if action == "remove":
+        res = remove_members(args.name, _split(args.bots))
+        print(f"removed {len(res['removed'])} from '{args.name}'")
+        return
+
+    if action == "rename":
+        res = rename_group(args.old, args.new)
+        print(f"renamed '{res['old']}' → '{res['new']}'")
+        return
+
+    if action == "disband":
+        disband_group(args.name)
+        print(f"disbanded '{args.name}'")
+        return
+
+    raise SystemExit(f"unknown group action: {action}")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -316,6 +316,7 @@ from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
 from hermes_cli.subcommands.profile import build_profile_parser
+from hermes_cli.subcommands.group import build_group_parser
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 
@@ -3247,6 +3248,13 @@ def _build_cli_parser():
     build_uninstall_parser(subparsers, cmd_uninstall=cmd_uninstall)
     build_acp_parser(subparsers, cmd_acp=cmd_acp)
     build_profile_parser(subparsers, cmd_profile=cmd_profile)
+
+    # =========================================================================
+    # group command  (parser in hermes_cli/subcommands/group.py)
+    # =========================================================================
+    from hermes_cli.groups import cmd_group
+
+    build_group_parser(subparsers, cmd_group=cmd_group)
     build_completion_parser(subparsers, cmd_completion=cmd_completion, parser=parser)
     build_dashboard_parser(
         subparsers,

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -645,6 +645,71 @@ def write_profile_meta(
     atomic_yaml_write(path, existing, sort_keys=False)
 
 
+def read_profile_ui_meta(profile_dir: Path, key: str):
+    """Read one ``ui_meta`` key from ``<profile_dir>/profile.yaml``.
+
+    Returns ``None`` when the file is missing/unreadable or the key is absent.
+    """
+    path = profile_dir / "profile.yaml"
+    if not path.is_file():
+        return None
+    import yaml
+
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f) or {}
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    ui = data.get("ui_meta")
+    if not isinstance(ui, dict):
+        return None
+    return ui.get(key)
+
+
+def set_profile_ui_meta(profile_dir: Path, key: str, value) -> None:
+    """Set (or delete) one ``ui_meta`` key in ``<profile_dir>/profile.yaml``.
+
+    Mirrors the gateway ``profiles.configure`` ui_meta write: read the full
+    file, merge the key (``value=None`` deletes it), bump
+    ``_ui_meta_revisions[key]`` for the CAS contract, and write atomically.
+    All other fields are preserved.
+    """
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"profile directory does not exist: {profile_dir}")
+    import yaml
+
+    path = profile_dir / "profile.yaml"
+    existing: dict = {}
+    if path.is_file():
+        try:
+            with open(path, "r", encoding="utf-8") as f:
+                loaded = yaml.safe_load(f) or {}
+            if isinstance(loaded, dict):
+                existing = loaded
+        except Exception:
+            existing = {}
+    ui = existing.get("ui_meta")
+    if not isinstance(ui, dict):
+        ui = {}
+    if value is None:
+        ui.pop(key, None)
+    else:
+        ui[key] = value
+    revisions = existing.get("_ui_meta_revisions")
+    revisions = dict(revisions) if isinstance(revisions, dict) else {}
+    revisions[key] = int(revisions.get(key, 0) or 0) + 1
+    if ui:
+        existing["ui_meta"] = ui
+    else:
+        existing.pop("ui_meta", None)
+    existing["_ui_meta_revisions"] = revisions
+    from utils import atomic_yaml_write
+
+    atomic_yaml_write(path, existing, sort_keys=False)
+
+
 def format_profile_label(name: str, display_name: Optional[str]) -> str:
     """``display_name (canonical_id)``, or the bare id when no display name is set (or it
     equals the id) — byte-for-byte the pre-feature rendering."""

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -1,0 +1,41 @@
+"""``hermes group`` subcommand parser (Bot Mode group chats)."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+
+def build_group_parser(subparsers, *, cmd_group: Callable) -> None:
+    """Attach the ``group`` subcommand to ``subparsers``."""
+    group_parser = subparsers.add_parser(
+        "group",
+        help="Manage Bot Mode group chats (the desktop Bots tab rooms)",
+    )
+    group_sub = group_parser.add_subparsers(dest="group_action")
+
+    group_sub.add_parser("bots", help="List available bots (profiles)")
+    group_sub.add_parser("list", help="List groups and their members")
+
+    create = group_sub.add_parser("create", help="Create a group chat")
+    create.add_argument("name")
+    create.add_argument("-b", "--bots", required=True, help="Comma-separated member bots (2-6)")
+
+    info = group_sub.add_parser("info", help="Show one group")
+    info.add_argument("name")
+
+    add = group_sub.add_parser("add", help="Add members to a group")
+    add.add_argument("name")
+    add.add_argument("-b", "--bots", required=True, help="Comma-separated bots to add")
+
+    remove = group_sub.add_parser("remove", help="Remove members from a group")
+    remove.add_argument("name")
+    remove.add_argument("-b", "--bots", required=True, help="Comma-separated bots to remove")
+
+    rename = group_sub.add_parser("rename", help="Rename a group")
+    rename.add_argument("old")
+    rename.add_argument("new")
+
+    disband = group_sub.add_parser("disband", help="Disband a group")
+    disband.add_argument("name")
+
+    group_parser.set_defaults(func=cmd_group)

--- a/tests/hermes_cli/test_group.py
+++ b/tests/hermes_cli/test_group.py
@@ -1,0 +1,144 @@
+"""``hermes group`` — Bot Mode group chat CRUD.
+
+Groups are backed by profile metadata (``ui_meta.hermes-bots.groups`` membership
++ ``ui_meta.hermes-bots-groups`` projection), not a database. These tests run
+against an isolated HERMES_HOME and never touch the real profile store.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli import groups
+from hermes_cli.groups import (
+    BOT_META_KEY,
+    PROJECTION_KEY,
+    add_members,
+    create_group,
+    disband_group,
+    group_info,
+    list_bots,
+    list_groups,
+    remove_members,
+    rename_group,
+)
+from hermes_cli.profiles import get_profile_dir, read_profile_ui_meta, set_profile_ui_meta
+
+BOTS = ("w-cto", "designer", "caretaker")
+
+
+@pytest.fixture()
+def env(tmp_path, monkeypatch):
+    """Isolated Hermes home with a default profile and three bot profiles."""
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for bot in BOTS:
+        (home / "profiles" / bot).mkdir(parents=True)
+    return home
+
+
+class TestUiMeta:
+    def test_round_trip_and_revision_bump(self, env):
+        set_profile_ui_meta(get_profile_dir("default"), "x", {"a": 1})
+        assert read_profile_ui_meta(get_profile_dir("default"), "x") == {"a": 1}
+        data = yaml.safe_load((env / "profile.yaml").read_text())
+        assert data["_ui_meta_revisions"]["x"] == 1
+
+    def test_none_deletes_key(self, env):
+        set_profile_ui_meta(get_profile_dir("default"), "x", {"a": 1})
+        set_profile_ui_meta(get_profile_dir("default"), "x", None)
+        assert read_profile_ui_meta(get_profile_dir("default"), "x") is None
+
+
+class TestCreateAndList:
+    def test_create_writes_membership_and_projection(self, env):
+        result = create_group("Build", ["w-cto", "designer", "caretaker"])
+        assert result["roomId"].startswith("r")
+
+        # membership on each bot
+        for bot in ("w-cto", "designer", "caretaker"):
+            meta = read_profile_ui_meta(get_profile_dir(bot), BOT_META_KEY)
+            assert "Build" in meta["groups"]
+
+        # projection on default
+        proj = read_profile_ui_meta(get_profile_dir("default"), PROJECTION_KEY)
+        room = next(v for v in proj["rooms"].values() if v.get("name") == "Build")
+        assert room["roomId"] == result["roomId"]
+        assert {m["name"] for m in room["members"]} == {"w-cto", "designer", "caretaker"}
+
+    def test_list_bots_and_groups(self, env):
+        create_group("Build", ["w-cto", "designer"])
+        assert "default" in list_bots()
+        assert "w-cto" in list_bots()
+        groups = list_groups()
+        assert "Build" in groups
+        assert groups["Build"]["members"] == ["designer", "w-cto"]
+
+    def test_create_preserves_bot_appearance(self, env):
+        meta = {"shape": "square", "color": "hsl(36 90% 55%)", "title": "w_CTO", "groups": ["Existing"], "group": "Existing"}
+        set_profile_ui_meta(get_profile_dir("w-cto"), BOT_META_KEY, meta)
+
+        create_group("Build", ["w-cto", "designer"])
+
+        after = read_profile_ui_meta(get_profile_dir("w-cto"), BOT_META_KEY)
+        assert after["shape"] == "square"
+        assert after["title"] == "w_CTO"
+        assert set(after["groups"]) == {"Existing", "Build"}
+
+    def test_rejects_under_2_and_over_6(self, env):
+        with pytest.raises(ValueError, match="at least 2"):
+            create_group("Solo", ["w-cto"])
+        with pytest.raises(ValueError, match="at most 6"):
+            create_group("Big", ["a", "b", "c", "d", "e", "f", "g"])
+
+    def test_collision_auto_suffixes(self, env):
+        create_group("Build", ["w-cto", "designer"])
+        result = create_group("Build", ["w-cto", "caretaker"])
+        assert result["name"] == "Build 2"
+
+
+class TestMutate:
+    def test_add_remove_members(self, env):
+        create_group("Build", ["w-cto", "designer"])
+        add_members("Build", ["caretaker"])
+        assert "caretaker" in list_groups()["Build"]["members"]
+        remove_members("Build", ["designer"])
+        assert "designer" not in list_groups()["Build"]["members"]
+        meta = read_profile_ui_meta(get_profile_dir("designer"), BOT_META_KEY)
+        assert "Build" not in meta.get("groups", [])
+
+    def test_rename_preserves_identity(self, env):
+        rid = create_group("Build", ["w-cto", "designer"])["roomId"]
+        rename_group("Build", "Ship")
+        groups = list_groups()
+        assert "Build" not in groups
+        assert groups["Ship"]["roomId"] == rid
+
+    def test_disband(self, env):
+        create_group("Build", ["w-cto", "designer"])
+        disband_group("Build")
+        assert "Build" not in list_groups()
+        proj = read_profile_ui_meta(get_profile_dir("default"), PROJECTION_KEY)
+        assert proj["deleted"]  # tombstone recorded
+
+    def test_info_unknown_group(self, env):
+        assert group_info("Nope")["exists"] is False
+
+
+class TestParser:
+    def test_build_group_parser_registers(self):
+        import argparse
+
+        from hermes_cli.subcommands.group import build_group_parser
+
+        root = argparse.ArgumentParser()
+        sub = root.add_subparsers(dest="cmd")
+        build_group_parser(sub, cmd_group=lambda args: None)
+        ns = root.parse_args(["group", "list"])
+        assert ns.cmd == "group"
+        assert ns.group_action == "list"


### PR DESCRIPTION
# feat(cli): add `hermes group` subcommand for Bot Mode group chat CRUD

## Summary

Adds a native `hermes group` subcommand to create, list, and manage **Bot Mode
group chats** (the desktop Bots tab rooms) from the CLI — no UI, no gateway
running. Fills a real gap: today `hermes` has `peer` (bot-to-bot DMs) but no
way to manage the group rooms the desktop Bots plugin creates.

```console
$ hermes group list
TASKMASTER  [8]  (id:rmthmuglt-ot1za)
    caretaker, default, designer, musician, outreach, planner, w-cto, youtube

$ hermes group create "Livepanchang" -b w-cto,taskmaster,designer,outreach,caretaker
created 'Livepanchang' (rmtiiwcou-0hv2q) with 5 bots

$ hermes group add "Livepanchang" -b planner
$ hermes group rename "Livepanchang" "LivePanchang"   # identity preserved (same roomId)
$ hermes group disband "Livepanchang"
```

Commands: `bots`, `list`, `create <name> -b a,b,c`, `info <name>`,
`add <name> -b …`, `remove <name> -b …`, `rename <old> <new>`, `disband <name>`.

## Why this is safe (the storage contract)

Bot Mode groups are **profile metadata, not a database**. Two `ui_meta` keys
under `profile.yaml`:

* each bot's own profile → `ui_meta.hermes-bots.groups` (membership list)
* the default profile   → `ui_meta.hermes-bots-groups` (the room projection:
  durable `roomId`, member descriptors, rename/disband tombstones)

This CLI writes the **same contract the desktop's Bots plugin writes** through
the core `profiles.configure` gateway RPC — same CAS revision bump
(`_ui_meta_revisions[key] += 1`), same atomic write (`atomic_yaml_write`),
same member-descriptor shape, same `roomId` format (`r<base36-ms>-<5 chars>`),
same 6-member cap. The desktop rehydrates rooms from this projection on every
cold start (`pullGroupChatServerState`), so a CLI-created group is
indistinguishable from one created in the UI.

## Design note (the one thing reviewers should weigh in on)

The `hermes-bots-groups` projection key is **currently owned by the desktop
`hermes-bots` plugin** (it publishes there via `profiles.configure`). This CLI
reads and writes that same key because it is the only durable, gateway-synced
store for room identity — writing membership alone would leave CLI-created
rooms without a durable `roomId` (they'd be legacy name-keyed rooms).

Two ways forward, in preference order:

1. **Promote the two keys (`hermes-bots`, `hermes-bots-groups`) to a documented
   core contract** — they already ride the core `profiles.configure` RPC, so
   this is mostly a naming/documentation change, not new machinery.
2. **CLI writes membership only** and lets the desktop project rooms — cleaner
   ownership, but CLI-created rooms lose durable `roomId` until first open.

This PR ships option 1 (write both keys, same as the plugin), and documents the
contract in the `hermes_cli/groups.py` module docstring.

## Implementation

* `hermes_cli/groups.py` — pure domain logic (no argparse), reuses
  `get_profile_dir` / `list_profile_names`.
* `hermes_cli/profiles.py` — adds `read_profile_ui_meta` + `set_profile_ui_meta`
  (the `profiles.configure` ui_meta write, factored for reuse).
* `hermes_cli/subcommands/group.py` — parser, mirrors the `profile` subcommand.
* `hermes_cli/main.py` — 8-line wiring (import + `build_group_parser` call).

## Testing

`tests/hermes_cli/test_group.py` — 12 tests (isolated `HERMES_HOME`, no real
store): ui_meta round-trip + revision bump, create/list, membership + projection
writes, appearance preservation, 2–6 member cap, collision auto-suffix,
add/remove/rename/disband, parser registration.

## Out of scope (possible follow-up)

A `message`/round-dispatch command (post a message and run member turns) was
deliberately left out: it shells out to `hermes chat` and a single-round
version doesn't match the desktop's 3-round / @mention / watermark engine. The
CRUD here is the clean, defensible core.
