### PR TITLE
fix(delegate): bound reasoning children without stale false-kills

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1080,6 +1080,27 @@ def _resolve_direct_stale_timeout(agent, api_kwargs: dict) -> float:
     return float(value)
 
 
+def _is_reasoning_subagent(agent, api_kwargs: dict) -> bool:
+    """Return whether a delegated child is doing pre-response reasoning.
+
+    A non-streaming reasoning request has no observable bytes while the model
+    thinks.  The direct-call watchdog measures that silence, so it cannot
+    distinguish healthy reasoning from a hung provider.  Keep this exception
+    scoped to delegated children: their owner controls the child lifetime,
+    while cron and interactive calls retain the existing stale bound.
+    """
+    if getattr(agent, "platform", None) != "subagent":
+        return False
+    model = api_kwargs.get("model") or getattr(agent, "model", None)
+    try:
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+        return get_reasoning_stale_timeout_floor(model) is not None
+    except Exception:
+        # A classification failure must not silently weaken the watchdog.
+        return False
+
+
 def _inline_nonstream_hard_timeout(stale_timeout: float):
     """Socket-level backstop for inline non-streaming calls (#85252).
 
@@ -1246,6 +1267,16 @@ def direct_api_call(agent, api_kwargs: dict):
     # stalls from the stall monitor.
     call_start = time.time()
     stale_timeout = _resolve_direct_stale_timeout(agent, api_kwargs)
+    if _is_reasoning_subagent(agent, api_kwargs):
+        # Non-streaming reasoning is silent by design until the complete
+        # response arrives.  Its delegated owner supplies the overall child
+        # lifetime; this watchdog is only valid for provider silence that can
+        # be observed as a stale response on non-reasoning calls.
+        logger.debug(
+            "Deferring direct stale watchdog for delegated reasoning model %s",
+            api_kwargs.get("model") or getattr(agent, "model", ""),
+        )
+        stale_timeout = float("inf")
     # Do not override an explicit per-call timeout (provider config /
     # transport already set one). Otherwise pin read=stale_timeout so a
     # no-op stranger-thread abort cannot leave the keepalive client's

--- a/tests/cron/test_cron_direct_api_call_watchdog.py
+++ b/tests/cron/test_cron_direct_api_call_watchdog.py
@@ -143,6 +143,77 @@ def test_healthy_call_is_untouched_by_the_watchdog():
     )
 
 
+def test_reasoning_subagent_can_finish_after_direct_stale_budget():
+    """Reasoning before a non-stream response is not provider staleness.
+
+    The delegation owner has its own overall child lifetime; the direct-call
+    stale watchdog must not kill a recognized reasoning model merely because
+    its first response byte arrives after the generic stale budget.
+    """
+    agent = _make_agent(stale_timeout=0.05, platform="subagent")
+    agent.model = "openai/o3-mini"
+    fake_client = MagicMock()
+
+    def _reasoning_wait(**_kwargs):
+        time.sleep(0.2)  # beyond stale budget, within the child lifetime
+        return SimpleNamespace(id="reasoned")
+
+    fake_client.chat.completions.create.side_effect = _reasoning_wait
+    agent._create_request_openai_client.return_value = fake_client
+
+    assert direct_api_call(
+        agent, {"model": agent.model, "messages": []}
+    ).id == "reasoned"
+    agent._abort_request_openai_client.assert_not_called()
+
+
+def test_non_reasoning_subagent_still_kills_a_silent_provider():
+    """Reasoning exceptions must not weaken the normal silent-hang bound."""
+    agent = _make_agent(stale_timeout=0.05, platform="subagent")
+    agent.model = "openai/gpt-4o"
+    _stalling_client(agent, aborted=[], release_after=1.0)
+
+    with pytest.raises(TimeoutError):
+        direct_api_call(
+            agent, {"model": agent.model, "messages": []}
+        )
+
+
+def test_reasoning_child_has_finite_owner_bound_without_global_child_cap(monkeypatch):
+    from tools import delegate_tool
+
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.delenv("DELEGATION_CHILD_TIMEOUT_SECONDS", raising=False)
+    child = SimpleNamespace(platform="subagent", model="openai/o3-mini")
+
+    assert delegate_tool._resolve_child_timeout(child) == 1800.0
+
+
+def test_reasoning_child_honors_explicit_timeout_override_or_opt_out(monkeypatch):
+    from tools import delegate_tool
+
+    child = SimpleNamespace(platform="subagent", model="openai/o3-mini")
+    monkeypatch.setattr(
+        delegate_tool, "_load_config", lambda: {"child_timeout_seconds": 90}
+    )
+    assert delegate_tool._resolve_child_timeout(child) == 90.0
+
+    monkeypatch.setattr(
+        delegate_tool, "_load_config", lambda: {"child_timeout_seconds": 0}
+    )
+    assert delegate_tool._resolve_child_timeout(child) is None
+
+
+def test_non_reasoning_child_keeps_unconfigured_timeout_behavior(monkeypatch):
+    from tools import delegate_tool
+
+    monkeypatch.setattr(delegate_tool, "_load_config", lambda: {})
+    monkeypatch.delenv("DELEGATION_CHILD_TIMEOUT_SECONDS", raising=False)
+    child = SimpleNamespace(platform="subagent", model="openai/gpt-4o")
+
+    assert delegate_tool._resolve_child_timeout(child) is None
+
+
 def test_local_endpoint_infinite_budget_leaves_the_watchdog_disarmed():
     """``_compute_non_stream_stale_timeout`` returns inf for a local endpoint
     on the implicit default — that opt-out must survive on this path too."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -992,13 +992,10 @@ def _get_child_timeout() -> Optional[float]:
     before being cut off, or ``None`` when no wall-clock cap applies.
 
     Default: ``None`` (no timeout). Subagents doing legitimate heavy work
