### PR TITLE
feat(skills): refresh obliteratus for local-model refusal removal

### DIFF
--- a/optional-skills/mlops/obliteratus/SKILL.md
+++ b/optional-skills/mlops/obliteratus/SKILL.md
@@ -1,342 +1,131 @@
 ---
 name: obliteratus
-description: "OBLITERATUS: abliterate LLM refusals (diff-in-means)."
-version: 2.0.0
-author: Hermes Agent
+description: Abliterate refusals from local open-weight LLMs.
+version: 2.1.0
+author: mr-r0b0t (@am423), Hermes Agent
 license: MIT
-dependencies: [obliteratus, torch, transformers, bitsandbytes, accelerate, safetensors]
 platforms: [linux, macos]
+prerequisites:
+  commands: [obliteratus]
 metadata:
   hermes:
-    tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, Mechanistic-Interpretability, HuggingFace, Model-Surgery]
+    tags: [Abliteration, Uncensoring, Refusal-Removal, LLM, Weight-Projection, SVD, HuggingFace, Model-Surgery]
     related_skills: [serving-llms-vllm, llama-cpp, huggingface-tokenizers]
+    requires_toolsets: [terminal]
 ---
 
 # OBLITERATUS Skill
 
-## What's inside
+OBLITERATUS (package `0.1.3`, AGPL-3.0) projects refusal directions out of a local HuggingFace checkpoint without fine-tuning. It does not retrain, does not serve the result, and does not guarantee 0% refusal on models under ~1B. Never `import obliteratus` inside Hermes (MIT); invoke the CLI through the `terminal` tool only.
 
-9 CLI methods, 28 analysis modules, 116 model presets across 5 compute tiers, tournament evaluation, and telemetry-driven recommendations.
+Upstream: https://github.com/elder-plinius/OBLITERATUS
 
-Remove refusal behaviors (guardrails) from open-weight LLMs without retraining or fine-tuning. Uses mechanistic interpretability techniques — including diff-in-means, SVD, whitened SVD, LEACE concept erasure, SAE decomposition, Bayesian kernel projection, and more — to identify and surgically excise refusal directions from model weights while preserving reasoning capabilities.
+## When to Use
 
-**License warning:** OBLITERATUS is AGPL-3.0. NEVER import it as a Python library. Always invoke via CLI (`obliteratus` command) or subprocess. This keeps Hermes Agent's MIT license clean.
+- User wants to abliterate, uncensor, or remove refusals/guardrails from an open-weight LLM
+- The model is already on disk as a HuggingFace directory, or a hub id that will resolve locally
+- Residual refusals remain after a first pass (`self-improve`, `--residue-file`)
+- Qwen3.8 hybrid Gated DeltaNet local surgery
 
-## Video Guide
+Do not use for hosted APIs, for importing the library into Hermes, or as a substitute for serving — load `serving-llms-vllm` or `llama-cpp` after the weights are saved.
 
-Walkthrough of OBLITERATUS used by a Hermes agent to abliterate Gemma:
-https://www.youtube.com/watch?v=8fG9BrNTeHs ("OBLITERATUS: An AI Agent Removed Gemma 4's Safety Guardrails")
+## Prerequisites
 
-Useful when the user wants a visual overview of the end-to-end workflow before running it themselves.
+- Python >= 3.10 and a CUDA GPU for anything above ~1B (CPU is tiny-models only)
+- A local snapshot: `config.json` plus weights. Confirm with `read_file` on `config.json`
+- Optional `HF_TOKEN` only for gated hub ids; local directories do not need it
 
-## When to Use This Skill
+Install (confirm with the user first — PyTorch-scale deps) through `terminal`:
 
-Trigger when the user:
-- Wants to "uncensor" or "abliterate" an LLM
-- Asks about removing refusal/guardrails from a model
-- Wants to create an uncensored version of Llama, Qwen, Mistral, etc.
-- Mentions "refusal removal", "abliteration", "weight projection"
-- Wants to analyze how a model's refusal mechanism works
-- References OBLITERATUS, abliterator, or refusal directions
-
-## Step 1: Installation
-
-Check if already installed:
-```bash
-obliteratus --version 2>/dev/null && echo "INSTALLED" || echo "NOT INSTALLED"
-```
-
-If not installed, clone and install from GitHub:
 ```bash
 git clone https://github.com/elder-plinius/OBLITERATUS.git
 cd OBLITERATUS
-pip install -e .
-# For Gradio web UI support:
-# pip install -e ".[spaces]"
+pip install -e ".[quantization]"
+obliteratus --version
 ```
 
-**IMPORTANT:** Confirm with user before installing. This pulls in ~5-10GB of dependencies (PyTorch, Transformers, bitsandbytes, etc.).
+- Qwen3.8 / hybrid Gated DeltaNet: also `pip install -e ".[qwen-hybrid]"` (`transformers>=5.8`, `flash-linear-attention>=0.5.2`, `causal-conv1d>=1.7.0`)
+- Gradio UI: `pip install -e ".[spaces]"`
+- After a CUDA wheel override, do not launch via `uv run` — it can resync the CPU wheel locked for portable CI
 
-## Step 2: Check Hardware
+## How to Run
 
-Before anything, check what GPU is available:
-```bash
-python3 -c "
-import torch
-if torch.cuda.is_available():
-    gpu = torch.cuda.get_device_name(0)
-    vram = torch.cuda.get_device_properties(0).total_memory / 1024**3
-    print(f'GPU: {gpu}')
-    print(f'VRAM: {vram:.1f} GB')
-    if vram < 4: print('TIER: tiny (models under 1B)')
-    elif vram < 8: print('TIER: small (models 1-4B)')
-    elif vram < 16: print('TIER: medium (models 4-9B with 4bit quant)')
-    elif vram < 32: print('TIER: large (models 8-32B with 4bit quant)')
-    else: print('TIER: frontier (models 32B+)')
-else:
-    print('NO GPU - only tiny models (under 1B) on CPU')
-"
-```
-
-### VRAM Requirements (with 4-bit quantization)
-
-| VRAM     | Max Model Size  | Example Models                              |
-|:---------|:----------------|:--------------------------------------------|
-| CPU only | ~1B params      | GPT-2, TinyLlama, SmolLM                    |
-| 4-8 GB   | ~4B params      | Qwen2.5-1.5B, Phi-3.5 mini, Llama 3.2 3B   |
-| 8-16 GB  | ~9B params      | Llama 3.1 8B, Mistral 7B, Gemma 2 9B       |
-| 24 GB    | ~32B params     | Qwen3-32B, Llama 3.1 70B (tight), Command-R |
-| 48 GB+   | ~72B+ params    | Qwen2.5-72B, DeepSeek-R1                    |
-| Multi-GPU| 200B+ params    | Llama 3.1 405B, DeepSeek-V3 (685B MoE)      |
-
-## Step 3: Browse Available Models & Get Recommendations
+The `model` argument is a HuggingFace id **or a local directory**. Always pass `--output-dir`.
 
 ```bash
-# Browse models by compute tier
-obliteratus models --tier medium
-
-# Get architecture info for a specific model
-obliteratus info <model_name>
-
-# Get telemetry-driven recommendation for best method & params
-obliteratus recommend <model_name>
-obliteratus recommend <model_name> --insights  # global cross-architecture rankings
-```
-
-## Step 4: Choose a Method
-
-### Method Selection Guide
-**Default / recommended for most cases: `advanced`.** It uses multi-direction SVD with norm-preserving projection and is well-tested.
-
-| Situation                         | Recommended Method | Why                                      |
-|:----------------------------------|:-------------------|:-----------------------------------------|
-| Default / most models             | `advanced`         | Multi-direction SVD, norm-preserving, reliable |
-| Quick test / prototyping          | `basic`            | Fast, simple, good enough to evaluate    |
-| Dense model (Llama, Mistral)      | `advanced`         | Multi-direction, norm-preserving         |
-| MoE model (DeepSeek, Mixtral)     | `nuclear`          | Expert-granular, handles MoE complexity  |
-| Reasoning model (R1 distills)     | `surgical`         | CoT-aware, preserves chain-of-thought    |
-| Stubborn refusals persist         | `aggressive`       | Whitened SVD + head surgery + jailbreak   |
-| Want reversible changes           | Use steering vectors (see Analysis section) |
-| Maximum quality, time no object   | `optimized`        | Bayesian search for best parameters      |
-| Experimental auto-detection       | `informed`         | Auto-detects alignment type — experimental, may not always outperform advanced |
-
-### 9 CLI Methods
-- **basic** — Single refusal direction via diff-in-means. Fast (~5-10 min for 8B).
-- **advanced** (DEFAULT, RECOMMENDED) — Multiple SVD directions, norm-preserving projection, 2 refinement passes. Medium speed (~10-20 min).
-- **aggressive** — Whitened SVD + jailbreak-contrastive + attention head surgery. Higher risk of coherence damage.
-- **spectral_cascade** — DCT frequency-domain decomposition. Research/novel approach.
-- **informed** — Runs analysis DURING abliteration to auto-configure. Experimental — slower and less predictable than advanced.
-- **surgical** — SAE features + neuron masking + head surgery + per-expert. Very slow (~1-2 hrs). Best for reasoning models.
-- **optimized** — Bayesian hyperparameter search (Optuna TPE). Longest runtime but finds optimal parameters.
-- **inverted** — Flips the refusal direction. Model becomes actively willing.
-- **nuclear** — Maximum force combo for stubborn MoE models. Expert-granular.
-
-### Direction Extraction Methods (--direction-method flag)
-- **diff_means** (default) — Simple difference-in-means between refused/complied activations. Robust.
-- **svd** — Multi-direction SVD extraction. Better for complex alignment.
-- **leace** — LEACE (Linear Erasure via Closed-form Estimation). Optimal linear erasure.
-
-### 4 Python-API-Only Methods
-(NOT available via CLI — require Python import, which violates AGPL boundary. Mention to user only if they explicitly want to use OBLITERATUS as a library in their own AGPL project.)
-- failspy, gabliteration, heretic, rdo
-
-## Step 5: Run Abliteration
-
-### Standard usage
-```bash
-# Default method (advanced) — recommended for most models
-obliteratus obliterate <model_name> --method advanced --output-dir ./abliterated-models
-
-# With 4-bit quantization (saves VRAM)
-obliteratus obliterate <model_name> --method advanced --quantization 4bit --output-dir ./abliterated-models
-
-# Large models (70B+) — conservative defaults
-obliteratus obliterate <model_name> --method advanced --quantization 4bit --large-model --output-dir ./abliterated-models
-```
-
-### Fine-tuning parameters
-```bash
-obliteratus obliterate <model_name> \
+obliteratus obliterate /abs/path/to/ckpt \
   --method advanced \
-  --direction-method diff_means \
-  --n-directions 4 \
-  --refinement-passes 2 \
-  --regularization 0.1 \
+  --dtype bfloat16 \
+  --output-dir ./liberated \
+  --gpus 0
+```
+
+VRAM-tight (requires `.[quantization]`):
+
+```bash
+obliteratus obliterate /abs/path/to/ckpt \
+  --method advanced \
   --quantization 4bit \
-  --output-dir ./abliterated-models \
-  --contribute  # opt-in telemetry for community research
+  --dtype float16 \
+  --output-dir ./liberated
 ```
 
