### PR TITLE
fix(raft): scope RAFT_PROFILE resolution to the active multiplex profile

### DIFF
--- a/plugins/platforms/raft/adapter.py
+++ b/plugins/platforms/raft/adapter.py
@@ -97,6 +97,52 @@ _RAFT_TURN_IDS: set[str] = set()
 _RAFT_PROMPT_TURN_IDS: set[str] = set()
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed, connected, and reloaded
+    inside ``_profile_runtime_scope`` (secret scope installed + multiplex
+    active) — the same discriminator the Buzz/SimpleX adapters use for this
+    bug class (#98738). The DEFAULT profile under multiplexing runs
+    unscoped: ``os.environ`` holds its own bridge output there and keeps its
+    legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _resolve_raft_profile() -> str:
+    """Scope-aware resolution of the ``RAFT_PROFILE`` slug.
+
+    Raft has no ``config.yaml`` equivalent for this value (env-only), so a
+    secondary multiplex profile's only way to configure Raft is via its own
+    ``.env`` file — which the installed secret scope (built from that
+    profile's ``.env`` by ``_profile_runtime_scope``) already carries.
+    Reading raw ``os.environ.get("RAFT_PROFILE")`` here would instead return
+    the DEFAULT profile's bridged value, misdirecting the bridge subprocess
+    or CLI hint at another profile's external Raft workspace/agent identity.
+
+    ``get_secret()`` is only called when ``_profile_scoped()`` is True — the
+    callers of this helper (``connect()``/``register()``) run inside
+    ``_profile_runtime_scope`` for secondary profiles, but the DEFAULT
+    profile's own startup path never installs a scope, where ``get_secret()``
+    would raise ``UnscopedSecretError``; the guard keeps that path on the
+    unchanged ``os.environ`` read.
+    """
+    if _profile_scoped():
+        try:
+            from agent.secret_scope import get_secret
+
+            return (get_secret("RAFT_PROFILE") or "").strip()
+        except Exception:
+            return ""
+    return os.environ.get("RAFT_PROFILE", "").strip()
+
+
 def check_raft_requirements() -> bool:
     """Check if Raft channel dependencies are available.
 
@@ -533,7 +579,7 @@ class RaftAdapter(BasePlatformAdapter):
             logger.warning("[raft] raft CLI not found in PATH; bridge not spawned — wake-only polling mode")
             return
 
-        profile = os.environ.get("RAFT_PROFILE", "")
+        profile = _resolve_raft_profile()
         if not profile:
             logger.warning("[raft] RAFT_PROFILE not set; bridge not spawned")
             return
@@ -777,8 +823,12 @@ def _env_enablement() -> Optional[dict]:
     """Seed PlatformConfig.extra from env vars during gateway config load.
 
     Auto-enables when RAFT_PROFILE is set (the adapter needs it anyway).
+    Scope-aware: consults the active profile's own RAFT_PROFILE (env, or a
+    secondary profile's own .env via the secret scope) instead of the
+    default profile's bridged env value (mirrors the Buzz/SimpleX fix for
+    #98738) — see ``_resolve_raft_profile``.
     """
-    if not os.getenv("RAFT_PROFILE"):
+    if not _resolve_raft_profile():
         return None
 
     return {"enabled": True}
@@ -839,12 +889,18 @@ def register(ctx) -> None:
         setup_fn=interactive_setup,
         env_enablement_fn=_env_enablement,
         emoji="🔔",
+        # Scope-aware (mirrors _resolve_raft_profile's docstring): register()
+        # runs inside _profile_runtime_scope for a secondary multiplex
+        # profile (via discover_plugins() in
+        # gateway/run.py::_start_one_profile_adapters), so this resolves
+        # that profile's own RAFT_PROFILE instead of the default profile's
+        # bridged env value baked into a shared registry entry.
         platform_hint=(
             "You are connected to Raft via an external-agent channel. "
             "Run `raft --profile {profile} profile show` to confirm which agent profile is active. "
             "Run `raft --profile {profile} manual get raft-cli-overview` to learn available Raft commands. "
             "Always pass `--profile {profile}` to every raft CLI call."
-        ).format(profile=os.environ.get("RAFT_PROFILE", "your-agent-profile")),
+        ).format(profile=_resolve_raft_profile() or "your-agent-profile"),
     )
     ctx.register_hook("on_session_start", _on_session_start)
     ctx.register_hook("pre_llm_call", _on_pre_llm_call)

--- a/tests/gateway/test_raft_adapter.py
+++ b/tests/gateway/test_raft_adapter.py
@@ -3,6 +3,7 @@
 import asyncio
 import json
 import os
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -217,4 +218,146 @@ class TestRaftConfig:
         assert env_path.read_text(encoding="utf-8") == "RAFT_PROFILE=existing\n"
         assert os.environ["RAFT_PROFILE"] == "existing"
         assert "Keeping RAFT_PROFILE=existing" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope (RAFT_PROFILE resolution)
+# ---------------------------------------------------------------------------
+#
+# _spawn_bridge, _env_enablement, and register()'s platform_hint all
+# previously read RAFT_PROFILE via raw os.environ.get unconditionally. Under
+# a multiplexed secondary profile, os.environ holds the DEFAULT profile's
+# YAML-to-env bridge output — a secondary profile with its own RAFT_PROFILE
+# (set only in its own .env, resolved via the installed secret scope) would
+# silently connect the bridge subprocess / CLI hint to the default profile's
+# external Raft workspace/agent identity instead of its own. Mirrors the
+# Buzz/SimpleX fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("RAFT_PROFILE", "default-profile-slug")
+
+
+class _FakeCtx:
+    """Minimal ``ctx`` capturing ``register_platform``'s kwargs."""
+
+    def __init__(self):
+        self.platform_kwargs = None
+
+    def register_platform(self, **kwargs):
+        self.platform_kwargs = kwargs
+
+    def register_hook(self, *args, **kwargs):
+        pass
+
+
+class TestMultiplexProfileScope:
+
+    def test_spawn_bridge_uses_scoped_profile(
+        self, multiplex_scope, default_profile_env, monkeypatch
+    ):
+        """The bridge subprocess must be spawned with the secondary
+        profile's own RAFT_PROFILE, not the default profile's env value."""
+        import plugins.platforms.raft.adapter as raft_mod
+
+        multiplex_scope({"RAFT_PROFILE": "secondary-profile-slug"})
+        monkeypatch.setattr(raft_mod.shutil, "which", lambda name: "/usr/bin/raft")
+        captured = {}
+
+        def fake_popen(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return SimpleNamespace(pid=12345)
+
+        monkeypatch.setattr(raft_mod.subprocess, "Popen", fake_popen)
+
+        adapter = _make_adapter()
+        adapter._spawn_bridge(9999)
+
+        assert captured["cmd"][:3] == ["/usr/bin/raft", "--profile", "secondary-profile-slug"]
+
+    def test_spawn_bridge_missing_scoped_profile_does_not_borrow_default(
+        self, multiplex_scope, default_profile_env, monkeypatch, caplog
+    ):
+        """A secondary profile with no RAFT_PROFILE of its own must fail
+        closed (bridge not spawned), not borrow the default profile's."""
+        import plugins.platforms.raft.adapter as raft_mod
+
+        multiplex_scope({})
+        monkeypatch.setattr(raft_mod.shutil, "which", lambda name: "/usr/bin/raft")
+        popen_called = []
+        monkeypatch.setattr(
+            raft_mod.subprocess, "Popen",
+            lambda cmd, **kwargs: popen_called.append(cmd),
+        )
+
+        adapter = _make_adapter()
+        adapter._spawn_bridge(9999)
+
+        assert popen_called == []
+
+    def test_env_enablement_scoped_reads_profiles_own_value(
+        self, multiplex_scope, monkeypatch
+    ):
+        """Env enablement must consult the secondary profile's own
+        RAFT_PROFILE via the secret scope even when the shared process env
+        has none at all — reading raw os.environ here would (incorrectly)
+        return None despite the profile being configured."""
+        monkeypatch.delenv("RAFT_PROFILE", raising=False)
+        multiplex_scope({"RAFT_PROFILE": "secondary-profile-slug"})
+        assert _env_enablement() == {"enabled": True}
+
+    def test_env_enablement_scoped_without_profile_fails_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        multiplex_scope({})
+        assert _env_enablement() is None
+
+    def test_register_platform_hint_uses_scoped_profile(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The Agent Card / system-prompt hint baked at register() time must
+        name the secondary profile's own slug, not the default's."""
+        multiplex_scope({"RAFT_PROFILE": "secondary-profile-slug"})
+        ctx = _FakeCtx()
+        register(ctx)
+        assert "--profile secondary-profile-slug" in ctx.platform_kwargs["platform_hint"]
+        assert "default-profile-slug" not in ctx.platform_kwargs["platform_hint"]
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            assert _env_enablement() == {"enabled": True}
+            ctx = _FakeCtx()
+            register(ctx)
+            assert "--profile default-profile-slug" in ctx.platform_kwargs["platform_hint"]
+        finally:
+            set_multiplex_active(False)
 


### PR DESCRIPTION
## What & why

`_spawn_bridge()`, `_env_enablement()`, and `register()`'s `platform_hint` all resolve `RAFT_PROFILE` via raw `os.environ.get` unconditionally.

Under a multiplexed gateway, a secondary profile's `connect()` (which calls `_spawn_bridge()`) and `discover_plugins()` (which calls `register()`) both run inside `_profile_runtime_scope` — confirmed directly in `gateway/run.py::_start_one_profile_adapters` (called only for non-active/secondary profiles; the active/default profile takes a separate, unscoped startup path). Inside that scope, `os.environ` still holds the **default** profile's YAML-to-env bridge output. A secondary profile with its own `RAFT_PROFILE` (configured only in its own `.env`) would silently:

- spawn the `raft agent bridge` subprocess with `--profile <default's slug>` — connecting the bridge to the **wrong external Raft workspace/agent identity**
- get auto-enabled/disabled by `_env_enablement()` based on whether the *default* profile has `RAFT_PROFILE` set, not its own
- have its system-prompt CLI hint (`platform_hint`, baked once at `register()` time) tell the agent to always pass `--profile <default's slug>` to every `raft` CLI call — actively misdirecting the agent's own tool use against the external Raft system

## Fix

Adds `_resolve_raft_profile()`, mirroring the established Buzz/SimpleX/A2A fix for this bug class (#98738), with one refinement specific to Raft: since Raft has no `config.yaml` equivalent for this value (env-only), a secondary profile's only way to configure it is via its own `.env` — which the secret scope installed by `_profile_runtime_scope` already carries. So inside a secondary profile's scope, this resolves via `get_secret("RAFT_PROFILE")` (reads that profile's own `.env` through the scope) instead of falling back to a placeholder. Outside any scope — single-profile gateways, and the default profile's own unscoped startup path (confirmed it never installs a scope) — it keeps the legacy `os.environ.get` precedence unchanged, so `get_secret()`'s `UnscopedSecretError` (raised for an unscoped read under active multiplex) is never reached from these call sites.

## Tests

Added `TestMultiplexProfileScope` to `tests/gateway/test_raft_adapter.py` (6 tests): the bridge subprocess uses the scoped profile / fails closed (not spawned) when the profile has none of its own, `_env_enablement` reads the profile's own value via the scope even with no ambient env / fails closed without one, `register()`'s `platform_hint` names the scoped profile not the default's, and the default profile stays unscoped with unchanged env precedence.

- `tests/gateway/test_raft_adapter.py` + `tests/plugins/test_raft_check_fn_silent.py` (only two files that import this adapter) — 14 passed
- Mutation-verify: reverting the fix makes 5 of 6 new tests fail as expected (the 6th, the default-profile-unscoped case, was never buggy). One test (`test_env_enablement_scoped_reads_profiles_own_value`) initially passed even without the fix because both the scoped-correct read and the raw-env-fallback produced the same `{"enabled": True}` result for that scenario — caught by mutation-verify and fixed by clearing the ambient env so only the scope carries the value, which does correctly differentiate.

## Scope note / prior art check

Three open PRs also touch `plugins/platforms/raft/adapter.py`:
- **#56245** — reworks `_spawn_bridge`'s subprocess env construction (`hermes_subprocess_env()` + explicit `env["RAFT_PROFILE"] = profile`) but does not touch the `profile = ...` resolution line itself — complementary, not conflicting; once both land, `#56245`'s `env["RAFT_PROFILE"] = profile` picks up this fix's now-correctly-scoped value.
- **#50369** — adds proxy-env cleanup to `_spawn_bridge` (different lines, no overlap) and separately rewrites `register()`'s `platform_hint` construction (adds a local `profile = os.environ.get(...)` var + new no-op-send warning content) — this **does** textually collide with this fix's `platform_hint` line, though it doesn't fix the scoping bug itself (still raw `os.environ.get`). A straightforward rebase either direction; flagging transparently rather than silently.
- **#59185** — adds bridge-process-exit monitoring; its diff hunk starts after this fix's target line, no overlap.

Root-cause/competitor keyword searches (`RAFT_PROFILE`, "raft multiplex profile", "raft platform_hint") found no PR fixing this specific scoping bug.