### PR TITLE
fix(skills/github): stop teaching self-merge, bare clones, and push-to-main

### DIFF
--- a/skills/software-development/github/references/code-review.md
+++ b/skills/software-development/github/references/code-review.md
@@ -227,13 +227,13 @@ curl -s -X POST \
 
 ### Submit a Formal Review (Approve / Request Changes)
 
-**With gh:**
+**Not with gh.** Prefer the API form below, whose `event` you choose deliberately — a
+formal APPROVE is a gate signal, and gates are not something an agent may assert on its
+own judgement:
 
-```bash
-gh pr review 123 --approve --body "LGTM!"
-gh pr review 123 --request-changes --body "See inline comments."
-gh pr review 123 --comment --body "Some suggestions, nothing blocking."
-```
+- `COMMENT` — the only event an agent should normally submit.
+- `REQUEST_CHANGES` — allowed; it blocks rather than advances.
+- `APPROVE` — reserved for a human. Do not submit it on your own judgement.
 
 **With curl — multi-comment review submitted atomically:**
 
@@ -393,14 +393,13 @@ Go through each category: Correctness, Security, Code Quality, Testing, Performa
 
 Collect your findings and submit them as a formal review with inline comments.
 
-**With gh:**
-```bash
-# If no issues — approve
-gh pr review $PR_NUMBER --approve --body "Reviewed by Hermes Agent. Code looks clean — good test coverage, no security concerns."
+**Not with gh** (see the formal-review note above). Post via the API, choosing `event`
+by what you found:
 
-# If issues found — request changes with inline comments
-gh pr review $PR_NUMBER --request-changes --body "Found a few issues — see inline comments."
-```
+- Issues found → `REQUEST_CHANGES`, with the findings as inline comments.
+- Nothing found → `COMMENT` stating that. An agent does not `APPROVE`; approval is a
+  human gate, and the review artifact an agent posts is what a human or a deterministic
+  gate then reads.
 
 **With curl — atomic review with multiple inline comments:**
 ```bash

--- a/skills/software-development/github/references/pr-workflow.md
+++ b/skills/software-development/github/references/pr-workflow.md
@@ -263,56 +263,25 @@ When asked to auto-fix CI, follow this loop:
 
 ## 6. Merging
 
-**With gh:**
+**You do not merge your own PRs.** Not with `gh pr merge`, and not with a curl
+`PUT /pulls/N/merge` either — reaching around the editor to do the same thing by hand is
+the same defect under another name, and worse, because nothing records that it happened.
 
-```bash
-# Squash merge + delete branch (cleanest for feature branches)
-gh pr merge --squash --delete-branch
+The person or process that reviews a PR is the one who merges it. An agent that merges
+its own work has removed the one review gate standing between the change and `main` —
+the review becomes theatre, because the actor who wanted the outcome is the one reading
+the verdict.
 