-### Key flags
-| Flag | Description | Default |
-|:-----|:------------|:--------|
-| `--method` | Abliteration method | advanced |
-| `--direction-method` | Direction extraction | diff_means |
-| `--n-directions` | Number of refusal directions (1-32) | method-dependent |
-| `--refinement-passes` | Iterative passes (1-5) | 2 |
-| `--regularization` | Regularization strength (0.0-1.0) | 0.1 |
-| `--quantization` | Load in 4bit or 8bit | none (full precision) |
-| `--large-model` | Conservative defaults for 120B+ | false |
-| `--output-dir` | Where to save the abliterated model | ./obliterated_model |
-| `--contribute` | Share anonymized results for research | false |
-| `--verify-sample-size` | Number of test prompts for refusal check | 20 |
-| `--dtype` | Model dtype (float16, bfloat16) | auto |
+Qwen3.8: one CUDA device, no generic multi-GPU shard. Load `references/local-models.md` with `skill_view`.
 
-### Other execution modes
-```bash
-# Interactive guided mode (hardware → model → preset)
-obliteratus interactive
+## Quick Reference
 
-# Web UI (Gradio)
-obliteratus ui --port 7860
+| Command | Purpose |
+|---|---|
+| `obliteratus obliterate <id-or-path>` | Weight-projection refusal removal (`abliterate` is a hidden alias) |
+| `obliteratus info <id-or-path>` | Architecture print |
+| `obliteratus models --tier {tiny,small,medium,large,frontier}` | Curated presets |
+| `obliteratus recommend <id-or-path>` | Telemetry-driven method/params (`--insights` for global) |
+| `obliteratus gpu-calc <id-or-path> --gpu-mem 80` | Minimum GPU count estimate |
+| `obliteratus self-improve <path> --audit <json> --output-dir <dir>` | Residue / hard-negative follow-up |
+| `obliteratus capability-check --abliterated <p> --stock <p>` | MMLU vs stock (`--quick`) |
+| `obliteratus tourney <id-or-path>` | Method tournament |
+| `obliteratus runs launch -- <args>` | Detached durable run |
+| `obliteratus ui --port 7860` | Local Gradio |
+| `obliteratus interactive` | Guided wizard |
 
-# Run a full ablation study from YAML config
-obliteratus run config.yaml --preset quick
+`--method`: `basic`, `advanced` (default), `aggressive`, `spectral_cascade`, `informed`, `surgical`, `optimized`, `som`, `inverted`, `nuclear`.
 
-# Tournament: pit all methods against each other
-obliteratus tourney <model_name>
-```
+`--direction-method`: `diff_means`, `svd`, `leace`, `som`. `--quantization`: `4bit`, `8bit`.
 
-## Step 6: Verify Results
+## Procedure
 
-After abliteration, check the output metrics:
+1. Confirm the checkpoint with `read_file` on `<ckpt>/config.json`. Prefer the on-disk tree; do not re-download a sibling official copy.
+2. Check GPU idle state through `terminal`. Pin an idle device with `--gpus N`. Do not steal a live serve.
+3. Size the job: `obliteratus gpu-calc <ckpt> --gpu-mem <GB>`. Native BF16 surgery needs ~2 bytes/param plus activations; `--quantization 4bit` is load-time only. FP8/NVFP4 checkpoints dequantize automatically — peak VRAM is the **BF16** size; saved output is BF16.
+4. Optional: `obliteratus recommend <ckpt>` then `obliteratus info <ckpt>`.
+5. Run `obliteratus obliterate` with `--method advanced` unless `references/methods-guide.md` says otherwise (MoE → `nuclear`, reasoning/CoT → `surgical`).
+6. Read the printed metrics. Target refusal rate ≤ 5% (ideally ~0–3%). Fail-closed defaults: `--max-perplexity-increase 3.0` (multiple of stock), `--min-coherence-retention 0.5`, `--max-degenerate-fraction 0.2`, `--verify-sample-size 30`.
+7. If refusals remain: `obliteratus self-improve <ckpt> --audit <json> --output-dir <next>`, or rerun with `--residue-file`, more `--n-directions`, `--refinement-passes 3`, `--direction-method svd`, or `--method aggressive`.
+8. Optional capability gate: `obliteratus capability-check --abliterated <out> --stock <ckpt> --quick`.
+9. The output is a standard HuggingFace directory. Serve with the related serving skills — not with `import obliteratus`.
 
-| Metric | Good Value | Warning |
-|:-------|:-----------|:--------|
-| Refusal rate | < 5% (ideally ~0%) | > 10% means refusals persist |
-| Perplexity change | < 10% increase | > 15% means coherence damage |
-| KL divergence | < 0.1 | > 0.5 means significant distribution shift |
-| Coherence | High / passes qualitative check | Degraded responses, repetition |
+Load `references/local-models.md` when the checkpoint is a local path, Qwen3.8, FP8/NVFP4, or a residue loop. Load `references/methods-guide.md` for method choice. Load `references/analysis-modules.md` only when the user asks to map refusal geometry first.
 
-### If refusals persist (> 10%)
-1. Try `aggressive` method
-2. Increase `--n-directions` (e.g., 8 or 16)
-3. Add `--refinement-passes 3`
-4. Try `--direction-method svd` instead of diff_means
+## Pitfalls
 
-### If coherence is damaged (perplexity > 15% increase)
-1. Reduce `--n-directions` (try 2)
-2. Increase `--regularization` (try 0.3)
-3. Reduce `--refinement-passes` to 1
-4. Try `basic` method (gentler)
+1. **AGPL boundary.** Never `from obliteratus import ...` in Hermes or other MIT/Apache code. CLI / subprocess only.
+2. **`--quantization` values are `4bit` and `8bit`.** Not `bitsandbytes-4bit`. Extra `.[quantization]` must be installed or the flag fails.
+3. **Qwen3.8 hybrid runtime.** Needs `.[qwen-hybrid]`, FLA + causal-conv1d CUDA kernels, the full text model on **one** CUDA device with 15% headroom. Generic PyTorch fallback and `device_map="auto"` sharding are rejected. A failed pristine load is never modified.
+4. **`--large-model` is for 120B+**, not 70B. Conservative defaults: fewer directions, 1 pass.
+5. **Sub-1B models respond poorly.** Expect leftover refusal. 3B+ is the realistic near-zero-refusal regime.
+6. **`informed` is slower and experimental.** Default is `advanced`.
+7. **`aggressive` can damage coherence** on small models. Use only when `advanced` leaves >10% refusal on 3B+.
+8. **Quantized-load ≠ quantized-save.** Abliterate, then re-quantize the BF16 output if you need a 4-bit serving artifact.
+9. **Multi-GPU is memory, not speed.** `--gpus 0,1` shards via accelerate pipeline parallel; Qwen3.8 forbids that path.
+10. **Spectral "incomplete" is not a fail.** Trust measured refusal rate, coherence, and degeneracy.
+11. **`--contribute` is opt-in telemetry.** Off by default on CLI (Spaces turns it on).
+12. **Do not use `uv run` after replacing the CPU-locked CI torch wheel with CUDA.**
 
-## Step 7: Use the Abliterated Model
-
-The output is a standard HuggingFace model directory.
+## Verification
 
 ```bash
-# Test locally with transformers
-python3 -c "
-from transformers import AutoModelForCausalLM, AutoTokenizer
-model = AutoModelForCausalLM.from_pretrained('./abliterated-models/<model>')
-tokenizer = AutoTokenizer.from_pretrained('./abliterated-models/<model>')
-inputs = tokenizer('How do I pick a lock?', return_tensors='pt')
-outputs = model.generate(**inputs, max_new_tokens=200)
-print(tokenizer.decode(outputs[0], skip_special_tokens=True))
-"
-
-# Upload to HuggingFace Hub
-huggingface-cli upload <username>/<model-name>-abliterated ./abliterated-models/<model>
-
-# Serve with vLLM
-vllm serve ./abliterated-models/<model>
+obliteratus --version
+obliteratus info /abs/path/to/ckpt
 ```
 
-## CLI Command Reference
-
-| Command | Description |
-|:--------|:------------|
-| `obliteratus obliterate` | Main abliteration command |
-| `obliteratus info <model>` | Print model architecture details |
-| `obliteratus models --tier <tier>` | Browse curated models by compute tier |
-| `obliteratus recommend <model>` | Telemetry-driven method/param suggestion |
-| `obliteratus interactive` | Guided setup wizard |
-| `obliteratus tourney <model>` | Tournament: all methods head-to-head |
-| `obliteratus run <config.yaml>` | Execute ablation study from YAML |
-| `obliteratus strategies` | List all registered ablation strategies |
-| `obliteratus report <results.json>` | Regenerate visual reports |
-| `obliteratus ui` | Launch Gradio web interface |
-| `obliteratus aggregate` | Summarize community telemetry data |
-
-## Analysis Modules
-
-OBLITERATUS includes 28 analysis modules for mechanistic interpretability.
-See `skill_view(name="obliteratus", file_path="references/analysis-modules.md")` for the full reference.
-
-### Quick analysis commands
-```bash
-# Run specific analysis modules
-obliteratus run analysis-config.yaml --preset quick
-
-# Key modules to run first:
-# - alignment_imprint: Fingerprint DPO/RLHF/CAI/SFT alignment method
-# - concept_geometry: Single direction vs polyhedral cone
-# - logit_lens: Which layer decides to refuse
-# - anti_ouroboros: Self-repair risk score
-# - causal_tracing: Causally necessary components
-```
-
-### Steering Vectors (Reversible Alternative)
-Instead of permanent weight modification, use inference-time steering:
-```python
-# Python API only — for user's own projects
-from obliteratus.analysis.steering_vectors import SteeringVectorFactory, SteeringHookManager
-```
-
-## Ablation Strategies
-
-Beyond direction-based abliteration, OBLITERATUS includes structural ablation strategies:
-- **Embedding Ablation** — Target embedding layer components
-- **FFN Ablation** — Feed-forward network block removal
-- **Head Pruning** — Attention head pruning
-- **Layer Removal** — Full layer removal
-
-List all available: `obliteratus strategies`
-
-## Evaluation
-
-OBLITERATUS includes built-in evaluation tools:
-- Refusal rate benchmarking
-- Perplexity comparison (before/after)
-- LM Eval Harness integration for academic benchmarks
-- Head-to-head competitor comparison
-- Baseline performance tracking
-
-## Platform Support
-
-- **CUDA** — Full support (NVIDIA GPUs)
-- **Apple Silicon (MLX)** — Supported via MLX backend
-- **CPU** — Supported for tiny models (< 1B params)
-
-## YAML Config Templates
-
-Load templates for reproducible runs via `skill_view`:
-- `templates/abliteration-config.yaml` — Standard single-model config
-- `templates/analysis-study.yaml` — Pre-abliteration analysis study
-- `templates/batch-abliteration.yaml` — Multi-model batch processing
-
-## Telemetry
-
-OBLITERATUS can optionally contribute anonymized run data to a global research dataset.
-Enable with `--contribute` flag. No personal data is collected — only model name, method, metrics.
-
-## Common Pitfalls
-
-1. **Don't use `informed` as default** — it's experimental and slower. Use `advanced` for reliable results.
-2. **Models under ~1B respond poorly to abliteration** — their refusal behaviors are shallow and fragmented, making clean direction extraction difficult. Expect partial results (20-40% remaining refusal). Models 3B+ have cleaner refusal directions and respond much better (often 0% refusal with `advanced`).
-3. **`aggressive` can make things worse** — on small models it can damage coherence and actually increase refusal rate. Only use it if `advanced` leaves > 10% refusals on a 3B+ model.
-4. **Always check perplexity** — if it spikes > 15%, the model is damaged. Reduce aggressiveness.
-5. **MoE models need special handling** — use `nuclear` method for Mixtral, DeepSeek-MoE, etc.
-6. **Quantized models can't be re-quantized** — abliterate the full-precision model, then quantize the output.
-7. **VRAM estimation is approximate** — 4-bit quant helps but peak usage can spike during extraction.
-8. **Reasoning models are sensitive** — use `surgical` for R1 distills to preserve chain-of-thought.
-9. **Check `obliteratus recommend`** — telemetry data may have better parameters than defaults.
-10. **AGPL license** — never `import obliteratus` in MIT/Apache projects. CLI invocation only.
-11. **Large models (70B+)** — always use `--large-model` flag for conservative defaults.
-12. **Spectral certification RED is common** — the spectral check often flags "incomplete" even when practical refusal rate is 0%. Check actual refusal rate rather than relying on spectral certification alone.
-
-## Complementary Skills
-
-- **vllm** — Serve abliterated models with high throughput
-- **gguf** — Convert abliterated models to GGUF for llama.cpp
-- **huggingface-tokenizers** — Work with model tokenizers
+A liberated tree is valid when it contains `config.json` plus safetensors, `obliteratus info <output-dir>` prints the architecture, and the CLI summary shows refusal rate ≤ 5% with degeneracy below `0.2`.

