### PR TITLE
fix(agent): keep stored prompt prefix across a mid-session /model switch

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1079,6 +1079,37 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
         return
     if stored_prompt:
         stored_state = "stale_runtime"
+        patched = _patch_runtime_identity_lines(stored_prompt, agent)
+        if patched != stored_prompt and _stored_prompt_matches_runtime(agent, patched):
+            logger.info(
+                "Stored system prompt for session %s has stale runtime "
+                "identity; patched Model/Provider/Platform trailer in "
+                "place for model=%s provider=%s (stable prefix kept).",
+                agent.session_id,
+                getattr(agent, "model", "") or "",
+                getattr(agent, "provider", "") or "",
+            )
+            agent._cached_system_prompt = patched
+            from agent.system_prompt import (
+                reconstruct_static_prefix,
+                restore_plugin_prompt_sections,
+            )
+
+            restore_plugin_prompt_sections(agent, patched)
+            reconstruct_static_prefix(agent, system_message=system_message)
+            if agent._session_db:
+                try:
+                    agent._session_db.update_system_prompt(
+                        agent.session_id, patched
+                    )
+                except Exception as exc:
+                    logger.warning(
+                        "Session DB update_system_prompt failed after "
+                        "runtime-identity patch (session=%s): %s. The "
+                        "patch will re-apply next turn.",
+                        agent.session_id, exc,
+                    )
+            return
         logger.info(
             "Stored system prompt for session %s has stale runtime identity; "
             "rebuilding for model=%s provider=%s.",
@@ -1107,29 +1138,33 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
     # Plugin hook: on_session_start — fired once when a brand-new
     # session is created (not on continuation).  Plugins can use this
     # to initialise session-scoped state (e.g. warm a memory cache).
-    try:
-        from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-        _invoke_hook(
-            "on_session_start",
-            session_id=agent.session_id,
-            model=agent.model,
-            platform=getattr(agent, "platform", None) or "",
-        )
-    except Exception as exc:
-        logger.warning("on_session_start hook failed: %s", exc)
+    # A /model switch used to NULL the snapshot and fall through here,
+    # re-firing the hook on a live conversation (#100336). Keep it
+    # gated to rows that never had a usable prompt.
+    if stored_state in ("missing", "null", "empty"):
+        try:
+            from hermes_cli.lifecycle import invoke_hook as _invoke_hook
+            _invoke_hook(
+                "on_session_start",
+                session_id=agent.session_id,
+                model=agent.model,
+                platform=getattr(agent, "platform", None) or "",
+            )
+        except Exception as exc:
+            logger.warning("on_session_start hook failed: %s", exc)
 
-    # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
-    # desktop build seeds at session OPEN (see seed_credits_at_session_start in
-    # tui_gateway), so this call is usually a no-op there (idempotent: skips when
-    # _credits_state already exists). For the plain CLI / any path that didn't seed
-    # at build, it primes credits state from /api/oauth/account (or a fixture) on the
-    # first turn so depletion / usage-band warnings fire. Fail-open inside the helper.
-    try:
-        from agent.credits_tracker import seed_credits_at_session_start
+        # Cold-start credits seed (L3) — fallback for the first-turn path. The TUI/
+        # desktop build seeds at session OPEN (see seed_credits_at_session_start in
+        # tui_gateway), so this call is usually a no-op there (idempotent: skips when
+        # _credits_state already exists). For the plain CLI / any path that didn't seed
+        # at build, it primes credits state from /api/oauth/account (or a fixture) on the
+        # first turn so depletion / usage-band warnings fire. Fail-open inside the helper.
+        try:
+            from agent.credits_tracker import seed_credits_at_session_start
 
-        seed_credits_at_session_start(agent)
-    except Exception:
-        logger.debug("cold-start credits seed failed (fail-open)", exc_info=True)
+            seed_credits_at_session_start(agent)
+        except Exception:
+            logger.debug("cold-start credits seed failed (fail-open)", exc_info=True)
 
     # Persist the system prompt snapshot in SQLite.  Failure here used
     # to log at DEBUG, which silently broke prefix-cache reuse on the
@@ -1145,6 +1180,56 @@ def _restore_or_build_system_prompt(agent, system_message, conversation_history)
                 "miss the prefix cache.",
                 agent.session_id, exc,
             )
