### PR TITLE
fix(gateway): keep Matrix password-auth configs in the reconnect retry queue

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2620,7 +2620,7 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     Platforms that do not use ``PlatformConfig.token`` always return True so we
     never skip them here (Signal session paths, port-binding HTTP adapters, etc.).
     """
-    from gateway.config import PLATFORM_TOKEN_ENV_NAMES
+    from gateway.config import PLATFORM_TOKEN_ENV_NAMES, Platform
 
     if platform not in PLATFORM_TOKEN_ENV_NAMES:
         return True
@@ -2631,6 +2631,26 @@ def _platform_has_bot_credential(platform: "Platform", platform_config: "Platfor
     api_key = getattr(platform_config, "api_key", None) or ""
     if isinstance(api_key, str) and api_key.strip():
         return True
+    # Matrix also authenticates by password login (MATRIX_USER_ID +
+    # MATRIX_PASSWORD, no MATRIX_ACCESS_TOKEN). Those credentials land in
+    # ``extra`` rather than ``.token``, so a token-only check reads a
+    # perfectly reconnectable password-auth config as credential-less and
+    # evicts it from the retry queue on the first transient failure — after
+    # which it stays down until the gateway is restarted by hand. Mirror the
+    # adapter's own gate: homeserver + user_id + password.
+    #
+    # Read ONLY from extra, never os.getenv: build_config() already copies all
+    # three env vars onto extra, and importing this module loads ~/.hermes/.env,
+    # so an env fallback would report "has credential" for every Matrix config
+    # on the box — including the empty-primary multiplex case (#64674) this
+    # check exists to evict.
+    if platform is Platform.MATRIX:
+        extra = getattr(platform_config, "extra", None) or {}
+        if all(
+            str(extra.get(key) or "").strip()
+            for key in ("homeserver", "user_id", "password")
+        ):
+            return True
     return False
 
 

--- a/tests/gateway/test_64674_multiplex_primary_token_scope.py
+++ b/tests/gateway/test_64674_multiplex_primary_token_scope.py
@@ -119,6 +119,60 @@ class TestPlatformHasBotCredential:
             Platform.TELEGRAM, PlatformConfig(enabled=True, token=None)
         ) is False
 
+    def test_matrix_password_login_is_a_credential(self):
+        """Matrix password auth has no .token but is fully reconnectable.
+
+        MATRIX_USER_ID + MATRIX_PASSWORD with no MATRIX_ACCESS_TOKEN is a
+        supported setup (build_config puts it on extra). Treating it as
+        credential-less evicted it from the reconnect queue on the first
+        transient failure, so a momentary DNS blip took Matrix down until
+        the gateway was restarted by hand.
+        """
+        from gateway.run import _platform_has_bot_credential
+
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra = {
+            "homeserver": "https://matrix.example.org",
+            "user_id": "@bot:matrix.example.org",
+            "password": "hunter2",
+        }
+        assert _platform_has_bot_credential(Platform.MATRIX, cfg) is True
+
+    @pytest.mark.parametrize(
+        "extra",
+        [
+            {},
+            {"homeserver": "https://matrix.example.org", "password": "hunter2"},
+            {"user_id": "@bot:matrix.example.org", "password": "hunter2"},
+            {"homeserver": "https://matrix.example.org", "user_id": "@bot:m.example.org"},
+            {"homeserver": "  ", "user_id": "  ", "password": "  "},
+        ],
+        ids=["empty", "no-user-id", "no-homeserver", "no-password", "blank"],
+    )
+    def test_matrix_incomplete_password_config_still_dropped(self, extra, monkeypatch):
+        """An incomplete Matrix config can never connect — keep evicting it.
+
+        Guards the #64674 intent, and specifically pins "read extra, not the
+        environment". A fully-populated MATRIX_* environment is set here on
+        purpose: on a real host those vars are present (build_config exports
+        them, and importing gateway.run loads ~/.hermes/.env), so an
+        implementation that falls back to os.getenv would report every Matrix
+        config as credentialed and never evict anything.
+
+        conftest sandboxes HERMES_HOME and scrubs MATRIX_* from the
+        environment, so without these explicit setenv calls this test would
+        pass against an env-reading implementation and guard nothing.
+        """
+        from gateway.run import _platform_has_bot_credential
+
+        monkeypatch.setenv("MATRIX_HOMESERVER", "https://env.example.org")
+        monkeypatch.setenv("MATRIX_USER_ID", "@envbot:env.example.org")
+        monkeypatch.setenv("MATRIX_PASSWORD", "env-password")
+
+        cfg = PlatformConfig(enabled=True)
+        cfg.extra = dict(extra)
+        assert _platform_has_bot_credential(Platform.MATRIX, cfg) is False
+
 
 class TestPrimaryStartupSkipsEmptyTokenUnderMultiplex:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

`_platform_has_bot_credential()` only recognises `PlatformConfig.token` (and
`api_key`). Matrix, however, also authenticates by password login —
`MATRIX_HOMESERVER` + `MATRIX_USER_ID` + `MATRIX_PASSWORD`, with no
`MATRIX_ACCESS_TOKEN`. Those credentials land in `PlatformConfig.extra`, not in
`.token`.

The reconnect watcher calls this helper to drop configs that can never
reconnect (the empty-primary multiplex case, #64674). A password-auth Matrix
config therefore reads as credential-less and is evicted from the retry queue
on the **first** transient failure:

```
WARNING gateway.run: Reconnect matrix: no bot credential on queued config, removing from retry queue
```

After that, Matrix stays down until the gateway is restarted by hand.

## How it shows up in practice

On my host this fired reproducibly at boot. The gateway starts ~3s into boot,
before DNS is ready, so the initial Matrix login fails:

```
ERROR hermes_plugins.matrix_platform.adapter: Matrix: login failed —
  Cannot connect to host <homeserver>:443 [Temporary failure in name resolution]
WARNING gateway.run: ✗ matrix failed to connect
WARNING gateway.run: Reconnect matrix: no bot credential on queued config, removing from retry queue
```

Every occurrence landed 1–2 minutes after a reboot. The failure is transient
and the config is perfectly reconnectable — but the retry queue has already
discarded it.

## Fix

Mirror the adapter's own auth gate: treat a Matrix config as having a
credential when `homeserver` + `user_id` + `password` are all present in
`extra`.

Two deliberate constraints:

- **Read only from `extra`, never `os.getenv`.** `build_config()` already
  copies all three env vars onto `extra`, and importing this module loads
  `~/.hermes/.env`. An env fallback would report "has credential" for every
  Matrix config on the box — including the empty-primary multiplex case that
  this check exists to evict.
- **Scoped to `Platform.MATRIX`**, so no other platform's eviction semantics
  change.

## Tests

Extends `tests/gateway/test_64674_multiplex_primary_token_scope.py`, covering
password-auth configs being retained, partial credentials still being evicted,
and the #64674 empty-primary multiplex case continuing to evict. 12 passed.