--- a/optional-skills/mlops/obliteratus/SKILL.md
+++ b/optional-skills/mlops/obliteratus/SKILL.md
@@ -98,7 +98,7 @@ Qwen3.8: one CUDA device, no generic multi-GPU shard. Load `references/local-mod
 2. Check GPU idle state through `terminal`. Pin an idle device with `--gpus N`. Do not steal a live serve.
 3. Size the job: `obliteratus gpu-calc <ckpt> --gpu-mem <GB>`. Native BF16 surgery needs ~2 bytes/param plus activations; `--quantization 4bit` is load-time only. FP8/NVFP4 checkpoints dequantize automatically — peak VRAM is the **BF16** size; saved output is BF16.
 4. Optional: `obliteratus recommend <ckpt>` then `obliteratus info <ckpt>`.
-5. Run `obliteratus obliterate` with `--method advanced` unless `references/methods-guide.md` says otherwise (MoE → `nuclear`, reasoning/CoT → `surgical`).
+5. Run `obliteratus obliterate` with `--method advanced` unless `references/methods-guide.md` says otherwise (precision MoE → `surgical`, quality auto-tune → `optimized`).
 6. Read the printed metrics. Target refusal rate ≤ 5% (ideally ~0–3%). Fail-closed defaults: `--max-perplexity-increase 3.0` (multiple of stock), `--min-coherence-retention 0.5`, `--max-degenerate-fraction 0.2`, `--verify-sample-size 30`.
 7. If refusals remain: `obliteratus self-improve <ckpt> --audit <json> --output-dir <next>`, or rerun with `--residue-file`, more `--n-directions`, `--refinement-passes 3`, `--direction-method svd`, or `--method aggressive`.
 8. Optional capability gate: `obliteratus capability-check --abliterated <out> --stock <ckpt> --quick`.

--- a/optional-skills/mlops/obliteratus/references/analysis-modules.md
+++ b/optional-skills/mlops/obliteratus/references/analysis-modules.md
@@ -1,166 +1,52 @@
-# OBLITERATUS Analysis Modules — Reference
+# OBLITERATUS analysis modules
 
-OBLITERATUS includes 28 analysis modules for mechanistic interpretability of refusal in LLMs.
-These modules help understand how and where refusal behaviors are encoded before performing abliteration.
+Public README documents **15** analysis modules. Load this only when the user wants to map refusal geometry *before* (or instead of) weight surgery. The `informed` CLI method already runs a subset during obliteration.
 
----
+Do not `import` these from Hermes. Analysis studies go through `obliteratus run <config.yaml> --preset ...` via the `terminal` tool.
 
-## Core Analysis (Run These First)
+## The 15 modules (README)
 
-### 1. Alignment Imprint Detection (`alignment_imprint.py`)
-Fingerprints whether a model was trained via DPO, RLHF, CAI, or SFT.
-This determines which extraction strategy will work best.
+| Module | Question |
+|---|---|
+| Cross-layer alignment | How does the refusal direction evolve across layers? |
+| Refusal logit lens | At which layer does the model decide to refuse? |
+| Whitened SVD | Principal refusal directions after whitening |
+| Activation probing | How much refusal signal exists at each layer? |
+| Defense robustness | Will guardrails self-repair (Ouroboros)? |
+| Concept cone geometry | One mechanism or many? Shared across categories? |
+| Alignment imprint detection | DPO vs RLHF vs CAI vs SFT fingerprint |
+| Multi-token position | Where in the sequence the refusal signal concentrates |
+| Sparse surgery | Which weight rows carry the most refusal |
+| Causal tracing | Which components are causally necessary |
+| Residual stream decomposition | Attention vs MLP contribution |
+| Linear probing classifiers | Learned probe vs analytical direction |
+| Cross-model transfer | Universality index |
+| Steering vectors | Inference-time disable without touching weights |
+| Evaluation suite | Refusal rate, perplexity, coherence, KL, CKA, effective rank |
 
-### 2. Concept Cone Geometry (`concept_geometry.py`)
-Determines if refusal is a single linear direction or a polyhedral cone
-(set of multiple mechanisms). Single-direction models respond well to `basic`;
-polyhedral models need `advanced` or `surgical`.
+## `informed` auto-config
 
-### 3. Refusal Logit Lens (`logit_lens.py`)
-Identifies the specific layer where a model "decides" to refuse by decoding
-intermediate layer representations into token space.
+The ANALYZE stage runs four modules and wires their outputs:
 
-### 4. Ouroboros Detection (`anti_ouroboros.py`)
-Identifies if a model attempts to "self-repair" refusal behaviors after
-excision. Reports a risk score (0-1). High scores mean additional refinement
-passes are needed.
+| Module | Configures |
+|---|---|
+| Alignment imprint | Regularization / projection aggressiveness |
+| Concept cone geometry | Direction count (1 if linear, up to 8 if polyhedral) |
+| Cross-layer alignment | Layer selection |
+| Defense robustness | Refinement passes; skip entangled layers |
 
-### 5. Causal Tracing (`causal_tracing.py`)
-Identifies which components (layers, heads, MLPs) are causally necessary
-for refusal behavior using activation patching.
+VERIFY then fires extra passes if Ouroboros self-repair is detected.
 
----
+## Running analysis via CLI
 
-## Geometric Analysis
-
-### 6. Cross-Layer Alignment (`cross_layer.py`)
-Measures how refusal directions align across different layers. High alignment
-means the refusal signal is consistent; low alignment suggests layer-specific
-mechanisms.
-
-### 7. Residual Stream Decomposition (`residual_stream.py`)
-Decomposes the residual stream into attention and MLP contributions to
-understand which component type contributes more to refusal.
-
-### 8. Riemannian Manifold Geometry (`riemannian_manifold.py`)
-Analyzes the curvature and geometry of the weight manifold near refusal
-directions. Informs how aggressively projections can be applied without
-damaging the manifold structure.
-
-### 9. Whitened SVD (`whitened_svd.py`)
-Covariance-normalized SVD extraction that separates guardrail signals from
-natural activation variance. More precise than standard SVD for models with
-high activation variance.
-
-### 10. Concept Cone Geometry (extended)
-Maps the full polyhedral structure of refusal, including cone angles,
-face counts, and intersection patterns.
-
----
-
-## Probing & Classification
-
-### 11. Activation Probing (`activation_probing.py`)
-Post-excision verification — probes for residual refusal concepts after
-abliteration to ensure complete removal.
-
-### 12. Probing Classifiers (`probing_classifiers.py`)
-Trains linear classifiers to detect refusal in activations. Used both
-before (to verify refusal exists) and after (to verify it's gone).
-
-### 13. Activation Patching (`activation_patching.py`)
-Interchange interventions — swaps activations between refused and complied
-runs to identify causal components.
-
-### 14. Tuned Lens (`tuned_lens.py`)
-Trained version of logit lens that provides more accurate per-layer
-decoding by learning affine transformations for each layer.
-
-### 15. Multi-Token Position Analysis (`multi_token_position.py`)
-Analyzes refusal signals across multiple token positions, not just the
-last token. Important for models that distribute refusal across the sequence.
-
----
-
-## Abliteration & Manipulation
-
-### 16. SAE-Based Abliteration (`sae_abliteration.py`)
-Uses Sparse Autoencoder features to identify and remove specific refusal
-features. More surgical than direction-based methods.
-
-### 17. Steering Vectors (`steering_vectors.py`)
-Creates and applies inference-time steering vectors for reversible refusal
-modification. Includes `SteeringVectorFactory` and `SteeringHookManager`.
-
-### 18. LEACE Concept Erasure (`leace.py`)
-Linear Erasure via Closed-form Estimation — mathematically optimal linear
-concept removal. Available as both analysis module and direction extraction method.
-
-### 19. Sparse Surgery (`sparse_surgery.py`)
-High-precision weight modification targeting individual neurons and
-weight matrix entries rather than full directions.
-
-### 20. Conditional Abliteration (`conditional_abliteration.py`)
-Targeted removal that only affects specific refusal categories while
-preserving others (e.g., remove weapons refusal but keep CSAM refusal).
-
----
-
-## Transfer & Robustness
-
-### 21. Cross-Model Transfer (`cross_model_transfer.py`)
-Tests whether refusal directions extracted from one model transfer to
-another architecture. Measures universality of guardrail directions.
-
-### 22. Defense Robustness (`defense_robustness.py`)
-Evaluates how robust the abliteration is against various defense mechanisms
-and re-alignment attempts.
-
-### 23. Spectral Certification (`spectral_certification.py`)
-Provides mathematical bounds on the completeness of refusal removal
-using spectral analysis of the projection.
-
-### 24. Wasserstein Optimal Extraction (`wasserstein_optimal.py`)
-Uses optimal transport theory for more precise direction extraction
-that minimizes distribution shift.
-
-### 25. Wasserstein Transfer (`wasserstein_transfer.py`)
-Distribution transfer between models using Wasserstein distance
-for cross-architecture refusal direction mapping.
-
----
-
-## Advanced / Research
-
-### 26. Bayesian Kernel Projection (`bayesian_kernel_projection.py`)
-Probabilistic feature mapping that estimates uncertainty in refusal
-direction identification.
-
-### 27. Cross-Model Universality Index
-Measures if guardrail directions generalize across different model
-architectures and training regimes.
-
-### 28. Visualization (`visualization.py`)
-Plotting and graphing utilities for all analysis modules. Generates
-heatmaps, direction plots, and layer-wise analysis charts.
-
----
-
-## Running Analysis
-
-### Via CLI
 ```bash
-# Run analysis from a YAML config
 obliteratus run analysis-study.yaml --preset quick