+
+
+def _patch_runtime_identity_lines(prompt: str, agent) -> str:
+    """Rewrite the volatile Model/Provider/Platform trailer in place.
+
+    These fields are emitted at the end of the system prompt. Replacing
+    only their last occurrences keeps the stable+context prefix
+    byte-identical across a mid-session /model switch so implicit
+    longest-prefix caches can still hit everything in front of the
+    trailer. Last-match is the same rule ``_stored_prompt_matches_runtime``
+    uses, so project-context lines earlier in the prompt are not edited.
+    """
+
+    model = str(getattr(agent, "model", "") or "").strip()
+    provider = str(getattr(agent, "provider", "") or "").strip()
+    platform = str(getattr(agent, "platform", "") or "").strip()
+    replacements = (
+        ("Model", model),
+        ("Provider", provider),
+        ("Platform", platform),
+    )
+    if not any(value for _label, value in replacements):
+        return prompt
+
+    lines = prompt.splitlines(keepends=True)
+    if not lines:
+        return prompt
+
+    def replace_last(label: str, value: str) -> bool:
+        prefix = f"{label}:"
+        idx = None
+        for i, line in enumerate(lines):
+            raw = line[:-1] if line.endswith("\n") else line
+            if raw.startswith(prefix):
+                idx = i
+        if idx is None:
+            return False
+        newline = "\n" if lines[idx].endswith("\n") else ""
+        lines[idx] = f"{prefix} {value}{newline}"
+        return True
+
+    for label, value in replacements:
+        if not value:
+            continue
+        if replace_last(label, value):
+            continue
+        if not lines[-1].endswith("\n"):
+            lines[-1] += "\n"
+        lines.append(f"{label}: {value}\n")
+    return "".join(lines)
 
 
 def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -9004,10 +9004,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Unlike ``update_token_counts`` which uses ``COALESCE(model, ?)``
         (only filling in NULL), this unconditionally sets the model column
         so that the dashboard reflects the user's latest /model choice.
