### PR TITLE
fix(memory): forward the documented new_text alias from both executor dispatch paths

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3572,6 +3572,7 @@ def invoke_tool(agent, function_name: str, function_args: dict, effective_task_i
                 target=target,
                 content=next_args.get("content"),
                 old_text=next_args.get("old_text"),
+                new_text=next_args.get("new_text"),
                 operations=operations,
                 store=agent._memory_store,
             )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2169,6 +2169,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     target=target,
                     content=next_args.get("content"),
                     old_text=next_args.get("old_text"),
+                    new_text=next_args.get("new_text"),
                     operations=operations,
                     store=agent._memory_store,
                 )

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1759,6 +1759,34 @@ class TestExecuteToolCalls:
         assert metadata["tool_call_id"] == "mem-1"
         assert messages[-1]["tool_call_id"] == "mem-1"
 
+    def test_sequential_memory_new_text_alias_reaches_handler(self, agent):
+        # The memory_tool handler documents new_text as an accepted alias for
+        # content, but both executor call sites (tool_executor.py and
+        # agent_runtime_helpers.py) dropped it, so an alias-shaped call failed
+        # with "content is required" through the real dispatch path even
+        # though handler-level tests passed.
+        tc = _mock_tool_call(
+            name="memory",
+            arguments=json.dumps({"target": "memory", "new_text": "alias written"}),
+            call_id="mem-2",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])
+        messages = []
+        captured = {}
+
+        def _capture_memory_tool(**kwargs):
+            captured.update(kwargs)
+            return json.dumps({"success": True})
+
+        agent._memory_store = object()
+
+        with patch("tools.memory_tool.memory_tool", side_effect=_capture_memory_tool):
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        assert captured.get("new_text") == "alias written"
+        assert messages[-1]["role"] == "tool"
+        assert messages[-1]["tool_call_id"] == "mem-2"
+
     def test_keyboard_interrupt_emits_cancelled_post_tool_hook(self, agent, monkeypatch):
         tc = _mock_tool_call(name="web_search", arguments='{"q":"test"}', call_id="c1")
         mock_msg = _mock_assistant_msg(content="", tool_calls=[tc])


### PR DESCRIPTION
## What does this PR do?

`memory_tool()` documents `new_text` as an accepted alias for `content` (docstring, `MEMORY_SCHEMA` description, and the handler's coalescing logic), and has handler-level tests for that alias. But both executor dispatch paths — `agent/tool_executor.py` and `agent/agent_runtime_helpers.py` — build the handler kwargs **without forwarding `new_text`**, so an alias-shaped call (`{"target": "memory", "new_text": ...}`) fails through the real dispatch path with `content is required for 'add' action` even though the handler unit tests pass.

This PR forwards `next_args.get("new_text")` at both sites and pins the dispatch path with a regression test.

## Related Issue

Complementary to #72067 / #72036 (null/omitted-action recovery, currently open): that PR infers `action` from the payload, but with the alias dropped at the executor, `content` arrives as `None` — so an alias-shaped call would still fail even with the inference in place. Observed in production (a Kimi-K3 profile) while diagnosing that class; this makes the alias path work end to end.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/tool_executor.py`: forward `new_text` to `memory_tool()` (one line)
- `agent/agent_runtime_helpers.py`: same (one line)
- `tests/run_agent/test_run_agent.py`: `test_sequential_memory_new_text_alias_reaches_handler` — dispatch-level regression test asserting the alias reaches the handler kwargs (next to the existing sequential-memory dispatch test)

## How to Test

1. On current `main`: `pytest tests/run_agent/test_run_agent.py -k "sequential_memory"` — note that the alias-shaped dispatch is not covered anywhere.
2. With this branch: the new test asserts `new_text` reaches the handler kwargs; the existing alias handler tests keep passing unchanged.
3. Handler behavior is unchanged; only the previously-dropped field is now forwarded.

Tested on Python 3.11.16 (Linux): targeted suites green — `tests/run_agent/test_run_agent.py` plus all three memory-tool test files (325 passed; the single failure in `TestAnthropicInterruptHandler` reproduces on clean `main` and is unrelated to this change). Full suite not run locally due to environment limitations.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(memory):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (#72067 overlaps with the action-inference topic but does **not** cover this dispatch gap; this PR touches no handler logic)
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — targeted suites only (see How to Test; full suite not runnable in my environment)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (Proxmox LXC), Python 3.11.16

### Documentation & Housekeeping

- [x] N/A — no config keys, architecture, tool schema, or platform behavior changed