-
-# Available study presets:
-# quick     — Fast sanity check (2-3 modules)
-# full      — All core + geometric analysis
-# jailbreak — Refusal circuit localization
-# knowledge — Knowledge preservation analysis
-# robustness — Stress testing / defense evaluation
+obliteratus presets
+obliteratus strategies
 ```
 
-### Via YAML Config
-See the `templates/analysis-study.yaml` template for a complete example.
-Load with: `skill_view(name="obliteratus", file_path="templates/analysis-study.yaml")`
+Presets mentioned in the CLI help include `quick`, `full`, `attention`, `jailbreak`, `guardrail`.
+
+Ablation strategies (structural, not direction projection): `layer_removal`, `head_pruning`, `ffn_ablation`, `embedding_ablation`.
+
+See `templates/analysis-study.yaml` for a YAML skeleton.

--- a/optional-skills/mlops/obliteratus/references/local-models.md
+++ b/optional-skills/mlops/obliteratus/references/local-models.md
@@ -1,0 +1,142 @@
+# Local checkpoints, Qwen3.8, and residue loops
+
+Load this file when the model is a directory on disk, a Qwen3.8 hybrid, an FP8/NVFP4 checkpoint, or a follow-up pass after leftover refusals.
+
+Source of truth: OBLITERATUS `0.1.3` CLI (`obliteratus/cli.py`) and README at https://github.com/elder-plinius/OBLITERATUS
+
+## Local path as `model`
+
+`obliteratus obliterate`, `info`, `recommend`, `gpu-calc`, `tourney`, and `self-improve` all take a HuggingFace **name or path**. A local tree is valid when it has `config.json` and weight shards. Confirm `config.json` with `read_file` before spending GPU time.
+
+Prefer the on-disk snapshot. Do not re-download a sibling official copy that is already present.
+
+Always set `--output-dir` to a new directory. Do not overwrite the source tree.
+
+Gated hub ids need `HF_TOKEN`. Local directories do not. Optional vault/file resolution order from the README: explicit arg → env var → `<NAME>_FILE` → `OBLITERATUS_SECRET_DIR` → `CREDENTIALS_DIRECTORY` → `OBLITERATUS_SECRET_COMMAND`.
+
+## GPU selection
+
+`--gpus` sets `CUDA_VISIBLE_DEVICES` before CUDA init:
+
+```bash
+obliteratus obliterate /abs/path/to/ckpt --gpus 0 --output-dir ./liberated
+obliteratus obliterate /abs/path/to/ckpt --gpus 0,1 --output-dir ./liberated
+obliteratus obliterate /abs/path/to/ckpt --gpus all --output-dir ./liberated
+```
+
+Multi-GPU uses accelerate `device_map="auto"` **pipeline** sharding: memory solution, not a speedup. Idle GPUs hold layers. Skip this path for Qwen3.8.
+
+`--gpu-memory-utilization` is a fraction in `(0, 1]`. Default reserve is 15% or 2 GiB per GPU, whichever is larger.
+
+`--trust-remote-code` is required only for custom modeling code (README example: Nemotron Omni).
+
+`--dtype` CLI default on `obliterate` is `float16`. Prefer `bfloat16` when the hardware supports it.
+
+## Quantization vs surgery dtype
+
+| Flag | Meaning |
+|---|---|
+| `--quantization 4bit` / `8bit` | bitsandbytes load. Requires `pip install -e ".[quantization]"` |
+| no quantization flag | native float load |
+| FP8 / NVFP4 checkpoint | detected from `quantization_config`; dequantized shard-by-shard to BF16; **no extra flag** |
+
+Peak VRAM for FP8/NVFP4 is the BF16 size, not the packed size. Saved output is plain BF16. Re-quantize afterward if you need a 4-bit serving artifact.
+
+Unsupported or ambiguous quantization layouts fail closed with the scheme named.
+
+README also shows UI labels like `bitsandbytes-4bit`; the **CLI choices are only `4bit` and `8bit`**.
+
+`--large-model` enables conservative defaults for **120B+** (fewer directions, 1 pass, lower SAE expansion). Do not set it for 70B.
+
+## Qwen3.8 hybrid contract
+
+From the README Qwen3.8 safety status:
+
+- Hybrid Gated DeltaNet needs supported FLA and causal-conv1d CUDA kernels for correct pristine logits.
+- Install: `pip install -e ".[qwen-hybrid]"` (`transformers>=5.8`, `flash-linear-attention>=0.5.2`, `causal-conv1d>=1.7.0`).
+- Place the complete text model on **one** CUDA device with 15% headroom. Stop before allocation if that cannot be met.
+- Generic PyTorch fallback and automatic multi-GPU layer sharding are **rejected**.
+- Saved-checkpoint Chat reloads use the same contract (FLA/causal-conv1d, SDPA, one CUDA device).
+- Pristine and post-edit quality gates remain mandatory. A failed pristine checkpoint is never modified.
+
+```bash
+obliteratus obliterate /abs/path/to/Qwen3.8-27B \
+  --dtype bfloat16 \
+  --gpus 0 \
+  --output-dir ./liberated-qwen38
+```
+
+Use `--quantization 4bit` only when native BF16 cannot fit that single device.
+
+## Layer / shield knobs (optional)
+
+Only set these when `recommend` or a failed first pass justifies it:
+
+| Flag | Role |
+|---|---|
+| `--min-layer-fraction` / `--max-layer-fraction` | Restrict edits to a depth band (e.g. `0.75` keeps the final quarter) |
+| `--harmless-pc-count` | Subtract top harmless activation PCs from refusal directions |
+| `--shield-concept-count` / `--shield-ridge` / `--shield-residualize` / `--shield-layer-penalty` | Capability/style shield atoms |
+| `--projection-target {all,attention,ffn,output}` | Which modules to project |
+| `--projection-row-fraction` | Project only the strongest fraction of rows/columns |
+| `--n-directions` | Override direction count |
+| `--regularization` | Fraction to preserve (`0.0`–`1.0`) |
+| `--refinement-passes` | Iterative re-probe passes |
+
+## Quality gates
+
+CLI fail-closed defaults on `obliterate`:
+
+| Flag | Default |
+|---|---|
+| `--verify-sample-size` | 30 harmful prompts |
+| `--refusal-max-tokens` | 128 |
+| `--max-perplexity-increase` | `3.0` × stock perplexity |
+| `--min-coherence-retention` | `0.5` |
+| `--max-degenerate-fraction` | `0.2` |
+
+Practical local-model target (not the CLI abort threshold): refusal rate ≤ 5%, ideally ≤ 3%, degeneracy well under `0.2`. A 3.0× perplexity abort is a catastrophe brake, not a quality goal.
+
+`--prompt-pairs-file` is a local UTF-8 JSON object with exactly `harmful` and `harmless` arrays. Mutually exclusive with `--residue-file`. `--dataset` / `--residue-weight` / `--residue-max` cannot mix with `--prompt-pairs-file`.
+
+## Residue loop (leftover refusals)
+
+```bash
+obliteratus self-improve /abs/path/to/ckpt \
+  --audit /abs/path/to/refusal-audit.json \
+  --output-dir ./liberated-pass2 \
+  --method advanced \
+  --direction-method diff_means
+```
+
+`--audit` is repeatable. `--dry-run` writes residue/plan without surgery.
+
+Or stay on `obliterate` and pass `--residue-file` (repeatable) with `--residue-weight` (default 5).
+
+## Capability check vs stock
+
+```bash
+obliteratus capability-check \
+  --abliterated ./liberated \
+  --stock /abs/path/to/ckpt \
+  --dtype bfloat16 \
+  --quick
+```
+
+`--quick` is 5 subjects. Full MMLU is the default without `--quick`.
+
+Vision/MTP restore after text-only surgery: `obliteratus restore-multimodal --abliterated <dir> --stock <dir> --output <dir>`.
+
+## Durable runs
+
+```bash
+obliteratus runs launch --notes "local 8B advanced" -- /abs/path/to/ckpt --method advanced --output-dir ./liberated
+obliteratus runs list
+obliteratus runs status <run_id>
+```
+
+Archive root defaults to `OBLITERATUS_RUN_ARCHIVE` or the user state directory.
+
+## Remote SSH (optional)
+
+`--remote [user@]host`, `--ssh-key`, `--ssh-port` (1–65535, default 22), `--remote-dir` (default `/tmp/obliteratus_run`), `--remote-python` (default `python3`), `--no-sync`.

--- a/optional-skills/mlops/obliteratus/references/methods-guide.md
+++ b/optional-skills/mlops/obliteratus/references/methods-guide.md
@@ -1,141 +1,81 @@
-# OBLITERATUS Methods — Detailed Guide
+# OBLITERATUS methods
 
-> The CLI accepts 9 methods via `--method`: basic, advanced, aggressive, spectral_cascade,
-> informed, surgical, optimized, inverted, nuclear.
-> Four additional methods (failspy, gabliteration, heretic, rdo) are available only via the Python API.
+CLI `--method` choices (package `0.1.3`): `basic`, `advanced`, `aggressive`, `spectral_cascade`, `informed`, `surgical`, `optimized`, `som`, `inverted`, `nuclear`.
 
-## How Abliteration Works (Theory)
+`--direction-method`: `diff_means`, `svd`, `leace`, `som`.
 
-Abliteration identifies a "refusal direction" — a vector in the model's activation space that
-corresponds to refusal behavior — and projects it out of the weight matrices.
+`som` is accepted by the CLI. The public README does not document the algorithm — do not invent flags or hyperparameters for it.
 
-Mathematically: `W_new = W_old - (W_old @ d @ d.T)` where `d` is the refusal direction.
+Four extra methods (`failspy`, `gabliteration`, `heretic`, `rdo`) appear only in Python imports. Do not use them from Hermes: AGPL + MIT boundary. CLI only.
 
-The key challenge is finding accurate refusal directions without damaging other capabilities.
+## Weight projection (permanent)
 
----
+README seven-preset table (escalating thoroughness):
 
-## Direction Extraction Methods
+| Method | Directions | Key features | Best for |
+|---|---|---|---|
+| `basic` | 1 (diff-in-means) | Fast baseline | Quick test, small models |
+| `advanced` | 4 (SVD) | Norm-preserving, bias projection, 2 passes | **Default.** Clean removal |
+| `aggressive` | 8 (SVD) | Whitened SVD, iterative refinement, 3 passes | Stubborn residual refusal |
+| `surgical` | 8 (SVD) | EGA, head surgery, SAE, layer-adaptive, MoE-aware | Precision / CoT |
+| `optimized` | 4 (SVD) | Bayesian auto-tuned, CoT-aware, KL co-optimized | Quality over wall-clock |
+| `inverted` | 8 (SVD) | Semantic refusal inversion (2× reflection) | Research inversion |
+| `nuclear` | 8 (SVD) | All techniques + expert transplant + steering | Stubborn MoE |
 
-Before projecting, OBLITERATUS extracts refusal directions using one of three methods:
+Also on the CLI, not in that seven-row table: `spectral_cascade`, `informed`, `som`.
 
-| Method | Flag | Description | Best For |
-|:-------|:-----|:------------|:---------|
-| Diff-in-Means | `--direction-method diff_means` | Difference between mean activations on refused vs. complied prompts | Default, fast, robust |
-| SVD | `--direction-method svd` | Multi-direction extraction via Singular Value Decomposition | Complex alignment, multiple refusal mechanisms |
-| LEACE | `--direction-method leace` | Linear Erasure via Closed-form Estimation — mathematically optimal | Maximum precision, research |
+- `informed` — analysis modules run *during* obliteration and auto-configure directions, layers, regularization, and Ouroboros passes. Experimental; slower than `advanced`.
+- `spectral_cascade` — DCT frequency-domain decomposition. Research path.
 
----
+## Direction extraction
 
-## Method Details
+| Flag | Description |
+|---|---|
+| `--direction-method diff_means` | Difference-in-means (default when unset on `self-improve`; `obliterate` default is method-dependent / None) |
+| `--direction-method svd` | Multi-direction SVD |
+| `--direction-method leace` | LEACE closed-form linear erasure |
+| `--direction-method som` | CLI-accepted; undocumented in README |
 
-### basic
-- **Directions:** 1 (single diff-in-means vector)
-- **Speed:** Fast (~5-10 min for 8B model)
-- **Risk:** Low
-- **Use case:** Quick tests, prototyping, evaluating if abliteration works for a model
-- **How it works:** Extracts one refusal direction and projects it out uniformly across all layers.
-
-### advanced (DEFAULT — RECOMMENDED)
-- **Directions:** 4 (multi-direction SVD)
-- **Speed:** Medium (~10-20 min for 8B model)
-- **Risk:** Low-Medium
-- **Refinement passes:** 2
-- **Use case:** Default for most models. Well-tested and reliable.
-- **How it works:** Extracts multiple refusal directions via SVD, applies norm-preserving bi-projection to maintain weight matrix norms. Two refinement passes catch residual refusal.
-
-### aggressive
-- **Directions:** 8+ (whitened SVD + jailbreak-contrastive)
-- **Speed:** Medium-Slow
-- **Risk:** Medium-High (may damage coherence)
-- **Use case:** When `advanced` leaves > 10% refusals. Stubborn models.
-- **How it works:** Uses whitened SVD for covariance-normalized extraction, adds jailbreak-contrastive directions, performs attention head surgery on the most refusal-active heads.
-
-### spectral_cascade
-- **Speed:** Medium
-- **Risk:** Medium
-- **Use case:** Research, novel approaches
-- **How it works:** DCT (Discrete Cosine Transform) frequency-domain decomposition of refusal signals. Separates high-frequency (surface-level) from low-frequency (deep) refusal patterns.
-
-### informed (EXPERIMENTAL)
-- **Speed:** Slow (~20-40 min for 8B model)
-- **Risk:** Variable — results depend on analysis quality
-- **Use case:** When you want auto-configuration, but be aware this is experimental and may not outperform `advanced`.
-- **How it works:** Runs 4 analysis modules first (alignment imprint, concept geometry, logit lens, ouroboros detection), then auto-configures extraction strategy. Includes an "Ouroboros loop" that detects and counteracts self-repair.
-- **Note:** The auto-detection can sometimes misconfigure. If results are poor, fall back to `advanced`.
-
-### surgical
-- **Speed:** Very slow (~1-2 hrs for 8B model)
-- **Risk:** Low (very precise)
-- **Use case:** Reasoning models (R1 distills, QwQ, etc.) where chain-of-thought must be preserved.
-- **How it works:** Uses SAE (Sparse Autoencoder) features + individual neuron masking + attention head surgery + per-expert decomposition (for MoE). CoT-aware — identifies and protects reasoning-critical directions before projecting.
-
-### optimized
-- **Speed:** Very slow (hours — runs many trials)
-- **Risk:** Low (finds optimal parameters)
-- **Use case:** When quality matters more than speed. Production models.
-- **How it works:** Bayesian hyperparameter search via Optuna TPE sampler. Optimizes n_directions, regularization, refinement passes, and layer selection jointly. Evaluates each configuration on refusal rate + perplexity.
-
-### inverted
-- **Speed:** Fast
-- **Risk:** High (model behavior changes dramatically)
-- **Use case:** Research, studying refusal mechanisms
-- **How it works:** Instead of projecting out the refusal direction, reflects it. The model actively complies rather than passively not-refusing. Useful for understanding the geometry of alignment.
-
-### nuclear
-- **Speed:** Slow
-- **Risk:** Medium-High
-- **Use case:** Stubborn MoE models (DeepSeek-MoE, Mixtral, etc.)
-- **How it works:** Combines expert-granular abliteration (EGA), steering vector injection, attention head pruning, and multi-pass refinement. Decomposes refusal signals into per-expert components for MoE architectures.
-
----
-
-## Method Selection Flowchart
+## Selection flowchart
 
 ```
