### PR TITLE
fix(doctor): recognize mem0 OSS/self-hosted modes without an API key

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -3310,10 +3310,28 @@ def run_doctor(args):
         try:
             from plugins.memory.mem0 import _load_config as _load_mem0_config
             mem0_cfg = _load_mem0_config()
+            mem0_mode = mem0_cfg.get("mode", "platform")
             mem0_key = mem0_cfg.get("api_key", "")
-            if mem0_key:
+            mem0_host = mem0_cfg.get("host", "")
+            if mem0_mode == "oss":
+                # OSS (local) mode needs no API key — mirror the provider's
+                # is_available(): active when a vector store is configured.
+                if mem0_cfg.get("oss", {}).get("vector_store"):
+                    check_ok("Mem0 OSS (local) mode configured")
+                    check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+                else:
+                    _fail_and_issue(
+                        "Mem0 OSS mode incomplete",
+                        "run: hermes memory setup",
+                        "Mem0 is in OSS mode but no vector store is configured",
+                        issues,
+                    )
+            elif mem0_key:
                 check_ok("Mem0 API key configured")
                 check_info(f"user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
+            elif mem0_host:
+                check_ok("Mem0 self-hosted endpoint configured")
+                check_info(f"host={mem0_host}  user_id={mem0_cfg.get('user_id', '?')}  agent_id={mem0_cfg.get('agent_id', '?')}")
             else:
                 _fail_and_issue(
                     "Mem0 API key not set",

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -340,6 +340,42 @@ class TestDoctorMemoryProviderSection:
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
 
+    def test_mem0_oss_mode_shows_ok_without_api_key(self, monkeypatch, tmp_path):
+        """OSS (local) mode needs no API key — doctor must not flag it."""
+        import json
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        (home / "mem0.json").write_text(json.dumps({
+            "mode": "oss",
+            "user_id": "hermes-user",
+            "agent_id": "hermes",
+            "oss": {
+                "llm": {"provider": "ollama", "config": {"model": "qwen3:4b"}},
+                "embedder": {"provider": "ollama", "config": {"model": "nomic-embed-text", "embedding_dims": 768}},
+                "vector_store": {"provider": "qdrant", "config": {"path": "mem0_qdrant"}},
+            },
+        }))
+        # _load_config reads $HERMES_HOME/mem0.json — not the doctor_mod attribute
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Memory Provider" in out
+        assert "Mem0 OSS (local) mode configured" in out
+        assert "API key not set" not in out
+
+    def test_mem0_oss_mode_without_vector_store_shows_fail(self, monkeypatch, tmp_path):
+        """OSS mode without a vector store is incomplete and must fail."""
+        import json
+        home = self._make_hermes_home(tmp_path, provider="mem0")
+        (home / "mem0.json").write_text(json.dumps({"mode": "oss", "oss": {}}))
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 OSS mode incomplete" in out
+
+    def test_mem0_platform_mode_without_key_shows_fail(self, monkeypatch, tmp_path):
+        """Cloud (platform) mode without a key still fails loudly."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
+        assert "Mem0 API key not set" in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()


### PR DESCRIPTION
## Summary

`hermes doctor` reports **"Mem0 API key not set"** for a correctly configured mem0 install in **OSS mode** (local Ollama + embedded Qdrant), where no API key exists by design. The check only tested `api_key` and ignored the configured mode entirely, sending OSS users toward a bogus fix (setting `MEM0_API_KEY` or re-running the setup wizard, which would flip them back to cloud mode).

The fix mirrors the provider's own `is_available()` logic (`plugins/memory/mem0/__init__.py`):

| Configuration | Before | After |
|---|---|---|
| `mode: oss` + vector store configured | ✗ "Mem0 API key not set" | ✓ "Mem0 OSS (local) mode configured" |
| `mode: oss` without vector store | ✗ "Mem0 API key not set" | ✗ "Mem0 OSS mode incomplete" + setup hint |
| `host` set (self-hosted HTTP endpoint) | ✗ "Mem0 API key not set" | ✓ "Mem0 self-hosted endpoint configured" |
| cloud (platform) mode without a key | ✗ "Mem0 API key not set" | ✗ unchanged |

## Reproduction

With `memory.provider: mem0` and a `mem0.json` in OSS mode (Ollama LLM + embedder, embedded Qdrant vector store), run `hermes doctor` → the Memory Provider section shows ✗ even though the provider works. Verified end-to-end that this is a false positive: a fresh agent session with the same config successfully calls `mem0_search` and returns stored memories.

## Test Plan

- [x] New tests in `tests/hermes_cli/test_doctor.py`:
  - OSS mode with vector store → doctor reports OK, no API key demanded
  - OSS mode without vector store → doctor fails with a setup hint
  - cloud mode without a key → failure unchanged
- [x] Full `tests/hermes_cli/test_doctor.py`: 71 passed
- [x] Manual: `hermes doctor` on a real OSS install now shows `✓ Mem0 OSS (local) mode configured` (user_id / agent_id echoed); cloud-mode behavior untouched

Note: tests set `HERMES_HOME` via `monkeypatch.setenv` because the mem0 plugin's `_load_config()` resolves `$HERMES_HOME/mem0.json`, not the `doctor_mod.HERMES_HOME` attribute.
