### PR TITLE
fix(cron): queue bot-chat delivery for CLI-only owners

### DIFF
--- a/cron/bot_chat_delivery.py
+++ b/cron/bot_chat_delivery.py
@@ -1,0 +1,349 @@
+"""Durable cron delivery into canonical Bot Chat sessions.
+
+Bot Chat turns cannot start a second process while CLI/TUI/Desktop owns the
+same session: the active-session lease correctly rejects stale transcript
+writers. This module durably admits each completed cron output, attempts the
+canonical one-shot chat lane immediately when unowned, and retries retained
+records on later scheduler ticks (#99956).
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+try:
+    import fcntl
+except ImportError:
+    fcntl = None
+    try:
+        import msvcrt
+    except ImportError:
+        msvcrt = None
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.config import load_config
+
+logger = logging.getLogger(__name__)
+
+QUEUE_DIR_NAME = "bot_chat_delivery_queue"
+
+
+def _ensure_private_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    try:
+        path.chmod(0o700)
+    except OSError:
+        pass
+
+
+@contextlib.contextmanager
+def _file_lock(queue_dir: Path, name: str):
+    """Take one blocking cross-process lock inside *queue_dir*."""
+    _ensure_private_dir(queue_dir)
+    fh = open(queue_dir / name, "a+b")
+    try:
+        if os.name == "nt" and msvcrt:
+            fh.seek(0, os.SEEK_END)
+            if fh.tell() == 0:
+                fh.write(b"\0")
+                fh.flush()
+            fh.seek(0)
+            msvcrt.locking(fh.fileno(), msvcrt.LK_LOCK, 1)
+        elif fcntl:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+        yield
+    finally:
+        try:
+            if os.name == "nt" and msvcrt:
+                fh.seek(0)
+                msvcrt.locking(fh.fileno(), msvcrt.LK_UNLCK, 1)
+            elif fcntl:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+        finally:
+            fh.close()
+
+
+def _queue_dir(source_home: Path) -> Path:
+    return Path(source_home) / "cron" / QUEUE_DIR_NAME
+
+
+def _queue_delivery(job: dict, message: str, profile: str, source_home: Path) -> str:
+    """Atomically persist one turn before the scheduler acknowledges it."""
+    delivery_id = uuid.uuid4().hex
+    record = {
+        "id": delivery_id,
+        "job_id": str(job.get("id") or "?"),
+        "job_name": str(job.get("name") or job.get("id") or "?"),
+        "profile": str(profile or ""),
+        "message": message,
+        "created_at": time.time(),
+    }
+    queue_dir = _queue_dir(source_home)
+    with _file_lock(queue_dir, ".queue.lock"):
+        path = queue_dir / f"{time.time_ns():020d}-{delivery_id}.json"
+        tmp = path.with_suffix(f".json.{os.getpid()}.{uuid.uuid4().hex}.tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                json.dump(record, fh, ensure_ascii=False, sort_keys=True)
+                fh.flush()
+                os.fsync(fh.fileno())
+            os.replace(tmp, path)
+            if os.name != "nt":
+                dir_fd = os.open(queue_dir, os.O_RDONLY)
+                try:
+                    os.fsync(dir_fd)
+                finally:
+                    os.close(dir_fd)
+        finally:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+    return delivery_id
+
+
+def _target_home(profile: str, source_home: Path) -> Path:
+    if not profile:
+        return Path(source_home)
+    from hermes_cli.profiles import get_profile_dir
+
+    return get_profile_dir(profile)
+
+
+def _target_has_live_owner(profile: str, source_home: Path) -> Optional[bool]:
+    """Return whether the target Bot Chat is leased, or None if unknown."""
+    try:
+        target_home = _target_home(profile, source_home)
+        db_path = target_home / "state.db"
+        if not db_path.exists():
+            return False
+
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=db_path, read_only=True)
+        try:
+            row = db.get_session_by_title("Bot Chat")
+            if not row:
+                return False
+            session_id = str(row.get("id") or "")
+            try:
+                session_id = str(db.get_compression_tip(session_id) or session_id)
+            except Exception:
+                pass
+        finally:
+            db.close()
+
+        from hermes_cli.active_sessions import active_session_registry_snapshot
+
+        return any(
+            str(entry.get("session_id") or "") == session_id
+            for entry in active_session_registry_snapshot(registry_home=target_home)
+        )
+    except Exception:
+        logger.warning(
+            "Could not prove Bot Chat ownership for profile '%s'; retaining queued delivery",
+            profile or "(own)",
+            exc_info=True,
+        )
+        return None
+
+
+def _delivery_timeout() -> int:
+    try:
+        cfg = load_config()
+        value = int(cfg.get("cron", {}).get("bot_chat_delivery_timeout_seconds", 600))
+        return value if value > 0 else 600
+    except Exception:
+        return 600
+
+
+def _run_delivery(record: dict) -> Optional[str]:
+    """Run one already-durable record through the canonical one-shot CLI lane."""
+    profile = str(record.get("profile") or "")
+    job_id = str(record.get("job_id") or "?")
+    message = str(record.get("message") or "")
+
+    hermes_bin = shutil.which("hermes")
+    if hermes_bin:
+        argv = [hermes_bin]
+    else:
+        try:
+            import importlib.util
+
+            if importlib.util.find_spec("hermes_cli") is not None:
+                argv = [sys.executable, "-m", "hermes_cli.main"]
+            else:
+                return "bot-chat delivery failed: hermes CLI not resolvable"
+        except Exception:
+            return "bot-chat delivery failed: hermes CLI not resolvable"
+
+    env = os.environ.copy()
+    if profile:
+        argv += ["-p", profile]
+        env.pop("HERMES_HOME", None)
+
+    query_file = None
+    try:
+        with tempfile.NamedTemporaryFile(
+            "w",
+            encoding="utf-8",
+            suffix=".txt",
+            prefix="hermes-cron-botchat-",
+            delete=False,
+        ) as fh:
+            fh.write(message)
+            query_file = fh.name
+
+        argv += [
+            "chat",
+            "--in",
+            "~",
+            "-c",
+            "Bot Chat",
+            "--create-if-missing",
+            "-Q",
+            "--query-file",
+            query_file,
+        ]
+        result = subprocess.run(
+            argv,
+            capture_output=True,
+            text=True,
+            timeout=_delivery_timeout(),
+            env=env,
+            creationflags=windows_hide_flags(),
+        )
+        if result.returncode != 0:
+            tail = (result.stderr or result.stdout or "").strip()[-500:]
+            msg = (
+                f"bot-chat delivery to profile '{profile or '(own)'}' failed "
+                f"(exit {result.returncode})" + (f": {tail}" if tail else "")
+            )
+            logger.warning("Job '%s': %s", job_id, msg)
+            return msg
+        logger.info(
+            "Job '%s': delivered to Bot Chat of profile '%s'",
+            job_id,
+            profile or "(own)",
+        )
+        return None
+    except subprocess.TimeoutExpired:
+        msg = (
+            f"bot-chat delivery to profile '{profile or '(own)'}' timed out "
+            f"after {_delivery_timeout()}s (the bot's turn may still complete; "
+            "the durable record is retained for retry)"
+        )
+        logger.warning("Job '%s': %s", job_id, msg)
+        return msg
+    except Exception as exc:
+        msg = f"bot-chat delivery failed: {str(exc) or type(exc).__name__}"
+        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
+        return msg
+    finally:
+        if query_file:
+            try:
+                os.unlink(query_file)
+            except OSError:
+                pass
+
+
+def drain_queue(source_home: Path) -> tuple[int, Optional[str]]:
+    """Retry retained turns in order per target profile.
+
+    One blocked profile does not head-of-line block independent profiles.
+    """
+    delivered = 0
+    first_error: Optional[str] = None
+    blocked_profiles: set[str] = set()
+    queue_dir = _queue_dir(source_home)
+    if not queue_dir.exists():
+        return 0, None
+    with _file_lock(queue_dir, ".drain.lock"):
+        for path in sorted(queue_dir.glob("*.json")):
+            try:
+                record = json.loads(path.read_text(encoding="utf-8"))
+                if not isinstance(record, dict) or not record.get("message"):
+                    raise ValueError("invalid queued bot-chat delivery")
+            except Exception as exc:
+                msg = f"bot-chat delivery queue record unreadable: {path.name}: {exc}"
+                logger.error(msg)
+                first_error = first_error or msg
+                continue
+
+            profile = str(record.get("profile") or "")
+            if profile in blocked_profiles:
+                continue
+            owner = _target_has_live_owner(profile, source_home)
+            if owner is not False:
+                reason = (
+                    "target session has a live owner"
+                    if owner
+                    else "target ownership is unknown"
+                )
+                first_error = first_error or reason
+                blocked_profiles.add(profile)
+                continue
+
+            error = _run_delivery(record)
+            if error:
+                first_error = first_error or error
+                blocked_profiles.add(profile)
+                continue
+            try:
+                path.unlink()
+            except OSError as exc:
+                msg = f"delivered bot-chat queue record could not be acknowledged: {exc}"
+                logger.warning(msg)
+                first_error = first_error or msg
+                blocked_profiles.add(profile)
+                continue
+            delivered += 1
+    return delivered, first_error
+
+
+def deliver(job: dict, content: str, profile: str, source_home: Path) -> Optional[str]:
+    """Durably admit one cron output and attempt immediate ordered delivery.
+
+    Returns None once the output is on disk. A live owner does not fail the
+    job: the turn retries on later scheduler ticks after the owner releases.
+    """
+    job_id = job.get("id", "?")
+    job_name = job.get("name", job_id)
+    message = (
+        f'[Cronjob "{job_name}" output — scheduled job, not the user. '
+        f"Review it, act on anything that needs action, and summarize "
+        f"for the chat.]\n\n{content}"
+    )
+    try:
+        delivery_id = _queue_delivery(job, message, profile, Path(source_home))
+    except Exception as exc:
+        msg = (
+            f"bot-chat delivery could not be durably queued: "
+            f"{str(exc) or type(exc).__name__}"
+        )
+        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
+        return msg
+
+    delivered, deferred_reason = drain_queue(Path(source_home))
+    if deferred_reason:
+        logger.info(
+            "Job '%s': Bot Chat delivery %s admitted; queue remains pending (%s)",
+            job_id,
+            delivery_id,
+            deferred_reason,
+        )
+    elif delivered:
+        logger.info("Job '%s': durably queued Bot Chat delivery completed", job_id)
+    return None

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2611,124 +2611,22 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
     }
 
 
-def _get_bot_chat_delivery_timeout() -> int:
-    """Timeout for one bot-chat delivery turn (the target bot runs a full
-    agent turn on the injected output, so this is minutes, not seconds).
-
-    ``cron.bot_chat_delivery_timeout_seconds`` in config.yaml; default 600.
-    """
-    try:
-        cfg = load_config()
-        value = int(cfg.get("cron", {}).get("bot_chat_delivery_timeout_seconds", 600))
-        return value if value > 0 else 600
-    except Exception:
-        return 600
-
-
 def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]:
-    """Deliver job output into a profile's canonical Bot Chat as an inbound turn.
+    """Durably admit a cron output for delivery to a canonical Bot Chat.
 
-    Runs ``hermes [-p <profile>] chat --in ~ -c "Bot Chat" --create-if-missing
-    -Q --query-file <tmp>`` — the exact lane Bot Mode agent-to-agent messages
-    use, so the adopt-before-mint canonical-session rules apply and the target
-    bot receives the output as a real user-role message it can act on.
-    Alternation-safe by construction: this is an inbound turn on the chat
-    command lane, not a transcript splice.
-
-    ``profile`` is ``""`` for the job's own profile (subprocess inherits this
-    scheduler's HERMES_HOME) or a validated local profile name.  Returns None
-    on success or an error string for ``last_delivery_error``.
+    A live CLI/TUI/Desktop owner of that session must not fail the job
+    (#99956): the turn is queued and retried after the owner releases.
     """
