### PR TITLE
fix(platforms): accept is_voice kwarg in mattermost/line send_voice — audio attachments silently failed (#100018)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -1463,6 +1463,7 @@ class LineAdapter(BasePlatformAdapter):
         audio_path: str,
         duration_ms: int = 1000,
         metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> SendResult:
         path = Path(audio_path)
         if not path.exists() or not path.is_file():

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -498,6 +498,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        **kwargs,
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(

--- a/tests/gateway/test_send_voice_is_voice_kwarg_100018.py
+++ b/tests/gateway/test_send_voice_is_voice_kwarg_100018.py
@@ -1,0 +1,82 @@
+"""Regression tests for #100018.
+
+The gateway media dispatch loop (``gateway/platforms/base.py``) passes
+``is_voice=...`` on every ``send_voice`` call for audio MEDIA: attachments.
+``MattermostAdapter.send_voice`` and ``LineAdapter.send_voice`` were the only
+adapters without a ``**kwargs`` catch-all, so the call raised ``TypeError``
+at argument-binding time — before any upload was attempted — and the
+attachment silently failed with no user-visible error.
+
+These tests pin both levels: the signature must bind the router's exact
+kwarg set, and a live call must reach the adapter's own guard/upload logic
+instead of dying at binding time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+
+from gateway.platforms.base import SendResult
+
+
+def _bind_router_kwargs(method) -> None:
+    """Bind the exact kwarg set used by the gateway media dispatch loop."""
+    inspect.signature(method).bind(
+        None, chat_id="C1", audio_path="/tmp/x.ogg", metadata=None, is_voice=True
+    )
+
+
+class TestMattermostSendVoiceKwarg:
+    def test_signature_binds_router_kwargs(self):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        _bind_router_kwargs(MattermostAdapter.send_voice)
+
+    def test_call_with_is_voice_reaches_local_file_upload(self):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        adapter = MattermostAdapter.__new__(MattermostAdapter)
+        seen: dict = {}
+
+        async def fake_send_local_file(chat_id, audio_path, caption, reply_to, metadata=None):
+            seen["args"] = (chat_id, audio_path, caption, reply_to, metadata)
+            return SendResult(success=True)
+
+        adapter._send_local_file = fake_send_local_file
+
+        result = asyncio.run(
+            adapter.send_voice(
+                chat_id="C1",
+                audio_path="/tmp/x.ogg",
+                metadata={"thread_id": "t1"},
+                is_voice=True,
+            )
+        )
+
+        assert result.success
+        assert seen["args"] == ("C1", "/tmp/x.ogg", None, None, {"thread_id": "t1"})
+
+
+class TestLineSendVoiceKwarg:
+    def test_signature_binds_router_kwargs(self):
+        from plugins.platforms.line.adapter import LineAdapter
+
+        _bind_router_kwargs(LineAdapter.send_voice)
+
+    def test_call_with_is_voice_returns_controlled_failure_for_missing_file(self):
+        from plugins.platforms.line.adapter import LineAdapter
+
+        adapter = LineAdapter.__new__(LineAdapter)
+
+        result = asyncio.run(
+            adapter.send_voice(
+                chat_id="C1",
+                audio_path="/nonexistent/x.ogg",
+                metadata=None,
+                is_voice=True,
+            )
+        )
+
+        assert not result.success
+        assert "not found" in (result.error or "")


### PR DESCRIPTION
## What does this PR do?

The gateway media dispatch loop (`gateway/platforms/base.py`, ~line 6956) passes `is_voice=...` on every `send_voice` call for audio `MEDIA:` attachments. 13 of the 16 platform adapters absorb the kwarg via a `**kwargs` catch-all — `MattermostAdapter.send_voice` and `LineAdapter.send_voice` do not, so on those two platforms the call raises `TypeError` at argument-binding time, before any upload is attempted. The dispatch loop's `except Exception` then logs a warning and continues, so the audio attachment silently fails and the user gets no failure notice at all.

This adds the same `**kwargs` catch-all the other adapters already use to both signatures. No behavior change: both adapters keep uploading voice messages as plain audio files (neither platform has a distinct voice-message form on this path), and the flag simply no longer kills the call at binding time. With the fix, a failed upload also returns a proper `SendResult(success=False)` so the router's `_notify_media_delivery_failure` path can actually notify the user.

(Matrix is the 16th adapter without the catch-all; it is already covered by #99712, so it is intentionally left untouched here.)

## Related Issue

Fixes #100018

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/mattermost/adapter.py` — added `**kwargs` to `send_voice()` signature so the router's `is_voice` kwarg binds instead of raising `TypeError`
- `plugins/platforms/line/adapter.py` — same one-line `**kwargs` addition to `send_voice()`
- `tests/gateway/test_send_voice_is_voice_kwarg_100018.py` — new regression tests pinning both the signature binding and the live-call behavior for both adapters

## How to Test

1. `python -m pytest tests/gateway/test_send_voice_is_voice_kwarg_100018.py -q`
   - Observed result: `4 passed` on this branch; on unmodified `main` the same file fails with `4 failed` (each test raises `TypeError: send_voice() got an unexpected keyword argument 'is_voice'`), confirming the tests capture the original bug.
2. `python -m pytest tests/gateway/test_mattermost.py tests/gateway/test_mattermost_plugin_setup.py -q`
   - Observed result: `24 passed`, no regressions in the existing Mattermost suite.
3. Pre-fix reproduction from the issue report: instantiating `MattermostAdapter`/`LineAdapter` via `cls.__new__(cls)` and calling `send_voice(..., metadata=None, is_voice=True)` raises `TypeError` on `main`; after this change the Mattermost call routes through `_send_local_file` and the LINE call returns its controlled `SendResult(success=False, error="audio file not found: ...")` guard instead.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — ran the affected suites: `tests/gateway/test_send_voice_is_voice_kwarg_100018.py`, `tests/gateway/test_mattermost.py`, `tests/gateway/test_mattermost_plugin_setup.py` (28 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A
