### PR TITLE
fix(agent): keep auxiliary free-only policy out of main fallback

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1370,7 +1370,11 @@ def init_agent(
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client
             _routed_client, _ = resolve_provider_client(
-                agent.provider or "auto", model=agent.model, raw_codex=True)
+                agent.provider or "auto",
+                model=agent.model,
+                raw_codex=True,
+                enforce_auxiliary_free_only=False,
+            )
             if _routed_client is not None:
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
@@ -1417,6 +1421,7 @@ def init_agent(
                             _fb["provider"], model=_fb["model"], raw_codex=True,
                             explicit_base_url=_fb.get("base_url"),
                             explicit_api_key=_fb_explicit_key,
+                            enforce_auxiliary_free_only=False,
                         )
                     except Exception as _fb_exc:
                         logger.debug(

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3177,10 +3177,15 @@ def _warn_paid_lane_once(model: str) -> None:
     )
 
 
-def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _try_openrouter(
+    explicit_api_key: str = None,
+    model: str = None,
+    *,
+    enforce_free_only: bool = True,
+) -> Tuple[Optional[OpenAI], Optional[str]]:
     free_only, cfg_model = _aux_openrouter_settings()
     or_model = model or cfg_model
-    if free_only and not _is_free_model(or_model):
+    if enforce_free_only and free_only and not _is_free_model(or_model):
         logger.warning(
             "Auxiliary client: auxiliary.free_only is enabled but the "
             "OpenRouter fallback model %r is not a :free SKU — skipping the "
@@ -3190,7 +3195,7 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
             or_model,
         )
         return None, None
-    if not _is_free_model(or_model):
+    if enforce_free_only and not _is_free_model(or_model):
         _warn_paid_lane_once(or_model)
 
     pool_present, entry = _select_pool_entry("openrouter")
@@ -3214,11 +3219,15 @@ def _try_openrouter(explicit_api_key: str = None, model: str = None) -> Tuple[Op
                    default_headers=build_or_headers()), or_model
 
 
-def _describe_openrouter_unavailable(model: str = None) -> str:
+def _describe_openrouter_unavailable(
+    model: str = None,
+    *,
+    enforce_free_only: bool = True,
+) -> str:
     """Return the policy or credential reason OpenRouter was unavailable."""
     free_only, cfg_model = _aux_openrouter_settings()
     or_model = model or cfg_model