-    import shutil as _shutil
-    import tempfile
+    from cron.bot_chat_delivery import deliver
 
-    job_id = job.get("id", "?")
-    job_name = job.get("name", job_id)
+    return deliver(job, content, profile, _get_hermes_home())
 
-    hermes_bin = _shutil.which("hermes")
-    if hermes_bin:
-        argv = [hermes_bin]
-    else:
-        try:
-            import importlib.util as _ilu
 
-            if _ilu.find_spec("hermes_cli") is not None:
-                argv = [sys.executable, "-m", "hermes_cli.main"]
-            else:
-                return "bot-chat delivery failed: hermes CLI not resolvable"
-        except Exception:
-            return "bot-chat delivery failed: hermes CLI not resolvable"
+def _drain_bot_chat_delivery_queue() -> tuple[int, Optional[str]]:
+    """Retry bot-chat turns retained by earlier deliveries."""
+    from cron.bot_chat_delivery import drain_queue
 
-    env = os.environ.copy()
-    if profile:
-        argv += ["-p", profile]
-        # -p owns profile resolution in the child; a leftover HERMES_HOME
-        # from THIS scheduler's profile must not shadow it.
-        env.pop("HERMES_HOME", None)
-
-    # The prefix tells the receiving bot this is scheduled output, not the
-    # human typing — mirrors the Bot Mode sender-attribution convention.
-    message = (
-        f'[Cronjob "{job_name}" output — scheduled job, not the user. '
-        f"Review it, act on anything that needs action, and summarize "
-        f"for the chat.]\n\n{content}"
-    )
-
-    query_file = None
-    try:
-        with tempfile.NamedTemporaryFile(
-            "w", encoding="utf-8", suffix=".txt", prefix="hermes-cron-botchat-",
-            delete=False,
-        ) as fh:
-            fh.write(message)
-            query_file = fh.name
-
-        argv += [
-            "chat", "--in", "~", "-c", "Bot Chat", "--create-if-missing",
-            "-Q", "--query-file", query_file,
-        ]
-
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=_get_bot_chat_delivery_timeout(),
-            env=env,
-            creationflags=windows_hide_flags(),
-        )
-        if result.returncode != 0:
-            tail = (result.stderr or result.stdout or "").strip()[-500:]
-            msg = (
-                f"bot-chat delivery to profile "
-                f"'{profile or '(own)'}' failed (exit {result.returncode})"
-                + (f": {tail}" if tail else "")
-            )
-            logger.warning("Job '%s': %s", job_id, msg)
-            return msg
-        logger.info(
-            "Job '%s': delivered to Bot Chat of profile '%s'",
-            job_id, profile or "(own)",
-        )
-        return None
-    except subprocess.TimeoutExpired:
-        msg = (
-            f"bot-chat delivery to profile '{profile or '(own)'}' timed out "
-            f"after {_get_bot_chat_delivery_timeout()}s (the bot's turn may "
-            "still complete; raise cron.bot_chat_delivery_timeout_seconds if "
-            "this recurs)"
-        )
-        logger.warning("Job '%s': %s", job_id, msg)
-        return msg
-    except Exception as e:
-        msg = f"bot-chat delivery failed: {str(e) or type(e).__name__}"
-        logger.warning("Job '%s': %s", job_id, msg, exc_info=True)
-        return msg
-    finally:
-        if query_file:
-            try:
-                os.unlink(query_file)
-            except OSError:
-                pass
+    return drain_queue(_get_hermes_home())
 
 
 def _normalize_deliver_value(deliver) -> str:
