### PR TITLE
fix(desktop): resolve notification-click runtime id through the durable session-state mirror

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.test.tsx
@@ -1,12 +1,18 @@
 import { renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { createClientSessionState } from '@/lib/chat-runtime'
 import { requestMcpInstallFromDeepLink } from '@/store/mcp-deeplink-install'
 import { _resetLegacyDiscardForTests } from '@/store/session'
+import {
+  dropSessionState,
+  publishSessionState
+} from '@/store/session-states'
 import type * as WindowsStore from '@/store/windows'
 import type { SessionInfo } from '@/types/hermes'
 
 import { makeSessionInfo } from '../../../test/session-info'
+import { sessionRoute } from '../../routes'
 
 import { useDesktopIntegrations } from './use-desktop-integrations'
 
@@ -509,6 +515,68 @@ describe('useDesktopIntegrations', () => {
       deepLink?.({ kind: 'mcp', name: 'install', params: { name: 'context7' } })
       expect(requestMcpInstallFromDeepLink).toHaveBeenCalledWith({ name: 'context7' })
       expect(navigate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('notification click -> focus-session id translation', () => {
+    function withFocusSession(): (sessionId: string) => void {
+      let handler: ((sessionId: string) => void) | undefined
+      desktopWindow.hermesDesktop = {
+        ...desktopWindow.hermesDesktop,
+        onFocusSession: (cb: (sessionId: string) => void) => {
+          handler = cb
+
+          return () => undefined
+        }
+      } as unknown as Window['hermesDesktop']
+
+      return sessionId => handler?.(sessionId)
+    }
+
+    function renderWithRuntimeMap(map: Map<string, string>) {
+      return renderHook(
+        ({ sessions }: { sessions: readonly SessionInfo[] }) =>
+          useDesktopIntegrations({
+            activeProfile: 'default',
+            chatOpen: false,
+            hasPreview: false,
+            locationPathname: '/',
+            navigate,
+            profileReady: true,
+            refreshSessions: vi.fn(),
+            resumeExhaustedSessionId: null,
+            routedSessionId: null,
+            runtimeIdByStoredSessionId: { current: map },
+            sessions
+          }),
+        { initialProps: { sessions: [] as readonly SessionInfo[] } }
+      )
+    }
+
+    it('translates a runtime id via the window map before navigating', () => {
+      const fire = withFocusSession()
+
+      renderWithRuntimeMap(new Map([['stored-abc', 'runtime-123']]))
+      fire('runtime-123')
+
+      // 'stack' intent spends the unoccupied main draft → in-place navigate.
+      expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-abc'))
+    })
+
+    it('falls back to the durable per-runtime state mirror when the window map has no binding', () => {
+      const fire = withFocusSession()
+      const { unmount } = renderWithRuntimeMap(new Map())
+
+      // Simulate a main-pane runtime whose ensureSessionState binding lives in
+      // the shared store mirror, not this window's map (window reload /
+      // pop-out window / gateway respawn).
+      publishSessionState('runtime-999', createClientSessionState('stored-xyz'))
+      fire('runtime-999')
+
+      expect(navigate).toHaveBeenCalledWith(sessionRoute('stored-xyz'))
+
+      unmount()
+      dropSessionState('runtime-999')
     })
   })
 })

--- a/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-desktop-integrations.ts
@@ -16,6 +16,7 @@ import {
 } from '@/store/native-notifications'
 import { openPluginInstallRequest } from '@/store/plugin-install-request'
 import { openFolderAsProject } from '@/store/projects'
+import { storedSessionIdForRuntimeId } from '@/store/session-states'
 import {
   getRememberedRoute,
   getRememberedSessionId,
@@ -187,7 +188,17 @@ export function useDesktopIntegrations({
   useEffect(() => {
     const unsubscribe = window.hermesDesktop?.onFocusSession?.(sessionId => {
       if (sessionId) {
-        openSession(storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current), navigate, 'stack')
+        // The notification carries the gateway's RUNTIME id. Translate it to
+        // the durable stored id via the window's live binding first, then the
+        // per-runtime state mirror ($sessionStates) — a main-pane runtime id
+        // whose ensureSessionState binding predates this window's map (window
+        // reload, pop-out window, gateway respawn) still lands on the real
+        // chat route instead of resuming a nonexistent stored session
+        // ("session not found", the #93080 identity split on the nav leg).
+        const viaLocalMap = storedSessionIdForNotification(sessionId, runtimeIdByStoredSessionId.current)
+        const storedId = viaLocalMap !== sessionId ? viaLocalMap : (storedSessionIdForRuntimeId(sessionId) ?? sessionId)
+
+        openSession(storedId, navigate, 'stack')
       }
     })
 


### PR DESCRIPTION
## Bug Description

Clicking a native OS notification (e.g. an approval request) errors **"session not found"** instead of focusing the session, whenever the notification's runtime id has no binding in the receiving window's `runtimeIdByStoredSessionId` map — routine after a gateway respawn (scale-to-zero backends re-mint runtime ids), a window reload, or a notification delivered to a window that never opened that session (pop-outs).

Fixes #100404

## Root Cause

Native notifications carry the gateway's *runtime* session id; the chat route keys on the *stored* id. The click-to-focus nav leg (`use-desktop-integrations.ts`, `onFocusSession` handler) translated the id via **only** the window-local map — `storedSessionIdForNotification()` returns its input unchanged when unmapped, so the raw runtime id flowed into `openSession()` and `session.activate` 4001'd on a stored id that doesn't exist.

The *respond* leg (approval buttons → `requestForOwnedSession`) already resolves runtime ids through the durable ladder (`storedSessionIdForRuntimeId` → `$sessionStates` mirror). The nav leg never got the same fallback — the two legs of one click disagreed about identity resolution.

## Fix

- `onFocusSession` handler: window map first (`storedSessionIdForNotification`); when it misses (`mapped === sessionId`), fall back to the durable `storedSessionIdForRuntimeId(sessionId)` mirror; pass through only when both are silent (id may already be a stored id).
- Two regression tests: local-map hit (unchanged behavior) and map-miss → durable mirror fallback (the bug).

## How to Verify

1. Connect Desktop to a remote gateway that idles out / respawns, trigger an approval, let the backend wake with fresh runtime ids, click the notification toast → app should resume the session, not error.
2. `npx vitest run src/app/contrib/hooks/use-desktop-integrations.test.tsx src/lib/session-ids.test.ts` — 27 + 5 pass.

## Test Plan

- [x] Added regression test for this bug (map-miss → `$sessionStates` mirror fallback)
- [x] Existing tests still pass (`use-desktop-integrations` 27/27, `session-ids` 5/5, `session-states-runtime-map` 12/12)
- [x] Manual verification: patched app repacked, packaged-asar chunk byte-compared against dist, behavior confirmed against a Fly.io scale-to-zero gateway install

## Risk Assessment

Low — one call site, additive fallback rung only. The local-map path is byte-identical to before when it has a binding; durable bindings already outrank nothing (the mirror is only consulted on a miss), so no cross-wired mapping can hijack the lookup — `storedSessionIdForRuntimeId` validates stored-id claims before runtime bindings.