### PR TITLE
fix(desktop): stop background tabs flooding reaped sessions

### DIFF
--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -194,3 +194,52 @@ describe('createSessionRpcDispatcher: exact owner rungs', () => {
     })
   })
 })
+
+describe('createSessionRpcDispatcher: stale-runtime replay', () => {
+  beforeEach(() => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+  })
+
+  it('resumes and replays an idempotent goal-status RPC on the same owner route', async () => {
+    gatewayMocks.requestGatewayForAgent.mockImplementation(
+      (async (_connectionId: string, _profile: string, method: string, params: Record<string, unknown>) => {
+        if (method === 'slash.exec' && params.session_id === 'rt-omar') {
+          throw new Error('session not found')
+        }
+
+        if (method === 'session.resume') {
+          return { session_id: 'rt-fresh' }
+        }
+
+        return { output: 'goal status' }
+      }) as never
+    )
+
+    const { request } = dispatcher()
+
+    await expect(request('slash.exec', { command: 'goal status', session_id: 'rt-omar' })).resolves.toEqual({
+      output: 'goal status'
+    })
+
+    const routedCalls = gatewayMocks.requestGatewayForAgent.mock.calls as unknown as Array<
+      [string, string, string, Record<string, unknown>]
+    >
+
+    expect(routedCalls.map(call => [call[2], call[3].session_id])).toEqual([
+      ['slash.exec', 'rt-omar'],
+      ['session.resume', 'stored-omar'],
+      ['slash.exec', 'rt-fresh']
+    ])
+  })
+
+  it('does not replay a state-changing slash command', async () => {
+    gatewayMocks.requestGatewayForAgent.mockRejectedValue(new Error('session not found'))
+
+    const { request } = dispatcher()
+
+    await expect(request('slash.exec', { command: 'model local/new-model', session_id: 'rt-omar' })).rejects.toThrow(
+      'session not found'
+    )
+    expect(gatewayMocks.requestGatewayForAgent).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -33,6 +33,7 @@
  */
 import type { MutableRefObject } from 'react'
 
+import { withSessionNotFoundResume } from '@/app/session/hooks/use-prompt-actions/utils'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
 import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows } from '@/store/session'
@@ -54,6 +55,14 @@ export interface SessionRpcDispatcherDeps {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+}
+
+function isSafeStaleRuntimeReplay(method: string, params: Record<string, unknown>): boolean {
+  if (method === 'approval.pending' || method === 'process.list') {
+    return true
+  }
+
+  return method === 'slash.exec' && params.command === 'goal status'
 }
 
 export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): AmbientGatewayRequest {
@@ -97,6 +106,27 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
     // backend "session not found" on a backend that never held the runtime.
     assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
 
-    return requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+    const requestParams = params ?? {}
+
+    const dispatch = <R>(rpcMethod: string, rpcParams: Record<string, unknown>, rpcTimeoutMs = timeoutMs) =>
+      requestForSessionProfile<R>(owner, ambientRequest, rpcMethod, rpcParams, rpcTimeoutMs, signal)
+
+    if (!paramSessionId || !routingSessionId || !isSafeStaleRuntimeReplay(method, requestParams)) {
+      return dispatch<T>(method, requestParams)
+    }
+
+    const recovered = await withSessionNotFoundResume(
+      paramSessionId,
+      routingSessionId,
+      liveSessionId => dispatch<T>(method, { ...requestParams, session_id: liveSessionId }),
+      {
+        requestGateway: (rpcMethod, rpcParams = {}, rpcTimeoutMs) => dispatch(rpcMethod, rpcParams, rpcTimeoutMs),
+        resolveProfile: async () => (typeof owner === 'string' ? owner : owner?.profile),
+        onRecovered: liveSessionId => runtimeIdByStoredSessionIdRef.current.set(routingSessionId, liveSessionId),
+        driftReason: () => (signal?.aborted ? 'request aborted' : null)
+      }
+    )
+
+    return recovered.result
   }
 }

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -17,7 +17,7 @@ import {
   resumeDesktopBootForRetry,
   setDesktopBootStep
 } from '@/store/boot'
