### PR TITLE
fix(desktop): keep the chat scrollbar off the right-sidebar sash

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/renderer/main-placement-floor.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/main-placement-floor.test.tsx
@@ -96,3 +96,23 @@ describe('the main placement floor in the renderer', () => {
     expect(zoneWrapper('grp-tools')?.style.display).toBe('none')
   })
 })
+
+describe('vertical sash vs leading-pane scrollbar (#99867)', () => {
+  it('keeps the grab band entirely in the trailing pane', () => {
+    const tree = split('row', [
+      group(['sessions'], { id: 'grp-sessions' }),
+      group(['workspace'], { id: 'grp-main' })
+    ])
+
+    $layoutTree.set(tree)
+    render(<TreeSplit node={tree} root rootRow />)
+
+    const sashes = document.querySelectorAll('[data-sash-overlap="trailing"]')
+
+    expect(sashes.length).toBeGreaterThan(0)
+    for (const sash of sashes) {
+      expect(sash.className).toContain('w-[8px]')
+      expect(sash.className).not.toContain('-translate-x-[1px]')
+    }
+  })
+})

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx
@@ -648,14 +648,15 @@ function Sash({
     <div
       className={cn(
         'group absolute z-20 [-webkit-app-region:no-drag]',
-        // Asymmetric grab band: only 1px reaches into the leading pane so its
-        // edge-hugging 4px scrollbar stays clickable (the old centered 9px band
-        // swallowed it entirely — the pointer got col-resize instead of the
-        // thumb). The trailing side keeps a generous 7px reach; total grab
-        // width stays ~8px so the sash is no harder to hit.
-        horizontal ? 'inset-y-0 left-0 w-[8px] -translate-x-[1px]' : 'inset-x-0 top-0 h-[8px] -translate-y-[1px]',
+        // Grab band lives entirely in the trailing pane. A 1px overlap into
+        // the leading pane (the previous asymmetric band) still stole the
+        // Windows overlay-scrollbar hit target on the chat — only ~3px of
+        // thumb remained clickable (#99867). The sash stays 8px wide, all
+        // on the sidebar/tool side of the seam.
+        horizontal ? 'inset-y-0 left-0 w-[8px]' : 'inset-x-0 top-0 h-[8px]',
         disabled ? 'pointer-events-none' : horizontal ? 'cursor-col-resize' : 'cursor-row-resize'
       )}
+      data-sash-overlap="trailing"
       onDoubleClick={disabled ? undefined : onDoubleClick}
       onPointerDown={disabled ? undefined : onPointerDown}
       role="separator"


### PR DESCRIPTION
## What does this PR do?

The vertical pane sash used an 8px grab band that reached 1px into the leading pane so the sash stayed easy to hit. On Windows that 1px overlap sits on the chat overlay scrollbar: the thumb's hit target collapsed to about 3px, so scrolling the transcript fought the right-sidebar resize handle.

The sash stays 8px wide and now lives entirely in the trailing pane (the sidebar/tool side of the seam). The chat scrollbar keeps its full hit target.

## Related Issue

Fixes #99867

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/components/pane-shell/tree/renderer/tree-split.tsx`: drop `-translate-x-[1px]` / `-translate-y-[1px]` from the sash grab band
- `main-placement-floor.test.tsx`: assert the sash reports trailing-only overlap

## How to Test

```text
cd apps/desktop
npx vitest run src/components/pane-shell/tree/renderer/main-placement-floor.test.tsx
# 5 passed
```

Not click-tested on a Windows Desktop build (no Windows box in this environment).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (vitest). Windows click path not runtime-tested here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (hit-target CSS; no visual change except where the pointer changes to col-resize)
