### PR TITLE
fix(honcho): add shared-brain observation preset for user-global recall

### DIFF
--- a/optional-skills/autonomous-ai-agents/honcho/SKILL.md
+++ b/optional-skills/autonomous-ai-agents/honcho/SKILL.md
@@ -108,9 +108,10 @@ Or use the shorthand presets:
 | Preset | User | AI | Use case |
 |--------|------|----|----------|
 | `"directional"` (default) | me:on, others:on | me:on, others:on | Multi-agent, full memory |
-| `"unified"` | me:on, others:off | me:off, others:on | Single agent, user-only modeling |
+| `"unified"` | me:on, others:off | me:off, others:on | Single agent, user-only modeling (AI-local recall) |
+| `"shared-brain"` (alias `"global"`) | me:on, others:off | me:off, others:off | Multi-client shared workspace — user-global recall |
 
-Settings changed in the [Honcho dashboard](https://app.honcho.dev) are synced back on session init -- server-side config wins over local defaults.
+Settings changed in the [Honcho dashboard](https://app.honcho.dev) are synced back on session init when local observation is using defaults. An explicit `observationMode` or `observation` object stays authoritative.
 
 ### Sessions
 

--- a/plugins/memory/honcho/README.md
+++ b/plugins/memory/honcho/README.md
@@ -207,7 +207,7 @@ Pick **[e]** at the prompt to set the three keys directly instead of going throu
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | `recallMode` | string | `"hybrid"` | `"hybrid"` (auto-inject + tools), `"context"` (auto-inject only, tools hidden), `"tools"` (tools only, no injection). Legacy `"auto"` → `"hybrid"` |
-| `observationMode` | string | `"directional"` | Preset: `"directional"` (all on) or `"unified"` (user observes self, AI observes others). Use `observation` object for granular control |
+| `observationMode` | string | `"directional"` | Preset: `"directional"` (all on), `"unified"` (user observes self, AI observes others), or `"shared-brain"` (user-global recall for multi-client workspaces). Use `observation` object for granular control |
 | `observation` | object | — | Per-peer observation config (see Observation section) |
 
 ### Write Behavior
@@ -330,6 +330,7 @@ Maps 1:1 to Honcho's per-peer `SessionPeerConfig`. When present, overrides `obse
 Presets:
 - `"directional"` (default): all four `true`
 - `"unified"`: user `observeMe=true`, AI `observeOthers=true`, rest `false`
+- `"shared-brain"` (alias `"global"`): user `observeMe=true`, rest `false`. Recall uses the user peer's global representation — the correct mode when multiple agents or harnesses share one Honcho workspace and user peer.
 
 ### Hardcoded Limits
 

--- a/plugins/memory/honcho/cli.py
+++ b/plugins/memory/honcho/cli.py
@@ -899,15 +899,14 @@ def cmd_setup(args) -> None:
             print("  Identity mapping left untouched.")
 
     # --- 4. Observation mode ---
+    from plugins.memory.honcho.client import _normalize_observation_mode
     current_obs = hermes_host.get("observationMode") or cfg.get("observationMode", "directional")
     print("\n  Observation mode:")
-    print("    directional  -- all observations on, each AI peer builds its own view (default)")
-    print("    unified      -- user observes self, AI observes others only")
+    print("    directional   -- all observations on, each AI peer builds its own view (default)")
+    print("    unified       -- user observes self, AI observes others only")
+    print("    shared-brain  -- user-global recall for multi-client shared workspaces")
     new_obs = _prompt("Observation mode", default=current_obs)
-    if new_obs in {"unified", "directional"}:
-        hermes_host["observationMode"] = new_obs
-    else:
-        hermes_host["observationMode"] = "directional"
+    hermes_host["observationMode"] = _normalize_observation_mode(new_obs)
 
     # --- 5. Write frequency ---
     current_wf = str(hermes_host.get("writeFrequency") or cfg.get("writeFrequency", "async"))

--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -322,8 +322,16 @@ def _resolve_optional_float(*values: Any) -> float | None:
     return None
 
 
-_VALID_OBSERVATION_MODES = {"unified", "directional"}
-_OBSERVATION_MODE_ALIASES = {"shared": "unified", "separate": "directional", "cross": "directional"}
+_VALID_OBSERVATION_MODES = {"unified", "directional", "shared-brain"}
+# "shared" stays mapped to unified — that alias predates shared-brain.
+# "global" is the issue-suggested name for the user-global / shared-brain preset.
+_OBSERVATION_MODE_ALIASES = {
+    "shared": "unified",
+    "separate": "directional",
+    "cross": "directional",
+    "global": "shared-brain",
+    "user-global": "shared-brain",
+}
 
 
 def _normalize_observation_mode(val: str) -> str:
@@ -343,6 +351,12 @@ _OBSERVATION_PRESETS = {
         "user_observe_me": True, "user_observe_others": False,
         "ai_observe_me": False, "ai_observe_others": True,
     },
+    # User-global recall: queries run as the user peer (target=None), so facts
+    # ingested by other clients that share the same user peer are visible.
+    "shared-brain": {
+        "user_observe_me": True, "user_observe_others": False,
+        "ai_observe_me": False, "ai_observe_others": False,
+    },
 }
 
 
@@ -353,7 +367,7 @@ def _resolve_observation(
     """Resolve per-peer observation booleans.
 
     Config forms:
-      String shorthand:  ``"observationMode": "directional"``
+      String shorthand:  ``"observationMode": "directional"`` / ``"unified"`` / ``"shared-brain"``
       Granular object:   ``"observation": {"user": {"observeMe": true, "observeOthers": true},
                                            "ai": {"observeMe": true, "observeOthers": false}}``
 
@@ -462,7 +476,8 @@ class HonchoClientConfig:
     # entirely (fully async first turn; context surfaces on later turns).
     first_turn_base_wait: float = 3.0
     first_turn_dialectic_wait: float = 2.0
-    # Observation mode: legacy string shorthand ("directional" or "unified").
+    # Observation mode: legacy string shorthand
+    # ("directional", "unified", or "shared-brain").
     # Kept for backward compat; granular per-peer booleans below are preferred.
     observation_mode: str = "directional"
     # Per-peer observation booleans — maps 1:1 to Honcho's SessionPeerConfig.
@@ -471,6 +486,10 @@ class HonchoClientConfig:
     user_observe_others: bool = True
     ai_observe_me: bool = True
     ai_observe_others: bool = True
+    # True when honcho.json set observationMode or a granular observation
+    # object. Session init must not overwrite those flags from stale
+    # server-side SessionPeerConfig ("last session init wins").
+    observation_explicit: bool = False
     # Session resolution
     session_strategy: str = "per-directory"
     session_peer_prefix: bool = False
@@ -800,6 +819,12 @@ class HonchoClientConfig:
                 host_block.get("observationMode")
                 or raw.get("observationMode")
                 or ("unified" if _explicitly_configured else "directional")
+            ),
+            observation_explicit=bool(
+                host_block.get("observationMode")
+                or raw.get("observationMode")
+                or host_block.get("observation")
+                or raw.get("observation")
             ),
             **_resolve_observation(
                 _normalize_observation_mode(

--- a/plugins/memory/honcho/config_schema.py
+++ b/plugins/memory/honcho/config_schema.py
@@ -313,10 +313,11 @@ CONFIG_SCHEMA = ProviderConfigSchema(
             label="Observation mode",
             kind=KIND_SELECT,
             default="directional",
-            description="Per-peer observation preset. Directional observes all directions; unified shares one view.",
+            description="Per-peer observation preset. Directional observes all directions; unified shares one AI-local view; shared-brain uses the user-global representation for multi-client recall.",
             options=(
                 ProviderFieldOption("directional", "Directional"),
                 ProviderFieldOption("unified", "Unified"),
+                ProviderFieldOption("shared-brain", "Shared brain (user-global)"),
             ),
             group="Observation",
         ),

--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -188,6 +188,11 @@ class HonchoSessionManager:
         self._user_observe_others: bool = config.user_observe_others if config else True
         self._ai_observe_me: bool = config.ai_observe_me if config else True
         self._ai_observe_others: bool = config.ai_observe_others if config else True
+        # Explicit local observationMode / observation object is authoritative.
+        # Stale SessionPeerConfig on older sessions must not flip the manager.
+        self._observation_explicit: bool = bool(
+            getattr(config, "observation_explicit", False)
+        ) if config else False
         self._message_max_chars: int = (
             config.message_max_chars if config else 25000
         )
@@ -419,19 +424,7 @@ class HonchoSessionManager:
                 server_user, server_ai = self._authed_call(
                     "peer configuration read", _read_server_configs
                 )
-                if server_user.observe_me is not None:
-                    self._user_observe_me = server_user.observe_me
-                if server_user.observe_others is not None:
-                    self._user_observe_others = server_user.observe_others
-                if server_ai.observe_me is not None:
-                    self._ai_observe_me = server_ai.observe_me
-                if server_ai.observe_others is not None:
-                    self._ai_observe_others = server_ai.observe_others
-                logger.debug(
-                    "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
-                    self._user_observe_me, self._user_observe_others,
-                    self._ai_observe_me, self._ai_observe_others,
-                )
+                self._apply_server_observation(server_user, server_ai)
             except HonchoAuthError:
                 raise
             except Exception as e:
@@ -1417,6 +1410,51 @@ class HonchoSessionManager:
             return session.assistant_peer_id
 
         return normalized
+
+    def _apply_server_observation(self, server_user: Any, server_ai: Any) -> bool:
+        """Maybe copy SessionPeerConfig back onto manager-scoped flags.
+
+        Returns True when local flags were overwritten. Explicit local
+        observationMode / observation config stays authoritative so a
+        shared-brain (or granular) override is not reverted by stale
+        observe_others=true on older sessions.
+        """
+        local = (
+            self._user_observe_me,
+            self._user_observe_others,
+            self._ai_observe_me,
+            self._ai_observe_others,
+        )
+        incoming = (
+            server_user.observe_me if server_user.observe_me is not None else local[0],
+            server_user.observe_others if server_user.observe_others is not None else local[1],
+            server_ai.observe_me if server_ai.observe_me is not None else local[2],
+            server_ai.observe_others if server_ai.observe_others is not None else local[3],
+        )
+        if incoming == local:
+            logger.debug(
+                "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
+                *local,
+            )
+            return False
+        if self._observation_explicit:
+            logger.info(
+                "Honcho observation: keeping explicit local config "
+                "user(me=%s,others=%s) ai(me=%s,others=%s); "
+                "server had user(me=%s,others=%s) ai(me=%s,others=%s)",
+                *local, *incoming,
+            )
+            return False
+        self._user_observe_me = incoming[0]
+        self._user_observe_others = incoming[1]
+        self._ai_observe_me = incoming[2]
+        self._ai_observe_others = incoming[3]
+        logger.debug(
+            "Honcho observation synced from server: user(me=%s,others=%s) ai(me=%s,others=%s)",
+            self._user_observe_me, self._user_observe_others,
+            self._ai_observe_me, self._ai_observe_others,
+        )
+        return True
 
     def _resolve_observer_target(
         self,

--- a/tests/honcho_plugin/test_client.py
+++ b/tests/honcho_plugin/test_client.py
@@ -382,6 +382,49 @@ class TestObservationModeMigration:
         assert cfg.user_observe_others is False
         assert cfg.ai_observe_me is False
         assert cfg.ai_observe_others is True
+        assert cfg.observation_explicit is True
+
+
+    def test_shared_brain_preset_selects_user_global_flags(self, tmp_path):
+        """shared-brain (and alias global) flips ai_observe_others off."""
+        from plugins.memory.honcho.client import (
+            _normalize_observation_mode,
+            _resolve_observation,
+        )
+
+        assert _normalize_observation_mode("global") == "shared-brain"
+        assert _normalize_observation_mode("user-global") == "shared-brain"
+        # Pre-existing alias must keep pointing at unified.
+        assert _normalize_observation_mode("shared") == "unified"
+
+        flags = _resolve_observation("shared-brain", None)
+        assert flags["user_observe_me"] is True
+        assert flags["user_observe_others"] is False
+        assert flags["ai_observe_me"] is False
+        assert flags["ai_observe_others"] is False
+
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {
+                "enabled": True,
+                "observationMode": "global",
+            }},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_mode == "shared-brain"
+        assert cfg.ai_observe_others is False
+        assert cfg.observation_explicit is True
+
+
+    def test_implicit_defaults_are_not_observation_explicit(self, tmp_path):
+        cfg_file = tmp_path / "config.json"
+        cfg_file.write_text(json.dumps({
+            "apiKey": "k",
+            "hosts": {"hermes": {"enabled": True, "aiPeer": "hermes"}},
+        }))
+        cfg = HonchoClientConfig.from_global_config(config_path=cfg_file)
+        assert cfg.observation_explicit is False
 
 
 class TestGetHonchoClient:

--- a/tests/plugins/memory/test_honcho_config_schema.py
+++ b/tests/plugins/memory/test_honcho_config_schema.py
@@ -53,7 +53,11 @@ def test_declares_the_new_field_kinds():
     assert by_key["dialecticMaxChars"].kind == KIND_NUMBER
     assert by_key["userPeerAliases"].kind == KIND_JSON
     assert by_key["recallMode"].allowed_values() == {"hybrid", "context", "tools"}
-    assert by_key["observationMode"].allowed_values() == {"directional", "unified"}
+    assert by_key["observationMode"].allowed_values() == {
+        "directional",
+        "unified",
+        "shared-brain",
+    }
 
 
 def test_selects_constrain_their_values():

--- a/tests/test_honcho_session_context.py
+++ b/tests/test_honcho_session_context.py
@@ -93,3 +93,38 @@ def test_session_context_user_alias_uses_user_self_observer_when_ai_cannot_obser
             "peer_perspective": "chris",
         }
     ]
+
+
+def test_shared_brain_preset_resolves_user_as_global_observer():
+    from plugins.memory.honcho.client import _resolve_observation
+
+    flags = _resolve_observation("shared-brain", None)
+    mgr, _ = _manager_with_cached_session(ai_observe_others=flags["ai_observe_others"])
+    session = mgr._cache["test-session"]
+
+    observer, target = mgr._resolve_observer_target(session, "user")
+
+    assert observer == session.user_peer_id
+    assert target is None
+
+
+def test_explicit_local_observation_is_not_overwritten_by_stale_server_config():
+    mgr, _ = _manager_with_cached_session(ai_observe_others=False)
+    mgr._observation_explicit = True
+    stale = SimpleNamespace(observe_me=True, observe_others=True)
+
+    overwritten = mgr._apply_server_observation(stale, stale)
+
+    assert overwritten is False
+    assert mgr._ai_observe_others is False
+
+
+def test_implicit_observation_defaults_still_accept_server_sync_back():
+    mgr, _ = _manager_with_cached_session(ai_observe_others=False)
+    mgr._observation_explicit = False
+    stale = SimpleNamespace(observe_me=True, observe_others=True)
+
+    overwritten = mgr._apply_server_observation(stale, stale)
+
+    assert overwritten is True
+    assert mgr._ai_observe_others is True

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -20,7 +20,7 @@ Honcho is integrated into the [Memory Providers](./memory-providers.md) system. 
 | User profile | ✔ Manual agent curation | ✔ Automatic dialectic reasoning |
 | Session summary | — | ✔ Session-scoped context injection |
 | Multi-agent isolation | — | ✔ Per-peer profile separation |
-| Observation modes | — | ✔ Unified or directional observation |
+| Observation modes | — | ✔ Directional, unified, or shared-brain observation |
 | Conclusions (derived insights) | — | ✔ Server-side reasoning about patterns |
 | Search across history | ✔ FTS5 session search | ✔ Semantic search over conclusions |
 
@@ -181,7 +181,7 @@ Flipping `pinUserPeer` from `true` to `false` does not migrate data — memory a
 `pinPeerName` is a legacy alias for `pinUserPeer` — still read for back-compat (`pinUserPeer` wins where both are set), never written. Re-running setup migrates it onto the canonical key.
 :::
 
-## Observation (Directional vs. Unified)
+## Observation (Directional, Unified, Shared-Brain)
 
 Honcho models a conversation as peers exchanging messages. Each peer has two observation toggles that map 1:1 to Honcho's `SessionPeerConfig`:
 
@@ -195,7 +195,8 @@ Two peers × two toggles = four flags. `observationMode` is a shorthand preset:
 | Preset | User flags | AI flags | Semantics |
 |--------|-----------|----------|-----------|
 | `"directional"` (default) | me: on, others: on | me: on, others: on | Full mutual observation. Enables cross-peer dialectic — "what does the AI know about the user, based on what the user said and the AI replied." |
-| `"unified"` | me: on, others: off | me: off, others: on | Shared-pool semantics — the AI observes the user's messages only, the user peer only self-models. Single-observer pool. |
+| `"unified"` | me: on, others: off | me: off, others: on | Shared-pool semantics — the AI observes the user's messages only, the user peer only self-models. Single-observer pool. Recall still runs from the AI peer's local view. |
+| `"shared-brain"` (alias `"global"`) | me: on, others: off | me: off, others: off | User-global recall. Search, context, profile, and dialectic query the user peer's global self-representation, so facts ingested by other clients that share the same workspace and user peer are visible. Use this when Hermes plus another harness share one Honcho "brain." |
 
 Override the preset with an explicit `observation` block for per-peer control:
 
@@ -211,10 +212,11 @@ Common patterns:
 | Intent | Config |
 |--------|--------|
 | Full observation (most users) | `"observationMode": "directional"` |
+| Multi-client shared workspace | `"observationMode": "shared-brain"` |
 | AI shouldn't re-model the user from its own replies | `"ai": {"observeMe": true, "observeOthers": false}` |
 | Strong persona the AI peer shouldn't update from self-observation | `"ai": {"observeMe": false, "observeOthers": true}` |
 
-Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over local defaults — Hermes syncs them back at session init.
+Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over **implicit local defaults** — Hermes syncs them back at session init. An explicit `observationMode` or `observation` object in `honcho.json` stays authoritative so a `shared-brain` (or granular) override is not reverted by stale session peer config.
 
 ## Tools
 

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -95,7 +95,7 @@ The legacy `hermes honcho setup` command still works (it now redirects to `herme
 | `recallMode` | `'hybrid'` | `hybrid` (auto-inject + tools), `context` (inject only), `tools` (tools only) |
 | `writeFrequency` | `'async'` | When to flush messages: `async` (background thread), `turn` (sync), `session` (batch on end), or integer N |
 | `saveMessages` | `true` | Whether to persist messages to Honcho API |
-| `observationMode` | `'directional'` | `directional` (all on) or `unified` (shared pool). Override with `observation` object |
+| `observationMode` | `'directional'` | `directional` (all on), `unified` (AI-local shared pool), or `shared-brain` (user-global multi-client recall). Override with `observation` object |
 | `messageMaxChars` | `25000` | Max chars per message (chunked if exceeded) |
 | `dialecticMaxInputChars` | `10000` | Max chars for dialectic query input to `peer.chat()` |
 | `sessionStrategy` | `'per-directory'` | `per-directory`, `per-repo`, `per-session`, `global` |
@@ -158,7 +158,7 @@ The mapping:
 | **Workspace** | Shared environment. All Hermes profiles under one workspace see the same user identity. |
 | **User peer** (`peerName`) | The human. Shared across profiles in the workspace. |
 | **AI peer** (`aiPeer`) | One per Hermes profile. Host key `hermes` → default; `hermes.<profile>` for others. |
-| **Observation** | Per-peer toggles controlling what Honcho models from whose messages. `directional` (default, all four on) or `unified` (single-observer pool). |
+| **Observation** | Per-peer toggles controlling what Honcho models from whose messages. `directional` (default, all four on), `unified` (single-observer pool, AI-local recall), or `shared-brain` (user-global recall for multi-client workspaces). |
 
 ### New profile, fresh Honcho peer
 
@@ -200,11 +200,12 @@ Each host block can override the observation config independently. Example: a co
 Presets via `observationMode`:
 
 - **`"directional"`** (default) — all four flags on. Full mutual observation; enables cross-peer dialectic.
-- **`"unified"`** — user `observeMe: true`, AI `observeOthers: true`, rest false. Single-observer pool; AI models the user but not itself, user peer only self-models.
+- **`"unified"`** — user `observeMe: true`, AI `observeOthers: true`, rest false. Single-observer pool; AI models the user but not itself, user peer only self-models. Recall still uses the AI peer's local view.
+- **`"shared-brain"`** (alias `"global"`) — user `observeMe: true`, rest false. Recall uses the user peer's global representation, so facts written by other clients that share the same workspace and user peer are visible.
 
-Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over local defaults — synced back at session init.
+Server-side toggles set via the [Honcho dashboard](https://app.honcho.dev) win over implicit local defaults — synced back at session init. An explicit `observationMode` or `observation` object stays authoritative.
 
-See the [Honcho page](./honcho.md#observation-directional-vs-unified) for the full observation reference.
+See the [Honcho page](./honcho.md#observation-directional-unified-shared-brain) for the full observation reference.
 
 ### Gateway identity mapping
 

--- a/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
+++ b/website/docs/user-guide/skills/optional/autonomous-ai-agents/autonomous-ai-agents-honcho.md
@@ -123,9 +123,10 @@ Or use the shorthand presets:
 | Preset | User | AI | Use case |
 |--------|------|----|----------|
 | `"directional"` (default) | me:on, others:on | me:on, others:on | Multi-agent, full memory |
-| `"unified"` | me:on, others:off | me:off, others:on | Single agent, user-only modeling |
+| `"unified"` | me:on, others:off | me:off, others:on | Single agent, user-only modeling (AI-local recall) |
+| `"shared-brain"` (alias `"global"`) | me:on, others:off | me:off, others:off | Multi-client shared workspace — user-global recall |
 
-Settings changed in the [Honcho dashboard](https://app.honcho.dev) are synced back on session init -- server-side config wins over local defaults.
+Settings changed in the [Honcho dashboard](https://app.honcho.dev) are synced back on session init when local observation is using defaults. An explicit `observationMode` or `observation` object stays authoritative.
 
 ### Sessions
 


### PR DESCRIPTION
## What does this PR do?

Honcho's wizard-selectable observation presets (`directional` and `unified`) both set `ai_observe_others=true`. User-directed search, context, profile, and dialectic then run from the AI peer's local observer view, so facts ingested by another client on the same workspace and user peer never appear.

This adds a `shared-brain` preset (`user observeMe=true`, remaining flags false) so recall uses the user peer's global representation. `global` and `user-global` normalize to that preset. `hermes memory setup` and the Honcho config panel expose it, and docs note that this is the mode for multi-client shared-memory setups.

When `observationMode` or a granular `observation` object is set locally, session init no longer overwrites manager-scoped flags from stale `SessionPeerConfig` (which previously re-flipped `ai_observe_others` on older sessions). Implicit defaults still accept dashboard sync-back.

## Related Issue

Fixes #100383

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/honcho/client.py` — add `shared-brain` preset and aliases; record `observation_explicit` when config sets `observationMode` or `observation`
- `plugins/memory/honcho/session.py` — `_apply_server_observation` keeps explicit local flags; INFO log when server config differs
- `plugins/memory/honcho/cli.py` — wizard lists `shared-brain` and writes the normalized mode
- `plugins/memory/honcho/config_schema.py` — desktop/select option for the new preset
- Docs: `website/docs/user-guide/features/honcho.md`, `memory-providers.md`, plugin README, honcho skill
- Tests: preset resolution, user-global observer, explicit local vs stale server sync-back

## How to Test

1. On current `main`, resolve observation for `directional` and `unified` and call `_resolve_observer_target(..., "user")`. Both return the AI peer as observer (`ai_observe_others=true`). `shared-brain` / `global` normalize to `directional`.
2. After this change, `_normalize_observation_mode("global")` is `shared-brain`, `_resolve_observation("shared-brain", None)` has `ai_observe_others=false`, and `_resolve_observer_target` returns `(user_peer_id, None)`.
3. Run:

```
scripts/run_tests.sh tests/honcho_plugin/test_client.py tests/test_honcho_session_context.py tests/plugins/memory/test_honcho_config_schema.py tests/honcho_plugin/test_session.py tests/honcho_plugin/test_cli.py -q
```

Expected: all collected tests pass (131 passed in this checkout).

4. `hermes memory setup` → Honcho observation prompt should list `shared-brain` as the multi-client / user-global option.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
=== Summary: 5 files, 131 tests passed, 0 failed, 15 skipped ===
shared-brain observer=shared-user target=None
explicit local survives stale server sync-back
loaded mode shared-brain ai_observe_others False explicit True
```
