### PR TITLE
fix(models): resolve named custom providers by their bare config key

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2956,6 +2956,44 @@ def _get_provider_config_dict(provider: str) -> dict[str, Any]:
     return {}
 
 
+def _custom_provider_aliases(provider: str) -> tuple[str, ...]:
+    """Every config key a ``custom:<name>`` provider may be filed under.
+
+    ``providers:`` entries are keyed by their bare config key
+    (``providers.anymodel``) while the router addresses them by slug
+    (``custom:anymodel``).  A slug-only lookup therefore misses every named
+    custom provider (#100088), so callers must try both spellings.  Ordered
+    most-specific first; the bare suffix is last so an unrelated provider that
+    happens to be named ``custom`` cannot shadow a real entry.
+    """
+    key = str(provider or "").strip()
+    if not key:
+        return ()
+    lowered = key.lower()
+    aliases = [lowered]
+    if lowered.startswith("custom:"):
+        suffix = lowered.split(":", 1)[1].strip()
+        if suffix:
+            aliases.append(suffix)
+    # The display name may differ from the config key; resolve it too.
+    try:
+        from hermes_cli.providers import custom_provider_aliases
+
+        for name in tuple(custom_provider_aliases(key)):
+            name = str(name).strip().lower()
+            if not name or name in aliases:
+                continue
+            # custom_provider_aliases() re-prefixes its own input, yielding
+            # junk like "custom:custom:anymodel" for a slug; skip those so a
+            # garbage key can never be preferred over a real one.
+            if name.count("custom:") > 1:
+                continue
+            aliases.append(name)
+    except Exception:
+        pass
+    return tuple(dict.fromkeys(a for a in aliases if a))
+
+
 def _root_for_ollama_native_api(base_url: str) -> str:
     """Convert an OpenAI-style Ollama base URL to the native API root."""
     root = str(base_url or "").strip().rstrip("/")
@@ -4169,13 +4207,30 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                     return live
         except Exception:
             pass
