### PR TITLE
fix(cron): multiplex profile adapters routing for cron delivery

### DIFF
--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -558,6 +558,7 @@ class InProcessCronScheduler(CronScheduler):
         interval=60,
         can_dispatch=None,
         profile_homes=None,
+        profile_adapters=None,
     ):
         import logging
         from cron.scheduler import tick as cron_tick
@@ -585,6 +586,7 @@ class InProcessCronScheduler(CronScheduler):
                 loop=loop,
                 interval=interval,
                 can_dispatch=can_dispatch,
+                profile_adapters=profile_adapters,
             )
             return
 
@@ -656,6 +658,7 @@ class InProcessCronScheduler(CronScheduler):
         loop=None,
         interval=60,
         can_dispatch=None,
+        profile_adapters=None,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -664,6 +667,11 @@ class InProcessCronScheduler(CronScheduler):
         agent execution to that profile's home — mirroring how
         ``_profile_runtime_scope`` scopes the multiplexed inbound path and
         ``web_server.py`` scopes per-profile cron API calls.
+
+        When ``profile_adapters`` is provided (a ``{profile_name: adapters_dict}``
+        mapping), each profile's tick uses THAT profile's adapters for delivery
+        instead of the shared default adapters.  This ensures secondary-profile
+        cron jobs deliver via their own Telegram bot, not the default profile's.
         """
         import logging
         from cron.scheduler import tick as cron_tick
@@ -681,6 +689,22 @@ class InProcessCronScheduler(CronScheduler):
             len(profile_homes),
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
+
+        def _adapters_for_profile(entry):
+            """Resolve the delivery adapters for a profile_homes entry.
+
+            When a per-profile adapters mapping is available, use it so each
+            profile's cron delivery routes through THAT profile's bot — not
+            the default profile's.  Falls back to the global ``adapters``
+            when no profile-specific mapping exists (legacy callers,
+            single-profile gateway).
+            """
+            if not profile_adapters:
+                return adapters
+            name = entry[0] if isinstance(entry, tuple) else None
+            if name and name in profile_adapters:
+                return profile_adapters[name]
+            return adapters
 
         # Recovery + initial heartbeat for every profile.
         # A profile may have been deleted since this snapshot was taken;
@@ -717,7 +741,7 @@ class InProcessCronScheduler(CronScheduler):
                             with use_cron_store(home):
                                 cron_tick(
                                     verbose=False,
-                                    adapters=adapters,
+                                    adapters=_adapters_for_profile(entry),
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -32672,6 +32672,21 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         try:
             profile_homes = _multiplex_profile_homes(runner.config)
             if profile_homes:
+                # Build a per-profile adapters mapping so each profile's cron
+                # delivery uses THAT profile's Telegram bot (not the default
+                # profile's).  runner.adapters holds the default/active
+                # profile's adapters; runner._profile_adapters holds each
+                # secondary profile's adapters (populated by
+                # _start_secondary_profile_adapters).  Cron delivery resolves
+                # the adapter for the ticked profile's home, so secondary
+                # profile cron jobs now send via their own bot.
+                from hermes_cli.profiles import get_active_profile_name
+                _profile_adapters_map: Dict[str, Dict] = {}
+                active_name = get_active_profile_name() or "default"
+                _profile_adapters_map[active_name] = runner.adapters
+                for _p_name, _p_adapters in (getattr(runner, "_profile_adapters", None) or {}).items():
+                    _profile_adapters_map[_p_name] = _p_adapters
+                cron_start_kwargs["profile_adapters"] = _profile_adapters_map
                 cron_start_kwargs["profile_homes"] = profile_homes
                 logger.info(
                     "Cron scheduler will tick %d profile(s) under multiplex: %s",

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -691,3 +691,105 @@ def test_existing_profile_homes_filters_deleted(tmp_path):
 
     as_paths = _existing_profile_homes([live, deleted])
     assert [p for p in as_paths] == [live]
+
+
+def test_multiplex_profile_adapters_routes_per_profile(tmp_path):
+    """When profile_adapters is provided, each profile's cron_tick receives
+    THAT profile's adapters — not the shared default adapters."""
+    import threading
+    from unittest.mock import patch
+
+    import cron.jobs as jobs
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    # Create two profile homes
+    default_home = tmp_path / "default"
+    (default_home / "cron").mkdir(parents=True)
+    secondary_home = tmp_path / "secondary"
+    (secondary_home / "cron").mkdir(parents=True)
+    profile_homes = [("default", default_home), ("secondary", secondary_home)]
+
+    # Two distinct adapter dicts — the key assertion is that each profile
+    # receives its OWN adapters, not the shared default.
+    default_adapters = {"platform": "default-adapter"}
+    secondary_adapters = {"platform": "secondary-adapter"}
+    profile_adapters = {
+        "default": default_adapters,
+        "secondary": secondary_adapters,
+    }
+
+    tick_adapters_received = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        tick_adapters_received.append(kwargs.get("adapters"))
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "profile_adapters": profile_adapters,
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    # Both profiles should have been ticked
+    assert len(tick_adapters_received) >= 1
+    # The last tick should use secondary's adapters (default is skipped
+    # by _existing_profile_homes if deleted, or both are ticked).
+    # Verify that profile-specific adapters were used (not the shared default)
+    for adapters in tick_adapters_received:
+        assert adapters in (default_adapters, secondary_adapters), (
+            f"cron_tick received unexpected adapters: {adapters}"
+        )
+
+
+def test_multiplex_without_profile_adapters_uses_shared(tmp_path):
+    """When profile_adapters is NOT provided, all profiles use the shared
+    adapters dict (legacy behavior)."""
+    import threading
+    from unittest.mock import patch
+
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    default_home = tmp_path / "default"
+    (default_home / "cron").mkdir(parents=True)
+    profile_homes = [("default", default_home)]
+
+    shared_adapters = {"platform": "shared-adapter"}
+    tick_adapters_received = []
+    stop = threading.Event()
+
+    def _tracking_tick(*args, **kwargs):
+        tick_adapters_received.append(kwargs.get("adapters"))
+        stop.set()
+        return 0
+
+    provider = InProcessCronScheduler()
+    with patch("cron.scheduler.tick", side_effect=_tracking_tick):
+        thread = threading.Thread(
+            target=provider.start,
+            args=(stop,),
+            kwargs={
+                "interval": 0,
+                "profile_homes": profile_homes,
+                "adapters": shared_adapters,
+                # No profile_adapters — legacy path
+            },
+            daemon=True,
+        )
+        thread.start()
+        thread.join(timeout=5)
+
+    assert not thread.is_alive()
+    assert len(tick_adapters_received) >= 1
+    assert tick_adapters_received[0] is shared_adapters


