### PR TITLE
fix(browser): claim the Chrome-fallback socket dir before using it

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1357,6 +1357,10 @@ def _run_chrome_fallback_command(
 
     task_socket_dir = os.path.join(_socket_safe_tmpdir(), f"agent-browser-{tmp_session}")
     os.makedirs(task_socket_dir, mode=0o700, exist_ok=True)
+    # Claim the dir before using it: another hermes process's orphan reaper
+    # rmtree's any agent-browser-* dir in the shared tmpdir that carries no
+    # live owner, which otherwise deletes this one mid-command.
+    _write_owner_pid(task_socket_dir, tmp_session)
     browser_env = _build_browser_env()
     browser_env["AGENT_BROWSER_SOCKET_DIR"] = task_socket_dir
     browser_env["PATH"] = _merge_browser_path(browser_env.get("PATH", ""))


### PR DESCRIPTION
`_run_chrome_fallback_command` creates `agent-browser-<session>` in the **shared** tmpdir and then opens `_stdout_<cmd>` / `_stderr_<cmd>` inside it, but it never writes the `<session>.owner_pid` marker that every other socket-dir user writes.

`_reap_orphaned_browser_sessions` globs that same shared tmpdir and `shutil.rmtree`s any `agent-browser-*` dir that has no live owner **and** is not in the calling process's `_active_sessions`. A second hermes process — or a parallel test worker — therefore deletes the directory in the window between `os.makedirs` (browser_tool.py:1359) and the first `os.open` (browser_tool.py:1377), and the command dies with:

```
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/agent-browser-h_cfb_<hash>/_stdout_open'
```

The fix is one call: claim the directory right after creating it, so another process's reaper sees a live owner and skips it.

### Repro (deterministic, on current main)

Run the fallback test while a second process sweeps in a loop:

```python
# sweeper.py
import tools.browser_tool as bt, time
end = time.time() + 30
while time.time() < end:
    bt._reap_orphaned_browser_sessions()
    time.sleep(0.005)
```

```
pytest tests/tools/test_browser_lightpanda.py::TestChromeFallback::test_chrome_fallback_injects_required_sandbox_args
```

| | result |
|---|---|
| quiet, before fix | 5/5 pass |
| concurrent sweeper, before fix | **5/5 fail** |
| concurrent sweeper, after fix | 6/6 pass |

### Why it matters beyond CI

This is how the test flaked on #100269 — with many workers sharing `/tmp`, whichever worker runs a reaper test can delete another worker's live socket dir. But it is not test-only: two hermes processes on one machine (a CLI session plus the gateway, say) hit the same window, and the user sees a Chrome fallback fail with a missing-file error that looks like a broken install.

93 tests pass across the browser lightpanda / orphan-reaper / cleanup / supervisor / hardening suites; `ruff` clean.
