### PR TITLE
fix(cron): an explicit manual run must bypass unchanged-monitor suppression

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -5683,10 +5683,19 @@ def run_job(
                 f"Time: {_mon_now}"
             )
             return False, _mon_doc, _mon_alert, _mon.error
-        if not _mon.changed:
+        if not _mon.changed and not job.get("manual_run_at"):
             # Unchanged output — suppress the agent run entirely. Recorded
             # as a silent no_change tick (visible in the executions ledger
             # via this doc; SILENT_MARKER blocks delivery).
+            #
+            # An explicit manual fire is exempt (#100282): suppressing it
+            # made monitor jobs untestable — `hermes cron run <id>` returned
+            # [SILENT] without invoking the agent, and with
+            # cron.silent_fallback configured it delivered the fallback
+            # instead, which reads as "the research found nothing" rather
+            # than "the run never happened". Scheduled ticks keep normal
+            # suppression. trigger_job() stamps manual_run_at; the direct
+            # cronjob(action="run") path passes an ephemeral marker.
             logger.info(
                 "Job '%s': monitor output unchanged — suppressing agent run",
                 job_id,
@@ -5699,9 +5708,18 @@ def run_job(
                 f"**Status:** no_change (agent run suppressed)\n"
             )
             return True, _mon_doc, SILENT_MARKER, None
-        # Changed (or first run): inject the monitor context into the prompt
-        # through the existing per-run context seam and fall through to a
-        # normal agent run.
+        if not _mon.changed:
+            # Manual fire on unchanged output: run the prompt anyway, but say
+            # so in the log so an operator reading a monitor job's history can
+            # tell a forced run from a change-triggered one.
+            logger.info(
+                "Job '%s': monitor output unchanged, but this is a manual "
+                "run — executing the agent anyway (#100282)",
+                job_id,
+            )
+        # Changed (or first run, or manual force): inject the monitor context
+        # into the prompt through the existing per-run context seam and fall
+        # through to a normal agent run.
         _monitor_context = _mon.context_block
         if _monitor_context:
             extra_prompt = (

--- a/tests/cron/test_monitor_kind.py
+++ b/tests/cron/test_monitor_kind.py
@@ -336,6 +336,137 @@ def test_changed_output_injects_diff(hermes_env, monkeypatch):
     assert "state B" in prompt  # new output included verbatim
 
 
+# ---------------------------------------------------------------------------
+# Manual force-run vs monitor suppression (#100282)
+#
+# An explicit `hermes cron run <id>` was still suppressed by unchanged
+# monitor output: it returned [SILENT] without invoking the agent, and with
+# cron.silent_fallback configured it delivered the fallback instead — which
+# reads as "the research found nothing" rather than "the run never happened".
+#
+# These stub check_monitor() rather than running a real monitor script, so
+# they exercise the gate itself and stay platform-independent (the
+# script-driven tests above need a POSIX shell).
+# ---------------------------------------------------------------------------
+
+
+def _stub_unchanged_monitor(monkeypatch):
+    """Force check_monitor() to report a healthy, UNCHANGED source.
+
+    run_job imports check_monitor from cron.monitor at call time, so the
+    patch has to land on the source module.
+    """
+    import cron.monitor as monitor_mod
+    from cron.monitor import MonitorOutcome
+
+    monkeypatch.setattr(
+        monitor_mod,
+        "check_monitor",
+        lambda _job: MonitorOutcome(
+            ok=True, changed=False, context_block="MONITOR OUTPUT\nstate A"
+        ),
+    )
+
+
+def _plain_monitor_job(hermes_env):
+    """A monitor job record — the monitor source itself is stubbed out."""
+    from cron.jobs import create_job
+
+    _write_script(hermes_env, "mon.sh", "echo 'state A'\n")
+    return create_job(
+        prompt="Summarize what changed",
+        schedule="every 5m",
+        monitor_script="mon.sh",
+        deliver="local",
+    )
+
+
+def test_scheduled_tick_still_suppressed_when_unchanged(hermes_env, monkeypatch):
+    """Control: without a manual marker, unchanged output still suppresses."""
+    from cron.scheduler import SILENT_MARKER, run_job
+
+    job = _plain_monitor_job(hermes_env)
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    _stub_unchanged_monitor(monkeypatch)
+
+    success, doc, final, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final == SILENT_MARKER
+    assert "no_change" in doc
+    assert observed["agent_runs"] == 0
+
+
+def test_manual_run_at_bypasses_unchanged_suppression(hermes_env, monkeypatch):
+    """trigger_job() stamps manual_run_at; run_job must honor it (#100282)."""
+    from cron.scheduler import SILENT_MARKER, run_job
+
+    job = dict(_plain_monitor_job(hermes_env))
+    job["manual_run_at"] = "2026-09-01T12:00:00"
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    _stub_unchanged_monitor(monkeypatch)
+
+    success, doc, final, error = run_job(job)
+
+    assert success is True
+    assert error is None
+    assert final != SILENT_MARKER
+    assert "no_change" not in doc
+    assert observed["agent_runs"] == 1, (
+        "an explicit manual run must invoke the agent despite unchanged output"
+    )
+
+
+def test_manual_run_still_injects_monitor_context(hermes_env, monkeypatch):
+    """A forced run should still see the monitor output in its prompt."""
+    from cron.scheduler import run_job
+
+    job = dict(_plain_monitor_job(hermes_env))
+    job["manual_run_at"] = "2026-09-01T12:00:00"
+    observed: dict = {}
+    _install_agent_stubs(monkeypatch, observed)
+    _stub_unchanged_monitor(monkeypatch)
+
+    run_job(job)
+
+    assert observed["agent_runs"] == 1
+    assert "state A" in observed["prompts"][0]
+
+
+def test_trigger_job_stamps_the_marker_run_job_reads(hermes_env):
+    """Wiring: the field trigger_job() writes is the one the gate checks."""
+    from cron.jobs import get_job, trigger_job
+
+    job = _plain_monitor_job(hermes_env)
+    trigger_job(job["id"])
+
+    assert get_job(job["id"]).get("manual_run_at"), (
+        "trigger_job must stamp manual_run_at for the monitor gate to honor"
+    )
+
+
+def test_direct_run_path_passes_an_ephemeral_manual_marker():
+    """The cronjob(action='run') path must mark the fire WITHOUT persisting.
+
+    Persisting it would make every later scheduled tick bypass suppression
+    too, so the marker is applied to a shallow copy only.
+    """
+    import inspect
+
+    from tools import cronjob_tools
+
+    source = inspect.getsource(cronjob_tools._run_claimed_job)
+    assert "_manual_job = dict(job)" in source, "must copy, not mutate the claim"
+    assert '"manual_run_at"' in source
+    # The copy — not the original claim — is what gets executed.
+    assert "run_one_job(\n                    _manual_job" in source or (
+        "run_one_job(" in source and "_manual_job," in source
+    )
+
+
 def test_hash_persists_across_scheduler_restart(hermes_env, monkeypatch):
     """Suppression state must survive a scheduler restart (module reload)."""
     import importlib

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1088,8 +1088,20 @@ def _run_claimed_job(
 
         try:
             try:
+                # Mark this fire as manual so the monitor gate in run_job()
+                # does not mistake it for a scheduled tick and suppress it on
+                # unchanged output (#100282). trigger_job() stamps
+                # manual_run_at persistently; this path is an explicit
+                # cronjob(action="run"), so the marker is EPHEMERAL — a
+                # shallow copy only, never written back to the jobs store and
+                # never touching monitor_state.
+                _manual_job = dict(job)
+                if not _manual_job.get("manual_run_at"):
+                    from cron.jobs import _hermes_now as _cron_now
+
+                    _manual_job["manual_run_at"] = _cron_now().isoformat()
                 processed = run_one_job(
-                    job, adapters=adapters, loop=gateway_loop,
+                    _manual_job, adapters=adapters, loop=gateway_loop,
                     extra_prompt=extra_prompt,
                 )
             finally:


### PR DESCRIPTION
Fixes #100282

## Problem

An explicit `hermes cron run <job_id>` was still suppressed by an unchanged monitor source. The gate in `run_job()` converted the fire to `[SILENT]` without invoking the agent, and with `cron.silent_fallback` configured it delivered the fallback instead — which reads as *"the research returned no results"* rather than *"the run never happened"*.

Net effect: monitor jobs were untestable. You could not exercise a monitor job's prompt or delivery without first mutating the monitored source.

Both manual-fire paths were affected, exactly as the report diagnoses:

1. `cron/jobs.py::trigger_job()` **stamped `manual_run_at`**, but the monitor gate in `run_job()` never looked at it.
2. `tools/cronjob_tools.py::_run_claimed_job()` passed the claimed snapshot straight to `run_one_job()` **with no manual marker at all**.

## Fix

Taken directly from the issue's minimal-fix sketch:

- **`run_job()`** suppresses unchanged output only when `manual_run_at` is absent: `if not _mon.changed and not job.get("manual_run_at")`. Scheduled ticks keep normal suppression.
- **`_run_claimed_job()`** executes an **ephemeral shallow copy** carrying `manual_run_at` — never written back to the jobs store, never touching `monitor_state`, so later scheduled ticks are unaffected.
- A forced run still receives the monitor context block in its prompt, and logs that it ran despite unchanged output so a forced run is distinguishable from a change-triggered one in the job's history.

## Verification

5 new tests in `tests/cron/test_monitor_kind.py`, stubbing `check_monitor` so they exercise the gate itself and run on any platform:

- **control**: no marker + unchanged output → still `SILENT_MARKER`, `no_change` doc, **0 agent runs**
- `manual_run_at` + unchanged output → agent invoked, no `SILENT_MARKER`, no `no_change`
- forced run still gets the monitor context in its prompt
- `trigger_job()` really stamps the field the gate reads (wiring, via the real function)
- the direct-run path copies rather than mutating the claim (so the marker can't persist)

5/5 pass. The 2 failures elsewhere in that file (`test_hash_persists_across_scheduler_restart`, `test_monitor_script_failure_is_error_not_change`) are **pre-existing on this Windows host** — the script-driven tests need a POSIX shell (`mon.sh` exits 1) — reproduced with my change stashed. My new tests deliberately avoid that dependency.