### PR TITLE
fix(cli): register one-shot workers in process-identity ledger

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -174,6 +174,23 @@ def run_oneshot(
     JSON usage report even when the run fails. Returns the exit code; the caller owns process
     termination.
     """
+    # Non-interactive one-shot: register in the process-identity ledger so machine-wide scans
+    # (`hermes update`, Desktop sweeps) can classify this process instead of guessing from cmdline
+    # archaeology. "worker" is deliberately NOT in REAPABLE_PURPOSES, so reapers leave it alone —
+    # registration is identification only. Windows: self-attach to a KILL_ON_JOB_CLOSE job so tool
+    # child trees die with this process (mirrors gateway/run.py). Best-effort + fail-safe by design.
+    try:
+        from hermes_cli.process_identity import (
+            attach_self_to_kill_on_close_job,
+            register_self,
+        )
+
+        register_self("worker")
+        if sys.platform == "win32":
+            attach_self_to_kill_on_close_job()
+    except Exception:
+        pass  # identity must never break a one-shot run
+
     # Silence every stdlib logger: AIAgent, tools and provider adapters log to stderr through the
     # root logger. File handlers from setup_logging() keep working (level-independent).
     logging.disable(logging.CRITICAL)

--- a/hermes_cli/process_identity.py
+++ b/hermes_cli/process_identity.py
@@ -191,9 +191,11 @@ def _pid_alive_matches(pid: int, create_time: Optional[float]) -> Optional[bool]
 def register_self(purpose: str, *, project_root: Optional[Path] = None, detail: Optional[dict] = None) -> bool:
     """Record this process in the machine spawn ledger. Best-effort.
 
-    Called at the top of every long-lived entry point; dead ``(pid, create_time)`` entries are
-    pruned on every write. ``detail`` may carry ``host``/``port``/``profile`` so the update
-    pipeline can relaunch a manually-started serve with its real bind address.
+    Called at the top of every entry point the update/sweep pipeline needs to classify —
+    long-lived (serve/dashboard backend, gateway run loop) and one-shot (non-interactive
+    ``-q``/``--query`` runs that back cron jobs and kanban workers). Dead ``(pid, create_time)``
+    entries are pruned on every write. ``detail`` may carry ``host``/``port``/``profile`` so the
+    update pipeline can relaunch a manually-started serve with its real bind address.
     """
     tag = parse_spawn_tag(os.environ.get(SPAWN_ENV_VAR))
     spawner_pid, spawner_create = (tag.spawner_pid, tag.spawner_create) if tag else _desktop_spawner_identity()


### PR DESCRIPTION
Replaces closed PR #94981 (bot-closed, could not be reopened).

## Summary

Non-interactive one-shot runs (`hermes -q` / `--query` — the same path that backs cron jobs and kanban workers) were invisible to the process-identity ledger (`hermes_cli/process_identity.py`). Machine-wide sweeps (`hermes update`, Desktop startup) had to guess their lineage from cmdline archaeology; a hung one-shot left no trace, and on Windows its tool child trees could outlive the one-shot.

## Fix

At the top of the single-query branch (`if query or image:` in `cli.py main()`), best-effort:

1. `register_self("worker")` — ledger entry so scans can classify the process.
2. On Windows, `attach_self_to_kill_on_close_job()` — child tool trees die with the one-shot (mirrors `gateway/run.py` / `hermes_cli/web_server.py`).

The import is scoped inside the branch, so interactive REPL startup pays zero import cost. Identity failures are fail-safe (never break a run).

## Design guardrail

`"worker"` is deliberately **NOT** added to `REAPABLE_PURPOSES` — reapers keep skipping these entries. Registration is identification + cleanup only; interactive and one-shot sessions stay out of reap scope. No TTY-heuristic sweep of interactive sessions was added.

## Since the previous PR

Docstring fix landed: `register_self` now reads "Called at the top of every entry point the update/sweep pipeline needs to classify — long-lived ... and one-shot (non-interactive `-q`/`--query` runs that back cron jobs and kanban workers)." This closes the automated review's only substantive concern about docstring drift.

## Verification

- `py_compile` clean.
- Targeted pytest (`test_tui_gateway_server.py`, `test_tui_gateway_loop_noise.py`, `test_process_identity.py`) — no regressions.
