### PR TITLE
feat(agent): bound reasoning replay and treat prior summaries as unverified

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2256,6 +2256,19 @@ def init_agent(
             _compression_cfg.get("proactive_prune_min_reclaim_tokens", 4096), 4096
         ),
     )
+    from agent.context_freshness import (
+        DEFAULT_REASONING_REPLAY_KEEP_LAST,
+        clamp_reasoning_replay_keep_last,
+    )
+
+    compression_reasoning_replay_keep_last = clamp_reasoning_replay_keep_last(
+        _parse_prune_int(
+            _compression_cfg.get(
+                "reasoning_replay_keep_last", DEFAULT_REASONING_REPLAY_KEEP_LAST
+            ),
+            DEFAULT_REASONING_REPLAY_KEEP_LAST,
+        )
+    )
     # protect_first_n is the number of non-system messages to protect at
     # the head, in addition to the system prompt (which is always
     # implicitly protected by the compressor).  Floor at 0 — a value of
@@ -2871,6 +2884,8 @@ def init_agent(
         _cc._micro_compact_defrag_threshold_tokens = (
             compression_micro_compact_defrag_tokens
         )
+    if _cc is not None:
+        _cc.reasoning_replay_keep_last = compression_reasoning_replay_keep_last
     agent.compression_checkpoint_required = compression_checkpoint_required
     agent.codex_app_server_auto_compaction = codex_app_server_auto_compaction
     agent.codex_responses_native_compaction = codex_responses_native_compaction

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1952,6 +1952,11 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
                 getattr(agent, "_codex_reasoning_replay_enabled", True)
             ),
             context_management=_context_management,
+            reasoning_replay_keep_last=getattr(
+                getattr(agent, "context_compressor", None),
+                "reasoning_replay_keep_last",
+                None,
+            ),
         )
 
     # ── chat_completions (default) ─────────────────────────────────────

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -19,6 +19,11 @@ import uuid
 from types import SimpleNamespace
 from typing import Any, Dict, List, NamedTuple, Optional
 
+from agent.context_freshness import (
+    DEFAULT_REASONING_REPLAY_KEEP_LAST,
+    clamp_reasoning_replay_keep_last,
+    reasoning_replay_keep_indices,
+)
 from agent.message_sanitization import deterministic_call_id
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
 