-        Also nulls ``system_prompt`` so stale ``Model:`` / ``Provider:``
-        footer metadata is rebuilt on the next turn. A successful /model
-        switch explicitly replaces any confirmed Browser runtime lock while
-        preserving unrelated lineage markers in ``model_config``.
+        The persisted system-prompt snapshot is kept: the next turn patches
+        only the volatile ``Model:`` / ``Provider:`` trailer (#100336)
+        instead of discarding the prefix and rebuilding from scratch.
+        A successful /model switch explicitly replaces any confirmed
+        Browser runtime lock while preserving unrelated lineage markers
+        in ``model_config``.
 
         When *provider* is given, it is merged into ``model_config``
         alongside the model (``$.model`` / ``$.provider``) so a later
@@ -9039,12 +9041,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return
             conn.execute(
                 "UPDATE sessions SET "
-                "model = ?, model_config = ?, "
-                "system_prompt = NULL, system_prompt_hash = NULL "
+                "model = ?, model_config = ? "
                 "WHERE id = ?",
                 (model, merged, session_id),
             )
-            self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
     def _merge_model_config_json(
@@ -9293,9 +9293,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         (only filling in NULL), this unconditionally sets the billing fields so
         that the dashboard reflects the user's latest /model switch.
 
-        Also nulls ``system_prompt`` so the cached snapshot (which embeds a
-        stale ``Model:`` / ``Provider:`` header) is rebuilt — matching the
-        behavior of ``update_session_model`` (see #48173, #48248).
+        The persisted system-prompt snapshot is kept so the next turn can
+        patch the volatile identity trailer instead of rebuilding the
+        whole prefix (#100336; identity correctness is still #48173).
         """
         # Barrier against queued token deltas — see update_session_model.
         self.flush_token_counts()
@@ -9305,13 +9305,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 """UPDATE sessions SET
                    billing_provider = ?,
                    billing_base_url = ?,
-                   billing_mode = COALESCE(?, billing_mode),
-                   system_prompt = NULL,
-                   system_prompt_hash = NULL
+                   billing_mode = COALESCE(?, billing_mode)
                    WHERE id = ?""",
                 (provider, base_url, billing_mode, session_id),
             )
-            self._delete_unreferenced_system_prompts(conn)
         self._execute_write(_do)
 
     # ── Async token accounting ──

--- a/tests/agent/test_system_prompt_restore.py
+++ b/tests/agent/test_system_prompt_restore.py
@@ -72,46 +72,74 @@ class TestStoredPromptReuse:
         _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
         assert agent._cached_system_prompt == stored
 
-    def test_present_row_with_stale_runtime_identity_rebuilds(self, caplog):
-        """Stored prompts are cache gold unless their runtime identity is stale.
+    def test_present_row_with_stale_runtime_identity_patches_trailer(self, caplog):
+        """A live /model switch updates the agent and DB model immediately.
 
-        A live /model switch updates the agent and DB model_config immediately.
-        If the old system_prompt snapshot still says the previous model,
-        blindly restoring it makes the next turn call the new model while the
-        model reads old `Model:` metadata ("what model are you?" lies).
+        The stored snapshot still carries the previous Model:/Provider:
+        trailer. Patch those last lines in place so identity is correct
+        without rebuilding the stable prefix (#100336).
         """
         stored = (
             "You are Hermes Agent.\n\n"
             "Conversation started: Tuesday, June 16, 2026\n"
             "Session ID: test-session-id\n"
             "Model: anthropic/claude-opus-4.8-fast\n"
-            "Provider: openrouter"
+            "Provider: openrouter\n"
+            "Platform: cli\n"
         )
         db = MagicMock()
         db.get_session.return_value = {"system_prompt": stored}
         agent = _make_agent(
             session_db=db,
-            prebuilt_prompt=(
-                "You are Hermes Agent.\n\n"
-                "Conversation started: Tuesday, June 16, 2026\n"
-                "Session ID: test-session-id\n"
-                "Model: openai/gpt-5.5\n"
-                "Provider: openrouter"
-            ),
+            prebuilt_prompt="MUST_NOT_REBUILD",
         )
         agent.model = "openai/gpt-5.5"
 
         with caplog.at_level(logging.INFO, logger="agent.conversation_loop"):
             _restore_or_build_system_prompt(agent, None, [{"role": "user", "content": "hi"}])
 
-        assert agent._cached_system_prompt.endswith(
-            "Model: openai/gpt-5.5\nProvider: openrouter"
+        assert agent._cached_system_prompt.startswith(
+            "You are Hermes Agent.\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Session ID: test-session-id\n"
         )
-        agent._build_system_prompt.assert_called_once_with(None)
+        assert "Model: openai/gpt-5.5\n" in agent._cached_system_prompt
+        assert "Model: anthropic/claude-opus-4.8-fast" not in agent._cached_system_prompt
+        assert "Provider: openrouter" in agent._cached_system_prompt
+        agent._build_system_prompt.assert_not_called()
         db.update_system_prompt.assert_called_once_with(
             agent.session_id, agent._cached_system_prompt
         )
-        assert any("stale runtime identity" in r.getMessage() for r in caplog.records)
+        assert any("stable prefix kept" in r.getMessage() for r in caplog.records)
+
+    def test_stale_cwd_still_rebuilds(self, monkeypatch):
+        """Cwd lives in the stable host-info block; a real path change
+        cannot be patched in the trailer and still requires a rebuild."""
+        stored = (
+            "You are Hermes Agent.\n"
+            "User home directory: /home/user\n"
+            "Current working directory: /old/workspace\n"
+            "Model: test-model\n"
+            "Provider: openrouter\n"
+            "Platform: cli\n"
+        )
+        db = MagicMock()
+        db.get_session.return_value = {"system_prompt": stored}
+        agent = _make_agent(session_db=db, prebuilt_prompt="REBUILT_FOR_CWD")
+        monkeypatch.setattr(
+            "agent.conversation_loop.resolve_agent_cwd",
+            lambda: "/new/workspace",
+        )
+
+        _restore_or_build_system_prompt(
+            agent, None, [{"role": "user", "content": "hi"}]
+        )
+
+        agent._build_system_prompt.assert_called_once_with(None)
+        assert agent._cached_system_prompt == "REBUILT_FOR_CWD"
+        db.update_system_prompt.assert_called_once_with(
+            agent.session_id, "REBUILT_FOR_CWD"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -445,6 +473,65 @@ class TestPerResponseSessionWritePath:
             assert second._cached_system_prompt == "GROUP_PROMPT"
             second._build_system_prompt.assert_not_called()
             assert "is null" not in caplog.text
+
+
+class TestModelSwitchKeepsPromptPrefix:
+    """#100336: /model must not throw away the persisted snapshot.
+
+    Nulling ``system_prompt_hash`` forced the next turn down the first-session
+    rebuild path, which re-evaluated skills/tools/guidance at the FRONT of
+    the prompt and collapsed implicit prefix-cache hits to ~2% on a long
+    history. Identity still has to update (#48173); do that by patching the
+    volatile trailer.
+    """
+
+    def test_update_session_model_keeps_stored_snapshot(self, tmp_path):
+        from hermes_state import SessionDB
+
+        stored = (
+            "You are Hermes Agent.\n\n"
+            "Conversation started: Tuesday, June 16, 2026\n"
+            "Session ID: sid-switch\n"
+            "Model: gx10\n"
+            "Provider: local\n"
+            "Platform: telegram\n"
+        )
+        with SessionDB(db_path=tmp_path / "state.db") as db:
+            db.create_session("sid-switch", source="telegram", model="gx10")
+            db.update_system_prompt("sid-switch", stored)
+            db.append_message("sid-switch", "user", "hi")
+            db.update_session_model("sid-switch", "zhipu", provider="zhipu")
+            db.update_session_billing_route(
+                "sid-switch",
+                provider="zhipu",
+                base_url="https://zhipu.example/v1",
+            )
+
+            row = db.get_session("sid-switch")
+            assert row["system_prompt"] == stored
+            assert row["model"] == "zhipu"
+
+            agent = _make_agent(session_db=db, prebuilt_prompt="MUST_NOT_BUILD")
+            agent.session_id = "sid-switch"
+            agent.model = "zhipu"
+            agent.provider = "zhipu"
+            agent.platform = "telegram"
+
+            _restore_or_build_system_prompt(
+                agent, None, [{"role": "user", "content": "hi"}]
+            )
+
+            agent._build_system_prompt.assert_not_called()
+            restored = agent._cached_system_prompt
+            assert restored.startswith(
+                "You are Hermes Agent.\n\n"
+                "Conversation started: Tuesday, June 16, 2026\n"
+                "Session ID: sid-switch\n"
+            )
+            assert "Model: zhipu\n" in restored
+            assert "Provider: zhipu\n" in restored
+            assert "Model: gx10" not in restored
+            assert db.get_session("sid-switch")["system_prompt"] == restored
 
 
 if __name__ == "__main__":

--- a/tests/test_session_system_prompt_dedup.py
+++ b/tests/test_session_system_prompt_dedup.py
@@ -86,8 +86,11 @@ def test_prompt_replacement_and_route_changes_collect_only_orphans(db):
         provider="openrouter",
         base_url="https://example.test/v1",
     )
-    assert db.get_session("s2")["system_prompt"] is None
-    assert _prompt_count(db) == 0
+    # Billing-route updates used to NULL the snapshot (forcing a full
+    # prefix rebuild on the next turn). They now keep it so identity can
+    # be patched in the volatile trailer instead (#100336).
+    assert db.get_session("s2")["system_prompt"] == shared_prompt
+    assert _prompt_count(db) == 1
 
     db.update_system_prompt("s2", "replacement")
     assert db.get_session("s2")["system_prompt"] == "replacement"


### PR DESCRIPTION
## Summary
- A mid-session `/model` switch nulled `sessions.system_prompt_hash`, so the next turn treated a live conversation as a first session: full `_build_system_prompt`, `on_session_start`, and a brand-new prefix. On implicit longest-prefix backends that is the measured 2% cache hit in [#100336](https://github.com/NousResearch/hermes-agent/issues/100336) (~136k tokens re-prefilled). Cross-model KV cache still cannot transfer; the bug is throwing away a still-valid stable prefix and rebuilding it from scratch.
- `update_session_model` / `update_session_billing_route` now keep the snapshot. Restore patches only the last `Model:` / `Provider:` / `Platform:` trailer lines so identity stays accurate ([#48173](https://github.com/NousResearch/hermes-agent/issues/48173)) without rewriting skills, guidance, or context. A real cwd change in the stable host-info block still rebuilds. `on_session_start` stays gated to rows that never had a usable prompt.
- Environment-flapping tool *schemas* (defect b) are a separate session-toolset freeze; this PR stops the switch itself from forking the stored system-prompt prefix.

Fixes #100336.

## Test plan
- [x] `scripts/run_tests.sh tests/agent/test_system_prompt_restore.py tests/test_session_system_prompt_dedup.py tests/run_agent/test_switch_model_context.py tests/gateway/test_model_switch_persistence.py -q`
- [ ] `/model` switch in a long gateway session: next turn should log the identity-patch path, not `Stored system prompt ... is null`
- [ ] After the switch, `Model:` / `Provider:` in the persisted prompt match the new route; bytes before that trailer stay identical to the pre-switch snapshot