### PR TITLE
feat(skills): add multilingual discovery triggers

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -31,6 +31,7 @@ from agent.skill_utils import (
     SKILL_SUPPORT_DIRS,
     extract_skill_conditions,
     extract_skill_description,
+    extract_skill_triggers,
     get_all_skills_dirs,
     get_disabled_skill_names,
     iter_skill_index_files,
@@ -1511,9 +1512,9 @@ def drain_truncation_warnings() -> list:
 _SKILLS_PROMPT_CACHE_MAX = 32
 _SKILLS_PROMPT_CACHE: OrderedDict[tuple, str] = OrderedDict()
 _SKILLS_PROMPT_CACHE_LOCK = threading.Lock()
-# v2: entries gained org provenance fields (org_id/org_author/rel_dir) for M2
-# org-shared skills; older snapshots are discarded and rebuilt.
-_SKILLS_SNAPSHOT_VERSION = 2
+# v3: entries gained multilingual trigger aliases; older snapshots are
+# discarded so the static skill index never serves description-only metadata.
+_SKILLS_SNAPSHOT_VERSION = 3
 
 
 def _skills_prompt_snapshot_path() -> Path:
@@ -1647,6 +1648,7 @@ def _build_snapshot_entry(
         "category": category,
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
+        "triggers": extract_skill_triggers(frontmatter),
         "platforms": [str(p).strip() for p in platforms if str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
@@ -1666,6 +1668,16 @@ def _build_snapshot_entry(
         except Exception:
             entry["org_author"] = ""
     return entry
+
+
+def _skill_index_description(entry: dict) -> str:
+    """Combine prose and bounded trigger aliases for model-side discovery."""
+    description = str(entry.get("description") or "").strip()
+    triggers = [str(value) for value in (entry.get("triggers") or []) if str(value)]
+    if not triggers:
+        return description
+    aliases = f"[triggers: {', '.join(triggers)}]"
+    return f"{description} {aliases}".strip()
 
 
 # =========================================================================
@@ -1939,7 +1951,10 @@ def _build_skills_system_prompt_inner(
                         continue
                     project_names.add(fm_name)
                     skills_by_category.setdefault(entry["category"], []).append(
-                        (fm_name, f"[project] {entry['description']}".strip())
+                        (
+                            fm_name,
+                            f"[project] {_skill_index_description(entry)}".strip(),
+                        )
                     )
                 except Exception as e:
                     logger.debug("Error reading project skill %s: %s", skill_file, e)
@@ -1969,7 +1984,7 @@ def _build_skills_system_prompt_inner(
         name_owners.setdefault(fm, set()).add(kind)
     for entry in visible_entries:
         fm = entry.get("frontmatter_name") or entry.get("skill_name") or ""
-        desc = entry.get("description", "")
+        desc = _skill_index_description(entry)
         org_id = entry.get("org_id")
         collided = len(name_owners.get(fm, set())) > 1
         if org_id:
@@ -2039,7 +2054,7 @@ def _build_skills_system_prompt_inner(
                     continue
                 seen_skill_names.add(frontmatter_name)
                 skills_by_category.setdefault(entry["category"], []).append(
-                    (frontmatter_name, entry["description"])
+                    (frontmatter_name, _skill_index_description(entry))
                 )
             except Exception as e:
                 logger.debug("Error reading external skill %s: %s", skill_file, e)

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -1180,6 +1180,9 @@ def resolve_skill_config_values(
 # ── Description extraction ────────────────────────────────────────────────
 
 SKILL_PROMPT_DESC_LIMIT = 60
+SKILL_PROMPT_TRIGGERS_LIMIT = 240
+SKILL_TRIGGER_MAX_LENGTH = 80
+SKILL_TRIGGER_MAX_COUNT = 24
 
 
 def _normalize_skill_description(frontmatter: Dict[str, Any]) -> str:
@@ -1202,6 +1205,39 @@ def is_skill_description_truncated_for_prompt(frontmatter: Dict[str, Any]) -> bo
     """True when the description will be truncated in the system prompt skill index."""
     desc = _normalize_skill_description(frontmatter)
     return len(desc) > SKILL_PROMPT_DESC_LIMIT
+
+
+def extract_skill_triggers(frontmatter: Dict[str, Any]) -> List[str]:
+    """Normalize optional multilingual trigger aliases for the skill index.
+
+    ``triggers`` may be a flat list or a mapping of language codes to lists.
+    Invalid values are ignored so hand-authored third-party skills cannot break
+    discovery. The bounded result keeps one skill from inflating every request's
+    system prompt; ``skill_manage`` validates the same public limits on writes.
+    """
+    raw = frontmatter.get("triggers")
+    groups = raw.values() if isinstance(raw, dict) else (raw,)
+    result: List[str] = []
+    seen: Set[str] = set()
+    used = 0
+    for group in groups:
+        values = group if isinstance(group, (list, tuple)) else (group,)
+        for value in values:
+            if not isinstance(value, str):
+                continue
+            trigger = " ".join(value.split())
+            if not trigger or len(trigger) > SKILL_TRIGGER_MAX_LENGTH:
+                continue
+            folded = trigger.casefold()
+            if folded in seen:
+                continue
+            added = len(trigger) + (2 if result else 0)
+            if len(result) >= SKILL_TRIGGER_MAX_COUNT or used + added > SKILL_PROMPT_TRIGGERS_LIMIT:
+                return result
+            result.append(trigger)
+            seen.add(folded)
+            used += added
+    return result
 
 
 # ── File iteration ────────────────────────────────────────────────────────

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -317,6 +317,32 @@ class TestBuildSkillsSystemPrompt:
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+    def test_multilingual_triggers_survive_cold_scan_and_snapshot(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "creative" / "storyboard"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: storyboard\n"
+            "description: Plan visual scenes.\n"
+            "triggers:\n"
+            "  en: [storyboard, shot breakdown]\n"
+            "  zh: [分鏡, 鏡頭分解]\n"
+            "---\n\n# Storyboard\n",
+            encoding="utf-8",
+        )
+
+        cold = build_skills_system_prompt()
+        assert "[triggers: storyboard, shot breakdown, 分鏡, 鏡頭分解]" in cold
+
+        from agent.prompt_builder import clear_skills_system_prompt_cache
+
+        clear_skills_system_prompt_cache(clear_snapshot=False)
+        warm = build_skills_system_prompt()
+        assert warm == cold
+
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -117,6 +117,33 @@ class TestValidateFrontmatter:
         content = "---\n: invalid: yaml: {{{\n---\n\nBody.\n"
         assert "YAML frontmatter parse error" in _validate_frontmatter(content)
 
+    def test_accepts_multilingual_trigger_mapping(self):
+        content = VALID_SKILL_CONTENT.replace(
+            "description: A test skill for unit testing.\n",
+            "description: A test skill for unit testing.\n"
+            "triggers:\n"
+            "  en: [storyboard, shot breakdown]\n"
+            "  zh: [分鏡, 鏡頭分解]\n",
+        )
+
+        assert _validate_frontmatter(content, new_skill=True) is None
+
+    @pytest.mark.parametrize(
+        "triggers, expected",
+        [
+            ("storyboard", "must be a list or a language-to-list mapping"),
+            ("{en: storyboard}", "language entry must be a list"),
+            ("[storyboard, STORYBOARD]", "contains duplicates"),
+        ],
+    )
+    def test_rejects_invalid_triggers(self, triggers, expected):
+        content = VALID_SKILL_CONTENT.replace(
+            "description: A test skill for unit testing.\n",
+            f"description: A test skill for unit testing.\ntriggers: {triggers}\n",
+        )
+
+        assert expected in _validate_frontmatter(content, new_skill=True)
+
 
 # ---------------------------------------------------------------------------
 # _validate_file_path — path traversal prevention

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -46,9 +46,13 @@ from utils import atomic_write_text, is_truthy_value
 from hermes_cli.config import cfg_get
 from agent.skill_utils import (
     extract_skill_description,
+    extract_skill_triggers,
     is_skill_description_truncated_for_prompt,
     parse_frontmatter as _parse_frontmatter,
     SKILL_PROMPT_DESC_LIMIT,
+    SKILL_PROMPT_TRIGGERS_LIMIT,
+    SKILL_TRIGGER_MAX_COUNT,
+    SKILL_TRIGGER_MAX_LENGTH,
 )
 
 logger = logging.getLogger(__name__)
@@ -646,6 +650,30 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
             f"longer descriptions to {SKILL_PROMPT_DESC_LIMIT - 3} chars + '...', "
             f"destroying the routing signal. Move detail into the skill body."
         )
+
+    raw_triggers = parsed.get("triggers")
+    if raw_triggers is not None:
+        if isinstance(raw_triggers, dict):
+            groups = list(raw_triggers.values())
+        elif isinstance(raw_triggers, list):
+            groups = [raw_triggers]
+        else:
+            return "Frontmatter 'triggers' must be a list or a language-to-list mapping."
+        if any(not isinstance(group, list) for group in groups):
+            return "Each 'triggers' language entry must be a list of strings."
+        values = [value for group in groups for value in group]
+        if not values or any(not isinstance(value, str) or not value.strip() for value in values):
+            return "Frontmatter 'triggers' entries must be non-empty strings."
+        if len(values) > SKILL_TRIGGER_MAX_COUNT:
+            return f"Frontmatter 'triggers' exceeds {SKILL_TRIGGER_MAX_COUNT} entries."
+        if any(len(" ".join(value.split())) > SKILL_TRIGGER_MAX_LENGTH for value in values):
+            return f"Each trigger must be at most {SKILL_TRIGGER_MAX_LENGTH} characters."
+        normalized = extract_skill_triggers(parsed)
+        if len(normalized) != len(values):
+            return "Frontmatter 'triggers' contains duplicates or exceeds the prompt budget."
+        rendered = ", ".join(normalized)
+        if len(rendered) > SKILL_PROMPT_TRIGGERS_LIMIT:
+            return f"Frontmatter 'triggers' exceeds {SKILL_PROMPT_TRIGGERS_LIMIT} prompt characters."
 
     body = content[end_match.end() + 3:].strip()
     if not body:

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -166,6 +166,9 @@ name: my-skill
 description: Brief description of what this skill does
 version: 1.0.0
 platforms: [macos, linux]     # Optional — restrict to specific OS platforms
+triggers:                       # Optional — multilingual discovery aliases
+  en: [storyboard, shot breakdown]
+  zh: [分鏡, 鏡頭分解]
 metadata:
   hermes:
     tags: [python, automation]
@@ -194,6 +197,29 @@ Trigger conditions for this skill.
 ## Verification
 How to confirm it worked.
 ```
+
+### Multilingual discovery triggers
+
+The optional `triggers` field adds short aliases to the static skill index the
+model scans before choosing `skill_view`. Use either a flat list or a mapping
+from language code to lists of strings:
+
+```yaml
+triggers: [storyboard, shot breakdown]
+
+# Or group aliases by language for maintainability:
+triggers:
+  en: [storyboard, shot breakdown]
+  zh: [分鏡, 鏡頭分解]
+  ja: [ストーリーボード, カット分け]
+```
+
+Descriptions remain the human-readable summary returned by `skills_list()`;
+triggers are discovery aliases shown only in the model's skill index. They are
+case-insensitive routing hints, so do not repeat the same alias with different
+capitalization. A skill may declare up to 24 aliases, each at most 80
+characters, with at most 240 rendered characters in total. Skills without
+`triggers` behave exactly as before.
 
 ### Platform-Specific Skills
 


### PR DESCRIPTION
## Summary

Hermes exposes skill names and short descriptions in a static system-prompt index, so an English-only description gives the model no reliable lexical signal for CJK or other translated requests. This adds bounded multilingual discovery aliases to `SKILL.md` frontmatter and carries them through the existing cache-stable prompt snapshot/index. It deliberately does not auto-load skills or rewrite user turns, keeping prompt caching and existing routing behavior intact.

---

## Changes

### `agent/skill_utils.py`
- Normalize flat trigger lists and language-to-list mappings.
- Deduplicate aliases case-insensitively.
- Bound aliases to 24 entries, 80 characters each, and 240 rendered characters.

### `agent/prompt_builder.py`
- Persist aliases in skill prompt snapshots.
- Render aliases for local, project, org-shared, and external skill entries.
- Bump the snapshot schema so existing description-only snapshots rebuild.

### `tools/skill_manager_tool.py`
- Validate trigger shape, values, duplicates, and prompt-size limits.

### Tests and documentation
- Add cold-scan and warm-snapshot multilingual regression coverage.
- Add validator coverage for accepted mappings and malformed values.
- Document the public frontmatter contract and limits.

## How to Test

```bash
python -m pytest tests/agent/test_prompt_builder.py tests/tools/test_skill_manager_tool.py -q
ruff check .
```

Direct pytest result: `137 passed`.

`scripts/run_tests.sh` could not execute tests on the Termux host because its per-file runner crashed with `PermissionError(13, 'Permission denied')`; direct pytest completed successfully.

## Checklist

- [x] Targeted tests pass — 137/137
- [x] Ruff passes
- [x] Follows Conventional Commits
- [x] Changes scoped to multilingual skill discovery
- [x] Existing skills without `triggers` remain unchanged
- [x] Prompt cache remains byte-stable during a conversation
- [x] No behavioral setting added to `.env`

## Risk & Impact

Low. The feature is opt-in metadata processed only while building the existing static skill index. It does not inject mid-turn context, rewrite user input, or change `skills_list()` descriptions.

Type: New feature

Closes #100056