-    if normalized == "custom":
-        base_url = _get_custom_base_url()
+    if normalized == "custom" or normalized.startswith("custom:"):
+        # Named custom providers (``custom:<key>``) carry their own
+        # ``base_url`` / ``api_key`` / ``models`` — but under the BARE config
+        # key (``providers.anymodel``), not the ``custom:`` slug the rest of
+        # the code routes on. Looking the slug up directly returns {},
+        # so every named provider silently fell through to the global
+        # ``model.base_url`` or to an empty catalog (#100088). Resolve through
+        # the provider's own alias set instead.
+        entry = {}
+        if normalized != "custom":
+            entry = _get_provider_config_dict(normalized)
+            if not entry:
+                for alias in _custom_provider_aliases(normalized):
+                    candidate = _get_provider_config_dict(alias)
+                    if candidate:
+                        entry = candidate
+                        break
+        base_url = str(entry.get("base_url") or "").strip() or _get_custom_base_url()
         if base_url:
             model_cfg = _get_model_config_dict()
             # Try common API key env vars for custom endpoints
             api_key = (
-                str(model_cfg.get("api_key", "") or "").strip()
+                str(entry.get("api_key") or "").strip()
+                or str(model_cfg.get("api_key", "") or "").strip()
                 or os.getenv("CUSTOM_API_KEY", "")
                 or os.getenv("OPENAI_API_KEY", "")
                 or os.getenv("OPENROUTER_API_KEY", "")
@@ -4184,6 +4239,14 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
             live = fetch_api_models(api_key, base_url, api_mode=api_mode)
             if live:
                 return live
+        # A configured ``models:`` block is an explicit static catalog. Honour
+        # it even when live discovery is off or the endpoint is unreachable —
+        # the user wrote these down on purpose.
+        configured = entry.get("models")
+        if isinstance(configured, dict) and configured:
+            return [str(m) for m in configured]
+        elif isinstance(configured, list) and configured:
+            return [str(m) for m in configured]
     # Bedrock uses live discovery keyed by the resolved AWS region so that
     # EU/AP users see eu.*/ap.* model IDs instead of the static us.* list.
     # Note: early return intentionally skips _MODELS_DEV_PREFERRED merge

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -804,3 +804,87 @@ class TestValidateRequestedModelNousPortalRecommendations:
             result = validate_requested_model("inclusionai/ling-2.6-flash", "nous")
         mock_portal.assert_not_called()
         assert result["accepted"] is True
+
+
+# ---------------------------------------------------------------------------
+# Named custom providers (custom:<key>) — #100088
+# ---------------------------------------------------------------------------
+
+
+class TestNamedCustomProviderCatalog:
+    """``custom:<key>`` must resolve its OWN config, not the global model.* block.
+
+    ``providers:`` entries are keyed by their bare config key while the router
+    addresses them by ``custom:`` slug. A slug-only lookup returns {}, so every
+    named custom provider fell through to ``model.base_url`` or to an empty
+    catalog and the picker showed 0 models.
+    """
+
+    NAMED = "custom:my-vllm"
+    BARE_KEY = "my-vllm"
+
+    @pytest.fixture
+    def named_provider_config(self):
+        """providers.my-vllm with its own base_url and a static model block."""
+        return {
+            "name": "my-vllm",
+            "base_url": "https://vllm.internal/v1",
+            "models": {"local/qwen": {}, "local/llama": {}},
+        }
+
+    def test_alias_resolution_includes_bare_config_key(self):
+        """The bare key must be among the aliases tried for a slug."""
+        from hermes_cli.models import _custom_provider_aliases
+
+        aliases = _custom_provider_aliases(self.NAMED)
+        assert self.BARE_KEY in aliases
+        # The slug itself stays first so an exact match is never shadowed.
+        assert aliases[0] == self.NAMED
+        # No double-prefixed junk (custom:custom:<key>).
+        assert not [a for a in aliases if a.count("custom:") > 1]
+
+    def test_slug_lookup_falls_back_to_bare_key(self, named_provider_config):
+        """A slug miss must retry under the bare key rather than giving up."""
+        from hermes_cli.models import _get_provider_config_dict
+
+        providers_cfg = {self.BARE_KEY: named_provider_config}
+        with patch("hermes_cli.config.load_config", return_value={"providers": providers_cfg}):
+            # Slug-only: this is the lookup that used to return {}.
+            assert _get_provider_config_dict(self.NAMED) == {}
+            # Bare key: where the config actually lives.
+            entry = _get_provider_config_dict(self.BARE_KEY)
+        assert entry.get("base_url") == named_provider_config["base_url"]
+
+    def test_named_custom_provider_offers_its_configured_models(
+        self, named_provider_config
+    ):
+        """Regression: the picker showed 0 models for every custom:<key>."""
+        providers_cfg = {self.BARE_KEY: named_provider_config}
+        with patch("hermes_cli.config.load_config", return_value={"providers": providers_cfg}), \
+             patch("hermes_cli.models.fetch_api_models", return_value=[]) as mock_fetch:
+            models = provider_model_ids(self.NAMED)
+
+        assert models, "named custom provider must not report an empty catalog"
+        assert set(models) == set(named_provider_config["models"])
+        # Its OWN endpoint was queried, not the global model.base_url.
+        assert mock_fetch.call_args is not None
+        assert mock_fetch.call_args[0][1] == named_provider_config["base_url"]
+
+    def test_live_discovery_wins_over_static_block(self, named_provider_config):
+        """A reachable endpoint still takes precedence over `models:`."""
+        providers_cfg = {self.BARE_KEY: named_provider_config}
+        with patch("hermes_cli.config.load_config", return_value={"providers": providers_cfg}), \
+             patch("hermes_cli.models.fetch_api_models",
+                   return_value=["live/model-a"]):
+            models = provider_model_ids(self.NAMED)
+        assert models == ["live/model-a"]
+
+    def test_bare_custom_provider_unchanged(self):
+        """The global `custom` provider must keep reading model.base_url."""
+        with patch("hermes_cli.models._get_custom_base_url",
+                   return_value="https://global.example/v1"), \
+             patch("hermes_cli.models.fetch_api_models",
+                   return_value=["global/model"]) as mock_fetch:
+            models = provider_model_ids("custom")
+        assert models == ["global/model"]
+        assert mock_fetch.call_args[0][1] == "https://global.example/v1"


### PR DESCRIPTION
## Summary

The model picker returns **0 models for every named custom provider** (`custom:<name>`), even when that provider's config carries both a `base_url` for live discovery and an explicit `models:` block. #100088.

## Root cause

`provider_model_ids()` special-cased only the **bare** `custom` provider:

```python
if normalized == "custom":
    base_url = _get_custom_base_url()
    ...
    live = fetch_api_models(api_key, base_url, api_mode=api_mode)
```

Named providers never entered that branch. They fell through to the static catalog: `curated_models_for_provider()` ends with `_PROVIDER_MODELS.get(normalized, [])`, and the catalog has **no `custom:*` key at all** (42 keys, 0 containing "custom"). Result: `[]`.

The deeper mismatch is *how the config is keyed* versus *how it is addressed*:

| | spelling |
|---|---|
| config file | `providers.anymodel` (bare key) |
| router / picker | `custom:anymodel` (slug) |

So `_get_provider_config_dict("custom:anymodel")` returns `{}` — measured on a real config — while `_get_provider_config_dict("anymodel")` returns the full entry. Every named custom provider silently resolved to nothing.

## Fix

Resolve named providers through `_custom_provider_aliases()`, which returns the slug first and the bare key second, so an exact match is never shadowed by a looser one.

Two details worth flagging:

- **Double-prefix filtering.** The shared `custom_provider_aliases()` helper re-prefixes its own input, so feeding it `custom:anymodel` also yields `custom:custom:anymodel`. Those are dropped so a garbage key can never beat a real entry.
- **`models:` honoured as an explicit catalog.** When live discovery returns nothing, a configured `models:` block is used. The user wrote those entries down on purpose. Live results still take precedence when the endpoint answers (they are tried first).

## Measurement

Run against a real config with two named providers, calling the real code paths:

```
provider                  before   after
custom:anymodel              0       94
custom:tokenrouter           0        4
custom                      33       33   (unchanged)
nous                       376      376   (unchanged)
```

The two named providers now return **different** lists, confirming each reads its own `base_url` / `models` rather than the global `model.base_url`.

## Tests

Invariants, per AGENTS.md — no source reading, no snapshot literals:

- aliases must include the bare key, keep the slug first, and never emit a double-prefixed entry;
- a named provider must offer its own configured models **and query its own endpoint** (the mock's URL is asserted, so falling back to the global base_url fails the test);
- live discovery must still win over the static block;
- the bare `custom` provider must keep reading the global `model.base_url`.

Red/green verified by copying the new tests onto a clean `git clone --shared` at `5a8e8a6` **without** the fix:

```
3 failed, 2 passed      (clean tree)
5 passed                (with fix)
```

The 2 that pass in both are the controls — `_get_provider_config_dict` behaves identically either way, and the bare provider is untouched.

## Regression check

`tests/test_model_tools.py`, `tests/test_model_picker_scroll.py`, `tests/test_empty_model_fallback.py`, `tests/providers`, `tests/test_minimax_model_validation.py` against a clean shared clone at the same commit:

```
base=11 failures   mine=11 failures
diff -> empty
```

All 11 are pre-existing (a `hermes_logging` import issue in a bare venv); the failure sets are **identical**, not merely equal in count.

`ruff check hermes_cli/models.py tests/hermes_cli/test_model_validation.py` → **All checks passed**.

(`ruff format --check` reports these files, but it reports the same for the **untouched originals** on a clean tree — a formatter-version difference, so I left formatting alone rather than pollute the diff.)

## Note on the issue body

#100088 was filed with an empty description. I could not confirm the reporter's exact configuration; this diagnosis comes from reproducing the symptom on a config with named custom providers and tracing it to the key/slug mismatch. If their setup differs, the measurement above still stands as the behaviour of the current code.

Fixes #100088
