### PR TITLE
feat(google): add partial Calendar event updates

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: google-workspace
 description: "Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python."
-version: 1.2.0
+version: 1.3.0
 author: Nous Research
 license: MIT
 platforms: [linux, macos, windows]
@@ -211,6 +211,12 @@ $GAPI calendar create --summary "Team Standup" --start 2026-03-01T10:00:00-06:00
 $GAPI calendar create --summary "Lunch" --start 2026-03-01T12:00:00Z --end 2026-03-01T13:00:00Z --location "Cafe"
 $GAPI calendar create --summary "Review" --start 2026-03-01T14:00:00Z --end 2026-03-01T15:00:00Z --attendees "alice@co.com,bob@co.com"
 
+# Update only the supplied fields. Omitted fields remain unchanged; an explicit
+# empty string clears summary, location, or description.
+$GAPI calendar update EVENT_ID --location "Room 2"
+$GAPI calendar update EVENT_ID --description "" --backend native
+$GAPI calendar update EVENT_ID --start 2026-03-01T11:00:00-06:00 --end 2026-03-01T11:30:00-06:00
+
 # Delete event
 $GAPI calendar delete EVENT_ID
 ```
@@ -296,6 +302,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 - **Gmail send/reply**: `{status: "sent", id, threadId}`
 - **Calendar list**: `[{id, summary, start, end, location, description, htmlLink}]`
 - **Calendar create**: `{status: "created", id, summary, htmlLink}`
+- **Calendar update**: `{status: "updated", id, summary, htmlLink, changedFields, verified: true}`
 - **Drive search**: `[{id, name, mimeType, modifiedTime, webViewLink}]`
 - **Drive get**: `{id, name, mimeType, modifiedTime, size, webViewLink, parents, owners}`
 - **Drive upload**: `{status: "uploaded", id, name, mimeType, webViewLink}`
@@ -311,7 +318,7 @@ All commands return JSON. Parse with `jq` or read directly. Key fields:
 
 ## Rules
 
-1. **Never send email, create/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, file IDs, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
+1. **Never send email, create/update/delete calendar events, delete Drive files, share files, or modify Docs/Sheets without confirming with the user first.** Show what will be done (recipients, event/file IDs, changed fields, content, share role) and ask for approval. For `drive delete`, prefer the default trash (reversible) over `--permanent`.
 2. **Check auth before first use** — run `setup.py --check`. If it fails, guide the user through setup.
 3. **Use the Gmail search syntax reference** for complex queries — load it with `skill_view("google-workspace", file_path="references/gmail-search-syntax.md")`.
 4. **Calendar times must include timezone** — always use ISO 8601 with offset (e.g., `2026-03-01T10:00:00-06:00`) or UTC (`Z`).

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -12,6 +12,7 @@ Usage:
   python google_api.py gmail reply MESSAGE_ID --body "Thanks"
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
+  python google_api.py calendar update EVENT_ID [--summary "New title"] [--location "Room 2"]
   python google_api.py drive search "budget report" [--max 10]
   python google_api.py contacts list [--max 20]
   python google_api.py sheets get SHEET_ID RANGE
@@ -551,6 +552,137 @@ def calendar_create(args):
         "htmlLink": result.get("htmlLink", ""),
     }, indent=2))
 
+
+def _calendar_update_datetime(value: str, field: str) -> str:
+    """Require an ISO 8601 date-time with an explicit UTC offset."""
+    candidate = value[:-1] + "+00:00" if value.endswith("Z") else value
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except (TypeError, ValueError):
+        raise SystemExit(f"ERROR: --{field} must be an ISO 8601 date-time with timezone")
+    if "T" not in value or parsed.tzinfo is None or parsed.utcoffset() is None:
+        raise SystemExit(f"ERROR: --{field} must include a timezone")
+    return value
+
+
+def _calendar_update_body(args) -> dict:
+    """Build a partial event patch while preserving omitted versus empty values."""
+    body = {}
+    for field in ("summary", "location", "description"):
+        value = getattr(args, field, None)
+        if value is not None:
+            body[field] = value
+
+    for field in ("start", "end"):
+        value = getattr(args, field, None)
+        if value is not None:
+            body[field] = {"dateTime": _calendar_update_datetime(value, field)}
+
+    attendees = getattr(args, "attendees", None)
+    if attendees is not None:
+        body["attendees"] = [
+            {"email": email.strip()}
+            for email in attendees.split(",")
+            if email.strip()
+        ]
+
+    if not body:
+        raise SystemExit("ERROR: at least one field must be supplied for calendar update")
+    return body
+
+
+def _calendar_update_uses_gws(args) -> bool:
+    backend = getattr(args, "backend", "auto")
+    if backend == "native":
+        return False
+    if backend == "gws" and not _gws_binary():
+        raise SystemExit("ERROR: --backend gws requested but gws is not installed")
+    return bool(_gws_binary())
+
+
+def _calendar_update_field_matches(field: str, expected, event: dict) -> bool:
+    if field in {"summary", "location", "description"}:
+        return event.get(field, "") == expected
+    if field in {"start", "end"}:
+        actual = event.get(field)
+        if not isinstance(actual, dict) or not isinstance(expected, dict):
+            return False
+        actual_value = actual.get("dateTime")
+        expected_value = expected.get("dateTime")
+        if not isinstance(actual_value, str) or not isinstance(expected_value, str):
+            return False
+        try:
+            actual_dt = datetime.fromisoformat(actual_value.replace("Z", "+00:00"))
+            expected_dt = datetime.fromisoformat(expected_value.replace("Z", "+00:00"))
+        except ValueError:
+            return False
+        return actual_dt == expected_dt
+    if field == "attendees":
+        actual = event.get("attendees", [])
+        if not isinstance(actual, list) or not isinstance(expected, list):
+            return False
+        actual_emails = [
+            item.get("email") for item in actual if isinstance(item, dict)
+        ]
+        expected_emails = [
+            item.get("email") for item in expected if isinstance(item, dict)
+        ]
+        return actual_emails == expected_emails
+    return False
+
+
+def _verify_calendar_update(event_id: str, body: dict, event) -> None:
+    if not isinstance(event, dict) or event.get("id") != event_id:
+        raise RuntimeError("Calendar update read-back returned an unexpected event ID")
+    mismatches = [
+        field
+        for field, expected in body.items()
+        if not _calendar_update_field_matches(field, expected, event)
+    ]
+    if mismatches:
+        raise RuntimeError(
+            "Calendar update read-back mismatch for: " + ", ".join(sorted(mismatches))
+        )
+
+
+def calendar_update(args):
+    body = _calendar_update_body(args)
+    use_gws = _calendar_update_uses_gws(args)
+    params = {"calendarId": args.calendar, "eventId": args.event_id}
+
+    if use_gws:
+        result = _run_gws(
+            ["calendar", "events", "patch"],
+            params=params,
+            body=body,
+        )
+        readback = _run_gws(
+            ["calendar", "events", "get"],
+            params=params,
+        )
+    else:
+        events = build_service("calendar", "v3").events()
+        result = events.patch(
+            calendarId=args.calendar,
+            eventId=args.event_id,
+            body=body,
+        ).execute()
+        readback = events.get(
+            calendarId=args.calendar,
+            eventId=args.event_id,
+        ).execute()
+
+    if not isinstance(result, dict) or result.get("id") != args.event_id:
+        raise RuntimeError("Calendar update returned an unexpected event ID")
+    _verify_calendar_update(args.event_id, body, readback)
+    print(json.dumps({
+        "status": "updated",
+        "id": readback["id"],
+        "summary": readback.get("summary", ""),
+        "htmlLink": readback.get("htmlLink", ""),
+        "changedFields": sorted(body),
+        "verified": True,
+    }, indent=2, ensure_ascii=False))
 
 
 def calendar_delete(args):
@@ -1113,6 +1245,18 @@ def main():
     p.add_argument("--attendees", default="", help="Comma-separated email addresses")
     p.add_argument("--calendar", default="primary")
     p.set_defaults(func=calendar_create)
+
+    p = cal_sub.add_parser("update")
+    p.add_argument("event_id")
+    p.add_argument("--summary", default=None, help="New title; pass an empty string to clear")
+    p.add_argument("--start", default=None, help="New start (ISO 8601 with timezone)")
+    p.add_argument("--end", default=None, help="New end (ISO 8601 with timezone)")
+    p.add_argument("--location", default=None, help="New location; pass an empty string to clear")
+    p.add_argument("--description", default=None, help="New description; pass an empty string to clear")
+    p.add_argument("--attendees", default=None, help="Comma-separated emails; pass an empty string to clear")
+    p.add_argument("--calendar", default="primary")
+    p.add_argument("--backend", choices=["auto", "native", "gws"], default="auto")
+    p.set_defaults(func=calendar_update)
 
     p = cal_sub.add_parser("delete")
     p.add_argument("event_id")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -7,7 +7,7 @@ import sys
 import types
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 
@@ -134,6 +134,154 @@ def test_api_calendar_list_uses_events_list(api_module):
     assert "timeMin" in params
     assert "timeMax" in params
     assert params["calendarId"] == "primary"
+
+
+def _calendar_update_args(api_module, **overrides):
+    values = {
+        "event_id": "event-123",
+        "summary": None,
+        "start": None,
+        "end": None,
+        "location": None,
+        "description": None,
+        "attendees": None,
+        "calendar": "primary",
+        "backend": "auto",
+        "func": api_module.calendar_update,
+    }
+    values.update(overrides)
+    return api_module.argparse.Namespace(**values)
+
+
+def test_api_calendar_update_gws_patches_only_changed_fields(api_module, monkeypatch, capsys):
+    updated_event = {
+        "id": "event-123",
+        "summary": "Existing title",
+        "location": "Room 2",
+        "htmlLink": "https://calendar.google.com/event?eid=event-123",
+    }
+    run_gws = MagicMock(side_effect=[updated_event, updated_event])
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+
+    api_module.calendar_update(_calendar_update_args(api_module, location="Room 2"))
+
+    assert run_gws.call_args_list == [
+        call(
+            ["calendar", "events", "patch"],
+            params={"calendarId": "primary", "eventId": "event-123"},
+            body={"location": "Room 2"},
+        ),
+        call(
+            ["calendar", "events", "get"],
+            params={"calendarId": "primary", "eventId": "event-123"},
+        ),
+    ]
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "updated"
+    assert output["id"] == "event-123"
+    assert output["verified"] is True
+
+
+def test_api_calendar_update_preserves_explicit_empty_string(api_module, monkeypatch):
+    run_gws = MagicMock(side_effect=[
+        {"id": "event-123", "location": ""},
+        {"id": "event-123", "location": ""},
+    ])
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+
+    api_module.calendar_update(_calendar_update_args(api_module, location=""))
+
+    assert run_gws.call_args_list[0].kwargs["body"] == {"location": ""}
+
+
+def test_api_calendar_update_native_uses_events_patch(api_module, monkeypatch, capsys):
+    run_gws = MagicMock()
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+    updated_event = {
+        "id": "event-123",
+        "summary": "Renamed",
+        "htmlLink": "https://calendar.google.com/event?eid=event-123",
+    }
+    request = MagicMock()
+    request.execute.return_value = updated_event
+    get_request = MagicMock()
+    get_request.execute.return_value = updated_event
+    events = MagicMock()
+    events.patch.return_value = request
+    events.get.return_value = get_request
+    service = MagicMock()
+    service.events.return_value = events
+    monkeypatch.setattr(api_module, "build_service", lambda *_args: service)
+
+    api_module.calendar_update(
+        _calendar_update_args(api_module, summary="Renamed", backend="native")
+    )
+
+    events.patch.assert_called_once_with(
+        calendarId="primary",
+        eventId="event-123",
+        body={"summary": "Renamed"},
+    )
+    events.get.assert_called_once_with(calendarId="primary", eventId="event-123")
+    run_gws.assert_not_called()
+    output = json.loads(capsys.readouterr().out)
+    assert output["status"] == "updated"
+    assert output["verified"] is True
+
+
+def test_api_calendar_update_fails_when_readback_does_not_match(api_module, monkeypatch):
+    run_gws = MagicMock(side_effect=[
+        {"id": "event-123", "location": "Room 2"},
+        {"id": "event-123", "location": "Room 1"},
+    ])
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+
+    with pytest.raises(RuntimeError, match="read-back mismatch"):
+        api_module.calendar_update(_calendar_update_args(api_module, location="Room 2"))
+
+    assert run_gws.call_count == 2
+
+
+def test_api_calendar_update_rejects_noop_before_provider(api_module, monkeypatch):
+    run_gws = MagicMock()
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+
+    with pytest.raises(SystemExit, match="at least one field"):
+        api_module.calendar_update(_calendar_update_args(api_module))
+
+    run_gws.assert_not_called()
+
+
+def test_api_calendar_update_rejects_datetime_without_timezone(api_module, monkeypatch):
+    run_gws = MagicMock()
+    monkeypatch.setattr(api_module, "_run_gws", run_gws)
+
+    with pytest.raises(SystemExit, match="timezone"):
+        api_module.calendar_update(
+            _calendar_update_args(api_module, start="2026-09-02T10:00:00")
+        )
+
+    run_gws.assert_not_called()
+
+
+def test_api_calendar_update_parser_preserves_omitted_and_empty(api_module, monkeypatch):
+    captured = {}
+
+    def capture(args):
+        captured.update(vars(args))
+
+    monkeypatch.setattr(api_module, "calendar_update", capture)
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["google_api.py", "calendar", "update", "event-123", "--location", ""],
+    )
+
+    api_module.main()
+
+    assert captured["summary"] is None
+    assert captured["location"] == ""
+    assert captured["description"] is None
 
 
 


### PR DESCRIPTION
## Summary
- add `calendar update` backed by Google Calendar `events.patch`
- preserve omitted vs explicit-empty values and reject no-op/timezone-less updates before provider calls
- add explicit `auto|native|gws` backend selection and fresh read-back verification
- document update output and confirmation requirements

## Tests
- `uv run --isolated --python /opt/homebrew/bin/python3.12 --with pytest python -m pytest -q -p no:cacheprovider tests/skills/test_google_workspace_api.py tests/skills/test_google_workspace_setup.py tests/skills/test_google_workspace_setup_deps.py tests/skills/test_google_workspace_credential_files.py` (19 passed)
- focused update matrix: native forced with gws present, exact patch/get payloads, explicit clear, no-op, timezone validation, mismatch detection