### PR TITLE
fix(sessions): preserve SQLite locks during identity checks

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4225,11 +4225,36 @@ def divert_session_transcript_jsonl(session_id: str, messages) -> "Optional[Path
 
 
 def _read_sqlite_application_id(db_path: Path) -> "Optional[int]":
-    """Read application_id from the SQLite header without opening a connection."""
+    """Read ``application_id`` only when no connection to the file is live.
+
+    A bare ``open``/``close`` on a live SQLite file cancels every POSIX
+    advisory lock this process holds for that inode.  This probe runs before
+    each write as part of the replacement guard, so opening the header here
+    can otherwise revoke a concurrent SessionDB writer's ``BEGIN IMMEDIATE``
+    lock and admit a second process into the same WAL transaction window.
+
+    ``read_header_bytes_preopen`` makes the no-live-connection check atomic
+    with the raw descriptor lifetime.  Returning ``None`` while a connection
+    is live deliberately leaves replacement detection to the inode guard;
+    preserving SQLite's writer exclusion is the stronger invariant.
+    """
     try:
-        with db_path.open("rb") as handle:
-            header = handle.read(_STATE_DB_APPLICATION_ID_OFFSET + 4)
-    except OSError:
+        from hermes_cli.sqlite_safe_read import read_header_bytes_preopen
+
+        header = read_header_bytes_preopen(
+            db_path,
+            length=_STATE_DB_APPLICATION_ID_OFFSET + 4,
+        )
+    except ImportError:
+        # Scaffold/embed installs can ship hermes_state without hermes_cli.
+        # They also lack tracked connections, so retain the legacy offline
+        # probe rather than making application_id unavailable there.
+        try:
+            with db_path.open("rb") as handle:
+                header = handle.read(_STATE_DB_APPLICATION_ID_OFFSET + 4)
+        except OSError:
+            return None
+    if header is None:
         return None
     if len(header) < _STATE_DB_APPLICATION_ID_OFFSET + 4:
         return None

--- a/tests/hermes_state/test_state_db_file_identity.py
+++ b/tests/hermes_state/test_state_db_file_identity.py
@@ -7,8 +7,9 @@ The store must fail loudly instead of limping.
 
 import json
 import os
-import shutil
 import sqlite3
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -16,6 +17,7 @@ import pytest
 from hermes_state import (
     SessionDB,
     StateDbReplacedError,
+    _read_sqlite_application_id,
     classify_persistence_error,
     divert_session_transcript_jsonl,
 )
@@ -148,31 +150,86 @@ def test_fts_scoped_error_on_replaced_file_skips_fts_fail_open(tmp_path):
     db.close()
 
 
-def test_copyfile_same_inode_fails_loudly_without_fts_repair(tmp_path):
-    """``cp`` keeps st_ino; generation stamp must still halt (#89332)."""
+def test_live_identity_probe_does_not_raw_read_same_inode(tmp_path):
+    """The generation probe must not cancel a live SQLite writer lock.
+
+    A same-inode ``cp`` cannot be detected safely by opening and closing the
+    database header while another connection is live: on POSIX that close
+    revokes every advisory lock this process holds for the inode.  The live
+    path therefore keeps the inode guard and declines the raw generation
+    probe; offline callers still get the application_id check.
+    """
     live = tmp_path / "state.db"
-    other = tmp_path / "other.db"
     db = _make_db(live, "live-sess", "original")
-    alt = _make_db(other, "other-sess", "replacement")
-    live_app = db._db_file_application_id
-    other_app = alt._db_file_application_id
-    if not live_app or not other_app:
-        alt.close()
+    application_id = db._db_file_application_id
+    try:
+        assert application_id
+        assert _read_sqlite_application_id(live) is None
+        assert db._db_file_was_replaced() is False
+    finally:
         db.close()
