### PR TITLE
fix(compression): make the auxiliary-window threshold clamp reversible

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -2463,6 +2463,61 @@ class _CompressionLockLeaseRefresher:
                 break
 
 
+def _restore_configured_compression_threshold(agent: Any) -> bool:
+    """Undo a previous auxiliary-window clamp, re-deriving from config.
+
+    Returns True when a clamp was active and has been lifted. The configured
+    trigger is recomputed through the compressor's own math (per-model
+    override → small-window floor → output reservation → absolute cap) rather
+    than restored from a snapshot, so a ``compression.threshold`` edit made
+    while the clamp was active is honoured on the way back up.
+
+    A no-op unless :func:`check_compression_model_feasibility` previously
+    clamped this compressor, so sessions that never hit a small auxiliary
+    model keep whatever threshold their host set.
+    """
+    compressor = getattr(agent, "context_compressor", None)
+    if compressor is None or not getattr(compressor, "_aux_window_clamped", False):
+        return False
+
+    from agent.context_compressor import ContextCompressor as _CC
+    from agent.context_compressor import resolve_model_threshold
+
+    compressor._aux_window_clamped = False
+    main_ctx = getattr(compressor, "context_length", 0)
+    if not main_ctx or not isinstance(compressor, _CC):
+        # External engines own their own compaction policy (#44439) and may
+        # not expose the built-in derivation; leave their trigger alone.
+        return False
+
+    base_pct = resolve_model_threshold(
+        getattr(agent, "model", "") or "",
+        getattr(compressor, "model_thresholds", None) or {},
+        getattr(compressor, "_config_threshold_percent", compressor.threshold_percent),
+    )
+    compressor.threshold_percent = _CC._effective_threshold_percent(main_ctx, base_pct)
+    compressor.threshold_tokens = _CC._compute_threshold_tokens(
+        main_ctx, compressor.threshold_percent, getattr(compressor, "max_tokens", None),
+    )
+    # The absolute cap (``compression.threshold_tokens``) is a first-class
+    # config value, not a one-time patch — re-apply it exactly as
+    # ``update_model()`` does so restoring can never exceed it.
+    apply_cap = getattr(compressor, "_apply_threshold_tokens_cap", None)
+    if callable(apply_cap):
+        apply_cap()
+    # ``tail_token_budget`` is derived from the trigger, so it moves with it.
+    # Reset to None and let the mode-aware property recompute (lean mode uses
+    # a window-relative budget, not 0.20x the trigger).
+    compressor._tail_token_budget = None
+    _ = compressor.tail_token_budget
+    logger.info(
+        "Auxiliary compression window no longer constrains the trigger — "
+        "restored session threshold to %d tokens.",
+        compressor.threshold_tokens,
+    )
+    return True
+
+
 def check_compression_model_feasibility(agent: Any) -> None:
     """Warn at session start if the auxiliary compression model's context
     window is smaller than the main model's compression threshold.
@@ -2575,6 +2630,16 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 f"detected value if it is wrong."
             )
 
+        # Restore first, then re-clamp. This function runs at agent
+        # construction AND whenever the live compression config is re-adopted
+        # (``auxiliary.compression.*`` is live-editable), so it must be
+        # idempotent in BOTH directions. Clamping alone made it a one-way
+        # ratchet: a session that once had a small auxiliary model stayed
+        # pinned to that lowered trigger for the rest of its life, even after
+        # the operator pointed compression at a full-window model again — it
+        # kept compacting ~1.6x more often than configured with no way back
+        # short of restarting the session.
+        _restore_configured_compression_threshold(agent)
         threshold = agent.context_compressor.threshold_tokens
         if aux_context < threshold:
             # Auto-correct: lower the live session threshold so
@@ -2602,14 +2667,19 @@ def check_compression_model_feasibility(agent: Any) -> None:
                 agent.context_compressor.tail_token_budget = int(
                     new_threshold * summary_target_ratio
                 )
-            # Keep threshold_percent in sync so future main-model
-            # context_length changes (update_model) re-derive from a
-            # sensible number rather than the original too-high value.
+            # Record the clamp so a later re-run can undo it. The configured
+            # trigger is re-derived from ``_config_threshold_percent`` rather
+            # than snapshotted, so a config edit between two runs is honoured.
+            #
+            # NOTE: ``threshold_percent`` is deliberately NOT overwritten with
+            # ``new_threshold / main_ctx``. That ratio bypasses
+            # ``_effective_threshold_percent``'s sub-512K floor (a 128K aux on
+            # a 272K main writes 0.47, below the 0.75 floor), and every
+            # re-derivation path already reads the pristine
+            # ``_config_threshold_percent`` instead. Writing it only made the
+            # clamp unrecoverable.
+            agent.context_compressor._aux_window_clamped = True
             main_ctx = agent.context_compressor.context_length
-            if main_ctx:
-                agent.context_compressor.threshold_percent = (
-                    new_threshold / main_ctx
-                )
             safe_pct = int((aux_context / main_ctx) * 100) if main_ctx else 50
             # The "lower the threshold" suggestion must survive the built-in
             # trigger recomputation (#67422): _effective_threshold_percent()

--- a/tests/agent/test_aux_window_threshold_clamp_symmetry.py
+++ b/tests/agent/test_aux_window_threshold_clamp_symmetry.py
@@ -1,0 +1,198 @@
+"""The auxiliary-window compaction clamp must be reversible, not a ratchet.
+
+``check_compression_model_feasibility`` lowers a session's compaction trigger
+to the auxiliary compression model's context window, so the summariser is
+never handed a region it cannot ingest. That clamp used to be one-way: it ran
+only at agent construction and only ever lowered.
+
+``auxiliary.compression.model`` is live-editable, so the inputs the clamp
+depends on change under a running session. Symptom: a 272K session whose aux
+model was temporarily a 128K one stayed pinned at a 128,000 trigger for the
+rest of its life — compacting ~1.6x more often than configured — even after
+the operator pointed compression back at a full-window model. The reverse is
+worse: raising the trigger from config while a small aux model is still
+configured re-opens the failure the clamp exists to prevent.
+
+These tests assert the relation both ways: the live trigger must always be
+``min(configured_trigger, aux_context)`` for the CURRENT aux model.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from agent.context_compressor import ContextCompressor
+from agent.conversation_compression import (
+    _restore_configured_compression_threshold,
+    check_compression_model_feasibility,
+)
+
+MAIN_CTX = 272_000
+BIG_AUX_CTX = 272_000
+SMALL_AUX_CTX = 128_000
+
+
+class _Agent:
+    """Minimal agent surface used by the feasibility check."""
+
+    def __init__(self, compressor):
+        self.context_compressor = compressor
+        self.compression_enabled = True
+        self.model = "main-model"
+        self.provider = "test-provider"
+        self._compression_warning = None
+        self._custom_providers = {}
+        self.status_callback = None
+        self.emitted: list[str] = []
+
+    def _current_main_runtime(self):
+        return {"model": self.model, "provider": self.provider}
+
+    def _emit_status(self, msg):
+        self.emitted.append(msg)
+
+
+def _compressor(threshold_percent=0.5):
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=MAIN_CTX
+    ):
+        c = ContextCompressor(
+            model="main-model",
+            provider="test-provider",
+            threshold_percent=threshold_percent,
+            quiet_mode=True,
+        )
+        _ = c.context_length
+    return c
+
+
+def _run_check(agent, aux_ctx, aux_model="aux-model"):
+    """Drive the real feasibility check with a stubbed aux route."""
+    with (
+        patch(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            return_value=(object(), aux_model),
+        ),
+        patch(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            return_value=("aux-provider", aux_model, "", "", ""),
+        ),
+        patch(
+            "agent.model_metadata.get_model_context_length", return_value=aux_ctx
+        ),
+    ):
+        check_compression_model_feasibility(agent)
+
+
+@pytest.fixture()
+def configured_threshold():
+    """The trigger a fresh session derives from config, with no clamp."""
+    return _compressor().threshold_tokens
+
+
+class TestClampIsReversible:
+    def test_small_aux_model_lowers_the_trigger(self, configured_threshold):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+        assert compressor.threshold_tokens == SMALL_AUX_CTX
+        assert compressor.threshold_tokens < configured_threshold
+
+    def test_switching_back_to_a_large_aux_model_restores_the_trigger(
+        self, configured_threshold
+    ):
+        """The bug: this used to stay pinned at the small model's window."""
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+        assert compressor.threshold_tokens == SMALL_AUX_CTX
+
+        _run_check(agent, BIG_AUX_CTX)
+        assert compressor.threshold_tokens == configured_threshold
+
+    def test_repeated_checks_are_idempotent(self, configured_threshold):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        for _ in range(3):
+            _run_check(agent, SMALL_AUX_CTX)
+            assert compressor.threshold_tokens == SMALL_AUX_CTX
+        for _ in range(3):
+            _run_check(agent, BIG_AUX_CTX)
+            assert compressor.threshold_tokens == configured_threshold
+
+    def test_trigger_always_fits_the_current_aux_window(self, configured_threshold):
+        """The invariant, stated directly: trigger == min(configured, aux)."""
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        for aux_ctx in (SMALL_AUX_CTX, BIG_AUX_CTX, 200_000, BIG_AUX_CTX, 90_000):
+            _run_check(agent, aux_ctx)
+            assert compressor.threshold_tokens == min(configured_threshold, aux_ctx)
+
+
+class TestClampDoesNotCorruptDerivation:
+    def test_clamp_never_writes_a_sub_floor_threshold_percent(self):
+        """A raw ``clamped/context`` ratio bypasses the small-window floor.
+
+        ``_effective_threshold_percent`` floors sub-512K windows; writing the
+        clamp back as a percentage stored 0.47 on a 272K model, below that
+        floor, so any later re-derivation produced a below-floor trigger.
+        """
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+        floor = ContextCompressor._effective_threshold_percent(MAIN_CTX, 0.5)
+        assert compressor.threshold_percent >= floor
+
+    def test_tail_budget_follows_the_trigger_in_both_directions(self):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        unclamped_tail = compressor.tail_token_budget
+
+        _run_check(agent, SMALL_AUX_CTX)
+        clamped_tail = compressor.tail_token_budget
+        assert clamped_tail <= compressor.threshold_tokens
+
+        _run_check(agent, BIG_AUX_CTX)
+        assert compressor.tail_token_budget == unclamped_tail
+
+    def test_restore_honours_a_config_edit_made_while_clamped(self):
+        """Restoring re-derives from config instead of replaying a snapshot."""
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+
+        # Operator lowers the configured threshold while the clamp is active.
+        compressor._config_threshold_percent = 0.30
+        _run_check(agent, BIG_AUX_CTX)
+
+        expected = ContextCompressor._compute_threshold_tokens(
+            MAIN_CTX,
+            ContextCompressor._effective_threshold_percent(MAIN_CTX, 0.30),
+            compressor.max_tokens,
+        )
+        assert compressor.threshold_tokens == expected
+
+    def test_restore_respects_the_absolute_threshold_cap(self):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+
+        compressor.threshold_tokens_cap = 100_000
+        _run_check(agent, BIG_AUX_CTX)
+        assert compressor.threshold_tokens == 100_000
+
+
+class TestRestoreHelper:
+    def test_no_op_when_no_clamp_was_applied(self):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        before = compressor.threshold_tokens
+        assert _restore_configured_compression_threshold(agent) is False
+        assert compressor.threshold_tokens == before
+
+    def test_reports_that_it_lifted_a_clamp(self):
+        compressor = _compressor()
+        agent = _Agent(compressor)
+        _run_check(agent, SMALL_AUX_CTX)
+        assert _restore_configured_compression_threshold(agent) is True
+        assert _restore_configured_compression_threshold(agent) is False

