### PR TITLE
fix(auth): stop cloned Anthropic OAuth from stranding sibling profiles

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -36,7 +36,7 @@ from collections import OrderedDict
 from pathlib import Path
 from typing import Any, Dict, Optional
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root, get_hermes_home
 from agent.secret_scope import get_secret as _get_secret
 
 logger = logging.getLogger(__name__)
@@ -726,50 +726,29 @@ def _prefer_refreshable_claude_code_token(env_token: str, creds: Optional[Dict[s
     return None
 
 
-def _resolve_anthropic_pool_token() -> Optional[str]:
+def _resolve_anthropic_pool_token(*, refresh_expired: bool = False) -> Optional[str]:
     """Return the first available Anthropic OAuth token from credential_pool.
 
-    Read-only: enumerates with ``clear_expired=False, refresh=False`` so a bare
-    token *resolve* (which runs from diagnostic/read-only call sites such as
-    ``account_usage`` and ``hermes models``) never mutates ``~/.hermes/auth.json``
-    or makes a network refresh call. Refresh-on-expiry is owned by the API call
-    path's pool recovery, not the resolver.
+    By default this is read-only: it enumerates with ``clear_expired=False,
+    refresh=False`` so diagnostic/read-only call sites can inspect the pool
+    without mutating ``auth.json`` or making a network refresh call.
+
+    Agent init / runtime resolution pass ``refresh_expired=True`` because an
+    expired pool-owned OAuth row can still be recovered via its refresh
+    token, and init happens before the API-call path's pool recovery can run
+    (#100339).
     """
     try:
         from agent.credential_pool import AUTH_TYPE_OAUTH, load_pool
     except Exception:
         return None
 
-    try:
-        pool = load_pool("anthropic")
-        # Enumerate read-only (clear_expired=False, refresh=False): never persist
-        # to auth.json or trigger a network refresh from a bare resolve. select()
-        # is deliberately NOT used — it runs clear_expired=True, refresh=True,
-        # which would violate this read-only contract.
-        entries, _pending = pool._available_entries(clear_expired=False, refresh=False)
-    except Exception:
-        logger.debug("Failed to read Anthropic credential_pool", exc_info=True)
-        return None
-
-    for entry in entries:
+    def _usable_oauth_token(entry: Any) -> Optional[str]:
         if getattr(entry, "auth_type", None) != AUTH_TYPE_OAUTH:
-            continue
-        # access_token is a declared field but a persisted entry can carry an
-        # explicit null (or a partially-written OAuth entry), so coerce before
-        # strip — a bare None.strip() here would escape the try/excepts above
-        # and crash the whole resolver, taking down the source #5 fallback too.
-        # Matches the aux-client analog (auxiliary_client.py: str(key or "")).
+            return None
         token = (getattr(entry, "access_token", None) or "").strip()
         if not token:
-            continue
-        # ``load_pool()`` re-seeds pool rows from the singleton files, so a
-        # rotation that was consumed upstream but never committed comes back
-        # here looking healthy.  Enumeration is deliberately read-only
-        # (refresh=False), which means nothing on this path would otherwise
-        # notice that the credential is spent.  Singleton-backed sources also
-        # consult the durable sidecar registry: the failed commit may have
-        # happened in a DIFFERENT process, whose process-local verdict this
-        # interpreter never saw.
+            return None
         entry_source_path = spent_rotation_source_path(getattr(entry, "source", None))
         if is_rotation_consumed_uncommitted(
             token, source_path=entry_source_path
@@ -780,8 +759,38 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
                 "Skipping Anthropic pool entry %s: rotated-but-uncommitted credential",
                 getattr(entry, "id", "?"),
             )
-            continue
+            return None
         return token
+
+    try:
+        pool = load_pool("anthropic")
+        if refresh_expired:
+            selected = getattr(pool, "select", None)
+            if callable(selected):
+                try:
+                    entry = selected()
+                except Exception:
+                    logger.debug(
+                        "Anthropic credential_pool select() failed during resolve",
+                        exc_info=True,
+                    )
+                    entry = None
+                token = _usable_oauth_token(entry) if entry is not None else None
+                if token:
+                    return token
+        # Enumerate read-only (clear_expired=False, refresh=False): never persist
+        # to auth.json or trigger a network refresh from a bare resolve. select()
+        # is deliberately NOT used here — it runs clear_expired=True, refresh=True,
+        # which would violate this read-only contract.
+        entries, _pending = pool._available_entries(clear_expired=False, refresh=False)
+    except Exception:
+        logger.debug("Failed to read Anthropic credential_pool", exc_info=True)
+        return None
+
+    for entry in entries:
+        token = _usable_oauth_token(entry)
+        if token:
+            return token
 
     return None
 
@@ -837,7 +846,7 @@ def resolve_anthropic_token() -> Optional[str]:
         return resolved_claude_token
 
     # 5. Hermes credential_pool OAuth entry.
-    resolved_pool_token = _resolve_anthropic_pool_token()
+    resolved_pool_token = _resolve_anthropic_pool_token(refresh_expired=True)
     if resolved_pool_token:
         return resolved_pool_token
 
@@ -913,8 +922,64 @@ _OAUTH_TOKEN_URL = _OAUTH_TOKEN_URLS[0]
 _OAUTH_TOKEN_USER_AGENT = "axios/1.7.9"
 _OAUTH_REDIRECT_URI = "https://console.anthropic.com/oauth/code/callback"
 _OAUTH_SCOPES = "org:create_api_key user:profile user:inference"
+
+
 def _get_hermes_oauth_file() -> Path:
     return get_hermes_home() / ".anthropic_oauth.json"
+
+
+def _global_hermes_oauth_file() -> Optional[Path]:
+    """Return the root-profile .anthropic_oauth.json when running in a named profile."""
+    try:
+        root = get_default_hermes_root()
+        profile = get_hermes_home()
+        if root.resolve(strict=False) == profile.resolve(strict=False):
+            return None
+        return root / ".anthropic_oauth.json"
+    except Exception:
+        return None
+
+
+def _oauth_file_expires_at(data: Dict[str, Any]) -> int:
+    raw = data.get("expiresAt")
+    if isinstance(raw, (int, float)):
+        return int(raw)
+    return 0
+
+
+def _read_oauth_file(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.exists():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError, IOError) as e:
+        logger.debug("Failed to read Hermes OAuth credentials from %s: %s", path, e)
+        return None
+    if isinstance(data, dict) and data.get("accessToken"):
+        return data
+    return None
+
+
+def _write_oauth_file(oauth_file: Path, oauth_data: Dict[str, Any]) -> None:
+    oauth_file.parent.mkdir(parents=True, exist_ok=True)
+    _tmp_oauth = oauth_file.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+    try:
+        fd = os.open(
+            str(_tmp_oauth),
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            stat.S_IRUSR | stat.S_IWUSR,
+        )
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(oauth_data, fh, indent=2)
+            fh.flush()
+            os.fsync(fh.fileno())
+        os.replace(_tmp_oauth, oauth_file)
+    except OSError:
+        try:
+            _tmp_oauth.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
 
 
 def _generate_pkce() -> tuple:
@@ -1062,15 +1127,14 @@ def run_hermes_oauth_login_pure() -> Optional[Dict[str, Any]]:
 
 def read_hermes_oauth_credentials() -> Optional[Dict[str, Any]]:
     """Read Hermes-managed OAuth credentials from ~/.hermes/.anthropic_oauth.json."""
-    oauth_file = _get_hermes_oauth_file()
-    if oauth_file.exists():
-        try:
-            data = json.loads(oauth_file.read_text(encoding="utf-8"))
-            if data.get("accessToken"):
-                return data
-        except (json.JSONDecodeError, OSError, IOError) as e:
-            logger.debug("Failed to read Hermes OAuth credentials: %s", e)
-    return None
+    local = _read_oauth_file(_get_hermes_oauth_file())
+    global_path = _global_hermes_oauth_file()
+    shared = _read_oauth_file(global_path) if global_path is not None else None
+    if local and shared:
+        if _oauth_file_expires_at(shared) > _oauth_file_expires_at(local):
+            return shared
+        return local
+    return local or shared
 
 
 def _write_hermes_oauth_credentials(
@@ -1089,36 +1153,41 @@ def _write_hermes_oauth_credentials(
     Raises ``CredentialPersistError`` when the rotated pair does not reach the
     file, for the same reason ``_write_claude_code_credentials`` does: this is
     the commit step of the refresh transaction.
+
+    When a named profile rotates a grant that also lives at the global root,
+    the same pair is write-through to the root singleton so sibling profiles
+    seeding from that file do not replay the consumed refresh token (#100339).
     """
     oauth_file = _get_hermes_oauth_file()
+    oauth_data = {
+        "accessToken": access_token,
+        "refreshToken": refresh_token,
+        "expiresAt": expires_at_ms,
+    }
     try:
-        oauth_data = {
-            "accessToken": access_token,
-            "refreshToken": refresh_token,
-            "expiresAt": expires_at_ms,
-        }
-        oauth_file.parent.mkdir(parents=True, exist_ok=True)
-        _tmp_oauth = oauth_file.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
-        try:
-            fd = os.open(
-                str(_tmp_oauth),
-                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
-                stat.S_IRUSR | stat.S_IWUSR,
-            )
-            with os.fdopen(fd, "w", encoding="utf-8") as fh:
-                json.dump(oauth_data, fh, indent=2)
-                fh.flush()
-                os.fsync(fh.fileno())
-            os.replace(_tmp_oauth, oauth_file)
-        except OSError:
-            try:
-                _tmp_oauth.unlink(missing_ok=True)
-            except OSError:
-                pass
-            raise
+        _write_oauth_file(oauth_file, oauth_data)
     except (OSError, IOError, ValueError) as e:
         logger.error(
             "Failed to write refreshed Hermes OAuth credentials to %s: %s", oauth_file, e
         )
         raise CredentialPersistError(oauth_file, e) from e
+    global_path = _global_hermes_oauth_file()
+    if global_path is None:
+        return
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        real_home_env = os.environ.get("HOME", "")
+        if real_home_env:
+            real_root = Path(real_home_env) / ".hermes" / ".anthropic_oauth.json"
+            try:
+                if global_path.resolve(strict=False) == real_root.resolve(strict=False):
+                    return
+            except Exception:
+                return
+    try:
+        _write_oauth_file(global_path, oauth_data)
+    except Exception:
+        logger.debug(
+            "hermes_pkce refresh: write-through to global singleton failed",
+            exc_info=True,
+        )
 

--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -26,6 +26,7 @@ import hermes_cli.auth as auth_mod
 from hermes_cli.auth import (
     CODEX_ACCESS_TOKEN_REFRESH_SKEW_SECONDS,
     PROVIDER_REGISTRY,
+    SINGLE_USE_REFRESH_POOL_PROVIDERS,
     _auth_store_lock,
     _codex_access_token_is_expiring,
     _decode_jwt_claims,
@@ -719,6 +720,123 @@ def _write_through_provider_state_to_global_root(
         )
 
 
+def _should_refuse_real_user_global_auth(global_path: Path) -> bool:
+    """Pytest seat belt: never write the developer's real ~/.hermes/auth.json."""
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return False
+    real_home_env = os.environ.get("HOME", "")
+    if not real_home_env:
+        return False
+    real_root = Path(real_home_env) / ".hermes" / "auth.json"
+    try:
+        return global_path.resolve(strict=False) == real_root.resolve(strict=False)
+    except Exception:
+        return True
+
+
+def _profile_owns_pool_provider(provider: str) -> bool:
+    """True when the active (profile) auth.json already has rows for *provider*."""
+    try:
+        pool = _load_auth_store().get("credential_pool")
+    except Exception:
+        return False
+    entries = pool.get(provider) if isinstance(pool, dict) else None
+    return isinstance(entries, list) and bool(entries)
+
+
+def _global_has_pool_provider(provider: str) -> bool:
+    try:
+        global_store = auth_mod._load_global_auth_store()
+    except Exception:
+        return False
+    pool = global_store.get("credential_pool") if isinstance(global_store, dict) else None
+    entries = pool.get(provider) if isinstance(pool, dict) else None
+    return isinstance(entries, list) and bool(entries)
+
+
+def _write_through_pool_entries_to_global_root(
+    provider_id: str,
+    entries: List[Dict[str, Any]],
+    *,
+    removed_ids: Optional[Set[str]] = None,
+) -> None:
+    """Merge rotated pool rows into the global-root credential_pool by id.
+
+    Only updates ids that already exist in root (or writes the slice when
+    root has none and this profile is borrowing that grant). Never appends a
+    profile-only credential into root — that would leak an independent
+    login into every other profile.
+    """
+    if provider_id not in SINGLE_USE_REFRESH_POOL_PROVIDERS:
+        return
+    try:
+        global_path = auth_mod._global_auth_file_path()
+    except Exception:
+        return
+    if global_path is None:
+        return
+    if _should_refuse_real_user_global_auth(global_path):
+        return
+    removed = {rid for rid in (removed_ids or ()) if rid}
+    incoming_by_id = {
+        entry.get("id"): entry
+        for entry in entries
+        if isinstance(entry, dict) and entry.get("id")
+    }
+    if not incoming_by_id and not removed:
+        return
+    try:
+        with _auth_store_lock(target_path=global_path):
+            store = _load_auth_store(global_path)
+            pool = store.get("credential_pool")
+            if not isinstance(pool, dict):
+                pool = {}
+                store["credential_pool"] = pool
+            existing = pool.get(provider_id)
+            existing_list = existing if isinstance(existing, list) else []
+            if not existing_list:
+                # Root has no slice: only materialize when this profile is
+                # borrowing (no local rows) so we don't fork a unique login.
+                if _profile_owns_pool_provider(provider_id):
+                    return
+                pool[provider_id] = [
+                    dict(entry) for entry in entries if isinstance(entry, dict)
+                ]
+                _save_auth_store(store, target_path=global_path)
+                return
+            merged: List[Dict[str, Any]] = []
+            changed = False
+            for entry in existing_list:
+                if not isinstance(entry, dict):
+                    merged.append(entry)
+                    continue
+                entry_id = entry.get("id")
+                if entry_id in removed:
+                    changed = True
+                    continue
+                incoming = incoming_by_id.get(entry_id) if entry_id else None
+                if incoming is not None:
+                    if (
+                        auth_mod._pool_entry_freshness_ms(incoming)
+                        >= auth_mod._pool_entry_freshness_ms(entry)
+                    ):
+                        merged.append(dict(incoming))
+                        changed = True
+                    else:
+                        merged.append(entry)
+                else:
+                    merged.append(entry)
+            if changed:
+                pool[provider_id] = merged
+                _save_auth_store(store, target_path=global_path)
+    except Exception as exc:  # pragma: no cover - best effort
+        logger.debug(
+            "%s pool refresh: write-through to global credential_pool failed: %s",
+            provider_id,
+            exc,
+        )
+
+
 class CredentialPool:
     def __init__(self, provider: str, entries: List[PooledCredential]):
         self.provider = provider
@@ -850,10 +968,28 @@ class CredentialPool:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
-            write_credential_pool(
+            payloads = [entry.to_dict() for entry in self._entries]
+            removed = list(removed_ids or [])
+            # A named profile that only sees this provider via the global-root
+            # fallback must not materialize a local credential_pool copy.
+            # That copy forks single-use refresh tokens: the first rotation
+            # commits only to the profile file and every sibling dies
+            # (#100339). Write through to root instead.
+            borrowing = (
+                self.provider in SINGLE_USE_REFRESH_POOL_PROVIDERS
+                and not _profile_owns_pool_provider(self.provider)
+                and _global_has_pool_provider(self.provider)
+            )
+            if not borrowing:
+                write_credential_pool(
+                    self.provider,
+                    payloads,
+                    removed_ids=removed,
+                )
+            _write_through_pool_entries_to_global_root(
                 self.provider,
-                [entry.to_dict() for entry in self._entries],
-                removed_ids=removed_ids,
+                payloads,
+                removed_ids=set(removed),
             )
 
     def _is_terminal_auth_failure(
@@ -2780,6 +2916,20 @@ def _upsert_entry(entries: List[PooledCredential], provider: str, source: str, p
         return True
 
     existing = entries[existing_idx]
+    incoming_exp = payload.get("expires_at_ms")
+    if (
+        incoming_exp is not None
+        and existing.expires_at_ms is not None
+        and existing.access_token
+    ):
+        try:
+            if int(incoming_exp) < int(existing.expires_at_ms):
+                # A stale singleton or cloned .anthropic_oauth.json must not
+                # overwrite a fresher pool row (the rotation another profile
+                # just write-through to root / this pool).
+                return bool(duplicate_indices)
+        except (TypeError, ValueError):
+            pass
     field_updates = {}
     extra_updates = {}
     _field_names = {f.name for f in fields(existing)}
@@ -3590,9 +3740,18 @@ def load_pool(provider: str) -> CredentialPool:
 
     if changed:
         new_ids = {entry.id for entry in entries}
-        write_credential_pool(
-            provider,
-            [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
-            removed_ids=disk_ids - new_ids,
+        # Same fork hazard as CredentialPool._persist: seeding a named
+        # profile from the global-root fallback must not copy single-use
+        # OAuth rows into the profile store.
+        borrowing = (
+            provider in SINGLE_USE_REFRESH_POOL_PROVIDERS
+            and not _profile_owns_pool_provider(provider)
+            and _global_has_pool_provider(provider)
         )
+        if not borrowing:
+            write_credential_pool(
+                provider,
+                [entry.to_dict() for entry in sorted(entries, key=lambda item: item.priority)],
+                removed_ids=disk_ids - new_ids,
+            )
     return CredentialPool(provider, entries)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1687,6 +1687,135 @@ def is_runtime_provider_routable(provider_id: str) -> bool:
     return True
 
 
+# Refresh tokens for these pool providers are single-use. Forking the same
+# grant into a named-profile auth.json (clone-all, desktop credential
+# mirroring, or load_pool persist-on-seed) means the first profile to rotate
+# consumes the token and every sibling copy dies with invalid_grant
+# (#100339, same class as #48415 / #43589).
+SINGLE_USE_REFRESH_POOL_PROVIDERS = frozenset({
+    "anthropic",
+    "openai-codex",
+    "xai-oauth",
+})
+
+
+def _pool_entry_freshness_ms(entry: Dict[str, Any]) -> int:
+    """Best-effort recency for choosing between cloned OAuth rows."""
+    ms = entry.get("expires_at_ms")
+    if isinstance(ms, (int, float)):
+        return int(ms)
+    last_refresh = entry.get("last_refresh")
+    if isinstance(last_refresh, (int, float)):
+        value = float(last_refresh)
+        return int(value * 1000) if value < 10_000_000_000 else int(value)
+    if isinstance(last_refresh, str) and last_refresh.strip():
+        try:
+            parsed = datetime.fromisoformat(last_refresh.replace("Z", "+00:00"))
+            return int(parsed.timestamp() * 1000)
+        except (TypeError, ValueError, OSError):
+            return 0
+    return 0
+
+
+def _is_oauth_pool_payload(entry: Dict[str, Any]) -> bool:
+    auth_type = str(entry.get("auth_type") or "").strip().lower()
+    if auth_type == "oauth":
+        return True
+    token = str(entry.get("access_token") or "")
+    return token.startswith("sk-ant-oat")
+
+
+def _merge_pool_entries_prefer_fresh(
+    local_entries: List[Dict[str, Any]],
+    global_entries: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Per-id merge: keep unique local rows, pick the fresher copy of a shared id.
+
+    Does not import global-only ids — a profile that independently added
+    credentials must not suddenly lease the root grant. Shared ids are the
+    clone/fallback case: the rotated chain must win regardless of which
+    auth.json still holds the stale copy.
+    """
+    global_by_id = {
+        entry.get("id"): entry
+        for entry in global_entries
+        if isinstance(entry, dict) and entry.get("id")
+    }
+    merged: List[Dict[str, Any]] = []
+    for entry in local_entries:
+        if not isinstance(entry, dict):
+            continue
+        entry_id = entry.get("id")
+        other = global_by_id.get(entry_id) if entry_id else None
+        if not isinstance(other, dict):
+            merged.append(entry)
+            continue
+        if _is_oauth_pool_payload(entry) or _is_oauth_pool_payload(other):
+            if _pool_entry_freshness_ms(entry) >= _pool_entry_freshness_ms(other):
+                merged.append(entry)
+            else:
+                merged.append(other)
+        else:
+            merged.append(entry)
+    return merged
+
+
+def strip_cloned_single_use_oauth_grants(auth_path: Path) -> None:
+    """Drop forked single-use OAuth grants from a cloned auth.json.
+
+    API-key pool rows stay so a clone can keep static keys. OAuth rows for
+    Anthropic / Codex / xAI are removed so the new profile reads them through
+    the global-root fallback instead of holding a duplicate refresh token.
+    """
+    if not auth_path.is_file():
+        return
+    try:
+        store = json.loads(auth_path.read_text(encoding="utf-8-sig"))
+    except (OSError, json.JSONDecodeError):
+        return
+    if not isinstance(store, dict):
+        return
+    changed = False
+    pool = store.get("credential_pool")
+    if isinstance(pool, dict):
+        for provider_id in list(pool):
+            if provider_id not in SINGLE_USE_REFRESH_POOL_PROVIDERS:
+                continue
+            entries = pool.get(provider_id)
+            if not isinstance(entries, list):
+                continue
+            kept = [
+                entry
+                for entry in entries
+                if isinstance(entry, dict) and not _is_oauth_pool_payload(entry)
+            ]
+            if len(kept) != len(entries):
+                changed = True
+                if kept:
+                    pool[provider_id] = kept
+                else:
+                    del pool[provider_id]
+        if not pool and "credential_pool" in store:
+            store.pop("credential_pool", None)
+            changed = True
+    providers = store.get("providers")
+    if isinstance(providers, dict):
+        for provider_id in ("openai-codex", "xai-oauth"):
+            if provider_id in providers:
+                del providers[provider_id]
+                changed = True
+    if not changed:
+        return
+    try:
+        _save_auth_store(store, target_path=auth_path)
+    except Exception:
+        logger.debug(
+            "Failed to strip cloned single-use OAuth grants from %s",
+            auth_path,
+            exc_info=True,
+        )
+
+
 def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     """Return the persisted credential pool, or one provider slice.
 
@@ -1700,7 +1829,14 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
     ``hermes auth add <provider>`` inside the profile, profile entries
     fully shadow global for that provider on the next read.
 
-    Writes always go to the profile (``write_credential_pool`` is unchanged).
+    Single-use OAuth providers (Anthropic, Codex, xAI) are the exception:
+    a cloned row with the same entry id as root is the *same grant*, not an
+    independent credential. Those rows merge per-id and the fresher copy
+    wins so a rotation written through to root is visible to sibling
+    profiles that still hold a stale clone (#100339).
+
+    Writes always go to the profile (``write_credential_pool`` is unchanged)
+    except for the dedicated global write-through on rotation.
     See issue #18594 follow-up.
     """
     auth_store = _load_auth_store()
@@ -1719,19 +1855,38 @@ def read_credential_pool(provider_id: Optional[str] = None) -> Dict[str, Any]:
         for gp_key, gp_entries in global_pool.items():
             if not isinstance(gp_entries, list) or not gp_entries:
                 continue
-            # Per-provider shadowing: profile wins whenever it has ANY entries.
             existing = merged.get(gp_key)
+            if (
+                gp_key in SINGLE_USE_REFRESH_POOL_PROVIDERS
+                and isinstance(existing, list)
+                and existing
+            ):
+                merged[gp_key] = _merge_pool_entries_prefer_fresh(
+                    existing, list(gp_entries)
+                )
+                continue
+            # Per-provider shadowing: profile wins whenever it has ANY entries.
             if isinstance(existing, list) and existing:
                 continue
             merged[gp_key] = list(gp_entries)
         return merged
 
     provider_entries = pool.get(provider_id)
-    if isinstance(provider_entries, list) and provider_entries:
-        return list(provider_entries)
-    # Profile has no entries for this provider — fall back to global.
+    local_entries = (
+        list(provider_entries) if isinstance(provider_entries, list) else []
+    )
     global_entries = global_pool.get(provider_id)
-    return list(global_entries) if isinstance(global_entries, list) else []
+    global_list = list(global_entries) if isinstance(global_entries, list) else []
+    if (
+        provider_id in SINGLE_USE_REFRESH_POOL_PROVIDERS
+        and local_entries
+        and global_list
+    ):
+        return _merge_pool_entries_prefer_fresh(local_entries, global_list)
+    if local_entries:
+        return local_entries
+    # Profile has no entries for this provider — fall back to global.
+    return global_list
 
 
 _POOL_STATUS_FIELDS = (

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -90,6 +90,7 @@ _CLONE_ALL_STRIP: list[str] = [
     "gateway.pid",
     "gateway_state.json",
     "processes.json",
+    ".anthropic_oauth.json",  # single-use Anthropic refresh token; fall back to root
 ]
 
 # Infrastructure artifacts excluded from --clone-all when the source is the
@@ -1261,6 +1262,10 @@ def create_profile(
         # Strip runtime files
         for stale in _CLONE_ALL_STRIP:
             (profile_dir / stale).unlink(missing_ok=True)
+        # Forking single-use OAuth refresh tokens into the clone strands
+        # every sibling after the first rotation (#100339). API keys stay.
+        from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+        strip_cloned_single_use_oauth_grants(profile_dir / "auth.json")
     else:
         # Bootstrap directory structure
         profile_dir.mkdir(parents=True, exist_ok=True)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -354,9 +354,10 @@ class TestResolveAnthropicToken:
 
 
     def test_pool_resolution_is_read_only(self, monkeypatch, tmp_path):
-        """The resolver must enumerate the pool read-only — clear_expired and
-        refresh must both be False so a bare resolve never writes auth.json or
-        triggers a network refresh from diagnostic call sites (#50108 MED)."""
+        """Diagnostic pool resolution must enumerate read-only — clear_expired
+        and refresh must both be False so a bare resolve never writes auth.json
+        or triggers a network refresh (#50108 MED). Runtime init uses
+        ``refresh_expired=True`` instead (#100339)."""
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.delenv("ANTHROPIC_TOKEN", raising=False)
         monkeypatch.delenv("CLAUDE_CODE_OAUTH_TOKEN", raising=False)
@@ -373,8 +374,11 @@ class TestResolveAnthropicToken:
         pool = SimpleNamespace(_available_entries=_available_entries)
         monkeypatch.setattr("agent.credential_pool.load_pool", lambda provider: pool)
 
-        assert resolve_anthropic_token() == "pool-oauth-token"
+        from agent.anthropic_credentials import _resolve_anthropic_pool_token
+
+        assert _resolve_anthropic_pool_token() == "pool-oauth-token"
         assert captured == {"clear_expired": False, "refresh": False}
+        assert resolve_anthropic_token() == "pool-oauth-token"
 
     def test_prefers_refreshable_claude_code_credentials_over_static_anthropic_token(self, monkeypatch, tmp_path):
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)

--- a/tests/agent/test_anthropic_spent_rotation_verdict.py
+++ b/tests/agent/test_anthropic_spent_rotation_verdict.py
@@ -136,6 +136,26 @@ def _add_independent_pool_entry(home):
     path.write_text(json.dumps(store), encoding="utf-8")
 
 
+def _add_expired_pool_owned_entry(home):
+    """Persist an expired Anthropic OAuth row whose refresh token the pool owns."""
+    path = home / "auth.json"
+    store = json.loads(path.read_text(encoding="utf-8"))
+    pool = store.setdefault("credential_pool", {})
+    pool.setdefault("anthropic", []).append(
+        {
+            "id": "anthropic-pool-owned",
+            "label": "profile oauth",
+            "auth_type": AUTH_TYPE_OAUTH,
+            "priority": 0,
+            "source": "manual:hermes_pkce",
+            "access_token": _STALE_ACCESS,
+            "refresh_token": _STALE_REFRESH,
+            "expires_at_ms": _EXPIRED_MS,
+        }
+    )
+    path.write_text(json.dumps(store), encoding="utf-8")
+
+
 # ---------------------------------------------------------------------------
 # The registry itself
 # ---------------------------------------------------------------------------
@@ -252,6 +272,32 @@ def test_successful_commit_leaves_the_credential_usable(
 
     assert AA.resolve_anthropic_token() == _ROTATED_ACCESS
     assert AA._SPENT_ROTATION_FINGERPRINTS == {}
+
+
+def test_resolve_refreshes_expired_pool_owned_oauth_entry(hermes_home, monkeypatch):
+    """Agent init must refresh an expired pool row before API-call recovery exists."""
+    _add_expired_pool_owned_entry(hermes_home)
+    monkeypatch.setattr(AA, "read_claude_code_credentials", lambda: None)
+    monkeypatch.setattr(AA, "refresh_anthropic_oauth_pure", _rotating_refresh)
+
+    assert AA.resolve_anthropic_token() == _ROTATED_ACCESS
+
+    pool = load_pool("anthropic")
+    refreshed = next(e for e in pool._entries if e.id == "anthropic-pool-owned")
+    assert refreshed.access_token == _ROTATED_ACCESS
+    assert refreshed.refresh_token == _ROTATED_REFRESH
+
+
+def test_pool_resolver_keeps_read_only_mode_for_diagnostics(hermes_home, monkeypatch):
+    """Bare pool resolution must not spend a refresh token unless requested."""
+    _add_expired_pool_owned_entry(hermes_home)
+
+    def _fail_refresh(*_args, **_kwargs):
+        raise AssertionError("read-only resolution must not refresh")
+
+    monkeypatch.setattr(AA, "refresh_anthropic_oauth_pure", _fail_refresh)
+
+    assert AA._resolve_anthropic_pool_token() == _STALE_ACCESS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_credential_pool_oauth_writethrough.py
+++ b/tests/agent/test_credential_pool_oauth_writethrough.py
@@ -427,3 +427,56 @@ def test_manual_hermes_pkce_refresh_does_not_create_duplicate_singleton(
     assert matching[0].source == "manual:hermes_pkce"
     assert matching[0].refresh_token == "manual-rt-1"
 
+
+def test_anthropic_pool_refresh_writes_through_to_global_root(
+    profile_and_root, monkeypatch
+):
+    """A cloned Anthropic pool row must write the rotated pair back to root.
+
+    Otherwise siblings that still hold the pre-rotation refresh token die
+    with invalid_grant / refresh_token_reused (#100339).
+    """
+    profile_path, root_path = profile_and_root
+    shared = {
+        "id": "pkce-1",
+        "label": "shared",
+        "auth_type": AUTH_TYPE_OAUTH,
+        "priority": 0,
+        "source": "hermes_pkce",
+        "access_token": "sk-ant-oat01-old",
+        "refresh_token": "rt-old",
+        "expires_at_ms": 1_000,
+    }
+    _write_store(
+        root_path,
+        {"version": 1, "providers": {}, "credential_pool": {"anthropic": [shared]}},
+    )
+    _write_store(
+        profile_path,
+        {"version": 1, "providers": {}, "credential_pool": {"anthropic": [dict(shared)]}},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials", lambda: None
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.refresh_anthropic_oauth_pure",
+        lambda refresh_token, use_json=False: {
+            "access_token": "sk-ant-oat01-new",
+            "refresh_token": "rt-new",
+            "expires_at_ms": int(time.time() * 1000) + 3_600_000,
+        },
+    )
+
+    entry = PooledCredential.from_dict("anthropic", shared)
+    pool = CredentialPool("anthropic", [entry])
+    updated = pool._refresh_entry(entry, force=True)
+    assert updated is not None
+    assert updated.refresh_token == "rt-new"
+
+    root_pool = _read_store(root_path)["credential_pool"]["anthropic"]
+    assert root_pool[0]["refresh_token"] == "rt-new"
+    assert root_pool[0]["access_token"] == "sk-ant-oat01-new"
+

--- a/tests/hermes_cli/test_auth_profile_fallback.py
+++ b/tests/hermes_cli/test_auth_profile_fallback.py
@@ -104,6 +104,116 @@ def test_malformed_global_auth_file_does_not_break_profile_read(profile_env):
     assert read_credential_pool("anthropic") == []
 
 
+def test_stale_cloned_anthropic_oauth_defers_to_fresher_global(profile_env):
+    """A cloned single-use OAuth row must not shadow a newer root rotation.
+
+    Profile copies of credential_pool.anthropic used to win unconditionally,
+    so after one profile rotated the grant, every sibling kept the spent
+    refresh token (#100339).
+    """
+    from hermes_cli.auth import read_credential_pool
+
+    shared_id = "pkce-1"
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "anthropic": [{
+            "id": shared_id,
+            "label": "root",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "hermes_pkce",
+            "access_token": "sk-ant-oat01-fresh",
+            "refresh_token": "rt-fresh",
+            "expires_at_ms": 9_000,
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "anthropic": [{
+            "id": shared_id,
+            "label": "stale-clone",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "hermes_pkce",
+            "access_token": "sk-ant-oat01-stale",
+            "refresh_token": "rt-stale",
+            "expires_at_ms": 1_000,
+        }],
+    }))
+
+    rows = read_credential_pool("anthropic")
+    assert len(rows) == 1
+    assert rows[0]["access_token"] == "sk-ant-oat01-fresh"
+    assert rows[0]["refresh_token"] == "rt-fresh"
+
+
+def test_independent_profile_oauth_is_not_replaced_by_global(profile_env):
+    """A profile that authenticated itself must keep its own grant."""
+    from hermes_cli.auth import read_credential_pool
+
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "anthropic": [{
+            "id": "root-pkce",
+            "auth_type": "oauth",
+            "access_token": "sk-ant-oat01-root",
+            "refresh_token": "rt-root",
+            "expires_at_ms": 9_000,
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={
+        "anthropic": [{
+            "id": "profile-pkce",
+            "auth_type": "oauth",
+            "access_token": "sk-ant-oat01-profile",
+            "refresh_token": "rt-profile",
+            "expires_at_ms": 1_000,
+        }],
+    }))
+
+    rows = read_credential_pool("anthropic")
+    assert [row["id"] for row in rows] == ["profile-pkce"]
+    assert rows[0]["access_token"] == "sk-ant-oat01-profile"
+
+
+def test_load_pool_does_not_clone_global_anthropic_oauth_into_profile(
+    profile_env, monkeypatch
+):
+    """First load_pool() in a named profile must not persist a local shadow copy."""
+    from agent.credential_pool import load_pool
+
+    monkeypatch.setattr(
+        "hermes_cli.auth.is_provider_explicitly_configured", lambda pid: True
+    )
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials", lambda: None
+    )
+
+    expires_at = int(time.time() * 1000) + 3_600_000
+    (profile_env["global"] / ".anthropic_oauth.json").write_text(json.dumps({
+        "accessToken": "sk-ant-oat01-root",
+        "refreshToken": "rt-root",
+        "expiresAt": expires_at,
+    }))
+    _write(profile_env["global"] / "auth.json", _make_auth_store(pool={
+        "anthropic": [{
+            "id": "pkce-1",
+            "label": "root",
+            "auth_type": "oauth",
+            "priority": 0,
+            "source": "hermes_pkce",
+            "access_token": "sk-ant-oat01-root",
+            "refresh_token": "rt-root",
+            "expires_at_ms": expires_at,
+        }],
+    }))
+    _write(profile_env["profile"] / "auth.json", _make_auth_store(pool={}))
+
+    pool = load_pool("anthropic")
+    assert any(entry.access_token == "sk-ant-oat01-root" for entry in pool._entries)
+
+    profile_store = json.loads((profile_env["profile"] / "auth.json").read_text())
+    local_pool = profile_store.get("credential_pool") or {}
+    assert not local_pool.get("anthropic")
+
+
 # ---------------------------------------------------------------------------
 # read_credential_pool — whole-pool reads (provider_id=None)
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -192,6 +192,42 @@ class TestCreateProfile:
         assert (profile_dir / "SOUL.md").read_text() == "Be helpful."
 
 
+    def test_clone_all_does_not_fork_single_use_oauth(self, profile_env):
+        """--clone-all must not copy Anthropic OAuth refresh tokens (#100339)."""
+        tmp_path = profile_env
+        default_home = tmp_path / ".hermes"
+        (default_home / "config.yaml").write_text("model:\n  provider: anthropic\n")
+        (default_home / ".anthropic_oauth.json").write_text(
+            json.dumps({"accessToken": "sk-ant-oat01-src", "refreshToken": "rt-src"})
+        )
+        (default_home / "auth.json").write_text(json.dumps({
+            "version": 1,
+            "credential_pool": {
+                "anthropic": [{
+                    "id": "pkce-1",
+                    "auth_type": "oauth",
+                    "source": "hermes_pkce",
+                    "access_token": "sk-ant-oat01-src",
+                    "refresh_token": "rt-src",
+                    "expires_at_ms": 9_999_999_999,
+                }],
+                "openrouter": [{
+                    "id": "or-1",
+                    "auth_type": "api_key",
+                    "source": "manual",
+                    "access_token": "sk-or-static",
+                }],
+            },
+        }))
+
+        profile_dir = create_profile("coder", clone_all=True, no_alias=True)
+
+        assert not (profile_dir / ".anthropic_oauth.json").exists()
+        cloned = json.loads((profile_dir / "auth.json").read_text())
+        assert "anthropic" not in cloned.get("credential_pool", {})
+        assert cloned["credential_pool"]["openrouter"][0]["access_token"] == "sk-or-static"
+
+
 
 
 

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -465,6 +465,11 @@ def _(rid, params: dict) -> dict:
                     os.chmod(str(dst_auth), 0o600)
                 except OSError:
                     pass
+                try:
+                    from hermes_cli.auth import strip_cloned_single_use_oauth_grants
+                    strip_cloned_single_use_oauth_grants(dst_auth)
+                except Exception:
+                    pass
                 mirrored["auth"] = True
         except Exception:
             pass


### PR DESCRIPTION
## Summary
- Profile copies of `credential_pool.anthropic` (clone-all, desktop auth mirroring, or `load_pool()` persisting the global-root fallback) fork a single-use refresh token. The first profile to rotate consumes it and every sibling dies with `invalid_grant` / `refresh_token_reused` (#100339).
- Named profiles now keep reading the shared grant from root (no local OAuth shadow), clone-all / credential-mirror copies strip those OAuth rows, and a successful rotation write-throughs the new pair to root. Same-id clones pick the fresher row so already-copied fleets heal without scanning sibling `auth.json` files.
- Agent init was a read-only resolve: an expired-but-refreshable pool row returned nothing and the turn died before the API-call recovery path could run. `resolve_anthropic_token()` now runs the pool's normal refresh; diagnostic `_resolve_anthropic_pool_token()` stays read-only.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_auth_profile_fallback.py tests/agent/test_credential_pool_oauth_writethrough.py tests/agent/test_anthropic_spent_rotation_verdict.py tests/hermes_cli/test_profiles.py tests/agent/test_credential_pool.py tests/agent/test_anthropic_credential_persist_failure.py tests/agent/test_credential_pool_anthropic_refresh_race.py tests/hermes_cli/test_xai_oauth_writethrough.py`
- [ ] `hermes -p <clone> chat` after access-token expiry: init refreshes instead of `No Anthropic credentials found`
- [ ] Two named profiles sharing one `hermes auth` Anthropic login: first rotation is visible to the sibling without copying `auth.json`

Fixes #100339