-    if free_only and not _is_free_model(or_model):
+    if enforce_free_only and free_only and not _is_free_model(or_model):
         return (
             f"auxiliary.free_only rejected non-free model {or_model!r}; "
             "the request was skipped before provider availability checks"
@@ -6611,6 +6620,7 @@ def resolve_provider_client(
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
     task: Optional[str] = None,
+    enforce_auxiliary_free_only: bool = True,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
@@ -6638,6 +6648,10 @@ def resolve_provider_client(
             "codex_responses", or None (auto-detect).  When set to
             "codex_responses", the client is wrapped in
             CodexAuxiliaryClient to route through the Responses API.
+        enforce_auxiliary_free_only: Apply ``auxiliary.free_only`` to an
+            OpenRouter route. Main-agent provider and fallback resolution set
+            this to False because the auxiliary cost policy does not govern
+            the user's explicit main inference chain.
 
     Returns:
         (client, resolved_model) or (None, None) if auth is unavailable.
@@ -6805,11 +6819,15 @@ def resolve_provider_client(
         client, default = _try_openrouter(
             explicit_api_key=explicit_api_key,
             model=model,
+            enforce_free_only=enforce_auxiliary_free_only,
         )
         if client is None:
             logger.warning(
                 "resolve_provider_client: openrouter requested but %s",
-                _describe_openrouter_unavailable(model=model),
+                _describe_openrouter_unavailable(
+                    model=model,
+                    enforce_free_only=enforce_auxiliary_free_only,
+                ),
             )
             return None, None
         final_model = _normalize_resolved_model(model or default, provider)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2655,7 +2655,9 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
             fb_provider, model=fb_model, raw_codex=True,
             explicit_base_url=fb_base_url_hint,
             explicit_api_key=fb_api_key_hint,
-            api_mode=fb_api_mode)
+            api_mode=fb_api_mode,
+            enforce_auxiliary_free_only=False,
+        )
         if fb_client is None:
             logger.warning(
                 "Fallback to %s failed: provider not configured",

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -319,9 +319,9 @@ class TestMoaAggregatorSharedResolution:
         import yaml
 
         home = self._write_moa_config(tmp_path, monkeypatch)
-        cfg = yaml.safe_load((home / "config.yaml").read_text())
+        cfg = yaml.safe_load((home / "config.yaml").read_text(encoding="utf-8"))
         cfg["auxiliary"] = {"title_generation": {"provider": "moa", "model": "opus-gpt"}}
-        (home / "config.yaml").write_text(yaml.safe_dump(cfg))
+        (home / "config.yaml").write_text(yaml.safe_dump(cfg), encoding="utf-8")
 
         resolved_provider, model, base_url, api_key, api_mode = _resolve_task_provider_model(
             task="title_generation",
@@ -1061,6 +1061,25 @@ class TestOpenRouterPaidLaneGuard:
         assert client is None
         assert model is None
         mock_openai.assert_not_called()
+
+    def test_main_agent_route_does_not_apply_auxiliary_free_only(self, monkeypatch):
+        """The auxiliary cost guard must not block an explicit main route."""
+        monkeypatch.setenv("OPENROUTER_API_KEY", "or-key")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)), \
+             patch("hermes_cli.config.load_config_readonly",
+                   return_value={"auxiliary": {"free_only": True}}), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+            client, model = resolve_provider_client(
+                "openrouter",
+                model="xiaomi/mimo-v2.5",
+                enforce_auxiliary_free_only=False,
+            )
+
+        assert client is mock_client
+        assert model == "xiaomi/mimo-v2.5"
+        mock_openai.assert_called_once()
 
     def test_resolver_forwards_explicit_free_model_to_gate(self, monkeypatch):
         """The concrete OpenRouter route gates the caller's model, not its default."""

--- a/tests/run_agent/test_init_fallback_on_exhausted_pool.py
+++ b/tests/run_agent/test_init_fallback_on_exhausted_pool.py
@@ -22,9 +22,11 @@ def test_init_tries_fallback_when_primary_returns_none():
     """When resolve_provider_client returns None for primary but succeeds for
     a fallback entry, __init__ should NOT raise RuntimeError."""
     fb = _mock_client()
+    calls = []
 
     def fake_resolve(provider, model=None, raw_codex=False,
-                     explicit_base_url=None, explicit_api_key=None):
+                     explicit_base_url=None, explicit_api_key=None, **kwargs):
+        calls.append((provider, kwargs.get("enforce_auxiliary_free_only")))
         if provider == "tencent-token-plan":
             return fb, "kimi2.5"
         return None, None  # primary exhausted
@@ -47,6 +49,10 @@ def test_init_tries_fallback_when_primary_returns_none():
         assert agent.provider == "tencent-token-plan"
         assert agent.model == "kimi2.5"
         assert agent._fallback_activated is True
+        assert calls == [
+            ("alibaba-coding-plan", False),
+            ("tencent-token-plan", False),
+        ]
 
 
 def test_init_raises_when_no_fallback_configured():
@@ -82,7 +88,7 @@ def test_init_tries_fallback_when_openrouter_pool_exhausted():
                       base_url="http://127.0.0.1:11434/v1")
 
     def fake_resolve(provider, model=None, raw_codex=False,
-                     explicit_base_url=None, explicit_api_key=None):
+                     explicit_base_url=None, explicit_api_key=None, **kwargs):
         if provider == "custom" and explicit_base_url:
             return fb, "qwen3.5:4b"
         return None, None  # openrouter pool exhausted

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -157,6 +157,40 @@ class TestFallbackChainAdvancement:
             "⚠️ Model fallback: glm-5.2 via zai unavailable "
             "(provider overloaded); using deepseek-v4-flash via deepseek.",
         ]