-    (deep code review, large research fan-outs, slow reasoning models) were
-    routinely killed mid-task by the old blanket cap even though they were
-    making steady progress. Failures should come from what the child is
-    actually doing — API errors, tool errors, iteration budget — not from a
-    generic delegation-level stopwatch. Stuck-child protection is handled
-    separately by the heartbeat staleness monitor, which stops refreshing
-    parent activity so the gateway inactivity timeout can fire.
+    (deep code review, large research fan-outs, slow reasoning models) are not
+    globally killed by a generic delegation stopwatch. Reasoning children are
+    given a separate generous bound at the execution seam below, because
+    their direct provider watchdog is intentionally deferred.
 
     Set ``delegation.child_timeout_seconds`` to a positive number to opt back
     in to a hard cap (floor 30 s); ``0`` or a negative value means disabled.
@@ -1025,6 +1022,53 @@ def _get_child_timeout() -> Optional[float]:
         else:
             return None if parsed <= 0 else max(30.0, parsed)
     return DEFAULT_CHILD_TIMEOUT
+
+
+# Reasoning models can legitimately spend several minutes before a
+# non-streaming response produces its first byte.  Keep their overall owner
+# bound generous while leaving ordinary child behavior unchanged.
+DEFAULT_REASONING_CHILD_TIMEOUT = 1800.0
+
+
+def _child_timeout_explicitly_disabled() -> bool:
+    """Return True when config explicitly opts out of the child cap."""
+    cfg = _load_config()
+    raw = cfg.get("child_timeout_seconds")
+    if raw is not None:
+        try:
+            return float(raw) <= 0
+        except (TypeError, ValueError):
+            pass
+    raw = os.getenv("DELEGATION_CHILD_TIMEOUT_SECONDS")
+    if raw:
+        try:
+            return float(raw) <= 0
+        except (TypeError, ValueError):
+            pass
+    return False
+
+
+def _is_reasoning_child(child: Any) -> bool:
+    """Use the shared reasoning classification for a delegated child."""
+    if getattr(child, "platform", None) != "subagent":
+        return False
+    model = getattr(child, "model", None)
+    try:
+        from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
+
+        return get_reasoning_stale_timeout_floor(model) is not None
+    except Exception:
+        return False
+
+
+def _resolve_child_timeout(child: Any) -> Optional[float]:
+    """Resolve the owner bound without changing ordinary child semantics."""
+    configured = _get_child_timeout()
+    if configured is not None:
+        return configured
+    if _child_timeout_explicitly_disabled() or not _is_reasoning_child(child):
+        return None
+    return DEFAULT_REASONING_CHILD_TIMEOUT
 
 
 def _get_max_spawn_depth() -> int:
