### PR TITLE
fix(simplex): scope multiplex secondary-profile config, not shared env

### DIFF
--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -91,6 +91,69 @@ def _parse_comma_list(value: str) -> List[str]:
     return [v.strip() for v in value.split(",") if v.strip()]
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed, connected, and reloaded
+    inside ``_profile_runtime_scope`` (secret scope installed + multiplex
+    active) — the same discriminator the Buzz adapter uses (#98738). The
+    DEFAULT profile under multiplexing runs unscoped: ``os.environ`` holds
+    its own bridge output there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _scoped_platform_setting(env_name, extra, key):
+    """Raw read of a non-secret SimpleX setting, multiplex-profile-correct.
+
+    Inside a secondary profile scope ``os.environ`` holds the DEFAULT
+    profile's YAML-to-env bridge output, so the profile's
+    ``PlatformConfig.extra`` is authoritative and env is not consulted: a
+    missing key yields ``None`` and callers fail closed to their default
+    instead of silently borrowing the default profile's daemon URL, group
+    allowlist, or auto-accept setting. Everywhere else — single-profile
+    gateways, the default profile under multiplexing — the legacy
+    ``os.getenv`` read is returned unchanged, so env-over-config precedence
+    is preserved.
+    """
+    if _profile_scoped():
+        return (extra or {}).get(key)
+    return os.getenv(env_name)
+
+
+def _profile_simplex_extra() -> dict:
+    """Read ``simplex.extra`` from the active profile's config.yaml (scoped path).
+
+    Only meaningful inside a secondary profile scope, where the hermes-home
+    override points at that profile's home. Used by ``check_requirements``
+    (which has no ``PlatformConfig`` argument) so the multiplex gate
+    consults the profile's own configuration instead of the process env.
+    Best-effort: any failure yields an empty mapping and the caller fails
+    closed.
+    """
+    if not _profile_scoped():
+        return {}
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import read_user_config_raw
+
+        cfg = read_user_config_raw(Path(get_hermes_home()) / "config.yaml")
+    except Exception:
+        return {}
+    if not isinstance(cfg, dict):
+        return {}
+    simplex = ((cfg.get("gateway") or {}).get("platforms") or {}).get("simplex")
+    if not isinstance(simplex, dict):
+        return {}
+    extra = simplex.get("extra", simplex)
+    return extra if isinstance(extra, dict) else {}
+
+
 def _redact_id(contact_id: str) -> str:
     """Redact a contact/group ID for logging."""
     if not contact_id:
@@ -152,20 +215,22 @@ class SimplexAdapter(BasePlatformAdapter):
 
         # Contact-request auto-accept (on by default — matches the way most
         # bot deployments expect to behave). Read from env first, then fall
-        # back to the value seeded by ``_env_enablement``.
-        env_auto = os.getenv("SIMPLEX_AUTO_ACCEPT")
-        if env_auto is not None:
-            self.auto_accept = env_auto.strip().lower() not in {"0", "false", "no", ""}
-        else:
-            self.auto_accept = bool(extra.get("auto_accept", True))
+        # back to the value seeded by ``_env_enablement``. Scope-aware: a
+        # secondary multiplex profile must not borrow the default profile's
+        # bridged env value (mirrors the Buzz fix for #98738).
+        _auto_raw = _scoped_platform_setting("SIMPLEX_AUTO_ACCEPT", extra, "auto_accept")
+        _auto_cfg = extra.get("auto_accept", True) if _auto_raw is None else _auto_raw
+        self.auto_accept = str(_auto_cfg).strip().lower() not in {"0", "false", "no", ""}
 
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
         # processes every member's traffic). Use ``*`` to accept any group.
-        group_allowed_str = os.getenv("SIMPLEX_GROUP_ALLOWED", "") or extra.get(
-            "group_allowed", ""
-        )
-        self.group_allow_from = set(_parse_comma_list(group_allowed_str))
+        # Scope-aware for the same reason as auto-accept above: a secondary
+        # profile's own (possibly tighter) allowlist must not be widened by
+        # the default profile's bridged env value.
+        _group_raw = _scoped_platform_setting("SIMPLEX_GROUP_ALLOWED", extra, "group_allowed")
+        group_allowed_str = _group_raw or extra.get("group_allowed", "")
+        self.group_allow_from = set(_parse_comma_list(group_allowed_str or ""))
 
         # Running state
         self._ws = None  # websockets connection
@@ -1172,7 +1237,15 @@ def check_requirements() -> bool:
     so the gateway never instantiates the adapter when the dependency is
     missing or no daemon URL is configured.
     """
-    if not os.getenv("SIMPLEX_WS_URL"):
+    if _profile_scoped():
+        # Multiplexed secondary profile: os.environ's SIMPLEX_WS_URL is the
+        # default profile's bridge output and must not satisfy this gate for
+        # a profile that never configured SimpleX itself (mirrors the Buzz
+        # fix for #98738). Consult the profile's own config.yaml instead; an
+        # unconfigured profile fails closed.
+        if not str(_profile_simplex_extra().get("ws_url", "")).strip():
+            return False
+    elif not os.getenv("SIMPLEX_WS_URL"):
         return False
     try:
         import websockets  # noqa: F401
@@ -1184,14 +1257,16 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    _ws_raw = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = _ws_raw or extra.get("ws_url", "")
     return bool(ws_url)
 
 
 def is_connected(config) -> bool:
     """Check whether SimpleX is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    _ws_raw = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = _ws_raw or extra.get("ws_url", "")
     return bool(ws_url)
 
 
@@ -1207,6 +1282,12 @@ def _env_enablement() -> Optional[dict]:
     becomes a proper ``HomeChannel`` dataclass on the ``PlatformConfig``
     rather than being merged into ``extra``.
     """
+    if _profile_scoped():
+        # Secondary profile scope: the process env's SIMPLEX_* values are
+        # the default profile's configuration, not this profile's — env
+        # enablement must not fabricate a SimpleX platform for a profile
+        # that did not configure one (mirrors the Buzz fix for #98738).
+        return None
     ws_url = os.getenv("SIMPLEX_WS_URL", "").strip()
     if not ws_url:
         return None
@@ -1257,9 +1338,8 @@ async def _standalone_send(
         return {"error": "websockets not installed. Run: pip install websockets"}
 
     extra = getattr(pconfig, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get(
-        "ws_url", "ws://127.0.0.1:5225"
-    )
+    _ws_raw = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = _ws_raw or extra.get("ws_url", "ws://127.0.0.1:5225")
     if not ws_url:
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -388,3 +388,245 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+# ---------------------------------------------------------------------------
+# 11. Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# ``__init__``'s auto-accept/group-allowlist reads, the registry gates
+# (``check_requirements``/``validate_config``/``is_connected``),
+# ``_env_enablement``, and ``_standalone_send`` all previously read raw
+# ``SIMPLEX_*`` env vars unconditionally. Under a multiplexed secondary
+# profile, ``os.environ`` holds the DEFAULT profile's YAML-to-env bridge
+# output — a secondary profile with its own (different, or absent) SimpleX
+# config would silently borrow the default profile's daemon URL, group
+# allowlist, or auto-accept setting. Mirrors the Buzz fix for #98738.
+
+_SIMPLEX_ENV_VARS = (
+    "SIMPLEX_WS_URL",
+    "SIMPLEX_AUTO_ACCEPT",
+    "SIMPLEX_GROUP_ALLOWED",
+    "SIMPLEX_HOME_CHANNEL",
+    "SIMPLEX_HOME_CHANNEL_NAME",
+    "SIMPLEX_ALLOWED_USERS",
+    "SIMPLEX_ALLOW_ALL_USERS",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_simplex_env(monkeypatch):
+    """Keep the new multiplex tests hermetic regardless of ambient env."""
+    for var in _SIMPLEX_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
+    monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "false")
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "*")
+    monkeypatch.setenv("SIMPLEX_HOME_CHANNEL", "default-contact")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config is authoritative, not the
+        default profile's wildcard group-allow / disabled auto-accept."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://profile-daemon:5225",
+                "auto_accept": True,
+                "group_allowed": "grp-secondary-only",
+            },
+        )
+        adapter = SimplexAdapter(cfg)
+        assert adapter.auto_accept is True
+        assert adapter.group_allow_from == {"grp-secondary-only"}
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's config must NOT borrow the default
+        profile's bridged env values — that would silently disable
+        auto-accept or widen the group allowlist to the default's wildcard."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = SimplexAdapter(PlatformConfig(enabled=True, extra={}))
+        # Default profile's env has AUTO_ACCEPT=false and GROUP_ALLOWED=*;
+        # an unconfigured secondary profile must fail closed to the
+        # documented safe defaults instead, not inherit either value.
+        assert adapter.auto_accept is True
+        assert adapter.group_allow_from == set()
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = SimplexAdapter(
+                PlatformConfig(enabled=True, extra={"auto_accept": True})
+            )
+        finally:
+            set_multiplex_active(False)
+        assert adapter.auto_accept is False
+        assert adapter.group_allow_from == {"*"}
+
+    def test_check_requirements_scoped_reads_profile_config(
+        self, multiplex_scope, default_profile_env, tmp_path
+    ):
+        """The gate must consult the profile's own config.yaml, not the
+        default profile's bridged SIMPLEX_WS_URL."""
+        import yaml
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
+
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(
+                {
+                    "gateway": {
+                        "platforms": {
+                            "simplex": {
+                                "enabled": True,
+                                "extra": {"ws_url": "ws://profile-daemon:5225"},
+                            }
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        multiplex_scope()
+        token = set_hermes_home_override(str(tmp_path))
+        try:
+            # The default profile's env WS_URL must NOT pass the gate on
+            # its own for a profile whose config.yaml has its own entry...
+            assert check_requirements() is True
+        finally:
+            reset_hermes_home_override(token)
+
+        # ...and a profile whose config.yaml has no simplex entry fails
+        # closed even though the default profile's env value is present.
+        empty_home = tmp_path / "empty-profile"
+        empty_home.mkdir()
+        multiplex_scope()
+        token = set_hermes_home_override(str(empty_home))
+        try:
+            assert check_requirements() is False
+        finally:
+            reset_hermes_home_override(token)
+
+    def test_validate_config_and_is_connected_scoped(
+        self, multiplex_scope, default_profile_env
+    ):
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        # Secondary profile's own extra is authoritative...
+        cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://profile-daemon:5225"})
+        assert validate_config(cfg) is True
+        assert is_connected(cfg) is True
+        # ...and an unconfigured secondary profile fails closed even though
+        # the default profile's env WS_URL is present.
+        empty_cfg = PlatformConfig(enabled=True, extra={})
+        assert validate_config(empty_cfg) is False
+        assert is_connected(empty_cfg) is False
+
+    def test_env_enablement_returns_none_when_profile_scoped(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Env enablement must not fabricate a SimpleX platform for a
+        secondary profile from the default profile's bridged env."""
+        multiplex_scope()
+        assert _env_enablement() is None
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_uses_scoped_ws_url(
+        self, default_profile_env, monkeypatch
+    ):
+        """Cron/out-of-process delivery must connect to the secondary
+        profile's own daemon, not the default profile's bridged env URL.
+
+        Scope is installed/reset inline (not via the ``multiplex_scope``
+        fixture) so the ``ContextVar`` set/reset pair stays inside the same
+        asyncio task context as this coroutine — resetting a token from the
+        surrounding sync fixture-teardown context raises ``ValueError:
+        token was created in a different Context``.
+        """
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+
+        set_multiplex_active(True)
+        token = set_secret_scope({})
+        try:
+            pconfig = MagicMock()
+            pconfig.extra = {"ws_url": "ws://profile-daemon:5225"}
+
+            class DummyWs:
+                async def __aenter__(self):
+                    return self
+
+                async def __aexit__(self, exc_type, exc, tb):
+                    return None
+
+                async def send(self, payload):
+                    pass
+
+            connected_urls = []
+
+            def fake_connect(url, **kwargs):
+                connected_urls.append(url)
+                return DummyWs()
+
+            import websockets
+
+            monkeypatch.setattr(websockets, "connect", fake_connect)
+            result = await _standalone_send(pconfig, "contact-42", "hi")
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+        assert result["success"] is True
+        assert connected_urls == ["ws://profile-daemon:5225"]
+
+


### PR DESCRIPTION
## What & why

The SimpleX adapter's `__init__` (`auto_accept`, group allowlist), `check_requirements`, `validate_config`, `is_connected`, `_env_enablement`, and `_standalone_send` all read `SIMPLEX_*` settings via raw `os.getenv` unconditionally.

Under a multiplexed gateway, a secondary profile's adapter construction and config-load hooks run inside a profile-scoped context (`_profile_runtime_scope`) where `os.environ` still holds the **default** profile's YAML-to-env bridge output. A secondary profile with its own (different, or absent) SimpleX configuration silently inherits the default profile's:

- daemon WebSocket URL (`SIMPLEX_WS_URL`) — cron/mid-turn delivery via `_standalone_send` connects to the wrong daemon
- group allowlist (`SIMPLEX_GROUP_ALLOWED`) — a secondary profile's own, possibly tighter, allowlist gets silently widened to the default profile's (e.g. the default's `*` wildcard)
- auto-accept setting (`SIMPLEX_AUTO_ACCEPT`)

`check_requirements`/`_env_enablement` also gate/seed platform enablement off the default profile's env during `load_gateway_config()`, which itself runs inside the secondary profile's scope.

Note: `SIMPLEX_ALLOWED_USERS`/`SIMPLEX_ALLOW_ALL_USERS` (the DM allowlist) are unaffected — those already route through the generic, already-scoped `gateway/authz_mixin.py::_auth_env()` mechanism via `register()`'s `allowed_users_env`/`allow_all_env`.

## Fix

Mirrors the established Buzz adapter fix for the same bug class (#98738):

- `_profile_scoped()` / `_scoped_platform_setting()` — a secondary profile's own `PlatformConfig.extra` becomes authoritative and env is not consulted; a missing key fails closed to the safe default instead of borrowing the default profile's value. Single-profile gateways and the default profile under multiplexing keep the legacy `os.getenv` precedence unchanged.
- `_profile_simplex_extra()` — `check_requirements()` has no `PlatformConfig` argument, so (like Buzz's `_profile_buzz_extra()`) it reads the profile's own `config.yaml` directly via the scoped home override when running inside a secondary profile's scope.
- `_env_enablement()` returns `None` under a secondary profile's scope, so it does not fabricate a SimpleX platform for a profile that never configured one from the default profile's env.

## Tests

Added `TestMultiplexProfileScope` to `tests/gateway/test_simplex_plugin.py` (7 tests), mirroring the existing Buzz adapter coverage for this exact scenario: secondary profile's extra wins over default's env, missing keys fail closed to safe defaults (not the default's wildcard/disabled values), the default profile stays unscoped and keeps env precedence, `check_requirements` consults the profile's own `config.yaml`, `validate_config`/`is_connected` respect scope, `_env_enablement` returns `None` when scoped, and `_standalone_send` connects to the scoped daemon URL rather than the default's.

- `tests/gateway/test_simplex_plugin.py` — 23 passed (16 pre-existing + 7 new)
- Mutation-verify: reverting the adapter fix makes 6 of the 7 new tests fail as expected (the 7th, the default-profile-unscoped case, was never buggy)
- Adjacent suites unaffected: `tests/hermes_cli/test_send_cmd.py`, `tests/gateway/test_channel_directory.py`, `tests/gateway/test_unauthorized_dm_behavior.py` — 45 passed

## Scope note / prior art check

Three open PRs currently touch `plugins/platforms/simplex/adapter.py` + `tests/gateway/test_simplex_plugin.py` — checked each diff directly and confirmed zero function-level overlap with this fix (textual proximity only, same files, different functions/concerns):

- #52241 — adds `role_authorized` to the group-message dispatch in `_handle_chat_item` (gateway authorization signal), unrelated to env/profile scoping
- #41246 — resolves contact/member names via `localDisplayName` in `_handle_new_chat_item` (allowlist spoofing via display-name), unrelated
- #35523 — adds a platform lock around the WebSocket connectivity check in `connect()` (duplicate-listener prevention), unrelated

Merged PR #65629 (multiplex credential isolation cluster) does not touch this file — confirmed via `gh pr view --json files`.