### PR TITLE
fix(security): allow coordinated persona naming rules

### DIFF
--- a/tests/tools/test_threat_patterns.py
+++ b/tests/tools/test_threat_patterns.py
@@ -140,6 +140,13 @@ class TestFalsePositives:
         findings = scan_for_threats(text, scope="context")
         assert findings == []
 
+    def test_identity_naming_rule_does_not_trip(self):
+        text = (
+            "Signing rule stands: name yourself and your recipient "
+            "in every message."
+        )
+        assert scan_for_threats(text, scope="context") == []
+
     def test_security_research_text_passes_at_all_scope(self):
         # A security-research paragraph mentioning C2 vocabulary should
         # NOT trigger the narrow "all" scope.  The context/strict

--- a/tools/threat_patterns.py
+++ b/tools/threat_patterns.py
@@ -79,9 +79,10 @@ _PATTERNS: List[Tuple[str, str, str]] = [
     (rf'(respond|answer|reply)\s+without\s+{_FILLER}(restrictions|limitations|filters|safety)', "remove_filters", "context"),
     (rf'you\s+have\s+been\s+{_FILLER}(updated|upgraded|patched)\s+to', "fake_update", "context"),
     # "name yourself X" is a Brainworm-specific tell — identity override
-    # via spec instead of jailbreak.  Anchored on the verb pair so it
-    # doesn't match "name your variables" etc.
-    (r'\bname\s+yourself\s+\w+', "identity_override", "context"),
+    # via spec instead of jailbreak. Coordinated naming rules such as "name
+    # yourself and your recipient" describe message metadata, not a new
+    # identity, so require the following word to be the proposed name.
+    (r'\bname\s+yourself\s+(?!and\b)\w+', "identity_override", "context"),
 
     # ── C2 / Brainworm-style promptware (context scope) ──────────────
     # These anchor on C2-specific vocabulary.  "register as a node" appears


### PR DESCRIPTION
## What does this PR do?

Stops the `identity_override` threat rule from classifying coordinated naming instructions such as "name yourself and your recipient" as an identity reassignment. Direct identity assignments such as "name yourself BRAINWORM" remain blocked.

### Symptom

A benign signing rule in `SOUL.md` matched `identity_override`, causing the prompt builder to replace the complete persona file with a blocked placeholder.

### Root Cause

The pattern `name\s+yourself\s+\w+` treated every word after "name yourself" as a proposed identity. In coordinated prose, the conjunction `and` occupied that position, but the scanner had no grammar guard to distinguish it from an assigned name.

### Fix

Exclude the `name yourself and ...` coordination form while preserving the existing direct identity-assignment match. Add the reported sentence as a false-positive regression alongside the existing Brainworm true-positive coverage.

Visible scanner notices and trusted recovery policy are already covered by #94917, so this change does not duplicate that broader prompt-builder work.

## Related Issue

Closes #100328

## Type of Change

- [x] Bug fix
- [x] Security fix
- [x] Tests

## How to Test

- `scripts/run_tests.sh tests/tools/test_threat_patterns.py -q`
- `scripts/run_tests.sh tests/agent/test_prompt_builder.py -q`
- `scripts/run_tests.sh tests/tools/test_memory_tool.py -q`
- Import `_scan_context_content` and verify the reported `SOUL.md` sentence is returned unchanged.

## Verification

- Threat-pattern suite: 29 passed.
- Prompt-builder suite: 68 passed, 1 skipped.
- Memory-tool suite: 41 passed.
- The reported `SOUL.md` sentence is preserved through `_scan_context_content`.
