### PR TITLE
feat(discord): allow send_message to DM a user by ID

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -909,6 +909,13 @@ class TestParseTargetRef:
             ("discord", "-1001234567890:17585", "-1001234567890", "17585"),
             ("discord", "1003724596514", "1003724596514", None),
             ("discord", "  123456:789  ", "123456", "789"),
+            # Discord user targets. A bare snowflake stays a CHANNEL (above):
+            # Discord user and channel IDs are indistinguishable, so only these
+            # explicit forms may address a person.
+            ("discord", "user:123456789012345678", "user:123456789012345678", None),
+            ("discord", "<@123456789012345678>", "user:123456789012345678", None),
+            ("discord", "<@!123456789012345678>", "user:123456789012345678", None),
+            ("discord", "  user:123456789012345678  ", "user:123456789012345678", None),
             # Matrix: room id, room:thread-event, user MXID
             ("matrix", "!HLOQwxYGgFPMPJUSNR:matrix.org:$thread123:matrix.org",
              "!HLOQwxYGgFPMPJUSNR:matrix.org", "$thread123:matrix.org"),

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -36,6 +36,11 @@ _WEIXIN_TARGET_RE = re.compile(r"^\s*((?:wxid|gh|v\d+|wm|wb)_[A-Za-z0-9_-]+|[A-Z
 _YUANBAO_TARGET_RE = re.compile(r"^\s*((?:group|direct):[^:]+)\s*$")
 # Discord snowflake IDs are numeric, same regex pattern as Telegram topic targets.
 _NUMERIC_TOPIC_RE = _TELEGRAM_TOPIC_TARGET_RE
+# Discord user targets must be written explicitly. A Discord user ID and a
+# channel ID are both snowflakes, so unlike Slack's "U..." IDs there is no way
+# to tell them apart by shape. A bare number therefore stays a channel, exactly
+# as before; only these unambiguous forms address a person.
+_DISCORD_USER_TARGET_RE = re.compile(r"^\s*(?:user:\s*(\d+)|<@!?(\d+)>)\s*$", re.IGNORECASE)
 # Platforms that address recipients by phone number and accept E.164 format
 # (with a leading '+'). Without this, "+15551234567" fails the isdigit() check
 # below and falls through to channel-name resolution, which has no way to
@@ -487,6 +492,19 @@ def _handle_send(args):
                 return json.dumps(_resolve_err)
             chat_id = _resolved
 
+    # Discord: resolve user targets to DM channel IDs before sending.
+    # _parse_target_ref emits ``user:<id>`` only for the explicit forms; a bare
+    # snowflake is deliberately left as a channel, since guessing wrong would
+    # deliver a private message to a channel.
+    if platform_name == "discord" and chat_id and str(chat_id).startswith("user:"):
+        from model_tools import _run_async
+        _resolved, _resolve_err = _run_async(
+            _resolve_discord_user_target(pconfig.token, str(chat_id))
+        )
+        if _resolve_err:
+            return json.dumps(_resolve_err)
+        chat_id = _resolved
+
     try:
         from model_tools import _run_async
         send_kwargs = {
@@ -554,6 +572,9 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         if match:
             return match.group(1), match.group(2), True
     if platform_name == "discord":
+        match = _DISCORD_USER_TARGET_RE.fullmatch(target_ref)
+        if match:
+            return f"user:{match.group(1) or match.group(2)}", None, True
         match = _NUMERIC_TOPIC_RE.fullmatch(target_ref)
         if match:
             return match.group(1), match.group(2), True
@@ -1898,6 +1919,63 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,
 # wired via standalone_sender_fn and reached through _registry_standalone_send. #41112.
+
+
+async def _resolve_discord_user_target(token, chat_id):
+    """Resolve a Discord user target to a DM channel ID.
+
+    ``chat_id`` may be a channel ID -- returned unchanged -- or an internal
+    ``user:<snowflake>`` target emitted by :func:`_parse_target_ref`. Discord's
+    message endpoint only accepts channel IDs, so a user target is opened as a
+    DM through ``POST /users/@me/channels``. Discord returns the already-open
+    DM channel when one exists, so this is safe to call repeatedly and needs no
+    cached directory of prior conversations.
+
+    Returns ``(chat_id, None)`` on success or ``(None, error_dict)`` on failure.
+    """
+    if not str(chat_id).startswith("user:"):
+        return chat_id, None
+    user_id = str(chat_id)[len("user:"):].strip()
+    if not user_id.isdigit():
+        return None, {
+            "error": f"Invalid Discord user target '{chat_id}': expected a numeric user ID."
+        }
+    try:
+        import aiohttp
+    except ImportError:
+        return None, {"error": "aiohttp not installed. Run: pip install aiohttp"}
+    try:
+        from gateway.platforms.base import resolve_proxy_url, proxy_kwargs_for_aiohttp
+        _proxy = resolve_proxy_url()
+        _sess_kw, _req_kw = proxy_kwargs_for_aiohttp(_proxy)
+        headers = {
+            "Authorization": f"Bot {token}",
+            "Content-Type": "application/json",
+        }
+        async with aiohttp.ClientSession(**_sess_kw) as session:
+            async with session.post(
+                "https://discord.com/api/v10/users/@me/channels",
+                headers=headers,
+                json={"recipient_id": user_id},
+                **_req_kw,
+            ) as resp:
+                if resp.status >= 400:
+                    body = (await resp.text())[:200]
+                    return None, {
+                        "error": (
+                            f"Discord could not open a DM with user {user_id} "
+                            f"(HTTP {resp.status}): {body}"
+                        )
+                    }
+                data = await resp.json()
+        dm_channel_id = str((data or {}).get("id") or "")
+        if not dm_channel_id:
+            return None, {
+                "error": f"Discord returned no DM channel id for user {user_id}."
+            }
+        return dm_channel_id, None
+    except Exception as e:
+        return None, {"error": f"Failed to open Discord DM with user {user_id}: {e}"}
 
 
 async def _resolve_slack_user_target(token, chat_id):


### PR DESCRIPTION
## What does this PR do?

`send_message` can open a DM from a user target on Slack (`user:U...`) and Telegram (`@handle`), but not on Discord. `_parse_target_ref` matches Discord targets with `_NUMERIC_TOPIC_RE` only, so a Discord user ID is interpreted as a channel ID and the send fails:

```
Discord API error (404): {"message": "Unknown Channel", "code": 10003}
```

The only way to reach a person today is a target already in the cached channel directory. That directory lists DMs the bot has *observed*, so a freshly started gateway cannot DM anyone until that person messages it first — which makes unprompted delivery (a scheduled briefing, an alert) impossible on a cold start.

**Why this approach:** Discord user IDs and channel IDs are both snowflakes, so unlike Slack's `U...` IDs there is no way to tell them apart by shape. Auto-detecting would risk posting a private message into a channel, so a bare number deliberately keeps meaning "channel", exactly as before. Only explicit forms address a person:

```
discord:user:123456789012345678
discord:<@123456789012345678>
discord:<@!123456789012345678>
```

These parse to the same internal `user:<id>` target Slack already uses, and are resolved to a DM channel before the send. `POST /users/@me/channels` returns the already-open DM when one exists, so the call is idempotent and needs no cached state — which is what makes cold-start delivery work.

The mention forms are accepted because they are what a user naturally pastes from the Discord UI; the adapter's existing `_clean_discord_id` already normalises the same three shapes elsewhere.

## Related Issue

No existing issue found — I searched open PRs and issues for Discord DM/user-target work and found none. Happy to open one first if you'd prefer that order.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `tools/send_message_tool.py`
  - Added `_DISCORD_USER_TARGET_RE`, matching `user:<id>`, `<@id>`, `<@!id>` only.
  - `_parse_target_ref`: for `discord`, try the user form first and emit `user:<id>`; the existing `_NUMERIC_TOPIC_RE` branch is untouched, so bare snowflakes and `channel:thread` behave exactly as before.
  - Added `_resolve_discord_user_target(token, chat_id)`, mirroring `_resolve_slack_user_target` — same `(chat_id, None)` / `(None, error_dict)` contract, same proxy handling via `resolve_proxy_url` / `proxy_kwargs_for_aiohttp`. Non-`user:` targets pass through unchanged.
  - Call site: resolve Discord user targets to a DM channel ID immediately after the equivalent Slack block, before `_send_to_platform`.
- `tests/tools/test_send_message_tool.py`
  - Added the four target forms to the `_parse_target_ref` table.

## How to Test

1. `send_message` with `target: "discord:user:<a user id>"` (or `discord:<@id>`) — the bot opens a DM and delivers, including on a gateway that has never seen a message from that user.
2. Confirm no regression: `target: "discord:<channel id>"` still posts to the channel, and `discord:<channel id>:<thread id>` still targets the thread.
3. `pytest tests/tools/test_send_message_tool.py -k explicit_targets_round_trip`

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — **could not run in my environment**, see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (Darwin 25.6, arm64)

> **On the test run — please treat this as unverified.** The suite skips this file without `python-telegram-bot`, and the interpreter I had available was Python 3.14, which `requires-python = ">=3.11,<3.14"` excludes, so I could not stand up a faithful environment. What I did verify: the new and existing target forms against the regexes standalone (explicit forms → `user:<id>`; `1003724596514` → channel; `123456:789` → channel+thread; `user:abc` → no match), and that both modified files compile. **The resolver's HTTP path is unexercised** — a mocked-`aiohttp` test in the style of `TestSendDiscordThreadId` would be the right addition, and I'd welcome direction on whether you want that in this PR.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings on the new resolver) — the tool description already documents user targets generically
- [x] `cli-config.yaml.example` — N/A, no config keys
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] Cross-platform impact — N/A, pure string parsing plus one HTTPS call
- [x] Tool descriptions/schemas — no schema change; `target` already accepts platform-prefixed strings