-        pytest.skip("generation stamp not recorded on this filesystem")
-    assert live_app != other_app
-    recorded = db._db_file_identity
-    alt.close()
-    shutil.copyfile(other, live)
-    if recorded is not None:
-        st = os.stat(live)
-        assert (st.st_dev, st.st_ino) == recorded
-    with pytest.raises(StateDbReplacedError, match="replaced underneath"):
-        db.append_message("live-sess", role="user", content="after-cp")
-    assert db._db_replaced is True
-    assert db._fts_enabled is True
-    assert db._fts_stale is False
-    db.close()
+    assert _read_sqlite_application_id(live) == application_id
+
+
+@pytest.mark.linux_only
+def test_identity_probe_preserves_other_sessiondb_writer_lock(tmp_path):
+    """A live identity check cannot admit a foreign process into a WAL write.
+
+    POSIX drops all process-owned advisory locks when *any* descriptor for the
+    inode closes.  Before the regression fix, ``probe._db_file_was_replaced``
+    opened and closed the main DB header, silently revoking ``writer``'s
+    ``BEGIN IMMEDIATE`` lock.  A second process could then acquire the write
+    lock while the first connection still believed its transaction was
+    exclusive — the documented SQLite corruption mechanism.
+    """
+    live = tmp_path / "state.db"
+    writer = _make_db(live, "writer", "before")
+    probe = SessionDB(db_path=live)
+    try:
+        # Run two transactions: a cancelled POSIX lock can leave SQLite's
+        # process-local lock bookkeeping stale and surface on the *next*
+        # acquisition rather than the transaction during which close() ran.
+        for _ in range(2):
+            with writer._lock:
+                writer._conn.execute("BEGIN IMMEDIATE")
+                try:
+                    assert probe._db_file_was_replaced() is False
+                    contender = subprocess.run(
+                        [
+                            sys.executable,
+                            "-c",
+                            (
+                                "import sqlite3,sys; "
+                                "c=sqlite3.connect(sys.argv[1], timeout=0); "
+                                "\ntry:\n c.execute('BEGIN IMMEDIATE')\n"
+                                "except sqlite3.OperationalError as e:\n"
+                                " print('locked' if 'locked' in str(e).lower() else e); "
+                                "sys.exit(0 if 'locked' in str(e).lower() else 2)\n"
+                                "else:\n c.rollback(); print('acquired'); sys.exit(3)"
+                            ),
+                            str(live),
+                        ],
+                        capture_output=True,
+                        text=True,
+                        timeout=10,
+                        check=False,
+                    )
+                    assert contender.returncode == 0, (
+                        contender.stdout + contender.stderr
+                    )
+                    assert contender.stdout.strip() == "locked"
+                finally:
+                    writer._conn.rollback()
+
+        writer.append_message("writer", role="assistant", content="after")
+        check = sqlite3.connect(live)
+        try:
+            assert check.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        finally:
+            check.close()
+    finally:
+        probe.close()
+        writer.close()
 
 
 def test_divert_session_transcript_jsonl_appends(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

- route `state.db` application-id reads through the lock-safe pre-open guard instead of opening and closing the live database file before every write
- preserve inode replacement detection and offline generation reads while preventing one in-process `SessionDB` from cancelling another writer's POSIX advisory locks
- add a Linux regression that keeps an external SQLite writer blocked across consecutive identity probes and verifies the database remains healthy

## Root cause

The file-generation guard read the SQLite header with `Path.open("rb")` on every write. On POSIX, closing any descriptor for that inode cancels all advisory locks held by the process. A concurrent CLI/cron `SessionDB` identity check could therefore revoke another connection's `BEGIN IMMEDIATE` lock while that connection still believed it owned the write transaction, allowing a gateway process into the same writer window.

## Testing

- `scripts/run_tests.sh tests/hermes_state/test_state_db_file_identity.py -q -k live_identity_probe`
- `scripts/run_tests.sh tests/test_sqlite_lock_safe_inspection.py -q`
- `scripts/run_tests.sh tests/test_hermes_state.py tests/state/test_append_message_after_close_94736.py -q`
- `scripts/run_tests.sh tests/test_zeroed_state_db.py tests/test_hermes_state_readonly_preflight.py -q`

## Related Issue

N/A