@@ -1159,11 +1203,10 @@ _SUMMARY_HEADROOM_FRACTION = 0.5
 # Floor so a single summary always gets a usable slice even when the parent is
 # already nearly full — below this we'd be truncating to noise.
 _MIN_SUMMARY_CHARS = 2000
-# No default wall-clock cap on child agents: legitimate heavy subagent work
-# (deep reviews, research fan-outs, slow reasoning models) was being killed
-# mid-task. Errors should come from what the child actually does; stuck-child
-# detection lives in the heartbeat staleness monitor below. Users can opt back
-# in via delegation.child_timeout_seconds.
+# No default wall-clock cap on ordinary child agents. Recognized reasoning
+# children use DEFAULT_REASONING_CHILD_TIMEOUT only at their execution seam,
+# where the direct non-stream watchdog is deferred. Users can override that
+# with delegation.child_timeout_seconds, or explicitly disable it with <= 0.
 DEFAULT_CHILD_TIMEOUT: Optional[float] = None
 _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during delegation
 # Stale-heartbeat thresholds. A child with no observable progress is either:
@@ -1179,7 +1222,8 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 # no activity doesn't mask the gateway timeout. The in-tool ceiling is much
 # higher so legit long-running tools get time to finish;
 # delegation.child_timeout_seconds (off by default) remains an optional hard
-# cap for users who want one.
+# cap for users who want one; reasoning children receive a finite default
+# because their provider stale watchdog is deferred.
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
@@ -2914,10 +2958,11 @@ def _run_single_child(
             list(file_state.known_reads(parent_task_id)) if parent_task_id else []
         )
 
-        # Run child with an optional hard timeout (off by default —
-        # result(timeout=None) blocks until the child finishes). Stuck-child
-        # protection comes from the heartbeat staleness monitor instead.
-        child_timeout = _get_child_timeout()
+        # Run ordinary children with the optional configured hard timeout;
+        # recognized reasoning children receive the finite default resolved
+        # above because their direct provider watchdog is deferred. Stuck-
+        # child protection for all other cases remains the heartbeat monitor.
+        child_timeout = _resolve_child_timeout(child)
         # Daemon worker (tools.daemon_pool): a timed-out child is abandoned
         # below; a stdlib non-daemon worker would then block interpreter
         # exit at atexit-join time if the child never unwinds.


### PR DESCRIPTION
Fixes #100260.

## User-visible behavior
Delegated reasoning children are no longer killed by the non-stream stale watchdog during normal pre-response thinking. The child result can return to the owning conversation after a long reasoning phase, while non-reasoning silent providers retain the existing stale kill behavior.

## Design
- Scope the stale-watchdog deferral to delegated children whose model matches the existing reasoning-model classification.
- Keep cron and non-reasoning behavior unchanged.
- Apply a finite 1800-second owner-level child bound only when no explicit child timeout is configured; positive overrides remain authoritative and an explicit non-positive opt-out remains supported.
- No new gate, database, schema, hook, or provider dependency.

## Validation
- 60 focused regression tests passed through the repository test runner.
- One delegated lifecycle exercise completed through child execution and the direct API path, returning the result after the stale threshold without an abort. This deterministic lifecycle exercise used a fake provider to reproduce the timing boundary.
- Post-PR natural verification was observed once using the candidate commit c29fa2abea875255ebfe8da898aca26f2796b869 imported by the parent surface, with the existing Copilot provider and gpt-5.3-codex model: exactly one parent delegate_task call launched exactly one child; the child returned; the parent produced a final response on the same surface; elapsed time was approximately 21.7 seconds; retry count was 0; no repository, Git, configuration, installation, service, or credential mutation occurred; failure category was NONE.

A real-provider exercise is therefore observed once. Continuous runtime behavior, installation/runtime adoption, general end-user acceptance, and broader provider coverage remain unclaimed.