### PR TITLE
fix(update): discharge the fleet-restart obligation on the receipt, not just the marker

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -3298,6 +3298,13 @@ def _receipt_reports_stale_runtime(expected_sha: str | None = None) -> bool:
     if not expected_sha:
         return False
 
+    # An out-of-band catch-up restart records the SHA it discharged the
+    # obligation against. Honour it: without this the empty-``fleet`` +
+    # failed-``outcome`` receipt below falls back to a pre-pull plan SHA that
+    # can never match HEAD, so the fleet is restarted on EVERY later update.
+    if str(receipt.get("fleet_restart_resolved_sha") or "") == str(expected_sha):
+        return False
+
     def _sha_mismatch(code_sha) -> bool:
         return bool(code_sha) and str(code_sha) != str(expected_sha)
 
@@ -3497,6 +3504,36 @@ def _run_pending_fleet_restart() -> bool:
         return False
 
 
+def _record_catchup_fleet_resolution() -> None:
+    """Tell the owing receipt that the catch-up restart happened.
+
+    ``_clear_fleet_restart_pending_marker()`` only removes the breadcrumb
+    file. ``_pending_fleet_restart_needed()`` ALSO consults the receipt, and
+    a receipt with an empty ``fleet`` and a failed/partial ``outcome`` falls
+    back to ``plan.runtimes[].code_sha`` — captured before the pull, so it
+    can never match the post-pull checkout. Recording the restart against
+    the current HEAD is what actually discharges the obligation. Never
+    raises: a failure here costs one redundant restart, not a broken update.
+    """
+    try:
+        from hermes_cli.update_receipt import (
+            collect_fleet_versions,
+            record_fleet_resolution,
+        )
+
+        expected_sha = _current_checkout_sha()
+        if not expected_sha:
+            return
+        try:
+            fleet = collect_fleet_versions()
+        except Exception as exc:
+            logger.debug("Catch-up fleet probe failed: %s", exc)
+            fleet = None
+        record_fleet_resolution(fleet, expected_sha)
+    except Exception as exc:
+        logger.debug("Could not record catch-up fleet resolution: %s", exc)
+
+
 def _apply_pending_fleet_restart_catchup() -> None:
     """On an already-up-to-date ``hermes update``, finish a skipped restart.
 
@@ -3510,6 +3547,7 @@ def _apply_pending_fleet_restart_catchup() -> None:
     print("→ Running the pending fleet restart...")
     if _run_pending_fleet_restart():
         _clear_fleet_restart_pending_marker()
+        _record_catchup_fleet_resolution()
         return
     print("  ⚠ Fleet restart incomplete. Recover with: hermes gateway restart")
     sys.exit(1)

--- a/hermes_cli/update_receipt.py
+++ b/hermes_cli/update_receipt.py
@@ -268,6 +268,56 @@ def finalize_pending_update_receipt(
     return finalize_update_receipt(outcome, stop_reason=stop_reason)
 
 
+def record_fleet_resolution(
+    fleet: list[dict[str, Any]] | None, resolved_sha: str
+) -> bool:
+    """Stamp a completed out-of-band fleet restart onto the latest receipt.
+
+    The pending-fleet-restart catch-up restarts gateways OUTSIDE any open
+    receipt (the already-up-to-date path never begins one), so the receipt
+    that owed the restart is never told the debt was paid. Recording the
+    discharge against ``resolved_sha`` is what actually clears
+    ``_receipt_reports_stale_runtime()``; a later pull moves HEAD and
+    correctly re-arms the obligation. Never raises.
+    """
+    if not resolved_sha:
+        return False
+    try:
+        directory = _receipt_dir()
+        latest = directory / "latest.json"
+        if not latest.is_file():
+            return False
+        data = json.loads(latest.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return False
+        if fleet:
+            data["fleet"] = fleet
+        data["fleet_restart_resolved_sha"] = str(resolved_sha)
+        data["fleet_restart_resolved_at"] = _utc_now_iso()
+        payload = json.dumps(data, indent=2, default=str)
+        latest.write_text(payload, encoding="utf-8")
+        # Keep the timestamped twin in sync when it mirrors this receipt, so
+        # the archived copy does not contradict the pointer.
+        try:
+            stamped = sorted(
+                (p for p in directory.glob("update_*.json") if p.is_file()),
+                key=lambda p: p.stat().st_mtime,
+                reverse=True,
+            )
+            if stamped:
+                twin = json.loads(stamped[0].read_text(encoding="utf-8"))
+                if isinstance(twin, dict) and twin.get("started_at") == data.get(
+                    "started_at"
+                ):
+                    stamped[0].write_text(payload, encoding="utf-8")
+        except (OSError, ValueError) as exc:
+            logger.debug("Could not sync timestamped receipt twin: %s", exc)
+        return True
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("Could not record fleet resolution: %s", exc)
+        return False
+
+
 def _prune_old_receipts(directory: Path) -> None:
     try:
         receipts = sorted(

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -422,3 +422,88 @@ def test_startup_warn_silent_when_nothing_pending(capsys):
     captured = capsys.readouterr()
     assert captured.err == ""
     assert captured.out == ""
+
+
+def _write_owing_receipt(disk_sha: str, old_sha: str) -> None:
+    """A failed receipt with an empty fleet — the shape that owes a restart."""
+    receipt_dir = get_hermes_home() / "logs" / "update_receipts"
+    receipt_dir.mkdir(parents=True, exist_ok=True)
+    (receipt_dir / "latest.json").write_text(
+        json.dumps(
+            {
+                "started_at": "T0",
+                "exit_code": 1,
+                "stop_reason": "sys.exit(1)",
+                "outcome": "failed",
+                "fleet": [],
+                "plan": {
+                    "expected_sha": disk_sha,
+                    "runtimes": [
+                        {
+                            "kind": "gateway",
+                            "profile": "default",
+                            "pid": 4242,
+                            "code_sha": old_sha,
+                        }
+                    ],
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_catchup_restart_discharges_the_receipt_obligation(monkeypatch):
+    """The catch-up must clear the condition, not just the marker.
+
+    Regression: the catch-up cleared only the breadcrumb file, so a failed
+    receipt with an empty ``fleet`` kept falling back to its pre-pull plan
+    SHA — which can never match HEAD — and every later ``hermes update``
+    restarted the whole fleet again.
+    """
+    from hermes_cli.update_receipt import record_fleet_resolution
+
+    disk_sha = "1" * 40
+    old_sha = "2" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+
+    _write_owing_receipt(disk_sha, old_sha)
+    assert update_cmd._pending_fleet_restart_needed() is True
+
+    # Clearing the marker alone must NOT be enough (the original bug).
+    update_cmd._clear_fleet_restart_pending_marker()
+    assert update_cmd._pending_fleet_restart_needed() is True
+
+    assert record_fleet_resolution(None, disk_sha) is True
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+
+def test_catchup_resolution_is_rearmed_by_a_later_pull(monkeypatch):
+    """A resolution is scoped to the SHA it discharged, not forever."""
+    from hermes_cli.update_receipt import record_fleet_resolution
+
+    disk_sha = "3" * 40
+    old_sha = "4" * 40
+    newer_sha = "5" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+
+    _write_owing_receipt(disk_sha, old_sha)
+    record_fleet_resolution([{"state": "current", "code_sha": disk_sha}], disk_sha)
+    assert update_cmd._pending_fleet_restart_needed() is False
+
+    # A later pull moves HEAD: the obligation must come back.
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: newer_sha)
+    assert update_cmd._pending_fleet_restart_needed() is True
+
+
+def test_record_fleet_resolution_refuses_an_empty_sha(monkeypatch):
+    """Without a SHA to scope it to, a resolution must not be recorded."""
+    from hermes_cli.update_receipt import record_fleet_resolution
+
+    disk_sha = "6" * 40
+    old_sha = "7" * 40
+    monkeypatch.setattr(update_cmd, "_current_checkout_sha", lambda: disk_sha)
+
+    _write_owing_receipt(disk_sha, old_sha)
+    assert record_fleet_resolution(None, "") is False
+    assert update_cmd._pending_fleet_restart_needed() is True


### PR DESCRIPTION
## Symptom

Every `hermes update` — including ones that pull nothing — reprints the
interrupted-update warning and restarts the entire fleet:

```
⚠ A previous `hermes update` pulled new code but did not restart running gateways.
  Gateways may still be serving pre-update modules (mixed sys.modules).
→ Running the pending fleet restart...
  ✓ Pending fleet restart completed.
```

It never stops. On my host this restarted the gateway on every invocation and
dropped a live Telegram connection each time.

## Cause

`_apply_pending_fleet_restart_catchup()` clears the `fleet_restart_pending`
breadcrumb after a successful restart. But `_pending_fleet_restart_needed()`
is the OR of two sources:

```python
if _fleet_restart_pending_marker_path().is_file():
    return True
return _receipt_reports_stale_runtime()
```

and the catch-up only ever addresses the first.

In `_receipt_reports_stale_runtime()` the post-restart `fleet` matrix is
preferred — but the guard is `if isinstance(fleet, list) and fleet:`, so an
**empty** fleet is falsy and falls through. For a receipt that also looks
unfinished (`outcome: failed`, `exit_code: 1`), it then falls back to
`plan.runtimes[].code_sha`, which the docstring notes is captured *before*
the pull. That SHA can never equal the post-pull checkout SHA, so the
function returns True forever.

Nothing in the catch-up path writes to the receipt, so the loop is stable:
restart → clear marker → receipt still stale → restart again next run.

Real-world receipt that triggered it (`fleet: []`, failed outcome, pre-pull
plan SHA):

```json
{ "outcome": "failed", "exit_code": 1, "stop_reason": "sys.exit(1)",
  "fleet": [],
  "plan": { "runtimes": [ { "kind": "gateway", "code_sha": "<pre-pull sha>" } ] } }
```

Note the already-up-to-date path never calls `begin_update_receipt()`, so no
later run replaces `latest.json` on its own — the bad receipt can persist
indefinitely.

## Fix

Record the catch-up restart on the receipt that owed it, scoped to the SHA it
discharged:

- `update_receipt.record_fleet_resolution(fleet, resolved_sha)` stamps
  `fleet_restart_resolved_sha` (plus the post-restart `fleet` rows when the
  probe returned any) onto `latest.json`, keeping the timestamped twin in
  sync when it mirrors the same run.
- `_receipt_reports_stale_runtime()` returns False when that recorded SHA
  matches the current checkout.

Scoping to a SHA rather than a boolean matters: a *later* pull moves HEAD and
correctly re-arms the obligation, so this cannot mask a genuine skew. An empty
`resolved_sha` is refused, and the whole path is best-effort — a failure costs
one redundant restart, never a broken update.

The fix deliberately does not change the `fleet: []` fallthrough itself. For a
genuinely interrupted update with no fleet matrix, falling back to the plan is
the intended #95294 behaviour; the bug is that the catch-up never recorded its
own completion.

## Tests

Three added to `tests/hermes_cli/test_update_fleet_restart_pending.py`:

- clearing the marker alone leaves the condition set (the original bug), and
  recording the resolution clears it
- a later pull re-arms the obligation
- an empty `resolved_sha` is refused

Full `-k "receipt or fleet or update"` run over `tests/hermes_cli/`: failure
set is byte-identical before and after this change (44 pre-existing
environment-dependent failures on this host, 0 regressions), with the 3 new
tests passing.
