### PR TITLE
fix(browser): preserve starting sessions during orphan reap

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -58,8 +58,25 @@ class TestReapOrphanedBrowserSessions:
         from tools.browser_tool import _reap_orphaned_browser_sessions
         d = _make_socket_dir(fake_tmpdir, "h_abc1234567")
         assert d.exists()
-        _reap_orphaned_browser_sessions()
+        with patch(
+            "tools.browser_tool._socket_dir_idle_seconds",
+            return_value=10_000,
+        ):
+            _reap_orphaned_browser_sessions()
         assert not d.exists()
+
+    def test_fresh_dir_without_pid_file_survives_creator_race(self, fake_tmpdir):
+        """A concurrent reaper must not delete a session still starting."""
+        from tools.browser_tool import _reap_orphaned_browser_sessions
+
+        d = _make_socket_dir(fake_tmpdir, "h_starting1234")
+        with patch(
+            "tools.browser_tool._socket_dir_idle_seconds",
+            return_value=0.0,
+        ):
+            _reap_orphaned_browser_sessions()
+
+        assert d.exists()
 
 
     def test_alive_legacy_daemon_is_reaped(self, fake_tmpdir):

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2642,7 +2642,14 @@ def _reap_orphaned_browser_sessions():
         # owner_alive is False (dead owner) OR legacy daemon not tracked here.
         pid_file = os.path.join(socket_dir, f"{session_name}.pid")
         if not os.path.isfile(pid_file):
-            # No daemon PID file — just a stale dir, remove it
+            # A newly-created session directory exists briefly before
+            # agent-browser writes its PID/owner files. Another Hermes process
+            # may run this global reaper during that window. Treat a pidless
+            # directory as stale only after the orphan grace period; deleting
+            # it immediately races the creator's first stdout/stderr open.
+            idle_s = _socket_dir_idle_seconds(socket_dir)
+            if idle_s is None or idle_s < BROWSER_ORPHAN_GRACE_SECONDS:
+                continue
             shutil.rmtree(socket_dir, ignore_errors=True)
             continue
 


### PR DESCRIPTION
## Problem

The global browser orphan reaper immediately deletes any `agent-browser-h_*` directory that has not acquired a daemon PID file yet. A concurrently starting Lightpanda→Chrome fallback creates that directory before its first stdout/stderr open, leaving a short window where another Hermes process can remove it and cause `FileNotFoundError`.

This reproduced under parallel pressure: 115 failures in 240 runs of `test_chrome_fallback_injects_required_sandbox_args`; isolated repetitions passed, matching the release-CI flake shape.

## Fix

Treat a PID-less socket directory as stale only after `BROWSER_ORPHAN_GRACE_SECONDS`. Fresh or age-unknown directories fail safe and survive. Old PID-less leftovers are still removed.

## Tests

- Sabotage proof: the new fresh-directory regression test fails against the previous source.
- `67 passed`: `test_browser_lightpanda.py` + `test_browser_orphan_reaper.py`.
- Ruff passed on the changed source and test.
- Local stress with the fix: 160/160 concurrent-path runs passed.

## Risk

Low. Cleanup of genuinely stale PID-less directories is delayed by the existing orphan grace period rather than performed immediately.
