### PR TITLE
fix(desktop): preserve composer caret during normalization

### DIFF
--- a/apps/desktop/src/app/chat/composer/rich-editor.test.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.test.ts
@@ -145,6 +145,38 @@ describe('normalizeComposerEditorDom', () => {
     expect(composerPlainText(editor)).toBe('@file:`src/foo.ts`')
     expect(editor.querySelector('br')).toBeNull()
   })
+
+  it('preserves a live caret anchored in an empty direct text node', () => {
+    const editor = document.createElement('div')
+    editor.dataset.slot = RICH_INPUT_SLOT
+    editor.contentEditable = 'true'
+    document.body.append(editor)
+
+    const leadingLitter = document.createTextNode('')
+    const caretContainer = document.createTextNode('')
+    const trailingLitter = document.createTextNode('')
+    editor.append(leadingLitter, refChipElement('file', '`src/foo.ts`'), caretContainer, trailingLitter)
+
+    const caret = document.createRange()
+    caret.setStart(caretContainer, 0)
+    caret.collapse(true)
+
+    const selection = window.getSelection()!
+    selection.removeAllRanges()
+    selection.addRange(caret)
+
+    normalizeComposerEditorDom(editor)
+
+    expect(leadingLitter.isConnected).toBe(false)
+    expect(trailingLitter.isConnected).toBe(false)
+    expect(caretContainer.isConnected).toBe(true)
+    expect(editor.contains(selection.getRangeAt(0).startContainer)).toBe(true)
+    expect(selection.getRangeAt(0).startContainer).toBe(caretContainer)
+    expect(composerPlainText(editor)).toBe('@file:`src/foo.ts`')
+
+    selection.removeAllRanges()
+    editor.remove()
+  })
 })
 
 describe('insertInlineRefsIntoEditor', () => {

--- a/apps/desktop/src/app/chat/composer/rich-editor.ts
+++ b/apps/desktop/src/app/chat/composer/rich-editor.ts
@@ -50,6 +50,19 @@ function meaningfulNextSibling(node: ChildNode | null): ChildNode | null {
   return next
 }
 
+/** The live collapsed selection container, if it belongs to this editor. */
+function composerCollapsedSelectionContainer(editor: HTMLElement): Node | null {
+  const selection = window.getSelection()
+
+  if (!selection?.isCollapsed || selection.rangeCount === 0) {
+    return null
+  }
+
+  const range = selection.getRangeAt(0)
+
+  return editor.contains(range.startContainer) ? range.startContainer : null
+}
+
 /** Keep the `data-empty` marker the placeholder paints on in step with the
  *  editor root's contents.
  *
@@ -716,10 +729,12 @@ function isBlankNode(node: ChildNode | null): boolean {
  *  rendering emits (we use text nodes + <br> + chips). Real <br> line breaks
  *  (Shift+Enter, which sit after actual text) are preserved. */
 export function normalizeComposerEditorDom(editor: HTMLElement) {
+  const selectedContainer = composerCollapsedSelectionContainer(editor)
+
   // Chromium's zero-length text nodes first: every check below reads siblings,
   // and litter between them makes a chip look like it has text either side.
   for (const child of Array.from(editor.childNodes)) {
-    if (isEmptyTextNode(child)) {
+    if (isEmptyTextNode(child) && child !== selectedContainer) {
       child.remove()
     }
   }


### PR DESCRIPTION
## Summary

Fixes #100302 by preventing the Desktop composer DOM normalizer from removing Chromium’s live collapsed caret container when that container is a zero-length direct text node. The normalizer still removes surrounding empty-node litter, but now keeps the active selection connected to the editor so ordinary typing can continue after the animation-frame draft flush.

---

## Changes

### `apps/desktop/src/app/chat/composer/rich-editor.ts`
- Detects the editor-owned collapsed selection container before normalization.
- Skips removing that exact empty text node while continuing to sweep other zero-length direct text nodes.

### `apps/desktop/src/app/chat/composer/rich-editor.test.ts`
- Adds a regression test for a focused editor whose caret is anchored in an empty direct text node.
- Verifies surrounding empty-node litter is removed and the resulting selection remains inside the editor.

---

## How to Test

```bash
cd apps/desktop
npm test -- --run src/app/chat/composer/rich-editor.test.ts
NODE_OPTIONS=--max-old-space-size=3072 npm run check:lint
```

```text
# ✅ rich-editor.test.ts: 23/23 passed
# ✅ check:lint: typecheck passed; eslint exited 0 with existing warnings
```

---

## Checklist

- [x] Tests pass — targeted Desktop test 23/23
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

---

## Risk & Impact

Low. This is a renderer DOM-only guard that preserves existing cleanup behavior except for the currently active collapsed caret container.

Type: Bug fix
Closes #100302
