### PR TITLE
fix(i18n): unescape doubled backslashes in locale picker titles so newlines render

### DIFF
--- a/locales/af.yaml
+++ b/locales/af.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nHuidige modus: `{mode}`\\n\\nKies \\'n opsie:"
+    picker_title:          "⚡ **Priority Processing**\n\nHuidige modus: `{mode}`\n\nKies 'n opsie:"
     choice_fast:           "fast — Priority Processing aan"
     choice_normal:         "normal — standaardverwerking"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` word nie ondersteun nie. Gebruik `/reasoning <level> --global` om die globale verstek te verander."
     reset_done:                "🧠 ✓ Sessie-redenering-oorskryf verwyder; val terug op globale konfigurasie."
     unknown_arg:               "⚠️ Onbekende argument: `{arg}`\n\n**Geldige vlakke:** none, minimal, low, medium, high, xhigh, max, ultra\n**Vertoon:** show, hide\n**Permanent:** voeg `--global` by om verby hierdie sessie te stoor"
-    picker_title:              "🧠 **Redenering-instellings**\\n\\n**Inspanning:** `{level}`\\n**Bereik:** {scope}\\n**Vertoon:** {display}\\n\\nKies \\'n opsie:"
+    picker_title:              "🧠 **Redenering-instellings**\n\n**Inspanning:** `{level}`\n**Bereik:** {scope}\n**Vertoon:** {display}\n\nKies 'n opsie:"
     choice_none:               "none — deaktiveer redenering"
     choice_reset:              "reset — vee sessie-oorskrywing uit"
     choice_show:               "wys redenering in antwoorde"

--- a/locales/de.yaml
+++ b/locales/de.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nAktueller Modus: `{mode}`\\n\\nOption wählen:"
+    picker_title:          "⚡ **Priority Processing**\n\nAktueller Modus: `{mode}`\n\nOption wählen:"
     choice_fast:           "fast — Priority Processing an"
     choice_normal:         "normal — Standardverarbeitung"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` wird nicht unterstützt. Verwenden Sie `/reasoning <level> --global`, um den globalen Standard zu ändern."
     reset_done:                "🧠 ✓ Sitzungs-Reasoning-Override gelöscht; Rückfall auf globale Konfiguration."
     unknown_arg:               "⚠️ Unbekanntes Argument: `{arg}`\n\n**Gültige Stärken:** none, minimal, low, medium, high, xhigh, max, ultra\n**Anzeige:** show, hide\n**Speichern:** `--global` hinzufügen, um über die Sitzung hinaus zu speichern"
-    picker_title:              "🧠 **Reasoning-Einstellungen**\\n\\n**Stärke:** `{level}`\\n**Geltungsbereich:** {scope}\\n**Anzeige:** {display}\\n\\nOption wählen:"
+    picker_title:              "🧠 **Reasoning-Einstellungen**\n\n**Stärke:** `{level}`\n**Geltungsbereich:** {scope}\n**Anzeige:** {display}\n\nOption wählen:"
     choice_none:               "none — Reasoning deaktivieren"
     choice_reset:              "reset — Sitzungs-Override löschen"
     choice_show:               "Reasoning in Antworten anzeigen"

