### PR TITLE
fix(acp): resolve reasoning_effort from config for ACP sessions

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -684,6 +684,26 @@ class SessionManager:
         except Exception:
             logger.debug("ACP: bounded MCP discovery wait failed", exc_info=True)
 
+        # Resolve reasoning effort through the shared chokepoint so ACP
+        # sessions (OpenDesign, Zed) honor ``agent.reasoning_effort`` /
+        # ``agent.reasoning_overrides`` from config.yaml — same contract as
+        # the CLI and TUI surfaces (see their resolve_reasoning_config call
+        # sites).  Without this, ACP sessions silently ran on the provider's
+        # server default (Z.AI GLM: below max) regardless of config.
+        try:
+            from hermes_constants import resolve_reasoning_config
+
+            kwargs["reasoning_config"] = resolve_reasoning_config(
+                config, str(kwargs.get("model") or "")
+            )
+            logger.info(
+                "ACP: reasoning_config resolved for %s: %s",
+                kwargs.get("model"),
+                kwargs["reasoning_config"],
+            )
+        except Exception:
+            logger.debug("ACP: could not resolve reasoning_config from config", exc_info=True)
+
         agent = AIAgent(**kwargs)
         # Codex app-server sessions are spawned lazily on the first turn. Stamp
         # the ACP workspace onto the agent so the Codex runtime starts from the

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -120,6 +120,106 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_id"] == "acp-session"
 
 
+def test_acp_real_agent_resolves_reasoning_config_from_config(monkeypatch):
+    """ACP sessions honor ``agent.reasoning_effort`` from config.yaml.
+
+    Parity with the CLI/TUI surfaces: _make_agent must resolve the effort
+    through the shared chokepoint and hand it to AIAgent, otherwise ACP
+    clients (Zed, OpenDesign) silently run on the provider's server default
+    regardless of the user's configured reasoning level.
+    """
+    captured = {}
+
+    class CapturingAgent(FakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    def mod(name, **attrs):
+        module = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {
+            "model": {"default": "m", "provider": "p"},
+            "agent": {"reasoning_effort": "max"},
+        }),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "base_url": "u",
+                "api_key": "k",
+                "command": None,
+                "args": [],
+            },
+        ),
+    )
+
+    manager = SessionManager(db=NoopDb())
+    agent = manager._make_agent(session_id="acp-session", cwd=".")
+
+    assert isinstance(agent, CapturingAgent)
+    assert captured["reasoning_config"] == {"enabled": True, "effort": "max"}
+
+
+def test_acp_real_agent_reasoning_config_absent_when_unset(monkeypatch):
+    """No ``agent.reasoning_effort`` in config → AIAgent gets None and the
+    provider default applies, exactly as before the fix."""
+    captured = {}
+
+    class CapturingAgent(FakeAgent):
+        def __init__(self, **kwargs):
+            super().__init__()
+            captured.update(kwargs)
+
+    def mod(name, **attrs):
+        module = ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=CapturingAgent))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {
+            "model": {"default": "m", "provider": "p"},
+        }),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "base_url": "u",
+                "api_key": "k",
+                "command": None,
+                "args": [],
+            },
+        ),
+    )
+
+    manager = SessionManager(db=NoopDb())
+    agent = manager._make_agent(session_id="acp-session", cwd=".")
+
+    assert isinstance(agent, CapturingAgent)
+    assert captured["reasoning_config"] is None
+
+
 @pytest.mark.asyncio
 async def test_acp_steer_slash_command_injects_into_running_agent():
     acp_agent, state, fake, _conn = make_agent_and_state()


### PR DESCRIPTION
## What does this PR do?

ACP sessions (`hermes acp` — used by Zed, OpenDesign, and other ACP clients) built their agent with `reasoning_config=None`, so `agent.reasoning_effort` from `config.yaml` never reached the model. The CLI (`cli.py`) and TUI Gateway (`tui_gateway/server.py`) both resolve reasoning effort through the shared chokepoint `hermes_constants.resolve_reasoning_config()`; the ACP adapter was the one surface that skipped it, despite the chokepoint's docstring claiming "shared by every surface".

The result was that ACP users' configured reasoning level was silently ignored — sessions ran on the **provider's server default** instead. Measured on the Z.AI coding endpoint with glm-5.3: server default emits ~50–90 reasoning tokens on a fixed probe prompt vs ~140–190 with `effort: max`, so the gap is real and user-visible (shallower reasoning than configured, plus silently different cost).

**The fix:** `SessionManager._make_agent()` now resolves the effort through `resolve_reasoning_config(config, model)` and passes it to `AIAgent`. One call site covers both `session/new` and `set_session_model` (model switches), since both build agents through `_make_agent`. When no `agent.reasoning_effort` is configured, `reasoning_config` stays `None` and the provider default applies exactly as before — no behavior change for users who never set the key.

This restores config parity only; interactive per-session effort control in ACP remains covered by the approach discussed in #18326 / #18956.

## Related Issue

Fixes #78229 (config-default half: ACP sessions now honor `agent.reasoning_effort`)
Refs #18326, #85153

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `acp_adapter/session.py` — `_make_agent()`: resolve `reasoning_config` via `resolve_reasoning_config()` (shared chokepoint, per-model override > global `agent.reasoning_effort`) and pass it to `AIAgent(**kwargs)`; wrapped in try/except so a config-load failure can never block session creation (falls back to prior behavior)
- `tests/acp_adapter/test_acp_commands.py` — two tests following the existing `test_acp_real_agent_gets_session_db_for_recall` pattern:
  - config with `agent.reasoning_effort: max` → AIAgent receives `{"enabled": True, "effort": "max"}`
  - config without the key → AIAgent receives `None` (provider default, unchanged behavior)

## How to Test

1. Set `agent.reasoning_effort: max` in `~/.hermes/config.yaml`, connect any ACP client (e.g. Zed) and start a session — before this PR the wire request carried no `reasoning_effort`; after, the provider receives the configured level (a log line `ACP: reasoning_config resolved for <model>: {...}` is emitted at session creation)
2. `pytest tests/acp_adapter/test_acp_commands.py -o 'addopts=' -q` → 5 passed (3 pre-existing + 2 new)
3. Verified end-to-end locally against `hermes acp` with a raw JSON-RPC handshake (initialize → session/new): the resolved config appears in the session log for both `glm-5.3` and `glm-5.3-flash`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.3.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no new config keys; `agent.reasoning_effort` semantics unchanged, now honored on the ACP surface as documented)
- [x] I've updated `cli-config.yaml.example` — N/A (no config key changes)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — N/A (pure Python config resolution, no platform-specific I/O)
- [x] I've updated tool descriptions/schemas — N/A

---

### Test-suite notes for reviewers

- `tests/acp_adapter/` + `tests/acp/`: fully green including the new tests.
- Broader local runs of `tests/agent/` show ~225 pre-existing failures/flakes on this machine (a live Hermes gateway/desktop runs alongside, disturbing port- and timing-sensitive tests). Verified as **not caused by this PR**: clean `main` via a throwaway worktree fails the same set (227 there vs 225 here — the 2-test delta is timer-sensitive flakes passing/failing between runs). Diff of failing test IDs between `main` and this branch is empty in the "new failures" direction. The affected modules (aux routing, image routing, file safety, memory sync, etc.) share no code paths with this change.
