### PR TITLE
fix(kanban): count kanban_request_review as terminal in worker exit guard (#98107)

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -17,7 +17,7 @@ import os
 from typing import Any, Iterable, Optional
 
 
-_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block"})
+_TERMINAL_KANBAN_TOOLS = frozenset({"kanban_complete", "kanban_block", "kanban_request_review"})
 
 _DEFAULT_MAX_ATTEMPTS = 2
 


### PR DESCRIPTION
Fixes #98107

The kanban worker exit guard (`agent/kanban_stop.py`) only treated `kanban_complete` and `kanban_block` as terminal tools. A worker that correctly finished with `kanban_request_review` was considered non-terminal and nudged to call `kanban_complete` on a card already in `review`, which always fails with `unknown id or already terminal`. The worker then burns turns arguing with the guard.

**Fix:** include `kanban_request_review` in `_TERMINAL_KANBAN_TOOLS` so `session_called_kanban_terminal` and `build_kanban_stop_nudge` recognize a review handoff as a valid terminal action.

**Test:** `pytest tests/agent/test_kanban_stop.py` (3 passed); verified `session_called_kanban_terminal` returns True for `kanban_request_review` tool calls/results and `build_kanban_stop_nudge` returns None after a review request.

Closes #98107