--- a/locales/es.yaml
+++ b/locales/es.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo actual: `{mode}`\\n\\nElige una opción:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo actual: `{mode}`\n\nElige una opción:"
     choice_fast:           "fast — Priority Processing activado"
     choice_normal:         "normal — procesamiento estándar"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` no es compatible. Usa `/reasoning <level> --global` para cambiar el valor global por defecto."
     reset_done:                "🧠 ✓ Anulación de razonamiento de la sesión borrada; volviendo a la configuración global."
     unknown_arg:               "⚠️ Argumento desconocido: `{arg}`\n\n**Niveles válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualización:** show, hide\n**Persistir:** añade `--global` para guardar más allá de esta sesión"
-    picker_title:              "🧠 **Ajustes de razonamiento**\\n\\n**Esfuerzo:** `{level}`\\n**Alcance:** {scope}\\n**Visualización:** {display}\\n\\nElige una opción:"
+    picker_title:              "🧠 **Ajustes de razonamiento**\n\n**Esfuerzo:** `{level}`\n**Alcance:** {scope}\n**Visualización:** {display}\n\nElige una opción:"
     choice_none:               "none — desactivar razonamiento"
     choice_reset:              "reset — borrar el ajuste de sesión"
     choice_show:               "mostrar razonamiento en respuestas"

--- a/locales/fr.yaml
+++ b/locales/fr.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMode actuel : `{mode}`\\n\\nChoisissez une option :"
+    picker_title:          "⚡ **Priority Processing**\n\nMode actuel : `{mode}`\n\nChoisissez une option :"
     choice_fast:           "fast — Priority Processing activé"
     choice_normal:         "normal — traitement standard"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` n'est pas pris en charge. Utilisez `/reasoning <level> --global` pour modifier la valeur globale par défaut."
     reset_done:                "🧠 ✓ Remplacement de raisonnement de la session effacé ; retour à la configuration globale."
     unknown_arg:               "⚠️ Argument inconnu : `{arg}`\n\n**Niveaux valides :** none, minimal, low, medium, high, xhigh, max, ultra\n**Affichage :** show, hide\n**Persister :** ajoutez `--global` pour enregistrer au-delà de cette session"
-    picker_title:              "🧠 **Paramètres de raisonnement**\\n\\n**Effort :** `{level}`\\n**Portée :** {scope}\\n**Affichage :** {display}\\n\\nChoisissez une option :"
+    picker_title:              "🧠 **Paramètres de raisonnement**\n\n**Effort :** `{level}`\n**Portée :** {scope}\n**Affichage :** {display}\n\nChoisissez une option :"
     choice_none:               "none — désactiver le raisonnement"
     choice_reset:              "reset — effacer le réglage de session"
     choice_show:               "afficher le raisonnement dans les réponses"

--- a/locales/ga.yaml
+++ b/locales/ga.yaml
@@ -138,7 +138,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMód reatha: `{mode}`\\n\\nRoghnaigh rogha:"
+    picker_title:          "⚡ **Priority Processing**\n\nMód reatha: `{mode}`\n\nRoghnaigh rogha:"
     choice_fast:           "fast — Priority Processing ar siúl"
     choice_normal:         "normal — gnáthphróiseáil"
 
@@ -217,7 +217,7 @@ gateway:
     reset_global_unsupported:  "⚠️ Ní thacaítear le `/reasoning reset --global`. Úsáid `/reasoning <level> --global` chun an réamhshocrú domhanda a athrú."
     reset_done:                "🧠 ✓ Sárú réasúnaíochta seisiúin glanta; ag titim siar ar an gcumraíocht dhomhanda."
     unknown_arg:               "⚠️ Argóint anaithnid: `{arg}`\n\n**Leibhéil bhailí:** none, minimal, low, medium, high, xhigh, max, ultra\n**Taispeáint:** show, hide\n**Coinnigh:** cuir `--global` leis chun sábháil thar an seisiún seo"
-    picker_title:              "🧠 **Socruithe Réasúnaíochta**\\n\\n**Iarracht:** `{level}`\\n**Scóip:** {scope}\\n**Taispeáint:** {display}\\n\\nRoghnaigh rogha:"
+    picker_title:              "🧠 **Socruithe Réasúnaíochta**\n\n**Iarracht:** `{level}`\n**Scóip:** {scope}\n**Taispeáint:** {display}\n\nRoghnaigh rogha:"
     choice_none:               "none — díchumasaigh réasúnaíocht"
     choice_reset:              "reset — glan sárú an tseisiúin"
     choice_show:               "taispeáin réasúnaíocht sna freagraí"

