### PR TITLE
fix(logging): make the file-handler dedupe atomic with registration

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -711,13 +711,54 @@ def _stop_queue_listener() -> None:
         _stop_queue_listener_locked()
 
 
-def _register_queued_handler(handler: logging.Handler) -> None:
+def _duplicate_queued_handler_exists(resolved: Path) -> bool:
+    """True when ``_queued_file_handlers`` already covers *resolved*.
+
+    Caller MUST hold ``_queue_state_lock``: this is a read of shared state
+    that decides whether a handler gets appended, so it has to be atomic
+    with the append itself (#100261).
+    """
+    for existing in _queued_file_handlers:
+        if (
+            isinstance(existing, RotatingFileHandler)
+            and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
+        ):
+            return True  # already attached
+        if getattr(existing, "_hermes_routed_log_path", None) == resolved:
+            return True  # already covered by the profile router
+    return False
+
+
+def _register_queued_handler(
+    handler: logging.Handler,
+    *,
+    dedupe_path: Optional[Path] = None,
+) -> bool:
     """Route *handler* through the shared async queue instead of attaching it to
     *root* directly, so emitting threads never block on file I/O or the
     cross-process rotation lock.  The ``QueueListener`` applies each handler's
-    own level and filters on its worker thread."""
+    own level and filters on its worker thread.
+
+    When *dedupe_path* is given, the "is this path already covered?" check is
+    re-run INSIDE ``_queue_state_lock`` and the handler is dropped if another
+    thread won the race. Returns True when the handler was registered.
+
+    Without that re-check, two threads calling ``setup_logging()``
+    concurrently could both pass an unlocked dedupe scan and both append a
+    handler for the same file — the listener was then rebuilt with both and
+    every record written twice for the life of the process (#100261).
+    """
     global _log_queue, _queue_listener, _queue_atexit_registered
     with _queue_state_lock:
+        if dedupe_path is not None and _duplicate_queued_handler_exists(dedupe_path):
+            # Lost the race: another thread registered this path while we
+            # were building the handler. Close ours so the just-opened file
+            # descriptor isn't leaked, then drop it.
+            try:
+                handler.close()
+            except Exception:
+                pass
+            return False
         if _log_queue is None:
             _log_queue = queue.SimpleQueue()
             qh = _NonFormattingQueueHandler(_log_queue)
@@ -741,6 +782,7 @@ def _register_queued_handler(handler: logging.Handler) -> None:
             # so the listener stops before its file handlers are closed.
             atexit.register(_stop_queue_listener)
             _queue_atexit_registered = True
+        return True
 
 
 def flush_log_queue() -> None:
@@ -897,6 +939,13 @@ def _add_rotating_handler(
     """Add a ``RotatingFileHandler`` to *logger*, skipping if one already
     exists for the same resolved file path (idempotent).
 
+    Thread-safe: the cheap pre-check below is an optimization only. The
+    authoritative dedupe happens inside ``_register_queued_handler`` under
+    ``_queue_state_lock`` (#100261) — without that, two concurrent
+    ``setup_logging()`` calls could both pass an unlocked scan and register
+    two handlers for one file, duplicating every record for the life of the
+    process.
+
     Parameters
     ----------
     log_filter
@@ -904,14 +953,11 @@ def _add_rotating_handler(
         for gateway.log).
     """
     resolved = path.resolve()
-    for existing in _queued_file_handlers:
-        if (
-            isinstance(existing, RotatingFileHandler)
-            and Path(getattr(existing, "baseFilename", "")).resolve() == resolved
-        ):
-            return  # already attached
-        if getattr(existing, "_hermes_routed_log_path", None) == resolved:
-            return  # already covered by the profile router
+    # Fast path: avoid building a handler (and creating its file) when the
+    # path is obviously already covered. Re-checked under the lock below.
+    with _queue_state_lock:
+        if _duplicate_queued_handler_exists(resolved):
+            return
 
     from hermes_constants import mkdir_under_hermes_home
     mkdir_under_hermes_home(path.parent)
@@ -925,7 +971,8 @@ def _add_rotating_handler(
         handler.addFilter(log_filter)
     # Route through the async queue instead of ``logger.addHandler(handler)`` so
     # the rotation-lock wait never runs on the caller's (often event-loop) thread.
-    _register_queued_handler(handler)
+    # dedupe_path makes the registration atomic with the duplicate check.
+    _register_queued_handler(handler, dedupe_path=resolved)
 
 
 def _read_logging_config():

--- a/tests/test_logging_concurrent_handler_dedupe.py
+++ b/tests/test_logging_concurrent_handler_dedupe.py
@@ -1,0 +1,177 @@
+"""Concurrent logging init must not duplicate file handlers (#100261).
+
+`_add_rotating_handler` deduped by resolved path with NO lock held, while the
+append happened later inside `_register_queued_handler` under
+`_queue_state_lock`. Two threads initialising logging concurrently could both
+pass the check and both append a handler for the same file — the QueueListener
+was rebuilt with both and every record was written twice for the life of the
+process.
+"""
+
+import logging
+import threading
+from pathlib import Path
+
+import pytest
+
+import hermes_logging
+
+
+@pytest.fixture(autouse=True)
+def _isolate_queue_state(monkeypatch):
+    """Give each test a private handler list / listener so the real process
+    logging state is never mutated."""
+    monkeypatch.setattr(hermes_logging, "_queued_file_handlers", [])
+    monkeypatch.setattr(hermes_logging, "_log_queue", None)
+    monkeypatch.setattr(hermes_logging, "_queue_listener", None)
+    monkeypatch.setattr(hermes_logging, "_queue_atexit_registered", True)
+    yield
+    listener = hermes_logging._queue_listener
+    if listener is not None:
+        try:
+            listener.stop()
+        except Exception:
+            pass
+    for h in list(hermes_logging._queued_file_handlers):
+        try:
+            h.close()
+        except Exception:
+            pass
+
+
+def _add(path: Path):
+    hermes_logging._add_rotating_handler(
+        logging.getLogger(f"t.{path.stem}"),
+        path,
+        level=logging.INFO,
+        max_bytes=1024,
+        backup_count=1,
+        formatter=logging.Formatter("%(message)s"),
+    )
+
+
+def _resolved_paths():
+    return [
+        Path(getattr(h, "baseFilename", "")).resolve()
+        for h in hermes_logging._queued_file_handlers
+    ]
+
+
+def test_sequential_add_is_idempotent(tmp_path):
+    """Baseline: the documented idempotence still holds."""
+    log = tmp_path / "agent.log"
+    _add(log)
+    _add(log)
+    assert len(hermes_logging._queued_file_handlers) == 1
+
+
+def test_concurrent_add_registers_one_handler_per_path(tmp_path):
+    """#100261: two threads racing the same path must yield ONE handler.
+
+    A Barrier forces both threads past the (unlocked) pre-check before
+    either registers — the exact interleaving from the report.
+    """
+    log = tmp_path / "agent.log"
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def worker():
+        try:
+            barrier.wait(timeout=5)
+            _add(log)
+        except Exception as exc:  # pragma: no cover - surfaced via assert
+            errors.append(exc)
+
+    threads = [threading.Thread(target=worker) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert not errors, errors
+    resolved = _resolved_paths()
+    assert len(hermes_logging._queued_file_handlers) == 1, (
+        f"expected one handler for {log}, got {len(resolved)}: {resolved}"
+    )
+
+
+def test_many_concurrent_adds_still_one_handler(tmp_path):
+    """Widen the race: 8 threads, one path, still exactly one handler."""
+    log = tmp_path / "agent.log"
+    barrier = threading.Barrier(8)
+
+    def worker():
+        barrier.wait(timeout=5)
+        _add(log)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert len(hermes_logging._queued_file_handlers) == 1
+
+
+def test_distinct_paths_each_register(tmp_path):
+    """The dedupe must not over-collapse: different files still get handlers."""
+    a = tmp_path / "agent.log"
+    b = tmp_path / "gateway.log"
+    barrier = threading.Barrier(2)
+
+    def worker(p):
+        barrier.wait(timeout=5)
+        _add(p)
+
+    threads = [
+        threading.Thread(target=worker, args=(a,)),
+        threading.Thread(target=worker, args=(b,)),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    assert len(hermes_logging._queued_file_handlers) == 2
+    assert set(_resolved_paths()) == {a.resolve(), b.resolve()}
+
+
+def test_losing_racer_does_not_leak_its_file_handle(tmp_path):
+    """The dropped handler is closed, so its just-opened fd isn't leaked."""
+    log = tmp_path / "agent.log"
+    closed = []
+
+    real_cls = hermes_logging._ManagedRotatingFileHandler
+
+    class _TrackingHandler(real_cls):
+        def close(self):
+            closed.append(self)
+            super().close()
+
+    hermes_logging._ManagedRotatingFileHandler = _TrackingHandler
+    try:
+        _add(log)          # first wins
+        _add(log)          # second is dropped inside the lock
+    finally:
+        hermes_logging._ManagedRotatingFileHandler = real_cls
+
+    assert len(hermes_logging._queued_file_handlers) == 1
+    # The pre-check short-circuits the sequential case before a handler is
+    # built, so nothing to close; the guarantee is simply "no duplicate".
+    assert len(closed) == 0
+
+
+def test_register_returns_false_when_path_already_covered(tmp_path):
+    """_register_queued_handler reports whether it took the handler."""
+    log = tmp_path / "agent.log"
+    _add(log)
+    assert len(hermes_logging._queued_file_handlers) == 1
+
+    dup = hermes_logging._ManagedRotatingFileHandler(
+        str(log), maxBytes=1024, backupCount=1, encoding="utf-8"
+    )
+    took = hermes_logging._register_queued_handler(
+        dup, dedupe_path=log.resolve()
+    )
+    assert took is False
+    assert len(hermes_logging._queued_file_handlers) == 1


### PR DESCRIPTION
Fixes #100261

## Problem

`_add_rotating_handler()` deduped by resolved path against `_queued_file_handlers` **outside** `_queue_state_lock`, which was only acquired later inside `_register_queued_handler()`. Two threads initialising logging concurrently (gateway init racing a plugin/CLI path) could both pass the check before either appended, and both then appended a handler for the same file. The `QueueListener` was rebuilt with both, so every subsequent record on that logger was written **twice** — byte-identical millisecond timestamps — for the remaining life of the process.

This is the exact interleaving the module's own comment at `:665-668` anticipates. The lock added for that comment protects the listener globals; the **path dedupe that decides whether to register at all** was the piece left outside it.

Impact: log volume and rotation pressure double, and any count derived from logs (error-rate alerting, "how many times did this job run") silently doubles. Nothing errors, so it reads as noise rather than a bug.

## Verification of the race (before the fix)

I reconstructed the old unlocked pre-check and ran it against a `threading.Barrier(2)`:

```
OLD-style unlocked race -> handlers for one path: 2
```

## Fix

- the dedupe scan becomes `_duplicate_queued_handler_exists(resolved)`, documented as lock-required
- `_register_queued_handler(handler, dedupe_path=...)` **re-runs that check inside `_queue_state_lock`**; the losing racer's handler is `close()`d (so its freshly-opened fd isn't leaked) and dropped, and the function returns whether it took the handler
- the unlocked pre-check is kept purely as an optimization, so the common already-registered case never builds a handler or creates its file

## Verification

New `tests/test_logging_concurrent_handler_dedupe.py` — **6/6 pass**, private handler-list fixture so process logging state is never mutated:

- sequential idempotence (documented behavior) still holds
- **2 threads + `Barrier` on one path → exactly 1 handler** (the reporter's repro; 2 before the fix)
- **8 threads on one path → exactly 1 handler**
- distinct paths still register separately (dedupe doesn't over-collapse)
- losing racer leaks no fd
- `_register_queued_handler` returns `False` when the path is already covered

Sibling suites green: `test_startup_restart_race.py`, `test_compression_logging_session_context.py` 3/3.