### PR TITLE
fix(delegation): let reasoning children finish long synthesis turns

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1061,9 +1061,10 @@ def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
     Same derivation the interrupt-worker path uses for its stale-call
     detector (provider ``stale_timeout_seconds`` →
     ``HERMES_API_CALL_STALE_TIMEOUT`` → reasoning-model floor → context-size
-    scaling, ``inf`` for a local endpoint on the implicit default), so cron and
-    delegated turns get exactly the patience every other non-streaming request
-    already gets.
+    scaling, ``inf`` for a local endpoint on the implicit default). Delegated
+    reasoning turns also resolve to ``inf`` because a non-streaming request has
+    no progress signal before its complete response arrives; the request/run
+    timeout remains their hard bound.
 
     A non-numeric result — an agent stub that never implements the resolver —
     leaves the watchdog disarmed rather than arming it on a bogus budget.
@@ -1077,6 +1078,29 @@ def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
     value = resolver(api_kwargs)
     if isinstance(value, bool) or not isinstance(value, (int, float)):
         return float("inf")
+
+    # A delegated reasoning turn cannot expose byte-level liveness through a
+    # non-streaming Chat Completions request: thinking and tool synthesis both
+    # happen before the one complete response becomes observable. Treating its
+    # TTFB as provider silence therefore kills healthy children at exactly the
+    # configured stale threshold (#100260). Keep the stale watchdog for cron
+    # and non-reasoning subagents, where a zero-byte wait remains useful, while
+    # reasoning children fall back to the request timeout / optional child run
+    # timeout as their hard bound.
+    delegated_child = getattr(agent, "platform", None) == "subagent"
+    if not delegated_child:
+        try:
+            from agent.delegation_context import is_delegated_child_context
+
+            delegated_child = is_delegated_child_context()
+        except Exception:
+            delegated_child = False
+    if delegated_child:
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+        model = api_kwargs.get("model") or getattr(agent, "model", None)
+        if get_reasoning_stale_timeout_floor(model) is not None:
+            return float("inf")
     return float(value)
 
 

--- a/agent/reasoning_timeouts.py
+++ b/agent/reasoning_timeouts.py
@@ -74,6 +74,11 @@ _REASONING_STALE_TIMEOUT_FLOORS: tuple[tuple[str, int], ...] = (
     ("deepseek-reasoner", 600),
     ("deepseek-v4-flash", 600),
     ("deepseek-v4-pro", 600),
+    # Z.AI GLM-5.2/5.3 — reasoning is server-enabled by default and the
+    # non-streaming coding-plan endpoint may spend several minutes thinking
+    # before the complete response becomes observable.
+    ("glm-5.2", 600),
+    ("glm-5.3", 600),
     # Qwen — QwQ reasoning + Qwen3 thinking variants.  QwQ-32B
     # preview is the stable slug; ``qwen3`` covers the family of
     # thinking-mode Qwen3 models (qwen3-235b-a22b, qwen3-32b, etc.)

--- a/tests/agent/test_reasoning_stale_timeout_floor.py
+++ b/tests/agent/test_reasoning_stale_timeout_floor.py
@@ -56,6 +56,9 @@ import pytest
     ("deepseek/deepseek-v4-flash", 600.0),
     ("deepseek/deepseek-v4-pro", 600.0),
     ("deepseek-v4-flash-free", 600.0),   # catalog -free variant inherits via separator anchor
+    # Z.AI GLM-5.2/5.3 reasoning models (including coding-plan variants).
+    ("z-ai/glm-5.2", 600.0),
+    ("glm-5.3-flash", 600.0),
     # Qwen QwQ + Qwen3 thinking variants (qwen3 family entry matches all).
     ("qwen/qwq-32b-preview", 300.0),
     ("qwen/qwen3-235b-a22b-thinking", 180.0),

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -143,6 +143,42 @@ def test_healthy_call_is_untouched_by_the_watchdog():
     )
 
 