-# Enable auto-merge (merges when all checks pass)
-gh pr merge --auto --squash --delete-branch
-```
+What you do instead, when your PR is ready:
 
-**With git + curl:**
+1. Make sure CI is green and the review artifact is posted (Sections 4–5).
+2. Report the PR as ready in the place your workflow tracks work — a human, or a merge
+   process that runs outside your context, merges from there.
+3. If it does not merge, it will say why — read that reason rather than merging by hand.
 
-```bash
-PR_NUMBER=<number>
-
-# Merge the PR via API (squash)
-curl -s -X PUT \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER/merge \
-  -d "{
-    \"merge_method\": \"squash\",
-    \"commit_title\": \"feat: add user authentication (#$PR_NUMBER)\"
-  }"
-
-# Delete the remote branch after merge
-BRANCH=$(git branch --show-current)
-git push origin --delete $BRANCH
-
-# Switch back to main locally
-git checkout main && git pull origin main
-git branch -d $BRANCH
-```
-
-Merge methods: `"merge"` (merge commit), `"squash"`, `"rebase"`
-
-### Enable Auto-Merge (curl)
-
-```bash
-# Auto-merge requires the repo to have it enabled in settings.
-# This uses the GraphQL API since REST doesn't support auto-merge.
-PR_NODE_ID=$(curl -s \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/repos/$OWNER/$REPO/pulls/$PR_NUMBER \
-  | python -c "import sys,json; print(json.load(sys.stdin)['node_id'])")
-
-curl -s -X POST \
-  -H "Authorization: token $GITHUB_TOKEN" \
-  https://api.github.com/graphql \
-  -d "{\"query\": \"mutation { enablePullRequestAutoMerge(input: {pullRequestId: \\\"$PR_NODE_ID\\\", mergeMethod: SQUASH}) { clientMutationId } }\"}"
-```
+**Auto-merge** is likewise not yours to enable. It is a repository setting (`repo edit`),
+and it changes how merges happen on that repo going forward. Ask the operator if a repo
+needs it.
 
 ## 7. Complete Workflow Example
 

--- a/skills/software-development/github/references/repo-management.md
+++ b/skills/software-development/github/references/repo-management.md
@@ -43,31 +43,37 @@ REPO=$(echo "$OWNER_REPO" | cut -d/ -f2)
 
 ## 1. Cloning Repositories
 
-Cloning is pure `git` — works identically either way:
+**A clone always names its destination, and that destination lives under the projects
+root (`${HERMES_PROJECTS_ROOT:-$HOME/projects}`).** A clone with no destination lands in
+whatever directory the agent happens to be in — regularly the config store or another
+team's workspace — so an explicit destination is not optional polish, it is the rule.
 
 ```bash
-# Clone via HTTPS (works with credential helper or token-embedded URL)
-git clone https://github.com/owner/repo-name.git
+DEST="${HERMES_PROJECTS_ROOT:-$HOME/projects}/repo-name"
 
-# Clone into a specific directory
-git clone https://github.com/owner/repo-name.git ./my-local-dir
+# Clone via HTTPS (works with credential helper or token-embedded URL)
+git clone https://github.com/owner/repo-name.git "$DEST"
 
 # Shallow clone (faster for large repos)
-git clone --depth 1 https://github.com/owner/repo-name.git
+git clone --depth 1 https://github.com/owner/repo-name.git "$DEST"
 
-# Clone a specific branch
-git clone --branch develop https://github.com/owner/repo-name.git
+# A specific branch
+git clone --branch develop https://github.com/owner/repo-name.git "$DEST"
 
-# Clone via SSH (if SSH is configured)
-git clone git@github.com:owner/repo-name.git
+# Via SSH (if SSH is configured)
+git clone git@github.com:owner/repo-name.git "$DEST"
 ```
 
-**With gh (shorthand):**
+**With gh (shorthand)** — same rule, the destination is the second argument:
 
 ```bash
-gh repo clone owner/repo-name
-gh repo clone owner/repo-name -- --depth 1
+gh repo clone owner/repo-name "${HERMES_PROJECTS_ROOT:-$HOME/projects}/repo-name"
+gh repo clone owner/repo-name "${HERMES_PROJECTS_ROOT:-$HOME/projects}/repo-name" -- --depth 1
 ```
+
+If the repo is already cloned, reuse the existing checkout rather than cloning a second
+copy under a new name — two clones of one repo drift, and a guard that reads "the" clone
+then reads whichever one it found first.
 
 ## 2. Creating Repositories
 
@@ -103,18 +109,16 @@ curl -s -X POST \
     "license_template": "mit"
   }'
 
-# Clone it
-git clone https://github.com/$GH_USER/my-new-project.git
-cd my-new-project
-
-# -- OR -- push an existing local directory to the new repo
-cd /path/to/existing/project
-git init
-git add .
-git commit -m "Initial commit"
-git remote add origin https://github.com/$GH_USER/my-new-project.git
-git push -u origin main
+# Clone it — destination is explicit and under the projects root (Section 1)
+DEST="${HERMES_PROJECTS_ROOT:-$HOME/projects}/my-new-project"
+git clone https://github.com/$GH_USER/my-new-project.git "$DEST"
 ```