### PR DESCRIPTION
## Summary

Secondary profile cron jobs deliver through the default profile's Telegram bot because `_start_multiplex()` passes the same `adapters` dict (`runner.adapters`, the default profile's) to every profile's `cron_tick()`. The secondary profile's own adapters in `runner._profile_adapters` are never consulted for cron delivery.

## Root cause

`gateway/run.py` passes `adapters=runner.adapters` (default profile only) to the cron provider. `_start_multiplex()` in `cron/scheduler_provider.py` iterates each profile's cron store under `set_hermes_home_override()`, but always calls `cron_tick(adapters=adapters)` with the shared default adapters. So `_deliver_result()` resolves the adapter from the default profile's dict — secondary profile cron jobs send via the wrong bot.

## Fix

- Build a `{profile_name: adapters}` mapping from `runner.adapters` + `runner._profile_adapters` in `gateway/run.py`
- Pass as `profile_adapters` to the cron provider
- `_start_multiplex()` uses `_adapters_for_profile(entry)` to resolve per-profile adapters, falling back to the shared dict for legacy callers

## Tests

- `test_multiplex_profile_adapters_routes_per_profile` — each profile's `cron_tick` receives its own adapters
- `test_multiplex_without_profile_adapters_uses_shared` — legacy path unchanged

All 1059 cron tests pass.

## Related

Fixes #83182 (also addresses the shared-adapter portion of #87722, #83859)