--- a/tests/tui_gateway/test_aux_compression_route_hot_reload.py
+++ b/tests/tui_gateway/test_aux_compression_route_hot_reload.py
@@ -1,0 +1,180 @@
+"""Switching the auxiliary compression model must reach the live compressor.
+
+The compaction trigger is clamped to the auxiliary compression model's
+context window (``check_compression_model_feasibility``), so
+``auxiliary.compression.model`` is a threshold input. It was absent from the
+live-config signature, which is keyed on ``compression.*`` /
+``model.context_length`` only — so pointing compression at a different model
+mid-session changed nothing until the session was restarted:
+
+  * away from a small model: the trigger stayed clamped to the OLD small
+    window, compacting far more often than configured, forever;
+  * toward a small model: the trigger stayed above the new window, handing
+    the summariser a region it cannot ingest — the failure the clamp exists
+    to prevent.
+
+Only the ROUTE keys belong in the signature. ``timeout`` /
+``reasoning_effort`` / ``extra_body`` are read per call by auxiliary_client
+and must not churn it.
+"""
+
+from types import SimpleNamespace
+
+from agent.context_compressor import ContextCompressor
+from tui_gateway import server
+
+MAIN_CTX = 272_000
+
+
+def _cfg(aux_compression: dict | None = None, **compression):
+    cfg = {
+        "model": {
+            "default": "gpt-5.6-sol",
+            "provider": "openai-codex",
+            "context_length": MAIN_CTX,
+        },
+        "compression": {"threshold": 0.75, **compression},
+    }
+    if aux_compression is not None:
+        cfg["auxiliary"] = {"compression": aux_compression}
+    return cfg
+
+
+def _session():
+    compressor = ContextCompressor(
+        model="gpt-5.6-sol",
+        threshold_percent=0.75,
+        config_context_length=MAIN_CTX,
+        quiet_mode=True,
+    )
+    agent = SimpleNamespace(
+        model="gpt-5.6-sol",
+        provider="openai-codex",
+        context_compressor=compressor,
+        compression_enabled=True,
+        compression_idle_compact_after_seconds=0,
+        codex_responses_native_compaction=False,
+        codex_responses_compact_threshold=200_000,
+    )
+    return {"agent": agent, "session_key": "sid-aux-route"}, compressor
+
+
+class TestSignatureTracksTheAuxRoute:
+    def test_changing_the_aux_model_changes_the_signature(self):
+        before = server._tui_compression_config_signature(
+            _cfg({"provider": "openai-codex", "model": "small-aux"})
+        )
+        after = server._tui_compression_config_signature(
+            _cfg({"provider": "openai-codex", "model": "big-aux"})
+        )
+        assert before != after, (
+            "the aux model decides the clamped trigger; a switch must be adopted"
+        )
+
+    def test_changing_the_aux_provider_or_base_url_changes_the_signature(self):
+        base = _cfg({"provider": "openai-codex", "model": "aux"})
+        assert server._tui_compression_config_signature(base) != (
+            server._tui_compression_config_signature(
+                _cfg({"provider": "openrouter", "model": "aux"})
+            )
+        )
+        assert server._tui_compression_config_signature(base) != (
+            server._tui_compression_config_signature(
+                _cfg({"provider": "openai-codex", "model": "aux",
+                      "base_url": "https://example.invalid/v1"})
+            )
+        )
+
+    def test_per_call_aux_knobs_do_not_churn_the_signature(self):
+        """timeout/reasoning_effort are read per call — they must not re-derive."""
+        before = server._tui_compression_config_signature(
+            _cfg({"provider": "openai-codex", "model": "aux", "timeout": 300})
+        )
+        after = server._tui_compression_config_signature(
+            _cfg({
+                "provider": "openai-codex",
+                "model": "aux",
+                "timeout": 900,
+                "reasoning_effort": "low",
+            })
+        )
+        assert before == after
+
+    def test_absent_auxiliary_section_is_stable(self):
+        assert server._tui_compression_config_signature(_cfg()) == (
+            server._tui_compression_config_signature(_cfg())
+        )
+
+
+class TestLiveAdoptionReClampsToTheCurrentAuxWindow:
+    def _adopt(self, monkeypatch, session, cfg, aux_ctx, aux_model="aux"):
+        monkeypatch.setattr(server, "_load_cfg", lambda: cfg)
+        monkeypatch.setattr(
+            "agent.auxiliary_client.get_text_auxiliary_client",
+            lambda *a, **k: (object(), aux_model),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_task_provider_model",
+            lambda *a, **k: ("openai-codex", aux_model, "", "", ""),
+        )
+        monkeypatch.setattr(
+            "agent.model_metadata.get_model_context_length",
+            lambda *a, **k: aux_ctx,
+        )
+        agent = session["agent"]
+        for attr, value in (
+            ("_compression_warning", None),
+            ("_custom_providers", {}),
+            ("status_callback", None),
+            ("_current_main_runtime", lambda: {}),
+            ("_emit_status", lambda _m: None),
+        ):
+            setattr(agent, attr, value)
+        server._sync_agent_compression_with_config("sid-aux-route", session)
+
+    def test_switching_to_a_small_aux_model_clamps_the_live_trigger(
+        self, monkeypatch
+    ):
+        session, compressor = _session()
+        configured = compressor.threshold_tokens
+        self._adopt(
+            monkeypatch,
+            session,
+            _cfg({"provider": "openai-codex", "model": "small-aux"}),
+            aux_ctx=128_000,
+        )
+        assert compressor.threshold_tokens == 128_000 < configured
+
+    def test_switching_back_to_a_large_aux_model_restores_the_trigger(
+        self, monkeypatch
+    ):
+        session, compressor = _session()
+        configured = compressor.threshold_tokens
+        self._adopt(
+            monkeypatch,
+            session,
+            _cfg({"provider": "openai-codex", "model": "small-aux"}),
+            aux_ctx=128_000,
+        )
+        assert compressor.threshold_tokens == 128_000
+
+        self._adopt(
+            monkeypatch,
+            session,
+            _cfg({"provider": "openai-codex", "model": "big-aux"}),
+            aux_ctx=MAIN_CTX,
+        )
+        assert compressor.threshold_tokens == configured
+
+    def test_adoption_never_raises_the_trigger_past_the_aux_window(
+        self, monkeypatch
+    ):
+        """Raising compression.threshold must not outrun a small aux model."""
+        session, compressor = _session()
+        self._adopt(
+            monkeypatch,
+            session,
+            _cfg({"provider": "openai-codex", "model": "small-aux"}, threshold=0.9),
+            aux_ctx=128_000,
+        )
+        assert compressor.threshold_tokens <= 128_000

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -6707,6 +6707,13 @@ def _tui_compression_config_signature(cfg: dict | None) -> tuple:
     messaging stay on the same key set. Adds ``idle_compact_after_seconds``
     and ``tail_mode``, which affect live TUI sessions but are not in the
     gateway tuple today.
