### PR TITLE
fix(a2a): honor configured reply timeout in watchdog

### DIFF
--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -60,7 +60,7 @@ from . import protocol, security
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 9900
-_ORPHAN_TIMEOUT = 300  # seconds before a pending task is considered orphaned
+_MIN_ORPHAN_TIMEOUT = 300  # preserve the existing five-minute floor
 _WATCHDOG_INTERVAL = 60  # seconds between orphaned task watchdog runs
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
@@ -72,6 +72,16 @@ def _reply_timeout() -> float:
         return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
     except (ValueError, TypeError):
         return 300.0
+
+
+def _orphan_timeout() -> float:
+    """Keep pending tasks alive through the configured reply deadline.
+
+    The watchdog runs independently from request waiters, so add one watchdog
+    interval of grace. Otherwise a reply timeout above five minutes is
+    ineffective because the task is marked failed at the old fixed deadline.
+    """
+    return max(float(_MIN_ORPHAN_TIMEOUT), _reply_timeout() + _WATCHDOG_INTERVAL)
 
 
 def _default_agent_name() -> str:
@@ -473,8 +483,9 @@ class A2AAdapter(BasePlatformAdapter):
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
-                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
+                orphan_timeout = _orphan_timeout()
+                for tid in self.tasks.fail_orphans(orphan_timeout):
+                    logger.warning("A2A: orphaned task %s marked failed (timeout %.0fs)", tid, orphan_timeout)
                     protocol.metrics.tasks_failed += 1
             except Exception:
                 logger.debug("A2A: watchdog error", exc_info=True)

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -36,6 +36,26 @@ def _free_port() -> int:
 
 
 # --------------------------------------------------------------------------
+# Timeouts
+# --------------------------------------------------------------------------
+
+class TestA2ATimeouts:
+    def test_orphan_timeout_never_preempts_configured_reply_timeout(self, monkeypatch):
+        from plugins.platforms.a2a import adapter
+
+        monkeypatch.setenv("A2A_REPLY_TIMEOUT", "900")
+        assert adapter._orphan_timeout() >= (
+            adapter._reply_timeout() + adapter._WATCHDOG_INTERVAL
+        )
+
+    def test_orphan_timeout_keeps_existing_five_minute_floor(self, monkeypatch):
+        from plugins.platforms.a2a import adapter
+
+        monkeypatch.setenv("A2A_REPLY_TIMEOUT", "1")
+        assert adapter._orphan_timeout() >= adapter._MIN_ORPHAN_TIMEOUT
+
+
+# --------------------------------------------------------------------------
 # Security
 # --------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- derive the A2A orphan watchdog deadline from `A2A_REPLY_TIMEOUT`
- keep the existing five-minute minimum while allowing configured long-running replies
- add one watchdog interval of grace so the watchdog cannot race the request waiter at the same deadline
- add regression coverage for long reply timeouts and the existing minimum

## Problem

`A2A_REPLY_TIMEOUT` can be configured above 300 seconds, but the orphan watchdog always failed pending tasks after a fixed 300 seconds. A task that legitimately needed longer than five minutes could therefore be marked failed before the configured reply deadline and later still produce a response.

## Related work

- #90158 covers per-route timeouts, but its default/root route still falls back to the fixed orphan floor rather than `A2A_REPLY_TIMEOUT`.
- #91686 is the broader config-native alternative. This PR intentionally keeps the existing configuration surface and fixes only the observed watchdog/reply-deadline contradiction with a small tested diff.

## Verification

- `uv run --with pytest pytest -q tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py tests/plugins/test_a2a_schema_registration.py tests/tools/test_a2a_reason_roundtrip.py`
- `uv run python -m py_compile plugins/platforms/a2a/adapter.py tests/plugins/test_a2a_plugin.py`
- `ruff check plugins/platforms/a2a/adapter.py tests/plugins/test_a2a_plugin.py`
