### PR TITLE
fix(desktop): keep busy group-chat members past the 20-minute turn cap

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import type * as groupActivity from './group-activity'
 import type * as groupChat from './group-chat'
@@ -853,5 +853,83 @@ describe('stopGroupThread (#91868/#94569)', () => {
     const reply = await room.turns.runGroupChatMemberTurn('Room', { name: 'helper', title: '' }, 'long task', 't1', [])
 
     expect(reply).toBe('finished anyway')
+  })
+})
+
+// A member still working past the old 20-minute hard cap must keep its
+// slot. The next member waits for the real reply instead of speaking into
+// a room that already declared the worker dead.
+describe('busy turn past the old 20-minute hard cap', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('keeps the working member and only then seats the next speaker', async () => {
+    let now = 1_700_000_000_000
+    const startedAt = now
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    let jumped = false
+    const room = await loadRoom({
+      onResumePoll: polls => {
+        if (!jumped && polls === 1) {
+          now = startedAt + 20 * 60_000 + 7_000
+          jumped = true
+        }
+      },
+      pollsBusy: 2,
+      turn: ({ profile }) => (profile === 'developer' ? 'deployed the change' : 'looks good')
+    })
+
+    const members: GroupMember[] = [
+      { name: 'developer', title: '' },
+      { name: 'architect', title: '' }
+    ]
+
+    room.rounds.sendToGroupChat('Ship', members, '@developer @architect ship the change')
+    await settle(room, 'Ship')
+
+    const events = (room.activity.$groupActivity.get().Ship?.events || []).map(event => event.kind)
+    const replies = log(room, 'Ship').filter(entry => entry.from.kind === 'member')
+
+    expect(room.chat.$groupChats.get().Ship.stranded?.developer).toBeUndefined()
+    expect(events).not.toContain('timed-out')
+    expect(replies.some(entry => entry.from.name === 'developer' && entry.text === 'deployed the change')).toBe(
+      true
+    )
+    expect(
+      room.gateway.calls.some(call => call.profile === 'architect' && call.prompt.includes('deployed the change'))
+    ).toBe(true)
+    expect(events).toContain('settled')
+  })
+
+  it('an explicit room cap still times out a member that stays busy', async () => {
+    let now = 1_700_000_000_000
+    const startedAt = now
+    vi.spyOn(Date, 'now').mockImplementation(() => now)
+
+    const room = await loadRoom({
+      onResumePoll: () => {
+        now = startedAt + 200_000
+      },
+      pollsBusy: 10_000,
+      turn: () => 'still going'
+    })
+
+    room.chat.updateGroupChat('Cap', current => {
+      current.turnHardCapMs = 90_000
+
+      return current
+    })
+
+    const reply = await room.turns.runGroupChatMemberTurn(
+      'Cap',
+      { name: 'helper', title: '' },
+      'finish quickly or not at all',
+      'legacy'
+    )
+
+    expect(reply).toBeNull()
+    expect(room.chat.$groupChats.get().Cap.stranded?.helper).toBeDefined()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -670,3 +670,50 @@ describe('room record', () => {
     expect('Gone' in durable).toBe(false)
   })
 })
+
+describe('extendGroupTurnDeadline', () => {
+  it('does not clamp a busy member when no cap is set', async () => {
+    const { turns } = await loadRoom()
+    const started = 1_000
+
+    expect(
+      turns.extendGroupTurnDeadline({
+        awaitingUser: false,
+        busy: true,
+        deadline: started + 180_000,
+        now: started + 20 * 60_000,
+        started
+      })
+    ).toBe(started + 20 * 60_000 + 180_000)
+  })
+
+  it('clamps when hardCapMs is set', async () => {
+    const { turns } = await loadRoom()
+    const started = 1_000
+
+    expect(
+      turns.extendGroupTurnDeadline({
+        awaitingUser: false,
+        busy: true,
+        deadline: started + 180_000,
+        hardCapMs: 90_000,
+        now: started + 200_000,
+        started
+      })
+    ).toBe(started + 90_000)
+  })
+
+  it('leaves an idle deadline alone', async () => {
+    const { turns } = await loadRoom()
+
+    expect(
+      turns.extendGroupTurnDeadline({
+        awaitingUser: false,
+        busy: false,
+        deadline: 5_000,
+        now: 4_000,
+        started: 1_000
+      })
+    ).toBe(5_000)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -230,8 +230,39 @@ export async function ensureGroupChatSession(group: string, member: GroupMember)
   }
 }
 
-const GROUP_TURN_TIMEOUT_MS = 180000
+export const GROUP_TURN_TIMEOUT_MS = 180000
 const GROUP_TURN_POLL_MS = 2000
+
+/** Last-resort ceiling for a room that opts into `turnHardCapMs`. The
+ *  previous shipped default (20 min) cut off members that were still
+ *  producing — 44% of turns in a local-model room. Idle members still
+ *  expire at `GROUP_TURN_TIMEOUT_MS`; a busy member is not a hang. */
+export const GROUP_TURN_HARD_CAP_MS = 180 * 60000
+
+/** Slide the poll deadline while the member is visibly working or waiting
+ *  on the user. An explicit `hardCapMs` clamps that slide; omitting it
+ *  (the default) never cuts off a busy turn. */
+export function extendGroupTurnDeadline(args: {
+  awaitingUser: boolean
+  busy: boolean
+  deadline: number
+  hardCapMs?: number
+  now: number
+  started: number
+}): number {
+  if (!args.busy && !args.awaitingUser) {
+    return args.deadline
+  }
+
+  const extended = Math.max(args.deadline, args.now + GROUP_TURN_TIMEOUT_MS)
+  const cap = args.hardCapMs
+
+  if (typeof cap === 'number' && Number.isFinite(cap) && cap > 0) {
+    return Math.min(args.started + cap, extended)
+  }
+
+  return extended
+}
 
 // --- group-turn session-lease helpers (#93602) ------------------------------
 // A member turn is a session-scoped RPC SEQUENCE (resume → attach → submit →
@@ -338,13 +369,6 @@ async function submitGroupTurnPrompt(
     return fresh
   }
 }
-
-// A member turn that is VISIBLY still working (session reports
-// inflight/running) keeps its slot alive up to this hard cap. The base
-// timeout alone silently dropped long real turns: a 7-minute research run
-// timed out at 3 minutes, read as a pass, and its finished result never
-// reached the room (db's Aug 2026 report).
-const GROUP_TURN_HARD_CAP_MS = 20 * 60000
 
 /** Mirror a member's pending prompt — clarify question OR command approval —
  *  from its resume snapshot into the room store, keyed
@@ -511,10 +535,10 @@ export async function answerGroupClarify(
 /** One member turn, gateway-native: submit the room delta as a prompt into
  *  the member's per-group session, then poll the session until a NEW
  *  assistant message lands (or timeout → pass). While the session visibly
- *  reports work in flight the deadline extends (bounded by the hard cap),
- *  so slow models aren't cut off mid-run. A turn that still times out
- *  records a stranded marker so the finished reply can be harvested into
- *  the room at the member's next turn instead of being lost. */
+ *  reports work in flight the deadline keeps sliding by the idle timeout,
+ *  so a long real turn is not declared dead. A turn that still times out
+ *  (idle, or a room that set `turnHardCapMs`) records a stranded marker so
+ *  the finished reply can be harvested into the room instead of being lost. */
 export async function runGroupChatMemberTurn(
   group: string,
   member: GroupMember,
@@ -685,11 +709,21 @@ async function runGroupChatMemberTurnLeased(
     }
 
     // Still visibly working — or waiting on the user's answer to a clarify:
-    // extend the deadline (never past the hard cap). A pending question must
-    // outlive the base turn timeout or it dies unanswered at 3 minutes.
-    if (busy || awaitingUser) {
-      deadline = Math.min(started + GROUP_TURN_HARD_CAP_MS, Math.max(deadline, Date.now() + GROUP_TURN_TIMEOUT_MS))
-    }
+    // slide the deadline. A pending question must outlive the base turn
+    // timeout or it dies unanswered at 3 minutes. Do not clamp a busy
+    // member to a wall-clock cap: that is what stranded 44% of working
+    // turns in a local-model room (the member kept running; the room
+    // moved on). A hang that stops reporting busy expires on the idle
+    // timeout. An explicit per-room `turnHardCapMs` is the opt-in ceiling.
+    const roomCap = ($groupChats.get()[group] || {}).turnHardCapMs
+    deadline = extendGroupTurnDeadline({
+      awaitingUser,
+      busy,
+      deadline,
+      ...(typeof roomCap === 'number' ? { hardCapMs: roomCap } : {}),
+      now: Date.now(),
+      started
+    })
   }
 
   // Timeout — clear any still-mirrored question card (the server-side

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -167,6 +167,10 @@ export interface GroupChat {
   sessionOwners?: Record<string, Partial<RosterRow>>
   sessions?: Record<string, string | true>
   stranded?: Record<string, number | { before: number; thread?: string }>
+  /** Opt-in busy-turn ceiling in ms. Absent = no wall-clock cap while the
+   *  member is still working or waiting on the user. Idle turns still expire
+   *  at `GROUP_TURN_TIMEOUT_MS`. Runtime-only until a room editor lands. */
+  turnHardCapMs?: number
   syncRevision?: number
   /** Left behind when a room is disbanded, so sync can't resurrect it. */
   tombstone?: boolean


### PR DESCRIPTION
## What does this PR do?

`GROUP_TURN_HARD_CAP_MS` (20 minutes) clamped the poll deadline while a group-chat member was still `inflight` / `running`. The member was recorded `timed-out`, marked `stranded`, and skipped by later rounds, so the room seated the next speaker and could settle while the worker kept running and delivered into a room that had stopped listening.

The idle timeout (`GROUP_TURN_TIMEOUT_MS`, 3 minutes) already expires a member that stops reporting work. A busy member is not a hang. This change stops clamping a visibly working turn unless the room sets an explicit `turnHardCapMs`. The finished reply is posted in the same drive, so the next speaker sees the real work.

## Related Issue

Fixes #100274

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-turns.ts` — extract `extendGroupTurnDeadline`; slide the poll deadline while `busy` or `awaitingUser` without the 20-minute clamp; honor optional `turnHardCapMs`
- `apps/desktop/src/plugins/hermes-bots/types.ts` — optional `GroupChat.turnHardCapMs`
- `apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts` — room drive past 20 minutes keeps the working member; explicit cap still times out a still-busy member
- `apps/desktop/src/plugins/hermes-bots/group-turns.test.ts` — deadline helper contracts (no clamp, clamp when set, idle deadline unchanged)

## How to Test

1. From `apps/desktop`, run: `npx vitest run src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-turns.test.ts`
2. Confirm `busy turn past the old 20-minute hard cap` passes: after a 20m+ clock jump while the first member is still inflight, that member is not stranded, there is no `timed-out` activity event, their reply lands in the room log, and a later speaker's prompt includes that reply.
3. Confirm `an explicit room cap still times out a member that stays busy` still strands when `turnHardCapMs` is set.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
 Test Files  4 passed (4)
      Tests  127 passed (127)
```
