### PR TITLE
fix: sort `sessions browse` and `sessions list` by last-active (MRU)

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -330,7 +330,10 @@ def cmd_sessions(args, sessions_parser=None):
         from hermes_state import workspace_key as _ws_key
 
         sessions = db.list_sessions_rich(
-            source=args.source, exclude_sources=_exclude, limit=args.limit
+            source=args.source,
+            exclude_sources=_exclude,
+            limit=args.limit,
+            order_by_last_active=True,
         )
 
         # Workspace filter: match a session by its workspace key (git repo
@@ -1210,7 +1213,10 @@ def cmd_sessions(args, sessions_parser=None):
         source = getattr(args, "source", None)
         _browse_exclude = None if source else ["tool"]
         sessions = db.list_sessions_rich(
-            source=source, exclude_sources=_browse_exclude, limit=limit
+            source=source,
+            exclude_sources=_browse_exclude,
+            limit=limit,
+            order_by_last_active=True,
         )
         if not sessions:
             db.close()


### PR DESCRIPTION
## Summary

`hermes sessions browse` and `hermes sessions list` sort by original conversation start time (`started_at DESC`), while every other session-listing surface — the desktop sidebar, `/resume`, and the profile session picker — already sorts by last-active via `list_sessions_rich(order_by_last_active=True)`.

This makes the CLI browser/list the odd one out: a session you actively resumed and continued yesterday stays pinned to its original creation-time slot instead of floating to the top like it does everywhere else in the product.

## Change

Pass `order_by_last_active=True` at both `list_sessions_rich(...)` call sites in `hermes_cli/sessions_cmd.py` (the `list` and `browse` actions), matching the existing behavior used elsewhere. No new flag/config — this is a consistency fix, not a new option, since `order_by_last_active` already exists and is the default everywhere else.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_session_browse.py` — 8/8 pass
- `scripts/run_tests.sh tests/hermes_cli/ -k "session and not kanban"` — 282/282 pass (pre-existing unrelated `test_kanban_notify.py` failures reproduce identically on `main`, unaffected by this change)
- Manual check: `hermes sessions list` now surfaces a session last touched moments ago at the top of the list instead of by its original creation date.