--- a/locales/hu.yaml
+++ b/locales/hu.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nJelenlegi mód: `{mode}`\\n\\nVálassz egy opciót:"
+    picker_title:          "⚡ **Priority Processing**\n\nJelenlegi mód: `{mode}`\n\nVálassz egy opciót:"
     choice_fast:           "fast — Priority Processing bekapcsolva"
     choice_normal:         "normal — normál feldolgozás"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ A `/reasoning reset --global` nem támogatott. Használd a `/reasoning <level> --global` parancsot a globális alapérték módosításához."
     reset_done:                "🧠 ✓ A munkamenet gondolkodási felülbírálása törölve; visszaállás a globális konfigurációra."
     unknown_arg:               "⚠️ Ismeretlen argumentum: `{arg}`\n\n**Érvényes szintek:** none, minimal, low, medium, high, xhigh, max, ultra\n**Megjelenítés:** show, hide\n**Megőrzés:** add hozzá a `--global` opciót a munkameneten túli mentéshez"
-    picker_title:              "🧠 **Gondolkodási beállítások**\\n\\n**Erőfeszítés:** `{level}`\\n**Hatókör:** {scope}\\n**Megjelenítés:** {display}\\n\\nVálassz egy opciót:"
+    picker_title:              "🧠 **Gondolkodási beállítások**\n\n**Erőfeszítés:** `{level}`\n**Hatókör:** {scope}\n**Megjelenítés:** {display}\n\nVálassz egy opciót:"
     choice_none:               "none — gondolkodás kikapcsolása"
     choice_reset:              "reset — munkameneti felülbírálás törlése"
     choice_show:               "gondolkodás megjelenítése a válaszokban"

--- a/locales/it.yaml
+++ b/locales/it.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModalità attuale: `{mode}`\\n\\nScegli un\\'opzione:"
+    picker_title:          "⚡ **Priority Processing**\n\nModalità attuale: `{mode}`\n\nScegli un'opzione:"
     choice_fast:           "fast — Priority Processing attivo"
     choice_normal:         "normal — elaborazione standard"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` non è supportato. Usa `/reasoning <level> --global` per cambiare il valore predefinito globale."
     reset_done:                "🧠 ✓ Override di reasoning della sessione cancellato; ripristino della configurazione globale."
     unknown_arg:               "⚠️ Argomento sconosciuto: `{arg}`\n\n**Livelli validi:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualizzazione:** show, hide\n**Persistenza:** aggiungi `--global` per salvare oltre questa sessione"
-    picker_title:              "🧠 **Impostazioni di reasoning**\\n\\n**Sforzo:** `{level}`\\n**Ambito:** {scope}\\n**Visualizzazione:** {display}\\n\\nScegli un\\'opzione:"
+    picker_title:              "🧠 **Impostazioni di reasoning**\n\n**Sforzo:** `{level}`\n**Ambito:** {scope}\n**Visualizzazione:** {display}\n\nScegli un'opzione:"
     choice_none:               "none — disattiva il reasoning"
     choice_reset:              "reset — cancella l'override di sessione"
     choice_show:               "mostra il reasoning nelle risposte"

--- a/locales/ja.yaml
+++ b/locales/ja.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n現在のモード: `{mode}`\\n\\nオプションを選択:"
+    picker_title:          "⚡ **Priority Processing**\n\n現在のモード: `{mode}`\n\nオプションを選択:"
     choice_fast:           "fast — Priority Processing オン"
     choice_normal:         "normal — 標準処理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` はサポートされていません。グローバルのデフォルトを変更するには `/reasoning <level> --global` を使用してください。"
     reset_done:                "🧠 ✓ セッションの推論オーバーライドをクリアしました。グローバル設定にフォールバックします。"
     unknown_arg:               "⚠️ 不明な引数: `{arg}`\n\n**有効なレベル:** none, minimal, low, medium, high, xhigh, max, ultra\n**表示:** show, hide\n**永続化:** セッションを越えて保存するには `--global` を追加"
