### PR TITLE
fix(state): fail closed when a state.db admission lock file cannot be opened

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -2272,10 +2272,11 @@ def _cross_process_repair_lock(db_path: Path):
     """Serialize state.db schema surgery across processes.
 
     Yields True when this process holds the repair lock for *db_path*, False
-    when the bounded acquire timed out.  Unlike the kanban init lock — whose
-    critical section is idempotent, so proceeding without the lock is merely
-    redundant work — proceeding here would be exactly the unsafe interleaving
-    we are trying to prevent, so a caller that gets False must NOT do surgery.
+    when the bounded acquire timed out or the lock file could not be opened at
+    all.  Unlike the kanban init lock — whose critical section is idempotent,
+    so proceeding without the lock is merely redundant work — proceeding here
+    would be exactly the unsafe interleaving we are trying to prevent, so a
+    caller that gets False must NOT do surgery.
 
     ``flock`` is the right primitive for this: the kernel drops the lock when
     the holding process dies, so a crashed repairer cannot leave a stale lock
@@ -2289,14 +2290,22 @@ def _cross_process_repair_lock(db_path: Path):
         lock_path.parent.mkdir(parents=True, exist_ok=True)
         handle = lock_path.open("a+b")
     except OSError as exc:
-        # Read-only dir, exhausted fds, exotic filesystem: fall back to the
-        # in-process behaviour that shipped before this lock existed rather
-        # than refusing to repair a DB we could otherwise heal.
+        # Fail closed, exactly as a timed-out acquire does.  A lock file we
+        # cannot even open means the filesystem is out of space, inodes or
+        # descriptors — and a sibling that opened ITS handle before the disk
+        # filled is still inside writable_schema surgery or VACUUM.  Yielding
+        # True here let two processes run schema surgery on the same live
+        # state.db concurrently, which is itself the corruption source this
+        # lock exists to remove (#100368: the disk-full trigger, then a fresh
+        # corruption on every boot with other writers alive).  Callers already
+        # handle False by re-probing and reporting, and on a read-only
+        # directory no repair strategy could have written anyway.
         logger.warning(
-            "Could not open state.db repair lock %s (%s) — proceeding with "
-            "in-process serialisation only.", lock_path, exc,
+            "Could not open state.db repair lock %s (%s) — skipping schema "
+            "surgery rather than running it without cross-process authority.",
+            lock_path, exc,
         )
-        yield True
+        yield False
         return
 
     acquired = False
@@ -3539,16 +3548,19 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
     result = report
     with _cross_process_repair_lock(db_path) as holding_lock:
         if not holding_lock:
-            # Another process is still inside its critical section. It may
-            # nonetheless have healed the file already (long VACUUM after a
-            # successful strategy), so re-probe before reporting failure.
+            # Another process is still inside its critical section, or the
+            # lock file itself could not be opened (full disk / no fds). It
+            # may nonetheless have healed the file already (long VACUUM after
+            # a successful strategy), so re-probe before reporting failure.
             if _db_opens_cleanly(db_path) is None:
                 report["repaired"] = True
                 report["strategy"] = "repaired_by_other_process"
             else:
                 report["error"] = (
-                    "another process holds the state.db repair lock; skipped "
-                    "schema surgery to avoid racing it"
+                    "could not obtain the state.db repair lock (held by "
+                    "another process, or the lock file was unopenable); "
+                    "skipped schema surgery to avoid racing a concurrent "
+                    "repairer"
                 )
         else:
             # The fast check above avoids taking the lock for a known-exhausted

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -918,10 +918,11 @@ def fts_rebuild_admission(db_path):
     """Serialize full structural FTS rebuilds on *db_path* across processes.
 
     Yields True when this process holds the rebuild authority, False when the
-    bounded acquire timed out. A caller that gets False must NOT perform a
-    full rebuild — proceeding is exactly the concurrent-rebuild interleaving
-    this lock exists to prevent (fail closed). The deferred/stale breadcrumb
-    machinery already guarantees a skipped rebuild is retried later.
+    bounded acquire timed out or the lock file could not be opened at all. A
+    caller that gets False must NOT perform a full rebuild — proceeding is
+    exactly the concurrent-rebuild interleaving this lock exists to prevent
+    (fail closed). The deferred/stale breadcrumb machinery already guarantees
+    a skipped rebuild is retried later.
 
     ``db_path`` may be a str or Path; None (in-memory DB / tests without a
     file path) yields True — a private in-memory DB has no cross-process
