### PR TITLE
fix(qqbot): authorize DM approval clicks (chat_type 'dm' vs legacy 'c2c')

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1131,7 +1131,9 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # DM session keys use chat_type "dm" (build_source for both c2c and
+        # guild channels); legacy "c2c" kept for pre-refactor session keys.
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## What does this PR do?

Fixes QQ bot DM approval buttons being rejected as unauthorized.

DM session keys are built with `chat_type="dm"` (see `build_session_key` /
`_parse_gateway_session_key`), but `_is_authorized_interaction_for_session`
only matched the legacy `"c2c"` value. Result: every approval button click in a
1:1 DM was rejected ("Rejected unauthorized approval click"), and the agent's
terminal call waited out its full timeout instead of running after the user
approved.

The fix widens the match to `{"c2c", "dm"}` — `"dm"` for current session keys,
`"c2c"` kept for pre-refactor keys that may still exist in long-lived sessions.

## Related Issue

No issue filed; found while running a QQ DM session where approval clicks never took effect.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/qqbot/adapter.py`: `_is_authorized_interaction_for_session` now accepts `chat_type in {"c2c", "dm"}` instead of only `"c2c"`.

## How to Test

1. Start a QQ 1:1 DM conversation with the bot (session key `…:dm:<openid>`).
2. Have the agent issue a command that needs approval (e.g. a terminal call) so the approval buttons render in the DM.
3. Click "Approve" — before this fix the log shows `Rejected unauthorized approval click for session …` and nothing happens; after the fix the action proceeds immediately.
4. Group/guild approvals are unaffected (separate branch of the same function).

## Checklist

- [x] I have read the [contribution guidelines](../blob/main/CONTRIBUTING.md)
- [x] Code is formatted and passes linting
- [ ] Tests added/updated for new behavior (existing qqbot adapter tests don't cover session-key authorization; happy to add one if maintainers want it)
- [x] No breaking changes
