### PR TITLE
fix(install): materialize the tag ref before checkout on the update path

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1473,16 +1473,32 @@ clone_repo() {
             # every ref, and this repo carries thousands of auto-generated
             # branches — on a non-single-branch checkout that turns each update
             # into a multi-minute download that can stall the installer.
+            #
+            # `git fetch origin <name>` stores the result ONLY in FETCH_HEAD;
+            # for a TAG it does not create refs/tags/<name>, so the checkout
+            # below then dies with "pathspec '<tag>' did not match any file(s)
+            # known to git" when updating an existing clone to a tag it does
+            # not already hold (#100222). Detect the tag case up front and
+            # fetch it with an explicit refspec so the local ref exists.
             git remote set-branches origin "$BRANCH" 2>/dev/null || true
-            git fetch origin "$BRANCH"
-            git checkout "$BRANCH"
-            # Managed installs should follow origin/$BRANCH exactly. If the
-            # checkout has diverged (or has local-only commits), ff-only pull
-            # cannot succeed — mirror ``hermes update`` and reset to the
-            # fetched remote so bootstrap/install can recover.
-            if ! git pull --ff-only origin "$BRANCH"; then
-                log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
-                git reset --hard "origin/$BRANCH"
+            if git ls-remote --exit-code --tags origin "refs/tags/$BRANCH" >/dev/null 2>&1; then
+                # Target is a tag: materialize refs/tags/<tag> locally.
+                # --force so a moved tag (retagged release) still updates.
+                git fetch --force origin "refs/tags/${BRANCH}:refs/tags/${BRANCH}"
+                git checkout --detach "refs/tags/${BRANCH}"
+                # A tag is a fixed point — no pull/reset follow-up (the
+                # branch-tracking block below would fail on origin/<tag>).
+            else
+                git fetch origin "$BRANCH"
+                git checkout "$BRANCH"
+                # Managed installs should follow origin/$BRANCH exactly. If the
+                # checkout has diverged (or has local-only commits), ff-only pull
+                # cannot succeed — mirror ``hermes update`` and reset to the
+                # fetched remote so bootstrap/install can recover.
+                if ! git pull --ff-only origin "$BRANCH"; then
+                    log_warn "Fast-forward not possible; resetting managed install to origin/$BRANCH..."
+                    git reset --hard "origin/$BRANCH"
+                fi
             fi
 
             if [ -n "$autostash_ref" ]; then


### PR DESCRIPTION
Fixes #100222

## Problem

`git fetch origin <name>` stores the result **only in `FETCH_HEAD`**; for a **tag** it does not create `refs/tags/<name>`. The existing-installation update path in `scripts/install.sh` fetched by name and then ran `git checkout <tag>`:

```bash
git remote set-branches origin "$BRANCH"
git fetch origin "$BRANCH"
git checkout "$BRANCH"     # <- dies here
```

so `--branch <newer-tag>` against an older managed install always failed:

```
 * tag                   v2026.8.31 -> FETCH_HEAD
error: pathspec 'v2026.8.31' did not match any file(s) known to git
```

Fresh clones were unaffected (different code path) — only the update path.

## Fix

The update path probes `git ls-remote --exit-code --tags origin refs/tags/$BRANCH`:

- **tag** → fetch with an explicit refspec (`refs/tags/X:refs/tags/X`, `--force` so a retagged release still updates), then `checkout --detach refs/tags/X`. The branch-tracking `pull --ff-only` / `reset --hard origin/$BRANCH` follow-up is skipped — a tag is a fixed point and `origin/<tag>` doesn't exist.
- **branch** → existing fetch / checkout / `pull --ff-only` / `reset --hard` behavior, unchanged.

This takes the issue's first suggested fix (explicit refspec) rather than the `FETCH_HEAD` fallback, so the local ref exists afterwards and `git describe` reports the pinned tag.

## Verification

`bash -n scripts/install.sh` clean, plus a real end-to-end repro against local git repos (bare upstream with two tags, clone pinned at the older tag with `--no-tags`):

| Scenario | Result |
|---|---|
| **old** behavior, tag not in clone | `* tag v2026.8.31 -> FETCH_HEAD` then `error: pathspec 'v2026.8.31' did not match any file(s) known to git` — **bug reproduced verbatim** |
| **new** behavior, same starting state | `* [new tag] v2026.8.31 -> v2026.8.31`, checkout OK, `git describe --tags` = `v2026.8.31`, file content is the tagged revision |
| **new** behavior, target is a real branch (`main`) | not detected as a tag → branch path taken, `pull --ff-only` runs as before |