### PR TITLE
fix(tools): reconcile docker_network with --network in docker_extra_args

### DIFF
--- a/tests/tools/test_docker_network_config.py
+++ b/tests/tools/test_docker_network_config.py
@@ -47,7 +47,9 @@ def test_sibling_container_config_sites_carry_docker_network():
         assert sites >= 1, f"expected at least one container_config site in {module.__name__}"
 
 
-def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
+def _reuse_guard_harness(
+    monkeypatch, *, existing_mode: str, network: bool, extra_args=None
+):
     """Drive DockerEnvironment through the cross-process reuse path with a
     fake existing container whose NetworkMode is *existing_mode*.
 
@@ -84,6 +86,7 @@ def _reuse_guard_harness(monkeypatch, *, existing_mode: str, network: bool):
         timeout=60,
         task_id="reuse-guard-test",
         network=network,
+        extra_args=extra_args,
         persist_across_processes=True,
     )
     return commands
@@ -114,3 +117,90 @@ def test_reuse_skips_inspect_when_network_enabled(monkeypatch):
     assert not any(cmd[1] == "inspect" for cmd in commands)
     assert not any(cmd[1] == "rm" for cmd in commands)
     assert not any(cmd[1] == "run" for cmd in commands)
+
+
+def test_extra_args_network_none_emits_flag_once(monkeypatch):
+    """docker_network=false plus an explicit --network=none in
+    docker_extra_args must emit the flag once, not twice.
+
+    Docker rejects a repeated --network outright ("network \"none\" is
+    specified multiple times", exit 125), so emitting both made every
+    container start fail. Issue #100248.
+    """
+    commands = _reuse_guard_harness(
+        monkeypatch,
+        existing_mode="bridge",
+        network=False,
+        extra_args=["--network=none", "--user", "1009:1009"],
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert run_cmd.count("--network=none") == 1, (
+        f"--network=none emitted {run_cmd.count('--network=none')} times: {run_cmd}"
+    )
+    # The operator's other extra args are untouched.
+    assert "--user" in run_cmd and "1009:1009" in run_cmd
+
+
+def test_extra_args_space_separated_network_none_emits_flag_once(monkeypatch):
+    commands = _reuse_guard_harness(
+        monkeypatch,
+        existing_mode="bridge",
+        network=False,
+        extra_args=["--network", "none"],
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert "--network=none" not in run_cmd, (
+        f"implicit --network=none added despite explicit --network none: {run_cmd}"
+    )
+    assert run_cmd.count("--network") == 1
+
+
+def test_lockdown_still_applies_without_extra_network_arg(monkeypatch):
+    """Unchanged common case: no network flag in extra args means the
+    implicit --network=none is still emitted."""
+    commands = _reuse_guard_harness(
+        monkeypatch,
+        existing_mode="bridge",
+        network=False,
+        extra_args=["--user", "1009:1009"],
+    )
+
+    run_cmd = next(cmd for cmd in commands if len(cmd) > 2 and cmd[1:3] == ["run", "-d"])
+    assert run_cmd.count("--network=none") == 1
+
+
+def test_contradictory_network_request_fails_closed(monkeypatch):
+    """docker_network=false with --network=host in extra args is contradictory.
+
+    Honouring the extra arg would defeat the configured lockdown, and the
+    reuse guard (which requires NetworkMode == "none") would then remove and
+    recreate that container on every startup. Fail loudly instead.
+    """
+    import pytest
+
+    with pytest.raises(RuntimeError, match="docker_network"):
+        _reuse_guard_harness(
+            monkeypatch,
+            existing_mode="bridge",
+            network=False,
+            extra_args=["--network=host"],
+        )
+
+
+def test_extra_args_network_mode_parsing():
+    from tools.environments.docker import _extra_args_network_mode
+
+    assert _extra_args_network_mode(["--network=none"]) == "none"
+    assert _extra_args_network_mode(["--network", "none"]) == "none"
+    assert _extra_args_network_mode(["--net=host"]) == "host"
+    assert _extra_args_network_mode(["--net", "host"]) == "host"
+    assert _extra_args_network_mode(["--network=my-net"]) == "my-net"
+    assert _extra_args_network_mode(["--user", "1009:1009"]) is None
+    assert _extra_args_network_mode([]) is None
+    assert _extra_args_network_mode(None) is None
+    # Non-string entries are skipped rather than raising.
+    assert _extra_args_network_mode([1009, None]) is None
+    # A trailing bare flag with no value must not IndexError.
+    assert _extra_args_network_mode(["--network"]) == ""

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -633,13 +633,39 @@ def _critical_egress_env_names(env_overrides: dict[str, str]) -> set[str]:
     return critical
 
 
+_NETWORK_FLAGS = frozenset({"--network", "--net"})
+
+
+def _extra_args_network_mode(extra_args: Optional[list[str]]) -> Optional[str]:
+    """Return the network mode requested by ``docker_extra_args``, if any.
+
+    Recognises ``--network none`` / ``--network=none`` and the ``--net``
+    aliases. Returns ``None`` when the operator set no network flag, else the
+    requested mode (``"none"``, ``"host"``, a named network, ...).
+
+    Docker rejects a repeated ``--network`` outright ("network ... is
+    specified multiple times", exit 125), so the implicit flag added for
+    ``docker_network: false`` and an operator-supplied one can never both be
+    emitted. Callers use this to reconcile the two before building the
+    command line.
+    """
+    args = [a for a in (extra_args or []) if isinstance(a, str)]
+    for i, arg in enumerate(args):
+        for flag in _NETWORK_FLAGS:
+            if arg == flag:
+                return args[i + 1] if i + 1 < len(args) else ""
+            if arg.startswith(f"{flag}="):
+                return arg.split("=", 1)[1]
+    return None
+
+
 def _extra_args_egress_collisions(
     extra_args: list[str], critical_names: set[str],
 ) -> list[str]:
     """Return docker_extra_args entries that can override egress controls."""
     collisions: list[str] = []
     env_flags = {"-e", "--env", "--env-file"}
-    network_flags = {"--network", "--net"}
+    network_flags = _NETWORK_FLAGS
     i = 0
     while i < len(extra_args):
         arg = extra_args[i]
@@ -976,7 +1002,30 @@ class DockerEnvironment(BaseEnvironment):
                     "(requires overlay2 on XFS with pquota). Container will run without disk quota."
                 )
         if not network:
-            resource_args.append("--network=none")
+            extra_network = _extra_args_network_mode(extra_args)
+            if extra_network is None:
+                resource_args.append("--network=none")
+            elif extra_network == "none":
+                # Same intent stated twice. Emit it once — Docker rejects a
+                # repeated --network with exit 125.
+                logger.info(
+                    "Docker: docker_network is false and docker_extra_args "
+                    "also requests --network=none; emitting the flag once."
+                )
+            else:
+                # Contradictory intent. Honouring the extra arg would hand the
+                # agent a networked container despite the configured lockdown,
+                # and the reuse guard (which requires NetworkMode == "none")
+                # would churn that container on every startup. Fail closed and
+                # name both keys rather than silently picking a winner.
+                raise RuntimeError(
+                    f"terminal.docker_network is false (air-gapped) but "
+                    f"terminal.docker_extra_args requests "
+                    f"--network={extra_network!r}. These contradict; Docker "
+                    f"would also reject the duplicate flag (exit 125). Remove "
+                    f"the --network entry from docker_extra_args, or set "
+                    f"docker_network: true to opt into that network."
+                )
 
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent


### PR DESCRIPTION
## What does this PR do?

`terminal.docker_network: false` and `terminal.docker_extra_args` are independently documented and independently valid, but combining them was unconditionally fatal. `DockerEnvironment.__init__` appended `--network=none` itself for the lockdown, then appended `docker_extra_args` verbatim, with nothing reconciling the two. Docker rejects a repeated `--network`:

```
docker: network "none" is specified multiple times
```

Every `docker run` for such a profile exited 125 and the Docker backend was unusable until one of the two settings was removed.

This reconciles them before the command line is built:

| `docker_network` | `docker_extra_args` | Result |
|---|---|---|
| `false` | no network flag | `--network=none` — unchanged |
| `false` | `--network=none` | flag emitted once, `logger.info` |
| `false` | `--network=host` / named net | `RuntimeError` naming both keys |

## Why the third row raises instead of letting the extra arg win

"Extra args are appended last so they can override defaults" is the natural reading, and it is what #100248's original Proposed Fix suggested. Implementing it showed that it is wrong here, because of the cross-process reuse guard:

```python
if not network:
    actual_mode = self._container_network_mode(container_id)
    mode_mismatch = actual_mode != "none"
```

Under override semantics, `docker_network: false` + `--network=host` would hand the agent a host-networked container despite the configured lockdown, and the guard would then remove and recreate that container on **every** startup, since its NetworkMode is permanently `host` and never `none`. A silent weakening of the lockdown plus unbounded container churn.

Those two settings genuinely contradict, so the honest resolution is to say so. This also matches the posture the module already takes next door — `_extra_args_egress_collisions()` raises rather than guessing when `enforce_on_docker` is set.

The `{"--network", "--net"}` flag set is lifted to a module constant so the new parser and the existing collision helper share a single definition.

## How to test

Reduced to plain Docker, this is the exact shape `all_run_args` produced:

```console
$ docker run --rm --network=none --user 1002:1002 --network=none --user 1009:1009 alpine id
docker: network "none" is specified multiple times
$ echo $?
125
```

Through Hermes:

```yaml
terminal:
  backend: docker
  docker_network: false
  docker_extra_args: ["--network=none", "--user", "1009:1009"]
```

Before: every sandbox creation fails with exit 125. After: the container starts, `--network=none` appears once, and `--user 1009:1009` is applied.

Automated:

```console
$ pytest tests/tools/test_docker_network_config.py -q
10 passed

$ pytest tests/tools/*docker* tests/tools/test_terminal_tool.py -q
150 passed
```

The four new tests fail on the unpatched tree (verified by reverting only `tools/environments/docker.py` and re-running) and pass with the fix. `test_lockdown_still_applies_without_extra_network_arg` is the no-regression guard for the common case, and passes either way.

New coverage:
- `--network=none` in extra args → flag emitted exactly once
- space-separated `--network none` → same
- no network flag in extra args → implicit `--network=none` still emitted
- contradictory `--network=host` → raises
- parser units: `--net` aliases, `=` and space forms, non-string entries, and a trailing bare `--network` that must not `IndexError`

## Platforms tested

Linux (Ubuntu 24.04, Docker 29.5.2, Python 3.11.15). The change is pure argument-list construction with no platform-specific behaviour.

## Related issue

Fixes #100248.

Note for reviewers: that issue's Proposed Fix section describes the simple override semantics. I have commented there explaining why this PR uses the three-way split instead, so the issue and PR do not disagree.

Adjacent but deliberately **not** touched here, to keep this focused: #84027 (`file_tools` / `code_execution_tool` drop `docker_extra_args` from their `container_config`). The two interact badly in production — the exit 125 above kills the terminal-tool creation, then a `file_tools` creation succeeds *because* it drops the extra args, silently yielding a container with the wrong uid. That is #84027's to fix (#35660 / #90050 are open for it).
