### PR TITLE
feat(browser): ownership-aware tab lifecycle + conversation-scoped CDP transport reuse

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -40,6 +40,7 @@ from agent.message_sanitization import (
     tool_result_id_variants,
 )
 from agent.prompt_builder import format_steer_marker
+from agent.prompt_cache_scope import resolve_browser_transport_scope
 from agent.tool_dispatch_helpers import _trajectory_normalize_msg, make_tool_result_message
 from agent.trajectory import convert_scratchpad_to_think
 from agent.credential_pool import (
@@ -3708,6 +3709,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
             dispatch_kwargs = dict(
                 tool_call_id=tool_call_id,
                 session_id=agent.session_id or "",
+                conversation_id=resolve_browser_transport_scope(agent, function_name),
                 turn_id=getattr(agent, "_current_turn_id", "") or "",
                 api_request_id=getattr(agent, "_current_api_request_id", "") or "",
                 enabled_tools=list(agent.valid_tool_names) if agent.valid_tool_names else None,

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3384,6 +3384,21 @@ def cleanup_task_resources(agent, task_id: str) -> None:
         if agent.verbose_logging:
             logger.warning("Failed to cleanup VM for task %s: %s", task_id, e)
     try:
+        from tools.browser_tool import finalize_browser_tab_lifecycle
+
+        owner_key = getattr(agent, "_current_turn_id", "") or task_id
+        report = finalize_browser_tab_lifecycle(owner_key)
+        if report.get("failed") and agent.verbose_logging:
+            logger.warning(
+                "Failed to finalize %s browser tab lease(s) for turn %s: %s",
+                report.get("failed"),
+                owner_key,
+                report.get("errors"),
+            )
+    except Exception as e:
+        if agent.verbose_logging:
+            logger.warning("Failed to finalize browser tabs for task %s: %s", task_id, e)
+    try:
         headed = False
         try:
             from tools.browser_tool import _is_headed_mode

--- a/agent/prompt_cache_scope.py
+++ b/agent/prompt_cache_scope.py
@@ -123,3 +123,18 @@ def resolve_prompt_cache_scope_safe(agent: Any) -> Optional[str]:
     except Exception:
         logger.debug("prompt-cache scope resolution failed", exc_info=True)
         return None
+
+
+def resolve_browser_transport_scope(agent: Any, function_name: str) -> str:
+    """Return the fork-aware, rotation-stable scope for ``browser_exec``.
+
+    Browser-harness transports must survive compression rotation without
+    collapsing explicit branches, delegate children, or tool children onto a
+    parent's mutable CDP connection. The prompt-cache scope already encodes
+    exactly those boundaries. Other tools receive no extra handler context.
+    """
+    if function_name != "browser_exec":
+        return ""
+    return resolve_prompt_cache_scope_safe(agent) or str(
+        getattr(agent, "session_id", None) or ""
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -33,6 +33,7 @@ from agent.display import (
     _detect_tool_failure,
 )
 from agent.message_sanitization import coalesce_tool_call_id
+from agent.prompt_cache_scope import resolve_browser_transport_scope
 from agent.tool_dispatch_helpers import (
     _NEVER_PARALLEL_TOOLS,
     _is_destructive_command,
@@ -2520,6 +2521,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             effective_task_id,
                             tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
+                            conversation_id=resolve_browser_transport_scope(
+                                agent, function_name
+                            ),
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",
@@ -2602,6 +2606,9 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             effective_task_id,
                             tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
+                            conversation_id=resolve_browser_transport_scope(
+                                agent, function_name
+                            ),
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
                             api_request_id=getattr(agent, "_current_api_request_id", "")
                             or "",

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -506,6 +506,13 @@ browser:
   # Inactivity timeout in seconds - browser sessions are automatically closed
   # after this period of no activity between agent loops (default: 120 = 2 minutes)
   inactivity_timeout: 120
+
+  # Opt-in ownership-aware cleanup for tabs created by browser_exec on an
+  # explicit plaintext loopback CDP browser. Cloud, TLS, and non-loopback
+  # browsers are never inspected by this guard (default: false).
+  resource_hygiene:
+    enabled: false
+
   # Let an authenticated browser extension register as the controller for an
   # existing Hermes session. Disabled by default. Local API registration also
   # requires the API server bearer key to be configured.

--- a/cli.py
+++ b/cli.py
@@ -467,6 +467,9 @@ def load_cli_config() -> Dict[str, Any]:
             "inactivity_timeout": 120,  # Auto-cleanup inactive browser sessions after 2 min
             "record_sessions": False,  # Auto-record browser sessions as WebM videos
             "engine": "auto",  # Browser engine: auto (Chrome), lightpanda, chrome
+            "resource_hygiene": {
+                "enabled": False,  # Close only locally owned Browser Use tabs after each call
+            },
             "camofox": {
                 "rewrite_loopback_urls": False,
                 "loopback_host_alias": "host.docker.internal",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -624,6 +624,9 @@ DEFAULT_CONFIG = {
         "engine": "auto",
         "auto_local_for_private_urls": True,  # When a cloud provider is set, auto-spawn local Chromium for LAN/localhost URLs instead of sending them to the cloud
         "cdp_url": "",  # Optional persistent CDP endpoint for attaching to an existing Chromium/Chrome
+        "resource_hygiene": {
+            "enabled": False,  # Per-turn ownership/cleanup for tabs on an explicit loopback CDP browser
+        },
         # Consent to browse with the user's REAL logins for local browsing.
         # When true, local browsing (the Browser Use CLI, or the built-in
         # browser tools) runs on a Hermes-managed SNAPSHOT of the user's

--- a/model_tools.py
+++ b/model_tools.py
@@ -1547,6 +1547,9 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        tool_call_id=tool_call_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
                         enabled_tools=sandbox_enabled,
                     )
             else:
@@ -1555,6 +1558,9 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        tool_call_id=tool_call_id,
+                        turn_id=turn_id,
+                        api_request_id=api_request_id,
                         user_task=user_task,
                     )
             if skip_tool_execution_middleware:

--- a/model_tools.py
+++ b/model_tools.py
@@ -1243,6 +1243,7 @@ def handle_function_call(
     task_id: Optional[str] = None,
     tool_call_id: Optional[str] = None,
     session_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
     turn_id: Optional[str] = None,
     api_request_id: Optional[str] = None,
     user_task: Optional[str] = None,
@@ -1382,6 +1383,7 @@ def handle_function_call(
                 task_id=task_id,
                 tool_call_id=tool_call_id,
                 session_id=session_id,
+                conversation_id=conversation_id,
                 turn_id=turn_id,
                 api_request_id=api_request_id,
                 user_task=user_task,
@@ -1538,6 +1540,11 @@ def handle_function_call(
         except Exception:
             reset_current_observability_context = None
         try:
+            conversation_context = (
+                {"conversation_id": conversation_id}
+                if function_name == "browser_exec" and conversation_id
+                else {}
+            )
             if function_name == "execute_code":
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
@@ -1551,6 +1558,7 @@ def handle_function_call(
                         turn_id=turn_id,
                         api_request_id=api_request_id,
                         enabled_tools=sandbox_enabled,
+                        **conversation_context,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1562,6 +1570,7 @@ def handle_function_call(
                         turn_id=turn_id,
                         api_request_id=api_request_id,
                         user_task=user_task,
+                        **conversation_context,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/tests/agent/test_prompt_cache_scope.py
+++ b/tests/agent/test_prompt_cache_scope.py
@@ -14,7 +14,10 @@ from types import SimpleNamespace
 
 import pytest
 
-from agent.prompt_cache_scope import resolve_prompt_cache_scope
+from agent.prompt_cache_scope import (
+    resolve_browser_transport_scope,
+    resolve_prompt_cache_scope,
+)
 from agent.transports.codex import _cache_scope_from_session_id, _content_cache_key
 from hermes_state import SessionDB
 
@@ -203,6 +206,30 @@ class TestResolvePromptCacheScope:
         # Normal path still resolves through to the plain variant.
         assert resolve_prompt_cache_scope_safe(_agent("sess-ok")) == "sess-ok"
         assert resolve_prompt_cache_scope_safe(_agent("")) is None
+
+    def test_browser_transport_reuses_rotation_scope_but_not_parent_forks(self, db):
+        db.create_session("root-sess", source="webui")
+        _rotate(db, "root-sess", "rotated-1")
+        assert (
+            resolve_browser_transport_scope(_agent("rotated-1", db), "browser_exec")
+            == "root-sess"
+        )
+
+        db.create_session(
+            "delegate-child",
+            source="webui",
+            parent_session_id="root-sess",
+            model_config={"_delegate_from": "root-sess"},
+        )
+        assert (
+            resolve_browser_transport_scope(
+                _agent("delegate-child", db), "browser_exec"
+            )
+            == "delegate-child"
+        )
+
+    def test_browser_transport_context_is_not_added_to_other_tools(self):
+        assert resolve_browser_transport_scope(_agent("sess-x"), "web_search") == ""
 
 
 class TestRotationContinuityEndToEnd:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1724,6 +1724,27 @@ class TestExecuteToolCalls:
         tool_results = [m for m in messages if m["role"] == "tool"]
         assert [m["tool_call_id"] for m in tool_results] == ["c1", "c2"]
 
+    def test_sequential_browser_exec_forwards_transport_scope(self, agent):
+        """browser_exec is a sequential barrier, so this is its production seam."""
+        agent.session_id = "compressed-child"
+        tc = _mock_tool_call(
+            name="browser_exec",
+            arguments=json.dumps({"code": "print(page_info())"}),
+            call_id="browser-1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        with (
+            patch(
+                "agent.tool_executor.resolve_browser_transport_scope",
+                return_value="lineage-root",
+            ),
+            patch("run_agent.handle_function_call", return_value="ok") as mock_hfc,
+        ):
+            agent._execute_tool_calls_sequential(mock_msg, [], "task-1")
+        assert mock_hfc.call_args.kwargs["session_id"] == "compressed-child"
+        assert mock_hfc.call_args.kwargs["conversation_id"] == "lineage-root"
+
+
     def test_sequential_memory_remove_notifies_provider_with_tool_result(self, agent):
         old_text = "stale preference entry"
         tc = _mock_tool_call(
@@ -2149,6 +2170,7 @@ class TestConcurrentToolExecution:
                 "web_search", {"q": "test"}, "task-1",
                 tool_call_id=None,
                 session_id=agent.session_id,
+                conversation_id="",
                 turn_id="",
                 api_request_id="",
                 enabled_tools=list(agent.valid_tool_names),
@@ -2159,6 +2181,7 @@ class TestConcurrentToolExecution:
                 tool_request_middleware_trace=[],
             )
             assert result == "result"
+
 
     def test_sequential_tool_callbacks_fire_in_order(self, agent):
         tool_call = _mock_tool_call(name="web_search", arguments='{"query":"hello"}', call_id="c1")

--- a/tests/test_dispatch_session_id.py
+++ b/tests/test_dispatch_session_id.py
@@ -73,3 +73,27 @@ class TestSessionIdForwarding:
                 skip_pre_tool_call_hook=True,
             )
         assert captured.get("task_id") == "task-999"
+
+    def test_conversation_lineage_is_forwarded_only_for_browser_exec(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "browser_exec", {"code": "print(1)"}, task_id="t1",
+                session_id="compressed-child", conversation_id="lineage-root",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("session_id") == "compressed-child"
+        assert captured.get("conversation_id") == "lineage-root"
+
+    def test_conversation_lineage_does_not_expand_other_handler_contracts(self):
+        captured = {}
+        with patch("model_tools.registry", _make_registry(captured)):
+            from model_tools import handle_function_call
+            handle_function_call(
+                "web_search", {"query": "test"}, task_id="t1",
+                session_id="compressed-child", conversation_id="lineage-root",
+                skip_pre_tool_call_hook=True,
+            )
+        assert captured.get("session_id") == "compressed-child"
+        assert "conversation_id" not in captured

--- a/tests/test_model_tools.py
+++ b/tests/test_model_tools.py
@@ -30,6 +30,24 @@ class TestHandleFunctionCall:
         assert "error" in result
         assert "totally_fake_tool_xyz" in result["error"]
 
+    def test_registry_dispatch_receives_turn_identity(self):
+        with patch("model_tools.registry.dispatch", return_value='{"ok":true}') as dispatch:
+            result = handle_function_call(
+                "web_search",
+                {"q": "test"},
+                task_id="task-1",
+                session_id="session-1",
+                tool_call_id="tool-1",
+                turn_id="turn-1",
+                api_request_id="request-1",
+            )
+        assert result == '{"ok":true}'
+        assert dispatch.call_args.kwargs["task_id"] == "task-1"
+        assert dispatch.call_args.kwargs["session_id"] == "session-1"
+        assert dispatch.call_args.kwargs["tool_call_id"] == "tool-1"
+        assert dispatch.call_args.kwargs["turn_id"] == "turn-1"
+        assert dispatch.call_args.kwargs["api_request_id"] == "request-1"
+
 
 
     def test_post_tool_call_receives_non_negative_integer_duration_ms(self):

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -156,6 +156,117 @@ class TestGetCdpOverride:
         with patch("hermes_cli.config.read_raw_config", return_value={}):
             assert bc.is_camofox_mode() is False
 
+class TestTabLifecycleResolution:
+    def test_only_plaintext_loopback_cdp_is_manageable(self):
+        from tools.browser_tool import _loopback_cdp_http_endpoint
+
+        assert _loopback_cdp_http_endpoint("http://127.0.0.1:9222") == "http://127.0.0.1:9222"
+        assert _loopback_cdp_http_endpoint("ws://localhost:9333/devtools/browser/x") == "http://localhost:9333"
+        assert _loopback_cdp_http_endpoint("ws://[::1]:9444/devtools/browser/x") == "http://[::1]:9444"
+        assert _loopback_cdp_http_endpoint("https://127.0.0.1:9222") is None
+        assert _loopback_cdp_http_endpoint("wss://127.0.0.1:9222/devtools/browser/x") is None
+        assert _loopback_cdp_http_endpoint("ws://192.168.1.20:9222/devtools/browser/x") is None
+        assert _loopback_cdp_http_endpoint("ws://user:pass@127.0.0.1:9222/devtools/browser/x") is None
+        assert _loopback_cdp_http_endpoint("ws://localhost:not-a-port") is None
+
+    def test_prepare_uses_browser_tools_native_resolved_websocket(self, monkeypatch):
+        import tools.browser_tab_lifecycle as lifecycle
+        import tools.browser_tool as browser_tool
+
+        seen = {}
+
+        class FakeGuard:
+            def __init__(self, **kwargs):
+                seen.update(kwargs)
+
+            def start(self):
+                return None
+
+        monkeypatch.setattr(browser_tool, "_tab_lifecycle_enabled", lambda: True)
+        monkeypatch.setattr(
+            browser_tool,
+            "_get_cdp_override",
+            lambda: "ws://127.0.0.1:9222/devtools/browser/native-resolved",
+        )
+        monkeypatch.setattr(lifecycle, "BrowserTabLifecycleGuard", FakeGuard)
+        cleanup_starts = []
+        monkeypatch.setattr(
+            browser_tool,
+            "_start_browser_cleanup_thread",
+            lambda: cleanup_starts.append(True),
+        )
+
+        guard, error = browser_tool.prepare_browser_tab_lifecycle(
+            session_name="",
+            owner_key="turn-123",
+            lease_minutes=10,
+            lease_reason="continue pagination",
+            lock_timeout_s=30,
+        )
+
+        assert guard is not None
+        assert error is None
+        assert seen["endpoint"] == "http://127.0.0.1:9222"
+        assert seen["owner_key"] == "turn-123"
+        assert cleanup_starts == [True]
+
+    def test_private_and_remote_sessions_are_never_managed(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.setattr(browser_tool, "_tab_lifecycle_enabled", lambda: True)
+        called = []
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: called.append(True) or WS_URL)
+        assert browser_tool.prepare_browser_tab_lifecycle(
+            session_name="isolated-cloud",
+            owner_key="turn-1",
+            lease_minutes=0,
+            lease_reason="",
+            lock_timeout_s=30,
+            private_browser=True,
+        ) == (None, None)
+        assert called == []
+
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: WS_URL)
+        guard, error = browser_tool.prepare_browser_tab_lifecycle(
+            session_name="",
+            owner_key="turn-1",
+            lease_minutes=0,
+            lease_reason="",
+            lock_timeout_s=30,
+        )
+        assert guard is None
+        assert error is None
+
+        monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
+        guard, error = browser_tool.prepare_browser_tab_lifecycle(
+            session_name="",
+            owner_key="turn-1",
+            lease_minutes=0,
+            lease_reason="",
+            lock_timeout_s=30,
+        )
+        assert guard is None
+        assert error is not None
+        assert "plaintext loopback" in error
+
+    def test_inactivity_cleanup_reaps_leases_without_expired_sessions(
+        self, monkeypatch
+    ):
+        import tools.browser_tool as browser_tool
+
+        monkeypatch.setattr(browser_tool, "_session_last_activity", {})
+        reaps = []
+        monkeypatch.setattr(
+            browser_tool,
+            "reap_expired_browser_tab_lifecycles",
+            lambda: reaps.append(True),
+        )
+
+        browser_tool._cleanup_inactive_browser_sessions()
+
+        assert reaps == [True]
+
+
 class TestCreateCdpSession:
     """_create_cdp_session() must sanitize the CDP URL before logging.
 

--- a/tests/tools/test_browser_headed_mode.py
+++ b/tests/tools/test_browser_headed_mode.py
@@ -92,6 +92,45 @@ class TestCleanupTaskResourcesHeadedSkip:
             cleanup_task_resources(_make_agent(), "task-x")
             mock_vm.assert_called_once_with("task-x")
 
+    def test_tab_lifecycle_finalizer_uses_turn_then_falls_back_to_task(self):
+        from agent.chat_completion_helpers import cleanup_task_resources
+
+        for agent, expected in (
+            (SimpleNamespace(verbose_logging=False, _current_turn_id="turn-x"), "turn-x"),
+            (_make_agent(), "task-x"),
+        ):
+            with (
+                patch("tools.browser_tool._is_headed_mode", return_value=False),
+                patch("tools.browser_tool.finalize_browser_tab_lifecycle") as finalize,
+                patch("run_agent.cleanup_vm"),
+                patch("run_agent.cleanup_browser"),
+                patch(
+                    "agent.chat_completion_helpers.is_persistent_env",
+                    return_value=False,
+                ),
+            ):
+                cleanup_task_resources(agent, "task-x")
+                finalize.assert_called_once_with(expected)
+
+    def test_tab_lifecycle_finalizer_failure_does_not_skip_normal_cleanup(self):
+        from agent.chat_completion_helpers import cleanup_task_resources
+
+        with (
+            patch("tools.browser_tool._is_headed_mode", return_value=False),
+            patch(
+                "tools.browser_tool.finalize_browser_tab_lifecycle",
+                side_effect=RuntimeError("ledger unavailable"),
+            ),
+            patch("run_agent.cleanup_vm"),
+            patch("run_agent.cleanup_browser") as cleanup_browser,
+            patch(
+                "agent.chat_completion_helpers.is_persistent_env",
+                return_value=False,
+            ),
+        ):
+            cleanup_task_resources(_make_agent(), "task-x")
+            cleanup_browser.assert_called_once_with("task-x")
+
 
 # ---------------------------------------------------------------------------
 # --headed flag injection in local mode

--- a/tests/tools/test_browser_tab_lifecycle.py
+++ b/tests/tools/test_browser_tab_lifecycle.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.parse
+from pathlib import Path
+
+import pytest
+
+from tools.browser_tab_lifecycle import (
+    BrowserTabLifecycleGuard,
+    _redact_url,
+    finalize_browser_tab_owner,
+    reap_expired_browser_tab_leases,
+)
+
+
+class MemoryGuard(BrowserTabLifecycleGuard):
+    def __init__(self, *args, pages=None, **kwargs):
+        self.pages = dict(pages or {})
+        self.requests = []
+        super().__init__(*args, **kwargs)
+
+    def _require_live_browser_identity(self) -> None:
+        # MemoryGuard's in-memory endpoint represents the browser_key passed by
+        # each test. Network identity behavior is covered by _FakeCdp below.
+        return None
+
+    def _request_json(self, path: str, *, method: str = "GET"):
+        self.requests.append((method, path))
+        if path == "/json/list":
+            return list(self.pages.values())
+        if path.startswith("/json/close/"):
+            target_id = path.rsplit("/", 1)[-1]
+            self.pages.pop(target_id, None)
+            return "Target is closing"
+        if path.startswith("/json/new?"):
+            target_id = f"baseline-{self.browser_key}"
+            self.pages[target_id] = {
+                "id": target_id,
+                "type": "page",
+                "url": "about:blank",
+                "title": "",
+            }
+            return self.pages[target_id]
+        raise AssertionError(path)
+
+
+@pytest.fixture
+def state_dir(tmp_path: Path) -> Path:
+    return tmp_path / "state"
+
+
+def _page(target_id: str, url: str, title: str = "") -> dict:
+    return {"id": target_id, "type": "page", "url": url, "title": title}
+
+
+class _BytesResponse:
+    def __init__(self, payload: bytes):
+        self.payload = payload
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        return False
+
+    def read(self):
+        return self.payload
+
+
+class _FakeCdp:
+    def __init__(self, websocket_url: str, pages: dict[str, dict]):
+        self.websocket_url = websocket_url
+        self.pages = pages
+        self.requests: list[tuple[str, str]] = []
+
+    def urlopen(self, request, *, timeout=5):
+        del timeout
+        if isinstance(request, str):
+            url = request
+            method = "GET"
+        else:
+            url = request.full_url
+            method = request.get_method()
+        parsed = urllib.parse.urlsplit(url)
+        path = parsed.path + (f"?{parsed.query}" if parsed.query else "")
+        self.requests.append((method, path))
+        if parsed.path == "/json/version":
+            return _BytesResponse(
+                json.dumps({"webSocketDebuggerUrl": self.websocket_url}).encode()
+            )
+        if parsed.path == "/json/list":
+            return _BytesResponse(json.dumps(list(self.pages.values())).encode())
+        if parsed.path.startswith("/json/close/"):
+            target_id = urllib.parse.unquote(parsed.path.rsplit("/", 1)[-1])
+            self.pages.pop(target_id, None)
+            return _BytesResponse(b"Target is closing")
+        if parsed.path == "/json/new":
+            self.pages["new-blank"] = _page("new-blank", "about:blank")
+            return _BytesResponse(json.dumps(self.pages["new-blank"]).encode())
+        raise AssertionError((method, path))
+
+
+def _browser_key(websocket_url: str) -> str:
+    return hashlib.sha256(websocket_url.encode()).hexdigest()
+
+
+def test_url_redaction_drops_credentials_query_and_fragment():
+    assert (
+        _redact_url("https://user:pass@example.com/path?a=secret#frag")
+        == "https://example.com/path"
+    )
+
+
+def test_closes_created_and_repurposed_targets_then_leaves_one_blank(state_dir: Path):
+    guard = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="task-a",
+        state_dir=state_dir,
+        pages={"base": _page("base", "about:blank")},
+    )
+    assert guard.start() is None
+    assert guard.target_id is not None
+    guard.pages[guard.target_id] = _page(
+        guard.target_id, "https://example.com/path?q=private", "Example"
+    )
+    guard.pages["popup"] = _page("popup", "https://example.com/popup", "Popup")
+
+    report = guard.finish()
+
+    assert report == {
+        "managed": True,
+        "ok": True,
+        "created": 2,
+        "repurposed": 0,
+        "closed": 2,
+        "leased": 0,
+        "remaining_pages": 1,
+        "errors": [],
+    }
+    assert list(guard.pages) == ["base"]
+    with guard._connect() as db:
+        rows = db.execute(
+            """SELECT target_id, state, close_verified, url_redacted
+               FROM browser_resources ORDER BY target_id"""
+        ).fetchall()
+    assert [(r[0], r[1], r[2]) for r in rows] == [
+        ("baseline-browser-a", "closed", 1),
+        ("popup", "closed", 1),
+    ]
+    assert rows[0][3] == "https://example.com/path"
+
+
+def test_explicit_lease_persists_then_next_unleased_call_closes_owned_target(state_dir: Path):
+    pages = {"base": _page("base", "about:blank")}
+    leased = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="task-a",
+        lease_minutes=20,
+        lease_reason="continue pagination",
+        state_dir=state_dir,
+        pages=pages,
+    )
+    assert leased.start() is None
+    assert leased.target_id is not None
+    leased.pages[leased.target_id] = _page(
+        leased.target_id, "https://example.com/page/1"
+    )
+    first = leased.finish()
+    assert first["leased"] == 1
+    assert first["closed"] == 0
+    assert set(leased.pages) == {"base", "baseline-browser-a"}
+
+    closing = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="task-a",
+        state_dir=state_dir,
+        pages=leased.pages,
+    )
+    assert closing.start() is None
+    second = closing.finish()
+    assert second["closed"] == 1
+    assert second["remaining_pages"] == 1
+    assert list(closing.pages) == ["base"]
+
+
+def test_browser_identity_scopes_leased_target_ids(state_dir: Path):
+    leased = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="turn-a",
+        lease_minutes=20,
+        lease_reason="continue",
+        state_dir=state_dir,
+        pages={"base": _page("base", "about:blank")},
+    )
+    assert leased.start() is None
+    leased.finish()
+
+    other = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9333",
+        browser_key="browser-b",
+        owner_key="turn-a",
+        state_dir=state_dir,
+        pages={"baseline-browser-a": _page("baseline-browser-a", "https://user.example")},
+    )
+    with other._connect() as db:
+        assert other._owned_active_ids(db) == set()
+
+
+def test_turn_finalizer_closes_leased_target(state_dir: Path, monkeypatch):
+    websocket_url = "ws://127.0.0.1:9222/devtools/browser/browser-a"
+    leased = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key=_browser_key(websocket_url),
+        owner_key="turn-a",
+        lease_minutes=20,
+        lease_reason="continue",
+        state_dir=state_dir,
+        pages={"base": _page("base", "about:blank")},
+    )
+    assert leased.start() is None
+    leased.finish()
+    fake_cdp = _FakeCdp(websocket_url, leased.pages)
+    monkeypatch.setattr(
+        "tools.browser_tab_lifecycle.urllib.request.urlopen",
+        fake_cdp.urlopen,
+    )
+    report = finalize_browser_tab_owner("turn-a", state_dir=state_dir)
+    assert report == {"closed": 1, "failed": 0, "errors": []}
+    assert any(path.startswith("/json/close/") for _, path in fake_cdp.requests)
+    assert not any(path.startswith("/json/new") for _, path in fake_cdp.requests)
+    with leased._connect() as db:
+        state = db.execute(
+            """SELECT state FROM browser_resources
+               WHERE browser_key=? AND owner_key='turn-a'""",
+            (_browser_key(websocket_url),),
+        ).fetchone()[0]
+    assert state == "closed"
+
+
+def test_expired_lease_reaper_closes_target(state_dir: Path, monkeypatch):
+    websocket_url = "ws://127.0.0.1:9222/devtools/browser/browser-a"
+    leased = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key=_browser_key(websocket_url),
+        owner_key="turn-a",
+        lease_minutes=20,
+        lease_reason="continue",
+        state_dir=state_dir,
+        pages={"base": _page("base", "about:blank")},
+    )
+    assert leased.start() is None
+    leased.finish()
+    with leased._connect() as db:
+        db.execute(
+            "UPDATE browser_resources SET lease_expires_at='2000-01-01T00:00:00+00:00'"
+        )
+    fake_cdp = _FakeCdp(websocket_url, leased.pages)
+    monkeypatch.setattr(
+        "tools.browser_tab_lifecycle.urllib.request.urlopen",
+        fake_cdp.urlopen,
+    )
+    report = reap_expired_browser_tab_leases(state_dir=state_dir)
+    assert report == {"closed": 1, "failed": 0, "errors": []}
+    assert any(path.startswith("/json/close/") for _, path in fake_cdp.requests)
+    assert not any(path.startswith("/json/new") for _, path in fake_cdp.requests)
+
+
+def test_reaper_never_writes_to_restarted_browser_on_same_endpoint(
+    state_dir: Path, monkeypatch
+):
+    old_websocket = "ws://127.0.0.1:9222/devtools/browser/old-guid"
+    leased = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key=_browser_key(old_websocket),
+        owner_key="turn-a",
+        lease_minutes=20,
+        lease_reason="continue",
+        state_dir=state_dir,
+        pages={"base": _page("base", "about:blank")},
+    )
+    assert leased.start() is None
+    leased.finish()
+    with leased._connect() as db:
+        db.execute(
+            "UPDATE browser_resources SET lease_expires_at='2000-01-01T00:00:00+00:00'"
+        )
+
+    restarted_pages = {"user-tab": _page("user-tab", "https://example.com")}
+    fake_cdp = _FakeCdp(
+        "ws://127.0.0.1:9222/devtools/browser/new-guid", restarted_pages
+    )
+    monkeypatch.setattr(
+        "tools.browser_tab_lifecycle.urllib.request.urlopen",
+        fake_cdp.urlopen,
+    )
+
+    report = reap_expired_browser_tab_leases(state_dir=state_dir)
+
+    assert report["closed"] == 0
+    assert report["failed"] == 1
+    assert "browser identity changed" in report["errors"][0]
+    assert fake_cdp.requests == [("GET", "/json/version")]
+    assert restarted_pages == {"user-tab": _page("user-tab", "https://example.com")}
+    with leased._connect() as db:
+        row = db.execute(
+            "SELECT state, close_verified, last_error FROM browser_resources"
+        ).fetchone()
+    assert tuple(row[:2]) == ("close_failed", 0)
+    assert "browser identity changed" in row[2]
+
+
+def test_unowned_nonblank_target_is_never_closed(state_dir: Path):
+    guard = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="task-a",
+        state_dir=state_dir,
+        pages={"other": _page("other", "https://example.org/user-work")},
+    )
+    assert guard.start() is None
+    report = guard.finish()
+    assert report["closed"] == 1
+    assert "other" in guard.pages
+    assert guard.pages["other"]["url"] == "https://example.org/user-work"
+    closed_paths = [path for _, path in guard.requests if path.startswith("/json/close/")]
+    assert all(not path.endswith("/other") for path in closed_paths)
+
+
+def test_start_fails_closed_before_execution_when_snapshot_breaks(state_dir: Path):
+    guard = MemoryGuard(
+        enabled=True,
+        endpoint="http://127.0.0.1:9222",
+        browser_key="browser-a",
+        owner_key="task-a",
+        state_dir=state_dir,
+    )
+
+    def broken_snapshot():
+        raise TimeoutError("CDP busy")
+
+    guard._snapshot = broken_snapshot  # type: ignore[method-assign]
+    error = guard.start()
+    assert error is not None
+    assert "could not prepare" in error
+    assert "CDP busy" in error

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -32,7 +32,7 @@ def _clean_env(monkeypatch):
 def _fake_cli(tmp_path, body):
     """Write an executable fake browser-use CLI and return its path."""
     script = tmp_path / "browser-use"
-    script.write_text("#!/bin/sh\n" + body)
+    script.write_text("#!/bin/sh\n" + body, encoding="utf-8")
     script.chmod(script.stat().st_mode | stat.S_IXUSR)
     return str(script)
 
@@ -906,7 +906,7 @@ class TestFindCliManagedBin:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         bu = bin_dir / "browser-use"
-        bu.write_text("#!/bin/sh\n")
+        bu.write_text("#!/bin/sh\n", encoding="utf-8")
         bu.chmod(bu.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(bu)]
 
@@ -914,7 +914,7 @@ class TestFindCliManagedBin:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         uvx = bin_dir / "uvx"
-        uvx.write_text("#!/bin/sh\n")
+        uvx.write_text("#!/bin/sh\n", encoding="utf-8")
         uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
 
@@ -928,7 +928,7 @@ class TestFindCliManagedBin:
         cli_dir = tmp_path / "userhome" / ".local" / "bin"
         cli_dir.mkdir(parents=True)
         cli = cli_dir / "browser-use"
-        cli.write_text("#!/bin/sh\n")
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(cli)]
 
@@ -940,12 +940,12 @@ class TestFindCliManagedBin:
         user_dir = tmp_path / "userhome" / ".local" / "bin"
         user_dir.mkdir(parents=True)
         user_cli = user_dir / "browser-use"
-        user_cli.write_text("#!/bin/sh\n")
+        user_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         user_cli.chmod(user_cli.stat().st_mode | stat.S_IXUSR)
         managed_dir = tmp_path / "home" / "bin"
         managed_dir.mkdir(parents=True)
         managed_cli = managed_dir / "browser-use"
-        managed_cli.write_text("#!/bin/sh\n")
+        managed_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
 
@@ -954,13 +954,13 @@ class TestFindCliManagedBin:
         path_dir = tmp_path / "onpath"
         path_dir.mkdir()
         path_cli = path_dir / "browser-use"
-        path_cli.write_text("#!/bin/sh\n")
+        path_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         path_cli.chmod(path_cli.stat().st_mode | stat.S_IXUSR)
         monkeypatch.setenv("PATH", str(path_dir))
         managed_dir = tmp_path / "home" / "bin"
         managed_dir.mkdir(parents=True)
         managed_cli = managed_dir / "browser-use"
-        managed_cli.write_text("#!/bin/sh\n")
+        managed_cli.write_text("#!/bin/sh\n", encoding="utf-8")
         managed_cli.chmod(managed_cli.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(managed_cli)]
 
@@ -968,7 +968,7 @@ class TestFindCliManagedBin:
         cli_dir = tmp_path / "userhome" / ".local" / "bin"
         cli_dir.mkdir(parents=True)
         uvx = cli_dir / "uvx"
-        uvx.write_text("#!/bin/sh\n")
+        uvx.write_text("#!/bin/sh\n", encoding="utf-8")
         uvx.chmod(uvx.stat().st_mode | stat.S_IXUSR)
         assert bu_cli._find_cli_unpatched() == [str(uvx), "browser-use"]
 
@@ -996,7 +996,7 @@ class TestInstallCli:
         bin_dir = tmp_path / "home" / "bin"
         bin_dir.mkdir(parents=True)
         cli = bin_dir / "browser-use"
-        cli.write_text("#!/bin/sh\n")
+        cli.write_text("#!/bin/sh\n", encoding="utf-8")
         cli.chmod(cli.stat().st_mode | stat.S_IXUSR)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
@@ -1049,7 +1049,9 @@ class TestInstallCli:
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.setenv("PATH", str(tmp_path / "empty"))
         uv = tmp_path / "uv"
-        uv.write_text('#!/bin/sh\necho "no network" >&2\nexit 1\n')
+        uv.write_text(
+            '#!/bin/sh\necho "no network" >&2\nexit 1\n', encoding="utf-8"
+        )
         uv.chmod(uv.stat().st_mode | stat.S_IXUSR)
         import sys as _sys
         import types as _types
@@ -1201,9 +1203,40 @@ class TestLightpandaPreamble:
         assert "_hermes_ensure_own_tab" not in result["output"]
         assert "print('payload')" in result["output"]
 
+    def test_lightpanda_skips_tab_lifecycle_even_when_enabled(
+        self, tmp_path, monkeypatch
+    ):
+        import tools.browser_tool as bt
+
+        monkeypatch.setattr(bt, "_get_cdp_override", lambda: "")
+        monkeypatch.setattr(bt, "_get_cloud_provider", lambda: None)
+        monkeypatch.setattr(bt, "_using_lightpanda_engine", lambda: True)
+        monkeypatch.setattr(
+            bt,
+            "_get_session_info",
+            lambda key: {"cdp_url": "http://127.0.0.1:43111"},
+        )
+        monkeypatch.setattr(bu_cli, "_resource_hygiene_enabled", lambda: True)
+        lifecycle_calls = []
+        monkeypatch.setattr(
+            bt,
+            "prepare_browser_tab_lifecycle",
+            lambda **kwargs: lifecycle_calls.append(kwargs) or (None, None),
+        )
+        cli = _fake_cli(tmp_path, "cat\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        raw = bu_cli.browser_exec("print('payload')", session="r7k2")
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+
+        assert result["success"] is True
+        assert lifecycle_calls == []
+
 
 class TestLightpandaHeader:
     def test_lightpanda_header_is_text_first_even_for_vision_models(self, monkeypatch):
+        monkeypatch.setattr(bu_cli, "_resource_hygiene_enabled", lambda: True)
         monkeypatch.setattr(
             "tools.vision_tools._should_use_native_vision_fast_path", lambda: True
         )
@@ -1215,6 +1248,7 @@ class TestLightpandaHeader:
         assert header.endswith(bu_cli._HEADER_LIGHTPANDA)
         assert "goto_url(url)" in header
         assert "attached to your context automatically" not in header
+        assert "TAB LIFECYCLE" not in header
         overrides = bu_cli._dynamic_schema_overrides()
         assert overrides["description"].startswith(bu_cli._HEADER_BASE)
         assert overrides["description"].endswith(bu_cli._HELPERS_DIGEST)
@@ -1308,3 +1342,128 @@ class TestLightpandaStatusLine:
         out = self._status(monkeypatch, used=False, reason="cloud provider Browserbase is selected")
         assert "NOT in use" in out
         assert "Browserbase" in out
+
+
+class TestBrowserResourceHygiene:
+    class FakeGuard:
+        instances = []
+
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.target_id = "owned-target"
+            self.started = False
+            self.finished = False
+            type(self).instances.append(self)
+
+        def start(self):
+            self.started = True
+            return None
+
+        def finish(self):
+            self.finished = True
+            return {
+                "managed": True,
+                "ok": True,
+                "created": 1,
+                "repurposed": 0,
+                "closed": 1,
+                "leased": 0,
+                "remaining_pages": 1,
+                "errors": [],
+            }
+
+    @pytest.fixture(autouse=True)
+    def _guard(self, monkeypatch):
+        import tools.browser_tool as browser_tool
+
+        self.FakeGuard.instances = []
+
+        def fake_prepare(**kwargs):
+            if kwargs.get("private_browser"):
+                return None, None
+            guard = self.FakeGuard(**kwargs)
+            return guard, guard.start()
+
+        monkeypatch.setattr(browser_tool, "prepare_browser_tab_lifecycle", fake_prepare)
+        monkeypatch.setattr(bu_cli, "_resource_hygiene_enabled", lambda: True)
+        monkeypatch.setattr(
+            bu_cli,
+            "_base_subprocess_env",
+            lambda: {"BU_CDP_URL": "http://127.0.0.1:9222"},
+        )
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", lambda env, task_id, **kw: None)
+
+    def test_schema_exposes_explicit_bounded_lease(self):
+        properties = bu_cli.BROWSER_EXEC_SCHEMA["parameters"]["properties"]
+        assert properties["lease_minutes"]["minimum"] == 0
+        assert properties["lease_minutes"]["maximum"] == 120
+        assert "lease_reason" in properties
+
+    def test_canonical_config_declares_tab_lifecycle_default(self):
+        from hermes_cli.config import DEFAULT_CONFIG
+
+        assert DEFAULT_CONFIG["browser"]["resource_hygiene"] == {"enabled": False}
+
+    def test_lease_requires_reason_before_browser_execution(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "should-not-run"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        raw = bu_cli.browser_exec("print(1)", lease_minutes=10)
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+        assert "lease_reason is required" in result["error"]
+        assert not self.FakeGuard.instances
+
+    def test_managed_local_call_starts_and_finishes_guard(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, 'cat\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        raw = bu_cli.browser_exec(
+            "print(1)",
+            task_id="task-123",
+            turn_id="turn-456",
+            lease_minutes=15,
+            lease_reason="continue pagination",
+        )
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+        guard = self.FakeGuard.instances[0]
+        assert guard.started is True
+        assert guard.finished is True
+        assert guard.kwargs["owner_key"] == "turn-456"
+        assert guard.kwargs["lease_minutes"] == 15
+        assert 'switch_tab("owned-target")' in result["output"]
+        assert result["hygiene"]["closed"] == 1
+
+    def test_timeout_still_finishes_guard(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, "cat > /dev/null\nsleep 30\n")
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        monkeypatch.setattr(bu_cli, "_MIN_TIMEOUT_S", 1)
+        raw = bu_cli.browser_exec("print(1)", timeout_s=1)
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+        assert "timed out" in result["error"]
+        assert self.FakeGuard.instances[0].finished is True
+
+    def test_named_shared_local_session_is_managed(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "local"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        raw = bu_cli.browser_exec("print(1)", session="local-a")
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert len(self.FakeGuard.instances) == 1
+        assert self.FakeGuard.instances[0].kwargs["session_name"] == "local-a"
+
+    def test_named_private_cloud_session_is_never_managed(self, tmp_path, monkeypatch):
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "cloud"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        def mark_private(env, task_id, **kwargs):
+            env[bu_cli._PRIVATE_BROWSER_SENTINEL] = "1"
+            return None
+
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", mark_private)
+        raw = bu_cli.browser_exec("print(1)", session="cloud-a")
+        assert isinstance(raw, str)
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert not self.FakeGuard.instances

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -14,7 +14,11 @@ Covers the three seams the integration relies on:
 import json
 import os
 import stat
+import subprocess
+import sys
+import threading
 import time
+from pathlib import Path
 
 import pytest
 
@@ -572,6 +576,204 @@ class TestOwnTabPreamble:
         ast.parse(bu_cli._OWN_TAB_PREAMBLE)
         # and composes with model code
         ast.parse(bu_cli._OWN_TAB_PREAMBLE + "print('x')")
+
+    def test_preamble_reselects_existing_logical_tab_every_call(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("BH_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("HERMES_BU_LOGICAL_SESSION", "research")
+        targets, created, switched = {}, [], []
+
+        def fake_cdp(method, **kwargs):
+            if method == "Target.getTargets":
+                return {"targetInfos": list(targets.values())}
+            target_id = f"target-{len(created) + 1}"
+            targets[target_id] = {"targetId": target_id, "type": "page"}
+            created.append(target_id)
+            return {"targetId": target_id}
+
+        for _ in range(2):
+            exec(bu_cli._OWN_TAB_PREAMBLE, {"cdp": fake_cdp, "switch_tab": switched.append})
+        assert created == ["target-1"]
+        assert switched == ["target-1", "target-1"]
+
+
+class TestSessionScopedTransport:
+    def test_lineage_reuses_runtime_across_logical_names_and_compression(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        env1, env2 = {}, {}
+        one = bu_cli._configure_session_transport(env1, conversation_id="root", logical_session="a", private_browser=False)
+        two = bu_cli._configure_session_transport(env2, conversation_id="root", logical_session="b", private_browser=False)
+        assert one is not None and two is not None
+        assert one.key == two.key
+        assert env1["BH_RUNTIME_DIR"] == env2["BH_RUNTIME_DIR"]
+        assert env1["HERMES_BU_LOGICAL_SESSION"] == "a"
+        assert env2["HERMES_BU_LOGICAL_SESSION"] == "b"
+
+    def test_different_lineage_endpoint_or_profile_gets_different_transport(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+        a = bu_cli._configure_session_transport({}, conversation_id="root-a", logical_session="x", private_browser=False)
+        b = bu_cli._configure_session_transport({}, conversation_id="root-b", logical_session="x", private_browser=False)
+        c = bu_cli._configure_session_transport({"BU_CDP_WS": "ws://127.0.0.1:9/other"}, conversation_id="root-a", logical_session="x", private_browser=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+        d = bu_cli._configure_session_transport({}, conversation_id="root-a", logical_session="x", private_browser=False)
+        assert a is not None and b is not None and c is not None and d is not None
+        assert len({a.key, b.key, c.key, d.key}) == 4
+
+    def test_private_browser_is_not_multiplexed(self):
+        env = {}
+        assert bu_cli._configure_session_transport(env, conversation_id="root", logical_session="x", private_browser=True) is None
+        assert "BH_RUNTIME_DIR" not in env
+
+    @pytest.mark.skipif(os.name == "nt", reason="AF_UNIX path applies on POSIX")
+    def test_runtime_socket_path_stays_under_macos_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / ("very-long-" * 20)))
+        info = bu_cli._configure_session_transport({}, conversation_id="root", logical_session="x", private_browser=False)
+        assert info is not None
+        assert len(os.fsencode(str(info.runtime_dir / "bu.sock"))) < 100
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX flock integration")
+    def test_transport_file_lock_serializes_processes(self, tmp_path):
+        runtime = tmp_path / "run"
+        scratch = tmp_path / "tmp"
+        runtime.mkdir(); scratch.mkdir()
+        output = tmp_path / "order.log"
+        script = tmp_path / "lock_probe.py"
+        script.write_text(
+            "import sys, threading, time\n"
+            "from pathlib import Path\n"
+            "from tools.browser_use_cli import _SessionTransport, _TransportExecutionLock\n"
+            "t=_SessionTransport('key', Path(sys.argv[2]), Path(sys.argv[3]), threading.RLock())\n"
+            "lock=_TransportExecutionLock(t, 5); lock.acquire()\n"
+            "with open(sys.argv[4], 'a', encoding='utf-8') as f: f.write('start '+sys.argv[1]+'\\n')\n"
+            "time.sleep(.2)\n"
+            "with open(sys.argv[4], 'a', encoding='utf-8') as f: f.write('end '+sys.argv[1]+'\\n')\n"
+            "lock.release()\n",
+            encoding="utf-8",
+        )
+        args = [str(runtime), str(scratch), str(output)]
+        repo_root = str(Path(__file__).resolve().parents[2])
+        child_env = dict(os.environ)
+        child_env["PYTHONPATH"] = repo_root + (
+            os.pathsep + child_env["PYTHONPATH"]
+            if child_env.get("PYTHONPATH")
+            else ""
+        )
+        first = subprocess.Popen(
+            [sys.executable, str(script), "a", *args],
+            cwd=repo_root,
+            env=child_env,
+        )
+        second = subprocess.Popen(
+            [sys.executable, str(script), "b", *args],
+            cwd=repo_root,
+            env=child_env,
+        )
+        assert first.wait(timeout=10) == 0
+        assert second.wait(timeout=10) == 0
+        lines = output.read_text(encoding="utf-8").splitlines()
+        assert len(lines) == 4
+        assert lines[0].split()[1] == lines[1].split()[1]
+        assert lines[2].split()[1] == lines[3].split()[1]
+        assert lines[0].split()[1] != lines[2].split()[1]
+
+    def test_registry_forwards_conversation_lineage(self, monkeypatch):
+        from tools.registry import registry
+        captured = {}
+        monkeypatch.setattr(bu_cli, "browser_exec", lambda **kw: captured.update(kw) or "ok")
+        entry = registry.get_entry("browser_exec")
+        assert entry is not None
+        assert entry.handler({"code": "print(1)"}, session_id="child", conversation_id="root") == "ok"
+        assert captured["conversation_id"] == "root"
+
+    def test_fake_daemon_reports_attach_reuse_and_drop_reconnect(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\nif [ ! -f "$BH_RUNTIME_DIR/alive" ]; then n=$(($(cat "$BH_RUNTIME_DIR/n" 2>/dev/null || echo 0)+1)); echo "$n" > "$BH_RUNTIME_DIR/n"; echo "$n" > "$BH_RUNTIME_DIR/bu.pid"; touch "$BH_RUNTIME_DIR/alive"; fi\necho "runtime:$BH_RUNTIME_DIR"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+        monkeypatch.setattr(
+            bu_cli,
+            "_probe_daemon_pid",
+            lambda runtime: (
+                int((runtime / "bu.pid").read_text(encoding="utf-8"))
+                if (runtime / "alive").exists() and (runtime / "bu.pid").exists()
+                else None
+            ),
+        )
+        raw1 = bu_cli.browser_exec("print(1)", session="a", conversation_id="root")
+        raw2 = bu_cli.browser_exec("print(2)", session="b", conversation_id="root")
+        assert isinstance(raw1, str) and isinstance(raw2, str)
+        one, two = json.loads(raw1), json.loads(raw2)
+        assert one["cdp_transport"]["attach_count"] == 1
+        assert two["cdp_transport"]["attach_count"] == 1
+        assert two["cdp_transport"]["reused"] is True
+        runtime = Path(one["output"].split("runtime:", 1)[1].strip())
+        (runtime / "alive").unlink(); (runtime / "bu.pid").unlink()
+        raw3 = bu_cli.browser_exec("print(3)", session="a", conversation_id="root")
+        assert isinstance(raw3, str)
+        three = json.loads(raw3)
+        assert three["cdp_transport"]["attach_count"] == 2
+        assert three["cdp_transport"]["attached_this_call"] == 1
+
+    def test_daemon_identity_requires_live_ping_matching_pid_file(
+        self, tmp_path, monkeypatch
+    ):
+        runtime = tmp_path / "run"
+        runtime.mkdir()
+        (runtime / "bu.pid").write_text("123", encoding="utf-8")
+
+        monkeypatch.setattr(bu_cli, "_probe_daemon_pid", lambda _runtime: None)
+        assert bu_cli._daemon_identity(runtime) is None
+
+        monkeypatch.setattr(bu_cli, "_probe_daemon_pid", lambda _runtime: 124)
+        assert bu_cli._daemon_identity(runtime) is None
+
+        monkeypatch.setattr(bu_cli, "_probe_daemon_pid", lambda _runtime: 123)
+        assert bu_cli._daemon_identity(runtime) is not None
+
+    def test_permission_failure_counts_attempt_not_attach_success(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        info = bu_cli._configure_session_transport(
+            {}, conversation_id="root", logical_session="a", private_browser=False
+        )
+        assert info is not None
+
+        report = bu_cli._record_transport_outcome(
+            info,
+            None,
+            None,
+            "a",
+            False,
+            "permission-blocked: Allow remote debugging? was not accepted",
+        )
+
+        assert report["attach_count"] == 1
+        assert report["attach_success_count"] == 0
+        assert report["attached_this_call"] == 1
+        assert report["reused"] is False
+        telemetry = json.loads(
+            (info.tmp_dir / "transport-telemetry.json").read_text(encoding="utf-8")
+        )
+        assert telemetry["events"][-1]["event"] == "attach_failed"
+        assert telemetry["events"][-1]["reason"] == "permission_blocked"
+
+    def test_telemetry_never_persists_endpoint_or_raw_session_ids(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile"))
+        endpoint = "ws://127.0.0.1:9/devtools/browser/SECRET-ENDPOINT"
+        env = {"BU_CDP_WS": endpoint}
+        info = bu_cli._configure_session_transport(
+            env, conversation_id="SECRET-LINEAGE", logical_session="SECRET-LOGICAL",
+            private_browser=False,
+        )
+        assert info is not None
+        bu_cli._record_transport_outcome(
+            info, None, "hashed-daemon", "SECRET-LOGICAL", True, ""
+        )
+        persisted = (info.tmp_dir / "transport-telemetry.json").read_text(
+            encoding="utf-8"
+        )
+        assert "SECRET-ENDPOINT" not in persisted
+        assert "SECRET-LINEAGE" not in persisted
+        assert "SECRET-LOGICAL" not in persisted
 
 
 class TestProviderPickerIntegration:
@@ -1442,6 +1644,41 @@ class TestBrowserResourceHygiene:
         result = json.loads(raw)
         assert "timed out" in result["error"]
         assert self.FakeGuard.instances[0].finished is True
+
+    def test_finish_exception_never_wedges_transport_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "ok"\n')
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: [cli])
+
+        def finish_boom(_guard):
+            raise RuntimeError("finish boom")
+
+        monkeypatch.setattr(self.FakeGuard, "finish", finish_boom)
+        with pytest.raises(RuntimeError, match="finish boom"):
+            bu_cli.browser_exec("print(1)", conversation_id="lineage-root")
+
+        info = bu_cli._configure_session_transport(
+            {"BU_CDP_URL": "http://127.0.0.1:9222"},
+            conversation_id="lineage-root",
+            logical_session="default",
+            private_browser=False,
+        )
+        assert info is not None
+        acquired = []
+
+        def acquire_from_another_thread():
+            lock = bu_cli._TransportExecutionLock(info, 0.2)
+            try:
+                lock.acquire()
+                acquired.append(True)
+            finally:
+                lock.release()
+
+        thread = threading.Thread(target=acquire_from_another_thread)
+        thread.start()
+        thread.join(timeout=1)
+        assert not thread.is_alive()
+        assert acquired == [True]
 
     def test_named_shared_local_session_is_managed(self, tmp_path, monkeypatch):
         cli = _fake_cli(tmp_path, 'cat > /dev/null\necho "local"\n')

--- a/tools/browser_tab_lifecycle.py
+++ b/tools/browser_tab_lifecycle.py
@@ -1,0 +1,700 @@
+"""Per-turn ownership records for a resolved local browser endpoint.
+
+The browser architecture owns backend selection, CDP discovery, and safety
+classification in :mod:`tools.browser_tool`.  This module receives an already
+validated loopback HTTP control endpoint and only manages tab ownership,
+leases, and verified cleanup.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import datetime as dt
+import hashlib
+import json
+import os
+import sqlite3
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+try:  # POSIX cross-process serialization; Windows keeps the in-process lock.
+    import fcntl
+except ImportError:  # pragma: no cover - exercised on Windows
+    fcntl = None  # type: ignore[assignment]
+
+
+_BLANK_URLS = {
+    "",
+    "about:blank",
+    "chrome://newtab/",
+    "chrome://new-tab-page/",
+}
+_PROCESS_LOCK = threading.Lock()
+
+
+def _utc_now() -> dt.datetime:
+    return dt.datetime.now(dt.timezone.utc)
+
+
+def _iso(value: Optional[dt.datetime] = None) -> str:
+    return (value or _utc_now()).isoformat()
+
+
+def _redact_url(url: str) -> str:
+    """Keep origin/path for debugging; remove credentials, query, fragment."""
+    try:
+        parsed = urllib.parse.urlsplit(str(url or ""))
+    except ValueError:
+        return "[invalid-url]"
+    if not parsed.scheme:
+        return str(url or "").split("?", 1)[0].split("#", 1)[0]
+    host = parsed.hostname or ""
+    if parsed.port:
+        host = f"{host}:{parsed.port}"
+    return urllib.parse.urlunsplit((parsed.scheme, host, parsed.path, "", ""))
+
+
+def _live_browser_key(endpoint: str, *, timeout_s: float = 5.0) -> str:
+    """Resolve the identity of the browser currently bound to ``endpoint``."""
+    with urllib.request.urlopen(
+        str(endpoint).rstrip("/") + "/json/version", timeout=timeout_s
+    ) as response:
+        raw = response.read()
+    try:
+        payload = json.loads(raw)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise RuntimeError("CDP /json/version returned invalid JSON") from exc
+    websocket_url = payload.get("webSocketDebuggerUrl") if isinstance(payload, dict) else None
+    if not isinstance(websocket_url, str) or not websocket_url.strip():
+        raise RuntimeError("CDP /json/version did not return webSocketDebuggerUrl")
+    return hashlib.sha256(websocket_url.strip().encode("utf-8")).hexdigest()
+
+
+def _default_state_dir() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        base = Path(get_hermes_home())
+    except Exception:
+        base = Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser()
+    return base / "state" / "resource-hygiene"
+
+
+def _private_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    with contextlib.suppress(OSError):
+        path.chmod(0o700)
+    return path
+
+
+class _ExclusiveFileLock:
+    """Thread + file lock with a bounded wait."""
+
+    def __init__(self, path: Path, timeout_s: float = 60.0):
+        self.path = path
+        self.timeout_s = max(0.1, float(timeout_s))
+        self._handle = None
+        self._thread_acquired = False
+
+    def acquire(self) -> None:
+        deadline = time.monotonic() + self.timeout_s
+        while not _PROCESS_LOCK.acquire(blocking=False):
+            if time.monotonic() >= deadline:
+                raise TimeoutError("another managed browser_exec call is still running")
+            time.sleep(0.05)
+        self._thread_acquired = True
+        try:
+            _private_dir(self.path.parent)
+            self._handle = open(self.path, "a+", encoding="utf-8")
+            with contextlib.suppress(OSError):
+                os.chmod(self.path, 0o600)
+            if fcntl is None:
+                return
+            while True:
+                try:
+                    fcntl.flock(self._handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    return
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("another managed browser_exec process is still running")
+                    time.sleep(0.05)
+        except Exception:
+            self.release()
+            raise
+
+    def release(self) -> None:
+        if self._handle is not None:
+            if fcntl is not None:
+                with contextlib.suppress(OSError):
+                    fcntl.flock(self._handle.fileno(), fcntl.LOCK_UN)
+            with contextlib.suppress(OSError):
+                self._handle.close()
+            self._handle = None
+        if self._thread_acquired:
+            self._thread_acquired = False
+            _PROCESS_LOCK.release()
+
+
+class BrowserTabLifecycleGuard:
+    """Own targets created by one local browser_exec call.
+
+    ``start`` acquires a process-wide/cross-process lock, reuses an unexpired
+    lease for this browser+turn when present, otherwise creates one dedicated
+    blank target, and snapshots the browser. ``finish`` leases or closes only
+    this scope's target plus targets created while the scope was active.
+    """
+
+    def __init__(
+        self,
+        *,
+        enabled: bool,
+        endpoint: str,
+        browser_key: str,
+        owner_key: str,
+        lease_minutes: int = 0,
+        lease_reason: str = "",
+        state_dir: Optional[Path] = None,
+        lock_timeout_s: float = 60.0,
+        request_timeout_s: float = 5.0,
+    ):
+        self.enabled = bool(enabled)
+        self.endpoint = str(endpoint or '').rstrip('/') or None
+        self.browser_key = str(browser_key or '')
+        self.owner_key = str(owner_key or "browser-exec-default")[:200]
+        self.lease_minutes = max(0, int(lease_minutes or 0))
+        self.lease_reason = str(lease_reason or "").strip()[:500]
+        self.state_dir = _private_dir(state_dir or _default_state_dir())
+        self.request_timeout_s = max(0.2, float(request_timeout_s))
+        self.run_id = uuid.uuid4().hex
+        self._lock = _ExclusiveFileLock(self.state_dir / "browser.lock", lock_timeout_s)
+        self._before: Dict[str, Dict[str, Any]] = {}
+        self.target_id: Optional[str] = None
+        self._started = False
+
+    @property
+    def managed(self) -> bool:
+        return self.enabled and self.endpoint is not None
+
+    def _request_json(self, path: str, *, method: str = "GET") -> Any:
+        if self.endpoint is None:
+            raise RuntimeError("managed browser endpoint is unavailable")
+        request = urllib.request.Request(self.endpoint + path, method=method)
+        with urllib.request.urlopen(request, timeout=self.request_timeout_s) as response:
+            raw = response.read()
+        if not raw:
+            return None
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            return raw.decode("utf-8", errors="replace")
+
+    def _snapshot(self) -> Dict[str, Dict[str, Any]]:
+        raw = self._request_json("/json/list")
+        if not isinstance(raw, list):
+            raise RuntimeError("CDP /json/list returned a non-list response")
+        result: Dict[str, Dict[str, Any]] = {}
+        for target in raw:
+            if not isinstance(target, dict) or target.get("type") != "page":
+                continue
+            target_id = str(target.get("id") or target.get("targetId") or "")
+            if target_id:
+                result[target_id] = target
+        return result
+
+    def _require_live_browser_identity(self) -> None:
+        live_key = _live_browser_key(
+            self.endpoint or "", timeout_s=self.request_timeout_s
+        )
+        if live_key != self.browser_key:
+            raise RuntimeError(
+                "browser identity changed at the managed CDP endpoint; cleanup skipped"
+            )
+
+    def _connect(self) -> sqlite3.Connection:
+        db_path = self.state_dir / "resources.sqlite3"
+        connection = sqlite3.connect(str(db_path), timeout=10)
+        connection.row_factory = sqlite3.Row
+        connection.executescript(
+            """
+            PRAGMA journal_mode=WAL;
+            PRAGMA synchronous=FULL;
+            """
+        )
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version < 2:
+            # v1 keyed only by target_id. Those rows cannot safely survive an
+            # endpoint/browser change, so discard the ephemeral ownership
+            # ledger rather than risk closing a target in another browser.
+            connection.executescript(
+                """
+                DROP TABLE IF EXISTS browser_resources;
+                DROP TABLE IF EXISTS browser_runs;
+                PRAGMA user_version=2;
+                """
+            )
+        connection.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS browser_resources (
+                browser_key TEXT NOT NULL,
+                endpoint TEXT NOT NULL,
+                target_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                run_id TEXT NOT NULL,
+                created_at TEXT NOT NULL,
+                heartbeat_at TEXT NOT NULL,
+                state TEXT NOT NULL,
+                lease_expires_at TEXT,
+                lease_reason TEXT,
+                url_redacted TEXT,
+                title TEXT,
+                closed_at TEXT,
+                close_verified INTEGER NOT NULL DEFAULT 0,
+                last_error TEXT,
+                PRIMARY KEY (browser_key, target_id)
+            );
+            CREATE INDEX IF NOT EXISTS idx_browser_resources_owner_state
+                ON browser_resources(browser_key, owner_key, state);
+            CREATE TABLE IF NOT EXISTS browser_runs (
+                run_id TEXT PRIMARY KEY,
+                browser_key TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                started_at TEXT NOT NULL,
+                finished_at TEXT,
+                requested_lease_minutes INTEGER NOT NULL,
+                created_count INTEGER NOT NULL DEFAULT 0,
+                repurposed_count INTEGER NOT NULL DEFAULT 0,
+                closed_count INTEGER NOT NULL DEFAULT 0,
+                leased_count INTEGER NOT NULL DEFAULT 0,
+                remaining_pages INTEGER,
+                ok INTEGER,
+                error TEXT
+            );
+            """
+        )
+        with contextlib.suppress(OSError):
+            os.chmod(db_path, 0o600)
+        return connection
+
+    def _insert_run_start(self) -> None:
+        with self._connect() as db:
+            db.execute(
+                "INSERT OR REPLACE INTO browser_runs "
+                "(run_id, browser_key, owner_key, started_at, requested_lease_minutes) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (self.run_id, self.browser_key, self.owner_key, _iso(), self.lease_minutes),
+            )
+
+    def start(self) -> Optional[str]:
+        if not self.enabled:
+            return None
+        if self.endpoint is None or not self.browser_key:
+            return "tab lifecycle requires a resolved local browser identity"
+        try:
+            self._lock.acquire()
+            reap_expired_browser_tab_leases(
+                state_dir=self.state_dir, acquire_lock=False
+            )
+            self._require_live_browser_identity()
+            self._before = self._snapshot()
+            with self._connect() as db:
+                reusable = self._owned_active_ids(db) & set(self._before)
+            if reusable:
+                self.target_id = sorted(reusable)[0]
+            else:
+                created = self._request_json("/json/new?about%3Ablank", method="PUT")
+                if not isinstance(created, dict):
+                    raise RuntimeError("CDP did not return the dedicated target")
+                self.target_id = str(created.get("id") or created.get("targetId") or "")
+                if not self.target_id:
+                    raise RuntimeError("CDP dedicated target has no id")
+            self._insert_run_start()
+            self._started = True
+            return None
+        except Exception as exc:
+            self._lock.release()
+            return f"tab lifecycle could not prepare the local browser: {exc}"
+
+    def _owned_active_ids(self, db: sqlite3.Connection) -> set[str]:
+        rows = db.execute(
+            """SELECT target_id FROM browser_resources
+               WHERE browser_key = ? AND owner_key = ? AND state = 'leased'
+                 AND lease_expires_at > ?""",
+            (self.browser_key, self.owner_key, _iso()),
+        ).fetchall()
+        return {str(row[0]) for row in rows}
+
+    @staticmethod
+    def _is_blank(target: Dict[str, Any]) -> bool:
+        return str(target.get("url") or "").strip() in _BLANK_URLS
+
+    def _upsert_resources(
+        self,
+        db: sqlite3.Connection,
+        targets: Dict[str, Dict[str, Any]],
+        target_ids: Iterable[str],
+        *,
+        state: str,
+        lease_expires_at: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        now = _iso()
+        for target_id in target_ids:
+            target = targets.get(target_id, {})
+            db.execute(
+                """
+                INSERT INTO browser_resources
+                    (browser_key, endpoint, target_id, owner_key, run_id,
+                     created_at, heartbeat_at, state, lease_expires_at,
+                     lease_reason, url_redacted, title, last_error)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(browser_key, target_id) DO UPDATE SET
+                    endpoint=excluded.endpoint,
+                    owner_key=excluded.owner_key,
+                    run_id=excluded.run_id,
+                    heartbeat_at=excluded.heartbeat_at,
+                    state=excluded.state,
+                    lease_expires_at=excluded.lease_expires_at,
+                    lease_reason=excluded.lease_reason,
+                    url_redacted=excluded.url_redacted,
+                    title=excluded.title,
+                    last_error=excluded.last_error
+                """,
+                (
+                    self.browser_key,
+                    self.endpoint,
+                    target_id,
+                    self.owner_key,
+                    self.run_id,
+                    now,
+                    now,
+                    state,
+                    lease_expires_at,
+                    self.lease_reason or None,
+                    _redact_url(str(target.get("url") or "")),
+                    str(target.get("title") or "")[:500],
+                    error,
+                ),
+            )
+
+    def _close_target(self, target_id: str) -> Optional[str]:
+        try:
+            self._request_json(f"/json/close/{urllib.parse.quote(target_id, safe='')}")
+            return None
+        except (OSError, urllib.error.URLError, RuntimeError) as exc:
+            return str(exc)
+
+    def _ensure_blank_baseline(self, snapshot: Dict[str, Dict[str, Any]]) -> Optional[str]:
+        if any(self._is_blank(target) for target in snapshot.values()):
+            return None
+        try:
+            self._require_live_browser_identity()
+            self._request_json("/json/new?about%3Ablank", method="PUT")
+            return None
+        except (OSError, urllib.error.URLError, RuntimeError) as exc:
+            return f"could not create blank baseline page: {exc}"
+
+    def _finish_run(
+        self,
+        db: sqlite3.Connection,
+        *,
+        created: int,
+        repurposed: int,
+        closed: int,
+        leased: int,
+        remaining: Optional[int],
+        errors: list[str],
+    ) -> None:
+        db.execute(
+            """
+            UPDATE browser_runs SET finished_at=?, created_count=?, repurposed_count=?,
+                closed_count=?, leased_count=?, remaining_pages=?, ok=?, error=?
+            WHERE run_id=?
+            """,
+            (
+                _iso(),
+                created,
+                repurposed,
+                closed,
+                leased,
+                remaining,
+                0 if errors else 1,
+                "; ".join(errors)[:2000] if errors else None,
+                self.run_id,
+            ),
+        )
+
+    def finish(self) -> Dict[str, Any]:
+        if not self.enabled:
+            return {"managed": False, "reason": "disabled"}
+        if not self._started:
+            return {"managed": False, "reason": "not-started"}
+
+        errors: list[str] = []
+        created_ids: set[str] = set()
+        repurposed_ids: set[str] = set()
+        leased_count = 0
+        closed_count = 0
+        remaining: Optional[int] = None
+        try:
+            self._require_live_browser_identity()
+            after = self._snapshot()
+            created_ids = set(after) - set(self._before)
+            scope_ids = {self.target_id} if self.target_id and self.target_id in after else set()
+            repurposed_ids = set()
+            with self._connect() as db:
+                previously_owned = self._owned_active_ids(db) & set(after)
+                candidates = created_ids | previously_owned | scope_ids
+                if self.lease_minutes:
+                    expiry = _iso(_utc_now() + dt.timedelta(minutes=self.lease_minutes))
+                    self._upsert_resources(
+                        db, after, candidates, state="leased", lease_expires_at=expiry
+                    )
+                    leased_count = len(candidates)
+                    remaining = len(after)
+                else:
+                    self._upsert_resources(db, after, candidates, state="closing")
+                    close_errors: Dict[str, str] = {}
+                    for target_id in sorted(candidates):
+                        err = self._close_target(target_id)
+                        if err:
+                            close_errors[target_id] = err
+                    deadline = time.monotonic() + 5.0
+                    current = after
+                    while time.monotonic() < deadline:
+                        current = self._snapshot()
+                        if not (candidates & set(current)):
+                            break
+                        time.sleep(0.1)
+                    survivors = candidates & set(current)
+                    for target_id in candidates - survivors:
+                        db.execute(
+                            """UPDATE browser_resources SET state='closed', closed_at=?,
+                               close_verified=1, last_error=NULL
+                               WHERE browser_key=? AND target_id=?""",
+                            (_iso(), self.browser_key, target_id),
+                        )
+                    for target_id in survivors:
+                        error = close_errors.get(target_id) or "target still present after close"
+                        db.execute(
+                            """UPDATE browser_resources SET state='close_failed',
+                               close_verified=0, last_error=?
+                               WHERE browser_key=? AND target_id=?""",
+                            (error[:1000], self.browser_key, target_id),
+                        )
+                        errors.append(f"target {target_id[:12]} was not closed")
+                    closed_count = len(candidates - survivors)
+                    baseline_error = self._ensure_blank_baseline(current)
+                    if baseline_error:
+                        errors.append(baseline_error)
+                    final = self._snapshot()
+                    remaining = len(final)
+                self._finish_run(
+                    db,
+                    created=len(created_ids),
+                    repurposed=len(repurposed_ids),
+                    closed=closed_count,
+                    leased=leased_count,
+                    remaining=remaining,
+                    errors=errors,
+                )
+        except Exception as exc:
+            errors.append(str(exc))
+            with contextlib.suppress(Exception):
+                with self._connect() as db:
+                    self._finish_run(
+                        db,
+                        created=len(created_ids),
+                        repurposed=len(repurposed_ids),
+                        closed=closed_count,
+                        leased=leased_count,
+                        remaining=remaining,
+                        errors=errors,
+                    )
+        finally:
+            self._lock.release()
+            self._started = False
+
+        return {
+            "managed": True,
+            "ok": not errors,
+            "created": len(created_ids),
+            "repurposed": len(repurposed_ids),
+            "closed": closed_count,
+            "leased": leased_count,
+            "remaining_pages": remaining,
+            "errors": errors,
+        }
+
+
+def _close_ledger_rows(rows: Iterable[sqlite3.Row], db: sqlite3.Connection) -> Dict[str, Any]:
+    closed = 0
+    failed = 0
+    errors: list[str] = []
+    grouped: Dict[tuple[str, str], list[sqlite3.Row]] = {}
+    for row in rows:
+        key = (str(row["browser_key"]), str(row["endpoint"]).rstrip("/"))
+        grouped.setdefault(key, []).append(row)
+
+    for (browser_key, endpoint), browser_rows in grouped.items():
+        try:
+            live_key = _live_browser_key(endpoint)
+            if live_key != browser_key:
+                raise RuntimeError("browser identity changed; cleanup skipped")
+        except Exception as exc:
+            for row in browser_rows:
+                target_id = str(row["target_id"])
+                db.execute(
+                    """UPDATE browser_resources SET state='close_failed',
+                       close_verified=0, last_error=?
+                       WHERE browser_key=? AND target_id=?""",
+                    (str(exc)[:1000], browser_key, target_id),
+                )
+                failed += 1
+                errors.append(f"target {target_id[:12]}: {exc}")
+            continue
+
+        browser_closed = 0
+        for row in browser_rows:
+            target_id = str(row["target_id"])
+            try:
+                request = urllib.request.Request(
+                    endpoint + f"/json/close/{urllib.parse.quote(target_id, safe='')}",
+                    method="GET",
+                )
+                with urllib.request.urlopen(request, timeout=5) as response:
+                    response.read()
+                with urllib.request.urlopen(endpoint + "/json/list", timeout=5) as response:
+                    raw_targets = response.read()
+                if not raw_targets:
+                    raise RuntimeError("CDP /json/list returned an empty response")
+                targets = json.loads(raw_targets)
+                if not isinstance(targets, list):
+                    raise RuntimeError("CDP /json/list returned a non-list response")
+                if any(
+                    str(target.get("id") or target.get("targetId") or "") == target_id
+                    for target in targets
+                    if isinstance(target, dict)
+                ):
+                    raise RuntimeError("target still present after close")
+                db.execute(
+                    """UPDATE browser_resources SET state='closed', closed_at=?,
+                       close_verified=1, last_error=NULL
+                       WHERE browser_key=? AND target_id=?""",
+                    (_iso(), browser_key, target_id),
+                )
+                closed += 1
+                browser_closed += 1
+            except Exception as exc:
+                db.execute(
+                    """UPDATE browser_resources SET state='close_failed',
+                       close_verified=0, last_error=?
+                       WHERE browser_key=? AND target_id=?""",
+                    (str(exc)[:1000], browser_key, target_id),
+                )
+                failed += 1
+                errors.append(f"target {target_id[:12]}: {exc}")
+
+        # A baseline is a write to the live browser. Only perform it when this
+        # cleanup closed something and the endpoint still identifies the same
+        # browser that owns the ledger rows.
+        if browser_closed == 0:
+            continue
+        try:
+            if _live_browser_key(endpoint) != browser_key:
+                raise RuntimeError("browser identity changed before baseline write")
+            with urllib.request.urlopen(endpoint + "/json/list", timeout=5) as response:
+                raw_targets = response.read()
+            if not raw_targets:
+                raise RuntimeError("CDP /json/list returned an empty response")
+            targets = json.loads(raw_targets)
+            if not isinstance(targets, list):
+                raise RuntimeError("CDP /json/list returned a non-list response")
+            has_blank = any(
+                isinstance(target, dict)
+                and str(target.get("url") or "").strip() in _BLANK_URLS
+                for target in targets
+            )
+            if not has_blank:
+                request = urllib.request.Request(
+                    endpoint + "/json/new?about%3Ablank", method="PUT"
+                )
+                with urllib.request.urlopen(request, timeout=5) as response:
+                    response.read()
+        except Exception as exc:
+            failed += 1
+            errors.append(f"blank baseline: {exc}")
+    return {"closed": closed, "failed": failed, "errors": errors}
+
+
+def _ledger_connection(state_dir: Optional[Path] = None) -> Optional[sqlite3.Connection]:
+    db_path = (state_dir or _default_state_dir()) / "resources.sqlite3"
+    if not db_path.exists():
+        return None
+    db = sqlite3.connect(str(db_path), timeout=10)
+    db.row_factory = sqlite3.Row
+    columns = {str(row[1]) for row in db.execute("PRAGMA table_info(browser_resources)")}
+    if not {"browser_key", "endpoint", "target_id"}.issubset(columns):
+        db.close()
+        return None
+    return db
+
+
+def reap_expired_browser_tab_leases(
+    *, state_dir: Optional[Path] = None, acquire_lock: bool = True
+) -> Dict[str, Any]:
+    """Close leases whose bounded expiry has passed."""
+    lock = _ExclusiveFileLock((state_dir or _default_state_dir()) / "browser.lock", 5)
+    if acquire_lock:
+        lock.acquire()
+    try:
+        db = _ledger_connection(state_dir)
+        if db is None:
+            return {"closed": 0, "failed": 0, "errors": []}
+        try:
+            rows = db.execute(
+                """SELECT browser_key, endpoint, target_id FROM browser_resources
+                   WHERE state='leased' AND lease_expires_at <= ?""",
+                (_iso(),),
+            ).fetchall()
+            report = _close_ledger_rows(rows, db)
+            db.commit()
+            return report
+        finally:
+            db.close()
+    finally:
+        if acquire_lock:
+            lock.release()
+
+
+def finalize_browser_tab_owner(
+    owner_key: str, *, state_dir: Optional[Path] = None
+) -> Dict[str, Any]:
+    """Close every still-leased target owned by one completed turn."""
+    key = str(owner_key or "").strip()
+    if not key:
+        return {"closed": 0, "failed": 0, "errors": []}
+    lock = _ExclusiveFileLock((state_dir or _default_state_dir()) / "browser.lock", 10)
+    lock.acquire()
+    try:
+        db = _ledger_connection(state_dir)
+        if db is None:
+            return {"closed": 0, "failed": 0, "errors": []}
+        try:
+            rows = db.execute(
+                """SELECT browser_key, endpoint, target_id FROM browser_resources
+                   WHERE owner_key=? AND state='leased'""",
+                (key,),
+            ).fetchall()
+            report = _close_ledger_rows(rows, db)
+            db.commit()
+            return report
+        finally:
+            db.close()
+    finally:
+        lock.release()

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -51,6 +51,7 @@ Usage:
 
 import atexit
 import functools
+import hashlib
 import json
 import logging
 import os
@@ -62,6 +63,7 @@ import sys
 import tempfile
 import threading
 import time
+import urllib.parse
 from datetime import datetime, timezone
 from typing import Dict, Any, Optional, List, Tuple, Union
 from pathlib import Path
@@ -615,6 +617,121 @@ def _get_cdp_override() -> str:
     if not raw:
         return ""
     return _resolve_cdp_override(raw)
+
+
+def _loopback_cdp_http_endpoint(value: str) -> Optional[str]:
+    """Convert a resolved local CDP URL to its HTTP target-control root.
+
+    ``_get_cdp_override`` already resolves discovery URLs to
+    ``webSocketDebuggerUrl``. Tab lifecycle therefore does no discovery of its
+    own; it only verifies that the resolved endpoint is plaintext loopback and
+    derives Chrome's sibling ``/json/*`` HTTP surface. Remote/cloud and TLS CDP
+    endpoints fail closed.
+    """
+    try:
+        parsed = urllib.parse.urlsplit(str(value or "").strip())
+        port = parsed.port
+    except ValueError:
+        return None
+    if parsed.scheme not in {"http", "ws"}:
+        return None
+    if parsed.hostname not in {"127.0.0.1", "localhost", "::1"}:
+        return None
+    if parsed.username or parsed.password or not port:
+        return None
+    host = f"[{parsed.hostname}]" if ":" in parsed.hostname else parsed.hostname
+    return f"http://{host}:{port}"
+
+
+def _tab_lifecycle_enabled() -> bool:
+    """Read the profile-local tab-lifecycle feature flag."""
+    try:
+        from hermes_cli.config import read_raw_config
+
+        cfg = read_raw_config()
+        browser_cfg = cfg.get("browser", {}) if isinstance(cfg, dict) else {}
+        lifecycle_cfg = browser_cfg.get("resource_hygiene", {}) if isinstance(browser_cfg, dict) else {}
+        return isinstance(lifecycle_cfg, dict) and is_truthy_value(
+            lifecycle_cfg.get("enabled"), default=False
+        )
+    except Exception as exc:
+        logger.debug("Could not read browser.resource_hygiene config: %s", exc)
+        return False
+
+
+def prepare_browser_tab_lifecycle(
+    *,
+    session_name: str,
+    owner_key: str,
+    lease_minutes: int,
+    lease_reason: str,
+    lock_timeout_s: float,
+    cdp_url: str = "",
+    private_browser: bool = False,
+):
+    """Create and start per-turn cleanup for the resolved shared local browser.
+
+    Browser backend/session resolution stays in this module. Browser instances
+    proven private to a named/cloud session are never inspected; named harness
+    daemons sharing the configured local browser receive the same per-turn
+    ownership boundary. Returns ``(guard, error)``; when disabled or not
+    applicable both are ``None``.
+    """
+    if not _tab_lifecycle_enabled() or private_browser:
+        return None, None
+
+    resolved_cdp = _resolve_cdp_override(cdp_url) if cdp_url else _get_cdp_override()
+    if not resolved_cdp:
+        return None, (
+            "tab lifecycle requires browser.cdp_url to resolve to a plaintext "
+            "loopback Chrome endpoint"
+        )
+    endpoint = _loopback_cdp_http_endpoint(resolved_cdp)
+    if endpoint is None:
+        # Cloud/TLS/non-loopback browsers have their own session lifecycle.
+        # Local tab hygiene must not inspect or block them.
+        return None, None
+
+    from tools.browser_tab_lifecycle import BrowserTabLifecycleGuard
+
+    guard = BrowserTabLifecycleGuard(
+        enabled=True,
+        endpoint=endpoint,
+        browser_key=hashlib.sha256(resolved_cdp.encode("utf-8")).hexdigest(),
+        owner_key=owner_key,
+        lease_minutes=lease_minutes,
+        lease_reason=lease_reason,
+        lock_timeout_s=lock_timeout_s,
+    )
+    start_error = guard.start()
+    if start_error is None:
+        # CDP overrides bypass _get_session_info(), the historical cleanup-thread
+        # start point. Start it explicitly so bounded leases are reaped even if
+        # no later browser_exec call or turn finalizer reaches this process.
+        _start_browser_cleanup_thread()
+    return guard, start_error
+
+
+def finalize_browser_tab_lifecycle(owner_key: str) -> Dict[str, Any]:
+    """Finalize any leases that survived the completed conversation turn."""
+    try:
+        from tools.browser_tab_lifecycle import finalize_browser_tab_owner
+
+        return finalize_browser_tab_owner(owner_key)
+    except Exception as exc:
+        logger.warning("Browser tab lifecycle finalization failed: %s", exc)
+        return {"closed": 0, "failed": 1, "errors": [str(exc)]}
+
+
+def reap_expired_browser_tab_lifecycles() -> Dict[str, Any]:
+    """Reap expired bounded leases from the browser cleanup thread."""
+    try:
+        from tools.browser_tab_lifecycle import reap_expired_browser_tab_leases
+
+        return reap_expired_browser_tab_leases()
+    except Exception as exc:
+        logger.debug("Browser tab lease reaper failed: %s", exc)
+        return {"closed": 0, "failed": 1, "errors": [str(exc)]}
 
 
 def _get_dialog_policy_config() -> Tuple[str, float]:
@@ -2390,6 +2507,8 @@ def _cleanup_inactive_browser_sessions():
                     del _session_last_activity[task_id]
         except Exception as e:
             logger.warning("Error cleaning up inactive session %s: %s", task_id, e)
+
+    reap_expired_browser_tab_lifecycles()
 
 
 def _write_owner_pid(socket_dir: str, session_name: str) -> None:

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -75,6 +75,7 @@ del _hermes_ensure_own_tab
 _DEFAULT_TIMEOUT_S = 300
 _MIN_TIMEOUT_S = 5
 _MAX_TIMEOUT_S = 1800
+_MAX_LEASE_MINUTES = 120
 _STDERR_CAP_CHARS = 4000
 
 # Filesystem-safe task ids for per-task workspace dirs.
@@ -173,6 +174,16 @@ def _read_browser_cfg() -> dict:
     except Exception as e:
         logger.debug("Could not read browser config section: %s", e)
         return {}
+
+
+def _resource_hygiene_enabled() -> bool:
+    """Compatibility shim; browser_tool owns tab-lifecycle configuration."""
+    try:
+        from tools.browser_tool import _tab_lifecycle_enabled
+
+        return _tab_lifecycle_enabled()
+    except Exception:
+        return False
 
 
 def get_browser_backend() -> str:
@@ -728,8 +739,11 @@ def browser_exec(
     code: str,
     session: str = "",
     timeout_s: int = _DEFAULT_TIMEOUT_S,
+    lease_minutes: int = 0,
+    lease_reason: str = "",
     task_id: Optional[str] = None,
     local: bool = False,
+    turn_id: Optional[str] = None,
 ):
     """Run Python code through the browser-use CLI, and return its output"""
     from tools.registry import tool_error, tool_result
@@ -740,6 +754,21 @@ def browser_exec(
     blocked = _blocked_url_in_code(code)
     if blocked:
         return tool_error(blocked)
+
+    try:
+        lease = int(lease_minutes or 0)
+    except (TypeError, ValueError):
+        return tool_error("lease_minutes must be an integer from 0 to 120.")
+    if lease < 0 or lease > _MAX_LEASE_MINUTES:
+        return tool_error(
+            f"lease_minutes must be between 0 and {_MAX_LEASE_MINUTES}."
+        )
+    reason = str(lease_reason or "").strip()
+    if lease and not reason:
+        return tool_error(
+            "lease_reason is required when lease_minutes is non-zero. "
+            "Use a short task-specific reason."
+        )
 
     cmd = _find_cli()
     if not cmd:
@@ -794,8 +823,6 @@ def browser_exec(
     # the model's code. Private per-name browsers (provider-keyed or BU
     # cloud) skip this: no one to collide with, and the extra tab would leak.
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
-    if session and not private_browser:
-        code = _OWN_TAB_PREAMBLE + code
 
     workspace = _workspace_dir(task_id)
     if workspace:
@@ -811,6 +838,31 @@ def browser_exec(
     except (TypeError, ValueError):
         timeout = _DEFAULT_TIMEOUT_S
 
+    hygiene_guard = None
+    hygiene_start_error = None
+    if _resource_hygiene_enabled() and not private_browser:
+        from tools.browser_tool import prepare_browser_tab_lifecycle
+
+        hygiene_guard, hygiene_start_error = prepare_browser_tab_lifecycle(
+            session_name=session,
+            owner_key=turn_id or task_id or "browser-exec-default",
+            lease_minutes=lease,
+            lease_reason=reason,
+            lock_timeout_s=min(60, timeout),
+            cdp_url=str(env.get("BU_CDP_URL") or env.get("BU_CDP_WS") or ""),
+            private_browser=bool(private_browser),
+        )
+        if hygiene_start_error:
+            return tool_error(
+                "Browser tab lifecycle blocked this call before navigation: "
+                f"{hygiene_start_error}. No browser code was executed."
+            )
+
+    if hygiene_guard is not None and hygiene_guard.target_id:
+        code = f"switch_tab({json.dumps(hygiene_guard.target_id)})\n" + code
+    elif session and not private_browser:
+        code = _OWN_TAB_PREAMBLE + code
+
     # Windows: hide the console the .cmd shim would flash (as browser_tool does)
     popen_extra: dict = {}
     if os.name == "nt":
@@ -825,6 +877,8 @@ def browser_exec(
             logger.debug("Windows hide-flags unavailable: %s", e)
 
     started = time.time()
+    proc = None
+    execution_error = None
     try:
         proc = subprocess.run(
             cmd,
@@ -836,7 +890,7 @@ def browser_exec(
             **popen_extra,
         )
     except subprocess.TimeoutExpired:
-        return tool_error(
+        execution_error = (
             f"browser-use exec timed out after {timeout}s. The daemon may "
             "still be working; retry with a larger timeout_s (max "
             f"{_MAX_TIMEOUT_S}), or split the work into several calls that "
@@ -844,7 +898,18 @@ def browser_exec(
             "workspace is preserved."
         )
     except OSError as e:
-        return tool_error(f"Failed to launch browser-use CLI: {e}")
+        execution_error = f"Failed to launch browser-use CLI: {e}"
+    finally:
+        hygiene_report = hygiene_guard.finish() if hygiene_guard is not None else None
+
+    if execution_error:
+        if hygiene_report and not hygiene_report.get("ok", True):
+            execution_error += " Cleanup also failed: " + "; ".join(
+                hygiene_report.get("errors") or ["unknown hygiene error"]
+            )
+        return tool_error(execution_error)
+
+    assert proc is not None
 
     result = {
         "success": proc.returncode == 0,
@@ -855,6 +920,10 @@ def browser_exec(
         result["workspace"] = workspace
     if session:
         result["session"] = session
+    if hygiene_report is not None:
+        result["hygiene"] = hygiene_report
+        if not hygiene_report.get("ok", False):
+            result["success"] = False
     stderr = (proc.stderr or "").strip()
     if stderr:
         if len(stderr) > _STDERR_CAP_CHARS:
@@ -928,19 +997,31 @@ _DESCRIPTION_HEADER = _HEADER_BASE  # back-compat alias for external imports
 
 
 def _description_header() -> str:
-    """Header tailored to whether the active model can see images natively"""
+    """Header tailored to the active engine, vision, and tab lifecycle."""
     if _lightpanda_engine_in_use():
-        # No screenshots at all on Lightpanda: the vision workflow cannot
-        # apply, whatever the model can see.
+        # Lightpanda sessions are private and one-page-only, so shared-CDP tab
+        # lifecycle instructions do not apply even when the feature is enabled.
         return _HEADER_BASE + _HEADER_TEXT_ONLY + _HEADER_LIGHTPANDA
+
+    hygiene = ""
+    if _resource_hygiene_enabled():
+        hygiene = (
+            "\n\nTAB LIFECYCLE: Local tabs created or claimed from a blank "
+            "baseline close automatically after each browser_exec call, including "
+            "errors and timeouts. The tool verifies closure and leaves one blank "
+            "baseline page. When the NEXT browser_exec call genuinely must reuse "
+            "the current tab, set lease_minutes (1-120) and a task-specific "
+            "lease_reason. On the final call, omit the lease so owned tabs close. "
+            "Never lease a tab merely because it may be useful later."
+        )
     try:
         from tools.vision_tools import _should_use_native_vision_fast_path
 
         if _should_use_native_vision_fast_path():
-            return _HEADER_BASE + _HEADER_VISION
+            return _HEADER_BASE + hygiene + _HEADER_VISION
     except Exception:
         pass
-    return _HEADER_BASE + _HEADER_TEXT_ONLY
+    return _HEADER_BASE + hygiene + _HEADER_TEXT_ONLY
 
 
 def _lightpanda_engine_in_use() -> bool:
@@ -1042,6 +1123,25 @@ BROWSER_EXEC_SCHEMA = {
                 "description": f"Max seconds to wait for the code to finish (default {_DEFAULT_TIMEOUT_S}, max {_MAX_TIMEOUT_S}).",
                 "default": _DEFAULT_TIMEOUT_S,
             },
+            "lease_minutes": {
+                "type": "integer",
+                "description": (
+                    "Keep local task-owned tabs for the next call for 1-120 "
+                    "minutes. Default 0 closes them after this call. Requires "
+                    "lease_reason; omit on the final call."
+                ),
+                "minimum": 0,
+                "maximum": _MAX_LEASE_MINUTES,
+                "default": 0,
+            },
+            "lease_reason": {
+                "type": "string",
+                "description": (
+                    "Short task-specific reason for a non-zero lease. Do not "
+                    "include URLs, credentials, or private page content."
+                ),
+                "maxLength": 500,
+            },
         },
         "required": ["code"],
     },
@@ -1061,8 +1161,11 @@ registry.register(
         code=args.get("code", ""),
         session=args.get("session", "") or "",
         timeout_s=args.get("timeout_s", _DEFAULT_TIMEOUT_S),
+        lease_minutes=args.get("lease_minutes", 0),
+        lease_reason=args.get("lease_reason", ""),
         task_id=kw.get("task_id"),
         local=bool(args.get("local", False)),
+        turn_id=kw.get("turn_id"),
     ),
     check_fn=is_browser_use_cli_mode,
     dynamic_schema_overrides=_dynamic_schema_overrides,

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -4,13 +4,18 @@ When browser.backend is "browser-use", the model gets ``browser_exec`` tool
 instead of default browser tools
 """
 
+import hashlib
 import json
 import logging
 import os
 import re
 import shutil
+import socket
 import subprocess
+import tempfile
+import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -30,44 +35,44 @@ _SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 # subprocess launches — never exported to the CLI.
 _PRIVATE_BROWSER_SENTINEL = "_HERMES_BU_PRIVATE_BROWSER"
 
-# Preamble prepended to the model's code for named sessions on SHARED
-# browsers (local Chrome / CDP override). The harness daemon attaches to the
-# first existing page at startup, so two fresh named daemons can land on the
-# SAME tab; steering this daemon onto a tab it created keeps concurrent named
-# sessions from clobbering each other before their first new_tab(). Runs
-# once per daemon (marker file keyed by BU_NAME under the harness runtime
-# state), costs one IPC round-trip on later calls.
+# Logical sessions on a shared physical daemon must reselect their own tab on
+# every call. Another logical session may have changed the daemon's current tab.
 _OWN_TAB_PREAMBLE = """\
-# hermes: pin this named session to its own tab (once per daemon process)
+# hermes: select this logical session's tab on the shared CDP transport
 def _hermes_ensure_own_tab():
-    import os as _os, tempfile as _tf
-    _name = _os.environ.get("BU_NAME", "default")
+    import hashlib as _hashlib, json as _json, os as _os, tempfile as _tf
+    _name = _os.environ.get("HERMES_BU_LOGICAL_SESSION") or _os.environ.get("BU_NAME", "default")
+    _runtime = _os.environ.get("BH_RUNTIME_DIR") or _tf.gettempdir()
+    _slot = _os.path.join(_runtime, "hermes-tab-%s.json" % _hashlib.sha256(_name.encode()).hexdigest()[:20])
+    _tid = None
     try:
-        # Key the marker by the daemon's pid so a daemon restart (which
-        # re-attaches to the first shared page) re-pins automatically,
-        # while agent-driven tab switches mid-session are left alone.
-        from browser_harness import _ipc as _bipc
-        _dpid = _bipc.pid_path(_name).read_text().strip() or "0"
+        with open(_slot, "r", encoding="utf-8") as _fh:
+            _tid = _json.load(_fh).get("target_id")
     except Exception:
-        _dpid = "0"
-    _uid = _os.getuid() if hasattr(_os, "getuid") else 0
-    _marker = _os.path.join(
-        _tf.gettempdir(), "hermes-bu-owntab-%s-%s-%s" % (_uid, _name, _dpid)
-    )
-    if _os.path.exists(_marker):
-        return
-    try:
-        # Force a fresh target: new_tab() would REUSE a blank current tab,
-        # which is exactly the tab a sibling daemon may also hold.
-        _tid = cdp("Target.createTarget", url="about:blank").get("targetId")
-        if _tid:
-            switch_tab(_tid)
-    except Exception:
-        pass  # best-effort: worst case is pre-fix behavior
-    try:
-        open(_marker, "w").close()
-    except OSError:
         pass
+    try:
+        _live = {t.get("targetId") for t in cdp("Target.getTargets").get("targetInfos", []) if t.get("type") == "page"}
+    except Exception:
+        _live = set()
+    if _tid not in _live:
+        try:
+            _tid = cdp("Target.createTarget", url="about:blank").get("targetId")
+        except Exception:
+            _tid = None
+        if _tid:
+            try:
+                _os.makedirs(_runtime, mode=0o700, exist_ok=True)
+                _fd, _tmp = _tf.mkstemp(prefix=".hermes-tab-", dir=_runtime)
+                with _os.fdopen(_fd, "w", encoding="utf-8") as _fh:
+                    _json.dump({"target_id": _tid}, _fh)
+                _os.replace(_tmp, _slot)
+            except OSError:
+                pass
+    if _tid:
+        try:
+            switch_tab(_tid)
+        except Exception:
+            pass
 _hermes_ensure_own_tab()
 del _hermes_ensure_own_tab
 """
@@ -92,6 +97,294 @@ _IMAGE_PATH_RE = re.compile(
 
 # http(s) URL literals in exec code checked against browser_navigate's policy
 _URL_RE = re.compile(r"https?://[^\s'\"\\)]+", re.IGNORECASE)
+
+try:
+    import fcntl as _fcntl
+except ImportError:  # pragma: no cover - Windows
+    _fcntl = None
+
+try:
+    import msvcrt as _msvcrt
+except ImportError:  # pragma: no cover - POSIX
+    _msvcrt = None
+
+
+@dataclass(frozen=True)
+class _SessionTransport:
+    key: str
+    runtime_dir: Path
+    tmp_dir: Path
+    thread_lock: threading.RLock
+
+
+_TRANSPORT_LOCK_GUARD = threading.Lock()
+_TRANSPORT_THREAD_LOCKS: Dict[str, threading.RLock] = {}
+
+
+def _private_dir(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _configure_session_transport(
+    env: dict, *, conversation_id: str, logical_session: str, private_browser: bool
+) -> Optional[_SessionTransport]:
+    """One browser-harness daemon per profile, conversation lineage, endpoint."""
+    scope = str(conversation_id or "").strip()
+    if not scope or private_browser:
+        return None
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = Path(get_hermes_home()).expanduser().resolve()
+    except Exception:
+        return None
+    endpoint = str(env.get("BU_CDP_URL") or env.get("BU_CDP_WS") or "local-auto")
+    key = hashlib.sha256(f"{home}\0{scope}\0{endpoint}".encode()).hexdigest()[:24]
+    tmp_dir = _private_dir(home / "cache" / "bu" / key / "tmp")
+    if os.name == "nt":
+        runtime_dir = _private_dir(home / "cache" / "bu" / key / "run")
+    else:
+        uid = os.getuid() if hasattr(os, "getuid") else 0
+        runtime_dir = _private_dir(Path(tempfile.gettempdir()) / f"hermes-bu-{uid}" / key)
+        if len(os.fsencode(str(runtime_dir / "bu.sock"))) >= 100:
+            runtime_dir = _private_dir(Path("/tmp") / f"hermes-bu-{uid}" / key)
+    env["BH_RUNTIME_DIR"] = str(runtime_dir)
+    env["BH_TMP_DIR"] = str(tmp_dir)
+    env["HERMES_BU_LOGICAL_SESSION"] = str(logical_session or "default")
+    with _TRANSPORT_LOCK_GUARD:
+        lock = _TRANSPORT_THREAD_LOCKS.setdefault(key, threading.RLock())
+    return _SessionTransport(key, runtime_dir, tmp_dir, lock)
+
+
+class _TransportExecutionLock:
+    """Thread + cross-process lock for one daemon's mutable current target."""
+
+    def __init__(self, transport: _SessionTransport, timeout_s: float):
+        self.transport = transport
+        self.timeout_s = max(0.1, float(timeout_s))
+        self.handle = None
+        self.thread_held = False
+
+    def acquire(self) -> None:
+        deadline = time.monotonic() + self.timeout_s
+        if not self.transport.thread_lock.acquire(timeout=self.timeout_s):
+            raise TimeoutError("another browser_exec call owns this CDP transport")
+        self.thread_held = True
+        try:
+            path = self.transport.runtime_dir / "exec.lock"
+            self.handle = open(path, "a+b")
+            try:
+                os.chmod(path, 0o600)
+            except OSError:
+                pass
+            if _fcntl is not None:
+                while True:
+                    try:
+                        _fcntl.flock(
+                            self.handle.fileno(), _fcntl.LOCK_EX | _fcntl.LOCK_NB
+                        )
+                        return
+                    except BlockingIOError:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                "another process owns this browser CDP transport"
+                            )
+                        time.sleep(0.05)
+            if _msvcrt is not None:  # pragma: no cover - Windows
+                self.handle.seek(0)
+                if self.handle.read(1) == b"":
+                    self.handle.write(b"0")
+                    self.handle.flush()
+                while True:
+                    try:
+                        self.handle.seek(0)
+                        getattr(_msvcrt, "locking")(
+                            self.handle.fileno(), getattr(_msvcrt, "LK_NBLCK"), 1
+                        )
+                        return
+                    except OSError:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                "another process owns this browser CDP transport"
+                            )
+                        time.sleep(0.05)
+            return
+        except Exception:
+            self.release()
+            raise
+
+    def release(self) -> None:
+        if self.handle is not None:
+            if _fcntl is not None:
+                try:
+                    _fcntl.flock(self.handle.fileno(), _fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            elif _msvcrt is not None:  # pragma: no cover - Windows
+                try:
+                    self.handle.seek(0)
+                    getattr(_msvcrt, "locking")(
+                        self.handle.fileno(), getattr(_msvcrt, "LK_UNLCK"), 1
+                    )
+                except OSError:
+                    pass
+            try:
+                self.handle.close()
+            except OSError:
+                pass
+            self.handle = None
+        if self.thread_held:
+            self.thread_held = False
+            self.transport.thread_lock.release()
+
+
+def _probe_daemon_pid(runtime_dir: Path) -> Optional[int]:
+    """Return the live harness daemon PID after an authenticated IPC ping."""
+    connection: Optional[socket.socket] = None
+    try:
+        request: Dict[str, Any] = {"meta": "ping"}
+        if os.name == "nt":
+            payload = json.loads(
+                (runtime_dir / "bu.port").read_text(encoding="utf-8")
+            )
+            port = int(payload["port"])
+            token = str(payload["token"])
+            if not token:
+                return None
+            request["token"] = token
+            connection = socket.create_connection(("127.0.0.1", port), timeout=1.0)
+        else:
+            connection = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            connection.settimeout(1.0)
+            connection.connect(str(runtime_dir / "bu.sock"))
+        connection.sendall((json.dumps(request) + "\n").encode("utf-8"))
+        raw = b""
+        while not raw.endswith(b"\n") and len(raw) <= 65536:
+            chunk = connection.recv(65536)
+            if not chunk:
+                break
+            raw += chunk
+        response = json.loads(raw or b"{}")
+        if not isinstance(response, dict) or response.get("pong") is not True:
+            return None
+        pid = response.get("pid")
+        return pid if type(pid) is int and 0 < pid < (1 << 31) else None
+    except (OSError, ValueError, KeyError, TypeError, json.JSONDecodeError):
+        return None
+    finally:
+        if connection is not None:
+            try:
+                connection.close()
+            except OSError:
+                pass
+
+
+def _daemon_identity(runtime_dir: Path) -> Optional[str]:
+    try:
+        path = runtime_dir / "bu.pid"
+        recorded_pid = int(path.read_text(encoding="utf-8").strip())
+        live_pid = _probe_daemon_pid(runtime_dir)
+        if live_pid is None or live_pid != recorded_pid:
+            return None
+        return hashlib.sha256(
+            f"{live_pid}:{path.stat().st_mtime_ns}".encode()
+        ).hexdigest()[:20]
+    except (OSError, ValueError):
+        return None
+
+
+def _record_transport_outcome(
+    transport: _SessionTransport,
+    before: Optional[str],
+    after: Optional[str],
+    logical_session: str,
+    success: bool,
+    error_text: str,
+) -> Dict[str, Any]:
+    """Local content-free attach telemetry; never records endpoint or raw IDs."""
+    path = transport.tmp_dir / "transport-telemetry.json"
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if data.get("schema_version") != 1:
+            raise ValueError("old schema")
+    except (OSError, ValueError, AttributeError):
+        data = {
+            "schema_version": 1,
+            "attach_attempts": 0,
+            "attach_successes": 0,
+            "reuses": 0,
+            "drops": 0,
+            "events": [],
+        }
+    attached = False
+    reused = False
+    event = "unknown"
+    reason = ""
+    lowered_error = error_text.lower()
+    permission_failed = (
+        "permission-blocked" in lowered_error
+        or "allow remote debugging" in lowered_error
+    )
+    if before and after == before:
+        data["reuses"] += 1
+        reused = True
+        event = "reuse"
+    elif after and after != before:
+        data["attach_attempts"] += 1
+        data["attach_successes"] += 1
+        attached = True
+        event = "attach_success"
+        reason = "cold_start" if before is None else "daemon_replaced"
+        if before is not None:
+            data["drops"] += 1
+    elif permission_failed:
+        data["attach_attempts"] += 1
+        attached = True
+        event = "attach_failed"
+        reason = "permission_blocked"
+        if before is not None:
+            data["drops"] += 1
+    elif before and after is None:
+        data["drops"] += 1
+        event = "drop_detected"
+        reason = "daemon_exited"
+    events = data.get("events", [])
+    events.append(
+        {
+            "at_unix_ms": int(time.time() * 1000),
+            "event": event,
+            "reason": reason,
+            "outcome": "success" if success else "error",
+        }
+    )
+    data["events"] = events[-100:]
+    data["logical_session_hash"] = hashlib.sha256(
+        (logical_session or "default").encode()
+    ).hexdigest()[:16]
+    temp = path.with_name(f".{path.name}.{os.getpid()}.tmp")
+    try:
+        temp.write_text(json.dumps(data, sort_keys=True), encoding="utf-8")
+        os.replace(temp, path)
+    finally:
+        try:
+            temp.unlink()
+        except FileNotFoundError:
+            pass
+    return {
+        "scope": "conversation_lineage",
+        "transport_key": transport.key,
+        "attach_count": data["attach_attempts"],
+        "attach_success_count": data["attach_successes"],
+        "attached_this_call": 1 if attached else 0,
+        "reuse_count": data["reuses"],
+        "reused": reused,
+        "drop_count": data["drops"],
+    }
 
 
 def _blocked_url_in_code(code: str) -> Optional[str]:
@@ -744,6 +1037,7 @@ def browser_exec(
     task_id: Optional[str] = None,
     local: bool = False,
     turn_id: Optional[str] = None,
+    conversation_id: Optional[str] = None,
 ):
     """Run Python code through the browser-use CLI, and return its output"""
     from tools.registry import tool_error, tool_result
@@ -823,6 +1117,12 @@ def browser_exec(
     # the model's code. Private per-name browsers (provider-keyed or BU
     # cloud) skip this: no one to collide with, and the extra tab would leak.
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
+    transport = _configure_session_transport(
+        env,
+        conversation_id=str(conversation_id or ""),
+        logical_session=session or "default",
+        private_browser=bool(private_browser),
+    )
 
     workspace = _workspace_dir(task_id)
     if workspace:
@@ -860,7 +1160,7 @@ def browser_exec(
 
     if hygiene_guard is not None and hygiene_guard.target_id:
         code = f"switch_tab({json.dumps(hygiene_guard.target_id)})\n" + code
-    elif session and not private_browser:
+    elif not private_browser and (session or transport is not None):
         code = _OWN_TAB_PREAMBLE + code
 
     # Windows: hide the console the .cmd shim would flash (as browser_tool does)
@@ -879,7 +1179,20 @@ def browser_exec(
     started = time.time()
     proc = None
     execution_error = None
+    hygiene_report = None
+    transport_telemetry = None
+    before_daemon = None
+    execution_lock = (
+        _TransportExecutionLock(transport, min(60, timeout))
+        if transport is not None
+        else None
+    )
+    lock_held = False
     try:
+        if execution_lock is not None and transport is not None:
+            execution_lock.acquire()
+            lock_held = True
+            before_daemon = _daemon_identity(transport.runtime_dir)
         proc = subprocess.run(
             cmd,
             input=code,
@@ -897,10 +1210,33 @@ def browser_exec(
             "append to workspace files — anything already written to the "
             "workspace is preserved."
         )
+    except TimeoutError as e:
+        execution_error = f"Browser CDP transport is busy: {e}"
     except OSError as e:
         execution_error = f"Failed to launch browser-use CLI: {e}"
     finally:
-        hygiene_report = hygiene_guard.finish() if hygiene_guard is not None else None
+        try:
+            hygiene_report = (
+                hygiene_guard.finish() if hygiene_guard is not None else None
+            )
+        finally:
+            if transport is not None and lock_held:
+                try:
+                    transport_telemetry = _record_transport_outcome(
+                        transport,
+                        before_daemon,
+                        _daemon_identity(transport.runtime_dir),
+                        session or "default",
+                        execution_error is None
+                        and proc is not None
+                        and proc.returncode == 0,
+                        execution_error
+                        or ((proc.stderr or "") if proc is not None else ""),
+                    )
+                except Exception:
+                    logger.debug("browser CDP telemetry failed", exc_info=True)
+            if lock_held and execution_lock is not None:
+                execution_lock.release()
 
     if execution_error:
         if hygiene_report and not hygiene_report.get("ok", True):
@@ -920,6 +1256,8 @@ def browser_exec(
         result["workspace"] = workspace
     if session:
         result["session"] = session
+    if transport_telemetry is not None:
+        result["cdp_transport"] = transport_telemetry
     if hygiene_report is not None:
         result["hygiene"] = hygiene_report
         if not hygiene_report.get("ok", False):
@@ -1116,7 +1454,13 @@ BROWSER_EXEC_SCHEMA = {
             },
             "session": {
                 "type": "string",
-                "description": "Named isolated browser session — its own daemon and (on cloud backends) own browser, so concurrent tasks don't share tabs. Reuse the same name on every related call; omit for the shared default session.",
+                "description": (
+                    "Named logical browser session. Related calls reuse its tab "
+                    "namespace; cloud backends may also allocate a browser. Shared "
+                    "local/CDP calls multiplex one persistent physical connection "
+                    "per Hermes conversation lineage, avoiding Chrome re-prompts. "
+                    "Reuse the same name for related calls; omit for default."
+                ),
             },
             "timeout_s": {
                 "type": "integer",
@@ -1166,6 +1510,7 @@ registry.register(
         task_id=kw.get("task_id"),
         local=bool(args.get("local", False)),
         turn_id=kw.get("turn_id"),
+        conversation_id=kw.get("conversation_id") or kw.get("session_id"),
     ),
     check_fn=is_browser_use_cli_mode,
     dynamic_schema_overrides=_dynamic_schema_overrides,


### PR DESCRIPTION
## What this adds

Two related browser-stack features, carried in production since late August and forward-ported across 0.20.6 → 0.21.0:

**1. Ownership-aware tab lifecycle** — tabs opened by a turn are leased to that turn's identity (turn + browser instance), reaped on expiry, and finalized at end-of-turn. Prevents delegated/concurrent turns from leaking tabs or closing each other's. Browser identity is re-resolved (`/json/version`) before every cleanup mutation, so a Chrome restart on a fixed debug port can never receive writes meant for its predecessor. Cross-process serialization; daemon-generation telemetry that proves a live daemon through IPC before counting reuse. Default-off (`browser.resource_hygiene.enabled`).

**2. Conversation-scoped CDP transport reuse** — one persistent CDP connection per browser per conversation lineage (surviving compression rotation), instead of dialing fresh per operation. Motivation: Chrome 144+ shows a per-connection remote-debugging consent dialog (see chrome-devtools-mcp#1794) — attach-per-call produced dozens of consent prompts per day for a headed automation browser. With reuse: at most one per conversation. Production evidence: 13 attaches / 12 consent triggers in the 24h before; attach sequence 1 → 1 with per-call attaches 1 → 0 after, second logical session reusing the first physical transport, clean daemon teardown.

## Testing
Focused suites 425+ green at export; broad browser/agent sweep 1054 passed, 7 skipped on the 0.21 base (one documented ordering-pollution deselect). Live real-Chrome proofs for both features (identity-gate refusal on browser swap; transport reuse and teardown telemetry).

Both features have survived three adversarial internal reviews (real-CDP reproduction of defects included) and two forward-ports; upstreaming so the maintenance lives where the code does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)