### PR TITLE
fix(tools): list every protected target path in the approval card

### DIFF
--- a/tests/tools/test_file_write_safety.py
+++ b/tests/tools/test_file_write_safety.py
@@ -616,6 +616,67 @@ class TestProtectedInstructionFiles:
         assert agents.read_text(encoding="utf-8") == "rules\n"
         assert len(approvals["calls"]) == 1
 
+    def test_patch_v4a_duplicate_basenames_list_every_target(
+        self, tmp_path, approvals
+    ):
+        """#100361: a multi-file patch whose protected targets share a
+        basename must list every distinct path (and the count) in the one
+        approval card — not collapse to a single basename label."""
+        from tools.file_tools import patch_tool
+        import json
+        alpha = tmp_path / "profiles" / "alpha" / "SOUL.md"
+        beta = tmp_path / "profiles" / "beta" / "SOUL.md"
+        alpha.parent.mkdir(parents=True)
+        beta.parent.mkdir(parents=True)
+        alpha.write_text("be kind\n", encoding="utf-8")
+        beta.write_text("be honest\n", encoding="utf-8")
+        patch = (
+            "*** Begin Patch\n"
+            f"*** Update File: {alpha}\n"
+            "@@\n"
+            "-be kind\n"
+            "+be very kind\n"
+            f"*** Update File: {beta}\n"
+            "@@\n"
+            "-be honest\n"
+            "+be very honest\n"
+            "*** End Patch"
+        )
+        approvals["answer"] = "deny"
+        res = json.loads(patch_tool(mode="patch", patch=patch))
+        assert res.get("error") and "BLOCKED" in res["error"]
+        assert len(approvals["calls"]) == 1
+        call = approvals["calls"][0]
+        assert str(alpha) in call["command"], call["command"]
+        assert str(beta) in call["command"], call["command"]
+        assert "2 protected agent-instruction file(s)" in call["description"]
+        assert alpha.read_text(encoding="utf-8") == "be kind\n"
+        assert beta.read_text(encoding="utf-8") == "be honest\n"
+
+    def test_protected_reason_label_is_distinguishing(self, tmp_path):
+        """The reason label must carry the matched path, not the bare
+        basename, so distinct targets stay distinct after dedup."""
+        from tools.file_tools import _protected_instruction_reason
+        alpha = tmp_path / "profiles" / "alpha" / "SOUL.md"
+        label = _protected_instruction_reason(str(alpha))
+        assert label is not None
+        assert label != "SOUL.md"
+        assert "SOUL.md" in label
+        assert "alpha" in label
+
+    def test_protected_target_label_shortens_home(self, monkeypatch):
+        import tools.file_tools as ft
+        monkeypatch.setattr(
+            ft.os.path, "expanduser",
+            lambda p: "/home/tester" if p == "~" else p,
+        )
+        assert ft._protected_target_label(
+            "/home/tester/profiles/alpha/SOUL.md"
+        ) == "~/profiles/alpha/SOUL.md"
+        assert ft._protected_target_label(
+            "/srv/project/SOUL.md"
+        ) == "/srv/project/SOUL.md"
+
     def test_patch_v4a_approved_applies(self, tmp_path, approvals):
         from tools.file_tools import patch_tool
         import json

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -787,11 +787,25 @@ def _protected_instruction_config() -> tuple[bool, list[str]]:
     return enabled, [str(p) for p in extra if p]
 
 
+def _protected_target_label(path: str) -> str:
+    """Shorten a matched target path for approval display (``~/`` prefix)."""
+    home = os.path.expanduser("~")
+    if home and home != "/" and (
+            path == home or path.startswith(home + os.sep)):
+        return "~" + path[len(home):]
+    return path
+
+
 def _protected_instruction_reason(filepath: str, task_id: str = "default",
                                   *, enabled: bool | None = None,
                                   extra_patterns: list[str] | None = None) -> str | None:
-    """Return a short label when ``filepath`` targets a protected
+    """Return a distinguishing label when ``filepath`` targets a protected
     agent-instruction file, else ``None``.
