### PR TITLE
fix(browser): bump agent-browser pin to ^0.36.0

### DIFF
--- a/tests/tools/test_browser_npx_warmup.py
+++ b/tests/tools/test_browser_npx_warmup.py
@@ -8,7 +8,7 @@ It must never raise, must accurately report success/failure via its return
 value, must use a credential-scrubbed and PATH-propagated environment (it
 runs registry-fetched, potentially install-scripted npm code on every
 `hermes update` — not only when a browser tool is actually used), must pass
---ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range, not an
+--ignore-scripts (AGENT_BROWSER_NPX_SPEC is a floating ^0.36.0 range, not an
 exact pin), and must kill the whole process tree — not just the top-level
 npx PID — on timeout.
 """

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -968,11 +968,18 @@ def _browser_install_hint() -> str:
 # changes.
 NPX_AGENT_BROWSER_SENTINEL = "npx agent-browser"
 
-# Pinned to match scripts/install.sh / scripts/install.ps1's
-# "agent-browser@^0.26.0" managed install so a git-clone install resolving
-# agent-browser via bare npx gets the same version as a managed install,
-# instead of floating latest with no integrity check. Update both together.
-AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.26.0"
+# The single source of truth for the agent-browser version: the install
+# scripts no longer install it (it resolves lazily via npx), so nothing else
+# pins it.
+#
+# Caret on a 0.x floats patches only: ^0.36.0 is >=0.36.0 <0.37.0, not "0.36
+# or newer". Upstream minors need a deliberate bump here — that is how this
+# sat on 0.26 while agent-browser shipped through 0.36.
+#
+# 0.36 is the floor for the Lightpanda engine: 0.26 passes `serve --timeout`,
+# which Lightpanda removed, so `--engine lightpanda` cannot launch on it
+# (vercel-labs/agent-browser#1750).
+AGENT_BROWSER_NPX_SPEC = "agent-browser@^0.36.0"
 
 
 def _is_npx_agent_browser_sentinel(browser_cmd: str) -> bool:
@@ -1347,8 +1354,8 @@ def _run_chrome_fallback_command(
     # WinError 193.
     if _is_npx_agent_browser_sentinel(browser_cmd):
         _npx_bin = _resolve_npx_bin() or "npx"
-        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0 range,
-        # not an exact pin — a compromised future 0.26.x patch must not get to
+        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.36.0 range,
+        # not an exact pin — a compromised future 0.36.x patch must not get to
         # run its own install-time lifecycle scripts on this machine.
         cmd_prefix = [_npx_bin, "--ignore-scripts", "--prefer-offline", "-y", AGENT_BROWSER_NPX_SPEC]
     else:
@@ -3460,8 +3467,8 @@ def warm_agent_browser_npx_cache(timeout: float = 60.0) -> bool:
 
     cmd = [
         npx_bin,
-        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.26.0
-        # range, not an exact pin — a compromised future 0.26.x patch must
+        # --ignore-scripts: AGENT_BROWSER_NPX_SPEC is a floating ^0.36.0
+        # range, not an exact pin — a compromised future 0.36.x patch must
         # not get to run its own install-time lifecycle scripts here.
         "--ignore-scripts",
         # --prefer-offline: once cached, repeat `hermes update`/`doctor


### PR DESCRIPTION
`AGENT_BROWSER_NPX_SPEC` is `agent-browser@^0.26.0` (= `<0.27`), and 0.26.0 launches Lightpanda with `serve --timeout` — an option Lightpanda removed. The process exits before CDP is ready, so on the built-in `browser_*` tools `--engine lightpanda` fails with `err = UnknownOption` on every call. Upstream dropped the flag in [vercel-labs/agent-browser#1750](https://github.com/vercel-labs/agent-browser/pull/1750), released in **0.36.0**; the current range cannot reach it.

Browser Use mode (the default) is unaffected — it spawns `lightpanda serve` itself and never invokes agent-browser. This only fixes the legacy path.

### Compatibility check

You mentioned wanting to be sure about the rest of the stack, so I exercised the agent-browser surface `tools/browser_tool.py` actually invokes against the 0.36.0 binary, on both engines:

| command | Chrome (default engine) | Lightpanda |
|---|---|---|
| `open` | ok | ok |
| `snapshot`, `snapshot --json` | ok | ok |
| `get text` / `get url` / `get title` | ok | ok |
| `eval` | ok | ok |
| `click` / `fill` / `type` / `press` | ok | ok (verified against a real form, value read back) |
| `scroll`, `back` | ok | ok |
| `console`, `errors` | ok | ok |
| `screenshot` | ok | n/a (no renderer; Hermes already routes these to Chrome) |
| `close`, `--session`, `--version` | ok | ok |

No output-shape changes surfaced in the commands Hermes parses (`snapshot --json` and `get url` in particular, which #99460 touched). On 0.26.0 the same Lightpanda run fails at `open`.

### On the range itself

`^0.36.0` on a `0.x` version floats **patches only** — it resolves to `>=0.36.0 <0.37.0`, not "0.36 or newer". That is exactly how the pin sat at 0.26 while agent-browser shipped ten minors, so it will need a deliberate bump again at 0.37.0. If you would rather track minors automatically, `>=0.36.0 <1` is the one-word change; I kept the caret to match the existing convention and because 0.x minors are allowed to break.

### Also in this PR

Two comments claimed the pin must be updated together with `scripts/install.sh` / `install.ps1`. Those scripts no longer install agent-browser — `tests/test_install_sh_browser_install.py::test_ensure_browser_no_longer_npm_installs_agent_browser` asserts `agent-browser@` is absent — so this constant is now the only place the version lives. Comments corrected to say so, otherwise the next person goes looking for a second pin that does not exist.

### Tests

The browser/install/doctor suites pass. One unrelated pre-existing failure shows up when that batch runs together, `TestLegacyCloudMigration::test_picker_highlights_cli_row_for_migrated_config`: it passes alone and fails in-batch identically on clean `main`, so it is test-ordering pollution rather than anything from this change. Happy to open a separate PR for it if useful.
