### PR TITLE
fix(state): commit FTS health probe so trigram idx collisions are visible

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3295,11 +3295,19 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
 
     Runs the same first-statement (``PRAGMA journal_mode``) that trips the
     malformed-schema parse, then ``PRAGMA integrity_check`` and a canonical
-    ``sessions`` read, and finally a rolled-back ``messages`` write so that
-    FTS5 index corruption — which leaves base-table reads and
+    ``sessions`` read, and finally a committed-then-deleted ``messages``
+    write so that FTS5 index corruption — which leaves base-table reads and
     ``integrity_check`` passing while every ``INSERT INTO messages`` fails
     through the FTS triggers — is reported as unhealthy rather than slipping
     past as a false "ok" (#50502).
+
+    The write probe must COMMIT. FTS5 materializes
+    ``INSERT INTO %_idx(segid, term, pgno)`` at transaction end, so a
+    rolled-back INSERT never raises the ``IntegrityError: constraint failed``
+    that a real ``append_message`` (BEGIN + INSERT + COMMIT) hits when the
+    trigram index has a segment-key collision. A single fixed probe string
+    is also insufficient: the collision can be term/segment dependent, so
+    several distinct contents are driven through one committed transaction.
     """
     conn = _connect_repair_durable(db_path)
     try:
@@ -3374,25 +3382,71 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # while reads of the FTS5 table itself parse fine.
                 return f"fts5 read probe failed on {fts_table}: {exc}"
 
-        # FTS write probe: drive a row through the messages_fts* triggers in a
-        # transaction that is always rolled back, so a corrupt FTS index that
-        # rejects writes is caught even though reads look healthy. The probe is
-        # best-effort — if the messages/sessions tables don't exist yet (brand
-        # new file mid-init) the OperationalError is treated as "not yet a
-        # populated DB", not corruption.
+        # FTS shadow-table consistency: a lagging trigram docsize vs the
+        # non-tool messages the view indexes is the corroborating signal
+        # on live DBs whose idx PK collision is segment-dependent. Skip
+        # while a deferred rebuild is in flight (docsize is expected to
+        # lag the base table then). Missing tables are not corruption.
+        try:
+            pending = conn.execute(
+                "SELECT 1 FROM state_meta WHERE key IN "
+                "('fts_rebuild_high_water', 'fts_cjk_rebuild_high_water') "
+                "LIMIT 1"
+            ).fetchone()
+            if pending is None:
+                expected = conn.execute(
+                    "SELECT COUNT(*) FROM messages WHERE role <> 'tool'"
+                ).fetchone()[0]
+                actual = conn.execute(
+                    "SELECT COUNT(*) FROM messages_fts_trigram_docsize"
+                ).fetchone()[0]
+                if expected != actual:
+                    return (
+                        "fts5 trigram docsize mismatch: "
+                        f"docsize={actual} messages={expected}"
+                    )
+        except sqlite3.OperationalError:
+            pass
+
+        # FTS write probe: drive several rows through the messages_fts*
+        # triggers and COMMIT so FTS5 flushes ``%_idx``. A corrupt trigram
+        # index that rejects the idx insert with SQLITE_CONSTRAINT is
+        # invisible to a rolled-back INSERT — the constraint fires at
+        # commit, which is also how ``SessionDB.append_message`` fails.
+        # Best-effort: missing tables (brand-new file mid-init) are
+        # treated as "not yet a populated DB", not corruption.
         probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
+        probe_variants = (
+            "_fts_health_probe",
+            "the quick brown fox jumps over the lazy dog and then the team "
+            "said it was one of those things for the project",
+            f"hermes fts health probe unique token {time.time_ns()}",
+            "abcdefghijklmnopqrstuvwxyz 0123456789",
+        )
         try:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
                 (probe_session_id, "_health_probe", time.time()),
             )
-            conn.execute(
-                "INSERT INTO messages (session_id, role, content, timestamp) "
-                "VALUES (?, ?, ?, ?)",
-                (probe_session_id, "user", "_fts_health_probe", time.time()),
-            )
-            conn.execute("ROLLBACK")
+            probe_ts = time.time()
+            for probe_content in probe_variants:
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp) "
+                    "VALUES (?, ?, ?, ?)",
+                    (probe_session_id, "user", probe_content, probe_ts),
+                )
+            conn.execute("COMMIT")
+        except sqlite3.IntegrityError as exc:
+            # PRIMARY KEY (segid, term) collision in messages_fts_trigram_idx
+            # surfaces here, on COMMIT, as IntegrityError — not
+            # OperationalError. Roll back any leftover txn and label the
+            # reason so doctor / sessions repair point at the FTS index.
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            return f"fts write probe failed: {exc}"
         except sqlite3.OperationalError as exc:
             # Missing tables / FTS disabled — not the corruption class we probe.
             try:
@@ -3409,6 +3463,21 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # a tokenizer-less one self-heals by dropping the triggers.
                 return None
             return str(exc)
+        else:
+            # Drop the committed probe rows so a healthy DB is unchanged.
+            # foreign_keys is not guaranteed ON on this connection, so
+            # delete messages explicitly rather than relying on CASCADE.
+            try:
+                conn.execute(
+                    "DELETE FROM messages WHERE session_id = ?",
+                    (probe_session_id,),
+                )
+                conn.execute(
+                    "DELETE FROM sessions WHERE id = ?",
+                    (probe_session_id,),
+                )
+            except sqlite3.Error:
+                pass
         return None
     except sqlite3.DatabaseError as exc:
         return str(exc)

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -274,7 +274,7 @@ def _corrupt_fts_index_data(db_path: Path) -> None:
 
 
 def test_fts_write_corruption_detected_by_write_probe(tmp_path):
-    """_db_opens_cleanly's rolled-back write probe flags FTS write corruption."""
+    """_db_opens_cleanly's committed write probe flags FTS write corruption."""
     from hermes_state import _db_opens_cleanly
 
     db_path = tmp_path / "state.db"

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -322,6 +322,137 @@ def test_fts_write_corruption_repaired_in_place(tmp_path):
         db.close()
 
 
+# ── FTS trigram idx commit-time constraint (#100227) ─────────────────────
+# A readable state.db can reject every *committed* message write with
+# IntegrityError("constraint failed") when messages_fts_trigram_idx already
+# holds the (segid, term) key FTS5 will insert at COMMIT. INSERT itself
+# succeeds; ROLLBACK therefore never sees the failure. The old single-string
+# rolled-back probe reported healthy, hermes doctor / sessions repair
+# --check-only printed "no repair needed", and repair_state_db_schema
+# short-circuited as already_healthy.
+
+
+def _poison_trigram_future_idx_segments(db_path: Path, *, upto: int = 256) -> int:
+    """Pre-insert directory rows for future FTS5 trigram segment ids.
+
+    FTS5 ``%_idx`` is ``PRIMARY KEY (segid, term)``. Occupying the empty-term
+    directory slot for segments the next COMMIT will allocate makes the
+    engine's ``INSERT INTO messages_fts_trigram_idx(segid, term, pgno)``
+    fail with SQLITE_CONSTRAINT — the on-disk failure class behind
+    ``append_message failed: constraint failed``. Returns how many rows
+    were planted.
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        existing = {
+            row[0]
+            for row in conn.execute("SELECT segid FROM messages_fts_trigram_idx")
+        }
+        planted = 0
+        for seg in range(1, upto):
+            if seg in existing:
+                continue
+            conn.execute(
+                "INSERT INTO messages_fts_trigram_idx(segid, term, pgno) "
+                "VALUES (?, ?, ?)",
+                (seg, b"", 2),
+            )
+            planted += 1
+        return planted
+    finally:
+        conn.close()
+
+
+def test_trigram_idx_constraint_missed_by_rollback_seen_on_commit(tmp_path):
+    """Document the real failure shape: INSERT ok, COMMIT IntegrityError."""
+    db_path = tmp_path / "state.db"
+    sid = _build_healthy_db(db_path)
+    planted = _poison_trigram_future_idx_segments(db_path)
+    assert planted > 0
+
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+        conn.execute("BEGIN IMMEDIATE")
+        conn.execute(
+            "INSERT INTO messages (session_id, role, content, timestamp) "
+            "VALUES (?, ?, ?, ?)",
+            (sid, "user", "_fts_health_probe", 0),
+        )
+        with pytest.raises(sqlite3.IntegrityError, match="constraint failed"):
+            conn.execute("COMMIT")
+        try:
+            conn.execute("ROLLBACK")
+        except sqlite3.Error:
+            pass
+    finally:
+        conn.close()
+
+
+def test_trigram_idx_commit_corruption_detected_by_write_probe(tmp_path):
+    """_db_opens_cleanly flags idx PK collisions that only fire on COMMIT."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    assert _db_opens_cleanly(db_path) is None
+
+    _poison_trigram_future_idx_segments(db_path)
+
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None
+    assert "fts write probe failed" in reason
+    assert "constraint failed" in reason
+
+
+def test_trigram_idx_commit_corruption_repaired(tmp_path):
+    """repair_state_db_schema no longer short-circuits as already_healthy."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    sid = _build_healthy_db(db_path)
+    _poison_trigram_future_idx_segments(db_path)
+
+    report = repair_state_db_schema(db_path, backup=False)
+    assert report["repaired"] is True
+    assert report["strategy"] != "already_healthy"
+    assert _db_opens_cleanly(db_path) is None
+
+    db = SessionDB(db_path=db_path)
+    try:
+        db.append_message(sid, role="user", content="post repair pizza message")
+        n = db._conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+        assert n == 11
+    finally:
+        db.close()
+
+
+def test_healthy_db_committed_fts_write_probe_leaves_no_residue(tmp_path):
+    """Committed probe rows are deleted; a healthy DB is unchanged."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    before = sqlite3.connect(str(db_path))
+    try:
+        sessions_before = before.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
+        messages_before = before.execute("SELECT COUNT(*) FROM messages").fetchone()[0]
+    finally:
+        before.close()
+
+    assert _db_opens_cleanly(db_path) is None
+
+    after = sqlite3.connect(str(db_path))
+    try:
+        assert after.execute("SELECT COUNT(*) FROM sessions").fetchone()[0] == sessions_before
+        assert after.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == messages_before
+        leftover = after.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id LIKE '_hermes_fts_health_probe_%'"
+        ).fetchone()[0]
+    finally:
+        after.close()
+    assert leftover == 0
 
 
 def _corrupt_btree_index(db_path: Path, index_name: str) -> None:


