### PR TITLE
fix(honcho): key identity cache by config content

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28,6 +28,7 @@ import asyncio
 import concurrent.futures
 import dataclasses
 import faulthandler
+import hashlib
 import inspect
 import json
 import logging
@@ -28167,7 +28168,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         "honcho.runtime_peer_prefix",
         "honcho.user_peer_aliases",
     )
-    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, int | None], dict[str, Any]] = {}
+    _HONCHO_CACHE_BUSTING_MEMO: dict[tuple[str, bytes | None], dict[str, Any]] = {}
 
     @classmethod
     def _empty_honcho_cache_busting_config(cls) -> dict[str, Any]:
@@ -28175,16 +28176,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     @classmethod
     def _extract_honcho_cache_busting_config(cls) -> dict[str, Any]:
-        """Extract Honcho identity keys, memoized by honcho.json mtime."""
+        """Extract Honcho identity keys, memoized by honcho.json metadata."""
         try:
             from plugins.memory.honcho.client import HonchoClientConfig, resolve_config_path
 
             path = resolve_config_path()
             try:
-                mtime_ns = path.stat().st_mtime_ns
+                content_digest = hashlib.sha256(path.read_bytes()).digest()
             except OSError:
-                mtime_ns = None
-            memo_key = (str(path), mtime_ns)
+                content_digest = None
+            memo_key = (str(path), content_digest)
             cached = cls._HONCHO_CACHE_BUSTING_MEMO.get(memo_key)
             if cached is not None:
                 return dict(cached)


### PR DESCRIPTION
## Problem

`GatewayRunner._HONCHO_CACHE_BUSTING_MEMO` is keyed by `honcho.json` path and `st_mtime_ns`. Two rapid rewrites can retain the same filesystem timestamp, so flipping identity-sensitive values such as `pinPeerName` can return the stale cached signature and fail to rebuild the gateway agent/session manager.

The existing `test_cache_busting_signature_reflects_pin_peer_name` reproduces this deterministically on filesystems where the two writes share an mtime.

## Fix

Key the small in-process memo by SHA-256 digest of the actual `honcho.json` bytes instead of filesystem mtime. The digest is retained only in memory; config content and credentials are not placed in the key or logs.

## Tests

- Sabotage proof: the existing pin transition test fails against the previous source.
- `25 passed`: complete `tests/honcho_plugin/test_pin_peer_name.py`.
- The exact transition regression passed 40/40 repeated runs on the release branch.
- Ruff passed on the changed source and test.

## Risk

Low. Each gateway cache-signature check reads and hashes one small local JSON config file; this happens at agent cache-validation boundaries, not per token or model request.