@@ -934,13 +935,22 @@ def fts_rebuild_admission(db_path):
     try:
         handle = open(lock_path, "a+b")
     except OSError as exc:
-        # Read-only dir, exhausted fds, exotic filesystem: fall back to the
-        # pre-lock behaviour rather than refusing a rebuild we could run.
+        # Fail closed, exactly as a timed-out acquire does. A lock file we
+        # cannot even open means the filesystem is out of space, inodes or
+        # descriptors — and a sibling process that opened ITS handle before
+        # the disk filled is still holding the authority and rebuilding.
+        # Yielding True here handed every process on a full disk a concurrent
+        # structural rebuild of the same live state.db with no cross-process
+        # authority at all: the disk-full trigger and the re-corruption on
+        # every multi-writer boot in #100368. Deferring costs nothing that
+        # was reachable anyway — the breadcrumb retries, and on a read-only
+        # directory the rebuild's own writes could not have committed either.
         logger.warning(
-            "Could not open FTS rebuild lock %s (%s) — proceeding with "
-            "in-process serialisation only.", lock_path, exc,
+            "Could not open FTS rebuild lock %s (%s) — deferring this rebuild "
+            "rather than running it without cross-process authority.",
+            lock_path, exc,
         )
-        yield True
+        yield False
         return
 
     acquired = False

