### PR TITLE
fix(memory): make honcho setup connection test prove credentials

### DIFF
--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -606,6 +606,10 @@ def cmd_setup(args) -> None:
             secret=True,
         )
         if new_local_key:
+            # Masked input hides clipboard races; the received length makes
+            # a wrong paste (e.g. a shell command instead of the JWT)
+            # visible before it is saved (#100384).
+            print(f"  Received {len(new_local_key)} chars.")
             hermes_host["apiKey"] = new_local_key
         elif current_host_key:
             print("  Keeping existing local JWT.")
@@ -1019,10 +1023,24 @@ def cmd_setup(args) -> None:
         from plugins.memory.honcho.client import HonchoClientConfig, get_honcho_client, reset_honcho_client
         reset_honcho_client()
         hcfg = HonchoClientConfig.from_global_config(host=_host_key())
-        get_honcho_client(hcfg)
+        client = get_honcho_client(hcfg)
+        # Constructing a client performs no network I/O, so a rejected
+        # credential used to pass here and only surface later, on the
+        # daemon's first memory operation (#100384). The SDK's workspace
+        # get-or-create is the authenticated call it runs before every
+        # workspace-scoped operation, so exercising it here proves the
+        # real auth path end to end.
+        client._ensure_workspace()
         print("OK")
     except Exception as e:
-        print(f"FAILED\n  Error: {e}")
+        _status = getattr(e, "status", 0)
+        _code = getattr(e, "code", "")
+        if _status in (401, 403):
+            print(f"FAILED (server reachable, but it rejected these credentials)\n  Error: {e}")
+        elif _code in ("connection_error", "timeout"):
+            print(f"FAILED (could not reach the Honcho server)\n  Error: {e}")
+        else:
+            print(f"FAILED\n  Error: {e}")
         return
 
     print("\n  Honcho is ready.")

--- a/tests/honcho_plugin/test_cli.py
+++ b/tests/honcho_plugin/test_cli.py
@@ -101,6 +101,127 @@ class TestCmdSetupLocalJwt:
         host_block = (cfg.get("hosts") or {}).get("hermes") or {}
         assert host_block.get("apiKey") == "my-local-jwt-token"
 