-import { resetBackgroundPollingGuard } from '@/store/composer-status'
+import { resetBackgroundPollingGuardForRuntimeIds } from '@/store/composer-status'
 import {
   $gateway,
   activeGatewayConnectionId,
@@ -363,19 +363,22 @@ export function useGatewayBoot({
 
         reconnectAttempt = 0
         reconnectFailingSince = null
+
         // A respawned backend re-mints (recycles) runtime ids, so any tile's
         // bound runtime id is now stale — drop them so each tile re-resumes.
         // A legacy remote primary has no registry identity to scope by; fall
         // back to preserving only Bot runtimes owned by provably-live
         // secondaries so the restarted backend's own tiles still rebind.
-        resetTileRuntimeBindings(
+        const invalidatedRuntimeIds = resetTileRuntimeBindings(
           primaryRuntimeConnectionId(conn) ?? { liveConnectionIds: liveSecondaryConnectionIds() }
         )
+
         // The status-stack poll guard latches session ids the OLD runtime
         // reported gone (4001). A respawned backend re-mints runtimes, so
         // those ids may be live again after re-resume — clear the latch with
         // the same lifetime as the runtime bindings it shadows.
-        resetBackgroundPollingGuard()
+        resetBackgroundPollingGuardForRuntimeIds(invalidatedRuntimeIds)
+
         // Same staleness, other half: pre-reconnect busy flags are keyed by
         // those dead runtime ids and would never receive their terminal
         // busy:false — clear them or the sidebar running arc lies forever

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -195,7 +195,12 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
 
       const isActiveEvent = !!sessionId && sessionId === activeSessionIdRef.current
 
-      const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
+      const replaySessionId = approvalReplaySessionId(
+        event.type,
+        activeSessionIdRef.current,
+        sessionId,
+        fromActiveSource()
+      )
 
       if (replaySessionId) {
         void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)

--- a/apps/desktop/src/lib/gateway-events.test.ts
+++ b/apps/desktop/src/lib/gateway-events.test.ts
@@ -9,6 +9,11 @@ describe('gateway event routing', () => {
     expect(approvalReplaySessionId('message.delta', 'active-1', 'routed-1')).toBeNull()
   })
 
+  it('does not cross-bind approval replay from a background gateway to the active socket', () => {
+    expect(approvalReplaySessionId('gateway.ready', 'active-1', null, false)).toBeNull()
+    expect(approvalReplaySessionId('session.info', 'active-1', 'background-runtime', false)).toBeNull()
+  })
+
   it('drops only unscoped subagent events (genuinely background work)', () => {
     expect(gatewayEventRequiresSessionId('subagent.progress')).toBe(true)
     expect(gatewayEventRequiresSessionId('subagent.start')).toBe(true)

--- a/apps/desktop/src/lib/gateway-events.ts
+++ b/apps/desktop/src/lib/gateway-events.ts
@@ -83,8 +83,16 @@ export interface GatewayEventSessionRoute {
 export function approvalReplaySessionId(
   eventType: string | undefined,
   activeSessionId: null | string,
-  routedSessionId: null | string
+  routedSessionId: null | string,
+  fromActiveSource = true
 ): null | string {
+  // The replay requester is the active gateway. A background profile's ready
+  // or session.info event cannot authorize sending its runtime id there: that
+  // cross-binds the poll to another backend and manufactures a 4001 loop.
+  if (!fromActiveSource) {
+    return null
+  }
+
   if (eventType === 'gateway.ready') {
     return activeSessionId
   }

--- a/apps/desktop/src/store/composer-status.test.ts
+++ b/apps/desktop/src/store/composer-status.test.ts
@@ -7,7 +7,8 @@ import {
   isSessionGoneForBackgroundPolling,
   reconcileBackgroundProcesses,
   refreshBackgroundProcesses,
-  resetBackgroundPollingGuard
+  resetBackgroundPollingGuard,
+  resetBackgroundPollingGuardForRuntimeIds
 } from './composer-status'
 import { $gateway } from './gateway'
 
@@ -294,7 +295,7 @@ describe('refreshBackgroundProcesses dead-session guard hardenings', () => {
     expect(isSessionGoneForBackgroundPolling(new JsonRpcGatewayError('session not found'))).toBe(true)
   })
 
-  it('a full guard reset (runtime re-mint) resumes polling every latched session', async () => {
+  it('a scoped runtime re-mint only resumes polling for that connection runtime', async () => {
     const request = vi.fn(async () => {
       throw new JsonRpcGatewayError('session not found', { code: 4001 })
     })
@@ -307,12 +308,13 @@ describe('refreshBackgroundProcesses dead-session guard hardenings', () => {
     await refreshBackgroundProcesses('sess-2')
     expect(request).toHaveBeenCalledTimes(2)
 
-    // Gateway reconnect re-mints runtimes: the no-arg reset (wired at the
-    // reconnect seams) must clear every latched id, not just one.
-    resetBackgroundPollingGuard()
+    // A secondary reconnect must only clear ids invalidated for that exact
+    // runtime scope. Clearing the whole set lets an unrelated reconnect wake
+    // every dead-session poller in the window.
+    resetBackgroundPollingGuardForRuntimeIds([SID])
     await refreshBackgroundProcesses(SID)
     await refreshBackgroundProcesses('sess-2')
 
-    expect(request).toHaveBeenCalledTimes(4)
+    expect(request).toHaveBeenCalledTimes(3)
   })
 })

--- a/apps/desktop/src/store/composer-status.ts
+++ b/apps/desktop/src/store/composer-status.ts
@@ -422,6 +422,15 @@ export function resetBackgroundPollingGuard(sid?: string): void {
   goneSessions.clear()
 }
 
+/** Re-enable polls only for runtime ids invalidated by the reconnecting
+ * gateway. A secondary reconnect must not wake dead pollers owned by every
+ * other connection in the window. */
+export function resetBackgroundPollingGuardForRuntimeIds(runtimeIds: Iterable<string>): void {
+  for (const runtimeId of runtimeIds) {
+    goneSessions.delete(runtimeId)
+  }
+}
+
 /** Pull the session's live process snapshot from the gateway. */
 export async function refreshBackgroundProcesses(sid: string): Promise<void> {
   const gateway = $gateway.get()

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -463,28 +463,27 @@ async function openSecondary(entry: Secondary): Promise<void> {
       try {
         const { reconcileBusyStatesOnReconnect, resetTileRuntimeBindings } = await import('@/store/session-states')
 
-        resetTileRuntimeBindings({
+        const invalidatedRuntimeIds = resetTileRuntimeBindings({
           connectionId: entry.connectionId || 'local',
           profile: entry.profile
         })
+
         reconcileBusyAfterOpen = () => reconcileBusyStatesOnReconnect(entry.scope)
+
+        // Clear only latches shadowing bindings from THIS runtime generation.
+        // A global clear lets one profile reconnect wake dead pollers owned by
+        // every other connection in the window.
+        void import('@/store/composer-status')
+          .then(({ resetBackgroundPollingGuardForRuntimeIds }) =>
+            resetBackgroundPollingGuardForRuntimeIds(invalidatedRuntimeIds)
+          )
+          .catch(() => {
+            // Best effort for partial test/HMR graphs, same as above.
+          })
       } catch {
         // Best effort for partial test/HMR graphs. Production always loads the
         // real store; a failed import must not make the transport unrecoverable.
       }
-
-      // Runtime re-mint also invalidates the status-stack gone-latch: ids
-      // the dead runtime 4001'd may be live again once tiles re-resume.
-      // Fire-and-forget: composer-status imports from this module, so the
-      // import must stay dynamic (cycle), and it must NOT sit on the timed
-      // redial path — awaiting the module load here pushed cold-start
-      // redials past test/waitFor budgets. The reset needs no ordering
-      // guarantee relative to the dial.
-      void import('@/store/composer-status')
-        .then(({ resetBackgroundPollingGuard }) => resetBackgroundPollingGuard())
-        .catch(() => {
-          // Best effort for partial test/HMR graphs, same as above.
-        })
     }
 
     // Registry-scoped entries dial through getConnectionFor when the bridge has

--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -173,7 +173,7 @@ describe('resetTileRuntimeBindings', () => {
       { runtimeId: 'runtime-session-dead', storedSessionId: 'stored-session' }
     ])
 
-    resetTileRuntimeBindings({ connectionId: 'barry', profile: 'oxcoder' })
+    const invalidatedRuntimeIds = resetTileRuntimeBindings({ connectionId: 'barry', profile: 'oxcoder' })
 
     const [barryBot, barrySibling, workBot, ordinarySession] = $sessionTiles.get()
 
@@ -187,6 +187,7 @@ describe('resetTileRuntimeBindings', () => {
     expect(ordinarySession).toMatchObject({ storedSessionId: 'stored-session' })
     expect(ordinarySession).not.toHaveProperty('runtimeId')
     expect(invalidateRuntimeBindings).toHaveBeenCalledWith(new Set(['stored-barry-sibling-bot', 'stored-work-bot']))
+    expect(invalidatedRuntimeIds).toEqual(new Set(['runtime-barry-dead', 'runtime-session-dead']))
   })
 
   it('unknown restarted identity preserves only Bot runtimes owned by provably-live connections', () => {

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -1120,7 +1120,7 @@ export interface UnknownRuntimeReconnectScope {
 
 export function resetTileRuntimeBindings(
   reconnectedScope?: null | string | RuntimeReconnectScope | UnknownRuntimeReconnectScope
-) {
+): Set<string> {
   const tiles = $sessionTiles.get()
 
   const liveConnectionIds =
@@ -1167,9 +1167,17 @@ export function resetTileRuntimeBindings(
 
   sessionTileDelegate()?.invalidateRuntimeBindings?.(preservedStoredIds)
 
-  if (tiles.some(tile => tile.runtimeId && !preservedStoredIds.has(tile.storedSessionId))) {
+  const invalidatedRuntimeIds = new Set(
+    tiles
+      .filter(tile => tile.runtimeId && !preservedStoredIds.has(tile.storedSessionId))
+      .map(tile => tile.runtimeId!)
+  )
+
+  if (invalidatedRuntimeIds.size > 0) {
     $sessionTiles.set(tiles.map(tile => (preservedStoredIds.has(tile.storedSessionId) ? tile : toStored(tile))))
   }
+
+  return invalidatedRuntimeIds
 }
 
 /** Unbind ONE reclaimed runtime from whichever tile holds it — the targeted


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop can keep background tabs bound to runtime sessions that a pooled backend already reaped. Reconnecting any secondary profile currently clears every dead-runtime polling latch, so unrelated tabs resume sending `approval.pending`, `process.list`, and read-only `slash.exec` calls that fail with 4001 and can flood logs for hours. This change scopes latch resets to the runtime IDs actually invalidated by the reconnecting gateway, prevents background gateway events from cross-binding approval replay to the active socket, and resumes then replays only explicitly idempotent session RPCs.

### Symptom

Affected tabs repeatedly send session-scoped RPCs against reaped runtime IDs. The gateway rejects them with `4001 session not found`, background polling continues after unrelated profile reconnects, and safe read-only commands can be dropped instead of replayed against a recovered runtime.

### Impact

Multi-profile Desktop users can accumulate thousands of rejection warnings, waste client and gateway work, and see read-only session commands appear to do nothing after a backend runtime is reaped.

### Bug Cause

**Trigger:** `apps/desktop/src/store/gateway.ts` / `openSecondary` and `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts` / primary reconnect.

**Causal chain:**
1. A backend reaps a runtime and a background poll receives 4001, latching that runtime ID as gone.
2. Any primary or secondary reconnect calls a global polling-guard reset, including reconnects for unrelated connection/profile scopes.
3. The next poll targets the same dead runtime, receives another 4001, and re-latches; repeated secondary reconnects sustain the cycle.
4. The shared session RPC dispatcher knows the durable session and exact owner route but returns the first 4001 without recovering safe read-only calls.

**Why it is wrong:** runtime IDs and their gone latches belong to one backend generation. A reconnect for one gateway cannot make another gateway's reaped runtime live again, and sending a background event's runtime ID through the active gateway cross-binds session identity.

**Working sibling / contrast:** fresh runtime rebinds already invalidate tile bindings by reconnect scope. Returning the invalidated runtime IDs lets the polling guard use the same scope instead of a process-wide clear.

**Ruled out:** transient transport failures are not latched or replayed. Recovery remains limited to the structured session-not-found path, and state-changing slash commands are deliberately excluded.

### Fix

- Return the exact invalidated runtime IDs from reconnect-time tile binding reset and clear only those polling latches.
- Ignore approval replay triggers from non-active gateway sources so background profile events cannot target the active socket.
- Resume and retry `approval.pending`, `process.list`, and `slash.exec` with exactly `goal status` once through the original owner route; leave state-changing slash commands untouched.
- Add regression coverage for scoped reconnects, cross-source approval events, exact owner routing, safe replay, and unsafe-command rejection.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session-states.ts` and `composer-status.ts` - carry exact invalidated runtime IDs into scoped polling-latch resets.
- `apps/desktop/src/store/gateway.ts` and `app/gateway/hooks/use-gateway-boot.ts` - apply scoped reset semantics to secondary and primary reconnects.
- `apps/desktop/src/app/contrib/session-rpc-dispatcher.ts` - recover and replay only explicitly idempotent stale-runtime RPCs on the original owner route.
- `apps/desktop/src/lib/gateway-events.ts` and the gateway event handler - suppress cross-source approval replay.
- Associated Vitest files - cover the reported multi-connection and replay failure modes.

## How to Test

1. Run the focused Desktop behavior suite:

```bash
cd apps/desktop
npx vitest run src/store/composer-status.test.ts src/store/session-states.test.ts src/app/contrib/session-rpc-dispatcher.test.ts src/store/gateway-connection-lifecycle.test.ts src/lib/gateway-events.test.ts
```

2. Run Desktop type checking:

```bash
cd apps/desktop
npm run typecheck
```

3. Run ESLint on the changed Desktop files.

Result: 103 focused tests pass; type checking and changed-file lint pass on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Desktop test entry and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior and invariants are documented in code
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no public architecture contract changed
- [x] I've considered cross-platform impact; the renderer logic is platform-independent and Windows behavior is covered locally
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed
