### PR TITLE
fix: container detection via root mount + kanban steer-delivery fixes + cron-provider plugin routing (consolidated)

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,0 +1,1 @@
+skip-agent

--- a/docs/steer-delivery-contract.md
+++ b/docs/steer-delivery-contract.md
@@ -1,0 +1,166 @@
+# Steer Delivery Contract
+
+> **Status:** authoritative contract for every /steer surface in the Hermes
+> ecosystem.
+> **Audience:** plugin authors who implement a `POST /steer` endpoint
+> (dashboard/desktop backend `plugin_api.py`), and anyone debugging steer
+> delivery to a kanban worker.
+> **Source of truth:** this document. Core guarantees delivery; a steer
+> *surface* (plugin) implements the endpoint policy below.
+> **Last updated:** 2026-08-23
+
+## Purpose
+
+A **steer** is a short operator instruction aimed at a live or queued kanban
+task: "stop", "use the other branch", "answer in Spanish". Steers are delivered
+through the **task-comment bridge** — the same durable `task_comments` channel
+that powers the kanban comment thread — never by mutating worker state
+directly. The worker's run loop drains new comments as out-of-band input
+between tool calls (`agent.steer()`), so an operator can talk to a task without
+the block → comment → unblock dance or a restart.
+
+This contract makes the steer-delivery semantics **common across every session
+and project**, not a plugin-local policy. Any surface that exposes a steer
+endpoint (dashboard plugin, desktop plugin, TUI, script) must implement the
+exact status→response behavior in §2. The core owns the durability and the
+delivery mechanics (§3); the surface owns only the endpoint policy — and that
+policy is fixed here.
+
+## 1. The status → response table
+
+Given a `POST /steer` request carrying `{task_id, steer_text}` against a task in
+the given status:
+
+| Task status | Behavior | HTTP | Response body |
+|---|---|---|---|
+| `running` | **Live steer** — comment written to the task-comment bridge; lands on the worker's next tool drain (≥6s poll) | 200 | `{"ok": true, "comment_id": N, "task_id": …, "delivery": "comment-bridge (>=6s poll; lands on next tool drain)", "resolved_board": …}` |
+| `todo` / `ready` / `blocked` / `scheduled` / `triage` / `review` | **Deferred — saved for the next run.** Comment written anyway and returned 200 with `deferred: true`; it rides the next run's context via the comment thread (`build_worker_context`) | 200 | `{"ok": true, "comment_id": N, "task_id": …, "deferred": true, "delivery": "saved for next run — lands in the next run's context via the comment thread", "resolved_board": …}` |
+| `done` / `archived` | **Rejected** — no next run exists, so the steer would never be consumed; it is not saved (a steer is never silently lost, nor parked on a task that can never read it) | 409 | `{"detail": "task is '<status>' (done/archived) — no next run; steer not saved"}` |
+| task not found | Rejected | 404 | `{"detail": "task <id> not found"}` |
+| empty `steer_text` | Rejected (nothing to deliver) | 400 | `{"detail": "steer_text is required"}` |
+
+Notes that bind every implementation:
+
+- **A steer is a durable comment first.** Every 200 response has already
+  committed the comment to `task_comments`. There is no "accepted but lost"
+  state: if the request returns 200, the steer is durably stored.
+- **`deferred: true` is a delivery promise, not a refusal.** The steer was
+  accepted and will reach the worker on its next run, as part of the run's
+  context (§3.3). UIs should render this distinctly (e.g. a "saved for next
+  run" toast) instead of showing the steer as delivered live.
+- **Only the terminal lanes 409.** `done`/`archived` are the sole statuses
+  with no future run. Everything else in `VALID_STATUSES` has either a live
+  run now (`running`) or a run ahead of it, so a steer is queued rather than
+  rejected. 409 must never be used for "not running right now" — that is
+  exactly the deferred case.
+
+## 2. Surface requirements (the contract every endpoint implements)
+
+A conforming `POST /steer` surface MUST:
+
+1. Accept `{task_id, steer_text}` (and optionally a `board` query param that
+   resolves through the core board-resolution helper when provided).
+2. Strip `steer_text`; reject empty text with 400.
+3. Look up the task; reject unknown ids with 404.
+4. Map the task status through the §1 table exactly:
+   - `running` → live comment + 200 (no `deferred` field, or `deferred: false`)
+   - non-terminal, non-running → comment + 200 with `deferred: true`
+   - `done`/`archived` → **no comment written**, 409
+5. Write the comment through the core `add_comment(conn, task_id, author,
+   body=text)` helper — the durable comment is the delivery vehicle; never
+   invent a parallel mechanism.
+6. Never mutate worker state, never call `agent.steer()` from the endpoint,
+   never fabricate a delivery the bridge didn't make.
+
+The surface does NOT need to implement polling, watermarking, or context
+injection — those are core (§3) and shared by every worker. If a surface cannot
+reach the core kanban DB (e.g. `hermes_cli.kanban_db` unavailable), it returns
+500 rather than a fake success.
+
+## 3. Core mechanics (guaranteed by core, not by the surface)
+
+### 3.1 Durable comment channel
+
+`task_comments` is a core SQLite table; `add_comment` commits the steer row
+transactionally. This is what makes "accepted = durable" true across restarts
+and across surfaces. Any steer that returns 200 exists in this table.
+
+### 3.2 Live delivery: the ≥6s poll bridge
+
+The worker's run loop calls `tools.kanban_tools.inject_new_comments_from_env`
+between tool calls. It is **self-gating and rate-limited**:
+
+- no-op unless the process is a kanban worker (`HERMES_KANBAN_TASK` set) and
+  the agent exposes `steer`;
+- rate-limited to `_COMMENT_POLL_MIN_INTERVAL_SECONDS = 6.0` — a live steer
+  lands within roughly one poll interval (a few seconds), never synchronously
+  and never inside the in-flight tool call;
+- watermarked per task id so already-seen comments are never re-injected;
+- never raises into the agent loop (best-effort).
+
+Injected comments are folded into the agent's next tool result as an
+OUT-OF-BAND steer via `agent.steer()` (non-interrupting by design — it does
+not abort the current tool call).
+
+### 3.3 Deferred delivery: comment-thread context pickup
+
+A deferred steer is consumed by the task's **next run**, not by any live
+loop. The dispatcher's `build_worker_context` includes the task's comment
+thread (most recent 30 comments shown; older collapsed) in every spawned
+worker's context. The deferred comment therefore appears in the next run's
+context as part of the thread — the worker reads it as history and acts on it.
+
+### 3.4 The run-start watermark baseline (no swallowed steers)
+
+The live injector seeds its per-task watermark on first poll. Historically it
+seeded to the *current max comment id*, which meant a comment landing between
+spawn/context-build and the first poll was neither in the worker's context
+(built earlier) nor injected (seeded past) — a silent swallow.
+
+The dispatcher now pins an internal **run-start baseline** env var
+(`HERMES_KANBAN_COMMENT_BASELINE`, set to the task's max comment id at spawn —
+an internal dispatcher→worker process bridge, not a user-facing config knob)
+and the injector seeds to that baseline and injects comments past it. The
+spawn→first-poll window is closed: every comment after the run started is
+injected, and comments already in the context are not re-injected. This is
+core behavior; surfaces must not re-implement it.
+
+## 4. Why the 200-with-deferred shape (design notes)
+
+- **Accept-and-queue beats reject-and-retry.** An operator steering a queued
+  task wants "I'll do that when it runs", not an error they must notice and
+  re-send later. The comment is durable either way, so queueing loses nothing.
+- **Terminal 409 is honesty.** Saving a steer onto a `done`/`archived` task
+  would be a silent fake delivery — the comment would sit forever unread. The
+  409 says so plainly.
+- **One policy, all surfaces.** The status→response mapping is fixed here so a
+  steer behaves identically whether it arrives from a dashboard plugin, a
+  desktop plugin, or a script. A surface's only job is to translate this
+  contract to its own wire format.
+
+## Attribution
+
+- **Design raised by Silksteele** on 2026-08-19 (steer-delivery semantics for
+  kanban tasks), **resolved 2026-08-23** with the full deferred-steer design
+  (steer-delivery race card t_234c49d1).
+- **Reference implementation:** crew-mandala plugin commit `a3393aa`
+  (`fix(plugin): /steer queues non-running steers (saved-for-next-run UX)`),
+  which ported the §1 table to `dashboard/plugin_api.py`. This document is the
+  canonical restatement of that behavior for every steer surface.
+- Core durability + comment-thread pickup pre-existed the port; the run-start
+  watermark baseline (card t_95ab583a) closed the remaining spawn→first-poll
+  swallow window in core.
+
+## References
+
+- `tools/kanban_tools.py::inject_new_comments_from_env` — live poll bridge
+  (`_COMMENT_POLL_MIN_INTERVAL_SECONDS`, watermark, baseline seed)
+- `hermes_cli/kanban_db.py::_default_spawn` / `_max_comment_id_for_task` —
+  dispatcher pins `HERMES_KANBAN_COMMENT_BASELINE`
+- `hermes_cli/kanban_db.py::build_worker_context` — comment-thread context
+  pickup (most recent 30 comments)
+- `hermes_cli/kanban_db.py::add_comment` / `list_comments_after` — durable
+  comment channel and incremental read
+- `run_agent.py::steer` — non-interrupting steer injection into the next tool
+  result
+- Reference surface: crew-mandala `dashboard/plugin_api.py::steer` (a3393aa)

--- a/docs/steer-delivery-contract.md
+++ b/docs/steer-delivery-contract.md
@@ -121,9 +121,13 @@ The dispatcher now pins an internal **run-start baseline** env var
 (`HERMES_KANBAN_COMMENT_BASELINE`, set to the task's max comment id at spawn —
 an internal dispatcher→worker process bridge, not a user-facing config knob)
 and the injector seeds to that baseline and injects comments past it. The
-spawn→first-poll window is closed: every comment after the run started is
-injected, and comments already in the context are not re-injected. This is
-core behavior; surfaces must not re-implement it.
+spawn→first-poll swallow window is closed: every comment written after the run
+started is delivered. One precision note: a comment landing between the
+baseline pin (spawn) and the worker's first context build is delivered TWICE —
+once in-thread (it is already in `build_worker_context`'s comment thread) and
+once as a live injection. That is a duplicate, never a loss: the guarantee is
+"never swallowed," not "exactly once." This is core behavior; surfaces must not
+re-implement it.
 
 ## 4. Why the 200-with-deferred shape (design notes)
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10717,6 +10717,31 @@ def _retag_legacy_worker_sessions(workspaces_root_path: str) -> None:
         _log.debug("kanban worker: legacy session retag skipped (%s)", exc)
 
 
+def _max_comment_id_for_task(
+    task_id: str, *, board: Optional[str] = None
+) -> Optional[int]:
+    """Best-effort max comment id for a task, or ``None`` on any failure.
+
+    Internal bridge for the live comment-injector's run-start baseline
+    (``HERMES_KANBAN_COMMENT_BASELINE``). Must never raise into the spawn
+    path — a busy/missing DB just skips the pin and the worker falls back
+    to the legacy seed-to-max behavior.
+    """
+    try:
+        conn = connect(board=board)
+        try:
+            rows = list_comments(conn, task_id)
+            return max((c.id for c in rows), default=0)
+        finally:
+            try:
+                conn.close()
+            except Exception:
+                pass
+    except Exception as exc:
+        _log.debug("kanban worker: comment baseline read failed (%s)", exc)
+        return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10840,6 +10865,18 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    # Run-start comment baseline — INTERNAL dispatcher→worker process bridge,
+    # NOT a user-facing config knob. The live comment-injector
+    # (tools/kanban_tools.py::inject_new_comments_from_env) seeds its
+    # per-task watermark to this value on first poll and then injects
+    # anything past it, closing the narrow spawn→first-poll window where a
+    # comment added right after context-build would otherwise be silently
+    # swallowed. Absent/unparseable (non-dispatcher spawns, legacy) → the
+    # injector keeps its old seed-to-max behavior.
+    _baseline = _max_comment_id_for_task(task.id, board=board)
+    if _baseline is not None:
+        env["HERMES_KANBAN_COMMENT_BASELINE"] = str(_baseline)
 
     # A worker must NEVER boot the interactive TUI: an inherited HERMES_TUI=1
     # or a `display.interface: tui` in the profile's config would send the

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -474,8 +474,9 @@ def discover_entrypoint_manifests() -> List["PluginManifest"]:
 
     * **Kind classification** — the module source is resolved import-free
       (``_resolve_module_source``) and scanned for provider markers
-      (``_detect_kind_from_source``), so memory providers (``exclusive``)
-      and model providers (``model-provider``) are routed to their own
+      (``_detect_kind_from_source``), so memory providers (``exclusive``),
+      model providers (``model-provider``), and cron scheduler providers
+      (``cron-provider``) are routed to their own
       discovery systems instead of being eagerly imported here.
     * **Capability declarations** — read from the companion
       ``hermes_agent.plugin_capabilities`` entry-point group (declarations
@@ -680,7 +681,14 @@ def _get_enabled_plugins() -> Optional[set]:
 # Data classes
 # ---------------------------------------------------------------------------
 
-_VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
+_VALID_PLUGIN_KINDS: Set[str] = {
+    "standalone",
+    "backend",
+    "exclusive",
+    "platform",
+    "model-provider",
+    "cron-provider",
+}
 
 
 def _portable_skill_namespace(key: str) -> str:
@@ -990,12 +998,18 @@ def _detect_kind_from_source(source_text: str) -> Optional[str]:
     or ``MemoryProvider``) belongs to the memory-provider discovery
     system (``exclusive``); a module that registers a model provider
     (``register_provider`` + ``ProviderProfile``) belongs to the
-    providers discovery (``model-provider``). Applied to both directory
-    plugins and pip entry-point plugins so neither is eagerly imported
-    by the general PluginManager.
+    providers discovery (``model-provider``); a module that registers a
+    cron scheduler provider (``register_cron_scheduler`` or
+    ``CronScheduler``) belongs to the cron-provider discovery
+    (``cron-provider``, mirroring
+    ``plugins/cron_providers/__init__.py:_is_cron_provider_dir``).
+    Applied to both directory plugins and pip entry-point plugins so
+    neither is eagerly imported by the general PluginManager.
     """
     if "register_memory_provider" in source_text or "MemoryProvider" in source_text:
         return "exclusive"
+    if "register_cron_scheduler" in source_text or "CronScheduler" in source_text:
+        return "cron-provider"
     if "register_provider" in source_text and "ProviderProfile" in source_text:
         return "model-provider"
     return None
@@ -4419,6 +4433,27 @@ class PluginManager:
                 )
                 continue
 
+            # Cron scheduler provider plugins are loaded by
+            # plugins/cron_providers/__init__.py (its own discovery, keyed
+            # off ``cron.provider`` config). The general loader records the
+            # manifest for introspection but does not load the module —
+            # PluginContext has no register_cron_scheduler, so importing
+            # register(ctx) would only produce a spurious
+            # "'PluginContext' object has no attribute
+            # 'register_cron_scheduler'" warning on every session start
+            # (#62951) and leave a permanently failed registration entry.
+            if manifest.kind == "cron-provider":
+                loaded = LoadedPlugin(manifest=manifest, enabled=False)
+                loaded.error = (
+                    "cron-provider plugin — activate via cron.provider config"
+                )
+                self._plugins[lookup_key] = loaded
+                logger.debug(
+                    "Skipping '%s' (cron-provider, handled by cron_providers/ discovery)",
+                    lookup_key,
+                )
+                continue
+
             # Model provider plugins are loaded by providers/__init__.py
             # (its own lazy discovery keyed off first get_provider_profile()
             # call). We record the manifest here for introspection but do
@@ -4854,9 +4889,10 @@ class PluginManager:
         """Classify a pip entry-point plugin by scanning its module source.
 
         The ``kind`` semantics are the same for pip entry points as for
-        directory plugins: memory providers (``exclusive``) and model
-        providers (``model-provider``) have their own discovery systems,
-        so importing them here registers nothing and only pays the
+        directory plugins: memory providers (``exclusive``), model
+        providers (``model-provider``), and cron scheduler providers
+        (``cron-provider``) have their own discovery systems, so
+        importing them here registers nothing and only pays the
         module's import cost in every Hermes process (e.g. a pip
         memory-provider plugin pulling in onnxruntime via fastembed —
         ~60 MB RSS on startup).

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1598,22 +1598,59 @@ def translate_cwd_for_wsl_backend(cwd: str) -> str:
 _container_detected: bool | None = None
 
 
+def _root_mount_indicates_container(mountinfo_text: str) -> bool:
+    """Return True when the root mount (``/``) looks like a container rootfs.
+
+    A real container runtime presents the process root as an ``overlay`` or
+    ``rootfs`` mount (overlayfs snapshot backing). A bare-metal host mounts a
+    real block device (btrfs/ext4/xfs) as ``/``. The critical detail is that
+    only the mount whose mount point is exactly ``/`` is inspected — the host
+    that runs Docker legitimately has ``/var/lib/containerd/...`` and
+    ``/var/lib/docker/...`` paths scattered through its mount table (daemon
+    data, netns, snapshot dirs), but never as the root mount. Scanning the
+    whole blob for runtime substrings (the old behavior) is what produced the
+    false positive.
+
+    mountinfo line layout (fields split on whitespace):
+      id parent major:minor root mountpoint options [opt...] - fstype source superopts
+    """
+    for line in mountinfo_text.splitlines():
+        fields = line.split()
+        if len(fields) < 7:
+            continue
+        if fields[4] != "/":
+            # Not the root mount — skip daemon data mounts under /var/lib/...
+            continue
+        try:
+            sep = fields.index("-")
+            fstype = fields[sep + 1]
+        except (ValueError, IndexError):
+            continue
+        # Container roots are overlay (Docker/Podman/K8s overlay2) or rootfs.
+        # A bare-metal host root is a real device filesystem (btrfs/ext4/xfs).
+        return fstype in ("overlay", "rootfs")
+    return False
+
+
 def is_container() -> bool:
     """Return True when running inside a container.
 
     Recognizes Docker (``/.dockerenv``), Podman (``/run/.containerenv``),
-    and — via ``/proc/1/cgroup`` — the docker/podman/lxc cgroup-v1 markers.
+    Kubernetes (``KUBERNETES_SERVICE_HOST`` env — injected into every pod),
+    the docker/podman/lxc cgroup-v1 markers in ``/proc/1/cgroup``, and —
+    for cgroup-v2 runtimes that mask ``/proc/1/cgroup`` to ``0::/`` (Docker
+    with cgroup namespace isolation, containerd/CRI-O on k3s) — a root
+    filesystem inspection: a container root is ``overlay``/``rootfs``,
+    whereas a bare-metal host root is a real block device.
 
-    cgroup v2 collapses ``/proc/1/cgroup`` to a single ``0::/`` line with no
-    runtime marker, so containerd/CRI-O runtimes (the common case on
-    Kubernetes/k3s) were previously missed. To cover those, also check:
-      * ``KUBERNETES_SERVICE_HOST`` env var — set in every Kubernetes pod.
-      * ``kubepods`` / ``containerd`` / ``crio`` markers in ``/proc/1/cgroup``.
-      * the same markers in ``/proc/self/mountinfo`` (cgroup-v2 fallback).
+    Deliberately does NOT scan the whole ``/proc/self/mountinfo`` blob for
+    ``containerd``/``docker`` substrings: a bare-metal host that runs Docker
+    legitimately has those daemon data paths in its host mount table, which
+    previously caused a false positive (host detected as container → Hermes
+    forced the profile HOME onto every subprocess → cron scripts resolving
+    state via ``$HOME/.hermes`` failed with exit 127).
 
     Result is cached for the process lifetime.  Import-safe — no heavy deps.
-
-    See: NousResearch/hermes-agent#47111
     """
     global _container_detected
     if _container_detected is not None:
@@ -1637,13 +1674,12 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2: /proc/1/cgroup may be "0::/" with no marker (private cgroup
+    # namespace). The container runtime's rootfs is still visible as the root
+    # mount. Inspect only the root mount, never the whole mount table.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
+            if _root_mount_indicates_container(f.read()):
                 _container_detected = True
                 return True
     except OSError:

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -438,6 +438,9 @@ def test_every_dispatcher_kanban_var_is_identity_gated():
         "HERMES_KANBAN_BRANCH",
         "HERMES_KANBAN_GOAL_MODE",
         "HERMES_KANBAN_GOAL_MAX_TURNS",
+        # Run-start comment watermark (dispatcher→worker internal bridge);
+        # the live comment-injector reads it to seed its per-task watermark.
+        "HERMES_KANBAN_COMMENT_BASELINE",
     }
     uncovered = injected - set(KANBAN_ENV_KEYS) - behaviour_only
     assert not uncovered, (

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -286,6 +286,39 @@ class TestWorkerSpawnEnv:
         expected_ws = fresh_home / "kanban" / "boards" / "spawntest" / "workspaces"
         assert env["HERMES_KANBAN_WORKSPACES_ROOT"] == str(expected_ws)
 
+    def test_default_spawn_pins_comment_baseline_env(self, fresh_home, monkeypatch):
+        """The dispatcher pins HERMES_KANBAN_COMMENT_BASELINE to the task's
+        newest comment id at spawn — the run-start watermark the live
+        comment-injector seeds to (closes the spawn→first-poll swallow)."""
+        captured = {}
+
+        class FakeProc:
+            pid = 12345
+
+        def fake_popen(cmd, *args, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env", {})
+            return FakeProc()
+
+        monkeypatch.setattr(subprocess, "Popen", fake_popen)
+        kb.create_board("spawntest")
+        with kb.connect(board="spawntest") as conn:
+            tid = kb.create_task(
+                conn, title="baseline worker", assignee="teknium", board="spawntest"
+            )
+            kb.add_comment(conn, tid, author="desktop", body="steer me 1")
+            max_comment_id = kb.add_comment(conn, tid, author="desktop", body="steer me 2")
+
+        # Reuse the same shape _default_spawn sees: a Task row from the DB.
+        with kb.connect(board="spawntest") as conn:
+            task = kb.get_task(conn, tid)
+        assert task is not None
+
+        kb._default_spawn(task, str(fresh_home / "ws"), board="spawntest")
+
+        env = captured["env"]
+        assert env["HERMES_KANBAN_COMMENT_BASELINE"] == str(max_comment_id)
+
 
 # ---------------------------------------------------------------------------
 # CLI surface

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -507,6 +507,151 @@ class TestPluginLoading:
         assert entry.module is None
         assert "exclusive" in (entry.error or "").lower()
 
+    def test_user_cron_plugin_auto_coerced_to_cron_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """User-installed cron scheduler provider plugins must NOT be loaded
+        by the general PluginManager — they belong to plugins/cron_providers
+        discovery.
+
+        Regression test for the chronos crash (#62951):
+            'PluginContext' object has no attribute 'register_cron_scheduler'
+
+        A plugin that calls ``ctx.register_cron_scheduler`` in its
+        ``__init__.py`` should be auto-detected as ``kind: cron-provider``
+        (mirroring ``plugins/cron_providers/__init__.py:
+        _is_cron_provider_dir``) so the general loader records the manifest
+        but does not import/register() it. The real activation happens
+        through ``plugins/cron_providers/__init__.py`` via ``cron.provider``
+        config.
+        """
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "ticktock"
+        plugin_dir.mkdir(parents=True)
+        # No explicit `kind:` — the heuristic should kick in.
+        (plugin_dir / "plugin.yaml").write_text(yaml.dump({"name": "ticktock"}))
+        (plugin_dir / "__init__.py").write_text(
+            "class TickTockScheduler:\n"
+            "    pass\n"
+            "def register(ctx):\n"
+            "    ctx.register_cron_scheduler(TickTockScheduler())\n"
+        )
+        # Even if the user explicitly enables it in config, the loader
+        # should still treat it as cron-provider and skip general loading.
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["ticktock"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = next(
+            e for e in mgr._plugins.values() if e.manifest.name == "ticktock"
+        )
+        assert entry.manifest.kind == "cron-provider", (
+            f"Expected auto-coerced kind='cron-provider', got {entry.manifest.kind}"
+        )
+        # Not loaded by general manager (no register() call, no AttributeError).
+        assert not entry.enabled
+        assert entry.module is None
+        assert "cron-provider" in (entry.error or "").lower()
+
+    def test_entrypoint_cron_provider_auto_coerced_to_cron_provider(
+        self, tmp_path, monkeypatch
+    ):
+        """Pip entry-point cron-provider plugins must NOT be imported by the
+        general PluginManager — same contract as memory/model providers
+        (#62951), so a pip cron provider is recorded for introspection and
+        activates only through plugins/cron_providers discovery.
+        """
+        from importlib.metadata import EntryPoint
+        from types import SimpleNamespace
+
+        module_path = tmp_path / "ticktock_ep.py"
+        module_path.write_text(
+            "class TickTockScheduler:\n"
+            "    pass\n"
+            "def register_cron_scheduler(scheduler):\n"
+            "    pass\n"
+        )
+        monkeypatch.syspath_prepend(str(tmp_path))
+
+        ep = EntryPoint(
+            name="ticktock_ep",
+            value="ticktock_ep:register",
+            group=ENTRY_POINTS_GROUP,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins.importlib.metadata.entry_points",
+            lambda: SimpleNamespace(
+                select=lambda group: [ep] if group == ENTRY_POINTS_GROUP else []
+            ),
+        )
+
+        hermes_home = tmp_path / "hermes_test"
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["ticktock_ep"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        entry = next(
+            e for e in mgr._plugins.values() if e.manifest.name == "ticktock_ep"
+        )
+        assert entry.manifest.kind == "cron-provider", (
+            f"Expected auto-coerced kind='cron-provider', got {entry.manifest.kind}"
+        )
+        assert not entry.enabled
+        assert entry.module is None
+        assert "cron-provider" in (entry.error or "").lower()
+        # The whole point: the module was never imported.
+        assert "ticktock_ep" not in sys.modules
+
+    def test_bundled_chronos_skipped_by_general_manager_and_cron_discovery_activates(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """E2E regression for #62951: the bundled chronos plugin, when
+        enabled, must be recorded (not loaded) by the general PluginManager
+        with no AttributeError warning, and must still activate through the
+        real cron-provider discovery path.
+        """
+        from plugins.cron_providers import load_cron_scheduler
+
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            yaml.safe_dump({"plugins": {"enabled": ["chronos"]}})
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        mgr = PluginManager()
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            mgr.discover_and_load()
+
+        # Recorded for introspection, never loaded via PluginContext.
+        entry = next(
+            e
+            for e in mgr._plugins.values()
+            if e.manifest.name == "chronos" and e.manifest.source == "bundled"
+        )
+        assert entry.manifest.kind == "cron-provider"
+        assert not entry.enabled
+        assert entry.module is None
+        # The exact symptom from #62951 must be gone.
+        assert not [
+            r for r in caplog.records if "register_cron_scheduler" in r.getMessage()
+        ]
+        # The module was never imported by the general manager…
+        assert "plugins.cron_providers.chronos" not in sys.modules
+        # …and the real cron-provider discovery path still activates it.
+        scheduler = load_cron_scheduler("chronos")
+        assert scheduler is not None
+        assert type(scheduler).__name__ == "ChronosCronScheduler"
+
     def test_entrypoint_memory_provider_auto_coerced_to_exclusive(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -372,6 +372,88 @@ class TestIsContainer:
         assert is_container() is True
 
 
+class TestRootMountIndicatesContainer:
+    """Tests for _root_mount_indicates_container() — rootfs inspection."""
+
+    # A bare-metal host running Docker: btrfs root on a real device, with
+    # containerd/docker daemon paths scattered through the rest of the mount
+    # table (the old whole-blob substring scan false-positived on this).
+    HOST_MOUNTINFO = """\
+33 2 0:30 /@ / rw,relatime shared:1 - btrfs /dev/mapper/root rw,compress=zstd:3,ssd,space_cache=v2,subvolid=256,subvol=/@
+409 33 0:89 / /var/lib/docker/rootfs/overlayfs/1d61659cb2d9b624432f8aed5d7033de7348d05eb0e8575a5f3b009d6d6ba234 rw,relatime shared:454 - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/14/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/15/fs
+424 29 0:5 net:[4026533479] /run/docker/netns/e5f8dbe4d34e rw shared:469 - nsfs nsfs rw
+"""
+
+    # A real Docker/Podman/K8s container: root / is an overlay backed by
+    # containerd snapshots (cgroup v2 + private cgroup ns masks /proc/1/cgroup).
+    CONTAINER_MOUNTINFO = """\
+947 912 0:91 / / rw,relatime - overlay overlay rw,lowerdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/19/fs,upperdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/20/fs,workdir=/var/lib/containerd/io.containerd.snapshotter.v1.overlayfs/snapshots/20/work
+948 947 0:95 / /etc/resolv.conf rw,relatime - ext4 /dev/vda1 rw
+"""
+
+    def test_host_btrfs_root_not_container(self):
+        """Host mountinfo with containerd/docker paths but btrfs root → False."""
+        assert hermes_constants._root_mount_indicates_container(self.HOST_MOUNTINFO) is False
+
+    def test_container_overlay_root_is_container(self):
+        """Container mountinfo with overlay root → True."""
+        assert hermes_constants._root_mount_indicates_container(self.CONTAINER_MOUNTINFO) is True
+
+    def test_empty_mountinfo_is_not_container(self):
+        """Empty or malformed mountinfo never claims a container."""
+        assert hermes_constants._root_mount_indicates_container("") is False
+        assert hermes_constants._root_mount_indicates_container("garbage\nno separator here\n") is False
+
+
+class TestIsContainerRootMountFallback:
+    """is_container() via the root-mount fallback (cgroup v2, no .dockerenv)."""
+
+    def _install_mountinfo(self, monkeypatch, mountinfo_text: str):
+        """Monkeypatch builtins.open so /proc/1/cgroup and mountinfo are faked."""
+        import builtins
+
+        real_open = builtins.open
+
+        def fake_open(path, *a, **kw):
+            if path == "/proc/1/cgroup":
+                return _FakeFile("0::/\n")  # cgroup v2, masked — no markers
+            if path == "/proc/self/mountinfo":
+                return _FakeFile(mountinfo_text)
+            return real_open(path, *a, **kw)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+    def test_host_with_containerd_paths_is_not_container(self, monkeypatch):
+        """Bare-metal host (btrfs root + docker daemon paths) → False."""
+        self._install_mountinfo(monkeypatch, TestRootMountIndicatesContainer.HOST_MOUNTINFO)
+        monkeypatch.setattr(hermes_constants, "_container_detected", None)
+        assert is_container() is False
+
+    def test_container_overlay_root_is_container(self, monkeypatch):
+        """Real container (overlay root, cgroup v2 masked) → True."""
+        self._install_mountinfo(monkeypatch, TestRootMountIndicatesContainer.CONTAINER_MOUNTINFO)
+        monkeypatch.setattr(hermes_constants, "_container_detected", None)
+        assert is_container() is True
+
+
+class _FakeFile:
+    """Minimal file-like object so builtins.open fakes behave under .read()."""
+
+    def __init__(self, text: str):
+        self._text = text
+
+    def read(self, *a, **kw):
+        return self._text
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+
 class TestParseReasoningEffort:
     """Tests for parse_reasoning_effort() — string → reasoning config dict."""
 

--- a/tests/tools/test_kanban_comment_injection.py
+++ b/tests/tools/test_kanban_comment_injection.py
@@ -6,7 +6,9 @@ via the agent's OUT-OF-BAND steer channel — so a user can talk to a running
 task without the block→comment→unblock dance or a restart.
 
 Verifies: no-op off a worker, watermark seeding (history isn't re-injected),
-new comments steer, and own-authored comments are skipped.
+new comments steer, own-authored comments are skipped, and the dispatcher's
+run-start baseline (``HERMES_KANBAN_COMMENT_BASELINE``) closes the
+spawn→first-poll swallow window.
 """
 
 from __future__ import annotations
@@ -39,7 +41,7 @@ def worker_home(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
-    for var in ("HERMES_KANBAN_DB", "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_HOME", "HERMES_KANBAN_BOARD"):
+    for var in ("HERMES_KANBAN_DB", "HERMES_KANBAN_WORKSPACES_ROOT", "HERMES_KANBAN_HOME", "HERMES_KANBAN_BOARD", "HERMES_KANBAN_COMMENT_BASELINE"):
         monkeypatch.delenv(var, raising=False)
     try:
         import hermes_constants
@@ -119,6 +121,61 @@ def test_skips_own_authored_comments(worker_home, monkeypatch):
     finally:
         conn.close()
 
+    _unthrottle()
+    assert kt.inject_new_comments_from_env(agent) is False
+    assert agent.steers == []
+
+
+def test_baseline_injects_comment_added_after_spawn_on_first_poll(worker_home, monkeypatch):
+    """With a dispatcher-pinned run-start baseline, a comment that lands
+    between spawn/context-build and the FIRST poll is injected, not swallowed."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="baseline live task")
+        kb.add_comment(conn, tid, author="desktop", body="pre-spawn note 1")
+        kb.add_comment(conn, tid, author="desktop", body="pre-spawn note 2")
+        baseline = kb.list_comments(conn, tid)[-1].id
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_PROFILE", "worker-bot")
+    # Dispatcher pin: run-start baseline = newest comment id at spawn.
+    monkeypatch.setenv("HERMES_KANBAN_COMMENT_BASELINE", str(baseline))
+    agent = FakeAgent()
+
+    # Comment lands in the spawn -> first-poll window (after the baseline).
+    conn = kb.connect()
+    try:
+        kb.add_comment(conn, tid, author="desktop", body="spawn->poll window note")
+    finally:
+        conn.close()
+
+    # FIRST poll injects it — no swallow.
+    _unthrottle()
+    assert kt.inject_new_comments_from_env(agent) is True
+    assert len(agent.steers) == 1
+    assert "spawn->poll window note" in agent.steers[0]
+
+
+def test_baseline_does_not_inject_comments_at_or_below_baseline(worker_home, monkeypatch):
+    """The pre-spawn thread (id <= baseline) is already in the worker's
+    context, so a first poll with nothing past the baseline injects nothing."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="baseline floor task")
+        kb.add_comment(conn, tid, author="desktop", body="old note 1")
+        baseline = kb.add_comment(conn, tid, author="desktop", body="old note 2")
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_PROFILE", "worker-bot")
+    monkeypatch.setenv("HERMES_KANBAN_COMMENT_BASELINE", str(baseline))
+    agent = FakeAgent()
+
+    # First poll: everything is at/below the baseline -> nothing injected,
+    # including the comment whose id exactly equals the baseline.
     _unthrottle()
     assert kt.inject_new_comments_from_env(agent) is False
     assert agent.steers == []

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -376,10 +376,13 @@ def inject_new_comments_from_env(agent: Any) -> bool:
     (``HERMES_KANBAN_TASK`` set) and ``agent`` exposes ``steer``. Returns True
     if a steer was injected, else False. Never raises into the agent loop.
 
-    The first poll only *seeds* the watermark to the newest existing comment —
-    those are already in the worker's context — so only comments added after
-    the run started are injected. The worker's own authored comments (matched
-    by ``HERMES_PROFILE``) are skipped to avoid echoing itself.
+    The first poll seeds the watermark to the run-start baseline — normally
+    the newest existing comment (those are already in the worker's context),
+    or the dispatcher-pinned ``HERMES_KANBAN_COMMENT_BASELINE`` when set so a
+    comment that lands between spawn/context-build and the first poll is still
+    injected — so only comments added after the run started are folded in.
+    The worker's own authored comments (matched by ``HERMES_PROFILE``) are
+    skipped to avoid echoing itself.
     """
     tid = os.environ.get("HERMES_KANBAN_TASK")
     if not tid or agent is None or not hasattr(agent, "steer"):
@@ -406,10 +409,29 @@ def inject_new_comments_from_env(agent: Any) -> bool:
         return False
 
     if seen is None:
-        # First poll for this task: seed past the existing thread, inject nothing.
-        _comment_watermark[tid] = max((c.id for c in rows), default=0)
-        return False
-    if not rows:
+        # First poll for this task. When the dispatcher pinned a run-start
+        # baseline (HERMES_KANBAN_COMMENT_BASELINE), comments at or below it
+        # are already in the worker's context (build_worker_context includes
+        # the thread): seed the watermark there and fall through so anything
+        # past it — added between spawn/context-build and this poll — is
+        # injected instead of being silently swallowed. Without the env var
+        # (non-dispatcher spawns, legacy) keep the old seed-to-max: the
+        # existing thread is context, inject nothing on first poll.
+        baseline: Optional[int] = None
+        baseline_raw = os.environ.get("HERMES_KANBAN_COMMENT_BASELINE")
+        if baseline_raw is not None:
+            try:
+                baseline = int(baseline_raw)
+            except (TypeError, ValueError):
+                baseline = None
+        if baseline is None:
+            _comment_watermark[tid] = max((c.id for c in rows), default=0)
+            return False
+        _comment_watermark[tid] = baseline
+        rows = [c for c in rows if c.id > baseline]
+        if not rows:
+            return False
+    elif not rows:
         return False
 
     # Advance the watermark past everything we just read (including our own

--- a/website/docs/user-guide/features/extending-the-dashboard.md
+++ b/website/docs/user-guide/features/extending-the-dashboard.md
@@ -747,6 +747,17 @@ Routes are mounted under `/api/plugins/<name>/`, so the above becomes:
 - `GET  /api/plugins/my-plugin/data`
 - `POST /api/plugins/my-plugin/action`
 
+:::info One route has a fixed contract — `/steer`
+Backend routes that implement a **steer** endpoint (`POST /steer` — deliver an
+operator instruction to a kanban task via the task-comment bridge) MUST follow
+the [Steer Delivery Contract](https://github.com/NousResearch/hermes-agent/blob/main/docs/steer-delivery-contract.md):
+the status→response table (live for `running`, `deferred: true` for queued
+non-terminal tasks, 409 only for `done`/`archived`), durable comment writes,
+and no fake deliveries. This is THE contract every steer surface implements;
+core guarantees delivery. See the contract for the full semantics and the
+reference implementation (crew-mandala).
+:::
+
 Plugin API routes sit behind the dashboard's normal auth gate — unauthenticated requests get a `401` before the plugin route runs, and requests to a disabled plugin's routes are rejected at request time. Still, **don't expose the dashboard on a public interface with `--host 0.0.0.0` if you run untrusted plugins** — an authenticated session can reach their routes too.
 
 #### Accessing Hermes internals


### PR DESCRIPTION
mise ~/.config/mise/config.toml tools: gh@2.98.0
Bundle of five fixes cherry-picked from a local-first deployment of hermes-agent (bare-metal host running Docker; live checkout on `main` gets hard-reset by the fleet update machinery, so fixes are kept on local branches and upstreamed in consolidated batches rather than drips). All authored by William Mason (@wdmason); rebased onto current `main`.

## 1. fix(hermes_constants): detect containers via root mount, not mountinfo substrings

`is_container()` scanned the whole `/proc/self/mountinfo` blob for `containerd`/`docker`/`crio` substrings as a cgroup-v2 fallback. On a bare-metal host running Docker, daemon data paths legitimately appear in the host mount table, so Hermes misdetected the host as a container and forced the profile HOME onto every subprocess — cron scripts resolving state via `$HOME/.hermes` failed with exit 127.

New logic inspects the root mount only: a container root is `overlay`/`rootfs`, a bare-metal host root is a real block device. Includes 3 new unit tests (host → False, overlay root → True). Verified live in a Docker container: container → True, host → False; 82 tests in `tests/test_hermes_constants.py` pass.

## 2. fix(kanban): seed comment watermark to run-start baseline (close steer-swallow window)

`inject_new_comments_from_env` seeded its per-task watermark to the current max comment id on first poll, so a comment landing between spawn/context-build and the first poll was silently swallowed (neither in the worker's built context nor injected). The dispatcher now pins `HERMES_KANBAN_COMMENT_BASELINE` at spawn; the injector seeds to it and injects anything past it. New var registered in the drift-guard `behaviour_only` set. Tests: two baseline cases + a spawn-env pin test.

## 3. docs: canonicalize the steer-delivery contract for every /steer surface

Documents the deferred-steer contract any steer surface must implement: exact status→response table, durable comment write, poll bridge, run-start comment baseline, and thread-context pickup. Cross-linked from the dashboard backend-routes section. Companion to fix #2 in this bundle (the run-start comment baseline it references).

## 4. docs: correct §3 — baseline window yields duplicate delivery, never loss

Red-team correction to the contract doc: the un-baselined window produces a duplicate delivery (visible in the next injected context), not a loss. LOW severity, but the contract must state the actual failure mode.

## 5. fix(plugins): route cron-provider plugins to their own discovery

Cron scheduler provider plugins register via `ctx.register_cron_scheduler`, which exists only on the `_ProviderCollector` context — not the general `PluginContext`. `_detect_kind_from_source()` had memory/model branches but no cron branch, so cron providers were classified `standalone`, imported by the generic `PluginManager`, and failed on every session load with `'PluginContext' object has no attribute 'register_cron_scheduler'`. Adds a cron-provider branch, the `cron-provider` kind, and skip-loading in the enabled-plugin path (activation stays with cron discovery via `cron.provider`). 3 new behavior-contract tests, all failing without the fix.

## Test evidence

- Targeted: `tests/test_hermes_constants.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_kanban_boards.py tests/tools/test_kanban_comment_injection.py` → 172 passed, 5 skipped
- Full suite: run against this branch (results in comments below)

