### PR TITLE
fix(qqbot): allow dm chat_type in approval authorization check

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -1131,7 +1131,8 @@ class QQAdapter(BasePlatformAdapter):
 
         chat_type = parsed.get("chat_type", "")
         chat_id = parsed.get("chat_id", "")
-        if chat_type == "c2c":
+        # QQ private chat: session keys may use "c2c" (official term) or "dm" (Hermes internal) — treat both as equivalent
+        if chat_type in {"c2c", "dm"}:
             return bool(chat_id) and operator == chat_id
 
         if chat_type in {"group", "guild"}:


### PR DESCRIPTION
## Problem

The QQ bot adapter builds session keys with `chat_type` `'dm'` for private
(1-on-1) chats, but `_is_authorized_interaction_for_session` only accepted
`'c2c'`. As a result, **every approval click in a QQ DM was rejected** with
`Rejected unauthorized approval click`, making interactive approvals
impossible on the QQ platform (the operator's own openid was rejected even
though it matched the session chat_id).

## Fix

Treat `'dm'` as equivalent to `'c2c'` (QQ's official term for 1-on-1 chats)
so the operator authorization check applies to both. One-line change in
`gateway/platforms/qqbot/adapter.py`.

## Verification

- Before fix: approval click in QQ DM → `Rejected unauthorized approval click`
- After fix: approval click in QQ DM → command approved and executed successfully