--- a/tests/state/test_state_db_lock_fail_closed.py
+++ b/tests/state/test_state_db_lock_fail_closed.py
@@ -1,0 +1,160 @@
+"""Unopenable admission lock files must fail CLOSED (#100368).
+
+`state.db` has two cross-process admission authorities that gate destructive
+work on a file several Hermes processes share (gateway service, the Desktop
+app's `hermes serve` backend, CLI sessions, the TUI slash worker):
+
+* `hermes_state_common.fts_rebuild_admission` — full structural FTS rebuilds
+* `hermes_state._cross_process_repair_lock`   — writable_schema surgery / VACUUM
+
+Both document themselves as fail-closed, and both honoured that only for a
+*timed-out* acquire. When the lock file could not be `open()`ed at all they
+yielded True and proceeded "with in-process serialisation only" — which is no
+cross-process authority whatsoever.
+
+That inversion is reachable exactly when it does the most damage. Creating the
+lock file needs a directory entry and an inode, so on a full disk `open()`
+raises ENOSPC — while a sibling process that opened ITS handle before the disk
+filled is still mid-rebuild or mid-surgery. Every process then ran concurrent
+destructive work on the same live DB, i.e. the precise interleaving PR #93200
+added these locks to prevent. #100368 reports that shape: a disk-full trigger,
+then a fresh corruption on every boot with other writers alive, and no
+re-corruption on a boot with zero other writers.
+
+These tests drive a real unopenable lock path (a directory where the code
+expects a file, so `open()` raises a genuine OSError from the kernel) rather
+than monkeypatching the helpers, and assert the deferral is honoured at both
+the primitive and the behavior level.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+import hermes_state_common
+from hermes_state import SessionDB, repair_state_db_schema
+
+
+def _make_unopenable(lock_path: Path) -> None:
+    """Make ``open(lock_path, "a+b")`` raise a real OSError.
+
+    A directory standing where the code expects a regular file yields
+    IsADirectoryError on POSIX and PermissionError on Windows — both OSError,
+    both raised by the kernel. This stands in for the ENOSPC/EMFILE the field
+    reports hit, without needing to fill a real disk.
+    """
+    lock_path.unlink(missing_ok=True)
+    lock_path.mkdir(parents=True, exist_ok=True)
+    with pytest.raises(OSError):
+        open(lock_path, "a+b").close()
+
+
+# ── FTS rebuild authority ───────────────────────────────────────────────────
+
+
+def test_fts_admission_fails_closed_when_lock_file_is_unopenable(tmp_path):
+    """The primitive must refuse admission, not fall back to no authority."""
+    db_path = tmp_path / "state.db"
+    _make_unopenable(db_path.with_name(db_path.name + ".fts_rebuild.lock"))
+
+    with hermes_state_common.fts_rebuild_admission(db_path) as admitted:
+        assert admitted is False
+
+
+def test_fts_admission_still_admits_a_pathless_db(tmp_path):
+    """Guardrail: an in-memory store has no cross-process surface at all.
+
+    The fix must not turn the legitimate no-op case into a permanent deferral.
+    """
+    with hermes_state_common.fts_rebuild_admission(None) as admitted:
+        assert admitted is True
+
+
+def test_rebuild_fts_defers_when_lock_file_is_unopenable(tmp_path):
+    """Behavior: the rebuild entry point reports no progress and rebuilds nothing."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    if not db._fts_enabled:
+        db.close()
+        pytest.skip("FTS5 unavailable in this build")
+    try:
+        db.create_session("s1", source="test")
+        db.append_message("s1", "user", "hello world")
+
+        # Sanity: with an openable lock the rebuild really runs, so a 0 below
+        # is the deferral and not an unrelated no-op.
+        assert db.rebuild_fts() >= 1
+
+        _make_unopenable(
+            db.db_path.with_name(db.db_path.name + ".fts_rebuild.lock")
+        )
+        assert db.rebuild_fts() == 0
+    finally:
+        try:
+            db.close()
+        except Exception:
+            pass
+
+
+# ── Schema-surgery authority ────────────────────────────────────────────────
+
+
+def _build_healthy_db(db_path: Path) -> None:
+    db = SessionDB(db_path=db_path)
+    db.create_session("s1", source="test")
+    db.append_message("s1", "user", "hello world")
+    db.close()
+
+
+def _corrupt_duplicate_fts(db_path: Path) -> None:
+    """Inject a duplicate messages_fts row into sqlite_master.
+
+    Reproduces 'malformed database schema (messages_fts) - table
+    messages_fts already exists'.
+    """
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA writable_schema=ON")
+    conn.execute(
+        "INSERT INTO sqlite_master (type, name, tbl_name, rootpage, sql) "
+        "SELECT type, name, tbl_name, rootpage, sql FROM sqlite_master "
+        "WHERE name='messages_fts'"
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_repair_lock_fails_closed_when_lock_file_is_unopenable(tmp_path):
+    """The primitive must refuse the repair authority."""
+    db_path = tmp_path / "state.db"
+    _make_unopenable(db_path.with_name(db_path.name + ".repair.lock"))
+
+    with hermes_state._cross_process_repair_lock(db_path) as holding:
+        assert holding is False
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="writable_schema corruption harness")
+def test_repair_skips_surgery_when_lock_file_is_unopenable(tmp_path):
+    """Behavior: no writable_schema surgery, no forensic backup, DB untouched.
+
+    A full disk is the worst possible moment to start an unsynchronised
+    VACUUM on a live shared DB, and it is exactly when the lock file cannot
+    be created.
+    """
+    db_path = tmp_path / "state.db"
+    _build_healthy_db(db_path)
+    _corrupt_duplicate_fts(db_path)
+    assert hermes_state._db_opens_cleanly(db_path) is not None
+    before = db_path.read_bytes()
+
+    _make_unopenable(db_path.with_name(db_path.name + ".repair.lock"))
+
+    report = repair_state_db_schema(db_path)
+
+    assert report["repaired"] is False
+    assert "repair lock" in (report["error"] or "")
+    assert report["backup_path"] is None
+    assert not list(tmp_path.glob("state.db.malformed-backup-*"))
+    # The damaged image is left byte-identical for the next (authorised) pass.
+    assert db_path.read_bytes() == before


### PR DESCRIPTION
## Summary

