### PR TITLE
fix(gateway): honor interim display policy for status callbacks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1055,6 +1055,23 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
     return text
 
 
+_REQUIRED_CHAT_STATUS_RE = re.compile(
+    r"(?:"
+    r"^Compressed(?:\s+with\s+fallback)?\s*:"
+    r"|^Compression\s+aborted:"
+    r"|^No\s+changes\s+from\s+compression:"
+    r"|^⚠\s*Compression\s+(?:aborted|returned\s+an\s+empty\s+transcript)"
+    r"|^⏳\s*Compression\s+(?:already\s+in\s+progress|skipped:\s+could\s+not\s+acquire)"
+    r"|^⚠\s*Context\s+is\s+over\s+the\s+compression\s+threshold"
+    r")",
+    re.IGNORECASE,
+)
+
+
+def _gateway_status_requires_delivery(message: str) -> bool:
+    return bool(_REQUIRED_CHAT_STATUS_RE.search(str(message or "").strip()))
+
+
 def render_notice_line(notice) -> str:
     """Render an AgentNotice to a single plaintext line for messaging platforms.
 
@@ -6270,7 +6287,18 @@ class TurnRunner:
         agent.step_callback = ctx._step_callback_sync if ctx._hooks_ref.loaded_hooks else None
         agent.stream_delta_callback = _stream_delta_cb
         agent.interim_assistant_callback = _interim_assistant_cb if _want_interim_messages else None
-        agent.status_callback = ctx._status_callback_sync
+        def _status_callback(event_type: str, message: str) -> None:
+            if _want_interim_messages or _gateway_status_requires_delivery(message):
+                ctx._status_callback_sync(event_type, message)
+            else:
+                logger.debug(
+                    "status_callback suppressed by interim display policy for %s/%s: %s",
+                    ctx.source.platform.value if ctx.source.platform else "unknown",
+                    event_type,
+                    _redact_gateway_user_facing_secrets(str(message or ""))[:160],
+                )
+
+        agent.status_callback = _status_callback
         # Credits / out-of-band notices (usage bands, depletion, restored).
         # Messaging has no persistent status bar, so each notice is a
         # standalone push: render to a single plaintext line and deliver via

--- a/tests/gateway/test_run_progress_topics.py
+++ b/tests/gateway/test_run_progress_topics.py
@@ -13,6 +13,7 @@ import gateway.platforms.base as base_platform
 from gateway.config import Platform, PlatformConfig, StreamingConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
 from gateway.session import SessionSource
+from agent.conversation_compression import CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE
 
 
 class ProgressCaptureAdapter(BasePlatformAdapter):
@@ -815,6 +816,43 @@ class CommentaryAgent:
         }
 
 
+class StatusWarningAgent:
+    def __init__(self, **kwargs):
+        self.status_callback = kwargs.get("status_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        callback = self.status_callback
+        if callback is not None:
+            callback("warn", "Latest Mercury query failed.")
+        time.sleep(0.1)
+        return {
+            "final_response": "Traveloka payment not found.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
+class RequiredStatusWarningAgent(StatusWarningAgent):
+    def run_conversation(self, message, conversation_history=None, task_id=None, **kwargs):
+        callback = self.status_callback
+        if callback is not None:
+            callback(
+                "warn",
+                CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE.format(
+                    tokens=85_000,
+                    threshold=72_000,
+                    reason="cooldown:30",
+                ),
+            )
+        time.sleep(0.1)
+        return {
+            "final_response": "Traveloka payment not found.",
+            "messages": [],
+            "api_calls": 1,
+        }
+
+
 class PreviewedResponseAgent:
     def __init__(self, **kwargs):
         self.interim_assistant_callback = kwargs.get("interim_assistant_callback")
@@ -1181,6 +1219,57 @@ async def test_display_streaming_does_not_enable_gateway_streaming(monkeypatch, 
     assert result.get("already_sent") is not True
     assert adapter.edits == []
     assert [call["content"] for call in adapter.sent] == ["I'll inspect the repo first."]
+
+
+@pytest.mark.asyncio
+async def test_disabled_interim_messages_suppress_discord_status_warnings(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StatusWarningAgent,
+        session_id="sess-discord-status-warning",
+        config_data={"display": {"interim_assistant_messages": False}},
+        platform=Platform.DISCORD,
+    )
+
+    assert result["final_response"] == "Traveloka payment not found."
+    assert adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_enabled_interim_messages_deliver_discord_status_warnings(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        StatusWarningAgent,
+        session_id="sess-discord-status-warning-enabled",
+        config_data={"display": {"interim_assistant_messages": True}},
+        platform=Platform.DISCORD,
+    )
+
+    assert result["final_response"] == "Traveloka payment not found."
+    assert [call["content"] for call in adapter.sent] == ["Latest Mercury query failed."]
+
+
+@pytest.mark.asyncio
+async def test_disabled_interim_messages_keep_required_discord_status_warnings(monkeypatch, tmp_path):
+    adapter, result = await _run_with_agent(
+        monkeypatch,
+        tmp_path,
+        RequiredStatusWarningAgent,
+        session_id="sess-discord-required-status-warning",
+        config_data={"display": {"interim_assistant_messages": False}},
+        platform=Platform.DISCORD,
+    )
+
+    assert result["final_response"] == "Traveloka payment not found."
+    assert [call["content"] for call in adapter.sent] == [
+        CONTEXT_OVERFLOW_BLOCKED_WARNING_TEMPLATE.format(
+            tokens=85_000,
+            threshold=72_000,
+            reason="cooldown:30",
+        )
+    ]
 
 
 class TransformedStreamAgent:


### PR DESCRIPTION
## Summary
- Gate chat-visible `status_callback` notifications behind `display.interim_assistant_messages`.
- Preserve status delivery when interim messages are explicitly enabled.
- Add Discord regression coverage for both disabled and enabled settings.

## Problem
A tool warning could be emitted into Discord before the authoritative final answer. This produced contradictory user-visible outcomes: a failed-query warning followed by a valid, successful result.

Fixes #100367

## Validation
- `uv run --with pytest --with pytest-asyncio python -m pytest -q tests/gateway/test_run_progress_topics.py` (30 passed)
- `uv run --with pytest --with pytest-asyncio python -m py_compile gateway/run.py tests/gateway/test_run_progress_topics.py`
- `git diff --check`

## Manual follow-up
Live Discord canary verification requires deploying this branch. With `display.interim_assistant_messages: false`, a fresh Mercury request should yield only the authoritative final result, not an intermediate warning.