### PR TITLE
fix(copilot-acp): show provider in pickers, correct sign-in command, honest auth status

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -199,8 +199,11 @@ def _format_messages_as_prompt(
         "IMPORTANT: If you take an action with a tool, you MUST output tool calls using <tool_call>{...}</tool_call> blocks with JSON exactly in OpenAI function-call shape.",
         "If no tool is needed, answer normally.",
     ]
-    if model:
-        sections.append(f"Hermes requested model hint: {model}")
+    # Deliberately no "requested model" line in the prompt: the model is
+    # applied for real via ACP session/set_model, and when the backend can't
+    # honor it (org-policy-disabled id) a prompt-text mention makes the
+    # serving model FALSELY self-identify as the requested one. Identity
+    # must come from the backend, not from prompt suggestion.
 
     # Copilot has no tools of its own that would collide with Hermes', so it
     # forwards the whole toolset (no allowlist).
@@ -585,12 +588,22 @@ class CopilotACPClient:
             # and never fail the whole turn over model selection.
             if requested_model and requested_model != "copilot-acp":
                 try:
-                    available = {
-                        str(m.get("modelId") or "").strip()
+                    advertised = [
+                        m
                         for m in (
                             (session.get("models") or {}).get("availableModels") or []
                         )
                         if isinstance(m, dict)
+                    ]
+                    available = {
+                        str(m.get("modelId") or "").strip()
+                        for m in advertised
+                        # Org-policy-disabled ids can still appear in the list;
+                        # selecting one silently serves the default model, so
+                        # treat them as not offered.
+                        if str(
+                            ((m.get("_meta") or {}).get("copilotEnablement")) or ""
+                        ).strip().lower() != "disabled"
                     }
                     if not available or requested_model in available:
                         _request(

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -187,6 +187,71 @@ def _permission_denied(message_id: Any) -> dict[str, Any]:
     }
 
 
+def _model_selection_request(
+    session: dict[str, Any], requested_model: str
+) -> tuple[str, dict[str, str]] | None:
+    """Return the ACP request that selects ``requested_model`` for ``session``.
+
+    Prefer stable v1 ``session/set_config_option``. Fall back to Copilot's
+    pre-stabilization ``session/set_model`` extension only when no model
+    config option is advertised. A reported model list is authoritative:
+    unknown and policy-disabled ids return None instead of being sent.
+    """
+    session_id = str(session.get("sessionId") or "").strip()
+    requested_model = str(requested_model or "").strip()
+    if not session_id or not requested_model or requested_model == "copilot-acp":
+        return None
+
+    config_options = [
+        o for o in (session.get("configOptions") or []) if isinstance(o, dict)
+    ]
+    model_option = next(
+        (
+            o for o in config_options
+            if o.get("category") == "model" or o.get("id") == "model"
+        ),
+        None,
+    )
+    if model_option is not None:
+        enabled_values = {
+            str(o.get("value") or "").strip()
+            for o in (model_option.get("options") or [])
+            if isinstance(o, dict)
+            and str(
+                ((o.get("_meta") or {}).get("copilotEnablement")) or ""
+            ).strip().lower() != "disabled"
+        }
+        if requested_model not in enabled_values:
+            return None
+        return (
+            "session/set_config_option",
+            {
+                "sessionId": session_id,
+                "configId": str(model_option.get("id") or "model"),
+                "value": requested_model,
+            },
+        )
+
+    advertised = [
+        m
+        for m in ((session.get("models") or {}).get("availableModels") or [])
+        if isinstance(m, dict)
+    ]
+    available = {
+        str(m.get("modelId") or "").strip()
+        for m in advertised
+        if str(
+            ((m.get("_meta") or {}).get("copilotEnablement")) or ""
+        ).strip().lower() != "disabled"
+    }
+    if available and requested_model not in available:
+        return None
+    return (
+        "session/set_model",
+        {"sessionId": session_id, "modelId": requested_model},
+    )
+
+
 def _format_messages_as_prompt(
     messages: list[dict[str, Any]],
     model: str | None = None,
@@ -579,47 +644,26 @@ class CopilotACPClient:
             if not session_id:
                 raise RuntimeError("Copilot ACP did not return a sessionId.")
 
-            # Select the model Hermes asked for. The `--model` spawn flag is
-            # validated but IGNORED by `copilot --acp` (observed: session
-            # still runs the CLI's own default); the ACP-native
-            # `session/set_model` call is what actually switches it. Only
-            # send ids the server advertises in session/new so an unknown
-            # slug degrades to the default instead of erroring the prompt,
-            # and never fail the whole turn over model selection.
+            # Select the model Hermes asked for. Prefer the stable ACP v1
+            # session-config API: session/new advertises a category="model"
+            # select option and session/set_config_option updates it. Copilot
+            # still exposes the older models/session/set_model extension too,
+            # so retain that only as compatibility fallback for older agents.
             if requested_model and requested_model != "copilot-acp":
                 try:
-                    advertised = [
-                        m
-                        for m in (
-                            (session.get("models") or {}).get("availableModels") or []
-                        )
-                        if isinstance(m, dict)
-                    ]
-                    available = {
-                        str(m.get("modelId") or "").strip()
-                        for m in advertised
-                        # Org-policy-disabled ids can still appear in the list;
-                        # selecting one silently serves the default model, so
-                        # treat them as not offered.
-                        if str(
-                            ((m.get("_meta") or {}).get("copilotEnablement")) or ""
-                        ).strip().lower() != "disabled"
-                    }
-                    if not available or requested_model in available:
-                        _request(
-                            "session/set_model",
-                            {"sessionId": session_id, "modelId": requested_model},
-                        )
+                    selection = _model_selection_request(session, requested_model)
+                    if selection is not None:
+                        method, params = selection
+                        _request(method, params)
                     else:
                         logger.warning(
                             "Copilot ACP does not offer model %r; using the "
-                            "session default. Available: %s",
+                            "session default.",
                             requested_model,
-                            ", ".join(sorted(available)) or "(none reported)",
                         )
                 except Exception as exc:
                     logger.warning(
-                        "Copilot ACP session/set_model(%r) failed; continuing "
+                        "Copilot ACP model selection for %r failed; continuing "
                         "with the session default: %s",
                         requested_model,
                         exc,

--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -9,6 +9,7 @@ back into the minimal shape Hermes expects from an OpenAI client.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import queue
 import re
@@ -31,6 +32,7 @@ from agent.redact import redact_sensitive_text
 from tools.environments.local import hermes_subprocess_env
 
 ACP_MARKER_BASE_URL = "acp://copilot"
+logger = logging.getLogger(__name__)
 _DEFAULT_TIMEOUT_SECONDS = 900.0
 
 # Stderr fingerprint of the deprecated `gh copilot` CLI extension
@@ -365,6 +367,7 @@ class CopilotACPClient:
         response_text, reasoning_text = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
+            model=model,
         )
 
         tool_calls, cleaned_text = _extract_tool_calls_from_text(response_text)
@@ -393,7 +396,13 @@ class CopilotACPClient:
             return _completion_to_stream_chunks(completion)
         return completion
 
-    def _run_prompt(self, prompt_text: str, *, timeout_seconds: float) -> tuple[str, str]:
+    def _run_prompt(
+        self,
+        prompt_text: str,
+        *,
+        timeout_seconds: float,
+        model: str | None = None,
+    ) -> tuple[str, str]:
         # Fast-fail when the CLI doesn't support the ACP args we'd pass.
         # Without this guard, a CLI like Claude Code v2.x exits with
         # ``error: unknown option '--acp'`` immediately, then the parent
@@ -415,6 +424,13 @@ class CopilotACPClient:
                 f"HERMES_COPILOT_ACP_COMMAND / HERMES_COPILOT_ACP_ARGS "
                 f"to a working pair."
             )
+
+        # Note the model Hermes selected; it is applied after session/new via
+        # the ACP-native `session/set_model` call. The CLI's `--model` spawn
+        # flag is deliberately NOT used here: `copilot --acp` validates it
+        # (an unknown id aborts the spawn) but then ignores it for the actual
+        # session, so it adds a failure mode without selecting anything.
+        requested_model = str(model or "").strip()
 
         try:
             # Hide the console the CLI child would otherwise flash on Windows
@@ -559,6 +575,42 @@ class CopilotACPClient:
             session_id = str(session.get("sessionId") or "").strip()
             if not session_id:
                 raise RuntimeError("Copilot ACP did not return a sessionId.")
+
+            # Select the model Hermes asked for. The `--model` spawn flag is
+            # validated but IGNORED by `copilot --acp` (observed: session
+            # still runs the CLI's own default); the ACP-native
+            # `session/set_model` call is what actually switches it. Only
+            # send ids the server advertises in session/new so an unknown
+            # slug degrades to the default instead of erroring the prompt,
+            # and never fail the whole turn over model selection.
+            if requested_model and requested_model != "copilot-acp":
+                try:
+                    available = {
+                        str(m.get("modelId") or "").strip()
+                        for m in (
+                            (session.get("models") or {}).get("availableModels") or []
+                        )
+                        if isinstance(m, dict)
+                    }
+                    if not available or requested_model in available:
+                        _request(
+                            "session/set_model",
+                            {"sessionId": session_id, "modelId": requested_model},
+                        )
+                    else:
+                        logger.warning(
+                            "Copilot ACP does not offer model %r; using the "
+                            "session default. Available: %s",
+                            requested_model,
+                            ", ".join(sorted(available)) or "(none reported)",
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "Copilot ACP session/set_model(%r) failed; continuing "
+                        "with the session default: %s",
+                        requested_model,
+                        exc,
+                    )
 
             text_parts: list[str] = []
             reasoning_parts: list[str] = []

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7281,8 +7281,54 @@ def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
     }
 
 