-Is this a quick test?
-  → YES: basic
-  → NO: continue
-
-Is it an MoE model (Mixtral, DeepSeek-MoE)?
-  → YES: nuclear
-  → NO: continue
-
-Is it a reasoning model (R1, QwQ, CoT-focused)?
-  → YES: surgical
-  → NO: continue
-
-Do you need the absolute best quality and have time?
-  → YES: optimized
-  → NO: advanced (recommended default)
-
-Did advanced leave > 10% refusals?
-  → YES: aggressive
-  → Still refusing: nuclear
+Quick test?                         → basic
+MoE (Mixtral, DeepSeek-MoE)?        → nuclear
+Reasoning / CoT (R1, QwQ)?          → surgical
+Need auto-tune and have hours?      → optimized
+Else                                → advanced
+advanced left >10% refusal on 3B+?  → aggressive, or self-improve with --audit
+Still refusing?                     → nuclear / residue loop
 ```
 
----
+Do not start with `informed` or `aggressive`.
 
-## Key Parameters
+## Key CLI overrides
 
-| Parameter | Range | Default | Effect |
-|:----------|:------|:--------|:-------|
-| `--n-directions` | 1-32 | method-dependent | More directions = more complete removal, but higher damage risk |
-| `--regularization` | 0.0-1.0 | 0.1 | Higher = more conservative (less removal, less damage) |
-| `--refinement-passes` | 1-5 | 2 | More passes catch residual refusal, but diminishing returns |
-| `--quantization` | 4bit, 8bit | none | Reduces VRAM usage; quality impact minimal for extraction |
-| `--verify-sample-size` | 10-200 | 20 | More samples = more accurate refusal rate estimate |
-
----
+| Flag | Notes |
+|---|---|
+| `--n-directions` | Override extracted direction count |
+| `--regularization` | Fraction to preserve, `0.0`–`1.0` |
+| `--refinement-passes` | Iterative re-probe |
+| `--quantization` | `4bit` or `8bit` only |
+| `--verify-sample-size` | Default 30 |
+| `--large-model` | 120B+ conservative defaults |
+| `--max-perplexity-increase` | Default `3.0` × stock (abort) |
+| `--min-coherence-retention` | Default `0.5` |
+| `--max-degenerate-fraction` | Default `0.2` |
 
 ## Troubleshooting
 
-| Problem | Likely Cause | Fix |
-|:--------|:-------------|:----|
-| Refusal rate > 20% | Too few directions | Increase `--n-directions`, try `aggressive` |
-| Refusal rate 5-20% | Residual refusal | Add `--refinement-passes 3`, try `--direction-method svd` |
-| Perplexity spike > 20% | Over-aggressive removal | Reduce `--n-directions`, increase `--regularization` |
-| Repetitive output | Weight matrix damage | Use `basic` with fewer directions, check norm preservation |
-| MoE model still refuses | Non-expert-aware method | Switch to `nuclear` |
-| Reasoning degraded | CoT directions damaged | Use `surgical` method |
-| OOM during extraction | Insufficient VRAM | Add `--quantization 4bit` and/or `--large-model` |
+| Problem | Fix |
+|---|---|
+| Refusal rate > 20% | More `--n-directions`, `aggressive`, or `self-improve --audit` |
+| Refusal rate 5–20% | `--refinement-passes 3`, `--direction-method svd`, `--residue-file` |
+| Coherence/degeneracy trip | Fewer directions, higher `--regularization`, drop to `basic` |
+| MoE still refuses | `nuclear` |
+| Reasoning degraded | `surgical` |
+| OOM | `--quantization 4bit`, `--gpus` with more cards (not Qwen3.8), `--gpu-memory-utilization` |
+| Qwen3.8 load rejected | `.[qwen-hybrid]`, one GPU, no `device_map=auto` |
+
+## Steering (reversible)
+
+Inference-time steering exists in the Python package (`SteeringVectorFactory`, `SteeringHookManager`). Hermes must not import it. If the user wants reversible changes, say so and keep the work in an AGPL-licensed project, or skip weight surgery.

--- a/optional-skills/mlops/obliteratus/references/methods-guide.md
+++ b/optional-skills/mlops/obliteratus/references/methods-guide.md
@@ -15,12 +15,12 @@ README seven-preset table (escalating thoroughness):
 | Method | Directions | Key features | Best for |
 |---|---|---|---|
 | `basic` | 1 (diff-in-means) | Fast baseline | Quick test, small models |
-| `advanced` | 4 (SVD) | Norm-preserving, bias projection, 2 passes | **Default.** Clean removal |
-| `aggressive` | 8 (SVD) | Whitened SVD, iterative refinement, 3 passes | Stubborn residual refusal |
-| `surgical` | 8 (SVD) | EGA, head surgery, SAE, layer-adaptive, MoE-aware | Precision / CoT |
-| `optimized` | 4 (SVD) | Bayesian auto-tuned, CoT-aware, KL co-optimized | Quality over wall-clock |
-| `inverted` | 8 (SVD) | Semantic refusal inversion (2× reflection) | Research inversion |
-| `nuclear` | 8 (SVD) | All techniques + expert transplant + steering | Stubborn MoE |
+| `advanced` | 4 (SVD) | Norm-preserving, bias projection, 2 passes | **Default.** Clean removal, minimal capability loss |
+| `aggressive` | 8 (SVD) | Whitened SVD, iterative refinement, 3 passes | Maximum guardrail removal |
+| `surgical` | 8 (SVD) | EGA, head surgery, SAE, layer-adaptive, MoE-aware | Precision MoE models |
+| `optimized` | 4 (SVD) | Bayesian auto-tuned, CoT-aware, KL co-optimized | Best quality with auto-tuning |
+| `inverted` | 8 (SVD) | Semantic refusal inversion (2x reflection) | Refusal inversion experiments |
+| `nuclear` | 8 (SVD) | All techniques + expert transplant + steering | Maximum force |
 
 Also on the CLI, not in that seven-row table: `spectral_cascade`, `informed`, `som`.
 
@@ -39,13 +39,13 @@ Also on the CLI, not in that seven-row table: `spectral_cascade`, `informed`, `s
 ## Selection flowchart
 
 ```
-Quick test?                         → basic
-MoE (Mixtral, DeepSeek-MoE)?        → nuclear
-Reasoning / CoT (R1, QwQ)?          → surgical
-Need auto-tune and have hours?      → optimized
-Else                                → advanced
-advanced left >10% refusal on 3B+?  → aggressive, or self-improve with --audit
-Still refusing?                     → nuclear / residue loop
+Quick test?                            → basic
+Precision MoE?                         → surgical
+Best quality with auto-tuning?         → optimized
+Else                                   → advanced
+Need maximum guardrail removal?        → aggressive
+Need maximum force?                    → nuclear
+advanced left >10% refusal on 3B+?     → aggressive, or self-improve --audit
 ```
 
 Do not start with `informed` or `aggressive`.
@@ -71,8 +71,8 @@ Do not start with `informed` or `aggressive`.
 | Refusal rate > 20% | More `--n-directions`, `aggressive`, or `self-improve --audit` |
 | Refusal rate 5–20% | `--refinement-passes 3`, `--direction-method svd`, `--residue-file` |
 | Coherence/degeneracy trip | Fewer directions, higher `--regularization`, drop to `basic` |
-| MoE still refuses | `nuclear` |
-| Reasoning degraded | `surgical` |
+| MoE still refuses | `surgical` (precision MoE), then `nuclear` (maximum force) |
+| Reasoning / CoT degraded | `optimized` (CoT-aware) |
 | OOM | `--quantization 4bit`, `--gpus` with more cards (not Qwen3.8), `--gpu-memory-utilization` |
 | Qwen3.8 load rejected | `.[qwen-hybrid]`, one GPU, no `device_map=auto` |
 

--- a/optional-skills/mlops/obliteratus/templates/abliteration-config.yaml
+++ b/optional-skills/mlops/obliteratus/templates/abliteration-config.yaml
@@ -1,33 +1,30 @@
-# OBLITERATUS Abliteration Config
-# Usage: obliteratus run this-file.yaml
-#
-# This is for reproducible, version-controlled abliteration runs.
-# For one-off usage, the CLI flags are simpler.
+# OBLITERATUS ablation-study YAML (obliteratus run <this-file>)
+# For one-off refusal removal, prefer: obliteratus obliterate <path> --method advanced
 
-# Model to abliterate
 model:
-  name: "meta-llama/Llama-3.1-8B-Instruct"
-  dtype: "bfloat16"         # float16, bfloat16, float32
-  quantization: null         # null, "4bit", "8bit"
-  device: "auto"             # auto, cuda, cuda:0, cpu
+  name: /abs/path/to/ckpt
+  task: causal_lm
+  dtype: bfloat16
+  device: cuda
 
