### PR TITLE
fix(desktop): stop HUD mode reading auto-TTS replies twice

### DIFF
--- a/apps/desktop/electron/ambient-claim.test.ts
+++ b/apps/desktop/electron/ambient-claim.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { hudOutranksSpeechClaim, isSpeechCue, SPEECH_CLAIM_TTL_MS } from './ambient-claim'
+import { createEventDeduper } from './event-dedupe'
+
+const quiet = { fromHud: false, hudOpen: false, senderDisplacedByHud: false }
+
+test('only the read-aloud cue is a speech cue', () => {
+  assert.equal(isSpeechCue('speak:m1'), true)
+  assert.equal(isSpeechCue('sound:turnDone:s1'), false)
+})
+
+test('the HUD outranks the app window it hid on its way up', () => {
+  assert.equal(
+    hudOutranksSpeechClaim('speak:m1', { ...quiet, hudOpen: true, senderDisplacedByHud: true }),
+    true
+  )
+})
+
+test('the HUD never outranks itself', () => {
+  assert.equal(
+    hudOutranksSpeechClaim('speak:m1', {
+      fromHud: true,
+      hudOpen: true,
+      senderDisplacedByHud: true
+    }),
+    false
+  )
+})
+
+test('a peer window the HUD did not displace still speaks', () => {
+  assert.equal(hudOutranksSpeechClaim('speak:m1', { ...quiet, hudOpen: true }), false)
+})
+
+test('with no HUD up nothing is outranked', () => {
+  assert.equal(hudOutranksSpeechClaim('speak:m1', { ...quiet, senderDisplacedByHud: true }), false)
+})
+
+test('the turn-end sound is left to the plain first-caller-wins collapse', () => {
+  assert.equal(
+    hudOutranksSpeechClaim('sound:turnDone:s1', {
+      ...quiet,
+      hudOpen: true,
+      senderDisplacedByHud: true
+    }),
+    false
+  )
+})
+
+test('a speech claim survives a throttled window waking well past one second', () => {
+  const claimed = createEventDeduper(SPEECH_CLAIM_TTL_MS)
+
+  assert.equal(claimed('speak:m1', 0), false, 'HUD claims and speaks')
+  assert.equal(claimed('speak:m1', 8_000), true, 'the late hidden window stays quiet')
+})
+
+test('a later reply is never suppressed — the key carries the message id', () => {
+  const claimed = createEventDeduper(SPEECH_CLAIM_TTL_MS)
+
+  assert.equal(claimed('speak:m1', 0), false)
+  assert.equal(claimed('speak:m2', 8_000), false, 'the next reply speaks')
+})