+
+    The auxiliary compression ROUTE is part of this signature even though it
+    lives under ``auxiliary.``: the compaction trigger is clamped to the
+    auxiliary model's context window
+    (``check_compression_model_feasibility``), so switching that model is a
+    threshold change. Adopting it here re-derives the live compressor in
+    place — no agent rebuild, so the prompt-cache prefix survives.
     """
     from gateway.run import GatewayRunner
 
@@ -6719,6 +6726,17 @@ def _tui_compression_config_signature(cfg: dict | None) -> tuple:
     compression = cfg.get("compression") if isinstance(cfg, dict) and isinstance(cfg.get("compression"), dict) else {}
     for extra in ("idle_compact_after_seconds", "tail_mode"):
         picked[f"compression.{extra}"] = compression.get(extra)
+    auxiliary = cfg.get("auxiliary") if isinstance(cfg, dict) else None
+    aux_compression = (
+        auxiliary.get("compression") if isinstance(auxiliary, dict) else None
+    )
+    if not isinstance(aux_compression, dict):
+        aux_compression = {}
+    # Only the route keys: these decide which window the trigger is clamped
+    # to. timeout / reasoning_effort / extra_body are read per call by
+    # auxiliary_client and must NOT churn the signature.
+    for route_key in ("provider", "model", "base_url"):
+        picked[f"auxiliary.compression.{route_key}"] = aux_compression.get(route_key)
     return tuple(sorted(picked.items()))
 
 
@@ -7001,9 +7019,34 @@ def _apply_live_compression_config(agent: Any, cfg: dict | None) -> None:
         if cap and current:
             cc.threshold_tokens = min(int(current), int(cap))
 
+    # The trigger just re-derived above is the CONFIGURED one. Re-run the
+    # auxiliary-window feasibility check so it is re-clamped when the current
+    # compression model still cannot ingest that much, and left alone when it
+    # can. Without this the adoption above could raise the trigger above a
+    # small aux model's window — reintroducing the very failure the clamp
+    # exists to prevent — and a stale clamp could never be lifted.
+    try:
+        from agent.conversation_compression import (
+            check_compression_model_feasibility,
+        )
+
+        check_compression_model_feasibility(agent)
+    except ValueError:
+        # A hard rejection (aux below the minimum context) is fatal at session
+        # START, but this is a live config edit on a running session: keep the
+        # session alive with the trigger we just derived and let the next
+        # compaction surface the failure.
+        logger.warning(
+            "Live compression config adopted, but the auxiliary compression "
+            "model is below the minimum context window."
+        )
+    except Exception as exc:
+        logger.debug("Auxiliary feasibility re-check skipped: %s", exc)
+
 
 def _sync_agent_compression_with_config(sid: str, session: dict) -> None:
-    """Adopt compression.* / model.context_length edits at turn start.
+    """Adopt compression.* / auxiliary.compression.* / model.context_length
+    edits at turn start.
 
     Messaging gateways already rebuild a cached agent when these keys change.
     Desktop/TUI only synced the model; the live compressor kept the threshold


### PR DESCRIPTION
## Symptom

A session compacts ~1.6x more often than configured, permanently, with no way back short of restarting it.

```
17:02  Auxiliary compression model <small-aux> has 128000 token context, below the
       main model's compression threshold of 231200 tokens — auto-lowered session
       threshold to 128000 to keep compression working.

       ... operator points auxiliary.compression.model back at a 272K model ...

22:22  Pre-API compression: ~135,812 request tokens >= 128,000 threshold (context=272,000)
```

The aux model had already been switched back to a full-window model — the aux call in that
very compaction ran on it. The trigger stayed at `128,000` anyway, for the rest of the
session's life. Configured value was `204,000`.

## Root cause

`check_compression_model_feasibility()` clamps the compaction trigger to the auxiliary
compression model's context window, so the summariser is never handed a region it cannot
ingest. Correct behaviour — but the clamp is a **one-way ratchet**:

- it runs **only at agent construction**, and
- it **only ever lowers**.

Meanwhile `auxiliary.compression.model` is live-editable, and
`_tui_compression_config_signature` keys live adoption on `compression.*` /
`model.context_length` only. So the single input the clamp depends on can change with
nothing re-evaluating it.

Both directions are broken, and the second is the dangerous one:

| aux model change | what should happen | what happened |
|---|---|---|
| small → large | trigger restored to configured | stays clamped low, forever |
| large → small | trigger clamped down | stays high — summariser gets a region it cannot ingest, i.e. the exact failure the clamp exists to prevent |

There is a second, quieter defect in the same block. The clamp wrote:

```python
agent.context_compressor.threshold_percent = new_threshold / main_ctx
```

`128000 / 272000 = 0.47`, which is **below** `_effective_threshold_percent`'s 0.75 floor for
sub-512K windows. That floor is applied at construction and in `update_model()`, and every
re-derivation path already reads the pristine `_config_threshold_percent` — so the write
bought nothing and only made the clamp unrecoverable. Its comment ("so future
`update_model()` re-derives from a sensible number") is stale: `update_model()` reads
`_config_threshold_percent`, not this attribute.

## Fix

**1. The clamp becomes idempotent and symmetric.** It restores the configured trigger before
re-evaluating, so the live value is always `min(configured_trigger, aux_context)` for the
*current* auxiliary model.

Restoration re-derives through the compressor's own math — per-model override →
small-window floor → output reservation → absolute cap — rather than replaying a snapshot,
so a `compression.threshold` edit made *while the clamp was active* is honoured on the way
back up. `tail_token_budget` moves with the trigger in both directions, through the
mode-aware property (lean mode uses a window-relative budget, not `0.20 x trigger`).

The floor-bypassing `threshold_percent` write is dropped.

**2. The auxiliary compression ROUTE joins the TUI live-config signature**, and adoption
re-runs the feasibility check after re-deriving the trigger.

Only `provider` / `model` / `base_url` are included — `timeout`, `reasoning_effort` and
`extra_body` are read per call by `auxiliary_client` and must not churn the signature.
Adoption mutates the live compressor **in place**, so no agent is rebuilt and the
prompt-cache prefix survives.

## Tests

Two files, 17 tests, asserting the *relation* rather than pinned numbers.

`tests/agent/test_aux_window_threshold_clamp_symmetry.py` (10)
- trigger `== min(configured, aux_context)` across a sequence of aux windows
  (`128K → 272K → 200K → 272K → 90K`)
- switching back to a large aux model restores the configured trigger
- repeated checks are idempotent in both directions
- `threshold_percent` never lands below `_effective_threshold_percent`'s floor
- `tail_token_budget` follows the trigger both ways
- restoration honours a `compression.threshold` edit made while clamped
- restoration respects the absolute `compression.threshold_tokens` cap

`tests/tui_gateway/test_aux_compression_route_hot_reload.py` (7)
- aux `model` / `provider` / `base_url` change the signature; `timeout` /
  `reasoning_effort` do not
- live adoption clamps when switching to a small aux model, restores when switching back
- adopting a *raised* `compression.threshold` never pushes the trigger past a small aux
  model's window

Reverting each half independently makes the tests fail with the incident's own numbers:

```
# half 1 reverted (restoration disabled)
7 failed — assert 128000 == 204000

# half 2 reverted (signature + re-clamp removed)
5 failed — aux route change invisible to the live compressor
```

```
scripts/run_tests.sh tests/agent/test_*compress*.py tests/tui_gateway/
  → 156 files, 1510 passed, 1 failed
scripts/run_tests.sh tests/agent/
  → 468 files, 6006 passed, 8 failed
```

All 9 failures are pre-existing on clean `origin/main` in this environment (Anthropic wire /
vision routing / custom-provider client-shape, and `test_hud_surface_note`) — verified by
stashing the patch and re-running them unchanged.

## Known remaining gap

`GatewayRunner._extract_cache_busting_config` (messaging gateways) also omits
`auxiliary.compression.*`, so an aux-route-only edit does not rebuild a cached messaging
agent. Adding it there would rebuild the agent — a prompt-cache break — which is a
maintainer tradeoff rather than an obvious win, so this PR leaves it alone. Half 1 already
makes every rebuild path land on the correct trigger; only the "no rebuild happens at all"
case remains.