+
+    def test_paid_openrouter_chain_ignores_auxiliary_free_only(self, monkeypatch):
+        """Main fallbacks are explicit routes, not auxiliary auto-fallbacks."""
+        agent = _make_agent(
+            fallback_model=[
+                {"provider": "openrouter", "model": "xiaomi/mimo-v2.5"},
+                {"provider": "openrouter", "model": "deepseek/deepseek-v4-flash-0731"},
+            ],
+        )
+        agent.provider = "alibaba"
+        agent.model = "qwen/qwen3.7-flash"
+        agent.base_url = "https://dashscope-intl.aliyuncs.com/compatible-mode/v1"
+        monkeypatch.setenv("OPENROUTER_API_KEY", "synthetic-openrouter-key")
+
+        clients = [_mock_client(), _mock_client()]
+        with (
+            patch("agent.auxiliary_client._select_pool_entry", return_value=(False, None)),
+            patch(
+                "hermes_cli.config.load_config_readonly",
+                return_value={"auxiliary": {"free_only": True}},
+            ),
+            patch("agent.auxiliary_client.OpenAI", side_effect=clients) as mock_openai,
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda model, provider: model,
+            ),
+        ):
+            assert agent._try_activate_fallback(FailoverReason.upstream_rate_limit) is True
+            assert agent.model == "xiaomi/mimo-v2.5"
+            assert agent._try_activate_fallback(FailoverReason.rate_limit) is True
+            assert agent.model == "deepseek/deepseek-v4-flash-0731"
+
+        assert mock_openai.call_count == 2
+
     def test_skips_unconfigured_provider_to_next(self):
         """If resolve_provider_client returns None, skip to next in chain."""
         fbs = [


### PR DESCRIPTION
## What does this PR do?

Prevents `auxiliary.free_only` from rejecting explicitly configured paid OpenRouter routes used by the main agent and its `fallback_providers` chain.

The shared provider resolver now accepts an explicit `enforce_auxiliary_free_only` context. It defaults to `true`, preserving the auxiliary cost guard for compression, vision, title generation, and other side tasks. The three main-agent resolution paths pass `false`:

- initial main-provider resolution;
- init-time fallback resolution;
- request-time fallback activation.

This keeps the policy in the namespace that owns it without deciding the separate global fallback-cost proposal in #97942.

## Related Issue

Fixes #100398

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`: makes application of the auxiliary OpenRouter guard explicit and safe-by-default.
- `agent/agent_init.py`: marks primary and init-time fallback resolution as main inference.
- `agent/chat_completion_helpers.py`: marks request-time `fallback_providers` activation as main inference.
- Tests preserve auxiliary paid-route blocking and cover sequential paid OpenRouter main fallbacks under `auxiliary.free_only: true`.
- Adds explicit UTF-8 encoding to two pre-existing config fixture accesses surfaced by the repository's Windows-footgun checker.

## How to Test

1. Configure `auxiliary.free_only: true` and a paid OpenRouter `fallback_providers` chain using synthetic model identifiers from issue #100398.
2. Run:
   ```bash
   scripts/run_tests.sh tests/agent/test_auxiliary_client.py
   scripts/run_tests.sh tests/run_agent/test_init_fallback_on_exhausted_pool.py
   scripts/run_tests.sh tests/run_agent/test_provider_fallback.py
   ```
3. Confirm paid auxiliary routes remain blocked while the explicit main chain advances from MiMo to DeepSeek without live provider calls.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the pytest suite locally — the isolated checkout has no dev dependencies, and none were installed; GitHub CI is the execution gate for this draft
- [x] I've added tests for my changes
- [x] I've tested syntax and static checks on WSL2

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A — no user-facing setting changed
- [x] `cli-config.yaml.example`: N/A — no config key changed
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow or architecture contract changed
- [x] Cross-platform impact considered; no OS-specific runtime behavior added
- [x] Tool descriptions/schemas: N/A

## Validation completed locally

```text
python3 -m py_compile <six changed Python files>  # passed
python3 scripts/check-windows-footguns.py         # passed, 6 files scanned
git diff --check                                  # passed
```

No live model calls, credentials, runtime files, sessions, memories, or real user data were used.