### PR TITLE
fix(plugins): route cron-provider plugins to their own discovery — stop spurious PluginContext.register_cron_scheduler failures

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -474,8 +474,9 @@ def discover_entrypoint_manifests() -> List["PluginManifest"]:
 
     * **Kind classification** — the module source is resolved import-free
       (``_resolve_module_source``) and scanned for provider markers
-      (``_detect_kind_from_source``), so memory providers (``exclusive``)
-      and model providers (``model-provider``) are routed to their own
+      (``_detect_kind_from_source``), so memory providers (``exclusive``),
+      model providers (``model-provider``), and cron scheduler providers
+      (``cron-provider``) are routed to their own
       discovery systems instead of being eagerly imported here.
     * **Capability declarations** — read from the companion
       ``hermes_agent.plugin_capabilities`` entry-point group (declarations
@@ -680,7 +681,14 @@ def _get_enabled_plugins() -> Optional[set]:
 # Data classes
 # ---------------------------------------------------------------------------
 
-_VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_VALID_PLUGIN_KINDS: Set[str] = {
+    "standalone",
+    "backend",
+    "exclusive",
+    "platform",
+    "model-provider",
+    "cron-provider",
+}
 
 
 def _portable_skill_namespace(key: str) -> str:
@@ -990,12 +998,18 @@ def _detect_kind_from_source(source_text: str) -> Optional[str]:
     or ``MemoryProvider``) belongs to the memory-provider discovery
     system (``exclusive``); a module that registers a model provider
     (``register_provider`` + ``ProviderProfile``) belongs to the
-    providers discovery (``model-provider``). Applied to both directory
-    plugins and pip entry-point plugins so neither is eagerly imported
-    by the general PluginManager.
+    providers discovery (``model-provider``); a module that registers a
+    cron scheduler provider (``register_cron_scheduler`` or
+    ``CronScheduler``) belongs to the cron-provider discovery
+    (``cron-provider``, mirroring
+    ``plugins/cron_providers/__init__.py:_is_cron_provider_dir``).
+    Applied to both directory plugins and pip entry-point plugins so
+    neither is eagerly imported by the general PluginManager.
     """
     if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
         return "exclusive"
+    if "register_cron_scheduler" in source_text or "CronScheduler" in source_text:
+        return "cron-provider"
     if "register_provider" in source_text and "ProviderProfile" in source_text:
         return "model-provider"
     return None
@@ -4419,6 +4433,27 @@ class PluginManager:
                 )
                 continue
 
+            # Cron scheduler provider plugins are loaded by
+            # plugins/cron_providers/__init__.py (its own discovery, keyed
+            # off ``cron.provider`` config). The general loader records the
+            # manifest for introspection but does not load the module —
+            # PluginContext has no register_cron_scheduler, so importing
+            # register(ctx) would only produce a spurious
+            # "'PluginContext' object has no attribute
+            # 'register_cron_scheduler'" warning on every session start
+            # (#62951) and leave a permanently failed registration entry.
+            if manifest.kind == "cron-provider":
+                loaded = LoadedPlugin(manifest=manifest, enabled=False)
+                loaded.error = (
+                    "cron-provider plugin — activate via cron.provider config"
+                )
+                self._plugins[lookup_key] = loaded
+                logger.debug(
+                    "Skipping '%s' (cron-provider, handled by cron_providers/ discovery)",
+                    lookup_key,
+                )
+                continue
+
             # Model provider plugins are loaded by providers/__init__.py
             # (its own lazy discovery keyed off first get_provider_profile()
             # call). We record the manifest here for introspection but do
@@ -4854,9 +4889,10 @@ class PluginManager:
         """Classify a pip entry-point plugin by scanning its module source.
 
         The ``kind`` semantics are the same for pip entry points as for
-        directory plugins: memory providers (``exclusive``) and model
-        providers (``model-provider``) have their own discovery systems,
-        so importing them here registers nothing and only pays the
+        directory plugins: memory providers (``exclusive``), model
+        providers (``model-provider``), and cron scheduler providers
+        (``cron-provider``) have their own discovery systems, so
+        importing them here registers nothing and only pays the
         module's import cost in every Hermes process (e.g. a pip
         memory-provider plugin pulling in onnxruntime via fastembed —
         ~60 MB RSS on startup).

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -507,6 +507,151 @@ class TestPluginLoading:
         assert entry.module is None
         assert "exclusive" in (entry.error or "").lower()
 
