### PR TITLE
fix(desktop): show named custom provider on the model-pill tooltip

### DIFF
--- a/apps/desktop/src/app/chat/composer/model-pill.test.tsx
+++ b/apps/desktop/src/app/chat/composer/model-pill.test.tsx
@@ -80,6 +80,25 @@ describe('ModelPill pinned-override badge', () => {
   })
 })
 
+describe('ModelPill named custom provider tooltip (#100250)', () => {
+  it('uses the durable custom:<key> identity, not the billing class', () => {
+    render(
+      <ModelPill
+        disabled={false}
+        model={modelState({
+          model: 'deepseek-v4-pro',
+          modelMenuContent: <div />,
+          provider: 'custom:b.ai'
+        })}
+      />
+    )
+
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe(
+      'Model · custom:b.ai: deepseek-v4-pro'
+    )
+  })
+})
+
 describe('ModelPill per-surface model label', () => {
   it('shows the chat-bar model even when the primary global differs', () => {
     setCurrentModel('primary/model')

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11972,6 +11972,21 @@ def test_session_info_includes_session_title(monkeypatch):
     assert info["title"] == "Dashboard title"
 
 
+def test_session_info_reports_named_custom_provider_not_billing_class():
+    """#100250: named custom entries resolve to billing class ``custom``.
+    session.info must carry the durable identity so Desktop's model pill
+    tooltip is not ``Model · custom: …``.
+    """
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="deepseek-v4-pro",
+        provider="custom",
+        requested_provider="custom:b.ai",
+    )
+    info = server._session_info(agent, {"history": []})
+    assert info["provider"] == "custom:b.ai"
+
+
 def test_session_info_reports_pending_model_switch(monkeypatch):
     """A model queued mid-turn shows as the session's model in session.info, so
     the end-of-turn settle doesn't blip the UI back to the still-live old model

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7505,6 +7505,35 @@ def _project_info_for_cwd(cwd: str) -> dict | None:
         return None
 
 
+def _session_info_provider(agent, mirrored_provider: object = None) -> str:
+    """Provider identity for session.info — never the bare billing class ``custom``.
+
+    Named ``providers:`` entries resolve to billing class ``custom`` on the
+    agent. Desktop's model-pill tooltip prints that field, so users saw
+    ``Model · custom: <model>`` instead of the config key (#100250). Prefer
+    ``requested_provider`` (the durable identity) and heal a leftover bare
+    ``custom`` through ``canonical_custom_identity``.
+    """
+    mirrored = str(mirrored_provider or "").strip()
+    resolved = str(getattr(agent, "provider", "") or "").strip()
+    requested = str(getattr(agent, "requested_provider", "") or "").strip()
+    raw = mirrored or resolved
+    if raw.lower() != "custom":
+        return raw
+    if requested and requested.lower() != "custom":
+        return requested
+    try:
+        from hermes_cli.runtime_provider import canonical_custom_identity
+
+        healed = canonical_custom_identity(
+            config_provider=requested or None,
+            model=getattr(agent, "model", None),
+        )
+    except Exception:
+        healed = None
+    return healed or raw
+
+
 def _session_info(agent, session: dict | None = None) -> dict:
     if session is None:
         for candidate in _sessions.values():
@@ -7569,7 +7598,7 @@ def _session_info(agent, session: dict | None = None) -> dict:
     info: dict = {
         "model": pending_model or mirror.get("model", getattr(agent, "model", "")),
         "provider": pending_provider
-        or mirror.get("provider", getattr(agent, "provider", "")),
+        or _session_info_provider(agent, mirror.get("provider")),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",


### PR DESCRIPTION
## What does this PR do?

Named `providers:` entries resolve to billing class `custom` on the agent. Desktop's model-pill tooltip prints `session.info.provider`, so hovering showed `Model · custom: <model>` instead of the config key (e.g. `custom:b.ai`).

`_session_info` now prefers `requested_provider` when the resolved class is bare `custom`, and heals leftovers through `canonical_custom_identity`. The pill itself is unchanged; it already renders whatever identity the backend sends.

## Related Issue

Fixes #100250

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: `_session_info_provider()` for the durable identity
- `tests/test_tui_gateway_server.py`: regression for `custom:b.ai`
- `apps/desktop/src/app/chat/composer/model-pill.test.tsx`: tooltip aria-label uses `custom:<key>`

## How to Test

```text
cd /tmp/hermes-100250
uv run --extra dev python -m pytest tests/test_tui_gateway_server.py::test_session_info_reports_named_custom_provider_not_billing_class tests/test_tui_gateway_server.py::test_session_info_reports_pending_model_switch -q
# 2 passed

cd apps/desktop
npx vitest run src/app/chat/composer/model-pill.test.tsx
# 6 passed
```

Not runtime-tested against a named custom provider in a live Desktop window.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit + vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (tooltip string; covered by the aria-label test)