`state.db` has two cross-process admission authorities that gate destructive work on a file several Hermes processes share (gateway service, the Desktop app's `hermes serve` backend, CLI sessions, the TUI slash worker):

- `hermes_state_common.fts_rebuild_admission` — full structural FTS rebuilds
- `hermes_state._cross_process_repair_lock` — `writable_schema` surgery / VACUUM

Both document themselves as fail-closed — "a caller that cannot acquire the lock must NOT rebuild" — and both honoured that only for a *timed-out* acquire. When the lock file could not be `open()`ed at all, they logged a warning and `yield True`, proceeding "with in-process serialisation only", which is no cross-process authority whatsoever.

That inversion is reachable exactly when it does the most damage. Creating the lock file needs a directory entry and an inode, so on a full disk `open()` raises ENOSPC — while a sibling process that opened *its* handle before the disk filled is still mid-rebuild or mid-surgery. Every process then ran concurrent destructive work on the same live DB: precisely the interleaving #93200 added these locks to prevent.

This matches the shape reported in #100368 on the reporter's box:

- episode 1 was triggered by **disk full (0 bytes free) during active writes**;
- re-corruption then happened on **every boot with >= 2 writers alive**, while the `_recover_stale_fts` structural rebuild ran;
- a boot with **zero other writers did not re-corrupt** — which is exactly when a missing cross-process authority costs nothing.

The locks are also recent enough (#93200) that on that install the lock files would not have existed yet, so the very first acquisition after the upgrade had to *create* them — the ENOSPC case, not the cheap append case.

## What changed

Both helpers now `yield False` on `OSError`. This does not invent a new outcome; it routes the error into the outcome the locks already define and every caller already handles:

- `rebuild_fts()` returns 0 and callers fall back to the stale-FTS breadcrumb;
- `_recover_stale_fts()` returns False, leaving canonical writes and LIKE search available;
- the `_init_schema` startup path detaches FTS triggers and persists the retryable breadcrumb;
- `repair_state_db_schema()` re-probes the file and reports.

Nothing reachable is lost. The old comment justified fail-open as "rather than refusing a rebuild we could run", but on a read-only directory the rebuild's and the repair's own writes could not have committed either — the operation failed anyway, just after taking the risk. On the transient resource-exhaustion errors it now defers and retries.

`repair_state_db_schema()`'s error string now names both ways the authority can be missing, since operators read it directly out of the report.

## Scope / what this does not claim

This fixes the amplifier that turns a disk-full event into repeated corruption, and it covers the reporter's Signature A (FTS shadow trees, re-corruption gated on other writers being alive) and the initial trigger.

It does **not** claim to explain Signature B (`system_prompts` / `messages` btrees plus desynchronized autoindexes, ~35 min after a clean cutover with zero other writers). Given episodes 1-3 ran unsynchronised schema surgery and structural rebuilds concurrently, residual damage carried through the table-by-table logical rebuild is a plausible reading, but I have not proven it and the SQLite 3.53.1 question stays open. The quarantined copies the reporter offered would be the way to settle that.

Deliberately out of scope here: a free-space preflight before state.db writes, and the observation that `fts_rebuild_step`'s chunked backfill is intentionally multi-process (it claims chunks under `BEGIN IMMEDIATE`, so it is serialised by SQLite's writer lock rather than by the file lock).

## Test plan

New `tests/state/test_state_db_lock_fail_closed.py` drives a **real** unopenable lock path — a directory where the code expects a regular file, so `open()` raises a genuine kernel `OSError` — instead of monkeypatching the helpers. That stands in for the ENOSPC/EMFILE the field reports hit without needing to fill a disk.

Primitive level:
- `fts_rebuild_admission` yields False when its lock file is unopenable
- `_cross_process_repair_lock` yields False when its lock file is unopenable
- guardrail: a pathless (in-memory) store is still admitted, so the fix cannot turn that legitimate no-op into a permanent deferral

Behavior level:
- `rebuild_fts()` returns 0, asserted against a preceding successful rebuild so the 0 is the deferral and not an unrelated no-op
- `repair_state_db_schema()` on a genuinely malformed DB runs no `writable_schema` surgery, takes no forensic backup, and leaves the damaged image byte-identical for the next authorised pass

All four deferral assertions fail on the pre-fix code; the repair test shows the surgery really did proceed there without cross-process authority.

Suites run (`scripts/run_tests.sh`): `tests/state/`, `tests/test_state_db_malformed_repair.py`, `tests/test_state_db_repair_non_destructive.py`, `tests/test_state_db_repair_live_writer_guard.py`, `tests/test_hermes_state.py`, `tests/test_wal_checkpoint_strategy.py`, `tests/test_hermes_state_wal_fallback.py`, `tests/hermes_cli/test_session_recovery_lost_and_found.py` — 447 passed, plus the 5 new tests. The one remaining failure, `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, reproduces identically on unmodified `main` and is unrelated to this change.