### PR TITLE
fix(delegation): summary budget must measure current context, not the lifetime token accumulator

### DIFF
--- a/tests/tools/test_delegate_summary_budget_metric.py
+++ b/tests/tools/test_delegate_summary_budget_metric.py
@@ -1,0 +1,77 @@
+"""Regression tests: summary budget must measure CURRENT context, not the
+session-lifetime token accumulator.
+
+``_parent_summary_char_budget`` used ``parent_agent.session_prompt_tokens``
+as "current context usage". That attribute is a lifetime accumulator
+(agent_init = 0, then ``+=`` on every API call, never reset), so on any
+long session the computed headroom goes permanently negative and every
+batch summary collapses to the minimum-char floor even when the live
+context is tiny. These tests pin the fix: use the compressor's last real
+prompt size (``last_prompt_tokens``), falling back to
+``last_real_prompt_tokens`` (post-compression boundary), then to the
+accumulator only as a last resort.
+"""
+
+import tools.delegate_tool as dt
+
+
+class _BudgetFakeCompressor:
+    def __init__(self, context_length, max_tokens, last_prompt_tokens=None,
+                 last_real_prompt_tokens=None):
+        self.context_length = context_length
+        self.max_tokens = max_tokens
+        self.last_prompt_tokens = last_prompt_tokens
+        self.last_real_prompt_tokens = last_real_prompt_tokens
+
+
+class _BudgetFakeParent:
+    def __init__(self, *, context_length, max_tokens,
+                 session_prompt_tokens=0,
+                 last_prompt_tokens=None,
+                 last_real_prompt_tokens=None):
+        self.context_compressor = _BudgetFakeCompressor(
+            context_length, max_tokens,
+            last_prompt_tokens=last_prompt_tokens,
+            last_real_prompt_tokens=last_real_prompt_tokens,
+        )
+        # Lifetime accumulator: large on a long session, regardless of the
+        # live context being small (e.g. right after a fresh compaction).
+        self.session_prompt_tokens = session_prompt_tokens
+
+
+def test_budget_uses_last_prompt_tokens_not_lifetime_accumulator():
+    # Long session: accumulator says 900k, but the live context (last real
+    # prompt) is only 30k of a 200k window. Headroom must be computed from
+    # 30k — NOT from 900k, which would collapse the budget to the floor.
+    parent = _BudgetFakeParent(
+        context_length=200_000, max_tokens=8_000,
+        session_prompt_tokens=900_000,          # lifetime accumulator (misleading)
+        last_prompt_tokens=30_000,              # actual current usage
+    )
+    budget = dt._parent_summary_char_budget(parent, n_summaries=4)
+    assert budget is not None
+    assert budget > dt._MIN_SUMMARY_CHARS
+
+
+def test_budget_falls_back_to_last_real_prompt_tokens():
+    # Right after a compression boundary last_prompt_tokens may be 0/-1;
+    # the post-compression measurement must be used next.
+    parent = _BudgetFakeParent(
+        context_length=200_000, max_tokens=8_000,
+        session_prompt_tokens=900_000,
+        last_prompt_tokens=0,
+        last_real_prompt_tokens=25_000,
+    )
+    budget = dt._parent_summary_char_budget(parent, n_summaries=4)
+    assert budget is not None
+    assert budget > dt._MIN_SUMMARY_CHARS
+
+
+def test_budget_accumulator_is_last_resort_only():
+    # No real measurements available: only then may the accumulator be used.
+    parent = _BudgetFakeParent(
+        context_length=200_000, max_tokens=8_000,
+        session_prompt_tokens=195_000,          # genuinely over budget
+    )
+    budget = dt._parent_summary_char_budget(parent, n_summaries=4)
+    assert budget == dt._MIN_SUMMARY_CHARS

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2491,7 +2491,19 @@ def _parent_summary_char_budget(parent_agent, n_summaries: int) -> Optional[int]
         if not isinstance(context_length, int) or context_length <= 0:
             return None
 
-        used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
+        # Measure CURRENT context usage, not the session-lifetime
+        # accumulator. session_prompt_tokens is a lifetime total
+        # (agent_init = 0, then += per API call, never reset), so on a long
+        # session the headroom below is permanently negative and every batch
+        # summary collapses to the minimum-char floor even when the live
+        # context is small. Prefer the compressor's latest real prompt size;
+        # fall back to the post-compression-boundary measurement, and only
+        # then to the accumulator.
+        used_tokens = getattr(compressor, "last_prompt_tokens", 0) or 0
+        if not isinstance(used_tokens, (int, float)) or used_tokens <= 0:
+            used_tokens = getattr(compressor, "last_real_prompt_tokens", 0) or 0
+        if not isinstance(used_tokens, (int, float)) or used_tokens <= 0:
+            used_tokens = getattr(parent_agent, "session_prompt_tokens", 0)
         if not isinstance(used_tokens, (int, float)) or used_tokens < 0:
             used_tokens = 0
 


### PR DESCRIPTION
## Problem

`_parent_summary_char_budget` used `parent_agent.session_prompt_tokens` as "current context usage". That attribute is a **lifetime accumulator** (`agent_init` = 0, then `+=` on every API call, never reset), not the live context size. On any long session the computed headroom goes permanently negative, so every batch summary collapses to the minimum-char floor (`_MIN_SUMMARY_CHARS = 2000`) even when the live context is tiny. Users see `[SUMMARY TRUNCATED]` on summaries that would comfortably fit — in one production system this fired 13–64×/day.

Related: #9126 introduced the summary cap mechanism (closed), but the headroom calculation still reads the accumulator.

## Fix

Measure the **current** context, via the compressor's latest real prompt count with a strict fallback chain:

```
last_prompt_tokens → last_real_prompt_tokens (post-compression boundary) → session_prompt_tokens (last resort)
```

All existing guards are preserved (static ceiling, char floor, over-budget branch still returns the floor), so the fix cannot flip over-truncation into context overflow.

## Testing

- New regression tests: `tests/tools/test_delegate_summary_budget_metric.py` (3 tests — pins each rung of the fallback chain; the first two fail on `main`)
- Existing budget tests: pass unchanged (3/3)
- Full delegate suite: 100 passed

## Backwards compatibility

None of the attribute reads are new — `context_compressor.last_prompt_tokens` / `last_real_prompt_tokens` are already maintained by the compressor on every provider response. When both are 0/-1 (fresh agent, before first call), behavior is identical to current `main` (accumulator path).

Draft while I double-check the compression-boundary semantics of `last_real_prompt_tokens` across providers.