@@ -7966,6 +7864,18 @@ def tick(
             _maybe_run_worktree_maintenance()
         except Exception as _wt_exc:
             logger.debug("Worktree maintenance dispatch failed: %s", _wt_exc)
+
+        # Bot Chat output is admitted durably before a job is marked delivered.
+        # Retry the oldest retained turn on idle ticks too: a CLI/TUI/Desktop
+        # owner may release the canonical session when no cron job is due.
+        try:
+            _retried, _retry_error = _drain_bot_chat_delivery_queue()
+            if _retried:
+                logger.info("Delivered %d queued Bot Chat cron turn(s)", _retried)
+            if _retry_error:
+                logger.debug("Bot Chat delivery queue remains pending: %s", _retry_error)
+        except Exception:
+            logger.warning("Bot Chat delivery queue retry failed", exc_info=True)
 
         due_jobs = get_due_jobs()
 

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -6,11 +6,13 @@ preflight exemption, create-time validation, the subprocess delivery lane,
 and the delivery-targets listing used by UI pickers.
 """
 
+import json
 import subprocess
 from unittest import mock
 
 import pytest
 
+from cron import bot_chat_delivery as bot_delivery
 from cron import scheduler as sched
 from cron.scheduler import (
     BOT_CHAT_PLATFORM,
@@ -117,9 +119,10 @@ def _completed(returncode=0, stderr=""):
     return subprocess.CompletedProcess(args=[], returncode=returncode, stdout="", stderr=stderr)
 
 
-def test_deliver_runs_canonical_bot_chat_lane():
+def test_deliver_runs_canonical_bot_chat_lane(tmp_path, monkeypatch):
     """The subprocess must use the Bot Mode agent-to-agent chat lane:
     chat --in ~ -c "Bot Chat" --create-if-missing -Q --query-file <tmp>."""
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
     calls = {}
 
     def fake_run(argv, **kwargs):
@@ -127,8 +130,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the output", "")
 
     assert err is None
@@ -144,7 +147,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
     assert not any("the output" in str(a) for a in argv)
 
 
-def test_deliver_named_profile_uses_p_flag_and_clears_home():
+def test_deliver_named_profile_uses_p_flag_and_clears_home(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
     calls = {}
 
     def fake_run(argv, **kwargs):
@@ -152,9 +156,9 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
-         mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.dict(bot_delivery.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
 
     assert err is None
@@ -164,27 +168,80 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
     assert "HERMES_HOME" not in calls["kwargs"]["env"]
 
 
-def test_deliver_failure_returns_error_string():
+def test_deliver_failure_is_durably_queued_for_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
     with mock.patch.object(
-        sched.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+        bot_delivery.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
-    assert err is not None
-    assert "boom" in err
+    assert err is None
+    queued = list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))
+    assert len(queued) == 1
 
-
-def test_deliver_timeout_returns_error_string():
     with mock.patch.object(
-        sched.subprocess, "run",
+        bot_delivery.subprocess, "run", return_value=_completed()
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
+        delivered, retry_error = bot_delivery.drain_queue(tmp_path)
+    assert delivered == 1
+    assert retry_error is None
+    assert list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json")) == []
+
+
+def test_deliver_timeout_is_durably_queued_for_retry(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
+    with mock.patch.object(
+        bot_delivery.subprocess, "run",
         side_effect=subprocess.TimeoutExpired(cmd="hermes", timeout=600),
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    ), mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
-    assert err is not None
-    assert "timed out" in err
+    assert err is None
+    assert len(list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))) == 1
 
 
-def test_deliver_message_carries_cron_attribution(tmp_path):
+def test_live_owner_defers_without_starting_second_session(tmp_path, monkeypatch):
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
+    with mock.patch.object(bot_delivery, "_target_has_live_owner", return_value=True), \
+         mock.patch.object(bot_delivery.subprocess, "run") as run:
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is None
+    run.assert_not_called()
+    queued = list((tmp_path / "cron" / bot_delivery.QUEUE_DIR_NAME).glob("*.json"))
+    assert len(queued) == 1
+    record = json.loads(queued[0].read_text(encoding="utf-8"))
+    assert record["profile"] == ""
+    assert record["message"].endswith("out")
+
+
+def test_live_owner_probe_resolves_exact_canonical_session(tmp_path):
+    from hermes_cli.active_sessions import try_acquire_active_session
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    try:
+        db.create_session("bot-session", source="cli")
+        db.set_session_title("bot-session", "Bot Chat")
+    finally:
+        db.close()
+
+    lease, refusal = try_acquire_active_session(
+        session_id="bot-session",
+        surface="cli",
+        config={},
+        metadata={"live_session_id": "bot-session"},
+        registry_home=tmp_path,
+    )
+    assert lease is not None and refusal is None
+    try:
+        assert bot_delivery._target_has_live_owner("", tmp_path) is True
+    finally:
+        lease.release()
+    assert bot_delivery._target_has_live_owner("", tmp_path) is False
+
+
+def test_deliver_message_carries_cron_attribution(tmp_path, monkeypatch):
     """The injected turn must self-identify as scheduled output, not the user."""
+    monkeypatch.setattr(sched, "_hermes_home", tmp_path)
     captured = {}
 
     def fake_run(argv, **kwargs):
@@ -193,8 +250,8 @@ def test_deliver_message_carries_cron_attribution(tmp_path):
             captured["message"] = fh.read()
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
-         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with mock.patch.object(bot_delivery.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(bot_delivery.shutil, "which", return_value="/usr/bin/hermes"):
         _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the payload", "")
 
     assert 'Cronjob "Daily digest" output' in captured["message"]


### PR DESCRIPTION
## What does this PR do?

#105442 landed the Desktop/TUI live-owner path and closed #99956. Cron can now admit into an advertised Desktop/TUI Bot Chat owner; that work is not repeated here.

This PR is the leftover that merge did not take: a general queue-before-subprocess for CLI-only / unsupported owners, plus scheduler-tick drain after the unowned CLI lane fails. While a live owner holds the session the one-shot `hermes chat` runner is skipped; after release (or after a CLI-lane failure) later ticks retry from the durable queue. It does not inject into the live transcript (that is #70406).

The branch still carries the original combined patch and **conflicts with current main**. It is not rebased onto the landed live-consumer path. At-least-once / ambiguous-retry behavior needs separate consideration before this residual should land.

## Related Issue

#99956 (completed by #105442). Residual only: CLI-only / unsupported owners and unowned-CLI failure drain.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `cron/bot_chat_delivery.py`: durable queue, live-owner probe, drain
- `cron/scheduler.py`: `_deliver_to_bot_chat` admits then drains; idle ticks retry the queue
- `tests/cron/test_cron_bot_chat_delivery.py`: live-owner defers without a second subprocess; drain after CLI failure

## How to Test

```text
uv run --extra dev python -m pytest tests/cron/test_cron_bot_chat_delivery.py -q
# 19 passed (on this branch, before the #105442 merge)
```

Not runtime-tested against a live Desktop or CLI owner. Not re-run against current main (CONFLICTING).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (pytest on this branch)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