+
+**Seeding an existing local directory is an operator step, not an agent one.** It ends in
+a first push to `main` — the commit that defines a repo's history, with no review in
+front of it. Ask the operator to run the `git init` / `git remote add` /
+`git push -u origin main` sequence (an agent may not push to the default branch), then
+clone the result as above and work through PRs from there.
 
 To create under an organization:
 
@@ -160,8 +164,9 @@ curl -s -X POST \
 
 # Wait a moment for GitHub to create it, then clone
 sleep 3
-git clone https://github.com/$GH_USER/repo-name.git
-cd repo-name
+DEST="${HERMES_PROJECTS_ROOT:-$HOME/projects}/repo-name"
+git clone https://github.com/$GH_USER/repo-name.git "$DEST"
+cd "$DEST"
 
 # Add the original repo as "upstream" remote
 git remote add upstream https://github.com/owner/repo-name.git
@@ -169,19 +174,17 @@ git remote add upstream https://github.com/owner/repo-name.git
 
 ### Keeping a Fork in Sync
 
-```bash
-# Pure git — works everywhere
-git fetch upstream
-git checkout main
-git merge upstream/main
-git push origin main
-```
-
-**With gh (shortcut):**
+**Use `gh repo sync`** — it moves the remote default branch server-side and touches no
+local branch, so there is nothing to clean up after. The pure-git alternative ends in a
+push to `main`, which an agent should not perform (see the merge section in
+`pr-workflow.md`):
 
 ```bash
 gh repo sync $GH_USER/repo-name
 ```
+
+To bring the sync down locally afterwards: `git fetch origin && git checkout main && git
+merge --ff-only origin/main`.
 
 ## 4. Repository Information
 
@@ -232,15 +235,12 @@ for r in json.load(sys.stdin)['items']:
 
 **With gh:**
 
-```bash
-gh repo edit --description "Updated description" --visibility public
-gh repo edit --enable-wiki=false --enable-issues=true
-gh repo edit --default-branch main
-gh repo edit --add-topic "machine-learning,python"
-gh repo edit --enable-auto-merge
-```
+**Repo settings are not an agent's to change.** Description, visibility, default branch,
+topics, auto-merge and wiki/issues toggles all change how every later CI check, guard and
+watcher behaves, and none of them are reviewable after the fact. Raise the change with
+the operator instead of using `gh repo edit` or reaching the same endpoint by hand.
 
-**With curl:**
+The curl form below is documented for an operator running outside agent context:
 
 ```bash
 curl -s -X PATCH \
@@ -400,11 +400,11 @@ gh workflow list
 gh run list --limit 10
 gh run view <RUN_ID>
 gh run view <RUN_ID> --log-failed
-gh run rerun <RUN_ID>
-gh run rerun <RUN_ID> --failed
-gh workflow run ci.yml --ref main
-gh workflow run deploy.yml -f environment=staging
-```
+# Re-running and dispatching are not agent actions (`run rerun`, `workflow run`).
+# A red run is evidence; re-rolling the dice on it is how a genuinely broken build
+# gets mistaken for a flake. Read the failure with `--log-failed` above, fix the
+# cause, and push — a new commit gives you a fresh run legitimately. If it is truly
+# a flake, post the re-run command for a human rather than running it.
 
 **With curl:**
 
@@ -492,12 +492,12 @@ for g in json.load(sys.stdin):
 
 | Action | gh | git + curl |
 |--------|-----|-----------|
-| Clone | `gh repo clone o/r` | `git clone https://github.com/o/r.git` |
+| Clone | `gh repo clone o/r "$DEST"` | `git clone https://github.com/o/r.git "$DEST"` (dest required) |
 | Create repo | `gh repo create name --public` | `curl POST /user/repos` |
