### PR TITLE
fix(recovery): preserve delivery_obligations during session salvage

### DIFF
--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -334,11 +334,17 @@ def _copy_direct_tables(
         "compression_locks",
         "gateway_routing",
         "async_delegations",
+        "delivery_obligations",
     ):
         source_columns = _table_columns(lf_conn, table)
         if not source_columns:
             continue
         dest_columns = _table_columns(dest, table)
+        if table == "delivery_obligations" and not dest_columns:
+            from gateway.delivery_ledger import _initialize_schema
+
+            _initialize_schema(dest)
+            dest_columns = _table_columns(dest, table)
         columns = [c for c in dest_columns if c in source_columns]
         if not columns:
             continue

--- a/hermes_cli/session_recovery.py
+++ b/hermes_cli/session_recovery.py
@@ -45,6 +45,20 @@ _TOPIC_TABLES = (
     "telegram_dm_topic_bindings",
 )
 
+# Durable gateway outbox. Created lazily by gateway.delivery_ledger, so a
+# fresh SessionDB destination does not have the table until we initialize it.
+# Omitting it from the copy inventory drops owed replies (#100313, #86236).
+_AUXILIARY_TABLES = (
+    "delivery_obligations",
+)
+
+_INVENTORY_TABLES = (
+    *_CANONICAL_TABLES,
+    "state_meta",
+    *_TOPIC_TABLES,
+    *_AUXILIARY_TABLES,
+)
+
 # These values describe derived indexes or the schema that owns an optional
 # table. A fresh destination must generate them from its own current schema.
 _GENERATED_META_KEYS = frozenset({
@@ -305,7 +319,7 @@ def _inspect_connection(conn: sqlite3.Connection) -> dict[str, Any]:
         # A damaged journal pragma must not block rows that are still readable.
         report["warnings"].append(f"journal mode: {exc}")
 
-    for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES):
+    for table in _INVENTORY_TABLES:
         report["tables"][table] = _table_inventory(conn, table)
 
     for required in ("sessions", "messages"):
@@ -383,6 +397,23 @@ def inspect_session_database(
         }
     finally:
         temp_dir.cleanup()
+
+
+def _ensure_auxiliary_destination_schema(
+    destination: sqlite3.Connection,
+    table: str,
+) -> None:
+    """Create a lazy auxiliary table on the recovered destination.
+
+    Recovery initializes the destination through base ``SessionDB``, which
+    does not create gateway-owned tables. Copying into a missing dest table
+    would report ``missing`` / ``no compatible columns`` and drop the rows.
+    """
+
+    if table == "delivery_obligations":
+        from gateway.delivery_ledger import _initialize_schema
+
+        _initialize_schema(destination)
 
 
 def _copy_table(
@@ -1243,7 +1274,7 @@ def _verify_recovered_database(
             )
 
         counts: dict[str, int] = {}
-        for table in (*_CANONICAL_TABLES, "state_meta", *_TOPIC_TABLES):
+        for table in _INVENTORY_TABLES:
             columns = _table_columns(conn, table)
             if columns:
                 counts[table] = int(
@@ -1251,7 +1282,7 @@ def _verify_recovered_database(
                 )
         verification["table_counts"] = counts
 
-        for table in ("sessions", "messages"):
+        for table in ("sessions", "messages", *_AUXILIARY_TABLES):
             expected = expected_counts.get(table)
             if expected is not None and counts.get(table) != expected:
                 message = (
@@ -1662,6 +1693,27 @@ def recover_session_database(
                     progress_cb=progress_cb,
                     source_rows=table_inspection.get("rows"),
                 )
+
+            for table in _AUXILIARY_TABLES:
+                table_inspection = inspection["tables"][table]
+                if not table_inspection.get("available"):
+                    copy_report[table] = {
+                        "status": "missing",
+                        "copied_rows": 0,
+                    }
+                    continue
+                _ensure_auxiliary_destination_schema(destination_conn, table)
+                copy_function = (
+                    _copy_table_salvage if allow_partial else _copy_table
+                )
+                copy_report[table] = copy_function(
+                    source_conn,
+                    destination_conn,
+                    table,
+                    chunk_size=chunk_size,
+                    progress_cb=progress_cb,
+                    source_rows=table_inspection.get("rows"),
+                )
             orphan_cleanup = (
                 _cleanup_partial_orphans(destination_conn)
                 if allow_partial
@@ -1678,8 +1730,15 @@ def recover_session_database(
         verification = _verify_recovered_database(
             output,
             expected_counts={
-                table: inspection["tables"][table].get("rows")
-                for table in _CANONICAL_TABLES
+                **{
+                    table: inspection["tables"][table].get("rows")
+                    for table in _CANONICAL_TABLES
+                },
+                **{
+                    table: inspection["tables"][table].get("rows")
+                    for table in _AUXILIARY_TABLES
+                    if inspection["tables"].get(table, {}).get("available")
+                },
             },
             copy_report=copy_report,
             allow_partial=allow_partial,

--- a/tests/hermes_cli/test_session_recovery.py
+++ b/tests/hermes_cli/test_session_recovery.py
@@ -648,4 +648,108 @@ def test_partial_recovery_clears_only_unreadable_system_prompt_refs(
         conn.close()
 
 
+def _insert_delivery_obligations(path: Path, rows: list[tuple[object, ...]]) -> None:
+    from gateway.delivery_ledger import _initialize_schema
+
+    conn = sqlite3.connect(str(path), isolation_level=None)
+    try:
+        _initialize_schema(conn)
+        conn.executemany(
+            """INSERT INTO delivery_obligations (
+                obligation_id, session_key, platform, chat_id, thread_id,
+                content, state, attempts, created_at, updated_at,
+                owner_pid, owner_started_at, last_error, adapter_profile
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            rows,
+        )
+    finally:
+        conn.close()
+
+
+def test_recovery_copies_delivery_obligations(tmp_path: Path) -> None:
+    """Owed replies must survive salvage — #100313 lost 6 obligation rows."""
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+    now = 1_720_000_000.0
+    _insert_delivery_obligations(
+        source,
+        [
+            (
+                "ob-pending",
+                "telegram:1:chat-1",
+                "telegram",
+                "chat-1",
+                None,
+                "owed reply",
+                "pending",
+                0,
+                now,
+                now,
+                4242,
+                99,
+                None,
+                "default",
+            ),
+            (
+                "ob-delivered",
+                "telegram:1:chat-1",
+                "telegram",
+                "chat-1",
+                None,
+                "already sent",
+                "delivered",
+                1,
+                now,
+                now + 1,
+                None,
+                None,
+                None,
+                "default",
+            ),
+        ],
+    )
+
+    inspection = inspect_session_database(source, work_dir=tmp_path)
+    assert inspection["tables"]["delivery_obligations"]["available"] is True
+    assert inspection["tables"]["delivery_obligations"]["rows"] == 2
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    copied = report["copy"]["delivery_obligations"]
+    assert copied["status"] == "complete"
+    assert copied["copied_rows"] == 2
+    assert report["verification"]["table_counts"]["delivery_obligations"] == 2
+    assert report["complete"] is True
+    assert report["verified"] is True
+    assert report["installed"] is False
+
+    conn = sqlite3.connect(str(output))
+    try:
+        recovered = conn.execute(
+            """SELECT obligation_id, state, content, owner_pid, adapter_profile
+               FROM delivery_obligations ORDER BY obligation_id"""
+        ).fetchall()
+    finally:
+        conn.close()
+    assert recovered == [
+        ("ob-delivered", "delivered", "already sent", None, "default"),
+        ("ob-pending", "pending", "owed reply", 4242, "default"),
+    ]
+
+
+def test_recovery_without_delivery_ledger_is_not_lossy(tmp_path: Path) -> None:
+    """CLI-only stores never created the lazy table; that is not data loss."""
+
+    source = tmp_path / "state.db"
+    output = tmp_path / "recovered.db"
+    _make_source(source)
+
+    report = recover_session_database(source, output, work_dir=tmp_path)
+    assert report["copy"]["delivery_obligations"]["status"] == "missing"
+    assert "delivery_obligations" not in report["verification"]["table_counts"]
+    assert report["complete"] is True
+    assert report["verified"] is True
+
+
 


### PR DESCRIPTION
## Summary
- `hermes sessions recover` copied a fixed canonical table list and never initialized the lazy `delivery_obligations` gateway outbox, so a verified salvage could drop owed replies. In [#100313](https://github.com/NousResearch/hermes-agent/issues/100313) that was 6 obligation rows on an otherwise fully recovered store.
- Recovery now inventories the table, creates it on the destination via the ledger schema, copies it (strict and `--allow-partial` salvage, including the lost-and-found lane), and treats a source-vs-dest count mismatch as verification loss.
- Stores that never created the lazy table still recover as complete. The concurrent-writer corruption itself remains the #90837 / #85004 class; the rowid-budget salvage gap for damaged `sessions` / `session_model_usage` edges is already covered by open [#98062](https://github.com/NousResearch/hermes-agent/pull/98062).

Fixes #100313 (salvage omission). Related: #86236.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_session_recovery.py tests/hermes_cli/test_session_recovery_lost_and_found.py -q`
- [ ] Recover a snapshot that contains pending + delivered `delivery_obligations` rows and confirm both land in the output DB
- [ ] Recover a CLI-only `state.db` with no delivery ledger and confirm `complete: true` with copy status `missing`