### PR TITLE
fix(plugins): log denied capability checks at DEBUG instead of INFO

### DIFF
--- a/hermes_cli/plugin_capabilities.py
+++ b/hermes_cli/plugin_capabilities.py
@@ -270,11 +270,23 @@ def plugin_capability_granted(
 def _log_capability_decision(
     plugin_id: str, capability: str, allowed: bool, evidence: str
 ) -> None:
-    """Audit line for capability gate decisions (the ``checked_by`` trail)."""
-    logger.info(
+    """Audit line for capability gate decisions (the ``checked_by`` trail).
+
+    ``allow`` stays at INFO — an authorization grant is a meaningful audit
+    event. ``deny`` is the fail-closed *default* state, so it is logged at
+    DEBUG: on hosts that re-probe plugin capabilities on a reload/heartbeat
+    cycle, a denied check fires every cycle and an INFO line for the same
+    denied grant adds no audit value, only log spam.
+    """
+    message = (
         "capability_check plugin=%s capability=%s decision=%s checked_by=plugin_capability_granted evidence=%s",
         plugin_id, capability, "allow" if allowed else "deny", evidence,
     )
+    if allowed:
+        logger.info(*message)
+    else:
+        logger.debug(*message)
+
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_plugin_capabilities.py
+++ b/tests/hermes_cli/test_plugin_capabilities.py
@@ -432,3 +432,46 @@ class TestConsentFlow:
         )
         assert granted is True
         console.input.assert_not_called()
+
+
+class TestCapabilityDecisionLogging:
+    """Audit-log level behavior for capability gate decisions.
+
+    ``allow`` is a meaningful authorization grant and stays at INFO.
+    ``deny`` is the fail-closed *default* state; on hosts that re-probe
+    plugin capabilities on a reload/heartbeat cycle, a denied check fires
+    every cycle, so an INFO line for the same denied grant would be pure
+    log spam.  It is logged at DEBUG instead (#plugin-capability-log-noise).
+    """
+
+    def test_allow_logs_at_info(self, caplog):
+        from hermes_cli import plugin_capabilities as pc
+
+        with caplog.at_level("INFO", logger="hermes_cli.plugin_capabilities"):
+            pc._log_capability_decision(
+                "capplug", "tools.override", True, "granted_capabilities"
+            )
+        assert caplog.records
+        for rec in caplog.records:
+            assert rec.levelname == "INFO"
+            assert "decision=allow" in rec.getMessage()
+
+    def test_deny_logs_at_debug_not_info(self, caplog):
+        from hermes_cli import plugin_capabilities as pc
+
+        with caplog.at_level("INFO", logger="hermes_cli.plugin_capabilities"):
+            pc._log_capability_decision(
+                "capplug", "tools.override", False, "not granted"
+            )
+        # At INFO level a denied decision must NOT surface (it's DEBUG-only).
+        assert not caplog.records
+
+        with caplog.at_level("DEBUG", logger="hermes_cli.plugin_capabilities"):
+            pc._log_capability_decision(
+                "capplug", "tools.override", False, "not granted"
+            )
+        assert caplog.records
+        for rec in caplog.records:
+            assert rec.levelname == "DEBUG"
+            assert "decision=deny" in rec.getMessage()
+


### PR DESCRIPTION
## Bug Description

The plugin capability gate (`hermes_cli/plugin_capabilities.py`) logs **every** capability decision at INFO via `_log_capability_decision()`. `decision=deny` is the fail-closed *default* state, so on hosts that re-probe plugin capabilities on a reload/heartbeat cycle, a denied check fires every cycle and floods `agent.log` with identical lines carrying no audit value.

Observed in the wild: `capability_check plugin=obsidian-auto-sync capability=tools.override decision=deny ...` repeated every ~10s (1100+ lines in 2h) because the gateway reloads plugins on a heartbeat and probes `tools.override` each time. `obsidian-auto-sync` is the only enabled *user* plugin, so it was the only one logging (bundled plugins short-circuit to `return True` without logging).

## Root Cause

`_log_capability_decision` unconditionally logs at INFO, including the `deny` branch — which is the default, expected state for any capability a plugin never requested. Heartbeat-driven re-probing makes each reload emit the same denied line.

## Fix

- Keep `allow` at INFO — a real authorization grant is a meaningful audit event.
- Demote `deny` to DEBUG — it is the default state; an INFO line per heartbeat cycle is log spam, and `--verbose` still surfaces it when someone actually needs the trail.

## How to Verify

1. Enable a user plugin that doesn't declare `tools.override` (e.g. any `source: user` plugin).
2. Run the gateway; watch `agent.log`.
3. Before: `capability_check ... decision=deny` every reload cycle at INFO.
4. After: no `decision=deny` at INFO; `--verbose`/DEBUG shows it.

## Test Plan

- [x] Added regression tests (`TestCapabilityDecisionLogging`): `allow` → INFO, `deny` → DEBUG (silent at INFO).
- [x] Full `test_plugin_capabilities.py` suite passes (41 tests).

## Risk Assessment

Low — logging level change only, no behavior of the gate itself. `deny` remains fully enforced; the audit trail is preserved at DEBUG and `allow` stays at INFO.