### PR TITLE
test(agent): isolate vision routing provider dependencies

### DIFF
--- a/tests/agent/test_vision_routing_31179.py
+++ b/tests/agent/test_vision_routing_31179.py
@@ -180,27 +180,58 @@ model:
         monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-test")
         _fresh_modules()
 
-        from agent.auxiliary_client import resolve_vision_provider_client
-        provider, client, _model = resolve_vision_provider_client(provider="auto")
+        from unittest.mock import patch
+
+        import agent.auxiliary_client as auxiliary_client
+
+        # Pin the capability contract instead of depending on models.dev cache
+        # state; this test owns the routing decision, not catalog hydration.
+        with patch.object(
+            auxiliary_client,
+            "_main_model_supports_vision",
+            return_value=False,
+        ):
+            provider, client, _model = auxiliary_client.resolve_vision_provider_client(
+                provider="auto"
+            )
         assert client is None, (
             f"Vision auto-detect must skip text-only main {provider!r} when "
             "no vision-capable aggregator is available, not return a client "
             "that will fail at API time"
         )
 
-    def test_vision_capable_main_used(self, isolated_home, monkeypatch):
+    def test_vision_capable_main_used(self, isolated_home):
         """Vision-capable main provider should be returned by auto chain."""
         _write_config(isolated_home, """
 model:
   provider: anthropic
   default: claude-sonnet-4-6
 """)
-        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
         _fresh_modules()
 
-        from agent.auxiliary_client import resolve_vision_provider_client
-        provider, client, _model = resolve_vision_provider_client(provider="auto")
-        assert client is not None
+        from unittest.mock import patch
+
+        import agent.auxiliary_client as auxiliary_client
+
+        expected_client = object()
+        # Exercise auto-chain ordering without requiring the optional
+        # Anthropic SDK in the hermetic test environment.
+        with (
+            patch.object(
+                auxiliary_client,
+                "_main_model_supports_vision",
+                return_value=True,
+            ),
+            patch.object(
+                auxiliary_client,
+                "_try_anthropic",
+                return_value=(expected_client, "claude-sonnet-4-6"),
+            ),
+        ):
+            provider, client, _model = auxiliary_client.resolve_vision_provider_client(
+                provider="auto"
+            )
+        assert client is expected_client
         assert provider == "anthropic"
 
     def test_unknown_capability_does_not_block(self, isolated_home, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Makes the issue #31179 vision-routing regression tests deterministic in a clean canonical test environment. The tests now stub the two external seams they do not own—models.dev capability lookup and optional Anthropic client construction—while continuing to exercise the real `resolve_vision_provider_client()` routing logic.

This is a test-only change; production routing behavior is unchanged.

## Related Issue

Follow-up regression-test isolation for #31179.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Isolate text-only main-model routing from models.dev cache/network state in `tests/agent/test_vision_routing_31179.py`.
- Isolate vision-capable Anthropic routing from optional SDK installation while asserting the configured main-provider path and returned client identity.

## How to Test

1. `HERMES_TEST_FILE_RETRIES=0 HERMES_PYTHON=/home/arkouda/Projects/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/agent/test_vision_routing_31179.py`
2. Repeat the command three times with retries disabled to verify cold-environment determinism.
3. `HERMES_TEST_FILE_RETRIES=0 HERMES_PYTHON=/home/arkouda/Projects/hermes-agent/.venv/bin/python scripts/run_tests.sh tests/agent/test_vision_routing_31179.py tests/agent/test_vision_resolved_args.py tests/agent/test_custom_providers_vision.py`

All commands exited 0 locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable; this is a test-isolation change.