-    picker_title:              "🧠 **推論設定**\\n\\n**強度:** `{level}`\\n**スコープ:** {scope}\\n**表示:** {display}\\n\\nオプションを選択:"
+    picker_title:              "🧠 **推論設定**\n\n**強度:** `{level}`\n**スコープ:** {scope}\n**表示:** {display}\n\nオプションを選択:"
     choice_none:               "none — 推論を無効化"
     choice_reset:              "reset — セッション上書きをクリア"
     choice_show:               "返信に推論を表示"

--- a/locales/ko.yaml
+++ b/locales/ko.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n현재 모드: `{mode}`\\n\\n옵션을 선택하세요:"
+    picker_title:          "⚡ **Priority Processing**\n\n현재 모드: `{mode}`\n\n옵션을 선택하세요:"
     choice_fast:           "fast — Priority Processing 켜기"
     choice_normal:         "normal — 표준 처리"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global`은 지원되지 않습니다. 전역 기본값을 변경하려면 `/reasoning <level> --global`을 사용하세요."
     reset_done:                "🧠 ✓ 세션 추론 재정의가 해제되었습니다. 전역 설정으로 돌아갑니다."
     unknown_arg:               "⚠️ 알 수 없는 인수: `{arg}`\n\n**유효한 수준:** none, minimal, low, medium, high, xhigh, max, ultra\n**표시:** show, hide\n**영구화:** 이 세션을 넘어 저장하려면 `--global`을 추가하세요"
-    picker_title:              "🧠 **추론 설정**\\n\\n**노력:** `{level}`\\n**범위:** {scope}\\n**표시:** {display}\\n\\n옵션을 선택하세요:"
+    picker_title:              "🧠 **추론 설정**\n\n**노력:** `{level}`\n**범위:** {scope}\n**표시:** {display}\n\n옵션을 선택하세요:"
     choice_none:               "none — 추론 비활성화"
     choice_reset:              "reset — 세션 재정의 초기화"
     choice_show:               "응답에 추론 표시"

--- a/locales/pt.yaml
+++ b/locales/pt.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nModo atual: `{mode}`\\n\\nEscolha uma opção:"
+    picker_title:          "⚡ **Priority Processing**\n\nModo atual: `{mode}`\n\nEscolha uma opção:"
     choice_fast:           "fast — Priority Processing ativado"
     choice_normal:         "normal — processamento padrão"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` não é suportado. Usa `/reasoning <level> --global` para alterar o predefinido global."
     reset_done:                "🧠 ✓ Substituição de raciocínio da sessão removida; a regressar à configuração global."
     unknown_arg:               "⚠️ Argumento desconhecido: `{arg}`\n\n**Níveis válidos:** none, minimal, low, medium, high, xhigh, max, ultra\n**Visualização:** show, hide\n**Persistir:** adiciona `--global` para guardar para além desta sessão"
-    picker_title:              "🧠 **Definições de raciocínio**\\n\\n**Esforço:** `{level}`\\n**Âmbito:** {scope}\\n**Visualização:** {display}\\n\\nEscolha uma opção:"
+    picker_title:              "🧠 **Definições de raciocínio**\n\n**Esforço:** `{level}`\n**Âmbito:** {scope}\n**Visualização:** {display}\n\nEscolha uma opção:"
     choice_none:               "none — desativar raciocínio"
     choice_reset:              "reset — limpar o override de sessão"
     choice_show:               "mostrar raciocínio nas respostas"

--- a/locales/ru.yaml
+++ b/locales/ru.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nТекущий режим: `{mode}`\\n\\nВыберите вариант:"
+    picker_title:          "⚡ **Priority Processing**\n\nТекущий режим: `{mode}`\n\nВыберите вариант:"
     choice_fast:           "fast — Priority Processing включён"
     choice_normal:         "normal — стандартная обработка"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не поддерживается. Используйте `/reasoning <level> --global`, чтобы изменить глобальное значение по умолчанию."
     reset_done:                "🧠 ✓ Переопределение рассуждений для сеанса сброшено; возврат к глобальной конфигурации."
     unknown_arg:               "⚠️ Неизвестный аргумент: `{arg}`\n\n**Допустимые уровни:** none, minimal, low, medium, high, xhigh, max, ultra\n**Отображение:** show, hide\n**Сохранение:** добавьте `--global`, чтобы сохранить за пределами этого сеанса"