@@ -486,6 +491,7 @@ def _chat_messages_to_responses_input(
     replay_encrypted_reasoning: bool = True,
     current_issuer_kind: Optional[str] = None,
     native_compaction_eligible: bool = False,
+    reasoning_replay_keep_last: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Convert internal chat-style messages to Responses input items.
 
@@ -548,6 +554,13 @@ def _chat_messages_to_responses_input(
     ``convert_messages``). Dropping the checkpoint costs nothing: Hermes'
     local history is never truncated by native compaction, so the full
     conversation is still on the wire.
+
+    ``reasoning_replay_keep_last`` bounds *which* assistant turns still
+    replay encrypted reasoning between compactions. Reasoning on turns at
+    or before the latest compaction summary is always dropped; among the
+    remaining reasoning-bearing assistant turns only the last N are
+    replayed (default 8; ``0`` = no extra turn cap). Persisted history is
+    not mutated — this is request-assembly only.
     """
     items: List[Dict[str, Any]] = []
     # Parallel to `items`: the raw chat message each converted item came
@@ -557,8 +570,18 @@ def _chat_messages_to_responses_input(
     # `function_call_output` wrapper) that no longer carries it (#90976).
     item_sources: List[Optional[Dict[str, Any]]] = []
     seen_item_ids: set = set()
+    keep_last = clamp_reasoning_replay_keep_last(
+        DEFAULT_REASONING_REPLAY_KEEP_LAST
+        if reasoning_replay_keep_last is None
+        else reasoning_replay_keep_last
+    )
+    keep_reasoning_at = (
+        reasoning_replay_keep_indices(messages, keep_last=keep_last)
+        if replay_encrypted_reasoning
+        else frozenset()
+    )
 
-    for msg in messages:
+    for msg_index, msg in enumerate(messages):
         if not isinstance(msg, dict):
             continue
         role = msg.get("role")
@@ -607,6 +630,15 @@ def _chat_messages_to_responses_input(
                             if (
                                 ri.get("type") == "compaction"
                                 and not native_compaction_eligible
+                            ):
+                                continue
+                            # Freshness bound: drop ordinary encrypted
+                            # reasoning outside the keep window. Native
+                            # compaction checkpoints are not a stale
+                            # interpretation — leave them to the gate above.
+                            if (
+                                ri.get("type") != "compaction"
+                                and msg_index not in keep_reasoning_at
                             ):
                                 continue
                             # Cross-issuer guard: drop reasoning blocks that

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -36,6 +36,7 @@ from agent.auxiliary_client import (
     extract_content_or_reasoning,
 )
 from agent.context_engine import ContextEngine, sanitize_memory_context
+from agent.context_freshness import PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_sanitization import tool_result_id_variants
 from agent.model_metadata import (
@@ -5251,7 +5252,7 @@ PREVIOUS SUMMARY:
 NEW TURNS TO INCORPORATE:
 {content_to_summarize}{_memory_section}
 
-Update the summary using this exact structure. PRESERVE all existing information that is still relevant. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information only if it is clearly obsolete. CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
+Update the summary using this exact structure. PRESERVE information that is still confirmed by the new turns. ADD new completed actions to the numbered list (continue numbering). Move items from "In Progress" to "Completed Actions" when done. Move answered questions to "Resolved Questions". Update "Active State" to reflect current state. Remove information that is clearly obsolete. {PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE} CRITICAL: Update "## Active Task" to reflect the user's most recent unfulfilled input — this includes any question, decision request, or discussion turn that the assistant has not yet answered. Only write "None" if the last exchange was fully resolved.
 
 {_template_sections}"""
         else:

--- a/agent/context_freshness.py
+++ b/agent/context_freshness.py
@@ -1,0 +1,116 @@
+"""Shared context-freshness / precedence helpers.
+
+First milestone of the context-drift design: bound replayed reasoning
+between compactions, and treat a previous compaction summary as unverified
+background rather than ground truth. Does not mutate the cached system
+prompt or persisted history — request assembly and the summarizer prompt
+only.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Iterable, Optional
+
+# --------------------------------------------------------------------------------------
+# Defaults
+# --------------------------------------------------------------------------------------
+
+# Keep the last N post-compaction assistant turns that carry encrypted
+# reasoning. 0 means no extra turn cap (still drop reasoning that predates
+# the most recent compaction summary).
+DEFAULT_REASONING_REPLAY_KEEP_LAST = 8
+_MAX_REASONING_REPLAY_KEEP_LAST = 64
+
+PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE = (
+    "IMPORTANT: The previous compaction summary is unverified background, "
+    "not ground truth. Prefer NEW TURNS, later user corrections, and current "
+    "file/system state over any conflicting decision, status, or outcome in "
+    "the previous summary. Do not preserve a load-bearing claim from the "
+    "previous summary unless the new turns confirm it; if they contradict "
+    "it, drop the stale claim or note the conflict under Key Decisions."
+)
+
+
+def clamp_reasoning_replay_keep_last(value: Any) -> int:
+    """Normalize a config / override into a keep-last count.
+
+    ``None`` / invalid / bool → default. Negative → 0 (summary-bound only).
+    Values above ``_MAX_REASONING_REPLAY_KEEP_LAST`` are capped.
+    """
+    if isinstance(value, bool) or value is None:
+        return DEFAULT_REASONING_REPLAY_KEEP_LAST
+    if isinstance(value, float):
+        if not value.is_integer():
+            return DEFAULT_REASONING_REPLAY_KEEP_LAST
+        value = int(value)
+    elif not isinstance(value, int):
+        try:
+            value = int(str(value).strip())
+        except (TypeError, ValueError):
+            return DEFAULT_REASONING_REPLAY_KEEP_LAST
+    if value < 0:
+        return 0
+    return min(value, _MAX_REASONING_REPLAY_KEEP_LAST)
+
+
+def resolve_reasoning_replay_keep_last(source: Any = None) -> int:
+    """Read keep-last from an int, a compressor-like object, or the default."""
+    if source is None:
+        return DEFAULT_REASONING_REPLAY_KEEP_LAST
+    if isinstance(source, (int, float, str)) and not isinstance(source, bool):
+        return clamp_reasoning_replay_keep_last(source)
+    raw = getattr(source, "reasoning_replay_keep_last", None)
+    if raw is None:
+        return DEFAULT_REASONING_REPLAY_KEEP_LAST
+    return clamp_reasoning_replay_keep_last(raw)
+
+
+def last_compaction_index(messages: Iterable[Any]) -> Optional[int]:
+    """Index of the most recent compaction-summary message, or ``None``."""
+    from agent.context_compressor import ContextCompressor
+
+    last: Optional[int] = None
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            continue
+        if ContextCompressor._has_compressed_summary_metadata(message):
+            last = index
+            continue
+        if ContextCompressor._is_context_summary_content(message.get("content")):
+            last = index
+    return last
+
+
+def _has_replayable_reasoning(message: Any) -> bool:
+    if not isinstance(message, dict) or message.get("role") != "assistant":
+        return False
+    items = message.get("codex_reasoning_items")
+    if not isinstance(items, list):
+        return False
+    return any(isinstance(item, dict) and item.get("encrypted_content") for item in items)
+
+
+def reasoning_replay_keep_indices(
+    messages: Iterable[Any],
+    *,
+    keep_last: Any = DEFAULT_REASONING_REPLAY_KEEP_LAST,
+) -> frozenset[int]:
+    """Message indices whose encrypted reasoning may be replayed.
+
+    1. Assistant reasoning at or before the latest compaction summary is
+       dropped — those turns were summarized and must not re-anchor.
+    2. Among remaining reasoning-bearing assistant turns, keep only the
+       last ``keep_last`` (``0`` = no extra cap).
+    """
+    message_list = list(messages)
+    cutoff = last_compaction_index(message_list)
+    start = 0 if cutoff is None else cutoff + 1
+    candidates = [
+        index
+        for index in range(start, len(message_list))
+        if _has_replayable_reasoning(message_list[index])
+    ]
+    limit = clamp_reasoning_replay_keep_last(keep_last)
+    if limit <= 0:
+        return frozenset(candidates)
+    return frozenset(candidates[-limit:])

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -497,6 +497,7 @@ class ResponsesApiTransport(ProviderTransport):
             native_compaction_eligible=_native_compaction_active(
                 kwargs.get("context_management")
             ),
+            reasoning_replay_keep_last=kwargs.get("reasoning_replay_keep_last"),
         )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
@@ -739,6 +740,7 @@ class ResponsesApiTransport(ProviderTransport):
                 replay_encrypted_reasoning=replay_encrypted_reasoning,
                 current_issuer_kind=issuer_kind,
                 native_compaction_eligible=native_compaction_active,
+                reasoning_replay_keep_last=params.get("reasoning_replay_keep_last"),
             ),
             "store": False,
         }

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -627,6 +627,12 @@ compression:
   # compression of older turns.
   protect_last_n: 20
 
+  # Encrypted Codex reasoning replayed on later Requests: keep only the last N
+  # post-compaction assistant turns that carry reasoning (default: 8). 0 means
+  # no extra turn cap (still drop reasoning older than the most recent
+  # compaction summary). Reasoning at or before that summary is never replayed.
+  reasoning_replay_keep_last: 8
+
   # Minimum number of REAL (actionable) user messages guaranteed to survive in
   # the uncompressed tail (default: 1 = the existing single last-user anchor,
   # behavior-preserving). Raise to e.g. 3 to keep the last 3 real user turns

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -882,6 +882,12 @@ DEFAULT_CONFIG = {
                                       #              tail (100-240K tokens on big-window
                                       #              or raised-threshold setups).
         "protect_last_n": 20,         # minimum recent messages to keep uncompressed
+        "reasoning_replay_keep_last": 8,  # encrypted Codex reasoning replayed on
+                                      # later Requests: keep only the last N
+                                      # post-compaction assistant turns that
+                                      # carry reasoning. 0 = no extra turn cap
+                                      # (still drop reasoning older than the
+                                      # most recent compaction summary).
         "min_tail_user_messages": 1,  # REAL (actionable) user messages guaranteed to
                                       # survive in the uncompressed tail. 1 = existing
                                       # single last-user anchor (default, behavior-

--- a/tests/agent/test_context_freshness.py
+++ b/tests/agent/test_context_freshness.py
@@ -1,0 +1,171 @@
+"""Contracts for the first-milestone context-freshness layer.
+
+The resolver must drop reasoning that predates the latest compaction
+summary and cap replay to the last N post-summary assistant turns.
+Persisted message dicts are left unchanged — only request assembly
+filters replay.
+"""
+
+from agent.context_freshness import (
+    DEFAULT_REASONING_REPLAY_KEEP_LAST,
+    PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE,
+    clamp_reasoning_replay_keep_last,
+    last_compaction_index,
+    reasoning_replay_keep_indices,
+)
+from agent.codex_responses_adapter import _chat_messages_to_responses_input
+from agent.context_compressor import SUMMARY_PREFIX
+
+
+def _reasoning(blob: str) -> list[dict]:
+    return [{"type": "reasoning", "encrypted_content": blob, "id": f"rs_{blob}"}]
+
+
+def _assistant(text: str, blob: str | None = None) -> dict:
+    msg = {"role": "assistant", "content": text}
+    if blob is not None:
+        msg["codex_reasoning_items"] = _reasoning(blob)
+    return msg
+
+
+def _summary() -> dict:
+    return {
+        "role": "user",
+        "content": f"{SUMMARY_PREFIX}\n## Goal\nPrior work.",
+    }
+
+
+def test_clamp_keep_last_rejects_bool_and_fraction():
+    assert clamp_reasoning_replay_keep_last(None) == DEFAULT_REASONING_REPLAY_KEEP_LAST
+    assert clamp_reasoning_replay_keep_last(True) == DEFAULT_REASONING_REPLAY_KEEP_LAST
+    assert clamp_reasoning_replay_keep_last(1.5) == DEFAULT_REASONING_REPLAY_KEEP_LAST
+    assert clamp_reasoning_replay_keep_last(-3) == 0
+    assert clamp_reasoning_replay_keep_last(0) == 0
+    assert clamp_reasoning_replay_keep_last(4) == 4
+
+
+def test_last_compaction_index_finds_latest_summary():
+    messages = [
+        {"role": "user", "content": "start"},
+        _assistant("old", "old_blob"),
+        _summary(),
+        {"role": "user", "content": "continue"},
+        _summary(),
+        _assistant("new", "new_blob"),
+    ]
+    assert last_compaction_index(messages) == 4
+
+
+def test_keep_indices_drop_pre_summary_and_cap_recent():
+    messages = [
+        {"role": "user", "content": "a"},
+        _assistant("one", "b1"),
+        {"role": "user", "content": "b"},
+        _assistant("two", "b2"),
+        _summary(),
+        {"role": "user", "content": "c"},
+        _assistant("three", "b3"),
+        {"role": "user", "content": "d"},
+        _assistant("four", "b4"),
+        {"role": "user", "content": "e"},
+        _assistant("five", "b5"),
+    ]
+    kept = reasoning_replay_keep_indices(messages, keep_last=2)
+    assert kept == frozenset({8, 10})
+    # History is not mutated.
+    assert messages[1]["codex_reasoning_items"][0]["encrypted_content"] == "b1"
+
+
+def test_keep_indices_zero_keep_last_is_summary_bound_only():
+    messages = [
+        _assistant("old", "old"),
+        _summary(),
+        _assistant("new1", "n1"),
+        _assistant("new2", "n2"),
+        _assistant("new3", "n3"),
+    ]
+    kept = reasoning_replay_keep_indices(messages, keep_last=0)
+    assert kept == frozenset({2, 3, 4})
+
+
+def test_adapter_replays_only_kept_reasoning():
+    messages = [
+        {"role": "user", "content": "start"},
+        _assistant("stale interpretation", "stale"),
+        _summary(),
+        {"role": "user", "content": "correction: use postgres"},
+        _assistant("ack", "recent1"),
+        {"role": "user", "content": "and pin 16"},
+        _assistant("ack2", "recent2"),
+        {"role": "user", "content": "go"},
+        _assistant("working", "recent3"),
+    ]
+    items = _chat_messages_to_responses_input(
+        messages, reasoning_replay_keep_last=2
+    )
+    blobs = [
+        item.get("encrypted_content")
+        for item in items
+        if isinstance(item, dict) and item.get("type") == "reasoning"
+    ]
+    assert "stale" not in blobs
+    assert blobs == ["recent2", "recent3"]
+    # Persisted history still holds the dropped blob.
+    assert messages[1]["codex_reasoning_items"][0]["encrypted_content"] == "stale"
+
+
+def test_adapter_keeps_native_compaction_checkpoint_outside_keep_window():
+    messages = [
+        {
+            "role": "assistant",
+            "content": "old",
+            "codex_reasoning_items": [
+                {
+                    "type": "compaction",
+                    "encrypted_content": "checkpoint_blob",
+                    "id": "cmp_1",
+                },
+                {
+                    "type": "reasoning",
+                    "encrypted_content": "stale_reason",
+                    "id": "rs_old",
+                },
+            ],
+        },
+        _summary(),
+        _assistant("new", "fresh"),
+    ]
+    items = _chat_messages_to_responses_input(
+        messages,
+        reasoning_replay_keep_last=1,
+        native_compaction_eligible=True,
+    )
+    blobs = [
+        (item.get("type"), item.get("encrypted_content"))
+        for item in items
+        if isinstance(item, dict) and item.get("encrypted_content")
+    ]
+    assert ("compaction", "checkpoint_blob") in blobs
+    assert ("reasoning", "stale_reason") not in blobs
+    assert ("reasoning", "fresh") in blobs
+
+
+def test_adapter_default_still_replays_a_single_recent_item():
+    messages = [
+        {"role": "user", "content": "hello"},
+        _assistant("hi", "enc123"),
+        {"role": "user", "content": "follow up"},
+    ]
+    items = _chat_messages_to_responses_input(messages)
+    blobs = [
+        item.get("encrypted_content")
+        for item in items
+        if isinstance(item, dict) and item.get("type") == "reasoning"
+    ]
+    assert blobs == ["enc123"]
+
+
+def test_unverified_guidance_is_actionable():
+    assert "unverified" in PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE.lower()
+    assert "new turns" in PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE.lower()
+    assert "ground truth" in PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE.lower()

--- a/tests/agent/test_pre_compress_memory_context.py
+++ b/tests/agent/test_pre_compress_memory_context.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from agent.context_compressor import ContextCompressor
+from agent.context_freshness import PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE
 
 
 def _make_compressor():
@@ -91,6 +92,7 @@ def test_memory_context_injected_into_iterative_summary_prompt():
 
     assert len(prompts) == 1
     assert "PREVIOUS SUMMARY:\nPrevious checkpoint." in prompts[0]
+    assert PREVIOUS_SUMMARY_UNVERIFIED_GUIDANCE in prompts[0]
     assert "MEMORY PROVIDER CONTEXT" in prompts[0]
     assert "Checkpoint id: ctx-123" in prompts[0]
 


### PR DESCRIPTION
## What does this PR do?

First milestone for context drift across compaction and reasoning replay.

Iterative compaction currently treats the previous summary as ground truth, and encrypted Codex reasoning can be replayed without a bound between compactions. Those two paths let stale decisions re-anchor the next request even after the user has corrected them.

This change:

1. Tells the iterative summarizer that the previous compaction summary is unverified background. New turns, later user corrections, and current file/system state win over conflicting claims in that summary.
2. Drops encrypted reasoning at or before the latest compaction summary, then keeps only the last N post-summary reasoning-bearing assistant turns (`compression.reasoning_replay_keep_last`, default 8; `0` disables the extra turn cap). Native compaction checkpoints (`type=compaction`) stay on their existing eligibility gate.

A full timestamped claim resolver across MEMORY.md, MCP recall, and files is intentionally out of scope. That would mutate the cached system prompt. Existing `SUMMARY_PREFIX` latest-user-wins / REFERENCE ONLY behavior is unchanged.

## Related Issue

https://github.com/NousResearch/hermes-agent/issues/99573

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/context_freshness.py` — shared helpers: previous-summary guidance, last-compaction index, reasoning replay keep-indices
- `agent/context_compressor.py` — interpolates the unverified-summary guidance into the iterative summarizer prompt
- `agent/codex_responses_adapter.py`, `agent/transports/codex.py`, `agent/chat_completion_helpers.py` — apply the keep-last filter at request assembly (compaction checkpoints not freshness-dropped)
- `agent/agent_init.py`, `hermes_cli/config_defaults.py`, `cli-config.yaml.example` — `compression.reasoning_replay_keep_last` (default 8; no `_config_version` bump)
- `tests/agent/test_context_freshness.py` — keep-indices, adapter filter, checkpoint survival
- `tests/agent/test_pre_compress_memory_context.py` — asserts the new summarizer guidance is present

## How to Test

1. From the repo root with the project venv: `scripts/run_tests.sh tests/agent/test_context_freshness.py tests/agent/test_pre_compress_memory_context.py`
2. Also run the existing adapter / prefix / transport coverage: `scripts/run_tests.sh tests/agent/test_codex_responses_adapter.py tests/agent/test_summary_prefix_semantics.py tests/agent/transports/test_codex_transport.py`
3. Optional: set `compression.reasoning_replay_keep_last` in `config.yaml` (or `0` for summary-bound only) and confirm a Codex Responses session after compaction no longer replays pre-summary encrypted reasoning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/agent/test_context_freshness.py \
  tests/agent/test_pre_compress_memory_context.py \
  tests/agent/test_codex_responses_adapter.py \
  tests/run_agent/test_provider_parity.py \
  tests/run_agent/test_codex_xai_oauth_recovery.py \
  tests/agent/test_summary_prefix_semantics.py \
  tests/agent/transports/test_codex_transport.py \
  tests/agent/test_proactive_prune_config.py \
  tests/agent/test_compression_max_attempts_config.py
```

All listed files passed.
