### PR TITLE
fix(desktop): keep cron jobs visible when Grouping=Project

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -1895,7 +1895,7 @@ export function ChatSidebar({
                 )
               })}
 
-            {!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0 && (
+            {!trimmedQuery && cronJobs.length > 0 && (
               <SidebarCronJobsSection
                 jobs={cronJobs}
                 label={s.cronJobs}


### PR DESCRIPTION
### What

Grouping=Project (`worktreeGroupingActive`) でサイドバーの `!worktreeGroupingActive` ガードが `Cron Jobs` セクションまで隠していました。

`cronJobs` はグローバルなので Project グルーピング中も表示を維持します。

### Fix
- `apps/desktop/src/app/chat/sidebar/index.tsx:1898`
  - `!trimmedQuery && !worktreeGroupingActive && cronJobs.length > 0`
  - → `!trimmedQuery && cronJobs.length > 0`
  - `messaging` のガードは Project 中は非表示のまま、`cron` のみ常時表示に分離

### Why
488ae376 で入ったガードが cron まで巻き込んでいました。Date グルーピングでは見えるのに Project では消えるため利便性が落ちていました。

### Verified
- `npm run build` で `dist` + `app.asar.unpacked/dist` が更新されることを確認
- Project グルーピングで Cron Jobs が再表示されることを手元で確認