### PR TITLE
fix: recognize hermes.upstream entrypoint in gateway cmdline matcher

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -328,9 +328,12 @@ def _gateway_command_subcommand(command: str | None) -> str | None:
     if any(b in ("hermes-gateway", "hermes-gateway.exe") for b in basenames):
         return "run"
     joined = " ".join(tokens)
-    if "hermes_cli.main" not in joined and "hermes_cli/main.py" not in joined and not any(
-        b in ("hermes", "hermes.exe") for b in basenames
-    ):
+    has_gateway_entry = (
+        "hermes_cli.main" in joined
+        or "hermes_cli/main.py" in joined
+        or any(t.rsplit("/", 1)[-1] in ("hermes", "hermes.exe", "hermes.upstream") for t in tokens)
+    )
+    if not has_gateway_entry:
         return None
     # Drop --profile X / -p X / --profile=X / -p=X (consumes a VALUE of "gateway" too).
     filtered: list[str] = []

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -61,7 +61,10 @@ def test_accepts_real_gateway_run(cmd):
 def test_accepts_docker_hermes_upstream_entrypoint():
     # Docker (s6) images v0.21.0+ launch the gateway via the `hermes.upstream`
     # console script; its basename must count as a Hermes gateway entrypoint.
-    assert matches_runtime(
+    # Positive case via the same strict `matches` helper the other tests use
+    # (consistency + it guards the real dashboard liveness path,
+    # `_looks_like_gateway_process`).
+    assert matches(
         "/opt/hermes/.venv/bin/hermes.upstream gateway run --replace"
     ) is True
     # `gateway status` is a management subcommand and must stay rejected.

--- a/tests/gateway/test_gateway_command_line_matcher.py
+++ b/tests/gateway/test_gateway_command_line_matcher.py
@@ -58,3 +58,11 @@ def test_accepts_real_gateway_run(cmd):
     assert matches(cmd) is True
 
 
+def test_accepts_docker_hermes_upstream_entrypoint():
+    # Docker (s6) images v0.21.0+ launch the gateway via the `hermes.upstream`
+    # console script; its basename must count as a Hermes gateway entrypoint.
+    assert matches_runtime(
+        "/opt/hermes/.venv/bin/hermes.upstream gateway run --replace"
+    ) is True
+    # `gateway status` is a management subcommand and must stay rejected.
+    assert matches("hermes.upstream gateway status") is False


### PR DESCRIPTION
## Problem

On Docker (s6) deployments of Hermes v0.21.0+, the dashboard shows the gateway as `stopped` (`/api/status` returns `gateway_state: "stopped"`, `gateway_running: false`) while the gateway is actually alive and serving traffic.

## Root cause

The Docker image launches the gateway as:

```
/opt/hermes/.venv/bin/python3 /opt/hermes/.venv/bin/hermes.upstream gateway run --replace
```

`_gateway_command_subcommand()` in `gateway/status.py` tokenizes the command line and recognizes Hermes entrypoints by basename — but the accepted set is only `hermes` / `hermes.exe` (plus `hermes-gateway` / `gateway/run.py`). The `hermes.upstream` binary used by the Docker image is not in the set, so `looks_like_gateway_runtime_command_line()` returns `False` for the live gateway process, `get_running_pid()`/liveness checks fail, and the dashboard reports the gateway as stopped. No `gateway.pid` file exists in the container, so the dashboard fully relies on `gateway_state.json` + this cmdline matcher.

## Fix

One line: add the `hermes.upstream` basename to the entrypoint set in `_gateway_command_subcommand()`.

## Verification

- Live Docker deployment (v0.21.0): dashboard `/api/status` flipped `gateway_running` from `false` → `true` after applying this patch and restarting the gateway.
- New regression test: `tests/gateway/test_gateway_command_line_matcher.py::test_accepts_docker_hermes_upstream_entrypoint` — asserts the docker-style `hermes.upstream gateway run --replace` cmdline matches, and that `hermes.upstream gateway status` (a management subcommand) stays rejected.
- Test run: `python -m pytest tests/gateway/test_gateway_command_line_matcher.py -o 'addopts=' -q` → **18 passed** (and `tests/gateway/test_status.py` → 74 passed, 2 skipped). New test confirmed to fail without the fix.

## Environment

Hermes 0.21.0, Docker s6 container (release 2026.8.31).