### PR TITLE
fix(docker): skip implicit --network=none when extra args set a network

### DIFF
--- a/tests/tools/test_docker_environment.py
+++ b/tests/tools/test_docker_environment.py
@@ -1668,6 +1668,70 @@ def test_extra_args_set_shm_size_helper():
     assert docker_env._extra_args_set_shm_size([42, None, "--shm-size=1g"]) is True
 
 
+# ── docker_network: false + --network in docker_extra_args (issue #100248) ────
+
+
+def _network_spec_count(run_args):
+    """Count network specifications the way docker parses them."""
+    return sum(
+        1
+        for a in run_args
+        if a in docker_env._NETWORK_FLAGS
+        or any(a.startswith(f"{flag}=") for flag in docker_env._NETWORK_FLAGS)
+    )
+
+
+def test_extra_args_specify_network_helper():
+    assert docker_env._extra_args_specify_network(["--network", "none"]) is True
+    assert docker_env._extra_args_specify_network(["--network=none"]) is True
+    assert docker_env._extra_args_specify_network(["--net", "bridge"]) is True
+    assert docker_env._extra_args_specify_network(["--net=host"]) is True
+    assert docker_env._extra_args_specify_network(["--memory", "512m"]) is False
+    assert docker_env._extra_args_specify_network([]) is False
+    assert docker_env._extra_args_specify_network(None) is False
+    # non-string entries must not crash (config.yaml can be malformed)
+    assert docker_env._extra_args_specify_network([42, None, "--network=none"]) is True
+
+
+def test_network_lockdown_still_applied_without_user_flag(monkeypatch):
+    """docker_network: false with no --network in docker_extra_args keeps the
+    implicit flag — the lockdown behavior itself must not regress."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network=False, extra_args=["--user", "1009:1009"])
+
+    run_args = _shm_run_args(calls)
+    assert "--network=none" in run_args
+    assert _network_spec_count(run_args) == 1
+
+
+@pytest.mark.parametrize(
+    "extra",
+    [
+        ["--network=none", "--user", "1009:1009"],
+        ["--network", "none"],
+        ["--net=none"],
+        ["--net", "none"],
+    ],
+)
+def test_implicit_network_none_skipped_when_user_sets_network(monkeypatch, extra):
+    """Regression #100248: docker rejects a repeated --network with exit 125
+    (unlike --user, where last-wins applies), so the implicit --network=none
+    from docker_network: false must be suppressed when docker_extra_args
+    already supplies one."""
+    monkeypatch.setattr(docker_env, "find_docker", lambda: "/usr/bin/docker")
+    calls = _mock_subprocess_run(monkeypatch)
+
+    _make_dummy_env(network=False, extra_args=list(extra))
+
+    run_args = _shm_run_args(calls)
+    # exactly one network spec survives — the operator's own
+    assert _network_spec_count(run_args) == 1, " ".join(run_args)
+    # unrelated user args are still forwarded verbatim
+    assert all(a in run_args for a in extra if not str(a).startswith(("--network", "--net")))
+
+
 # ── issue #96268: secrets must never appear in docker argv ────────────
 
 

--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -408,6 +408,28 @@ def _extra_args_set_shm_size(extra_args: list) -> bool:
         for a in (extra_args or [])
     )
 
+
+# Network flag aliases understood by `docker run`; shared by the implicit
+# --network=none suppression below and the egress-args collision scan.
+_NETWORK_FLAGS = ("--network", "--net")
+
+
+def _extra_args_specify_network(extra_args: list) -> bool:
+    """True when user-supplied docker_extra_args already set a network.
+
+    Unlike ``--user`` (where Docker applies last-wins), a repeated
+    ``--network`` makes ``docker run`` fail outright with exit 125, so the
+    implicit ``--network=none`` from ``docker_network: false`` must be
+    suppressed whenever the operator supplied one explicitly.
+    """
+    return any(
+        isinstance(a, str) and (
+            a in _NETWORK_FLAGS
+            or any(a.startswith(f"{flag}=") for flag in _NETWORK_FLAGS)
+        )
+        for a in (extra_args or [])
+    )
+
 # /run is split out from _BASE_SECURITY_ARGS because s6-overlay images need it
 # mounted ``exec``: s6 stage0 later runs ``exec /run/s6/basedir/bin/init``, which
 # fails with "Permission denied" (exit 126) on a ``noexec`` mount. For all other
@@ -639,7 +661,7 @@ def _extra_args_egress_collisions(
     """Return docker_extra_args entries that can override egress controls."""
     collisions: list[str] = []
     env_flags = {"-e", "--env", "--env-file"}
-    network_flags = {"--network", "--net"}
+    network_flags = set(_NETWORK_FLAGS)
     i = 0
     while i < len(extra_args):
         arg = extra_args[i]
@@ -976,7 +998,17 @@ class DockerEnvironment(BaseEnvironment):
                     "(requires overlay2 on XFS with pquota). Container will run without disk quota."
                 )
         if not network:
-            resource_args.append("--network=none")
+            # Docker rejects a repeated --network (exit 125) instead of
+            # applying last-wins like it does for --user, so never emit the
+            # implicit --network=none alongside an explicit one.
+            if _extra_args_specify_network(extra_args):
+                logger.info(
+                    "docker_network is disabled but docker_extra_args already "
+                    "specifies a network; keeping the explicit arg and skipping "
+                    "the implicit --network=none."
+                )
+            else:
+                resource_args.append("--network=none")
 
         # Persistent workspace via bind mounts from a configurable host directory
         # (TERMINAL_SANDBOX_DIR, default ~/.hermes/sandboxes/). Non-persistent


### PR DESCRIPTION
## What does this PR do?

`terminal.docker_network: false` makes Hermes append an implicit `--network=none` to every `docker run`, while `terminal.docker_extra_args` entries are appended verbatim with no reconciliation between the two. Docker rejects a repeated `--network` outright (`docker: network "none" is specified multiple times`, exit 125) — unlike `--user`, where last-wins applies — so the two independently-valid config keys are jointly fatal: every container start for that profile fails and the Docker backend is unusable until one of the keys is removed, with an error that names Docker rather than the config keys that produced it.

This PR suppresses the implicit `--network=none` whenever `docker_extra_args` already specify a network, mirroring the existing `--shm-size` handling (`_extra_args_set_shm_size`): the operator's explicit arg wins, and a `logger.info` records the precedence decision. The `{"--network", "--net"}` alias set is lifted into a shared `_NETWORK_FLAGS` constant so the new predicate and the existing `_extra_args_egress_collisions()` scan use one definition.

## Related Issue

Fixes #100248

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/docker.py`: added `_NETWORK_FLAGS` (shared alias set) and `_extra_args_specify_network()` predicate next to `_extra_args_set_shm_size()`
- `tools/environments/docker.py`: the `if not network:` site now skips the implicit `--network=none` (with a `logger.info`) when `docker_extra_args` already supply `--network`/`--net`, in either `=value` or flag+value form
- `tools/environments/docker.py`: `_extra_args_egress_collisions()` now derives its `network_flags` from `_NETWORK_FLAGS` instead of a duplicated literal
- `tests/tools/test_docker_environment.py`: regression tests — helper unit test (both flag forms, aliases, malformed entries), lockdown behavior preserved when no user flag is present, and implicit flag suppressed for all four user-supplied forms

## How to Test

1. `python -m pytest tests/tools/test_docker_environment.py tests/tools/test_docker_network_config.py -q` — Observed result: 74 passed, 0 failed.
2. `python -m pytest` across the full docker test domain (`test_docker_*.py`, `test_dockerfile_*.py`) plus the terminal container-config paths (`test_terminal_tool.py`, `test_terminal_env_bridge.py`, `test_terminal_config_env_sync.py`) — Observed result: 167 passed, 0 failed.
3. Manual equivalent (no Hermes needed) of the pre-fix failure: `docker run --rm --network=none --user 1002:1002 --network=none --user 1009:1009 alpine id` should fail with exit 125 ("network none is specified multiple times"); with this change Hermes no longer emits the duplicate flag when `docker_extra_args` contains `--network=none`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (full docker test domain + terminal container-config paths: 167 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin, arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (behavior now matches the documented "appended last so they can override defaults if needed" contract)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config keys added or changed)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (docker argv assembly is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (no tool surface change)

## Screenshots / Logs

Pre-fix command line assembled by Hermes (from the issue):

```
docker run ... --network=none ... --network=none --user 1009:1009 ...
→ docker: network "none" is specified multiple times (exit 125)
```

Post-fix, with `docker_network: false` + `docker_extra_args: ["--network=none", "--user", "1009:1009"]`, the run args contain exactly one network spec (the operator's own) and container creation succeeds.