### PR DESCRIPTION
## What does this PR do?

`_db_opens_cleanly` (used by `hermes doctor` and `hermes sessions repair --check-only`) drove a single probe `INSERT` and then `ROLLBACK`. FTS5 materializes `INSERT INTO messages_fts_trigram_idx(segid, term, pgno)` at **COMMIT**, so a corrupt trigram index that raises `IntegrityError: constraint failed` on every real `append_message` still looked healthy. The probe reported `None`, repair short-circuited as `already_healthy`, and turns aborted with `session_persistence_failed`.

This change COMMITs several distinct probe contents so the idx flush actually runs, catches `IntegrityError` with a labelled reason, deletes the probe rows, and flags a trigram `docsize` vs non-tool `messages` mismatch when no deferred rebuild is pending.

## Related Issue

Fixes #100227

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_state.py` — `_db_opens_cleanly`: committed multi-content FTS write probe; explicit `IntegrityError` handling (`fts write probe failed: …`); cleanup of probe session/message rows; trigram docsize consistency check (skipped while `fts_rebuild_high_water` / `fts_cjk_rebuild_high_water` is set).
- `tests/test_state_db_malformed_repair.py` — real `messages_fts_trigram_idx` directory-row poison: INSERT succeeds / COMMIT raises `constraint failed`; probe detects it; `repair_state_db_schema` uses `rebuild_fts` instead of `already_healthy`; healthy DB leaves no residue.

## How to Test

1. Build a normal `SessionDB`, then pre-insert empty-term directory rows into `messages_fts_trigram_idx` for future `segid` values (the engine's next COMMIT will collide on `PRIMARY KEY (segid, term)`).
2. Confirm the failure shape: `INSERT INTO messages … '_fts_health_probe'` succeeds; `COMMIT` raises `IntegrityError: constraint failed`. Dropping only `messages_fts_trigram_insert` makes the same write succeed.
3. On current `main`, `_db_opens_cleanly` returns `None` and `hermes sessions repair --check-only` prints `opens cleanly — no repair needed` while `SessionDB.append_message` still fails.
4. With this branch: `_db_opens_cleanly` returns `fts write probe failed: constraint failed`; `hermes sessions repair --check-only` prints `does not open cleanly: fts write probe failed: constraint failed`; `repair_state_db_schema` reports `strategy=rebuild_fts`; a following `append_message` succeeds.
5. `scripts/run_tests.sh tests/test_state_db_malformed_repair.py -k 'trigram_idx or healthy_db_committed or fts_write_corruption or fts_read_corruption' -q` — 7 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Python 3.12, SQLite 3.45.1)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
_db_opens_cleanly after idx poison: fts write probe failed: constraint failed
hermes sessions repair --check-only:
✗ …/state.db does not open cleanly: fts write probe failed: constraint failed
repair_state_db_schema: strategy=rebuild_fts
append_message after repair: OK
```

A concurrent open PR still rolls back the probe INSERT. That never flushes `%_idx`, so the same poison still reports healthy.
