### PR TITLE
fix(state): detect content-dependent FTS index corruption in the health probe

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3374,25 +3374,60 @@ def _db_opens_cleanly(db_path: Path) -> Optional[str]:
                 # while reads of the FTS5 table itself parse fine.
                 return f"fts5 read probe failed on {fts_table}: {exc}"
 
-        # FTS write probe: drive a row through the messages_fts* triggers in a
+        # FTS write probe: drive rows through the messages_fts* triggers in a
         # transaction that is always rolled back, so a corrupt FTS index that
         # rejects writes is caught even though reads look healthy. The probe is
         # best-effort — if the messages/sessions tables don't exist yet (brand
         # new file mid-init) the OperationalError is treated as "not yet a
         # populated DB", not corruption.
+        #
+        # Trigram-segment corruption is CONTENT-DEPENDENT (#100227): the
+        # trigram index rejects an insert with IntegrityError
+        # ("constraint failed" on messages_fts_trigram_idx's (segid, term)
+        # PRIMARY KEY) only when the row's terms land in the damaged segment.
+        # A single fixed probe string whose trigrams miss that segment writes
+        # cleanly, so the probe reported healthy, `hermes doctor` passed, and
+        # `sessions repair --check-only` said "no repair needed" while every
+        # real append failed with session_persistence_failed. Drive SEVERAL
+        # distinct contents spanning different trigram token sets so a damaged
+        # segment is hit regardless of which terms it holds.
         probe_session_id = f"_hermes_fts_health_probe_{time.time_ns()}"
+        _probe_contents = (
+            "_fts_health_probe",
+            # Distinct trigram token sets: digits, punctuation-delimited
+            # ASCII, mixed case, hex-ish and unicode runs. Each produces a
+            # different set of 3-char windows in the trigram index, so the
+            # probe is no longer hostage to one string's token placement.
+            "0123456789 4815162342 90210 314159",
+            "alpha-bravo_charlie.delta/echo:foxtrot",
+            "QwErTyUiOp ZxCvBnM AsDfGhJkL",
+            "deadbeef cafebabe f00dfeed 0xdeadc0de",
+            "café naïve résumé — 日本語 テスト 中文 测试",
+        )
         try:
             conn.execute("BEGIN IMMEDIATE")
             conn.execute(
                 "INSERT INTO sessions (id, source, started_at) VALUES (?, ?, ?)",
                 (probe_session_id, "_health_probe", time.time()),
             )
-            conn.execute(
-                "INSERT INTO messages (session_id, role, content, timestamp) "
-                "VALUES (?, ?, ?, ?)",
-                (probe_session_id, "user", "_fts_health_probe", time.time()),
-            )
+            for _probe_content in _probe_contents:
+                conn.execute(
+                    "INSERT INTO messages (session_id, role, content, timestamp) "
+                    "VALUES (?, ?, ?, ?)",
+                    (probe_session_id, "user", _probe_content, time.time()),
+                )
             conn.execute("ROLLBACK")
+        except sqlite3.IntegrityError as exc:
+            # Segment-dependent FTS corruption surfaces here, NOT as an
+            # OperationalError: the shadow-table insert violates the index's
+            # own PRIMARY KEY. Before #100227 this escaped _db_opens_cleanly
+            # entirely (only OperationalError/DatabaseError were handled), so
+            # callers saw an exception instead of a corruption verdict.
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            return f"fts write probe failed (index constraint violated): {exc}"
         except sqlite3.OperationalError as exc:
             # Missing tables / FTS disabled — not the corruption class we probe.
             try:

--- a/tests/test_state_db_malformed_repair.py
+++ b/tests/test_state_db_malformed_repair.py
@@ -322,6 +322,100 @@ def test_fts_write_corruption_repaired_in_place(tmp_path):
         db.close()
 
 