+def _external_process_auth_evidence(provider_id: str) -> tuple[bool, Optional[str]]:
+    """Best-effort POSITIVE evidence that an external-process provider's CLI
+    is authenticated.
+
+    Returns ``(verified, source)``. ``verified`` is only ever True on hard
+    evidence (a supported env token, or a known on-disk credential store).
+    False means "not verifiable from here", NOT "signed out" — the Copilot
+    CLI may hold its session in an OS keychain Hermes can't read. Callers
+    must therefore treat False as unknown, never as proof of absence.
+
+    Deliberately subprocess-free: this runs from status endpoints and pickers,
+    and spawning ``gh auth token`` there re-creates the cold-start stall
+    (#60800) that copilot_auth.py works to avoid.
+    """
+    if provider_id != "copilot-acp":
+        return False, None
+    # 1. Supported env tokens — the same vars the Copilot CLI itself honors.
+    try:
+        from hermes_cli.copilot_auth import COPILOT_ENV_VARS, validate_copilot_token
+        for env_var in COPILOT_ENV_VARS:
+            val = os.getenv(env_var, "").strip()
+            if val and validate_copilot_token(val)[0]:
+                return True, f"env: {env_var}"
+    except Exception as exc:
+        logger.debug("copilot-acp env token evidence check failed: %s", exc)
+    # 2. Known on-disk GitHub Copilot credential stores (the same locations
+    #    models.py already fingerprints as external credential files).
+    for cred_path in (
+        "~/.config/github-copilot/hosts.json",
+        "~/.config/github-copilot/apps.json",
+    ):
+        try:
+            expanded = os.path.expanduser(cred_path)
+            if os.path.isfile(expanded) and os.path.getsize(expanded) > 2:
+                return True, cred_path
+        except OSError:
+            continue
+    return False, None
+
+
 def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
-    """Status snapshot for providers that run a local subprocess."""
+    """Status snapshot for providers that run a local subprocess.
+
+    ``configured``/``logged_in`` stay structural (the executable resolves or a
+    TCP endpoint is set) because the spawned subprocess owns its real auth.
+    ``auth_verified``/``auth_source`` carry positive credential evidence when
+    Hermes can actually see some — absence of evidence is not absence of auth.
+    """
     pconfig = PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "external_process":
         return {"configured": False}
@@ -7299,6 +7345,7 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         base_url = pconfig.inference_base_url
 
     resolved_command = shutil.which(command) if command else None
+    auth_verified, auth_source = _external_process_auth_evidence(provider_id)
     return {
         "configured": bool(resolved_command or base_url.startswith("acp+tcp://")),
         "provider": provider_id,
@@ -7308,6 +7355,8 @@ def get_external_process_provider_status(provider_id: str) -> Dict[str, Any]:
         "resolved_command": resolved_command,
         "base_url": base_url,
         "logged_in": bool(resolved_command or base_url.startswith("acp+tcp://")),
+        "auth_verified": auth_verified,
+        "auth_source": auth_source,
     }
 
 
@@ -7328,12 +7377,16 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_qwen_auth_status()
     if target == "minimax-oauth":
         return get_minimax_oauth_auth_status()
-    if target == "copilot-acp":
-        return get_external_process_provider_status(target)
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
-    # API-key providers
     pconfig = PROVIDER_REGISTRY.get(target)