+
+    The label carries the matched path (not just the basename) so that a
+    multi-file patch touching several protected files with the same
+    basename (e.g. one SOUL.md per profile) lists every distinct target
+    in the approval card instead of collapsing to one name (#100361).
 
     Matching runs on BOTH the normalized input path and its realpath so
     neither a symlink pointing AT a protected file (#41351) nor a protected
@@ -824,10 +838,10 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
         base = os.path.basename(candidate)
         base_lower = base.lower()
         if base_lower in _PROTECTED_INSTRUCTION_BASENAMES:
-            return base
+            return _protected_target_label(candidate)
         for pattern in extra_patterns:
             if fnmatch.fnmatch(base_lower, pattern.lower()):
-                return base
+                return _protected_target_label(candidate)
         # Project-local .hermes config dirs (e.g. <repo>/.hermes/config.yaml)
         # are loaded as project context and steer behavior the same way.
         # Scope: the file's IMMEDIATE parent must be ``.hermes`` — matching
@@ -836,7 +850,7 @@ def _protected_instruction_reason(filepath: str, task_id: str = "default",
         # hermes-agent repo itself at ~/.hermes/hermes-agent).
         parts = candidate.replace("\\", "/").rstrip("/").split("/")
         if len(parts) >= 2 and parts[-2] == ".hermes":
-            return candidate
+            return _protected_target_label(candidate)
     return None
 
 
@@ -852,7 +866,8 @@ def _request_protected_instruction_approval(
     """
     targets = ", ".join(dict.fromkeys(reasons))
     description = (
-        f"Write to protected agent-instruction file(s): {targets}. "
+        f"Write to {len(set(reasons))} protected agent-instruction "
+        f"file(s): {targets}. "
         "These files steer future agent behavior; approval is always "
         "required (not bypassed by auto-approve)."
     )


### PR DESCRIPTION
## What does this PR do?

The protected-instruction approval card collapses multi-file patches that touch protected instruction files sharing a basename (e.g. one `SOUL.md` per profile) into a single ambiguous label: an atomic patch over 24 distinct profile paths renders as just `<write to SOUL.md>`. Since this gate is intentionally one-operation-only and cannot be bypassed by `--yolo` or `approvals.mode: off`, meaningful consent requires the exact target scope (#100361).

`_protected_instruction_reason()` now returns the matched path (with the user's home directory shortened to `~/`) instead of the bare basename, so `_request_protected_instruction_approval()`'s `dict.fromkeys` dedup keeps every distinct target visible on every surface that renders the request (CLI panel, gateway buttons, Desktop/TUI all render the same description/command string). The description also states the distinct target count. Symlinked inputs still resolve to the real protected path, so they dedup to the correct target.

Gate semantics are unchanged: still fail-closed, one-operation approval, no session/permanent scope, no yolo bypass, deny applies nothing.

## Related Issue

Fixes #100361

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/file_tools.py` — added `_protected_target_label()` helper (privacy-safe `~/` shortening); `_protected_instruction_reason()` returns the matched path for basename matches, fnmatch extra-pattern matches, and project-local `.hermes` files instead of the bare basename; `_request_protected_instruction_approval()` states the distinct target count in the description.
- `tests/tools/test_file_write_safety.py` — regression tests: multi-file V4A patch over `profiles/alpha/SOUL.md` + `profiles/beta/SOUL.md` must list both distinct paths and the count in one approval card; reason label is distinguishing; home shortening.

## How to Test

1. `uv run pytest -o addopts= tests/tools/test_file_write_safety.py -q` → Observed result: **62 passed** (59 pre-existing + 3 new).
2. The new `test_patch_v4a_duplicate_basenames_list_every_target` submits one V4A patch over two `SOUL.md` files in different profile dirs and asserts the single approval card contains both full paths and `2 protected agent-instruction file(s)`; before the fix it rendered only `SOUL.md`.
3. `uv run pytest -o addopts= tests/cli/test_cli_approval_ui.py tests/gateway/test_tui_approval_redaction.py -q` → Observed result: **20 passed** (rendering surfaces unaffected).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites listed above all pass; two pre-existing failures in `tests/tools/test_file_tools.py` (`test_writes_content`, `test_replace_mode_calls_patch_replace`) reproduce on a clean upstream/main checkout without this change and are unrelated to it
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (function docstring updated in place)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — path labels use `os.sep`-agnostic startswith on the expanded home; no new path parsing
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (approval card rendering only)

## For New Skills

N/A

## Screenshots / Logs

```
$ pytest -o addopts= tests/tools/test_file_write_safety.py -q
62 passed, 6 warnings in 4.50s
```
