### PR TITLE
fix(gateway): add fmsg to display-config platform tiers

### DIFF
--- a/gateway/display_config.py
+++ b/gateway/display_config.py
@@ -174,6 +174,14 @@ _PLATFORM_DEFAULTS: dict[str, dict[str, Any]] = {
     "photon":          _TIER_LOW,
     "bluebubbles":     _TIER_LOW,
     "weixin":          _TIER_LOW,
+    # fmsg (federated messaging plugin, hermes-fmsg): the fmsg-webapi REST
+    # surface has no edit-message route, so every progress heartbeat
+    # ("⏳ Working — N min", tool-progress bubbles, busy-ack iteration
+    # detail) posts as a new, permanent fmsg message instead of editing one
+    # bubble in place. Without this entry fmsg inherited the noisy global
+    # ("all"/True) defaults and flooded threads with status noise on any
+    # multi-turn/long-running request (markmnl/hermes-fmsg).
+    "fmsg":            _TIER_LOW,
     # WeCom is technically non-editable but exposes a native streaming
     # transport (msgtype: "stream" via aibot_respond_msg) that the gateway
     # consumer routes mid-stream content through. Enable streaming by default

--- a/tests/gateway/test_display_config.py
+++ b/tests/gateway/test_display_config.py
@@ -136,8 +136,18 @@ class TestPlatformDefaults:
         """Signal, BlueBubbles, etc. default to 'off' tool progress."""
         from gateway.display_config import resolve_display_setting
 
-        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud"):
+        for plat in ("signal", "bluebubbles", "weixin", "wecom", "dingtalk", "whatsapp_cloud", "fmsg"):
             assert resolve_display_setting({}, plat, "tool_progress") == "off", plat
+
+    def test_fmsg_defaults_quiet_no_edit_support(self):
+        """fmsg has no message-edit API — every heartbeat/status/tool-progress
+        update would otherwise post as a permanent, separate fmsg message."""
+        from gateway.display_config import resolve_display_setting
+
+        assert resolve_display_setting({}, "fmsg", "tool_progress") == "off"
+        assert resolve_display_setting({}, "fmsg", "busy_ack_detail") is False
+        assert resolve_display_setting({}, "fmsg", "long_running_notifications") is False
+        assert resolve_display_setting({}, "fmsg", "interim_assistant_messages") is False
 
 
     def test_telegram_mobile_chatter_defaults(self):


### PR DESCRIPTION
## Problem

The `fmsg` platform (federated messaging, [hermes-fmsg](https://github.com/markmnl/hermes-fmsg) plugin) has no `_PLATFORM_DEFAULTS` entry in `gateway/display_config.py`. fmsg-webapi's REST surface has no message-edit route, so without a built-in tier fmsg silently inherits the noisiest `_GLOBAL_DEFAULTS` (`busy_ack_detail=True`, `tool_progress="all"`, `long_running_notifications=True`).

The practical effect: every progress heartbeat (`⏳ Working — N min — iteration X/150…`, tool-progress bubbles, busy-ack iteration detail) posts as a brand-new, permanent fmsg message instead of editing one bubble in place — flooding threads on any multi-turn or long-running request.

## Fix

Add `"fmsg": _TIER_LOW` to `_PLATFORM_DEFAULTS`, alongside Signal / BlueBubbles / Photon / weixin, which share the same "no message-edit support, permanent messages" characteristic.

## Testing

- Added `test_fmsg_defaults_quiet_no_edit_support` and included `fmsg` in the existing `test_low_tier_platforms` parametrized check.
- `pytest tests/gateway/test_display_config.py` — 24 passed.

## Related

A matching plugin-side mitigation (seeding `display.platforms.fmsg` into `config.yaml` on install, for users on older hermes-agent versions without this tier) has landed in hermes-fmsg v0.2.3: markmnl/hermes-fmsg@562f45a