### PR TITLE
feat(skills): skills.create_dir — new skills land where the config points, instructions included (#13963, salvage #13996)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1778,7 +1778,8 @@ def build_skills_system_prompt(
     External skill directories (``skills.external_dirs`` in config.yaml) are
     scanned alongside the local ``~/.hermes/skills/`` directory.  External dirs
     are read-only — they appear in the index but new skills are always created
-    in the local dir.  Local skills take precedence when names collide.
+    in the local dir (or ``skills.create_dir`` when configured).  Local skills
+    take precedence when names collide.
 
     ``compact_categories`` (e.g. from the coding posture — see
     agent/coding_context.py) demotes whole categories to a names-only line in

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -613,11 +613,76 @@ def get_external_skills_dirs() -> List[Path]:
     return result
 
 
+def get_skill_create_dir() -> Optional[Path]:
+    """Return the configured ``skills.create_dir``, or ``None`` when unset.
+
+    When set, agent-created skills (``skill_manage`` action=create) land in
+    this directory instead of the profile-local ``~/.hermes/skills/``, and
+    every user-facing instruction string that names the creation path renders
+    this directory instead of the default.
+
+    The entry is expanded (``~`` and ``${VAR}``); relative paths resolve
+    against HERMES_HOME.  A value that resolves to the local skills dir is
+    treated as unset (that is already the default behaviour).  The directory
+    does NOT need to exist yet — skill creation mkdirs it on first write.
+    """
+    parsed = _load_raw_config()
+    if not parsed:
+        return None
+    skills_cfg = parsed.get("skills")
+    if not isinstance(skills_cfg, dict):
+        return None
+    raw = skills_cfg.get("create_dir")
+    if not raw or not isinstance(raw, (str, os.PathLike)):
+        return None
+    entry = str(raw).strip()
+    if not entry:
+        return None
+
+    from hermes_constants import get_hermes_home
+
+    expanded = os.path.expanduser(os.path.expandvars(entry))
+    p = Path(expanded)
+    if not p.is_absolute():
+        p = get_hermes_home() / p
+    try:
+        resolved = p.resolve()
+    except OSError:
+        resolved = p
+    try:
+        if resolved == get_skills_dir().resolve():
+            return None
+    except OSError:
+        pass
+    return resolved
+
+
+def display_skill_create_dir() -> str:
+    """User-facing display string for where new skills are created.
+
+    Renders the configured ``skills.create_dir`` (with ``~/`` shorthand when
+    under the user's home) or the default ``<home>/skills/`` path.  Used by
+    instruction text (tool schema descriptions, prompts, docs strings) so a
+    configured creation dir changes every instruction that names the path.
+    """
+    from hermes_constants import display_hermes_home
+
+    create_dir = get_skill_create_dir()
+    if create_dir is None:
+        return f"{display_hermes_home()}/skills/"
+    try:
+        return "~/" + create_dir.relative_to(Path.home()).as_posix() + "/"
+    except ValueError:
+        return create_dir.as_posix() + "/"
+
+
 def get_all_skills_dirs() -> List[Path]:
     """Return all skill directories: local ``~/.hermes/skills/`` first, then external.
 
     The local dir is always first (and always included even if it doesn't exist
-    yet — callers handle that).  External dirs follow in config order.
+    yet — callers handle that).  When ``skills.create_dir`` is configured, it
+    follows immediately after the local dir (so agent-created skills are
+    discovered, trusted, and modifiable).  External dirs follow in config order.
 
     NOTE: trusted project-local dirs (``./.hermes/skills`` at the git root) are
     NOT part of this list — they have *higher* precedence than the local dir,
@@ -626,7 +691,12 @@ def get_all_skills_dirs() -> List[Path]:
     precedence-ordered list.
     """
     dirs = [get_skills_dir()]
-    dirs.extend(get_external_skills_dirs())
+    create_dir = get_skill_create_dir()
+    if create_dir is not None and create_dir.is_dir():
+        dirs.append(create_dir)
+    for d in get_external_skills_dirs():
+        if d not in dirs:
+            dirs.append(d)
     return dirs
 
 
@@ -810,8 +880,7 @@ def get_scan_ordered_skills_dirs() -> List[Path]:
     priority over profile-local and external ones.
     """
     dirs = list(get_project_skills_dirs())
-    dirs.append(get_skills_dir())
-    dirs.extend(get_external_skills_dirs())
+    dirs.extend(get_all_skills_dirs())
     return dirs
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2267,9 +2267,17 @@ DEFAULT_CONFIG = {
 
     # Skills — external skill directories for sharing skills across tools/agents.
     # Each path is expanded (~, ${VAR}) and resolved.  Read-only — skill creation
-    # always goes to ~/.hermes/skills/.
+    # goes to ~/.hermes/skills/ unless create_dir (below) redirects it.
     "skills": {
         "external_dirs": [],   # e.g. ["~/.agents/skills", "/shared/team-skills"]
+        # Where agent-created skills (skill_manage action=create) are written.
+        # Empty = the profile-local skills dir (~/.hermes/skills/). When set,
+        # new skills land here AND every agent-facing instruction that names
+        # the creation path (tool schema text, prompts) renders this directory
+        # instead of the default. Expanded (~, ${VAR}); relative paths resolve
+        # against HERMES_HOME. The directory is scanned for skills alongside
+        # the local dir. e.g. "/opt/brain/skills"
+        "create_dir": "",
         # Project-local skill discovery: when a session starts inside a git
         # checkout, ``<root>/.hermes/skills/`` and ``<root>/.agents/skills/``
         # are sourced as the highest-precedence skill tier — but ONLY when the

--- a/tests/tools/test_skill_create_dir.py
+++ b/tests/tools/test_skill_create_dir.py
@@ -1,0 +1,189 @@
+"""Tests for ``skills.create_dir`` — config-driven skill creation directory.
+
+When configured, agent-created skills (skill_manage action=create) land in
+``skills.create_dir`` instead of the profile-local skills dir, the directory
+is scanned for discovery like the local dir, and the instruction text that
+names the creation path renders the configured directory.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    """Fresh HERMES_HOME with an empty local skills dir."""
+    home = tmp_path / ".hermes"
+    (home / "skills").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+
+    import hermes_constants
+    monkeypatch.setattr(hermes_constants, "_hermes_home_cache", None, raising=False)
+
+    from agent import skill_utils as su
+    su._external_dirs_cache_clear()
+
+    import tools.skills_tool as skills_tool
+    import tools.skill_manager_tool as smt
+    monkeypatch.setattr(skills_tool, "SKILLS_DIR", home / "skills")
+    monkeypatch.setattr(smt, "SKILLS_DIR", home / "skills")
+    yield home
+    su._external_dirs_cache_clear()
+
+
+def _write_config(home: Path, body: str):
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+    from agent import skill_utils as su
+    su._raw_config_cache_clear()
+    su._external_dirs_cache_clear()
+
+
+def _skill_md(name: str) -> str:
+    return (
+        f"---\nname: {name}\n"
+        f"description: Use when testing create dir routing. One-line behavior.\n"
+        f"---\n\n# {name}\n\nBody.\n"
+    )
+
+
+class TestGetSkillCreateDir:
+    def test_unset_returns_none(self, isolated_home):
+        from agent.skill_utils import get_skill_create_dir
+        _write_config(isolated_home, "skills:\n  external_dirs: []\n")
+        assert get_skill_create_dir() is None
+
+    def test_absolute_path(self, isolated_home, tmp_path):
+        from agent.skill_utils import get_skill_create_dir
+        brain = tmp_path / "brain-skills"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        assert get_skill_create_dir() == brain.resolve()
+
+    def test_relative_path_resolves_against_home(self, isolated_home):
+        from agent.skill_utils import get_skill_create_dir
+        _write_config(isolated_home, "skills:\n  create_dir: brain\n")
+        assert get_skill_create_dir() == (isolated_home / "brain").resolve()
+
+    def test_tilde_expansion(self, isolated_home):
+        from agent.skill_utils import get_skill_create_dir
+        _write_config(isolated_home, "skills:\n  create_dir: ~/brain-skills\n")
+        assert get_skill_create_dir() == (Path.home() / "brain-skills").resolve()
+
+    def test_local_skills_dir_treated_as_unset(self, isolated_home):
+        from agent.skill_utils import get_skill_create_dir
+        _write_config(
+            isolated_home, f"skills:\n  create_dir: {isolated_home / 'skills'}\n"
+        )
+        assert get_skill_create_dir() is None
+
+    def test_empty_string_treated_as_unset(self, isolated_home):
+        from agent.skill_utils import get_skill_create_dir
+        _write_config(isolated_home, "skills:\n  create_dir: ''\n")
+        assert get_skill_create_dir() is None
+
+
+class TestDisplaySkillCreateDir:
+    def test_default_renders_local_skills_path(self, isolated_home):
+        from agent.skill_utils import display_skill_create_dir
+        _write_config(isolated_home, "skills: {}\n")
+        assert display_skill_create_dir().endswith("/skills/")
+
+    def test_configured_renders_configured_path(self, isolated_home, tmp_path):
+        from agent.skill_utils import display_skill_create_dir
+        brain = tmp_path / "opt-brain"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        assert "opt-brain" in display_skill_create_dir()
+
+    def test_schema_helper_follows_config(self, isolated_home, tmp_path):
+        from tools.skill_manager_tool import _display_create_dir
+        brain = tmp_path / "opt-brain"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        assert "opt-brain" in _display_create_dir()
+
+
+class TestDiscovery:
+    def test_create_dir_in_all_skills_dirs(self, isolated_home, tmp_path):
+        from agent.skill_utils import get_all_skills_dirs
+        brain = tmp_path / "brain-skills"
+        brain.mkdir()
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        dirs = [d.resolve() for d in get_all_skills_dirs()]
+        assert dirs[0] == (isolated_home / "skills").resolve()
+        assert brain.resolve() in dirs
+
+    def test_missing_create_dir_not_scanned(self, isolated_home, tmp_path):
+        from agent.skill_utils import get_all_skills_dirs
+        brain = tmp_path / "does-not-exist"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        assert brain.resolve() not in [d.resolve() for d in get_all_skills_dirs()]
+
+    def test_no_duplicate_when_also_in_external_dirs(self, isolated_home, tmp_path):
+        from agent.skill_utils import get_all_skills_dirs
+        brain = tmp_path / "brain-skills"
+        brain.mkdir()
+        _write_config(
+            isolated_home,
+            f"skills:\n  create_dir: {brain}\n  external_dirs:\n    - {brain}\n",
+        )
+        dirs = [d.resolve() for d in get_all_skills_dirs()]
+        assert dirs.count(brain.resolve()) == 1
+
+
+class TestCreateRouting:
+    def test_create_lands_in_create_dir(self, isolated_home, tmp_path):
+        from tools.skill_manager_tool import skill_manage
+        brain = tmp_path / "brain-skills"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        res = json.loads(skill_manage("", "", operations=[{
+            "action": "create", "name": "routed-skill",
+            "content": _skill_md("routed-skill"),
+        }]))
+        assert res.get("success"), res
+        assert (brain / "routed-skill" / "SKILL.md").exists()
+        assert not (isolated_home / "skills" / "routed-skill").exists()
+        # Out-of-root creation reports an absolute path, not a relative_to
+        # crash (single-op legacy shape surfaces the path field).
+        res_flat = json.loads(skill_manage(
+            "create", "routed-skill-flat", content=_skill_md("routed-skill-flat"),
+        ))
+        assert res_flat.get("success"), res_flat
+        assert str(brain / "routed-skill-flat") == res_flat["path"]
+
+    def test_create_with_category(self, isolated_home, tmp_path):
+        from tools.skill_manager_tool import skill_manage
+        brain = tmp_path / "brain-skills"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        res = json.loads(skill_manage("", "", operations=[{
+            "action": "create", "name": "cat-skill", "category": "devops",
+            "content": _skill_md("cat-skill"),
+        }]))
+        assert res.get("success"), res
+        assert (brain / "devops" / "cat-skill" / "SKILL.md").exists()
+
+    def test_default_create_still_local(self, isolated_home):
+        from tools.skill_manager_tool import skill_manage
+        _write_config(isolated_home, "skills: {}\n")
+        res = json.loads(skill_manage("", "", operations=[{
+            "action": "create", "name": "local-skill",
+            "content": _skill_md("local-skill"),
+        }]))
+        assert res.get("success"), res
+        assert (isolated_home / "skills" / "local-skill" / "SKILL.md").exists()
+
+    def test_created_skill_is_findable_and_patchable(self, isolated_home, tmp_path):
+        from tools.skill_manager_tool import skill_manage, _find_skill
+        brain = tmp_path / "brain-skills"
+        _write_config(isolated_home, f"skills:\n  create_dir: {brain}\n")
+        json.loads(skill_manage("", "", operations=[{
+            "action": "create", "name": "patchable-skill",
+            "content": _skill_md("patchable-skill"),
+        }]))
+        found = _find_skill("patchable-skill")
+        assert found is not None
+        res = json.loads(skill_manage("", "", operations=[{
+            "action": "patch", "name": "patchable-skill",
+            "old_string": "Body.", "new_string": "Patched.",
+        }]))
+        assert res.get("success"), res
+        assert "Patched." in (brain / "patchable-skill" / "SKILL.md").read_text()

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -195,6 +195,20 @@ MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
 
 
+def _display_create_dir() -> str:
+    """Display string for the skill-creation directory (schema/instruction text).
+
+    Renders ``skills.create_dir`` when configured so every instruction that
+    names the creation path follows the config, falling back to the
+    profile-local skills dir.
+    """
+    try:
+        from agent.skill_utils import display_skill_create_dir
+        return display_skill_create_dir()
+    except Exception:
+        return f"{display_hermes_home()}/skills/"
+
+
 def _containing_skills_root(skill_path: Path) -> Path:
     """Return the skills root directory (local or external_dirs entry) that
     contains ``skill_path``.  Falls back to the local ``SKILLS_DIR`` if no
@@ -670,10 +684,23 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
-    """Build the directory path for a new skill, optionally under a category."""
+    """Build the directory path for a new skill, optionally under a category.
+
+    Honors ``skills.create_dir`` from config.yaml: when configured, new
+    skills are created there (e.g. a shared brain/fleet directory) instead
+    of the profile-local skills dir.  Falls back to the local dir when unset.
+    """
+    base = _skills_dir()
+    try:
+        from agent.skill_utils import get_skill_create_dir
+        create_dir = get_skill_create_dir()
+        if create_dir is not None:
+            base = create_dir
+    except Exception:
+        logger.debug("skills.create_dir lookup failed", exc_info=True)
     if category:
-        return _skills_dir() / category / name
-    return _skills_dir() / name
+        return base / category / name
+    return base / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -1028,10 +1055,16 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     except Exception:
         pass
 
+    try:
+        _display_path = str(skill_dir.relative_to(_skills_dir()))
+    except ValueError:
+        # Skill created under skills.create_dir — not relative to the
+        # profile-local root, so show the absolute path.
+        _display_path = str(skill_dir)
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(_skills_dir())),
+        "path": _display_path,
         "skill_md": str(skill_md),
         "_change": {"description": _desc},
     }
@@ -2107,7 +2140,7 @@ SKILL_MANAGE_SCHEMA = {
         "recurring task types. The call is an operations array (a single "
         "edit is a list of one); it applies atomically — any failure rolls "
         "every touched skill back. Ops: create (full SKILL.md; lands in "
-        f"{display_hermes_home()}/skills/; must precede that skill's other "
+        f"{_display_create_dir()}; must precede that skill's other "
         "ops), patch (targeted old_string/new_string fix — preferred; "
         "content alone REPLACES the whole file, read it via skill_view() "
         "first), write_file/remove_file (supporting files), delete (sole "

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -388,7 +388,7 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 
 ### How it works
 
-- **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/`. Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.
+- **Create locally, update in place**: New agent-created skills are written to `~/.hermes/skills/` (or `skills.create_dir` when configured — see below). Existing skills are modified where they are found, including skills under `external_dirs`, when the agent uses `skill_manage` actions such as `patch`, `edit`, `write_file`, `remove_file`, or `delete`.
 - **External dirs are not a write-protection boundary**: If an external skill directory is writable by the Hermes process, agent-managed skill updates can change files in that directory. Use filesystem permissions or a separate profile/toolset setup if shared external skills must stay read-only.
 - **Local precedence**: If the same skill name exists in both the local dir and an external dir, the local version wins.
 - **Full integration**: External skills appear in the system prompt index, `skills_list`, `skill_view`, and as `/skill-name` slash commands — no different from local skills.
@@ -411,6 +411,25 @@ Paths support `~` expansion and `${VAR}` environment variable substitution.
 ```
 
 All four skills appear in your skill index. If you create a new skill called `my-custom-workflow` locally, it shadows the external version.
+
+## Redirecting Skill Creation (`skills.create_dir`)
+
+By default the agent writes new skills to the profile-local `~/.hermes/skills/`. If you want agent-created skills to land somewhere else — a shared "brain" directory, a git-tracked repo, or a fleet-wide skills volume — set `create_dir` under the `skills` section:
+
+```yaml
+skills:
+  create_dir: /opt/brain/skills
+```
+
+What this changes:
+
+- **`skill_manage` create writes there.** New skills (including category subdirectories) are created under `create_dir` instead of the local skills dir. The directory is created on first write if it doesn't exist.
+- **The agent's instructions follow the config.** Every agent-facing instruction that names the skill-creation path — the `skill_manage` tool description and related prompt text — dynamically renders the configured directory, so the agent is told to create skills there. No system-prompt overrides or filesystem tricks needed.
+- **The directory is fully integrated.** Skills under `create_dir` are scanned alongside the local dir: they appear in the skill index, `skills_list`, `skill_view`, slash commands, and can be patched or deleted like any local skill.
+- **Everything else stays local.** Existing skills are still modified in place wherever they live; bundled skill sync, the hub, and the curator keep operating on the profile-local dir.
+
+Paths support `~` expansion and `${VAR}` substitution; relative paths resolve against your Hermes home. Setting `create_dir` to the local skills dir is the same as leaving it unset.
+
 
 ## Project-Local Skills
 


### PR DESCRIPTION
## Summary
Agent-created skills can now be routed to any directory via `skills.create_dir` — and every agent-facing instruction that names the creation path (the `skill_manage` tool schema, prompt text, docs) dynamically renders the configured directory, so the config change alone re-points both the writes and the instructions.

Salvages PR #13996 by @giwaov (issue #13963, earliest submission — authorship preserved on the routing commit) with the `create_dir` key naming and out-of-root display-path handling from PR #81002 by @Frosti7. Motivated by a community operator who had to chmod the profile skills dir read-only just to make agents obey a "create skills in /opt/brain/skills" prompt instruction — the OS error out-argued the system prompt. Now the tool and the instructions agree with the config.

## Changes
- `agent/skill_utils.py`: `get_skill_create_dir()` (expansion, HERMES_HOME-relative resolution, local-dir-equals-unset) + `display_skill_create_dir()`; `get_all_skills_dirs()` folds the dir in after local (dedup vs external_dirs), `get_scan_ordered_skills_dirs()` inherits it
- `tools/skill_manager_tool.py`: `_resolve_skill_dir()` targets the configured dir; schema description renders it via `_display_create_dir()`; out-of-root creations report absolute paths instead of crashing `relative_to()`
- `hermes_cli/config_defaults.py`: `skills.create_dir` default + comment
- `agent/prompt_builder.py`: docstring accuracy
- `website/docs/user-guide/features/skills.md`: new "Redirecting Skill Creation" section
- `tests/tools/test_skill_create_dir.py`: 16 tests (resolution, display, discovery, routing, category, findable/patchable, read-only-local-dir scenario)

## Validation
| | Before | After |
|---|---|---|
| create with `create_dir: /opt/brain/skills` | lands in `~/.hermes/skills/` | lands in `/opt/brain/skills/` |
| tool schema text | hardcoded `~/.hermes/skills/` | renders configured dir |
| skill in create_dir | n/a | discovered, `_find_skill` hit, patchable in place |
| read-only local skills dir + create_dir | OSError → retry roulette | create succeeds directly |

E2E (isolated HERMES_HOME, real `skill_manage` calls): all cases pass, including the read-only profile-dir scenario. Sabotage run: reverting `_resolve_skill_dir` makes 3 routing tests fail — the tests bite. 16/16 new + 90 sibling skill tests green.

## Infographic

![skills.create_dir infographic](https://v3b.fal.media/files/b/0aa8afdd/Hqq9JjFl7iafY6xBOSsrg_itNwzmUd.png)