-# Abliteration method and parameters
-abliteration:
-  method: "informed"         # See SKILL.md Step 4 for all 13 methods
-  n_directions: null         # null = auto-detect, or integer (e.g., 8)
-  regularization: 0.0        # 0.0-1.0, fraction of original to preserve
-  refinement_passes: 1       # Iterative passes (increase for self-repair)
-  norm_preserve: true        # Keep weight norms intact after projection
+dataset:
+  name: wikitext
+  subset: wikitext-2-raw-v1
+  split: test
+  text_column: text
+  max_samples: 100
 
-# Output
-output:
-  directory: "./abliterated-models"
-  save_metadata: true        # Save abliteration_metadata.json alongside model
-  contribute: false          # Save community contribution data
+strategies:
+  - name: layer_removal
+  - name: head_pruning
+  - name: ffn_ablation
+  - name: embedding_ablation
+    params:
+      chunk_size: 48
 
-# Verification
-verify:
-  enabled: true
-  test_prompts: null         # null = use built-in test prompts
-  compute_perplexity: true
-  compute_kl: true
+metrics:
+  - perplexity
+
+batch_size: 4
+max_length: 256
+output_dir: results/my_run

--- a/optional-skills/mlops/obliteratus/templates/analysis-study.yaml
+++ b/optional-skills/mlops/obliteratus/templates/analysis-study.yaml
@@ -23,7 +23,7 @@ study:
   #   - ffn_ablation
   #   - embedding_ablation
 
-# Analysis modules to run (subset of the 27 available)
+# Analysis modules to run (subset of the 15 documented in the README)
 analysis:
   - alignment_imprint        # Detect DPO/RLHF/CAI/SFT training method
   - concept_geometry          # Map refusal cone geometry

--- a/optional-skills/mlops/obliteratus/templates/batch-abliteration.yaml
+++ b/optional-skills/mlops/obliteratus/templates/batch-abliteration.yaml
@@ -2,13 +2,13 @@
 # Abliterate multiple models with the same method for comparison.
 #
 # Run each one sequentially:
-#   for model in models; do obliteratus obliterate $model --method informed; done
+#   for model in models; do obliteratus obliterate $model --method advanced --output-dir ./liberated; done
 #
 # Or use this as a reference for which models to process.
 
 # Common settings
 defaults:
-  method: "informed"
+  method: "advanced"
   quantization: "4bit"
   output_dir: "./abliterated-models"
 