-    picker_title:              "🧠 **Настройки рассуждений**\\n\\n**Усилия:** `{level}`\\n**Область:** {scope}\\n**Отображение:** {display}\\n\\nВыберите вариант:"
+    picker_title:              "🧠 **Настройки рассуждений**\n\n**Усилия:** `{level}`\n**Область:** {scope}\n**Отображение:** {display}\n\nВыберите вариант:"
     choice_none:               "none — отключить рассуждения"
     choice_reset:              "reset — сбросить переопределение сессии"
     choice_show:               "показывать рассуждения в ответах"

--- a/locales/tr.yaml
+++ b/locales/tr.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nMevcut mod: `{mode}`\\n\\nBir seçenek seçin:"
+    picker_title:          "⚡ **Priority Processing**\n\nMevcut mod: `{mode}`\n\nBir seçenek seçin:"
     choice_fast:           "fast — Priority Processing açık"
     choice_normal:         "normal — standart işleme"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` desteklenmiyor. Genel varsayılanı değiştirmek için `/reasoning <level> --global` kullanın."
     reset_done:                "🧠 ✓ Oturumun akıl yürütme geçersiz kılması temizlendi; genel yapılandırmaya geri dönülüyor."
     unknown_arg:               "⚠️ Bilinmeyen argüman: `{arg}`\n\n**Geçerli seviyeler:** none, minimal, low, medium, high, xhigh, max, ultra\n**Görüntüleme:** show, hide\n**Kalıcı:** bu oturumun ötesinde kaydetmek için `--global` ekleyin"
-    picker_title:              "🧠 **Akıl Yürütme Ayarları**\\n\\n**Güç:** `{level}`\\n**Kapsam:** {scope}\\n**Görüntüleme:** {display}\\n\\nBir seçenek seçin:"
+    picker_title:              "🧠 **Akıl Yürütme Ayarları**\n\n**Güç:** `{level}`\n**Kapsam:** {scope}\n**Görüntüleme:** {display}\n\nBir seçenek seçin:"
     choice_none:               "none — akıl yürütmeyi kapat"
     choice_reset:              "reset — oturum geçersiz kılmasını temizle"
     choice_show:               "yanıtlarda akıl yürütmeyi göster"

--- a/locales/uk.yaml
+++ b/locales/uk.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\nПоточний режим: `{mode}`\\n\\nОберіть варіант:"
+    picker_title:          "⚡ **Priority Processing**\n\nПоточний режим: `{mode}`\n\nОберіть варіант:"
     choice_fast:           "fast — Priority Processing увімкнено"
     choice_normal:         "normal — стандартна обробка"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ `/reasoning reset --global` не підтримується. Використовуйте `/reasoning <level> --global`, щоб змінити глобальне значення за замовчуванням."
     reset_done:                "🧠 ✓ Перевизначення мислення для сеансу скинуто; повернення до глобальної конфігурації."
     unknown_arg:               "⚠️ Невідомий аргумент: `{arg}`\n\n**Дійсні рівні:** none, minimal, low, medium, high, xhigh, max, ultra\n**Показ:** show, hide\n**Зберегти:** додайте `--global`, щоб зберегти поза цим сеансом"
-    picker_title:              "🧠 **Налаштування мислення**\\n\\n**Зусилля:** `{level}`\\n**Область:** {scope}\\n**Показ:** {display}\\n\\nОберіть варіант:"
+    picker_title:              "🧠 **Налаштування мислення**\n\n**Зусилля:** `{level}`\n**Область:** {scope}\n**Показ:** {display}\n\nОберіть варіант:"
     choice_none:               "none — вимкнути мислення"
     choice_reset:              "reset — скинути перевизначення сесії"
     choice_show:               "показувати мислення у відповідях"

--- a/locales/zh-hant.yaml
+++ b/locales/zh-hant.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **Priority Processing**\\n\\n目前模式：`{mode}`\\n\\n請選擇："
+    picker_title:          "⚡ **Priority Processing**\n\n目前模式：`{mode}`\n\n請選擇："
     choice_fast:           "fast — 開啟 Priority Processing"
     choice_normal:         "normal — 標準處理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支援 `/reasoning reset --global`。請使用 `/reasoning <level> --global` 變更全域預設值。"
     reset_done:                "🧠 ✓ 已清除本工作階段的推理覆寫；回退至全域設定。"
     unknown_arg:               "⚠️ 未知參數：`{arg}`\n\n**有效級別：** none, minimal, low, medium, high, xhigh, max, ultra\n**顯示：** show, hide\n**持久化：** 加上 `--global` 可跨工作階段儲存"
-    picker_title:              "🧠 **推理設定**\\n\\n**強度：** `{level}`\\n**範圍：** {scope}\\n**顯示：** {display}\\n\\n請選擇："
+    picker_title:              "🧠 **推理設定**\n\n**強度：** `{level}`\n**範圍：** {scope}\n**顯示：** {display}\n\n請選擇："
     choice_none:               "none — 停用推理"
     choice_reset:              "reset — 清除工作階段覆寫"
     choice_show:               "在回覆中顯示推理"

--- a/locales/zh.yaml
+++ b/locales/zh.yaml
@@ -134,7 +134,7 @@ gateway:
     label_normal:          "NORMAL"
     status_fast:           "fast"
     status_normal:         "normal"
-    picker_title:          "⚡ **优先处理**\\n\\n当前模式：`{mode}`\\n\\n请选择："
+    picker_title:          "⚡ **优先处理**\n\n当前模式：`{mode}`\n\n请选择："
     choice_fast:           "fast — 开启优先处理"
     choice_normal:         "normal — 标准处理"
 
@@ -213,7 +213,7 @@ gateway:
     reset_global_unsupported:  "⚠️ 不支持 `/reasoning reset --global`。请使用 `/reasoning <level> --global` 修改全局默认值。"
     reset_done:                "🧠 ✓ 已清除本会话的推理覆盖；回退到全局配置。"
     unknown_arg:               "⚠️ 未知参数：`{arg}`\n\n**有效级别：** none, minimal, low, medium, high, xhigh, max, ultra\n**显示：** show, hide\n**持久化：** 添加 `--global` 以跨会话保存"
-    picker_title:              "🧠 **推理设置**\\n\\n**强度：** `{level}`\\n**作用域：** {scope}\\n**显示：** {display}\\n\\n请选择："
+    picker_title:              "🧠 **推理设置**\n\n**强度：** `{level}`\n**作用域：** {scope}\n**显示：** {display}\n\n请选择："
     choice_none:               "none — 关闭推理"
     choice_reset:              "reset — 清除会话覆盖"
     choice_show:               "在回复中显示推理"

--- a/tests/agent/test_i18n.py
+++ b/tests/agent/test_i18n.py
@@ -71,6 +71,36 @@ def test_catalog_placeholders_match_english(lang: str):
 
 
 # ---------------------------------------------------------------------------
+# Escaping -- catalog values must never contain literal escape sequences.
+# Regression for #100321: the /fast and /reasoning picker titles were written
+# with doubled backslashes ("\\n") in every non-English catalog, so Telegram
+# printed the two characters backslash-n instead of rendering a newline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("lang", list(i18n.SUPPORTED_LANGUAGES))
+def test_catalog_values_have_no_literal_escape_sequences(lang: str):
+    """No catalog value may contain a literal backslash-n or backslash-quote.
+
+    In YAML double-quoted scalars ``\\n`` decodes to the two characters ``\\``
+    + ``n`` (which users see printed verbatim), while ``\\n`` written once is a
+    real newline.  Doubled backslashes are always a translation-pipeline
+    escaping bug here -- no catalog string legitimately needs a literal
+    backslash-n or backslash-quote.
+    """
+    flat = _flatten(_load_raw(lang))
+    for key, value in flat.items():
+        assert "\\n" not in value, (
+            f"{lang}.yaml key={key!r}: contains a literal backslash-n "
+            f"(doubled backslash in the YAML source); users see '\\n' printed"
+        )
+        assert "\\'" not in value, (
+            f"{lang}.yaml key={key!r}: contains a literal backslash-quote "
+            f"(doubled backslash in the YAML source); users see '\\' printed"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Language resolution
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Fixes #100321: the `/reasoning` (and `/fast`) interactive picker titles printed a literal `\n` two-character sequence instead of rendering newlines on Telegram (and any platform) for every non-English language, e.g. `🧠 推理设置\n\n强度： max\n作用域： ...`.

Root cause: in YAML double-quoted scalars, `\\n` decodes to the two characters backslash + `n`, while `\n` decodes to a real newline. `locales/en.yaml` and `locales/ar.yaml` use the correct single-backslash form, but the other 15 catalogs (`zh`, `zh-hant`, `ja`, `de`, `es`, `fr`, `tr`, `uk`, `af`, `ko`, `it`, `ga`, `pt`, `ru`, `hu`) wrote the `gateway.fast.picker_title` and `gateway.reasoning.picker_title` strings with doubled backslashes — a translation-pipeline escaping artifact. Afrikaans and Italian had the same doubling on escaped quotes (`\\'` → users see a literal `\`). `agent/i18n.t()` loads these via `yaml.safe_load` and passes them straight through, so the literal sequences reached the adapter verbatim; inline-keyboard buttons were unaffected only because their labels contain no newlines.