+    def test_local_jwt_prompt_echoes_received_length(self, monkeypatch, capsys, tmp_path):
+        """The masked JWT prompt must echo the received length so a clipboard
+        race (wrong paste) is visible before the credential is saved (#100384)."""
+        self._run_setup(
+            monkeypatch,
+            tmp_path,
+            initial_cfg={},
+            prompt_answers=[
+                "local",                       # deployment
+                "http://localhost:8000",       # base URL
+                "my-local-jwt-token",          # local JWT (18 chars)
+            ],
+        )
+        out = capsys.readouterr().out
+        assert "Received 18 chars." in out
+
+
+class TestCmdSetupConnectionTest:
+    """The setup wizard's connection test must make a real authenticated call.
+
+    Constructing the SDK client performs no network I/O, so a client-only
+    check reports OK regardless of credentials: against a self-hosted Honcho
+    with AUTH_USE_AUTH=true, setup looked successful while the daemon failed
+    every memory operation (#100384).
+    """
+
+    def _run_setup(self, monkeypatch, tmp_path, ensure_workspace):
+        """Run the wizard against a fake client whose `_ensure_workspace`
+        raises whatever `ensure_workspace` raises."""
+        import plugins.memory.honcho.cli as honcho_cli
+
+        cfg_path = tmp_path / "honcho.json"
+        cfg_path.write_text("{}")
+        monkeypatch.setattr(honcho_cli, "_read_config", lambda: {})
+        monkeypatch.setattr(honcho_cli, "_local_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_config_path", lambda: cfg_path)
+        monkeypatch.setattr(honcho_cli, "_host_key", lambda: "hermes")
+        monkeypatch.setattr(honcho_cli, "_ensure_sdk_installed", lambda: True)
+        monkeypatch.setattr(honcho_cli, "_write_config", lambda cfg, path=None: None)
+
+        answers = [
+            "local",                       # deployment
+            "http://localhost:8000",       # base URL
+            "my-local-jwt-token",          # local JWT
+        ]
+
+        def _fake_prompt(label, default=None, secret=False):
+            if answers:
+                return answers.pop(0)
+            return default or ""
+
+        monkeypatch.setattr(honcho_cli, "_prompt", _fake_prompt)
+
+        fake_config = SimpleNamespace(
+            workspace_id="hermes",
+            peer_name="eri",
+            ai_peer="hermes",
+            observation_mode="off",
+            write_frequency="async",
+            recall_mode="hybrid",
+            session_strategy="per-session",
+            resolve_session_name=lambda: "hermes",
+        )
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.HonchoClientConfig.from_global_config",
+            lambda host=None: fake_config,
+        )
+
+        class FakeClient:
+            def _ensure_workspace(self):
+                ensure_workspace()
+
+        monkeypatch.setattr(
+            "plugins.memory.honcho.client.get_honcho_client",
+            lambda cfg: FakeClient(),
+        )
+
+        honcho_cli.cmd_setup(SimpleNamespace())
+
+    def test_rejected_credentials_fail_setup(self, monkeypatch, capsys, tmp_path):
+        class _AuthRejected(Exception):
+            status = 401
+            code = "api_error"
+
+        def _ensure():
+            raise _AuthRejected("Invalid JWT")
+
+        self._run_setup(monkeypatch, tmp_path, _ensure)
+
+        out = capsys.readouterr().out
+        assert "FAILED (server reachable, but it rejected these credentials)" in out
+        assert "Invalid JWT" in out
+        assert "Honcho is ready." not in out
+
+    def test_unreachable_server_is_distinguished(self, monkeypatch, capsys, tmp_path):
+        class _Unreachable(Exception):
+            status = 0
+            code = "connection_error"
+
+        def _ensure():
+            raise _Unreachable("Connection refused")
+
+        self._run_setup(monkeypatch, tmp_path, _ensure)
+
+        out = capsys.readouterr().out
+        assert "FAILED (could not reach the Honcho server)" in out
+        assert "Honcho is ready." not in out
+
+    def test_authenticated_roundtrip_reports_ok(self, monkeypatch, capsys, tmp_path):
+        calls = []
+
+        def _ensure():
+            calls.append("ensured")
+
+        self._run_setup(monkeypatch, tmp_path, _ensure)
+
+        out = capsys.readouterr().out
+        assert calls == ["ensured"]
+        assert "Testing connection... OK" in out
+        assert "Honcho is ready." in out
+
 
 class TestCmdStatus:
     def test_reports_connection_failure_when_session_setup_fails(self, monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## What does this PR do?

The `hermes memory setup` (honcho) wizard's "Testing connection... OK" only constructed the SDK client — the honcho-ai `Honcho` constructor performs no network I/O, so the check succeeded regardless of credentials. Against a self-hosted Honcho with `AUTH_USE_AUTH=true`, setup reported success while the daemon then failed every memory operation ("No access token provided" / "Invalid JWT"), i.e. silent memory-death that looked configured.

This PR makes the wizard's connection test exercise the SDK's workspace get-or-create (`client._ensure_workspace()`) — the exact authenticated call the SDK runs before every workspace-scoped operation — so a rejected credential fails setup loudly. The failure output now distinguishes:

- **reachable but credentials rejected** (401/403) — `FAILED (server reachable, but it rejected these credentials)`
- **unreachable** (SDK `connection_error`/`timeout`) — `FAILED (could not reach the Honcho server)`
- anything else keeps the plain `FAILED\n Error: ...`

It also echoes the received length at the masked local-JWT prompt (`Received 18 chars.`), a one-line defense from the issue against clipboard races pasting the wrong string into the masked prompt.

The wizard already uses the pinned `honcho-ai==2.2.0`, so `_ensure_workspace` (idempotent get-or-create via `POST /v3/workspaces`) is stable; the error classification uses duck-typed `status`/`code` attributes instead of importing SDK exception classes.

## Related Issue

Fixes #100384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/memory/honcho/cli.py` (setup wizard connection test): call `client._ensure_workspace()` after `get_honcho_client()` so the test makes a real authenticated round-trip instead of a constructor-only check; classify the failure as rejected-credentials vs unreachable vs generic.
- `plugins/memory/honcho/cli.py` (local JWT prompt): echo the received input length before saving, so a wrong paste is visible despite masked input.
- `tests/honcho_plugin/test_cli.py`: new `TestCmdSetupConnectionTest` class with regression tests (rejected credentials fail setup; unreachable server is distinguished; an authenticated round-trip reports OK and actually invokes the check), plus a test that the JWT prompt echoes the received length.

## How to Test

1. Run `pytest tests/honcho_plugin/ -q` — Observed result: `309 passed, 16 skipped` (includes the 4 new tests).
2. Regression proof: `tests/honcho_plugin/test_cli.py::TestCmdSetupConnectionTest::test_rejected_credentials_fail_setup` drives the wizard with a fake client whose workspace call raises a 401-shaped error — the wizard must print `FAILED (server reachable, but it rejected these credentials)` and must NOT print `Honcho is ready.`. On `main`, no authenticated call is made at all, so this path cannot fail there — that is the bug.
3. Manual (self-hosted, `AUTH_USE_AUTH=true`): run `hermes memory setup`, paste a deliberately wrong JWT at the masked prompt — the wizard now fails at "Testing connection" with the rejected-credentials message instead of reporting OK.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A