### PR TITLE
fix(files): verify writes to newline paths

### DIFF
--- a/tests/tools/test_write_verification.py
+++ b/tests/tools/test_write_verification.py
@@ -27,6 +27,20 @@ class TestWriteVerification:
         r = json.loads(write_file_tool(str(f), content, task_id="t-wv"))
         assert r.get("verified") is True
 
+    @pytest.mark.skipif(
+        __import__("sys").platform == "win32",
+        reason="Newlines are not valid in Windows filenames",
+    )
+    def test_newline_in_path_reports_verified(self, workdir):
+        f = workdir / "evil\nproof.yml"
+        content = "name: inert proof\n"
+
+        r = json.loads(write_file_tool(str(f), content, task_id="t-wv-newline"))
+
+        assert "error" not in r
+        assert r.get("verified") is True
+        assert f.read_text() == content
+
     def test_crlf_preservation_still_verifies(self, workdir):
         # Existing CRLF file: write_file converts LF content to CRLF before
         # writing; verification hashes the shim-adjusted content, so it must
@@ -51,6 +65,23 @@ class TestWriteVerification:
 
         with mock_patch.object(fo.hashlib, "sha256", _WrongHash):
             r = json.loads(write_file_tool(str(f), "actual content\n", task_id="t-wv"))
+        assert "error" in r
+        assert "did not persist" in r["error"]
+
+    def test_malformed_successful_hash_output_is_hard_error(self, workdir):
+        f = workdir / "malformed.txt"
+        import tools.file_operations as fo
+
+        real_exec = fo.ShellFileOperations._exec
+
+        def malformed_hash_exec(self, cmd, **kw):
+            if "sha256sum" in cmd:
+                return fo.ExecuteResult(stdout="not-a-sha  malformed.txt\n", exit_code=0)
+            return real_exec(self, cmd, **kw)
+
+        with mock_patch.object(fo.ShellFileOperations, "_exec", malformed_hash_exec):
+            r = json.loads(write_file_tool(str(f), "actual content\n", task_id="t-wv-malformed"))
+
         assert "error" in r
         assert "did not persist" in r["error"]
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -2189,10 +2189,19 @@ class ShellFileOperations(FileOperations):
             hash_cmd = f"sha256sum {self._escape_shell_arg(path)} 2>/dev/null"
             hash_result = self._exec(hash_cmd)
             if hash_result.exit_code == 0 and hash_result.stdout.strip():
-                disk_sha = hash_result.stdout.strip().split()[0]
-                expected_sha = hashlib.sha256(content_bytes).hexdigest()
-                content_verified = disk_sha == expected_sha
-                if not content_verified:
+                # GNU sha256sum prefixes the digest with ``\\`` when the
+                # filename contains a newline or backslash, then escapes the
+                # filename in its human-readable output.  Strip only that
+                # documented marker; otherwise a successful write to a legal
+                # POSIX pathname is falsely reported as corrupt.
+                hash_token = hash_result.stdout.strip().split()[0]
+                disk_sha = hash_token[1:] if hash_token.startswith("\\") else hash_token
+                if not re.fullmatch(r"[0-9a-fA-F]{64}", disk_sha):
+                    content_verified = False
+                else:
+                    expected_sha = hashlib.sha256(content_bytes).hexdigest()
+                    content_verified = disk_sha.lower() == expected_sha
+                if content_verified is False:
                     return WriteResult(
                         error=(
                             f"Post-write verification failed for {path}: on-disk "


### PR DESCRIPTION
## Summary
- handle GNU `sha256sum` escaped digest markers for legal POSIX paths containing newlines or backslashes
- retain fail-closed behavior for mismatched or malformed successful hash output
- add regression coverage for the exact false-negative that triggered a misleading file-mutation footer

## Root cause
GNU `sha256sum` prefixes its digest token with `\` when it escapes a filename containing a newline or backslash. The verifier compared that prefixed token directly with the expected digest, so the bytes landed correctly but `write_file` reported a false hash mismatch.

## Verification
- RED: newline-path regression reproduced the false post-write mismatch
- GREEN: `tests/tools/test_write_verification.py` — 7 passed
- adjacent file-operation suites — 87 passed, 2 skipped
- direct newline-path write — `verified=true`, exact content preserved
- `git diff --check` and `py_compile` passed
- independent Luna review: PASS