### PR TITLE
fix(goals): carry evidence across background wait resumes

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -63,6 +63,12 @@ DEFAULT_JUDGE_TIMEOUT = 30.0
 DEFAULT_JUDGE_MAX_TOKENS = 4096
 # Cap how much of the last response + recent messages we send to the judge.
 _JUDGE_RESPONSE_SNIPPET_CHARS = 4000
+# Bounded cross-turn evidence for the judge. This is serialized with the goal
+# state so a WAIT -> wake/reload turn can still connect a terse completion
+# response to the earlier process-start/progress evidence.
+_GOAL_PRIOR_EVIDENCE_MAX_ENTRIES = 4
+_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS = 1200
+_JUDGE_PRIOR_EVIDENCE_CHARS = 3000
 # After this many consecutive judge *parse* failures (empty output / non-JSON),
 # the loop auto-pauses and points the user at the goal_judge config. API /
 # transport errors do NOT count toward this — those are transient. This guards
@@ -198,9 +204,16 @@ JUDGE_BACKGROUND_BLOCK_TEMPLATE = (
 )
 
 
+JUDGE_PRIOR_EVIDENCE_BLOCK_TEMPLATE = (
+    "Relevant evidence from prior turns in this same goal run:\n"
+    "{prior_evidence}\n\n"
+)
+
+
 JUDGE_USER_PROMPT_TEMPLATE = (
     "Goal:\n{goal}\n\n"
     "Agent's most recent response:\n{response}\n\n"
+    "{prior_evidence_block}"
     "{background_block}"
     "Current time: {current_time}\n\n"
     "Is the goal satisfied — done, continue, or wait?"
@@ -213,6 +226,7 @@ JUDGE_USER_PROMPT_WITH_SUBGOALS_TEMPLATE = (
     "Additional criteria the user added mid-loop (all must also be "
     "satisfied for the goal to be DONE):\n{subgoals_block}\n\n"
     "Agent's most recent response:\n{response}\n\n"
+    "{prior_evidence_block}"
     "{background_block}"
     "Current time: {current_time}\n\n"
     "Decision: For each numbered criterion above, find concrete "
@@ -235,6 +249,7 @@ JUDGE_USER_PROMPT_WITH_CONTRACT_TEMPLATE = (
     "Completion contract (the authoritative definition of done):\n"
     "{contract_block}\n\n"
     "Agent's most recent response:\n{response}\n\n"
+    "{prior_evidence_block}"
     "{background_block}"
     "Current time: {current_time}\n\n"
     "Decision rules:\n"
@@ -599,6 +614,11 @@ class GoalState:
     # must ALL pass before the judge may declare the goal done. Empty by
     # default — a goal with no gates behaves exactly as before.
     gates: List[GoalGate] = field(default_factory=list)
+    # Bounded snippets from earlier goal turns in this run. This is
+    # judge-only context: it is never appended to the agent's continuation
+    # prompt or conversation history, preserving prompt-cache and transcript
+    # shape while still letting the judge evaluate evidence across WAIT/reload.
+    prior_turn_evidence: List[str] = field(default_factory=list)
 
     def to_json(self) -> str:
         data = asdict(self)
@@ -612,6 +632,14 @@ class GoalState:
         subgoals: List[str] = []
         if isinstance(raw_subgoals, list):
             subgoals = [str(s).strip() for s in raw_subgoals if str(s).strip()]
+        raw_evidence = data.get("prior_turn_evidence") or []
+        prior_turn_evidence: List[str] = []
+        if isinstance(raw_evidence, list):
+            prior_turn_evidence = [
+                str(e).strip()[:_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS]
+                for e in raw_evidence[-_GOAL_PRIOR_EVIDENCE_MAX_ENTRIES:]
+                if str(e).strip()
+            ]
         return cls(
             goal=data.get("goal", ""),
             status=data.get("status", "active"),
@@ -636,6 +664,7 @@ class GoalState:
                 for g in (data.get("gates") or [])
                 if isinstance(g, dict) and str(g.get("command") or "").strip()
             ],
+            prior_turn_evidence=prior_turn_evidence,
         )
 
     # --- contract helpers -------------------------------------------------
@@ -651,6 +680,17 @@ class GoalState:
         if not self.subgoals:
             return ""
         return "\n".join(f"- {i}. {text}" for i, text in enumerate(self.subgoals, start=1))
+
+    def render_prior_evidence_block(self) -> str:
+        """Render bounded prior-turn evidence for the judge. Empty when none."""
+        if not self.prior_turn_evidence:
+            return ""
+        lines = [
+            f"- Turn evidence {i}: {text}"
+            for i, text in enumerate(self.prior_turn_evidence, start=1)
+            if text.strip()
+        ]
+        return _truncate("\n".join(lines), _JUDGE_PRIOR_EVIDENCE_CHARS)
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -1174,6 +1214,7 @@ def judge_goal(
     subgoals: Optional[List[str]] = None,
     background_processes: Optional[List[Dict[str, Any]]] = None,
     contract: Optional[GoalContract] = None,
+    prior_evidence: str = "",
 ) -> Tuple[str, str, bool, Optional[Dict[str, Any]], bool]:
     """Ask the auxiliary model whether the goal is satisfied.
 
@@ -1205,6 +1246,9 @@ def judge_goal(
     — a contract, subgoals, and a background-process list can coexist in one
     judge prompt; when none are set, behavior is identical to the original
     free-form judge.
+    ``prior_evidence`` is a bounded judge-only summary of earlier goal turns,
+    used after WAIT/resume so a terse completion turn can be evaluated against
+    evidence already produced in this goal run.
 
     This is deliberately fail-open: transport errors return ``("continue", ..., ..., None, True)``
     — the ``transport_failed=True`` flag lets callers track and auto-pause after
@@ -1234,6 +1278,12 @@ def judge_goal(
     # truth.
     clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]
     background_block = _render_background_block(background_processes)
+    prior_evidence = _truncate((prior_evidence or "").strip(), _JUDGE_PRIOR_EVIDENCE_CHARS)
+    prior_evidence_block = (
+        JUDGE_PRIOR_EVIDENCE_BLOCK_TEMPLATE.format(prior_evidence=prior_evidence)
+        if prior_evidence
+        else ""
+    )
     current_time = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
 
     if contract is not None and not contract.is_empty():
@@ -1248,6 +1298,7 @@ def judge_goal(
             goal=_truncate(goal, 2000),
             contract_block=_truncate(contract_block, 2500),
             response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            prior_evidence_block=prior_evidence_block,
             background_block=background_block,
             current_time=current_time,
         )
@@ -1259,6 +1310,7 @@ def judge_goal(
             goal=_truncate(goal, 2000),
             subgoals_block=_truncate(subgoals_block, 2000),
             response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            prior_evidence_block=prior_evidence_block,
             background_block=background_block,
             current_time=current_time,
         )
@@ -1266,6 +1318,7 @@ def judge_goal(
         prompt = JUDGE_USER_PROMPT_TEMPLATE.format(
             goal=_truncate(goal, 2000),
             response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
+            prior_evidence_block=prior_evidence_block,
             background_block=background_block,
             current_time=current_time,
         )
@@ -1741,6 +1794,28 @@ class GoalManager:
         save_goal(self.session_id, state)
         return None
 
+    def _remember_turn_evidence(
+        self,
+        last_response: str,
+        background_processes: Optional[List[Dict[str, Any]]] = None,
+    ) -> None:
+        """Remember bounded judge-only evidence from this goal turn."""
+        state = self._state
+        if state is None:
+            return
+        response = (last_response or "").strip()[:_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS]
+        background = _render_background_block(background_processes).strip()
+        parts = []
+        if response:
+            parts.append(f"Response: {response}")
+        if background:
+            parts.append(f"Background: {background[:_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS]}")
+        entry = "\n".join(parts).strip()[:_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS]
+        if not entry:
+            return
+        state.prior_turn_evidence.append(entry)
+        state.prior_turn_evidence = state.prior_turn_evidence[-_GOAL_PRIOR_EVIDENCE_MAX_ENTRIES:]
+
     # --- /goal wait barrier -------------------------------------------
 
     def wait_on(self, pid: int, reason: str = "") -> GoalState:
@@ -1952,6 +2027,7 @@ class GoalManager:
             subgoals=state.subgoals or None,
             background_processes=background_processes,
             contract=state.contract if state.has_contract() else None,
+            prior_evidence=state.render_prior_evidence_block(),
         )
         state.last_verdict = verdict
         state.last_reason = reason
@@ -1973,6 +2049,9 @@ class GoalManager:
             state.consecutive_transport_failures += 1
         else:
             state.consecutive_transport_failures = 0
+
+        if verdict != "done":
+            self._remember_turn_evidence(last_response, background_processes)
 
         # WAIT verdict: the judge decided the agent is blocked on async work
         # and re-poking now would be busy-work. Set the barrier and park —

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -690,7 +690,7 @@ class GoalState:
             for i, text in enumerate(self.prior_turn_evidence, start=1)
             if text.strip()
         ]
-        return _truncate("\n".join(lines), _JUDGE_PRIOR_EVIDENCE_CHARS)
+        return "\n".join(lines)
 
 
 # ──────────────────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -96,6 +96,37 @@ class TestJudgeGoal:
         assert verdict == "done"
         assert reason == "achieved"
 
+    def test_judge_prompt_includes_prior_evidence_only_when_provided(self):
+        from hermes_cli import goals
+
+        captured = {}
+
+        class _FakeMsg:
+            content = '{"done": true, "reason": "achieved"}'
+        class _FakeChoice:
+            message = _FakeMsg()
+        class _FakeResp:
+            choices = [_FakeChoice()]
+        def _fake_call_llm(**kwargs):
+            captured.update(kwargs)
+            return _FakeResp()
+
+        with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+            goals.judge_goal("goal", "agent response", prior_evidence="prior process evidence")
+
+        sent_messages = captured.get("messages") or []
+        user_msg = next((m["content"] for m in sent_messages if m["role"] == "user"), "")
+        assert "Relevant evidence from prior turns" in user_msg
+        assert "prior process evidence" in user_msg
+
+        captured.clear()
+        with patch("agent.auxiliary_client.call_llm", side_effect=_fake_call_llm):
+            goals.judge_goal("goal", "agent response")
+
+        sent_messages = captured.get("messages") or []
+        user_msg = next((m["content"] for m in sent_messages if m["role"] == "user"), "")
+        assert "Relevant evidence from prior turns" not in user_msg
+
 
 # ──────────────────────────────────────────────────────────────────────
 # GoalManager lifecycle + persistence
@@ -245,6 +276,45 @@ class TestGoalStateSubgoalsBackcompat:
         state = GoalState.from_json(legacy)
         assert state.goal == "do a thing"
         assert state.subgoals == []
+
+
+class TestGoalStatePriorEvidenceBackcompat:
+    def test_old_state_meta_row_loads_without_prior_evidence(self):
+        from hermes_cli.goals import GoalState
+
+        legacy = json.dumps({
+            "goal": "do a thing",
+            "status": "active",
+            "turns_used": 2,
+            "max_turns": 20,
+            "created_at": 1.0,
+            "last_turn_at": 2.0,
+        })
+        state = GoalState.from_json(legacy)
+        assert state.goal == "do a thing"
+        assert state.prior_turn_evidence == []
+
+    def test_prior_evidence_roundtrip_is_bounded(self):
+        from hermes_cli.goals import (
+            _GOAL_PRIOR_EVIDENCE_ENTRY_CHARS,
+            _GOAL_PRIOR_EVIDENCE_MAX_ENTRIES,
+            GoalState,
+        )
+
+        state = GoalState(
+            goal="do a thing",
+            prior_turn_evidence=[
+                f"old-{i}-" + ("x" * (_GOAL_PRIOR_EVIDENCE_ENTRY_CHARS + 50))
+                for i in range(_GOAL_PRIOR_EVIDENCE_MAX_ENTRIES + 2)
+            ],
+        )
+        restored = GoalState.from_json(state.to_json())
+        assert len(restored.prior_turn_evidence) == _GOAL_PRIOR_EVIDENCE_MAX_ENTRIES
+        assert restored.prior_turn_evidence[0].startswith("old-2-")
+        assert all(
+            len(entry) <= _GOAL_PRIOR_EVIDENCE_ENTRY_CHARS
+            for entry in restored.prior_turn_evidence
+        )
 
 
 class TestMigrateGoalToSession:
@@ -519,6 +589,114 @@ class TestJudgeDrivenWait:
         assert decision["verdict"] == "continue"
         assert decision["should_continue"] is True
         assert mgr.state.waiting_on_pid is None
+
+    def test_prior_evidence_accumulation_is_bounded(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import (
+            _GOAL_PRIOR_EVIDENCE_MAX_ENTRIES,
+            GoalManager,
+        )
+
+        mgr = GoalManager(session_id="jw-evidence-bounded", default_max_turns=20)
+        mgr.set("finish all steps")
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "more work", False, None, False),
+        ):
+            for i in range(_GOAL_PRIOR_EVIDENCE_MAX_ENTRIES + 3):
+                mgr.evaluate_after_turn(f"turn-{i}-evidence")
+
+        evidence = mgr.state.prior_turn_evidence
+        assert len(evidence) == _GOAL_PRIOR_EVIDENCE_MAX_ENTRIES
+        joined = "\n".join(evidence)
+        assert "turn-0-evidence" not in joined
+        assert "turn-1-evidence" not in joined
+        assert "turn-6-evidence" in joined
+
+    def test_prior_evidence_not_added_to_continuation_prompt(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-evidence-prompt", default_max_turns=5)
+        mgr.set("finish all steps")
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "more work", False, None, False),
+        ):
+            decision = mgr.evaluate_after_turn("private prior evidence")
+
+        prompt = decision["continuation_prompt"]
+        assert prompt is not None
+        assert "Relevant evidence from prior turns" not in prompt
+        assert "private prior evidence" not in prompt
+
+    def test_new_goal_resets_prior_evidence(self, hermes_home):
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="jw-evidence-reset", default_max_turns=5)
+        mgr.set("first goal")
+        with patch.object(
+            goals,
+            "judge_goal",
+            return_value=("continue", "more work", False, None, False),
+        ):
+            mgr.evaluate_after_turn("first-goal-evidence")
+        assert mgr.state.prior_turn_evidence
+
+        mgr.clear()
+        mgr.set("second goal")
+        assert mgr.state.prior_turn_evidence == []
+
+    def test_wait_then_done_can_use_prior_turn_evidence_after_reload(self, hermes_home):
+        """A completion turn after WAIT may be terse; the judge still needs
+        bounded evidence from the turn that parked the goal."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        captured = []
+
+        def judge(goal, response, **kwargs):
+            captured.append({"response": response, **kwargs})
+            if len(captured) == 1:
+                return (
+                    "wait",
+                    "process is running",
+                    False,
+                    {"session_id": "proc-evidence"},
+                    False,
+                )
+            prior = kwargs.get("prior_evidence") or ""
+            assert "PROCESS-STARTED" in prior
+            assert "proc-evidence" in prior
+            assert "notify_on_complete" in prior
+            return "done", "completion evidence links back to parked work", False, None, False
+
+        with patch.object(goals, "judge_goal", side_effect=judge):
+            mgr = GoalManager(session_id="jw-evidence", default_max_turns=3)
+            mgr.set("finish the background job")
+            d1 = mgr.evaluate_after_turn(
+                "PROCESS-STARTED proc-evidence: notify_on_complete watcher is running.",
+                background_processes=[{
+                    "session_id": "proc-evidence",
+                    "pid": 4242,
+                    "status": "running",
+                    "command": "notify_on_complete.sh",
+                    "notify_on_complete": True,
+                }],
+            )
+            assert d1["verdict"] == "wait"
+
+            # Model the real wake path: a later process-completion turn reloads
+            # persisted GoalState before the judge sees the terse final answer.
+            resumed = GoalManager(session_id="jw-evidence", default_max_turns=3)
+            resumed.state.waiting_on_session = None
+            d2 = resumed.evaluate_after_turn("GOAL-THREAD-PASS")
+
+        assert d2["verdict"] == "done"
+        assert captured[1]["response"] == "GOAL-THREAD-PASS"
 
 
 # ──────────────────────────────────────────────────────────────────────
@@ -797,4 +975,3 @@ class TestContractAndBackgroundCompose:
         # The judge can return a wait verdict on a contract goal.
         assert verdict == "wait"
         assert wait_directive and wait_directive.get("pid") == 4242
-


### PR DESCRIPTION
## Outcome
Preserve bounded evidence from prior `/goal` turns so a goal that parks on background work can terminate correctly after its wake-up turn.

Live failure reproduced this sequence:
1. Agent started a `notify_on_complete` process and returned `PROCESS-STARTED`.
2. Goal judge correctly returned `WAIT`.
3. Process completion resumed the same session; agent returned `GOAL-THREAD-PASS`.
4. Judge saw only the latest response, could not connect it to the earlier process evidence, returned `CONTINUE`, and the two-turn brake paused an already-complete goal.

## Fix
- Persist at most four prior-turn evidence snippets, 1,200 characters each, inside the existing per-session `GoalState`.
- Supply at most 3,000 characters of that evidence to the goal judge only.
- Keep continuation prompts and normal conversation history unchanged.
- Preserve legacy state loading, WAIT behavior, fail-safe judge handling, and fresh-state reset on a new goal.

## Verification
- RED: the WAIT → reload → terse completion regression failed because the reloaded judge received no prior evidence.
- GREEN: 13 goal/gateway test files, 106 tests passed.
- Opposite-family adversarial review of `aa6c3117a3`: correctness PASS; intent/impact preservation PASS.
- Exact-head opposite-family adversarial re-review of `1f34d88303`: correctness PASS; intent/impact preservation PASS.

## Privacy note
The new bounded snippets persist assistant output in the same local SessionDB trust boundary that already stores the goal and judge reason. This adds no audience or network boundary. No new encryption/redaction machinery is warranted.

## Non-goals
No `/goal` redesign, token special-case, turn-budget increase, iMessage routing change, or speculative evidence scoring/decay.