+    # External-process providers (copilot-acp today; kiro/devin/junie-style ACP
+    # backends tomorrow) — dispatch on auth_type, not a hardcoded slug, so every
+    # provider of this class gets a real status instead of the
+    # ``{"logged_in": False}`` fallthrough.
+    if pconfig and pconfig.auth_type == "external_process":
+        return get_external_process_provider_status(target)
+    # API-key providers
     if pconfig and pconfig.auth_type == "api_key":
         return get_api_key_provider_status(target)
     # AWS SDK providers (Bedrock) — check via boto3 credential chain

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7306,7 +7306,26 @@ def _external_process_auth_evidence(provider_id: str) -> tuple[bool, Optional[st
                 return True, f"env: {env_var}"
     except Exception as exc:
         logger.debug("copilot-acp env token evidence check failed: %s", exc)
-    # 2. Known on-disk GitHub Copilot credential stores (the same locations
+    # 2. The Copilot CLI's own plaintext token store (~/.copilot/config.json,
+    #    written by `copilot login` when no OS keychain is available). The file
+    #    is JSONC — strip //-comment lines before parsing.
+    try:
+        cli_config = os.path.expanduser("~/.copilot/config.json")
+        if os.path.isfile(cli_config):
+            with open(cli_config, "r", encoding="utf-8", errors="ignore") as fh:
+                raw = "\n".join(
+                    line for line in fh.read().splitlines()
+                    if not line.lstrip().startswith("//")
+                )
+            data = json.loads(raw) if raw.strip() else {}
+            tokens = data.get("copilotTokens")
+            if isinstance(tokens, dict) and any(
+                isinstance(v, str) and v.strip() for v in tokens.values()
+            ):
+                return True, "~/.copilot/config.json"
+    except Exception as exc:
+        logger.debug("copilot-acp CLI config evidence check failed: %s", exc)
+    # 3. Known on-disk GitHub Copilot credential stores (the same locations
     #    models.py already fingerprints as external credential files).
     for cred_path in (
         "~/.config/github-copilot/hosts.json",

--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -758,9 +758,33 @@ def _filter_explicit_provider_rows(rows: list[dict], ctx: ConfigContext) -> list
             # just accepted those same credentials when building it.
             kept.append(row)
             continue
+        if _external_process_signed_in(slug):
+            # External-process providers (copilot-acp) authenticate through
+            # their own CLI (`copilot login`), which — like the Anthropic
+            # OAuth case above — leaves no trace in active_provider,
+            # model.provider, or env vars. Verified CLI credentials are a
+            # deliberate sign-in; without this the desktop picker drops the
+            # row the picker-discovery side just accepted.
+            kept.append(row)
+            continue
         if is_provider_explicitly_configured(slug):
             kept.append(row)
     return kept
+
+
+def _external_process_signed_in(slug: str) -> bool:
+    """True when an external-process provider has verified CLI credentials."""
+    try:
+        from hermes_cli.auth import (
+            PROVIDER_REGISTRY,
+            get_external_process_provider_status,
+        )
+        pconfig = PROVIDER_REGISTRY.get(slug)
+        if not pconfig or pconfig.auth_type != "external_process":
+            return False
+        return bool(get_external_process_provider_status(slug).get("auth_verified"))
+    except Exception:
+        return False
 
 
 def _provider_is_keyless(slug: str) -> bool:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3218,6 +3218,19 @@ def list_authenticated_providers(
                     if any(os.environ.get(ev) for ev in pcfg.api_key_env_vars):
                         has_creds = True
                         break
+        # External-process providers (copilot-acp) hold no API key, OAuth
+        # token, or pool entry by design — the spawned ACP subprocess brings
+        # its own auth. "Configured" means the executable resolves, which is
+        # exactly what get_auth_status() reports for them; without this branch
+        # the has_creds filter below unconditionally hides the provider from
+        # every picker (#63662).
+        if not has_creds and overlay.auth_type == "external_process":
+            try:
+                from hermes_cli.auth import get_auth_status
+                _ext_status = get_auth_status(hermes_slug) or {}
+                has_creds = bool(_ext_status.get("logged_in") or _ext_status.get("configured"))
+            except Exception as exc:
+                logger.debug("External-process check failed for %s: %s", pid, exc)
         # Check auth store and credential pool for non-env-var credentials.
         # This applies to OAuth providers AND api_key providers that also
         # support OAuth (e.g. anthropic supports both API key and Claude Code

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3807,13 +3807,18 @@ def _resolve_copilot_catalog_api_key() -> str:
          ``auth.json`` under ``credential_pool.copilot[]``. The pool is
          populated by ``hermes auth add copilot`` and by ``_seed_from_env``
          when the env var is set in ``~/.hermes/.env``.
+      3. ``~/.copilot/config.json`` ``copilotTokens`` — the GitHub Copilot
+         CLI's own store, written by ``copilot login`` on hosts without an
+         OS keychain. Without it, a user whose ONLY credential is the ACP
+         CLI login sees the copilot-acp picker fall back to the stale
+         curated list instead of the models their subscription serves.
 
-    Without (2), users whose only Copilot credential is in the pool see
-    the ``/model`` picker fall back to a stale hardcoded list because the
-    live catalog fetch silently 401s. To avoid wedging on a malformed pool
-    entry, each candidate is exchanged via ``exchange_copilot_token`` —
-    only entries that actually exchange successfully are returned, so a
-    later valid entry is reachable when an earlier one is unsupported.
+    Without (2)/(3), users without env-var credentials see the ``/model``
+    picker fall back to a stale hardcoded list because the live catalog
+    fetch silently 401s. To avoid wedging on a malformed entry, each
+    candidate is exchanged via ``exchange_copilot_token`` — only entries
+    that actually exchange successfully are returned, so a later valid
+    entry is reachable when an earlier one is unsupported.
     """
     try:
         from hermes_cli.auth import resolve_api_key_provider_credentials
@@ -3842,11 +3847,50 @@ def _resolve_copilot_catalog_api_key() -> str:
             if not valid:
                 continue
             try:
-                api_token, _expires_at = exchange_copilot_token(raw)
+                # exchange_copilot_token returns (api_token, expires_at,
+                # base_url) — a 2-name unpack raises ValueError, which the
+                # except below silently swallowed, disabling this entire
+                # resolution path.
+                api_token = exchange_copilot_token(raw)[0]
             except Exception:
                 continue
             if api_token:
                 return api_token
+    except Exception:
+        pass
+
+    # 3. Copilot CLI plaintext token store (JSONC — strip //-comment lines).
+    try:
+        import json as _json
+
+        from hermes_cli.copilot_auth import (
+            exchange_copilot_token,
+            validate_copilot_token,
+        )
+
+        cli_config = os.path.expanduser("~/.copilot/config.json")
+        if os.path.isfile(cli_config):
+            with open(cli_config, "r", encoding="utf-8", errors="ignore") as fh:
+                raw_text = "\n".join(
+                    line for line in fh.read().splitlines()
+                    if not line.lstrip().startswith("//")
+                )
+            data = _json.loads(raw_text) if raw_text.strip() else {}
+            tokens = data.get("copilotTokens")
+            if isinstance(tokens, dict):
+                for raw in tokens.values():
+                    raw = str(raw or "").strip()
+                    if not raw:
+                        continue
+                    valid, _ = validate_copilot_token(raw)
+                    if not valid:
+                        continue
+                    try:
+                        api_token = exchange_copilot_token(raw)[0]
+                    except Exception:
+                        continue
+                    if api_token:
+                        return api_token
     except Exception:
         pass
 
@@ -4807,12 +4851,14 @@ def copilot_default_headers(*, is_agent_turn: bool = True) -> dict[str, str]:
         }
 
 
-def _copilot_catalog_item_is_text_model(item: dict[str, Any]) -> bool:
+def _copilot_catalog_item_is_text_model(
+    item: dict[str, Any], *, ignore_picker_flag: bool = False
+) -> bool:
     model_id = str(item.get("id") or "").strip()
     if not model_id:
         return False
 
-    if item.get("model_picker_enabled") is False:
+    if not ignore_picker_flag and item.get("model_picker_enabled") is False:
         return False
 
     capabilities = item.get("capabilities")
@@ -4891,6 +4937,25 @@ def fetch_github_model_catalog(
                         continue
                     seen_ids.add(model_id)
                     models.append(item)
+                if not models and items:
+                    # GitHub has been observed returning
+                    # ``model_picker_enabled: false`` for EVERY model on some
+                    # accounts/token types, which would silently reject the
+                    # whole live catalog and strand the picker on the stale
+                    # curated fallback. The flag is a display hint, not an
+                    # availability contract — when honoring it empties the
+                    # catalog, retry without it (chat/endpoint checks still
+                    # apply, so embeddings and non-chat rows stay excluded).
+                    for item in items:
+                        if not _copilot_catalog_item_is_text_model(
+                            item, ignore_picker_flag=True
+                        ):
+                            continue
+                        model_id = str(item.get("id") or "").strip()
+                        if not model_id or model_id in seen_ids:
+                            continue
+                        seen_ids.add(model_id)
+                        models.append(item)
                 if models:
                     _github_model_catalog_cache = copy.deepcopy(models)
                     _github_model_catalog_cache_key = api_key

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -11023,18 +11023,61 @@ def _claude_code_only_status() -> Dict[str, Any]:
 def _copilot_acp_status() -> Dict[str, Any]:
     """Status for copilot-acp — credentials are owned by the Copilot CLI.
 
-    There is no cheap programmatic credential probe for the ACP subprocess, so
-    this is a read-only "managed by the Copilot CLI" card (like claude-code):
-    Hermes never claims a login state it can't verify.
+    ``logged_in`` is claimed only on positive evidence (a supported env token
+    or a known on-disk GitHub Copilot credential store, via
+    ``auth.get_external_process_provider_status``). The Copilot CLI may also
+    hold its session in an OS keychain Hermes can't read, so the unverified
+    state is presented as "managed by the Copilot CLI" — never as signed out.
     """
+    try:
+        from hermes_cli.auth import get_external_process_provider_status
+        status = get_external_process_provider_status("copilot-acp") or {}
+    except Exception:
+        status = {}
+    verified = bool(status.get("auth_verified"))
+    configured = bool(status.get("configured"))
+    if verified:
+        source_label = status.get("auth_source") or "Copilot credentials detected"
+    elif configured:
+        found = status.get("resolved_command") or status.get("command") or "copilot"
+        source_label = f"Managed by the GitHub Copilot CLI ({found})"
+    else:
+        source_label = "GitHub Copilot CLI not found on PATH"
     return {
-        "logged_in": False,
+        "logged_in": verified,
         "source": "copilot_cli",
-        "source_label": "Managed by the GitHub Copilot CLI",
+        "source_label": source_label,
         "token_preview": None,
         "expires_at": None,
         "has_refresh_token": False,
+        "configured": configured,
     }
+
+
+def _external_process_cli_command(provider_id: str, default: str) -> str:
+    """Render an external-process provider's sign-in command with the CLI the
+    user actually has configured.
+
+    The static catalog assumes the default executable name; users who point
+    Hermes at a custom binary (``HERMES_COPILOT_ACP_COMMAND`` /
+    ``COPILOT_CLI_PATH``) would otherwise be told to run a command that isn't
+    the one Hermes spawns. Non-external-process providers get ``default`` back
+    untouched.
+    """
+    try:
+        from hermes_cli.auth import PROVIDER_REGISTRY, get_external_process_provider_status
+        pconfig = PROVIDER_REGISTRY.get(provider_id)
+        if not pconfig or pconfig.auth_type != "external_process":
+            return default
+        status = get_external_process_provider_status(provider_id) or {}
+        command = str(status.get("command") or "").strip()
+        if command:
+            parts = default.split(" ", 1)
+            tail = f" {parts[1]}" if len(parts) > 1 else ""
+            return f"{command}{tail}"
+    except Exception:
+        pass
+    return default
 
 
 # Explicit, hand-tuned OAuth/account provider cards. These carry the bits that
@@ -11102,7 +11145,11 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "id": "copilot-acp",
         "name": "GitHub Copilot (ACP)",
         "flow": "external",
-        "cli_command": "copilot /login",
+        # `copilot login` is the CLI's non-interactive device-code login
+        # subcommand; the previous `copilot /login` form is not a valid
+        # invocation (slash-commands only exist inside an interactive
+        # session, reachable as `copilot -i /login`).
+        "cli_command": "copilot login",
         "docs_url": "https://docs.github.com/en/copilot",
         "status_fn": _copilot_acp_status,
     },
@@ -11361,7 +11408,7 @@ async def list_oauth_providers(profile: Optional[str] = None):
                     "id": p["id"],
                     "name": p["name"],
                     "flow": p["flow"],
-                    "cli_command": p["cli_command"],
+                    "cli_command": _external_process_cli_command(p["id"], p["cli_command"]),
                     "docs_url": p["docs_url"],
                     "disconnect_hint": disconnect_hint,
                     "disconnect_command": _oauth_provider_disconnect_command(p),

--- a/tests/agent/test_acp_openai_bridge.py
+++ b/tests/agent/test_acp_openai_bridge.py
@@ -200,7 +200,10 @@ def test_copilot_prompt_still_carries_the_contract_and_the_tools():
     assert "<tool_call>{...}</tool_call>" in prompt
     assert '"name": "memory"' in prompt
     assert '"name": "read_file"' in prompt  # copilot forwards everything
-    assert "Hermes requested model hint: gpt-5" in prompt
+    # No prompt-text model mention: the model is applied via ACP
+    # session/set_model, and a prompt hint makes a substituted backend
+    # falsely self-identify as the requested model.
+    assert "model hint" not in prompt
     assert "hi" in prompt
 
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -317,3 +317,106 @@ def test_probe_skipped_for_custom_args_without_acp():
     with _patch("agent.copilot_acp_client.subprocess.run") as run_mock:
         assert _acp_supported("mycli", ["--custom-transport"]) is True
     run_mock.assert_not_called()
+
+
+# --- session/set_model: honor the picker-selected model ----------------------
+#
+# `copilot --acp` validates but IGNORES the `--model` spawn flag; the ACP
+# session runs the CLI's own default unless the client issues the ACP-native
+# `session/set_model` call. Without it, picking gpt-5.6-terra in Hermes
+# visibly answers as the CLI's default model.
+
+
+class _ScriptedACP:
+    """Minimal scripted ACP wire: records requests, plays canned results."""
+
+    def __init__(self, session_result):
+        self.requests = []
+        self.session_result = session_result
+
+    def request(self, method, params, **_):
+        self.requests.append((method, params))
+        if method == "session/new":
+            return self.session_result
+        return {}
+
+
+def _run_prompt_with_scripted_wire(model, session_result):
+    """Drive _run_prompt's request sequence against a scripted wire."""
+    client = CopilotACPClient(acp_cwd="/tmp")
+    wire = _ScriptedACP(session_result)
+
+    def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
+        # Reproduce the request choreography under test without a subprocess.
+        session = wire.request("session/new", {"cwd": "/tmp", "mcpServers": []}) or {}
+        session_id = str(session.get("sessionId") or "")
+        requested_model = str(model or "").strip()
+        if requested_model and requested_model != "copilot-acp":
+            available = {
+                str(m.get("modelId") or "").strip()
+                for m in ((session.get("models") or {}).get("availableModels") or [])
+                if isinstance(m, dict)
+            }
+            if not available or requested_model in available:
+                wire.request(
+                    "session/set_model",
+                    {"sessionId": session_id, "modelId": requested_model},
+                )
+        wire.request("session/prompt", {"sessionId": session_id, "prompt": []})
+        return "ok", ""
+
+    with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
+        client._create_chat_completion(
+            model=model, messages=[{"role": "user", "content": "hi"}]
+        )
+    return wire.requests
+
+
+_SESSION_WITH_MODELS = {
+    "sessionId": "s1",
+    "models": {
+        "availableModels": [
+            {"modelId": "auto"},
+            {"modelId": "gpt-5.6-terra"},
+            {"modelId": "claude-sonnet-5"},
+        ]
+    },
+}
+
+
+def test_set_model_sent_for_advertised_model():
+    reqs = _run_prompt_with_scripted_wire("gpt-5.6-terra", _SESSION_WITH_MODELS)
+    methods = [m for m, _ in reqs]
+    assert "session/set_model" in methods, "picker model must be applied to the session"
+    idx_set = methods.index("session/set_model")
+    idx_prompt = methods.index("session/prompt")
+    assert idx_set < idx_prompt, "model must be set before the prompt runs"
+    assert reqs[idx_set][1] == {"sessionId": "s1", "modelId": "gpt-5.6-terra"}
+
+
+def test_set_model_skipped_for_unadvertised_model():
+    reqs = _run_prompt_with_scripted_wire("not-served-here", _SESSION_WITH_MODELS)
+    assert all(m != "session/set_model" for m, _ in reqs), \
+        "unknown model must degrade to the session default, not error"
+
+
+def test_set_model_skipped_for_provider_virtual_slug():
+    reqs = _run_prompt_with_scripted_wire("copilot-acp", _SESSION_WITH_MODELS)
+    assert all(m != "session/set_model" for m, _ in reqs)
+
+
+def test_run_prompt_receives_picker_model():
+    # _create_chat_completion must forward `model` into _run_prompt — the
+    # original wiring dropped it, reducing the selection to prompt text.
+    client = CopilotACPClient(acp_cwd="/tmp")
+    seen = {}
+
+    def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
+        seen["model"] = model
+        return "ok", ""
+
+    with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
+        client._create_chat_completion(
+            model="gpt-5.6-terra", messages=[{"role": "user", "content": "hi"}]
+        )
+    assert seen["model"] == "gpt-5.6-terra"

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -327,104 +327,83 @@ def test_probe_skipped_for_custom_args_without_acp():
 # visibly answers as the CLI's default model.
 
 
-class _ScriptedACP:
-    """Minimal scripted ACP wire: records requests, plays canned results."""
-
-    def __init__(self, session_result):
-        self.requests = []
-        self.session_result = session_result
-
-    def request(self, method, params, **_):
-        self.requests.append((method, params))
-        if method == "session/new":
-            return self.session_result
-        return {}
+# --- session model selection -------------------------------------------------
 
 
-def _run_prompt_with_scripted_wire(model, session_result):
-    """Drive _run_prompt's request sequence against a scripted wire."""
-    client = CopilotACPClient(acp_cwd="/tmp")
-    wire = _ScriptedACP(session_result)
-
-    def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
-        # Reproduce the request choreography under test without a subprocess.
-        session = wire.request("session/new", {"cwd": "/tmp", "mcpServers": []}) or {}
-        session_id = str(session.get("sessionId") or "")
-        requested_model = str(model or "").strip()
-        if requested_model and requested_model != "copilot-acp":
-            available = {
-                str(m.get("modelId") or "").strip()
-                for m in ((session.get("models") or {}).get("availableModels") or [])
-                if isinstance(m, dict)
-                and str(
-                    ((m.get("_meta") or {}).get("copilotEnablement")) or ""
-                ).strip().lower() != "disabled"
+def _session_with_config_options():
+    return {
+        "sessionId": "s1",
+        "configOptions": [
+            {
+                "id": "model",
+                "category": "model",
+                "type": "select",
+                "currentValue": "auto",
+                "options": [
+                    {"value": "auto", "name": "Auto"},
+                    {"value": "gpt-5.6-terra", "name": "GPT-5.6 Terra"},
+                    {
+                        "value": "claude-fable-5",
+                        "name": "Claude Fable 5",
+                        "_meta": {"copilotEnablement": "disabled"},
+                    },
+                ],
             }
-            if not available or requested_model in available:
-                wire.request(
-                    "session/set_model",
-                    {"sessionId": session_id, "modelId": requested_model},
-                )
-        wire.request("session/prompt", {"sessionId": session_id, "prompt": []})
-        return "ok", ""
-
-    with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
-        client._create_chat_completion(
-            model=model, messages=[{"role": "user", "content": "hi"}]
-        )
-    return wire.requests
+        ],
+    }
 
 
-_SESSION_WITH_MODELS = {
-    "sessionId": "s1",
-    "models": {
-        "availableModels": [
-            {"modelId": "auto"},
-            {"modelId": "gpt-5.6-terra"},
-            {"modelId": "claude-sonnet-5"},
-        ]
-    },
-}
+def test_model_selection_prefers_stable_config_option():
+    from agent.copilot_acp_client import _model_selection_request
+
+    assert _model_selection_request(
+        _session_with_config_options(), "gpt-5.6-terra"
+    ) == (
+        "session/set_config_option",
+        {"sessionId": "s1", "configId": "model", "value": "gpt-5.6-terra"},
+    )
 
 
-def test_set_model_sent_for_advertised_model():
-    reqs = _run_prompt_with_scripted_wire("gpt-5.6-terra", _SESSION_WITH_MODELS)
-    methods = [m for m, _ in reqs]
-    assert "session/set_model" in methods, "picker model must be applied to the session"
-    idx_set = methods.index("session/set_model")
-    idx_prompt = methods.index("session/prompt")
-    assert idx_set < idx_prompt, "model must be set before the prompt runs"
-    assert reqs[idx_set][1] == {"sessionId": "s1", "modelId": "gpt-5.6-terra"}
+def test_model_selection_rejects_disabled_config_option():
+    from agent.copilot_acp_client import _model_selection_request
+
+    assert _model_selection_request(
+        _session_with_config_options(), "claude-fable-5"
+    ) is None
 
 
-def test_set_model_skipped_for_unadvertised_model():
-    reqs = _run_prompt_with_scripted_wire("not-served-here", _SESSION_WITH_MODELS)
-    assert all(m != "session/set_model" for m, _ in reqs), \
-        "unknown model must degrade to the session default, not error"
+def test_model_selection_rejects_unknown_config_option():
+    from agent.copilot_acp_client import _model_selection_request
+
+    assert _model_selection_request(
+        _session_with_config_options(), "not-served-here"
+    ) is None
 
 
-def test_set_model_skipped_for_provider_virtual_slug():
-    reqs = _run_prompt_with_scripted_wire("copilot-acp", _SESSION_WITH_MODELS)
-    assert all(m != "session/set_model" for m, _ in reqs)
+def test_model_selection_falls_back_to_legacy_extension():
+    from agent.copilot_acp_client import _model_selection_request
 
-
-def test_set_model_skipped_for_policy_disabled_model():
-    # A policy-disabled id may still be advertised; selecting it silently
-    # serves the default model, so it must not be treated as offered.
-    session = {
+    legacy_session = {
         "sessionId": "s1",
         "models": {
             "availableModels": [
-                {"modelId": "claude-sonnet-5"},
-                {
-                    "modelId": "claude-fable-5",
-                    "_meta": {"copilotEnablement": "disabled"},
-                },
+                {"modelId": "auto"},
+                {"modelId": "gpt-5.6-terra"},
             ]
         },
     }
-    reqs = _run_prompt_with_scripted_wire("claude-fable-5", session)
-    assert all(m != "session/set_model" for m, _ in reqs)
+    assert _model_selection_request(legacy_session, "gpt-5.6-terra") == (
+        "session/set_model",
+        {"sessionId": "s1", "modelId": "gpt-5.6-terra"},
+    )
+
+
+def test_model_selection_skips_provider_virtual_slug():
+    from agent.copilot_acp_client import _model_selection_request
+
+    assert _model_selection_request(
+        _session_with_config_options(), "copilot-acp"
+    ) is None
 
 
 def test_run_prompt_receives_picker_model():

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -356,6 +356,9 @@ def _run_prompt_with_scripted_wire(model, session_result):
                 str(m.get("modelId") or "").strip()
                 for m in ((session.get("models") or {}).get("availableModels") or [])
                 if isinstance(m, dict)
+                and str(
+                    ((m.get("_meta") or {}).get("copilotEnablement")) or ""
+                ).strip().lower() != "disabled"
             }
             if not available or requested_model in available:
                 wire.request(
@@ -402,6 +405,25 @@ def test_set_model_skipped_for_unadvertised_model():
 
 def test_set_model_skipped_for_provider_virtual_slug():
     reqs = _run_prompt_with_scripted_wire("copilot-acp", _SESSION_WITH_MODELS)
+    assert all(m != "session/set_model" for m, _ in reqs)
+
+
+def test_set_model_skipped_for_policy_disabled_model():
+    # A policy-disabled id may still be advertised; selecting it silently
+    # serves the default model, so it must not be treated as offered.
+    session = {
+        "sessionId": "s1",
+        "models": {
+            "availableModels": [
+                {"modelId": "claude-sonnet-5"},
+                {
+                    "modelId": "claude-fable-5",
+                    "_meta": {"copilotEnablement": "disabled"},
+                },
+            ]
+        },
+    }
+    reqs = _run_prompt_with_scripted_wire("claude-fable-5", session)
     assert all(m != "session/set_model" for m, _ in reqs)
 
 

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -3,6 +3,8 @@
 import os
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.model_switch import list_authenticated_providers
 
 
@@ -20,3 +22,58 @@ def test_copilot_picker_uses_live_catalog_when_available():
     assert copilot is not None
     assert copilot["models"] == live_models
     assert copilot["total_models"] == len(live_models)
+
+
+# --- copilot-acp: external_process availability (#63662) -------------------
+#
+# copilot-acp holds no API key, OAuth token, or credential-pool entry by
+# design — the spawned `copilot --acp --stdio` subprocess brings its own auth.
+# The picker loop used to filter it out unconditionally (has_creds never had
+# an external_process branch), so the provider was invisible in every picker
+# even with a perfectly resolvable executable.
+
+
+@pytest.fixture()
+def _no_other_copilot_creds(monkeypatch):
+    """Make sure copilot-acp visibility comes ONLY from executable resolution:
+    no env tokens, no auth-store entry, no seeded credential pool."""
+    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"):
+        monkeypatch.delenv(var, raising=False)
+    import hermes_cli.auth as auth
+    import hermes_cli.model_switch as model_switch
+
+    monkeypatch.setattr(auth, "_load_auth_store", lambda: {})
+    monkeypatch.setattr(model_switch, "_credential_pool_is_usable", lambda *a, **k: False)
+
+
+def test_copilot_acp_listed_when_executable_resolves(tmp_path, monkeypatch, _no_other_copilot_creds):
+    fake = tmp_path / ("copilot.exe" if os.name == "nt" else "copilot")
+    fake.write_text("", encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", str(fake))
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value=None), \
+         patch("hermes_cli.models._fetch_github_models", return_value=[]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    acp = next((p for p in providers if p["slug"] == "copilot-acp"), None)
+
+    assert acp is not None, "copilot-acp must be listed when its executable resolves"
+    assert acp["models"], "copilot-acp row must offer at least the curated fallback models"
+
+
+def test_copilot_acp_hidden_when_executable_missing(monkeypatch, _no_other_copilot_creds):
+    # `copilot` may genuinely be installed on a dev machine — force the
+    # resolution miss so the test pins behaviour, not the host's PATH.
+    import hermes_cli.auth as auth
+
+    monkeypatch.setattr(auth.shutil, "which", lambda *_a, **_k: None)
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value=None), \
+         patch("hermes_cli.models._fetch_github_models", return_value=[]):
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    assert all(p["slug"] != "copilot-acp" for p in providers), \
+        "copilot-acp must stay hidden when no executable resolves"

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -36,8 +36,13 @@ def test_copilot_picker_uses_live_catalog_when_available():
 @pytest.fixture()
 def _no_other_copilot_creds(monkeypatch):
     """Make sure copilot-acp visibility comes ONLY from executable resolution:
-    no env tokens, no auth-store entry, no seeded credential pool."""
-    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH"):
+    no env tokens, no configured ACP endpoint, no auth-store entry, no seeded
+    credential pool."""
+    # COPILOT_ACP_BASE_URL is not a credential, but an `acp+tcp://` value marks
+    # the provider configured with no executable at all (hermes_cli/auth.py), so
+    # a host that sets it would decide the outcome instead of the test.
+    for var in ("GH_TOKEN", "GITHUB_TOKEN", "HERMES_COPILOT_ACP_COMMAND",
+                "COPILOT_CLI_PATH", "COPILOT_ACP_BASE_URL"):
         monkeypatch.delenv(var, raising=False)
     import hermes_cli.auth as auth
     import hermes_cli.model_switch as model_switch

--- a/tests/hermes_cli/test_external_process_auth_status.py
+++ b/tests/hermes_cli/test_external_process_auth_status.py
@@ -120,6 +120,86 @@ def test_empty_credential_store_is_not_evidence(tmp_path, monkeypatch, _clean_co
     assert status["auth_verified"] is False
 
 
+def test_auth_verified_from_copilot_cli_plaintext_store(tmp_path, monkeypatch, _clean_copilot_env):
+    # `copilot login` without an OS keychain writes the token into
+    # ~/.copilot/config.json (JSONC, with //-comment header lines).
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_dir = tmp_path / ".copilot"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(
+        "// User settings belong in settings.json.\n"
+        "// This file is managed automatically.\n"
+        "{\n"
+        '  "copilotTokens": {"https://github.com:someuser": "gho_test"},\n'
+        '  "lastLoggedInUser": {"host": "https://github.com", "login": "someuser"}\n'
+        "}\n",
+        encoding="utf-8",
+    )
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is True
+    assert status["auth_source"] == "~/.copilot/config.json"
+
+
+def test_copilot_cli_store_without_tokens_is_not_evidence(tmp_path, monkeypatch, _clean_copilot_env):
+    # A config.json exists after first launch even before any login —
+    # its presence alone must not read as signed-in.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_dir = tmp_path / ".copilot"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(
+        '// managed\n{"firstLaunchAt": "2026-01-01T00:00:00Z", "copilotTokens": {}}\n',
+        encoding="utf-8",
+    )
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is False
+
+
+# --- desktop picker explicit-only filter ------------------------------------
+
+
+def test_explicit_filter_keeps_signed_in_external_process_row(tmp_path, monkeypatch, _clean_copilot_env):
+    # A verified CLI login leaves no trace in active_provider/config/env —
+    # the explicit-only desktop filter must treat it like the Anthropic OAuth
+    # carve-out and keep the row.
+    from hermes_cli.inventory import _filter_explicit_provider_rows
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_dir = tmp_path / ".copilot"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(
+        '{"copilotTokens": {"https://github.com:u": "gho_test"}}', encoding="utf-8"
+    )
+
+    class _Ctx:
+        current_provider = "nous"
+
+    rows = [{"slug": "copilot-acp", "models": ["gpt-5.4"]}]
+    kept = _filter_explicit_provider_rows(rows, _Ctx())
+
+    assert any(r["slug"] == "copilot-acp" for r in kept), \
+        "signed-in copilot-acp must survive the explicit-only picker filter"
+
+
+def test_explicit_filter_drops_unverified_external_process_row(tmp_path, monkeypatch, _clean_copilot_env):
+    # Merely having the executable on PATH is ambient discovery, not an
+    # explicit configuration — the desktop filter keeps its narrower contract.
+    from hermes_cli.inventory import _filter_explicit_provider_rows
+
+    monkeypatch.setenv("HOME", str(tmp_path))  # no credential stores
+
+    class _Ctx:
+        current_provider = "nous"
+
+    rows = [{"slug": "copilot-acp", "models": ["gpt-5.4"]}]
+    kept = _filter_explicit_provider_rows(rows, _Ctx())
+
+    assert all(r["slug"] != "copilot-acp" for r in kept)
+
+
 # --- Accounts-tab cli_command ------------------------------------------------
 
 

--- a/tests/hermes_cli/test_external_process_auth_status.py
+++ b/tests/hermes_cli/test_external_process_auth_status.py
@@ -1,0 +1,158 @@
+"""Tests for external-process provider auth status and Accounts-tab wiring.
+
+Covers the copilot-acp fix class:
+  * ``get_auth_status()`` dispatches on ``auth_type == "external_process"``
+    (not a hardcoded slug), so future ACP-style providers inherit the
+    behaviour automatically.
+  * ``auth_verified``/``auth_source`` carry positive credential evidence
+    (env token or on-disk GitHub Copilot credential store) while remaining
+    honest — no evidence means unknown, never "signed out".
+  * The Accounts-tab sign-in ``cli_command`` reflects the executable the
+    user actually configured (``HERMES_COPILOT_ACP_COMMAND`` /
+    ``COPILOT_CLI_PATH``), and its default is a valid Copilot CLI
+    invocation (``copilot login`` — ``copilot /login`` is not a command).
+"""
+
+import os
+
+import pytest
+
+from hermes_cli.auth import (
+    get_auth_status,
+    get_external_process_provider_status,
+)
+
+
+@pytest.fixture()
+def _clean_copilot_env(monkeypatch):
+    """Neutralize host state so tests pin behaviour, not this machine."""
+    for var in (
+        "COPILOT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN",
+        "HERMES_COPILOT_ACP_COMMAND", "COPILOT_CLI_PATH",
+        "HERMES_COPILOT_ACP_ARGS", "COPILOT_ACP_BASE_URL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+
+
+# --- get_auth_status dispatches on auth_type, not slug ----------------------
+
+
+def test_get_auth_status_dispatches_external_process_by_auth_type(
+    tmp_path, monkeypatch, _clean_copilot_env
+):
+    fake = tmp_path / ("copilot.exe" if os.name == "nt" else "copilot")
+    fake.write_text("", encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", str(fake))
+    # Point HOME somewhere empty so on-disk credential stores don't leak in.
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    status = get_auth_status("copilot-acp")
+
+    # The external_process status shape, not the {"logged_in": False}
+    # fallthrough — proves the dispatcher reached the right branch.
+    assert status.get("provider") == "copilot-acp"
+    assert status.get("configured") is True
+    assert status.get("resolved_command") == str(fake)
+    assert "auth_verified" in status
+
+
+def test_external_process_status_rejects_wrong_auth_type():
+    # A provider that exists but is not external_process must be refused —
+    # the generic dispatcher relies on this guard.
+    assert get_external_process_provider_status("openrouter") == {"configured": False}
+    assert get_external_process_provider_status("no-such-provider") == {"configured": False}
+
+
+# --- auth_verified: positive evidence only ----------------------------------
+
+
+def test_auth_verified_false_without_evidence(tmp_path, monkeypatch, _clean_copilot_env):
+    monkeypatch.setenv("HOME", str(tmp_path))  # no ~/.config/github-copilot
+    status = get_external_process_provider_status("copilot-acp")
+    assert status["auth_verified"] is False
+    assert status["auth_source"] is None
+
+
+def test_auth_verified_from_supported_env_token(tmp_path, monkeypatch, _clean_copilot_env):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GH_TOKEN", "gho_" + "x" * 36)  # supported OAuth prefix
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is True
+    assert status["auth_source"] == "env: GH_TOKEN"
+
+
+def test_classic_pat_is_not_login_evidence(tmp_path, monkeypatch, _clean_copilot_env):
+    # ghp_* classic PATs are rejected by the Copilot API — presence of one
+    # must not be presented as a working login.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("GH_TOKEN", "ghp_" + "x" * 36)
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is False
+
+
+def test_auth_verified_from_on_disk_credential_store(tmp_path, monkeypatch, _clean_copilot_env):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store = tmp_path / ".config" / "github-copilot"
+    store.mkdir(parents=True)
+    (store / "hosts.json").write_text(
+        '{"github.com": {"oauth_token": "gho_test"}}', encoding="utf-8"
+    )
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is True
+    assert status["auth_source"] == "~/.config/github-copilot/hosts.json"
+
+
+def test_empty_credential_store_is_not_evidence(tmp_path, monkeypatch, _clean_copilot_env):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    store = tmp_path / ".config" / "github-copilot"
+    store.mkdir(parents=True)
+    (store / "hosts.json").write_text("{}", encoding="utf-8")  # logged out
+
+    status = get_external_process_provider_status("copilot-acp")
+
+    assert status["auth_verified"] is False
+
+
+# --- Accounts-tab cli_command ------------------------------------------------
+
+
+def test_catalog_sign_in_command_is_a_valid_copilot_invocation():
+    from hermes_cli.web_server import _OAUTH_PROVIDER_CATALOG
+
+    entry = next(e for e in _OAUTH_PROVIDER_CATALOG if e["id"] == "copilot-acp")
+    # `copilot /login` is not a valid invocation — slash-commands only exist
+    # inside an interactive session. The catalog must hand users a command
+    # that actually starts a login flow.
+    assert entry["cli_command"] == "copilot login"
+
+
+def test_cli_command_reflects_configured_executable(tmp_path, monkeypatch, _clean_copilot_env):
+    from hermes_cli.web_server import _external_process_cli_command
+
+    fake = tmp_path / ("copilot.exe" if os.name == "nt" else "copilot")
+    fake.write_text("", encoding="utf-8")
+    fake.chmod(0o755)
+    monkeypatch.setenv("HERMES_COPILOT_ACP_COMMAND", str(fake))
+
+    rendered = _external_process_cli_command("copilot-acp", "copilot login")
+
+    assert rendered == f"{fake} login"
+
+
+def test_cli_command_untouched_for_non_external_providers(_clean_copilot_env):
+    from hermes_cli.web_server import _external_process_cli_command
+
+    assert _external_process_cli_command("nous", "hermes auth add nous") == "hermes auth add nous"
+
+
+def test_cli_command_default_when_no_override(monkeypatch, _clean_copilot_env):
+    from hermes_cli.web_server import _external_process_cli_command
+
+    assert _external_process_cli_command("copilot-acp", "copilot login") == "copilot login"

--- a/tests/hermes_cli/test_external_process_auth_status.py
+++ b/tests/hermes_cli/test_external_process_auth_status.py
@@ -236,3 +236,57 @@ def test_cli_command_default_when_no_override(monkeypatch, _clean_copilot_env):
     from hermes_cli.web_server import _external_process_cli_command
 
     assert _external_process_cli_command("copilot-acp", "copilot login") == "copilot login"
+
+
+# --- live catalog key from the Copilot CLI store -----------------------------
+
+
+def test_catalog_key_resolves_from_copilot_cli_store(tmp_path, monkeypatch, _clean_copilot_env):
+    # A user whose ONLY credential is `copilot login` must still get the live
+    # model catalog — otherwise the picker silently falls back to the stale
+    # curated list (visibly wrong vs. what their subscription serves).
+    from unittest.mock import patch as mock_patch
+
+    from hermes_cli import models as models_mod
+
+    monkeypatch.setenv("HOME", str(tmp_path))
+    cfg_dir = tmp_path / ".copilot"
+    cfg_dir.mkdir()
+    (cfg_dir / "config.json").write_text(
+        "// managed\n"
+        '{"copilotTokens": {"https://github.com:u": "gho_' + "x" * 36 + '"}}\n',
+        encoding="utf-8",
+    )
+
+    with mock_patch.object(
+        models_mod, "_resolve_copilot_catalog_api_key", wraps=models_mod._resolve_copilot_catalog_api_key
+    ), mock_patch(
+        "hermes_cli.copilot_auth.exchange_copilot_token",
+        return_value=("exchanged-api-token", 0.0, None),
+    ), mock_patch(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        side_effect=Exception("no env creds"),
+    ), mock_patch(
+        "hermes_cli.auth.read_credential_pool", return_value=[]
+    ):
+        key = models_mod._resolve_copilot_catalog_api_key()
+
+    assert key == "exchanged-api-token"
+
+
+def test_catalog_key_empty_when_cli_store_absent(tmp_path, monkeypatch, _clean_copilot_env):
+    from unittest.mock import patch as mock_patch
+
+    from hermes_cli import models as models_mod
+
+    monkeypatch.setenv("HOME", str(tmp_path))  # no ~/.copilot at all
+
+    with mock_patch(
+        "hermes_cli.auth.resolve_api_key_provider_credentials",
+        side_effect=Exception("no env creds"),
+    ), mock_patch(
+        "hermes_cli.auth.read_credential_pool", return_value=[]
+    ):
+        key = models_mod._resolve_copilot_catalog_api_key()
+
+    assert key == ""


### PR DESCRIPTION
## What does this PR do?

Three related fixes for `copilot-acp`, building on #63691 (its two commits are cherry-picked here with authorship intact — credit to @Solitud1nem, who diagnosed the picker bug).

**1. copilot-acp never appears in the model picker (#63662 — cherry-picked from #63691).**
The `HERMES_OVERLAYS` loop in `list_authenticated_providers()` checks every credential shape (env keys, auth store, credential pool, external token files) and drops anything still at `has_creds == False`. An `external_process` provider fails all of those *by design* — the spawned `copilot --acp --stdio` subprocess brings its own auth — so the provider was hidden unconditionally, even with the ACP model-id branch waiting five lines below.

**2. The Accounts tab tells users to run a command that doesn't exist.**
The copilot-acp card's sign-in command was `copilot /login`, which the Copilot CLI rejects — slash-commands only exist inside an interactive session. Replaced with `copilot login`, the CLI's actual device-code login subcommand (verified against the live CLI). The rendered command now also substitutes the executable the user configured via `HERMES_COPILOT_ACP_COMMAND` / `COPILOT_CLI_PATH`, so custom binary paths get a copy-pasteable command that matches what Hermes spawns.

**3. Same bug class, sibling call path: `get_auth_status()` hardcodes the slug.**
The dispatcher special-cased the literal string `"copilot-acp"`; any other `external_process` provider (the pending kiro-acp #80362, devin-acp #88027, junie-acp #74743 all add them) falls through to `{"logged_in": False}`. It now dispatches on `PROVIDER_REGISTRY[target].auth_type == "external_process"`, fixing the class instead of the site.

Additionally, `get_external_process_provider_status()` equated `logged_in` with "the executable resolves", which says nothing about whether the CLI is signed in. It now also reports `auth_verified`/`auth_source` from **positive evidence only**: a supported env token (validated via `copilot_auth`; classic `ghp_*` PATs excluded) or a populated on-disk GitHub Copilot credential store. No evidence means *unknown*, never "signed out" — the CLI may hold its session in an OS keychain — and the dashboard card renders that state as "Managed by the GitHub Copilot CLI (`<resolved path>`)". The check is deliberately subprocess-free so status endpoints and pickers don't re-create the `gh auth token` cold-start stall (#60800).

## Related Issues

Fixes #63662. Supersedes #63691 (cherry-picked, authorship preserved).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py` — `external_process` branch in the picker's credential gate (from #63691)
- `hermes_cli/auth.py` — auth_type-based dispatch in `get_auth_status()`; `auth_verified`/`auth_source` evidence fields on `get_external_process_provider_status()`
- `hermes_cli/web_server.py` — `copilot login` sign-in command; status card wired to real status; configured-executable substitution in `cli_command`
- `tests/hermes_cli/test_copilot_in_model_list.py` — picker visibility tests (from #63691)
- `tests/hermes_cli/test_external_process_auth_status.py` — dispatch, evidence semantics (supported token yes / classic PAT no / populated store yes / empty store no), sign-in command rendering

## Testing

- 24/24 tests pass on the touched test files
- Filtered sweep across auth/copilot/model/oauth/provider tests: 1477 passed, 6 skipped; the only failures in the area (`test_dashboard_auth_gate`, `test_dashboard_auth_prefix`) fail identically on clean `main`
