### PR TITLE
fix(gateway): stop logging an AttributeError traceback when AF_UNIX i…

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -526,59 +526,76 @@ async def loop_heartbeat_forever(
     # disables the witness, and the payload flag tells probes that staleness is
     # no longer sufficient authority to escalate.
     #
-    # Windows: asyncio.start_unix_server raises (no AF_UNIX event-loop
+    # Windows: asyncio.start_unix_server does not exist (no AF_UNIX event-loop
     # support), so the witness is PERMANENTLY absent there — the payload
     # records loop_tick_socket=False and every stale-file probe classifies
     # UNKNOWN, never WEDGED. That is deliberate fail-safe: a wedged native
     # Windows gateway keeps the graceful-drain backstop instead of an
     # escalation verdict built on a witness that cannot exist. (WSL2 — the
     # #90502 incident environment — is Linux and arms the socket normally.)
+    #
+    # Gate on the capability instead of letting the call raise into the
+    # except-arm below: an expected, permanent platform limitation is not a
+    # bind failure, and logging it with a traceback on every startup reads as
+    # a crash to operators. Attribute check rather than sys.platform so any
+    # other AF_UNIX-less build takes the same calm path.
     tick_server = None
     tick_socket_path = None
-    try:
-        tick_socket_path = get_loop_tick_socket_path(home)
-        tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
-        # Re-bind over a leftover node from a dead process (os._exit(75) /
-        # SIGKILL skip the finally-unlink; PID reuse re-lands on this
-        # PID-suffixed path) is handled by asyncio itself:
-        # create_unix_server os.remove()s an existing socket node before
-        # binding — guarded by test_producer_rebinds_over_stale_socket_node.
-        # What asyncio does NOT do is clean up SIBLING nodes from other
-        # dead PIDs, so sweep those to keep state/ from accumulating
-        # gateway.loop-tick.*.sock nodes across crash-restart cycles.
-        # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
-        # Windows os.kill calls TerminateProcess for non-CTRL signals —
-        # and AF_UNIX server nodes are never created there anyway.
-        if os.name == "posix":
-            try:
-                for _stale in tick_socket_path.parent.glob(
-                    "gateway.loop-tick.*.sock"
-                ):
-                    if _stale == tick_socket_path:
-                        continue
-                    try:
-                        _stale_pid = int(_stale.name.split(".")[-2])
-                    except (ValueError, IndexError):
-                        _stale.unlink(missing_ok=True)
-                        continue
-                    try:
-                        os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
-                    except OSError:
-                        _stale.unlink(missing_ok=True)
-            except Exception:
-                logger.debug(
-                    "stale loop-tick socket sweep failed", exc_info=True
-                )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
+    if not hasattr(asyncio, "start_unix_server"):
+        logger.info(
+            "Loop tick socket unsupported on this platform — liveness probes "
+            "will have no loop-scheduling witness and will not escalate on a "
+            "stale heartbeat (graceful drain remains the backstop)"
         )
-    except Exception:
-        tick_server = None
-        logger.warning(
-            "Loop tick socket unavailable — liveness probes will have no "
-            "loop-scheduling witness and will not escalate on a stale heartbeat",
-            exc_info=True,
-        )
+    else:
+        try:
+            tick_socket_path = get_loop_tick_socket_path(home)
+            tick_socket_path.parent.mkdir(parents=True, exist_ok=True)
+            # Re-bind over a leftover node from a dead process (os._exit(75) /
+            # SIGKILL skip the finally-unlink; PID reuse re-lands on this
+            # PID-suffixed path) is handled by asyncio itself:
+            # create_unix_server os.remove()s an existing socket node before
+            # binding — guarded by test_producer_rebinds_over_stale_socket_node.
+            # What asyncio does NOT do is clean up SIBLING nodes from other
+            # dead PIDs, so sweep those to keep state/ from accumulating
+            # gateway.loop-tick.*.sock nodes across crash-restart cycles.
+            # POSIX-only: os.kill(pid, 0) is a liveness probe here, but on
+            # Windows os.kill calls TerminateProcess for non-CTRL signals —
+            # and AF_UNIX server nodes are never created there anyway.
+            if os.name == "posix":
+                try:
+                    for _stale in tick_socket_path.parent.glob(
+                        "gateway.loop-tick.*.sock"
+                    ):
+                        if _stale == tick_socket_path:
+                            continue
+                        try:
+                            _stale_pid = int(_stale.name.split(".")[-2])
+                        except (ValueError, IndexError):
+                            _stale.unlink(missing_ok=True)
+                            continue
+                        try:
+                            os.kill(_stale_pid, 0)  # windows-footgun: ok — inside os.name == "posix" gate
+                        except OSError:
+                            _stale.unlink(missing_ok=True)
+                except Exception:
+                    logger.debug(
+                        "stale loop-tick socket sweep failed", exc_info=True
+                    )
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        except Exception:
+            # A real bind failure (permissions, path length, exhausted fds) —
+            # unexpected on a platform that has AF_UNIX, so it keeps the
+            # traceback.
+            tick_server = None
+            logger.warning(
+                "Loop tick socket unavailable — liveness probes will have no "
+                "loop-scheduling witness and will not escalate on a stale "
+                "heartbeat",
+                exc_info=True,
+            )
 
     async def _write_off_loop() -> None:
         # write_loop_heartbeat never raises, so a failure here is an executor

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -403,3 +403,49 @@ def test_loop_scheduling_witness_is_served_by_the_loop_itself():
     assert "await asyncio.start_unix_server(" in body, (
         "the loop-scheduling witness socket is not armed by the loop task"
     )
+
+
+def test_witness_absent_platform_logs_calmly_without_a_traceback(tmp_path):
+    """No AF_UNIX (native Windows) is a platform fact, not a bind failure.
+
+    Letting ``asyncio.start_unix_server`` raise into the except-arm printed an
+    ``AttributeError`` traceback on every gateway startup, which operators read
+    as a crash. The witness is still absent — ``loop_tick_socket`` stays False
+    so probes classify UNKNOWN, never WEDGED — but the log stays a one-liner.
+    """
+    written = {}
+
+    def capture_write(**kwargs):
+        written.update(kwargs)
+        return pathlib.Path("/dev/null")
+
+    async def scenario() -> None:
+        # Delete rather than patch to False: the production gate is a
+        # hasattr() capability check, matching a real AF_UNIX-less build.
+        with (
+            patch.object(asyncio, "start_unix_server", create=True),
+            patch(
+                "gateway.shutdown_watchdog.write_loop_heartbeat", capture_write
+            ),
+            patch("gateway.shutdown_watchdog.logger.warning") as warning,
+            patch("gateway.shutdown_watchdog.logger.info") as info,
+        ):
+            delattr(asyncio, "start_unix_server")
+            await loop_heartbeat_forever(
+                interval_s=60.0,
+                home=tmp_path,
+                should_continue=lambda: False,
+            )
+        assert not warning.called, (
+            "the absent-witness platform still logs a warning traceback: %r"
+            % (warning.call_args_list,)
+        )
+        assert info.called, "the absent witness was not reported at all"
+        assert any(
+            "Loop tick socket unsupported" in str(call.args[0])
+            for call in info.call_args_list
+        ), "no calm one-liner explaining the missing witness"
+
+    asyncio.run(scenario())
+    # The fail-safe half of the contract: probes must still see no witness.
+    assert written["extra"]["loop_tick_socket"] is False


### PR DESCRIPTION
## What does this PR do?

On native Windows, `asyncio` has no `start_unix_server`, so arming the loop-scheduling witness socket in `loop_heartbeat_forever` raised an `AttributeError` straight into the surrounding best-effort `except` arm — which logs with `exc_info=True`. The result was a full traceback printed on **every** gateway startup:

```
2026-08-31 10:52:33,693 WARNING gateway.shutdown_watchdog: Loop tick socket unavailable — liveness probes will have no loop-scheduling witness and will not escalate on a stale heartbeat
Traceback (most recent call last):
  File "...\hermes-agent\gateway\shutdown_watchdog.py", line 572, in loop_heartbeat_forever
    tick_server = await asyncio.start_unix_server(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'asyncio' has no attribute 'start_unix_server'
```

Nothing is actually broken — the witness being absent on Windows is intended, documented behavior — but a traceback on a healthy startup reads as a crash, and Windows users reasonably report it as one.

The fix gates the arming block on the capability rather than letting the call raise. A permanent platform limitation is not a bind failure, so it gets a calm one-line `INFO`. The `except` arm keeps its traceback for *real* bind failures (permissions, path length, exhausted fds), which remain genuinely unexpected on a platform that has AF_UNIX.

The fail-safe contract is unchanged: `loop_tick_socket` stays `False` in the heartbeat payload, so stale-file probes still classify UNKNOWN and never escalate to WEDGED. A wedged native-Windows gateway keeps the graceful-drain backstop, exactly as before.

I used `hasattr(asyncio, "start_unix_server")` rather than `sys.platform == "win32"` so any other AF_UNIX-less build takes the same path. `gateway/control_socket.py` keeps its `_IS_WINDOWS` constant because it branches to a real named-pipe implementation; here there is no fallback to select between, only "arm it" or "don't".

## Related Issue

No existing issue — found in the wild on a native Windows gateway startup (v0.20.6).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/shutdown_watchdog.py` — gate the loop-tick witness arming on `hasattr(asyncio, "start_unix_server")`; log a one-line `INFO` when the platform has no AF_UNIX instead of routing an expected `AttributeError` through the `exc_info=True` warning. The `try`/`except` block is otherwise unchanged (the diff is mostly re-indentation into the new `else:`), and a comment now records why the except arm still keeps its traceback.
- `tests/gateway/test_loop_liveness_watchdog.py` — new `test_witness_absent_platform_logs_calmly_without_a_traceback`.

## How to Test

1. `pytest tests/gateway/test_loop_liveness_watchdog.py tests/hermes_cli/test_update_wedged_gateway.py -q` → 42 passed.
2. The new test simulates an AF_UNIX-less build by deleting `asyncio.start_unix_server`, then asserts no `logger.warning` fires, that the `INFO` one-liner does, and that `loop_tick_socket` is still `False` in the heartbeat payload — i.e. the noise goes away without weakening the fail-safe.
3. Proof it isn't vacuous: reverting only the `shutdown_watchdog.py` change makes the new test fail with exactly the call from the report above —
   ```
   AssertionError: the absent-witness platform still logs a warning traceback:
   [call('Loop tick socket unavailable — liveness probes will have no loop-scheduling
     witness and will not escalate on a stale heartbeat', exc_info=True)]
   ```
4. The pre-existing `test_loop_scheduling_witness_is_served_by_the_loop_itself` still passes: it asserts `await asyncio.start_unix_server(` stays inline in `loop_heartbeat_forever`, and the call is only indented, never moved into a helper.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not the full suite.** I ran the two suites covering this code (`tests/gateway/test_loop_liveness_watchdog.py`, `tests/hermes_cli/test_update_wedged_gateway.py`, 42 passed). Happy to run more if CI flags anything.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0), Python 3.11. **Note:** the changed branch is Windows-only, so it is covered by the simulated test rather than by a native Windows run — the original traceback was reported from a native Windows gateway on v0.20.6.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A *(N/A — the existing in-code comment block on the Windows behavior is updated in place; `start_unix_server` "raises" became "does not exist", which is the accurate description.)*
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A *(N/A — no config keys.)*
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A *(N/A.)*
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — this change is entirely about cross-platform behavior. POSIX behavior is byte-for-byte identical: the gate is true there, so the same `try` block runs and the same socket is armed.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A *(N/A.)*