+def test_reasoning_subagent_wait_is_not_treated_as_provider_staleness():
+    """A non-streaming reasoning turn has no observable progress before the
+    complete response arrives, so its TTFB is not a stale-provider signal."""
+    agent = _make_agent(stale_timeout=0.05, platform="subagent")
+    fake_client = MagicMock()
+
+    def _reason_then_reply(**_kwargs):
+        time.sleep(0.2)
+        return SimpleNamespace(id="reasoned")
+
+    fake_client.chat.completions.create.side_effect = _reason_then_reply
+    agent._create_request_openai_client.return_value = fake_client
+
+    response = direct_api_call(
+        agent,
+        {
+            "model": "glm-5.3-flash",
+            "messages": [{"role": "user", "content": "work"}],
+        },
+    )
+
+    assert response.id == "reasoned"
+    agent._abort_request_openai_client.assert_not_called()
+
+
+def test_non_reasoning_subagent_still_aborts_a_silent_provider():
+    agent = _make_agent(stale_timeout=0.05, platform="subagent")
+    aborted: list[str] = []
+    _stalling_client(agent, aborted=aborted)
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(agent, {"model": "gpt-4o-mini", "messages": []})
+
+    assert aborted == ["stale_call_kill"]
+
+
 def test_local_endpoint_infinite_budget_leaves_the_watchdog_disarmed():
     """``_compute_non_stream_stale_timeout`` returns inf for a local endpoint
     on the implicit default — that opt-out must survive on this path too."""


### PR DESCRIPTION
## What does this PR do?

Delegated GLM reasoning children can now finish long post-tool synthesis turns instead of being aborted at the non-streaming stale threshold. The fix disables the time-to-first-byte watchdog only for known reasoning models in delegated-child execution; cron calls and non-reasoning delegated calls retain silent-provider detection.

### Symptom

Heavy delegated tasks using `glm-5.3-flash` fail at exactly the configured `stale_timeout_seconds` while the model is reasoning before its non-streaming response becomes available.

### Impact

Affected delegated children cannot complete long reasoning or multi-tool synthesis turns. Raising the threshold only delays the same failure.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py:1058` / `_resolve_direct_stale_timeout` when a delegated child uses a known reasoning model through `chat_completions`.

**Causal chain:**
1. A delegated child sends a non-streaming Chat Completions request for a reasoning model.
2. `direct_api_call` arms a stale timer from request start, but a non-streaming response exposes no reasoning progress before the complete response arrives.
3. The timer interprets normal reasoning time as provider silence and aborts the child's request at the configured threshold.

**Why it is wrong:** time to first byte is not a liveness signal for non-streaming reasoning requests because healthy thinking and a hung provider are observationally identical until completion.

**Working sibling / contrast:** non-reasoning delegated calls keep the watchdog, where a zero-byte wait remains a useful stale-provider signal. Foreground streaming calls can observe deltas and do not depend on this non-streaming timer.

**Ruled out:** provider timeout configuration was not being ignored. The reported failure moved from 90 seconds to exactly 420 seconds when configured, proving that the watchdog honored the threshold but applied the wrong liveness heuristic.

### Fix

Known reasoning models now bypass the inline non-streaming stale timer only in delegated-child execution and remain bounded by the request timeout or an optional delegation child timeout. GLM-5.2 and GLM-5.3 are added to the shared reasoning-model classifier. Regression tests verify that a slow GLM reasoning child is not aborted while an equivalent non-reasoning silent child still is.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - bypass the TTFB stale watchdog for known reasoning models in delegated children.
- `agent/reasoning_timeouts.py` - classify GLM-5.2 and GLM-5.3 as reasoning models.
- `tests/cron/test_cron_direct_api_call_watchdog.py` - cover reasoning and non-reasoning delegated waits.
- `tests/agent/test_reasoning_stale_timeout_floor.py` - cover GLM reasoning classification.

## How to Test

1. Run the direct-call, nested-pool, and reasoning-classifier regression suites.
2. Confirm the reasoning subagent wait survives beyond its synthetic stale threshold.
3. Confirm the non-reasoning subagent stall is still aborted.

```bash
scripts/run_tests.sh tests/cron/test_cron_direct_api_call_watchdog.py tests/cron/test_cron_direct_api_call_62151.py tests/agent/test_reasoning_stale_timeout_floor.py -q
```

Result: 63 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant repository test entry and all targeted tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant docstrings are updated; user documentation is N/A because no user-facing setting changes
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] Cross-platform impact was considered; the change is platform-independent Python logic
- [x] Tool descriptions and schemas are N/A because no tool surface changed

## Screenshots / Logs

N/A - automated regression coverage exercises the affected direct-call path.
