### PR TITLE
fix(state): catch segment-dependent FTS corruption in the health probe

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3385,10 +3385,12 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
         # damage can be segment-state dependent (#100227) — a probe whose
         # trigram tokens land in a healthy segment succeeds while real user
         # messages whose terms hit the corrupt (segid, term) key range fail
-        # with IntegrityError. The variants cover high-frequency English
-        # trigrams (most likely present in any populated segment) plus a
-        # per-run unique token, spanning the token space real messages draw
-        # from.
+        # with IntegrityError. The variants widen which segments get
+        # exercised: high-frequency English trigrams are the most likely to
+        # be populated, and the per-run unique token samples a fresh key
+        # range each run. Content probing stays heuristic — it narrows this
+        # corruption class without eliminating it; an inspection-based
+        # shadow-table consistency check is the deterministic complement.
         probe_variants = (
             "_fts_health_probe",
             "the quick brown fox jumps over the lazy dog and then the team "

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3374,24 +3374,39 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # while reads of the FTS5 table itself parse fine.
                 return f"fts5 read probe failed on {fts_table}: {exc}"
 
-        # FTS write probe: drive a row through the messages_fts* triggers in a
+        # FTS write probe: drive rows through the messages_fts* triggers in a
         # transaction that is always rolled back, so a corrupt FTS index that
         # rejects writes is caught even though reads look healthy. The probe is
         # best-effort — if the messages/sessions tables don't exist yet (brand
         # new file mid-init) the OperationalError is treated as "not yet a
         # populated DB", not corruption.
         probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
+        # Several distinct contents, not one fixed string: FTS5 shadow-table
+        # damage can be segment-state dependent (#100227) — a probe whose
+        # trigram tokens land in a healthy segment succeeds while real user
+        # messages whose terms hit the corrupt (segid, term) key range fail
+        # with IntegrityError. The variants cover high-frequency English
+        # trigrams (most likely present in any populated segment) plus a
+        # per-run unique token, spanning the token space real messages draw
+        # from.
+        probe_variants = (
+            "_fts_health_probe",
+            "the quick brown fox jumps over the lazy dog and then the team "
+            "said it was one of those things for the project",
+            f"hermes fts health probe unique token {time.time_ns()}",
+        )
         try:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
                 (probe_session_id, "_health_probe", time.time()),
             )
-            conn.execute(
-                "INSERT INTO messages (session_id, role, content, timestamp) "
-                "VALUES (?, ?, ?, ?)",
-                (probe_session_id, "user", "_fts_health_probe", time.time()),
-            )
+            for probe_content in probe_variants:
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp) "
+                    "VALUES (?, ?, ?, ?)",
+                    (probe_session_id, "user", probe_content, time.time()),
+                )
             conn.execute("ROLLBACK")
         except sqlite3.OperationalError as exc:
             # Missing tables / FTS disabled — not the corruption class we probe.
@@ -3409,6 +3424,18 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # a tokenizer-less one self-heals by dropping the triggers.
                 return None
             return str(exc)
+        except sqlite3.IntegrityError as exc:
+            # Segment-dependent FTS corruption surfaces as a shadow-table
+            # constraint violation (PRIMARY KEY (segid, term) collision in
+            # messages_fts_trigram_idx, #100227) — IntegrityError, not
+            # OperationalError. Roll back so the probe stays
+            # non-destructive, and label the reason so the operator is sent
+            # to the FTS index, not the base tables.
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            return f"fts write probe failed: {exc}"
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -321,6 +321,100 @@ def test_fts_write_corruption_repaired_in_place(tmp_path):
     finally:
         db.close()
 