+    def test_user_cron_plugin_auto_coerced_to_cron_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """User-installed cron scheduler provider plugins must NOT be loaded
+        by the general PluginManager — they belong to plugins/cron_providers
+        discovery.
+
+        Regression test for the chronos crash (#62951):
+            'PluginContext' object has no attribute 'register_cron_scheduler'
+
+        A plugin that calls ``ctx.register_cron_scheduler`` in its
+        ``__init__.py`` should be auto-detected as ``kind: cron-provider``
+        (mirroring ``plugins/cron_providers/__init__.py:
+        _is_cron_provider_dir``) so the general loader records the manifest
+        but does not import/register() it. The real activation happens
+        through ``plugins/cron_providers/__init__.py`` via ``cron.provider``
+        config.
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "ticktock"
+        plugin_dir.mkdir(parents=True)
+        # No explicit `kind:` — the heuristic should kick in.
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "ticktock"}))
+        (plugin_dir / "__init__.py").write_text(
+            "class TickTockScheduler:\n"
+            "    pass\n"
+            "def register(ctx):\n"
+            "    ctx.register_cron_scheduler(TickTockScheduler())\n"
+        )
+        # Even if the user explicitly enables it in config, the loader
+        # should still treat it as cron-provider and skip general loading.
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["ticktock"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = next(
+            e for e in mgr._plugins.values() if e.manifest.name == "ticktock"
+        )
+        assert entry.manifest.kind == "cron-provider", (
+            f"Expected auto-coerced kind='cron-provider', got {entry.manifest.kind}"
+        )
+        # Not loaded by general manager (no register() call, no AttributeError).
+        assert not entry.enabled
+        assert entry.module is None
+        assert "cron-provider" in (entry.error or "").lower()
+
+    def test_entrypoint_cron_provider_auto_coerced_to_cron_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point cron-provider plugins must NOT be imported by the
+        general PluginManager — same contract as memory/model providers
+        (#62951), so a pip cron provider is recorded for introspection and
+        activates only through plugins/cron_providers discovery.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "ticktock_ep.py"
+        module_path.write_text(
+            "class TickTockScheduler:\n"
+            "    pass\n"
+            "def register_cron_scheduler(scheduler):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="ticktock_ep",
+            value="ticktock_ep:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["ticktock_ep"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = next(
+            e for e in mgr._plugins.values() if e.manifest.name == "ticktock_ep"
+        )
+        assert entry.manifest.kind == "cron-provider", (
+            f"Expected auto-coerced kind='cron-provider', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "cron-provider" in (entry.error or "").lower()
+        # The whole point: the module was never imported.
+        assert "ticktock_ep" not in sys.modules
+
+    def test_bundled_chronos_skipped_by_general_manager_and_cron_discovery_activates(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """E2E regression for #62951: the bundled chronos plugin, when
+        enabled, must be recorded (not loaded) by the general PluginManager
+        with no AttributeError warning, and must still activate through the
+        real cron-provider discovery path.
+        """
+        from plugins.cron_providers import load_cron_scheduler
+
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr.discover_and_load()
+
+        # Recorded for introspection, never loaded via PluginContext.
+        entry = next(
+            e
+            for e in mgr._plugins.values()
+            if e.manifest.name == "chronos" and e.manifest.source == "bundled"
+        )
+        assert entry.manifest.kind == "cron-provider"
+        assert not entry.enabled
+        assert entry.module is None
+        # The exact symptom from #62951 must be gone.
+        assert not [
+            r for r in caplog.records if "register_cron_scheduler" in r.getMessage()
+        ]
+        # The module was never imported by the general manager…
+        assert "plugins.cron_providers.chronos" not in sys.modules
+        # …and the real cron-provider discovery path still activates it.
+        scheduler = load_cron_scheduler("chronos")
+        assert scheduler is not None
+        assert type(scheduler).__name__ == "ChronosCronScheduler"
+
     def test_entrypoint_memory_provider_auto_coerced_to_exclusive(
         self, tmp_path, monkeypatch
     ):


### PR DESCRIPTION
## Summary

Fixes #62951.

Cron scheduler provider plugins (the bundled `chronos`, and any user-installed provider under `$HERMES_HOME/plugins/`) register via `ctx.register_cron_scheduler(...)`. That method exists only on the fake `_ProviderCollector` context used by `plugins/cron_providers/__init__.py` — not on the general `PluginContext`.

`_detect_kind_from_source()` routes plugins belonging to other discovery systems away from the generic `PluginManager` (memory providers → `exclusive`, model providers → `model-provider`), but had **no cron branch**. Cron providers therefore classified as `standalone`, and the generic manager imported them and called `register(ctx)` with the real `PluginContext`, producing on every session load:

```
WARNING hermes_cli.plugins: Failed to load plugin 'chronos': 'PluginContext' object has no attribute 'register_cron_scheduler'
```

plus a permanently failed registration entry (reported on v0.18.2 in #62951, still present on `main` @ `21b2095d`).

## Changes

- Extend `_detect_kind_from_source()` with a `cron-provider` branch (`register_cron_scheduler` or `CronScheduler` in the module source — mirroring the existing `plugins/cron_providers/_is_cron_provider_dir` heuristic), applied to both directory and pip entry-point plugins.
- Add `"cron-provider"` to `_VALID_PLUGIN_KINDS`.
- Skip loading `cron-provider`-kind plugins in the generic manager's enabled-plugin path, exactly as `exclusive` is skipped: the manifest is recorded for introspection (`LoadedPlugin` with a pointer to `cron.provider` config) and activation stays with the cron discovery system.

Functional cron behavior is unchanged: `load_cron_scheduler()` / `discover_cron_schedulers()` are untouched and still resolve chronos (verified: returns a real `ChronosCronScheduler` with the patch applied).

## Test plan

- **3 new behavior-contract tests** in `tests/hermes_cli/test_plugins.py`: user-installed directory plugin must not be loaded; pip entry-point cron provider must not be imported; bundled-chronos E2E against a temp `HERMES_HOME` (general manager records the manifest, cron discovery activates the scheduler). All three **fail without the fix and pass with it** (verified via stash control).
- `tests/hermes_cli/test_plugins.py`: 77 passed.
- `tests/plugins` + `tests/cron`: green.
- **3,204 tests across the 141 files that import the plugin manager**: green except 5 failures verified pre-existing on unpatched `main` (hindsight memory provider, a2a, TUI gateway-server — stash-baselined, unrelated to this change). Note the full `tests/hermes_cli` tree is ~7,100 tests and was not run end-to-end locally (runtime); every file exercising the changed module was.
- Live repro check: `PluginManager.discover_and_load()` emits zero chronos warnings post-fix; the registry records `cron_providers/chronos → (not enabled, "cron-provider plugin — activate via cron.provider config")`.

Fixes #62951