--- a/apps/desktop/electron/ambient-claim.ts
+++ b/apps/desktop/electron/ambient-claim.ts
@@ -1,0 +1,37 @@
+// Arbitration for the `speak:<messageId>` ambient cue. Pure — no Electron
+// import — so the decision is unit-testable without a window.
+
+/** A speech claim stands for the life of one reply, not one event tick. */
+export const SPEECH_CLAIM_TTL_MS = 60_000
+
+const SPEECH_CUE_PREFIX = 'speak:'
+
+/** `speak:<messageId>` — the read-aloud cue, keyed by backend message id. */
+export function isSpeechCue(key: string): boolean {
+  return key.startsWith(SPEECH_CUE_PREFIX)
+}
+
+export interface SpeechClaimContext {
+  /** The claim came from the HUD's own renderer. */
+  fromHud: boolean
+  /** A HUD window is up right now. */
+  hudOpen: boolean
+  /** The claimer is the app window this HUD hid on its way up, still hidden. */
+  senderDisplacedByHud: boolean
+}
+
+/**
+ * True when an open HUD outranks this claim and the caller must stay quiet.
+ * Only speech is arbitrated: the turn-end sound is one instant beep the
+ * existing first-caller-wins collapse already handles.
+ */
+export function hudOutranksSpeechClaim(
+  key: string,
+  { fromHud, hudOpen, senderDisplacedByHud }: SpeechClaimContext
+): boolean {
+  if (!hudOpen || fromHud || !senderDisplacedByHud) {
+    return false
+  }
+
+  return isSpeechCue(key)
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { hudOutranksSpeechClaim, isSpeechCue, SPEECH_CLAIM_TTL_MS } from './ambient-claim'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
@@ -16173,10 +16174,37 @@ ipcMain.handle('hermes:api', async (_event, request) => {
 // handles IPC serially, so the first window to claim a key wins with no race.
 const isDuplicateNotification = createEventDeduper()
 const claimedAmbientCue = createEventDeduper()
+// Speech is seconds of audio keyed by backend message id, not one instant beep
+// keyed by kind+session, so its claim stands for the life of the reply — a
+// throttled hidden window waking late must not find the claim expired and read
+// the same reply aloud a second time (#99717). See ambient-claim.ts.
+const claimedSpeechCue = createEventDeduper(SPEECH_CLAIM_TTL_MS)
 
 // A window asks "do I own this ambient cue (turn-end sound / spoken reply)?".
 // The first caller within the window gets true; peers get false and stay quiet.
-ipcMain.handle('hermes:ambient:claim', (_event, key) => !claimedAmbientCue(String(key ?? '')))
+// An open HUD outranks the app window it hid on its way up: the visible surface
+// owns the audio, so the stop control is the one the user can actually reach.
+ipcMain.handle('hermes:ambient:claim', (event, key) => {
+  const cue = String(key ?? '')
+  const hud = hudWindow && !hudWindow.isDestroyed() ? hudWindow : null
+
+  if (
+    hudOutranksSpeechClaim(cue, {
+      fromHud: Boolean(hud) && event.sender === hud.webContents,
+      hudOpen: Boolean(hud),
+      senderDisplacedByHud:
+        hudRestoreMainWindow &&
+        Boolean(mainWindow) &&
+        !mainWindow.isDestroyed() &&
+        event.sender === mainWindow.webContents &&
+        !mainWindow.isVisible()
+    })
+  ) {
+    return false
+  }
+
+  return !(isSpeechCue(cue) ? claimedSpeechCue(cue) : claimedAmbientCue(cue))
+})
 
 ipcMain.handle('hermes:notify', (_event, payload) => {
   if (!Notification.isSupported()) {


### PR DESCRIPTION
## What does this PR do?

With `voice.auto_tts: true`, a reply spoken while HUD mode is active can play twice while appearing once in the transcript.

Both the HUD renderer and the hidden app window claim the same `speak:<messageId>` cue through `hermes:ambient:claim`, and the shared arbiter collapsed it with the 1s `createEventDeduper`.

**The root cause is that 1s is the wrong _unit_ for speech, not merely too short a race window.** That interval is tuned for peers reacting to one backend event in the same tick — correct for notifications and the turn-end beep. Speech is different: the cue is *seconds of audio* keyed by a durable backend message id. `openHudWindow` hides the app window behind the HUD (`hudRestoreMainWindow` → `mainWindow.hide()`), Chromium throttles the hidden renderer, its `$messages` subscription fires well past 1s, it finds the key pruned, is told it owns the cue, and reads aloud a reply the HUD already spoke.

So the fix is two parts, in order of importance:

1. **Give the speech cue its own 60s claim** (`claimedSpeechCue`), so a throttled window waking late cannot find the claim expired. The claim can never suppress a *later* reply, because the key carries the message id, and the deduper still prunes on every call so the map stays bounded.
2. **Let an open HUD outrank the app window it hid on the way up**, so the visible surface owns the audio and its stop control is the one the user can actually reach. This is the tiebreak, not the fix.

Part 2 is deliberately scoped to *that one displaced window*, reusing `main.ts`'s existing `hudRestoreMainWindow` latch. An earlier cut of this patch denied any hidden or minimized window while a HUD was up, which silently killed auto-TTS for a minimized peer window sitting on a *different* conversation — the kind of quiet degradation `AGENTS.md` warns about. Verified the HUD does mount the composer (`hud-shell.tsx` → `WiredPane` → `ChatView` → `useComposerVoice` → `useAutoSpeakReplies`), so after the denial the HUD is genuinely the one speaking.

No renderer, preload, `global.d.ts`, or IPC-signature change.

### Relationship to #99810

[#99810](https://github.com/NousResearch/hermes-agent/pull/99810) is an open PR addressing the same issue, and I found it only after this work was done — maintainers should pick one rather than merge both. Recording the differences so that choice is easy:

- **Scope of the denial.** #99810 pins ownership by sender id whenever a HUD is live, so *any* non-HUD renderer is denied `speak:` cues. A second ordinary window on a different conversation loses its auto-TTS while a HUD is open. This PR denies only the app window the HUD displaced.
- **The TTL.** #99810 leaves the 1s interval in place for speech. It resolves the filed repro, but two non-HUD windows can still double-speak past 1s — a throttled hidden window alongside a visible one, no HUD involved. This PR closes that.

Otherwise the approaches are close in spirit, and the arbitration in both is a pure, unit-testable module.

## Related Issue

Fixes #99717

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/ambient-claim.ts` (new) — pure, no Electron import: `SPEECH_CLAIM_TTL_MS = 60_000`, `isSpeechCue`, and `hudOutranksSpeechClaim`, which returns true only when an open HUD outranks a claim from the app window it displaced. Only speech is arbitrated; the turn-end sound stays on the existing first-caller-wins collapse.
- `apps/desktop/electron/ambient-claim.test.ts` (new) — 8 tests: cue classification, all four HUD-rank branches, the turn-end-sound carve-out, a claim surviving an 8s-late wake, and a later reply not being suppressed.
- `apps/desktop/electron/main.ts` — added `claimedSpeechCue = createEventDeduper(SPEECH_CLAIM_TTL_MS)`; the `hermes:ambient:claim` handler now takes `event`, denies the HUD-displaced hidden app window, and routes `speak:` keys to the long-TTL deduper.

## How to Test

Automated, from `apps/desktop`:

1. `npx vitest run electron/ambient-claim.test.ts electron/event-dedupe.test.ts` — 12 passed
2. `npx tsc -p tsconfig.electron.json --noEmit` — clean
3. `npx eslint electron/ambient-claim.ts electron/ambient-claim.test.ts electron/main.ts` — clean
4. `npx vitest run --project electron` — 1966 passed

On the full electron project, 38 tests fail on my Windows 11 machine both with and without this patch. I confirmed they are environmental by stashing the change and re-running the suite against the same base: POSIX file-mode assertions (`0o700` vs Windows defaults), darwin-only TCC path tests, and ssh control-socket tests, none of which touch ambient cues. The failing-set diff between the baseline and patched runs was a single line, `wsl-path-bridge-gate.test.ts`, which is flaky under full-suite parallelism — it passes 3/3 when run alone with the patch applied.

Manual repro, for a reviewer to confirm on the desktop app (`npm run dev` from `apps/desktop`; note that `electron/main.ts` edits need a `dev` restart):

1. Voice settings → enable "Read replies aloud"
2. Open an active chat, enter HUD mode (`Ctrl+Shift+H`)
3. Send a prompt from the HUD
4. Listen after the first playback completes — before the patch the message could replay; it should now play once

To watch the arbitration directly: `npm run profile:main` opens `--inspect=9229`, attach with `{"type":"node","request":"attach","port":9229}` and breakpoint the `hermes:ambient:claim` handler to see `fromHud` / `senderDisplacedByHud` per window.

I have not run that manual loop myself — my verification is the automated suites above plus the reasoning about the hidden-window throttle. Worth a reviewer's ears before merge.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — found #99810 on the same issue; see the comparison above
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run.** This change is confined to the Electron main process and touches no Python; the JS/TS suites above are the relevant coverage
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11 (the platform on the issue) — automated suites only; the manual audio repro is noted above as unrun

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal main-process behavior with comments at both call sites
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the arbitration is pure and platform-independent; the throttling that triggers the bug is Chromium's hidden-window behavior, not Windows-specific, so the fix applies on all platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no IPC signature or renderer API change

🤖 Generated with [Claude Code](https://claude.com/claude-code)