-| Fork | `gh repo fork o/r --clone` | `curl POST /repos/o/r/forks` + `git clone` |
+| Fork | `gh repo fork o/r` | `curl POST /repos/o/r/forks`, then clone with a dest |
 | Repo info | `gh repo view o/r` | `curl GET /repos/o/r` |
-| Edit settings | `gh repo edit --...` | `curl PATCH /repos/o/r` |
+| Edit settings | operator only | `curl PATCH /repos/o/r` (operator context) |
 | Create release | `gh release create v1.0` | `curl POST /repos/o/r/releases` |
 | List workflows | `gh workflow list` | `curl GET /repos/o/r/actions/workflows` |
-| Rerun CI | `gh run rerun ID` | `curl POST /repos/o/r/actions/runs/ID/rerun` |
+| Rerun CI | operator only | `curl POST /repos/o/r/actions/runs/ID/rerun` (operator context) |
 | Set secret | `gh secret set KEY` | `curl PUT /repos/o/r/actions/secrets/KEY` (+ encryption) |


### PR DESCRIPTION
## What

The bundled `github` skill teaches agents to run commands that defeat or bypass the review gate. This PR rewrites those sections to teach what an agent should actually do, and why.

## Changes (`skills/software-development/github/references/`)

**repo-management.md**
- Cloning: a clone always names a destination under `${HERMES_PROJECTS_ROOT:-$HOME/projects}` — bare `git clone URL` / `gh repo clone o/r` lands in the current directory, regularly the config store or another workspace. All clone examples rewritten, plus a "reuse the existing checkout" note.
- New-repo seeding: the old flow ended in `git push -u origin main`. Now documented as an operator step (first commit of a repo defines its history with no review in front of it); agents ask the operator, then clone and work through PRs.
- Fork sync: `gh repo sync` (server-side, touches no local branch) instead of the pure-git `fetch upstream / merge / push origin main` flow.
- Repo settings: `gh repo edit` removed from the agent path — description, visibility, default branch, topics, auto-merge change how every later check/watcher behaves and aren't reviewable after the fact. Curl forms kept, marked operator-context.
- CI reruns: `gh run rerun` / `gh workflow run` removed. A red run is evidence; read `--log-failed`, fix, push. Reruns/dispatches are human actions.
- Quick-reference table rows updated to match.

**pr-workflow.md**
- "You do not merge your own PRs" replaces the `gh pr merge` (incl. `--auto`) and curl `PUT /pulls/N/merge` blocks, including the auto-merge GraphQL recipe. The reviewer is the merger; an agent merging its own work makes the review theatre. Ready-PR flow: CI green + review artifact posted → report ready → the human/merge process acts.
- Auto-merge documented as an operator repo-setting change.

**code-review.md**
- Formal reviews: prefer the API form with a deliberate `event` — `COMMENT` (agent default), `REQUEST_CHANGES` (blocks), `APPROVE` (human-only gate signal). `gh pr review --approve` removed from both agent flows.

## Why

A skill that tells an agent to merge its own PR — or to reach past a refusing wrapper with curl — is a skill that makes the review gate theatre. Same class of defect: `run rerun` re-rolling a red build, forks "synced" by pushing to main, settings changed with no record.

These exact rewrites are already merged and CI-verified in the corresponding user-config tracked copy (isair/hermes, PR #54/#55); several deployments additionally gate these commands at the shell level. This change brings the bundled skill in line with both.

## NOTE for downstream consumers

Once this merges, users who run `hermes update` will have their local `github` skill converge with the bundle. Any deployment that had **fixed its tracked copy locally** (isair/hermes shape) will lose its "user-modified" protection at that moment — if such a deployment guards tracked skills against update clobbers (baseline-hash check), the re-sync after this merge is the moment that guard must be re-baselined deliberately, not silently accepted.