--- a/tests/skills/test_obliteratus_skill.py
+++ b/tests/skills/test_obliteratus_skill.py
@@ -1,0 +1,121 @@
+"""Contract tests for the optional obliteratus skill.
+
+Asserts authoring shape and the AGPL/CLI/local-path invariants that keep
+Hermes (MIT) from importing the AGPL package. No live network, no GPU.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import yaml
+
+REPO = Path(__file__).resolve().parents[2]
+SKILL_DIR = REPO / "optional-skills" / "mlops" / "obliteratus"
+SKILL_MD = SKILL_DIR / "SKILL.md"
+REQUIRED_HEADINGS = (
+    "## When to Use",
+    "## Prerequisites",
+    "## How to Run",
+    "## Quick Reference",
+    "## Procedure",
+    "## Pitfalls",
+    "## Verification",
+)
+CLI_METHODS = (
+    "basic",
+    "advanced",
+    "aggressive",
+    "spectral_cascade",
+    "informed",
+    "surgical",
+    "optimized",
+    "som",
+    "inverted",
+    "nuclear",
+)
+
+
+def _frontmatter_and_body() -> tuple[dict, str]:
+    src = SKILL_MD.read_text(encoding="utf-8")
+    assert src.startswith("---"), "SKILL.md must start with ---"
+    m = re.search(r"^---\n(.*)\n---\n", src, re.S)
+    assert m, "unclosed frontmatter"
+    fm = yaml.safe_load(m.group(1))
+    assert isinstance(fm, dict)
+    return fm, src[m.end() :]
+
+
+def test_skill_files_present() -> None:
+    assert SKILL_MD.is_file()
+    assert (SKILL_DIR / "references" / "local-models.md").is_file()
+    assert (SKILL_DIR / "references" / "methods-guide.md").is_file()
+    assert (SKILL_DIR / "references" / "analysis-modules.md").is_file()
+    assert (SKILL_DIR / "templates" / "abliteration-config.yaml").is_file()
+
+
+def test_description_hardline() -> None:
+    fm, _ = _frontmatter_and_body()
+    desc = str(fm["description"])
+    assert len(desc) <= 60, f"description is {len(desc)} chars: {desc!r}"
+    assert desc.endswith(".")
+    assert re.search(
+        r"\b(powerful|comprehensive|seamless|revolutionary|cutting-edge|state-of-the-art)\b",
+        desc,
+        re.I,
+    ) is None
+
+
+def test_required_frontmatter_fields() -> None:
+    fm, _ = _frontmatter_and_body()
+    assert fm["name"] == "obliteratus"
+    for field in ("version", "author", "license", "platforms"):
+        assert fm.get(field), f"missing frontmatter field: {field}"
+    author = str(fm["author"])
+    assert "Hermes Agent" in author
+    assert author.strip() != "Hermes Agent"
+    hermes = (fm.get("metadata") or {}).get("hermes") or {}
+    assert hermes.get("tags")
+    related = hermes.get("related_skills") or []
+    names = {p.parent.name for p in REPO.glob("skills/**/SKILL.md")} | {
+        p.parent.name for p in REPO.glob("optional-skills/**/SKILL.md")
+    }
+    dangling = [r for r in related if r not in names]
+    assert dangling == [], f"dangling related_skills: {dangling}"
+
+
+def test_modern_sections_present() -> None:
+    _, body = _frontmatter_and_body()
+    for heading in REQUIRED_HEADINGS:
+        assert heading in body, f"missing {heading}"
+
+
+def test_cli_not_python_import_as_howto() -> None:
+    _, body = _frontmatter_and_body()
+    how = body.split("## How to Run", 1)[1].split("## Quick Reference", 1)[0]
+    assert "obliteratus obliterate" in how
+    assert "from obliteratus" not in how
+    assert "import obliteratus" not in how
+    assert "`terminal`" in body
+    assert "AGPL" in body
+
+
+def test_local_path_and_quantization_flags() -> None:
+    src = SKILL_MD.read_text(encoding="utf-8")
+    assert "local directory" in src.lower() or "local directories" in src.lower()
+    assert "--quantization 4bit" in src
+    assert "--output-dir" in src
+    for method in CLI_METHODS:
+        assert method in src, f"missing CLI method {method!r}"
+    assert "--quantization bitsandbytes-4bit" not in src
+    assert "qwen-hybrid" in src
+    assert "self-improve" in src
+
+
+def test_no_machine_local_paths() -> None:
+    src = SKILL_MD.read_text(encoding="utf-8")
+    for ref in (SKILL_DIR / "references").glob("*.md"):
+        src += "\n" + ref.read_text(encoding="utf-8")
+    m = re.search(r"/home/(?!runner\b)[a-z0-9_-]+/", src)
+    assert m is None, f"machine-local path {m.group(0)!r}"

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -171,7 +171,7 @@ hermes skills uninstall <skill-name>
 | [**llava**](/docs/user-guide/skills/optional/mlops/mlops-llava) | Vision-language chat: VQA, captioning, image dialogue. |
 | [**modal**](/docs/user-guide/skills/optional/mlops/mlops-modal) | Serverless GPU cloud for ML jobs and model APIs. |
 | [**nemo-curator**](/docs/user-guide/skills/optional/mlops/mlops-nemo-curator) | Curate LLM training data: dedupe, filter, PII redaction. |
-| [**obliteratus**](/docs/user-guide/skills/optional/mlops/mlops-obliteratus) | OBLITERATUS: abliterate LLM refusals (diff-in-means). |
+| [**obliteratus**](/docs/user-guide/skills/optional/mlops/mlops-obliteratus) | Abliterate refusals from local open-weight LLMs. |
 | [**outlines**](/docs/user-guide/skills/optional/mlops/mlops-inference-outlines) | Outlines: structured JSON/regex/Pydantic LLM generation. |
 | [**peft**](/docs/user-guide/skills/optional/mlops/mlops-peft) | Fine-tune large LLMs with LoRA on limited GPU memory. |
 | [**pinecone**](/docs/user-guide/skills/optional/mlops/mlops-pinecone) | Managed vector DB for production RAG and search. |

--- a/website/docs/user-guide/skills/optional/mlops/mlops-obliteratus.md
+++ b/website/docs/user-guide/skills/optional/mlops/mlops-obliteratus.md
@@ -1,27 +1,26 @@
 ---
-title: "Obliteratus — OBLITERATUS: abliterate LLM refusals (diff-in-means)"
+title: "Obliteratus — Abliterate refusals from local open-weight LLMs"
 sidebar_label: "Obliteratus"
-description: "OBLITERATUS: abliterate LLM refusals (diff-in-means)"
+description: "Abliterate refusals from local open-weight LLMs"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Obliteratus
 
-OBLITERATUS: abliterate LLM refusals (diff-in-means).
+Abliterate refusals from local open-weight LLMs.
 
 ## Skill metadata
 
 | | |
 |---|---|
 | Source | Optional — install with `hermes skills install official/mlops/obliteratus` |
-| Path | `optional-skills/mlops\obliteratus` |
-| Version | `2.0.0` |
-| Author | Hermes Agent |
+| Path | `optional-skills/mlops/obliteratus` |
+| Version | `2.1.0` |
+| Author | mr-r0b0t (@am423), Hermes Agent |
 | License | MIT |
-| Dependencies | `obliteratus`, `torch`, `transformers`, `bitsandbytes`, `accelerate`, `safetensors` |
 | Platforms | linux, macos |
-| Tags | `Abliteration`, `Uncensoring`, `Refusal-Removal`, `LLM`, `Weight-Projection`, `SVD`, `Mechanistic-Interpretability`, `HuggingFace`, `Model-Surgery` |
+| Tags | `Abliteration`, `Uncensoring`, `Refusal-Removal`, `LLM`, `Weight-Projection`, `SVD`, `HuggingFace`, `Model-Surgery` |
 | Related skills | [`serving-llms-vllm`](/docs/user-guide/skills/optional/mlops/mlops-inference-serving-llms-vllm), [`llama-cpp`](/docs/user-guide/skills/optional/mlops/mlops-inference-llama-cpp), [`huggingface-tokenizers`](/docs/user-guide/skills/optional/mlops/mlops-huggingface-tokenizers) |
 
 ## Reference: full SKILL.md
@@ -32,329 +31,116 @@ The following is the complete skill definition that Hermes loads when this skill
 
 # OBLITERATUS Skill
 
-## What's inside
+OBLITERATUS (package `0.1.3`, AGPL-3.0) projects refusal directions out of a local HuggingFace checkpoint without fine-tuning. It does not retrain, does not serve the result, and does not guarantee 0% refusal on models under ~1B. Never `import obliteratus` inside Hermes (MIT); invoke the CLI through the `terminal` tool only.
 
-9 CLI methods, 28 analysis modules, 116 model presets across 5 compute tiers, tournament evaluation, and telemetry-driven recommendations.
+Upstream: https://github.com/elder-plinius/OBLITERATUS
 
-Remove refusal behaviors (guardrails) from open-weight LLMs without retraining or fine-tuning. Uses mechanistic interpretability techniques — including diff-in-means, SVD, whitened SVD, LEACE concept erasure, SAE decomposition, Bayesian kernel projection, and more — to identify and surgically excise refusal directions from model weights while preserving reasoning capabilities.
+## When to Use
 
-**License warning:** OBLITERATUS is AGPL-3.0. NEVER import it as a Python library. Always invoke via CLI (`obliteratus` command) or subprocess. This keeps Hermes Agent's MIT license clean.
+- User wants to abliterate, uncensor, or remove refusals/guardrails from an open-weight LLM
+- The model is already on disk as a HuggingFace directory, or a hub id that will resolve locally
+- Residual refusals remain after a first pass (`self-improve`, `--residue-file`)
+- Qwen3.8 hybrid Gated DeltaNet local surgery
 
-## Video Guide
+Do not use for hosted APIs, for importing the library into Hermes, or as a substitute for serving — load `serving-llms-vllm` or `llama-cpp` after the weights are saved.
 
-Walkthrough of OBLITERATUS used by a Hermes agent to abliterate Gemma:
-https://www.youtube.com/watch?v=8fG9BrNTeHs ("OBLITERATUS: An AI Agent Removed Gemma 4's Safety Guardrails")
+## Prerequisites
 
-Useful when the user wants a visual overview of the end-to-end workflow before running it themselves.
+- Python >= 3.10 and a CUDA GPU for anything above ~1B (CPU is tiny-models only)
+- A local snapshot: `config.json` plus weights. Confirm with `read_file` on `config.json`
+- Optional `HF_TOKEN` only for gated hub ids; local directories do not need it
 
-## When to Use This Skill
+Install (confirm with the user first — PyTorch-scale deps) through `terminal`:
 
-Trigger when the user:
-- Wants to "uncensor" or "abliterate" an LLM
-- Asks about removing refusal/guardrails from a model
-- Wants to create an uncensored version of Llama, Qwen, Mistral, etc.
-- Mentions "refusal removal", "abliteration", "weight projection"
-- Wants to analyze how a model's refusal mechanism works
-- References OBLITERATUS, abliterator, or refusal directions
-
-## Step 1: Installation
-
-Check if already installed:
-```bash
-obliteratus --version 2>/dev/null && echo "INSTALLED" || echo "NOT INSTALLED"
-```
-
-If not installed, clone and install from GitHub:
 ```bash
 git clone https://github.com/elder-plinius/OBLITERATUS.git
 cd OBLITERATUS
-pip install -e .
-# For Gradio web UI support:
-# pip install -e ".[spaces]"
+pip install -e ".[quantization]"
+obliteratus --version
 ```
 
-**IMPORTANT:** Confirm with user before installing. This pulls in ~5-10GB of dependencies (PyTorch, Transformers, bitsandbytes, etc.).
+- Qwen3.8 / hybrid Gated DeltaNet: also `pip install -e ".[qwen-hybrid]"` (`transformers>=5.8`, `flash-linear-attention>=0.5.2`, `causal-conv1d>=1.7.0`)
+- Gradio UI: `pip install -e ".[spaces]"`
+- After a CUDA wheel override, do not launch via `uv run` — it can resync the CPU wheel locked for portable CI
 
-## Step 2: Check Hardware
+## How to Run
 
-Before anything, check what GPU is available:
-```bash
-python3 -c "
-import torch
-if torch.cuda.is_available():
-    gpu = torch.cuda.get_device_name(0)
-    vram = torch.cuda.get_device_properties(0).total_memory / 1024**3
-    print(f'GPU: {gpu}')
-    print(f'VRAM: {vram:.1f} GB')
-    if vram < 4: print('TIER: tiny (models under 1B)')
-    elif vram < 8: print('TIER: small (models 1-4B)')
-    elif vram < 16: print('TIER: medium (models 4-9B with 4bit quant)')
-    elif vram < 32: print('TIER: large (models 8-32B with 4bit quant)')
-    else: print('TIER: frontier (models 32B+)')
-else:
-    print('NO GPU - only tiny models (under 1B) on CPU')
-"
-```
-
-### VRAM Requirements (with 4-bit quantization)
-
-| VRAM     | Max Model Size  | Example Models                              |
-|:---------|:----------------|:--------------------------------------------|
-| CPU only | ~1B params      | GPT-2, TinyLlama, SmolLM                    |
-| 4-8 GB   | ~4B params      | Qwen2.5-1.5B, Phi-3.5 mini, Llama 3.2 3B   |
-| 8-16 GB  | ~9B params      | Llama 3.1 8B, Mistral 7B, Gemma 2 9B       |
-| 24 GB    | ~32B params     | Qwen3-32B, Llama 3.1 70B (tight), Command-R |
-| 48 GB+   | ~72B+ params    | Qwen2.5-72B, DeepSeek-R1                    |
-| Multi-GPU| 200B+ params    | Llama 3.1 405B, DeepSeek-V3 (685B MoE)      |
-
-## Step 3: Browse Available Models & Get Recommendations
+The `model` argument is a HuggingFace id **or a local directory**. Always pass `--output-dir`.
 
 ```bash
-# Browse models by compute tier
-obliteratus models --tier medium
-
-# Get architecture info for a specific model
-obliteratus info <model_name>
-
-# Get telemetry-driven recommendation for best method & params
-obliteratus recommend <model_name>
-obliteratus recommend <model_name> --insights  # global cross-architecture rankings
-```
-
-## Step 4: Choose a Method
-
-### Method Selection Guide
-**Default / recommended for most cases: `advanced`.** It uses multi-direction SVD with norm-preserving projection and is well-tested.
-
-| Situation                         | Recommended Method | Why                                      |
-|:----------------------------------|:-------------------|:-----------------------------------------|
-| Default / most models             | `advanced`         | Multi-direction SVD, norm-preserving, reliable |
-| Quick test / prototyping          | `basic`            | Fast, simple, good enough to evaluate    |
-| Dense model (Llama, Mistral)      | `advanced`         | Multi-direction, norm-preserving         |
-| MoE model (DeepSeek, Mixtral)     | `nuclear`          | Expert-granular, handles MoE complexity  |
-| Reasoning model (R1 distills)     | `surgical`         | CoT-aware, preserves chain-of-thought    |
-| Stubborn refusals persist         | `aggressive`       | Whitened SVD + head surgery + jailbreak   |
-| Want reversible changes           | Use steering vectors (see Analysis section) |
-| Maximum quality, time no object   | `optimized`        | Bayesian search for best parameters      |
-| Experimental auto-detection       | `informed`         | Auto-detects alignment type — experimental, may not always outperform advanced |
-
-### 9 CLI Methods
-- **basic** — Single refusal direction via diff-in-means. Fast (~5-10 min for 8B).
-- **advanced** (DEFAULT, RECOMMENDED) — Multiple SVD directions, norm-preserving projection, 2 refinement passes. Medium speed (~10-20 min).
-- **aggressive** — Whitened SVD + jailbreak-contrastive + attention head surgery. Higher risk of coherence damage.
-- **spectral_cascade** — DCT frequency-domain decomposition. Research/novel approach.
-- **informed** — Runs analysis DURING abliteration to auto-configure. Experimental — slower and less predictable than advanced.
-- **surgical** — SAE features + neuron masking + head surgery + per-expert. Very slow (~1-2 hrs). Best for reasoning models.
-- **optimized** — Bayesian hyperparameter search (Optuna TPE). Longest runtime but finds optimal parameters.
-- **inverted** — Flips the refusal direction. Model becomes actively willing.
-- **nuclear** — Maximum force combo for stubborn MoE models. Expert-granular.
-
-### Direction Extraction Methods (--direction-method flag)
-- **diff_means** (default) — Simple difference-in-means between refused/complied activations. Robust.
-- **svd** — Multi-direction SVD extraction. Better for complex alignment.
-- **leace** — LEACE (Linear Erasure via Closed-form Estimation). Optimal linear erasure.
-
-### 4 Python-API-Only Methods
-(NOT available via CLI — require Python import, which violates AGPL boundary. Mention to user only if they explicitly want to use OBLITERATUS as a library in their own AGPL project.)
-- failspy, gabliteration, heretic, rdo
-
-## Step 5: Run Abliteration
-
-### Standard usage
-```bash
-# Default method (advanced) — recommended for most models
-obliteratus obliterate <model_name> --method advanced --output-dir ./abliterated-models
-
-# With 4-bit quantization (saves VRAM)
-obliteratus obliterate <model_name> --method advanced --quantization 4bit --output-dir ./abliterated-models
-
-# Large models (70B+) — conservative defaults
-obliteratus obliterate <model_name> --method advanced --quantization 4bit --large-model --output-dir ./abliterated-models
-```
-
-### Fine-tuning parameters
-```bash
-obliteratus obliterate <model_name> \
+obliteratus obliterate /abs/path/to/ckpt \
   --method advanced \
-  --direction-method diff_means \
-  --n-directions 4 \
-  --refinement-passes 2 \
-  --regularization 0.1 \
+  --dtype bfloat16 \
+  --output-dir ./liberated \
+  --gpus 0
+```
+
+VRAM-tight (requires `.[quantization]`):
+
+```bash
+obliteratus obliterate /abs/path/to/ckpt \
+  --method advanced \
   --quantization 4bit \
-  --output-dir ./abliterated-models \
-  --contribute  # opt-in telemetry for community research
+  --dtype float16 \
+  --output-dir ./liberated
 ```
 
-### Key flags
-| Flag | Description | Default |
-|:-----|:------------|:--------|
-| `--method` | Abliteration method | advanced |
-| `--direction-method` | Direction extraction | diff_means |
-| `--n-directions` | Number of refusal directions (1-32) | method-dependent |
-| `--refinement-passes` | Iterative passes (1-5) | 2 |
-| `--regularization` | Regularization strength (0.0-1.0) | 0.1 |
-| `--quantization` | Load in 4bit or 8bit | none (full precision) |
-| `--large-model` | Conservative defaults for 120B+ | false |
-| `--output-dir` | Where to save the abliterated model | ./obliterated_model |
-| `--contribute` | Share anonymized results for research | false |
-| `--verify-sample-size` | Number of test prompts for refusal check | 20 |
-| `--dtype` | Model dtype (float16, bfloat16) | auto |
+Qwen3.8: one CUDA device, no generic multi-GPU shard. Load `references/local-models.md` with `skill_view`.
 
-### Other execution modes
-```bash
-# Interactive guided mode (hardware → model → preset)
-obliteratus interactive
+## Quick Reference
 
-# Web UI (Gradio)
-obliteratus ui --port 7860
+| Command | Purpose |
+|---|---|
+| `obliteratus obliterate <id-or-path>` | Weight-projection refusal removal (`abliterate` is a hidden alias) |
+| `obliteratus info <id-or-path>` | Architecture print |
+| `obliteratus models --tier {tiny,small,medium,large,frontier}` | Curated presets |
+| `obliteratus recommend <id-or-path>` | Telemetry-driven method/params (`--insights` for global) |
+| `obliteratus gpu-calc <id-or-path> --gpu-mem 80` | Minimum GPU count estimate |
+| `obliteratus self-improve <path> --audit <json> --output-dir <dir>` | Residue / hard-negative follow-up |
+| `obliteratus capability-check --abliterated <p> --stock <p>` | MMLU vs stock (`--quick`) |
+| `obliteratus tourney <id-or-path>` | Method tournament |
+| `obliteratus runs launch -- <args>` | Detached durable run |
+| `obliteratus ui --port 7860` | Local Gradio |
+| `obliteratus interactive` | Guided wizard |
 
-# Run a full ablation study from YAML config
-obliteratus run config.yaml --preset quick
+`--method`: `basic`, `advanced` (default), `aggressive`, `spectral_cascade`, `informed`, `surgical`, `optimized`, `som`, `inverted`, `nuclear`.
 
-# Tournament: pit all methods against each other
-obliteratus tourney <model_name>
-```
+`--direction-method`: `diff_means`, `svd`, `leace`, `som`. `--quantization`: `4bit`, `8bit`.
 
-## Step 6: Verify Results
+## Procedure
 
-After abliteration, check the output metrics:
+1. Confirm the checkpoint with `read_file` on `<ckpt>/config.json`. Prefer the on-disk tree; do not re-download a sibling official copy.
+2. Check GPU idle state through `terminal`. Pin an idle device with `--gpus N`. Do not steal a live serve.
+3. Size the job: `obliteratus gpu-calc <ckpt> --gpu-mem <GB>`. Native BF16 surgery needs ~2 bytes/param plus activations; `--quantization 4bit` is load-time only. FP8/NVFP4 checkpoints dequantize automatically — peak VRAM is the **BF16** size; saved output is BF16.
+4. Optional: `obliteratus recommend <ckpt>` then `obliteratus info <ckpt>`.
+5. Run `obliteratus obliterate` with `--method advanced` unless `references/methods-guide.md` says otherwise (precision MoE → `surgical`, quality auto-tune → `optimized`).
+6. Read the printed metrics. Target refusal rate ≤ 5% (ideally ~0–3%). Fail-closed defaults: `--max-perplexity-increase 3.0` (multiple of stock), `--min-coherence-retention 0.5`, `--max-degenerate-fraction 0.2`, `--verify-sample-size 30`.
+7. If refusals remain: `obliteratus self-improve <ckpt> --audit <json> --output-dir <next>`, or rerun with `--residue-file`, more `--n-directions`, `--refinement-passes 3`, `--direction-method svd`, or `--method aggressive`.
+8. Optional capability gate: `obliteratus capability-check --abliterated <out> --stock <ckpt> --quick`.
+9. The output is a standard HuggingFace directory. Serve with the related serving skills — not with `import obliteratus`.
 
-| Metric | Good Value | Warning |
-|:-------|:-----------|:--------|
-| Refusal rate | &lt; 5% (ideally ~0%) | > 10% means refusals persist |
-| Perplexity change | &lt; 10% increase | > 15% means coherence damage |
-| KL divergence | &lt; 0.1 | > 0.5 means significant distribution shift |
-| Coherence | High / passes qualitative check | Degraded responses, repetition |
+Load `references/local-models.md` when the checkpoint is a local path, Qwen3.8, FP8/NVFP4, or a residue loop. Load `references/methods-guide.md` for method choice. Load `references/analysis-modules.md` only when the user asks to map refusal geometry first.
 
-### If refusals persist (> 10%)
-1. Try `aggressive` method
-2. Increase `--n-directions` (e.g., 8 or 16)
-3. Add `--refinement-passes 3`
-4. Try `--direction-method svd` instead of diff_means
+## Pitfalls
 
-### If coherence is damaged (perplexity > 15% increase)
-1. Reduce `--n-directions` (try 2)
-2. Increase `--regularization` (try 0.3)
-3. Reduce `--refinement-passes` to 1
-4. Try `basic` method (gentler)
+1. **AGPL boundary.** Never `from obliteratus import ...` in Hermes or other MIT/Apache code. CLI / subprocess only.
+2. **`--quantization` values are `4bit` and `8bit`.** Not `bitsandbytes-4bit`. Extra `.[quantization]` must be installed or the flag fails.
+3. **Qwen3.8 hybrid runtime.** Needs `.[qwen-hybrid]`, FLA + causal-conv1d CUDA kernels, the full text model on **one** CUDA device with 15% headroom. Generic PyTorch fallback and `device_map="auto"` sharding are rejected. A failed pristine load is never modified.
+4. **`--large-model` is for 120B+**, not 70B. Conservative defaults: fewer directions, 1 pass.
+5. **Sub-1B models respond poorly.** Expect leftover refusal. 3B+ is the realistic near-zero-refusal regime.
+6. **`informed` is slower and experimental.** Default is `advanced`.
+7. **`aggressive` can damage coherence** on small models. Use only when `advanced` leaves >10% refusal on 3B+.
+8. **Quantized-load ≠ quantized-save.** Abliterate, then re-quantize the BF16 output if you need a 4-bit serving artifact.
+9. **Multi-GPU is memory, not speed.** `--gpus 0,1` shards via accelerate pipeline parallel; Qwen3.8 forbids that path.
+10. **Spectral "incomplete" is not a fail.** Trust measured refusal rate, coherence, and degeneracy.
+11. **`--contribute` is opt-in telemetry.** Off by default on CLI (Spaces turns it on).
+12. **Do not use `uv run` after replacing the CPU-locked CI torch wheel with CUDA.**
 
-## Step 7: Use the Abliterated Model
-
-The output is a standard HuggingFace model directory.
+## Verification
 
 ```bash
-# Test locally with transformers
-python3 -c "
-from transformers import AutoModelForCausalLM, AutoTokenizer
-model = AutoModelForCausalLM.from_pretrained('./abliterated-models/<model>')
-tokenizer = AutoTokenizer.from_pretrained('./abliterated-models/<model>')
-inputs = tokenizer('How do I pick a lock?', return_tensors='pt')
-outputs = model.generate(**inputs, max_new_tokens=200)
-print(tokenizer.decode(outputs[0], skip_special_tokens=True))
-"
-
-# Upload to HuggingFace Hub
-huggingface-cli upload <username>/<model-name>-abliterated ./abliterated-models/<model>
-
-# Serve with vLLM
-vllm serve ./abliterated-models/<model>
+obliteratus --version
+obliteratus info /abs/path/to/ckpt
 ```
 
-## CLI Command Reference
-
-| Command | Description |
-|:--------|:------------|
-| `obliteratus obliterate` | Main abliteration command |
-| `obliteratus info <model>` | Print model architecture details |
-| `obliteratus models --tier <tier>` | Browse curated models by compute tier |
-| `obliteratus recommend <model>` | Telemetry-driven method/param suggestion |
-| `obliteratus interactive` | Guided setup wizard |
-| `obliteratus tourney <model>` | Tournament: all methods head-to-head |
-| `obliteratus run <config.yaml>` | Execute ablation study from YAML |
-| `obliteratus strategies` | List all registered ablation strategies |
-| `obliteratus report <results.json>` | Regenerate visual reports |
-| `obliteratus ui` | Launch Gradio web interface |
-| `obliteratus aggregate` | Summarize community telemetry data |
-
-## Analysis Modules
-
-OBLITERATUS includes 28 analysis modules for mechanistic interpretability.
-See `skill_view(name="obliteratus", file_path="references/analysis-modules.md")` for the full reference.
-
-### Quick analysis commands
-```bash
-# Run specific analysis modules
-obliteratus run analysis-config.yaml --preset quick
-
-# Key modules to run first:
-# - alignment_imprint: Fingerprint DPO/RLHF/CAI/SFT alignment method
-# - concept_geometry: Single direction vs polyhedral cone
-# - logit_lens: Which layer decides to refuse
-# - anti_ouroboros: Self-repair risk score
-# - causal_tracing: Causally necessary components
-```
-
-### Steering Vectors (Reversible Alternative)
-Instead of permanent weight modification, use inference-time steering:
-```python
-# Python API only — for user's own projects
-from obliteratus.analysis.steering_vectors import SteeringVectorFactory, SteeringHookManager
-```
-
-## Ablation Strategies
-
-Beyond direction-based abliteration, OBLITERATUS includes structural ablation strategies:
-- **Embedding Ablation** — Target embedding layer components
-- **FFN Ablation** — Feed-forward network block removal
-- **Head Pruning** — Attention head pruning
-- **Layer Removal** — Full layer removal
-
-List all available: `obliteratus strategies`
-
-## Evaluation
-
-OBLITERATUS includes built-in evaluation tools:
-- Refusal rate benchmarking
-- Perplexity comparison (before/after)
-- LM Eval Harness integration for academic benchmarks
-- Head-to-head competitor comparison
-- Baseline performance tracking
-
-## Platform Support
-
-- **CUDA** — Full support (NVIDIA GPUs)
-- **Apple Silicon (MLX)** — Supported via MLX backend
-- **CPU** — Supported for tiny models (&lt; 1B params)
-
-## YAML Config Templates
-
-Load templates for reproducible runs via `skill_view`:
-- `templates/abliteration-config.yaml` — Standard single-model config
-- `templates/analysis-study.yaml` — Pre-abliteration analysis study
-- `templates/batch-abliteration.yaml` — Multi-model batch processing
-
-## Telemetry
-
-OBLITERATUS can optionally contribute anonymized run data to a global research dataset.
-Enable with `--contribute` flag. No personal data is collected — only model name, method, metrics.
-
-## Common Pitfalls
-
-1. **Don't use `informed` as default** — it's experimental and slower. Use `advanced` for reliable results.
-2. **Models under ~1B respond poorly to abliteration** — their refusal behaviors are shallow and fragmented, making clean direction extraction difficult. Expect partial results (20-40% remaining refusal). Models 3B+ have cleaner refusal directions and respond much better (often 0% refusal with `advanced`).
-3. **`aggressive` can make things worse** — on small models it can damage coherence and actually increase refusal rate. Only use it if `advanced` leaves > 10% refusals on a 3B+ model.
-4. **Always check perplexity** — if it spikes > 15%, the model is damaged. Reduce aggressiveness.
-5. **MoE models need special handling** — use `nuclear` method for Mixtral, DeepSeek-MoE, etc.
-6. **Quantized models can't be re-quantized** — abliterate the full-precision model, then quantize the output.
-7. **VRAM estimation is approximate** — 4-bit quant helps but peak usage can spike during extraction.
-8. **Reasoning models are sensitive** — use `surgical` for R1 distills to preserve chain-of-thought.
-9. **Check `obliteratus recommend`** — telemetry data may have better parameters than defaults.
-10. **AGPL license** — never `import obliteratus` in MIT/Apache projects. CLI invocation only.
-11. **Large models (70B+)** — always use `--large-model` flag for conservative defaults.
-12. **Spectral certification RED is common** — the spectral check often flags "incomplete" even when practical refusal rate is 0%. Check actual refusal rate rather than relying on spectral certification alone.
-
-## Complementary Skills
-
-- **vllm** — Serve abliterated models with high throughput
-- **gguf** — Convert abliterated models to GGUF for llama.cpp
-- **huggingface-tokenizers** — Work with model tokenizers
+A liberated tree is valid when it contains `config.json` plus safetensors, `obliteratus info <output-dir>` prints the architecture, and the CLI summary shows refusal rate ≤ 5% with degeneracy below `0.2`.


### PR DESCRIPTION
## Summary

Refresh the official optional `obliteratus` skill so an agent can abliterate **local HuggingFace checkpoints** with the current OBLITERATUS `0.1.3` CLI, without importing the AGPL package into Hermes (MIT).

- Rewrote `optional-skills/mlops/obliteratus/SKILL.md` to the AGENTS.md hardline section order (`When to Use` → `Verification`), ≤60-char description, human author credit, CLI-only invocation through `terminal`
- Added `references/local-models.md` for on-disk paths, Qwen3.8 hybrid single-GPU contract, FP8/NVFP4 auto-dequant, residue/`self-improve` loop, and fail-closed quality gates
- Aligned methods/analysis notes and YAML templates with CLI flags (`--quantization {4bit,8bit}`, `--method` including `som`, `--verify-sample-size` default 30, `--large-model` = 120B+)
- Added `tests/skills/test_obliteratus_skill.py` (stdlib + pytest only, no network)

## Why

The previous skill was hub-id oriented, documented stale flags (`--quantization` vs `bitsandbytes-*`, `--large-model` at 70B, verify sample 20), and showed Python `import obliteratus` paths that violate the AGPL/MIT boundary.

## How to test

```bash
scripts/run_tests.sh tests/skills/test_obliteratus_skill.py tests/skills/test_authoring_standards.py -q
```

Expected: both files pass (1179 tests in this worktree).

## Platforms tested

- Linux (authoring + skill contract tests only; no GPU obliteration run in this PR)

## Notes / Risks

- Optional skill only (`hermes skills install official/mlops/obliteratus`); not bundled
- Does not change runtime code
- Website optional-skill page is not regenerated in this PR