### PR TITLE
fix(installer): allow existing installs to update to a new tag

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1381,20 +1381,32 @@ clone_repo() {
                 autostash_ref="stash@{0}"
             fi
 
-            # Fetch only the target branch. A bare `git fetch origin` pulls
-            # every ref, and this repo carries thousands of auto-generated
-            # branches — on a non-single-branch checkout that turns each update
-            # into a multi-minute download that can stall the installer.
-            git remote set-branches origin "$BRANCH" 2>/dev/null || true
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
-            if ! git pull --ff-only origin "$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+            local branch_ref_status=0
+            git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null || branch_ref_status=$?
+            if [ "$branch_ref_status" -eq 0 ]; then
+                # Fetch only the target branch. A bare `git fetch origin` pulls
+                # every ref, and this repo carries thousands of auto-generated
+                # branches — on a non-single-branch checkout that turns each update
+                # into a multi-minute download that can stall the installer.
+                git remote set-branches origin "$BRANCH" 2>/dev/null || true
+                git fetch origin "$BRANCH"
+                git checkout "$BRANCH"
+                # Managed installs should follow origin/$BRANCH exactly. If the
+                # checkout has diverged (or has local-only commits), ff-only pull
+                # cannot succeed — mirror ``hermes update`` and reset to the
+                # fetched remote so bootstrap/install can recover.
+                if ! git pull --ff-only origin "$BRANCH"; then
+                    log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
+                    git reset --hard "origin/$BRANCH"
+                fi
+            elif [ "$branch_ref_status" -eq 2 ]; then
+                # A fetch without a destination can leave a tag only in
+                # FETCH_HEAD on older Git versions. Materialize the ref and use
+                # a detached checkout, matching the install.ps1 tag path.
+                git fetch origin "refs/tags/${BRANCH}:refs/tags/${BRANCH}"
+                git checkout --detach "refs/tags/$BRANCH"
+            else
+                return "$branch_ref_status"
             fi
 
             if [ -n "$autostash_ref" ]; then

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1382,7 +1382,7 @@ clone_repo() {
             fi
 
             local branch_ref_status=0
-            git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null || branch_ref_status=$?
+            git ls-remote --exit-code origin "refs/heads/$BRANCH" >/dev/null || branch_ref_status=$?
             if [ "$branch_ref_status" -eq 0 ]; then
                 # Fetch only the target branch. A bare `git fetch origin` pulls
                 # every ref, and this repo carries thousands of auto-generated

--- a/tests/test_install_tag_update.py
+++ b/tests/test_install_tag_update.py
@@ -54,7 +54,15 @@ def _make_remote_with_unfetched_tag(tmp_path: Path) -> tuple[Path, Path, str]:
     remote = tmp_path / "origin.git"
     _git(tmp_path, "init", "-q", "--bare", str(remote))
     _git(seed, "remote", "add", "origin", str(remote))
-    _git(seed, "push", "-q", "origin", "main", "refs/tags/release-test")
+    _git(
+        seed,
+        "push",
+        "-q",
+        "origin",
+        "main",
+        "main:refs/heads/nested/release-test",
+        "refs/tags/release-test",
+    )
     _git(remote, "symbolic-ref", "HEAD", "refs/heads/main")
 
     managed = tmp_path / "hermes-agent"

--- a/tests/test_install_tag_update.py
+++ b/tests/test_install_tag_update.py
@@ -1,0 +1,157 @@
+"""Regression coverage for updating an existing install to a remote tag.
+
+Some Git versions leave ``git fetch origin <tag>`` only in ``FETCH_HEAD``.
+The installer must materialize the requested tag before checking it out while
+keeping the normal branch-update path attached to its branch.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+REAL_GIT = shutil.which("git")
+pytestmark = [
+    pytest.mark.linux_only,
+    pytest.mark.skipif(
+        REAL_GIT is None or shutil.which("bash") is None,
+        reason="needs git and bash",
+    ),
+]
+
+
+def _git(cwd: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [REAL_GIT, "-c", "user.email=t@t", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _make_remote_with_unfetched_tag(tmp_path: Path) -> tuple[Path, Path, str]:
+    seed = tmp_path / "seed"
+    seed.mkdir()
+    _git(seed, "init", "-q", "-b", "main")
+    (seed / "version.txt").write_text("old\n", encoding="utf-8")
+    _git(seed, "add", "version.txt")
+    _git(seed, "commit", "-qm", "old")
+
+    _git(seed, "checkout", "-qb", "tag-source")
+    (seed / "version.txt").write_text("tagged\n", encoding="utf-8")
+    _git(seed, "commit", "-qam", "tagged")
+    tag_commit = _git(seed, "rev-parse", "HEAD").stdout.strip()
+    _git(seed, "tag", "release-test")
+    _git(seed, "checkout", "-q", "main")
+
+    remote = tmp_path / "origin.git"
+    _git(tmp_path, "init", "-q", "--bare", str(remote))
+    _git(seed, "remote", "add", "origin", str(remote))
+    _git(seed, "push", "-q", "origin", "main", "refs/tags/release-test")
+    _git(remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+    managed = tmp_path / "hermes-agent"
+    # Force the transport path: local-clone optimization copies every local
+    # ref even with --no-tags, which would pre-materialize the regression tag.
+    _git(
+        tmp_path,
+        "clone",
+        "-q",
+        "--no-tags",
+        "--branch",
+        "main",
+        remote.as_uri(),
+        str(managed),
+    )
+    # Local-clone transports may still opportunistically copy tag refs. The
+    # reported update starts from a checkout where this target ref is absent.
+    _git(managed, "update-ref", "-d", "refs/tags/release-test")
+    assert _git(
+        managed, "show-ref", "--verify", "refs/tags/release-test", check=False
+    ).returncode != 0
+    return managed, seed, tag_commit
+
+
+def _git_wrapper(tmp_path: Path) -> Path:
+    """Emulate Git versions that keep a fetched tag only in FETCH_HEAD."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    wrapper = bin_dir / "git"
+    wrapper.write_text(
+        """#!/usr/bin/env bash
+"$REAL_GIT" "$@"
+status=$?
+if [ "$status" -eq 0 ] && [ "$1" = fetch ] && [ "$2" = origin ] && [ "$3" = release-test ]; then
+    "$REAL_GIT" update-ref -d refs/tags/release-test
+fi
+exit "$status"
+""",
+        encoding="utf-8",
+    )
+    wrapper.chmod(0o755)
+    return bin_dir
+
+
+def _run_repository_stage(
+    tmp_path: Path, managed: Path, branch: str, *, emulate_fetch_head_only: bool = False
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ | {
+        "HERMES_HOME": str(tmp_path / "hermes-home"),
+        "HERMES_INSTALL_DIR": str(managed),
+    }
+    if emulate_fetch_head_only:
+        env["REAL_GIT"] = Path(REAL_GIT).as_posix()
+        env["PATH"] = f"{_git_wrapper(tmp_path)}:{env['PATH']}"
+    return subprocess.run(
+        [
+            "bash",
+            str(INSTALL_SH),
+            "--stage",
+            "repository",
+            "--branch",
+            branch,
+            "--non-interactive",
+        ],
+        cwd=tmp_path,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+@pytest.mark.live_system_guard_bypass
+def test_existing_install_materializes_remote_tag_before_checkout(tmp_path: Path) -> None:
+    managed, _seed, tag_commit = _make_remote_with_unfetched_tag(tmp_path)
+
+    result = _run_repository_stage(
+        tmp_path, managed, "release-test", emulate_fetch_head_only=True
+    )
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(managed, "rev-parse", "HEAD").stdout.strip() == tag_commit
+    assert _git(
+        managed, "show-ref", "--verify", "refs/tags/release-test"
+    ).returncode == 0
+    assert _git(managed, "symbolic-ref", "-q", "HEAD", check=False).returncode != 0
+
+
+@pytest.mark.live_system_guard_bypass
+def test_existing_install_branch_update_remains_attached(tmp_path: Path) -> None:
+    managed, seed, _tag_commit = _make_remote_with_unfetched_tag(tmp_path)
+    (seed / "version.txt").write_text("new branch\n", encoding="utf-8")
+    _git(seed, "commit", "-qam", "new branch")
+    branch_commit = _git(seed, "rev-parse", "HEAD").stdout.strip()
+    _git(seed, "push", "-q", "origin", "main")
+
+    result = _run_repository_stage(tmp_path, managed, "main")
+
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert _git(managed, "rev-parse", "HEAD").stdout.strip() == branch_commit
+    assert _git(managed, "symbolic-ref", "--short", "HEAD").stdout.strip() == "main"


### PR DESCRIPTION
## What does this PR do?

Existing Bash-installer checkouts can now update to a tag that is not yet present locally. On affected Git versions, the previous fetch left the tag only in `FETCH_HEAD`, so `git checkout <tag>` aborted the repository stage and prevented the update.

### Symptom

Re-running `install.sh --branch <tag>` against an existing install can fail with `pathspec '<tag>' did not match any file(s) known to git` after the fetch reports `<tag> -> FETCH_HEAD`.

### Impact

Operators pinning an existing Linux install to a newly published tag cannot complete the update without manually materializing the tag ref first. Fresh clones and the PowerShell installer's explicit tag path are not affected.

### Bug Cause

**Trigger:** `scripts/install.sh:1384` in the existing-install branch of `clone_repo()` when `--branch` names a remote tag rather than a remote branch.

**Causal chain:**
1. The installer scopes `git fetch origin "$BRANCH"` to the requested name.
2. Affected Git versions store a fetched tag without a destination ref only in `FETCH_HEAD`.
3. The subsequent checkout cannot resolve the requested tag name and aborts the repository stage.

**Why it is wrong:** The update path assumes every fetched name creates a locally resolvable ref, but that is not guaranteed for a tag fetched without an explicit destination refspec.

**Working sibling / contrast:** Fresh clones discover tags through clone behavior, and `install.ps1` already fetches `refs/tags/<tag>:refs/tags/<tag>` before a detached tag checkout.

**Ruled out:** Normal branch tracking is not the cause. Remote branches have a dedicated `refs/remotes/origin/<branch>` destination and continue through the existing checkout, fast-forward pull, and diverged-reset path.

### Fix

Probe whether the requested name is a remote branch. Branches retain the existing scoped fetch and managed-update behavior. If no matching branch exists, fetch the exact tag with an explicit source and destination refspec, then check it out detached to match the PowerShell tag path. Transport failures remain failures instead of being misclassified as tags.

## Related Issue

Closes #100222

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/install.sh` - distinguish remote branches from tags and materialize tag refs before detached checkout.
- `tests/test_install_tag_update.py` - exercise missing-tag updates under FETCH_HEAD-only behavior and preserve attached branch updates.

## How to Test

1. Clone a remote branch without the target tag, then run the repository stage with `--branch <tag>` and confirm HEAD matches the tag in detached state.
2. Advance the remote branch, run the same stage with `--branch <branch>`, and confirm HEAD advances while remaining attached to the branch.
3. Run the focused tests and shell syntax check:

```bash
scripts/run_tests.sh tests/test_install_tag_update.py tests/test_install_diverged_update.py -q
bash -n scripts/install.sh
```

Local Windows result: 2 passed and 2 Linux-only tests skipped; `bash -n` and Ruff passed. The Linux-only end-to-end cases run on the Linux test lane.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all platform-eligible tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (shell syntax and platform-eligible tests)

### Documentation & Housekeeping

- [x] Documentation update: N/A - installer behavior and regression tests are self-contained
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the PowerShell tag path already uses the same explicit refspec and detached checkout
- [x] Tool descriptions/schemas update: N/A - no model tool changed

## Screenshots / Logs

N/A - command-line installer fix with automated regression coverage.