+def _corrupt_fts_segment_dependent(db_path: Path) -> None:
+    """Simulate segment-dependent FTS trigram corruption (#100227).
+
+    The reported on-disk corruption rejects writes into
+    ``messages_fts_trigram_idx`` with a PRIMARY KEY (segid, term) collision
+    only for messages whose trigrams land in the corrupt segment; a probe
+    string whose tokens live in a healthy segment passes. Model that shape
+    with a BEFORE INSERT trigger raising the exact IntegrityError signature
+    for contents carrying a common English trigram, while the legacy fixed
+    probe content passes — the exact blind spot of the single-string health
+    probe.
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.execute(
+        "CREATE TRIGGER messages_simulated_corrupt_segment "
+        "BEFORE INSERT ON messages WHEN NEW.content LIKE '% the %' "
+        "BEGIN SELECT RAISE(ABORT, "
+        "'UNIQUE constraint failed: "
+        "messages_fts_trigram_idx.segid, messages_fts_trigram_idx.term'); END"
+    )
+    conn.close()
+
+
+def test_segment_dependent_fts_corruption_detected_by_probe(tmp_path):
+    """The multi-variant write probe flags corruption a single fixed string misses.
+
+    Regression for #100227: ``hermes doctor`` / ``sessions repair
+    --check-only`` reported the DB healthy while every real message append
+    failed, because the probe's fixed content never hit the corrupt
+    (segid, term) key range.
+    """
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    assert _db_opens_cleanly(db_path) is None  # healthy before
+
+    _corrupt_fts_segment_dependent(db_path)
+
+    # Prove the corruption is content-dependent in the simulated shape: the
+    # legacy fixed probe content still writes fine, a common-English content
+    # fails with the constraint signature — so only a multi-variant probe
+    # can see it.
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        conn.execute("BEGIN")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES ((SELECT id FROM sessions LIMIT 1), 'user', "
+            "'_fts_health_probe', 0)"
+        )
+        try:
+            conn.execute(
+                "INSERT INTO messages (session_id, role, content, timestamp) "
+                "VALUES ((SELECT id FROM sessions LIMIT 1), 'user', "
+                "'over the lazy dog', 0)"
+            )
+            pytest.fail("simulated corrupt-segment insert unexpectedly succeeded")
+        except sqlite3.IntegrityError as exc:
+            assert "messages_fts_trigram_idx" in str(exc)
+        conn.execute("ROLLBACK")
+    finally:
+        conn.close()
+
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert reason.startswith("fts write probe failed:")
+    assert "messages_fts_trigram_idx" in reason
+
+
+def test_healthy_db_fts_write_probe_leaves_no_residue(tmp_path):
+    """The multi-variant probe is still non-destructive on a healthy DB."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    assert _db_opens_cleanly(db_path) is None
+
+    # The probe rolled back: no probe session or message rows leaked in.
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        probe_sessions = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id LIKE '_hermes_fts_health_probe_%'"
+        ).fetchone()[0]
+        probe_messages = conn.execute(
+            "SELECT COUNT(*) FROM messages WHERE content LIKE "
+            "'%fts health probe unique token%'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert probe_sessions == 0
+    assert probe_messages == 0
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

`_db_opens_cleanly` (the probe behind `hermes doctor` and `hermes sessions repair --check-only`) drove a **single fixed probe string** through the FTS triggers. Per #100227, FTS5 shadow-table damage can be **segment-state dependent**: a probe whose trigram tokens land in a healthy segment succeeds while real user messages whose terms hit the corrupt `(segid, term)` key range fail with `sqlite3.IntegrityError: constraint failed` — so the probe reported the DB healthy while every real message append aborted with `session_persistence_failed`.

This PR:

- drives **several distinct probe contents** through the same rolled-back transaction instead of one fixed string: the legacy fixed string (kept for continuity), a high-frequency-English-trigram sentence (most likely to collide with terms in any populated segment), and a per-run unique token (samples a fresh key range each run). This **narrows the segment-dependent corruption class — it does not eliminate it**: content probing is a heuristic, and no finite variant set is guaranteed to reach an unknown corrupt segment. A deterministic shadow-table consistency check (suggestion 3 in #100227) is the natural follow-up complement;
- catches `sqlite3.IntegrityError` explicitly at the write probe and returns a labelled reason (`fts write probe failed: ...`) with a rollback, instead of letting it fall through to the bare outer `DatabaseError` catch with no context. `IntegrityError` is not an `OperationalError` subclass, so it previously bypassed the probe's own error handling entirely.

The read probe, capability-classification (no fts5 module / no tokenizer), and the fail-open paths for brand-new DBs are unchanged.

## Related Issue

Fixes #100227

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py` — `_db_opens_cleanly`: multi-variant FTS write probe (3 distinct contents in one rolled-back transaction) + explicit `IntegrityError` handling with a labelled reason; comment scoped to "narrows, not eliminates" per review.
- `tests/test_state_db_malformed_repair.py` — regression tests: a content-dependent shadow-table constraint violation that the legacy fixed string passes but a common-English content trips is now reported unhealthy; the multi-variant probe leaves no residue on a healthy DB.

## How to Test

1. `pytest tests/test_state_db_malformed_repair.py tests/test_state_db_repair_live_writer_guard.py tests/test_state_db_repair_non_destructive.py -q` → Observed result: 50 passed, 2 skipped.
2. `pytest tests/test_hermes_state.py -q` → Observed result: 243 passed, 2 skipped.
3. The new `test_segment_dependent_fts_corruption_detected_by_probe` first proves the simulated corruption is content-dependent (the legacy fixed probe content inserts fine; a common-English content raises the exact `(segid, term)` constraint signature), then asserts the probe reports it with a labelled reason — should pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(state):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (state/repair suites listed above)
- [x] I've added tests for my changes (required for bug fixes)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — or N/A (internal probe logic, behaviour unchanged for healthy DBs)
- [x] I've updated `cli-config.yaml.example` — or N/A (no config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — or N/A
- [x] I've considered cross-platform impact — or N/A (stdlib sqlite3 semantics, platform-independent)
- [x] I've updated tool descriptions/schemas — or N/A
