### PR TITLE
fix(desktop): keep pinned sidebar sessions from hopping projects

### DIFF
--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -2,7 +2,7 @@ import { atom } from 'nanostores'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { NO_PROJECT_ID, type SidebarProjectTree } from '@/app/chat/sidebar/projects/workspace-groups'
-import { $sidebarAgentsGrouped, setSidebarAgentsGrouped } from '@/store/layout'
+import { $pinnedSessionIds, $sidebarAgentsGrouped, pinSession, setSidebarAgentsGrouped } from '@/store/layout'
 import { $activeGatewayProfile, setShowAllProfiles } from '@/store/profile'
 import { $currentCwd, $selectedStoredSessionId, $sessions, applyConfiguredDefaultProjectDir } from '@/store/session'
 
@@ -22,6 +22,7 @@ import {
   enterProject,
   exitProjectScope,
   fetchProjectSessions,
+  followActiveSessionCwd,
   openProjectCreate,
   pickProjectFolder,
   projectIdForCwd,
@@ -31,6 +32,7 @@ import {
   refreshWorktrees,
   resolveNewSessionCwd,
   scanAndRecordRepos,
+  shouldEnterFollowedProject,
   startWorkInRepo,
   tombstoneSessions
 } from './projects'
@@ -913,5 +915,59 @@ describe('tombstone pruning', () => {
     await refreshProjectTree()
 
     expect($removedSessionIds.get().has('sess-1')).toBe(false)
+  })
+})
+
+describe('followActiveSessionCwd pin lock', () => {
+  const treeNode = (
+    over: Partial<SidebarProjectTree> & Pick<SidebarProjectTree, 'id' | 'label' | 'path'>
+  ): SidebarProjectTree => ({
+    repos: [],
+    sessionCount: 0,
+    ...over
+  })
+
+  beforeEach(() => {
+    window.localStorage.clear()
+    $projectScope.set('p1')
+    $projectTree.set([
+      treeNode({ id: 'p1', label: 'Project 1', path: '/work/proj1' }),
+      treeNode({ id: 'p2', label: 'Project 2', path: '/work/proj2' })
+    ])
+    $selectedStoredSessionId.set('sess-1')
+    $sessions.set([{ id: 'sess-1', cwd: '/work/proj1' } as never])
+    $pinnedSessionIds.set([])
+    setSidebarAgentsGrouped(true)
+  })
+
+  afterEach(() => {
+    $projectScope.set(ALL_PROJECTS)
+    $projectTree.set([])
+    $selectedStoredSessionId.set(null)
+    $sessions.set([])
+    $pinnedSessionIds.set([])
+  })
+
+  it('refuses to drill into another project when the conversation is pinned', () => {
+    expect(shouldEnterFollowedProject('p2', true)).toBe(false)
+    expect(shouldEnterFollowedProject('p2', false)).toBe(true)
+    expect(shouldEnterFollowedProject(null, false)).toBe(false)
+  })
+
+  it('keeps the sidebar on the original project when a pinned session cwd moves', async () => {
+    pinSession('sess-1')
+    setSidebarAgentsGrouped(false)
+
+    await followActiveSessionCwd('/work/proj2')
+
+    expect($projectScope.get()).toBe('p1')
+    expect($sidebarAgentsGrouped.get()).toBe(false)
+  })
+
+  it('still follows an unpinned session into the project that now owns its cwd', async () => {
+    await followActiveSessionCwd('/work/proj2')
+
+    expect($projectScope.get()).toBe('p2')
+    expect($sidebarAgentsGrouped.get()).toBe(true)
   })
 })

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -919,25 +919,34 @@ describe('tombstone pruning', () => {
 })
 
 describe('followActiveSessionCwd pin lock', () => {
-  const treeNode = (
-    over: Partial<SidebarProjectTree> & Pick<SidebarProjectTree, 'id' | 'label' | 'path'>
-  ): SidebarProjectTree => ({
-    repos: [],
-    sessionCount: 0,
-    ...over
-  })
+  const treeProjects = [
+    { id: 'p1', label: 'Project 1', path: '/work/proj1', repos: [], sessionCount: 0 },
+    { id: 'p2', label: 'Project 2', path: '/work/proj2', repos: [], sessionCount: 0 }
+  ]
 
   beforeEach(() => {
     window.localStorage.clear()
+    vi.clearAllMocks()
     $projectScope.set('p1')
-    $projectTree.set([
-      treeNode({ id: 'p1', label: 'Project 1', path: '/work/proj1' }),
-      treeNode({ id: 'p2', label: 'Project 2', path: '/work/proj2' })
-    ])
+    $projectTree.set(treeProjects as SidebarProjectTree[])
     $selectedStoredSessionId.set('sess-1')
     $sessions.set([{ id: 'sess-1', cwd: '/work/proj1' } as never])
     $pinnedSessionIds.set([])
+    $activeGatewayProfile.set('default')
+    setShowAllProfiles(false)
     setSidebarAgentsGrouped(true)
+
+    const request = vi.fn(async (method: string) => {
+      if (method === 'projects.tree') {
+        return { active_id: null, projects: treeProjects, scoped_session_ids: [] }
+      }
+
+      return { active_id: null, projects: [] }
+    })
+    const gateway = { connectionState: 'open', request }
+
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
   })
 
   afterEach(() => {
@@ -946,6 +955,8 @@ describe('followActiveSessionCwd pin lock', () => {
     $selectedStoredSessionId.set(null)
     $sessions.set([])
     $pinnedSessionIds.set([])
+    activeGateway.mockReturnValue(null as never)
+    gatewayAtom.set(null)
   })
 
   it('refuses to drill into another project when the conversation is pinned', () => {

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -14,7 +14,7 @@ import { isMissingRestEndpoint, isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { isUnderPath } from '@/lib/path-compare'
 import { persistentAtom } from '@/lib/persisted'
 import { $gateway, activeGateway, ensureActiveGatewayOpen } from '@/store/gateway'
-import { setSidebarAgentsGrouped } from '@/store/layout'
+import { $pinnedSessionIds, setSidebarAgentsGrouped } from '@/store/layout'
 import { notify } from '@/store/notifications'
 import {
   $activeGatewayProfile,
@@ -27,6 +27,7 @@ import {
   $selectedStoredSessionId,
   $sessions,
   sessionMatchesStoredId,
+  sessionPinId,
   setSessions,
   workspaceCwdForNewSession
 } from '@/store/session'
@@ -300,12 +301,48 @@ export function projectNameForCwd(cwd: string): null | string {
   return best
 }
 
+// True when the conversation currently on screen is pinned (local pin ids or
+// the durable `sessions.pinned` flag). A pin is "keep this chat where I put
+// it" — the sidebar must not treat that as a licence to follow cwd into
+// another project.
+export function isActiveSessionPinned(): boolean {
+  const selected = $selectedStoredSessionId.get()
+
+  if (!selected) {
+    return false
+  }
+
+  const pinnedIds = $pinnedSessionIds.get()
+
+  if (pinnedIds.includes(selected)) {
+    return true
+  }
+
+  const row = $sessions.get().find(session => sessionMatchesStoredId(session, selected))
+
+  if (!row) {
+    return false
+  }
+
+  return pinnedIds.includes(sessionPinId(row)) || pinnedIds.includes(row.id) || row.pinned === true
+}
+
+// Whether a same-session cwd move should drill the sidebar into `nextProjectId`.
+// Membership still follows cwd on the next tree refresh; this only gates the
+// view yank (`enterProject`). A pin refuses the yank so a pinned chat cannot
+// silently relocate the user from Project 1 into Project 2.
+export function shouldEnterFollowedProject(nextProjectId: string | null, pinned: boolean): boolean {
+  return Boolean(nextProjectId) && !pinned
+}
+
 // The active session's agent relocated itself (created/entered another repo or
 // worktree via the terminal — backend re-anchors its cwd and emits session.info).
 // Re-pull projects + tree so a freshly created/auto project and the relocated
 // session row show live, then follow the view into the session's new project
 // (from the overview or a now-stale project alike). Caller gates this on a real
 // same-session cwd move, so a plain session switch never reaches here.
+// Pinned sessions skip the drill-in: the tree still refreshes, but `$projectScope`
+// stays put so a pin cannot be overridden by an unsolicited project hop.
 export async function followActiveSessionCwd(cwd: string): Promise<void> {
   const target = cwd.trim()
 
@@ -318,15 +355,17 @@ export async function followActiveSessionCwd(cwd: string): Promise<void> {
   // Resolve only after the refresh, so a just-created/auto project is in the tree.
   const projectId = projectIdForCwd(target)
 
-  if (projectId) {
-    // The Projects tree only renders in grouped mode, so flip the sidebar into
-    // it — otherwise following from the flat Sessions list would change scope
-    // invisibly. Then drill into the thread's project.
-    setSidebarAgentsGrouped(true)
+  if (!shouldEnterFollowedProject(projectId, isActiveSessionPinned())) {
+    return
+  }
 
-    if (projectId !== $projectScope.get()) {
-      enterProject(projectId)
-    }
+  // The Projects tree only renders in grouped mode, so flip the sidebar into
+  // it — otherwise following from the flat Sessions list would change scope
+  // invisibly. Then drill into the thread's project.
+  setSidebarAgentsGrouped(true)
+
+  if (projectId && projectId !== $projectScope.get()) {
+    enterProject(projectId)
   }
 }
 

--- a/tests/tui_gateway/test_project_tree.py
+++ b/tests/tui_gateway/test_project_tree.py
@@ -459,6 +459,26 @@ def test_nested_project_folders_pick_the_deepest_match():
     assert by_id["p_outer"]["sessionCount"] == 1  # /work/other → only the outer project
 
 
+def test_pinned_session_stays_with_persisted_workspace_when_cwd_visits_another_project():
+    """A pin nails membership to the stored git_repo_root, not a later cwd."""
+    proj1 = _project("p1", "Project 1", ["/work/proj1"])
+    proj2 = _project("p2", "Project 2", ["/work/proj2"])
+    resolve = _resolver(
+        {
+            "/work/proj1": ("/work/proj1", "/work/proj1"),
+            "/work/proj2": ("/work/proj2", "/work/proj2"),
+        }
+    )
+    pinned = _session("/work/proj2", repo_root="/work/proj1", pinned=True)
+    loose = _session("/work/proj2", repo_root="/work/proj1")
+
+    tree = pt.build_tree([proj1, proj2], [pinned, loose], [], resolve, hydrate=True)
+    by_id = {p["id"]: p for p in tree["projects"]}
+
+    assert [s["id"] for s in _sessions_of(by_id["p1"])] == [pinned["id"]]
+    assert [s["id"] for s in _sessions_of(by_id["p2"])] == [loose["id"]]
+
+
 def test_junk_root_never_becomes_an_auto_project():
     # A session whose git root is HERMES_HOME (config/state) must not spawn a
     # phantom project; it lands in the Home bucket. A real repo alongside it

--- a/tui_gateway/project_tree.py
+++ b/tui_gateway/project_tree.py
@@ -494,6 +494,15 @@ def _project_for_session(session: dict, index: _FolderIndex, resolve: Optional[R
     cwd = (session.get("cwd") or "").strip()
     if not cwd:
         return None
+    # A pin is a keep-here mark. Group by the persisted workspace root — not a
+    # later cwd visit, and not a live git probe of that visit — so creating a
+    # nested Project 2 (or an agent stepping into it) cannot steal a pinned
+    # chat from the project it was nailed to.
+    if session.get("pinned"):
+        persisted = (session.get("git_repo_root") or "").strip()
+        pinned_match, _ = index.match(persisted or cwd)
+        if pinned_match:
+            return pinned_match
     repo_root = _session_repo_root(session, resolve)
     candidates = [cwd, repo_root] if repo_root and repo_root != cwd else [cwd]
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -15409,6 +15409,9 @@ def _project_tree_row(r: dict) -> dict:
         "cwd": r.get("cwd"),
         "git_branch": r.get("git_branch"),
         "git_repo_root": r.get("git_repo_root"),
+        # Grouping consults this so a pinned chat stays in its stored workspace
+        # project instead of drifting when cwd later matches a different folder.
+        "pinned": bool(r.get("pinned")),
     }
 
 


### PR DESCRIPTION
## What does this PR do?

Pinned Desktop chats could hop from Project 1 into Project 2 with no user action. Two independent paths caused it:

1. The sidebar follows the active session's cwd (`followActiveSessionCwd`). A pin did not stop that drill-in, so a cwd visit into another project's folder yanked the view.
2. Project-tree membership used live cwd / longest folder prefix. Creating a more-specific Project 2 under Project 1's folder silently stole sessions whose cwd sat under the new folder.

A pin now means "keep this chat where I put it": the tree still refreshes on cwd change, but the sidebar does not enter the other project. Pinned rows group by persisted `git_repo_root` instead of the live cwd. Unpinned sessions keep the existing deepest-folder / cwd-follow behavior.

Move to project is already on the session-actions menu (`MoveToProjectItems` / `moveSessionToProject`); this PR does not add a second control.

## Related Issue

Fixes #100262

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/projects.ts` — `isActiveSessionPinned()` and `shouldEnterFollowedProject()`; `followActiveSessionCwd` refreshes the tree but skips `enterProject` / grouped-mode flip when the active session is pinned.
- `tui_gateway/project_tree.py` — `_project_for_session` matches pinned sessions on persisted `git_repo_root`.
- `tui_gateway/server.py` — `_project_tree_row` includes `pinned`.
- `apps/desktop/src/store/projects.test.ts` — pin-lock coverage; gateway stub so refresh does not wipe the fixture tree.
- `tests/tui_gateway/test_project_tree.py` — pinned session stays on stored workspace when cwd visits another project.

## How to Test

1. Create Project 1 on a parent folder and start a session there. Pin the session.
2. Create Project 2 on a nested folder (or `cd` the same session into that folder). Confirm the pinned session stays listed under Project 1 and the sidebar does not drill into Project 2.
3. Unpin, or use session actions → Move to project, and confirm an unpinned cwd follow / explicit move still works.

```
cd apps/desktop && npx vitest run src/store/projects.test.ts --project ui
PYTHONPATH=. python3 -m pytest tests/tui_gateway/test_project_tree.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
npx vitest run src/store/projects.test.ts --project ui
 Test Files  1 passed (1)
      Tests  43 passed (43)

python3 -m pytest tests/tui_gateway/test_project_tree.py -q
34 passed
```