The fix normalizes all 15 catalogs to the same single-backslash escapes already used by `en.yaml`/`ar.yaml` (30 lines of mechanical `\\n` → `\n`, plus `\\'` → `'` in af/it), and pins the invariant with a catalog-wide regression test so a future re-run of the translation pipeline cannot reintroduce it.

## Related Issue

Fixes #100321

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `locales/{zh,zh-hant,ja,de,es,fr,tr,uk,af,ko,it,ga,pt,ru,hu}.yaml` — `gateway.fast.picker_title` + `gateway.reasoning.picker_title`: `\\n` → `\n` (real newline after YAML decode); af/it also `\\'` → `'`
- `tests/agent/test_i18n.py` — new parametrized test `test_catalog_values_have_no_literal_escape_sequences`: no locale value may contain a literal backslash-n or backslash-quote (fail-closed against future double-escaping)

## How to Test

1. `python -m pytest tests/agent/test_i18n.py tests/gateway/test_reasoning_command.py tests/gateway/test_fast_command.py -q` — Observed result: 53 + 11 passed, all green.
2. On unpatched main, the new test fails for exactly the 15 affected languages (15 failed / 2 passed for en+ar) — confirming it pins the bug; with this patch it passes for all 17.
3. End-to-end (issue reproduction, no Telegram account needed):
   ```
   HERMES_LANGUAGE=zh python -c "
   from agent.i18n import t
   print(t('gateway.reasoning.picker_title', level='max', scope='全局配置', display='开 ✓'))"
   ```
   Observed result on main: one line with literal `\n` sequences. Observed result with this patch: multi-line output, real newlines rendered:
   ```
   🧠 **推理设置**

   **强度：** `max`
   **作用域：** 全局配置
   **显示：** 开 ✓

   请选择：
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(i18n): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites: `tests/agent/test_i18n.py`, `tests/gateway/test_reasoning_command.py`, `tests/gateway/test_fast_command.py` — 64 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (locale data fix)
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — locale data is platform-independent YAML
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A