+# ── Segment-dependent trigram corruption (#100227) ─────────────────────
+#
+# The trigram index rejects an insert with IntegrityError ("constraint
+# failed" on messages_fts_trigram_idx's (segid, term) PRIMARY KEY) only when
+# the row's terms land in the damaged segment. A single fixed probe string
+# whose trigrams miss that segment writes cleanly, so the probe reported
+# healthy while every real append failed with session_persistence_failed.
+
+
+def _integrity_error_on_specific_content(db_path, poisoned_substring):
+    """Install a trigger that raises IntegrityError only for some content.
+
+    Faithful to the reported failure MODE (content-dependent constraint
+    violation from an FTS shadow-table insert) without needing a genuinely
+    damaged segment, which cannot be synthesized portably.
+    """
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    conn.executescript(
+        f"""
+        CREATE TABLE IF NOT EXISTS _seg_guard (term TEXT PRIMARY KEY);
+        INSERT OR IGNORE INTO _seg_guard (term) VALUES ('{poisoned_substring}');
+        CREATE TRIGGER IF NOT EXISTS _seg_corrupt
+        AFTER INSERT ON messages
+        WHEN new.content LIKE '%{poisoned_substring}%'
+        BEGIN
+            INSERT INTO _seg_guard (term) VALUES ('{poisoned_substring}');
+        END;
+        """
+    )
+    conn.close()
+
+
+def test_probe_catches_corruption_that_only_some_content_triggers(tmp_path):
+    """#100227: a segment that only rejects SOME contents must still be
+    detected. The old single-string probe returned healthy here."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    assert _db_opens_cleanly(db_path) is None  # healthy before
+
+    # Poison a token that the ORIGINAL fixed probe string does not contain,
+    # but that one of the varied probe contents does.
+    _integrity_error_on_specific_content(db_path, "cafebabe")
+
+    reason = _db_opens_cleanly(db_path)
+    assert reason is not None, (
+        "content-dependent index corruption must not be reported as healthy"
+    )
+    assert "constraint" in reason.lower()
+
+
+def test_integrity_error_is_a_corruption_verdict_not_an_exception(tmp_path):
+    """The probe must RETURN a reason for IntegrityError, not raise it.
+
+    Before #100227 only OperationalError/DatabaseError were handled, so a
+    constraint violation escaped _db_opens_cleanly and callers
+    (hermes doctor, sessions repair --check-only) saw a traceback instead
+    of a corruption verdict.
+    """
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    # Poison a token present in the FIRST probe content, so the very first
+    # insert raises.
+    _integrity_error_on_specific_content(db_path, "_fts_health_probe")
+
+    reason = _db_opens_cleanly(db_path)  # must not raise
+    assert reason is not None
+    assert "constraint" in reason.lower()
+
+
+def test_healthy_db_still_passes_the_multi_content_probe(tmp_path):
+    """The extra probe contents must not create false positives — a healthy
+    DB (unicode/digit/punctuation trigrams included) stays healthy."""
+    from hermes_state import _db_opens_cleanly
+
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+
+    assert _db_opens_cleanly(db_path) is None
+    # And the probe leaves nothing behind (every insert is rolled back).
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        leaked = conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE source = '_health_probe'"
+        ).fetchone()[0]
+        assert leaked == 0
+        assert conn.execute("SELECT COUNT(*) FROM messages").fetchone()[0] == 10
+    finally:
+        conn.close()
+
+
 
 
 def _corrupt_btree_index(db_path: Path, index_name: str) -> None:


### PR DESCRIPTION
Fixes #100227

## Problem

The write probe in `_db_opens_cleanly` drove **one fixed message** (`_fts_health_probe`) through the FTS triggers. Trigram-segment corruption is **content-dependent**: the index rejects an insert with `IntegrityError` (`constraint failed` on `messages_fts_trigram_idx`'s `(segid, term)` PRIMARY KEY) only when the row's terms land in the damaged segment.

A probe string whose trigrams miss that segment wrote cleanly — so the probe reported healthy, `hermes doctor` passed, and `hermes sessions repair --check-only` printed *"opens cleanly — no repair needed"* and exited, while every real message append failed with `session_persistence_failed` and `errors.log` filled with `append_message failed: constraint failed`. `PRAGMA integrity_check` and FTS5 `'integrity-check'` both return clean (base tables are fine; only the derived segment is bad), so nothing else caught it either.

## Fix

**1. Multi-content probe.** Six distinct contents now go through the triggers inside the same rolled-back transaction — the original string plus digit runs, punctuation-delimited ASCII, mixed case, hex-ish tokens, and unicode/CJK. Each produces a different set of 3-char windows, so a damaged segment is exercised regardless of which terms it holds. This is the issue's suggested fix #1.

**2. `IntegrityError` is caught and returned as a corruption verdict.** It was previously **unhandled** — only `OperationalError`/`DatabaseError` were — so a constraint violation escaped `_db_opens_cleanly` entirely and callers got a traceback instead of a reason. This is arguably the sharper half of the bug: even when the probe *did* hit the corrupt segment, it couldn't report it.

The repair path itself is untouched — `_recover_stale_fts_locked` (drop + recreate + rebuild + reinstall triggers) already fixes this class once detection works, which the reporter confirmed.

## Verification

`tests/test_state_db_malformed_repair.py`: **24 passed / 3 skipped**, with three new tests:

- **content-dependent corruption is detected** — poison a token absent from the original fixed probe string but present in one of the varied contents; the old probe returned healthy here, the new one reports `constraint`
- **`IntegrityError` returns a verdict rather than raising** — poison a token in the *first* probe content so the very first insert violates; `_db_opens_cleanly` must return a reason, not propagate
- **no false positives, no leakage** — a healthy DB still passes with the extra unicode/digit/punctuation contents, and every probe row is rolled back (0 `_health_probe` sessions, message count unchanged)

Sibling suites green: `test_state_db_repair_non_destructive.py` + `test_state_db_repair_live_writer_guard.py` 26/26.