### PR TITLE
fix(slack): approval/clarify button clicks are never silently swallowed

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7434,7 +7434,7 @@ class SlackAdapter(BasePlatformAdapter):
             result = await self._get_client(chat_id).chat_postMessage(**kwargs)
             msg_ts = result.get("ts", "")
             if msg_ts:
-                # Mark unresolved so the action handler's atomic-pop guard can
+                # Mark unresolved so the action handler's consume-marker guard can
                 # reject double-clicks (mirrors _approval_resolved).
                 self._clarify_resolved[msg_ts] = False
                 self._trim_oldest_dict_entries(
@@ -7672,7 +7672,7 @@ class SlackAdapter(BasePlatformAdapter):
                 channel=channel_id,
                 user=user_id,
                 text=(
-                    "You're not authorized to resolve this approval — "
+                    "You're not authorized to resolve this prompt — "
                     "ask an authorized user to press the button."
                 ),
             )
@@ -7748,13 +7748,25 @@ class SlackAdapter(BasePlatformAdapter):
             # restart) — the dict is in-process memory, so restart-orphaned
             # prompts are absent, NOT already-resolved. Treating absent as
             # resolved silently swallowed the first legitimate click
-            # (enterprise field report 2026-08-20). Fall through: resolve
-            # (0 pending renders the honest "expired" outcome); the consumed
-            # marker set here keeps a double-click on the orphan a no-op.
+            # (enterprise field report 2026-08-20).
+            #
+            # Do NOT resolve anything from this branch: the orphan's waiter
+            # died with the old process, and resolve_gateway_approval() is
+            # FIFO within the session — an orphaned click could otherwise
+            # approve a DIFFERENT, live command (review finding). Render the
+            # honest outcome directly and consume the key so double-clicks
+            # on the orphan stay no-ops.
             self._approval_resolved[approval_key] = True
             self._trim_oldest_dict_entries(
                 self._approval_resolved, self._APPROVAL_RESOLVED_MAX
             )
+            await self._render_approval_outcome(
+                channel_id, msg_ts, message, team_id,
+                "⌛ Approval expired — command was not run "
+                "(the gateway restarted since this prompt was sent; "
+                "re-run the task to get a fresh prompt)",
+            )
+            return
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)
@@ -7790,6 +7802,21 @@ class SlackAdapter(BasePlatformAdapter):
                 "(already timed out or resolved elsewhere)"
             )
 
+        await self._render_approval_outcome(
+            channel_id, msg_ts, message, team_id, decision_text
+        )
+
+        # (approval already resolved above; guard marker consumed in place)
+
+    async def _render_approval_outcome(
+        self,
+        channel_id: str,
+        msg_ts: str,
+        message: dict,
+        team_id: Optional[str],
+        decision_text: str,
+    ) -> None:
+        """Rewrite an approval message with its outcome and drop the buttons."""
         # Get original text from the section block
         original_text = ""
         for block in message.get("blocks", []):
@@ -7828,8 +7855,6 @@ class SlackAdapter(BasePlatformAdapter):
         except Exception as e:
             logger.warning("[Slack] Failed to update approval message: %s", e)
 
-        # (approval already resolved above; state consumed by atomic pop)
-
     async def _update_clarify_message(
         self,
         channel_id: str,
@@ -7862,6 +7887,7 @@ class SlackAdapter(BasePlatformAdapter):
         """Handle a clarify button click (a choice or "Other") from Block Kit."""
         await ack()
 
+        team_id = self._event_team_id({}, body)
         action_id = action.get("action_id", "")
         value = action.get("value", "")
         message = body.get("message", {})
@@ -7879,7 +7905,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
                 user_name, user_id,
             )
-            await self._notify_unauthorized_click(channel_id, user_id, None)
+            await self._notify_unauthorized_click(channel_id, user_id, team_id)
             return
 
         # value packs ``clarify_id|<idx|other>``.

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -7533,6 +7533,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Unauthorized slash-confirm click by %s (%s) - ignoring",
                 user_name, user_id,
             )
+            await self._notify_unauthorized_click(channel_id, user_id, team_id)
             return
 
         # Authorization — reuse the exec-approval allowlist.
@@ -7654,6 +7655,30 @@ class SlackAdapter(BasePlatformAdapter):
             message.get("ts", ""),
         )
 
+    async def _notify_unauthorized_click(
+        self, channel_id: str, user_id: str, team_id: Optional[str]
+    ) -> None:
+        """Ephemeral 'not authorized' notice for a rejected button click.
+
+        Feedback, not silence (enterprise field report 2026-08-20: "buttons
+        often do nothing"): the clicker cannot distinguish an auth rejection
+        from a broken button unless we tell them. Best-effort — a failed
+        ephemeral send never blocks the rejection itself.
+        """
+        try:
+            await self._get_client(
+                channel_id, team_id=team_id or None
+            ).chat_postEphemeral(
+                channel=channel_id,
+                user=user_id,
+                text=(
+                    "You're not authorized to resolve this approval — "
+                    "ask an authorized user to press the button."
+                ),
+            )
+        except Exception as exc:
+            logger.debug("[Slack] ephemeral auth notice failed: %s", exc)
+
     async def _handle_approval_action(self, ack, body, action) -> None:
         """Handle an approval button click from Block Kit."""
         await ack()
@@ -7677,6 +7702,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Unauthorized approval click by %s (%s) - ignoring",
                 user_name, user_id,
             )
+            await self._notify_unauthorized_click(channel_id, user_id, team_id)
             return
 
         # Only authorized users may click approval buttons.  Button clicks
@@ -7702,7 +7728,10 @@ class SlackAdapter(BasePlatformAdapter):
         }
         choice = choice_map.get(action_id, "deny")
 
-        # Prevent double-clicks — atomic pop; first caller gets False, others get True (default)
+        # Prevent double-clicks — first caller flips the marker to True and
+        # proceeds; later callers see True and return. The marker is SET, not
+        # popped: a popped key would be indistinguishable from a prompt this
+        # process never sent, and that distinction now matters (below).
         # Check both the workspace-scoped marker and the bare ts: the approval
         # may have been stored without a team id (metadata-poor send path)
         # while the click event carries one, and that mismatch must not
@@ -7710,8 +7739,22 @@ class SlackAdapter(BasePlatformAdapter):
         approval_key = self._workspace_message_marker(team_id, msg_ts)
         if msg_ts in self._approval_resolved:
             approval_key = msg_ts
-        if self._approval_resolved.pop(approval_key, True):
-            return
+        if approval_key in self._approval_resolved:
+            if self._approval_resolved[approval_key]:
+                return  # genuine double-click — already consumed
+            self._approval_resolved[approval_key] = True
+        else:
+            # Unknown ts: this prompt predates the current process (gateway
+            # restart) — the dict is in-process memory, so restart-orphaned
+            # prompts are absent, NOT already-resolved. Treating absent as
+            # resolved silently swallowed the first legitimate click
+            # (enterprise field report 2026-08-20). Fall through: resolve
+            # (0 pending renders the honest "expired" outcome); the consumed
+            # marker set here keeps a double-click on the orphan a no-op.
+            self._approval_resolved[approval_key] = True
+            self._trim_oldest_dict_entries(
+                self._approval_resolved, self._APPROVAL_RESOLVED_MAX
+            )
 
         # Resolve the approval FIRST — this unblocks the agent thread. Render
         # after, so a click that lands past the approval timeout (count == 0)
@@ -7836,6 +7879,7 @@ class SlackAdapter(BasePlatformAdapter):
                 "[Slack] Unauthorized clarify click by %s (%s) - ignoring",
                 user_name, user_id,
             )
+            await self._notify_unauthorized_click(channel_id, user_id, None)
             return
 
         # value packs ``clarify_id|<idx|other>``.
@@ -7844,10 +7888,20 @@ class SlackAdapter(BasePlatformAdapter):
             return
         clarify_id, token = value.split("|", 1)
 
-        # Double-click guard — atomic pop; first caller gets False (proceed),
-        # any later click gets the True default and bails (mirrors approval).
-        if self._clarify_resolved.pop(msg_ts, True):
-            return
+        # Double-click guard — first caller flips the marker and proceeds;
+        # later clicks bail (mirrors approval). An UNKNOWN ts is a prompt from
+        # before a gateway restart, not a resolved one: proceed — the clarify
+        # module's own expiry handling below renders the honest outcome
+        # (enterprise field report 2026-08-20: silent swallows).
+        if msg_ts in self._clarify_resolved:
+            if self._clarify_resolved[msg_ts]:
+                return
+            self._clarify_resolved[msg_ts] = True
+        else:
+            self._clarify_resolved[msg_ts] = True
+            self._trim_oldest_dict_entries(
+                self._clarify_resolved, self._CLARIFY_RESOLVED_MAX
+            )
 
         # Preserve the original question so the resolved message keeps context.
         original_text = ""

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -875,12 +875,51 @@ class TestRestartOrphanedApprovalClick:
         with patch("tools.approval.resolve_gateway_approval", return_value=0) as mock_resolve:
             await adapter._handle_approval_action(ack, self._click_body(), action)
 
-        mock_resolve.assert_called_once()
+        # CRITICAL: the orphan branch must NOT call the FIFO resolver — the
+        # orphan's waiter died with the old process, and a FIFO resolve could
+        # approve a DIFFERENT live command in the same session (salt review
+        # finding on the first version of this fix).
+        mock_resolve.assert_not_called()
         assert mock_client.chat_update.called, (
             "restart-orphaned click was silently swallowed — no feedback"
         )
         update_text = mock_client.chat_update.call_args[1]["text"]
         assert "expired" in update_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_orphan_click_cannot_approve_a_live_pending_approval(self):
+        """End-to-end FIFO-hazard probe with the REAL approval queue: a live
+        pending approval for a different command must still be pending after
+        an orphaned click lands in the same session."""
+        from tools import approval as approval_mod
+
+        session_key = "orphan-fifo-probe-session"
+        approval_mod._gateway_queues.pop(session_key, None)
+        try:
+            entry = approval_mod._ApprovalEntry(
+                {"command": "deploy --prod", "description": "live command",
+                 "pattern_key": "dangerous", "pattern_keys": ["dangerous"]}
+            ) if hasattr(approval_mod, "_ApprovalEntry") else None
+            if entry is None:
+                pytest.skip("_ApprovalEntry not accessible")
+            approval_mod._gateway_queues.setdefault(session_key, []).append(entry)
+
+            adapter = _make_adapter()
+            _attach_auth_runner(adapter)
+            ack = AsyncMock()
+            body = self._click_body("8888.0001")
+            action = {"action_id": "hermes_approve_once", "value": session_key}
+            adapter._team_clients["T1"].chat_update = AsyncMock()
+
+            await adapter._handle_approval_action(ack, body, action)
+
+            queue = approval_mod._gateway_queues.get(session_key) or []
+            assert len(queue) == 1, (
+                "orphaned click consumed a LIVE pending approval for a "
+                "different command — FIFO hazard"
+            )
+        finally:
+            approval_mod._gateway_queues.pop(session_key, None)
 
     @pytest.mark.asyncio
     async def test_genuine_double_click_stays_silent(self):

--- a/tests/gateway/test_slack_approval_buttons.py
+++ b/tests/gateway/test_slack_approval_buttons.py
@@ -841,3 +841,151 @@ class TestSlackReactionAuthorizationGate:
         assert runner.handled == []
         adapter.handle_message.assert_not_called()
 
+
+
+# ===========================================================================
+# Silent-swallow fixes (enterprise field report 2026-08-20): clicks must
+# NEVER be silently ignored — every press gets feedback or resolution.
+# ===========================================================================
+
+class TestRestartOrphanedApprovalClick:
+    """A prompt sent before a gateway restart is unknown to the new
+    process's _approval_resolved dict. The first click on it must not be
+    silently swallowed: attempt resolution (0 pending → renders expired)."""
+
+    def _click_body(self, ts="9999.0001"):
+        return {
+            "message": {"ts": ts, "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": "cmd"}},
+            ]},
+            "channel": {"id": "C1"},
+            "user": {"name": "flong", "id": "U_FLONG"},
+        }
+
+    @pytest.mark.asyncio
+    async def test_unknown_ts_click_renders_expired_not_silence(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        # NOTE: no _approval_resolved entry for this ts — restart-orphaned.
+        ack = AsyncMock()
+        action = {"action_id": "hermes_approve_once", "value": "sess-key"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=0) as mock_resolve:
+            await adapter._handle_approval_action(ack, self._click_body(), action)
+
+        mock_resolve.assert_called_once()
+        assert mock_client.chat_update.called, (
+            "restart-orphaned click was silently swallowed — no feedback"
+        )
+        update_text = mock_client.chat_update.call_args[1]["text"]
+        assert "expired" in update_text.lower()
+
+    @pytest.mark.asyncio
+    async def test_genuine_double_click_stays_silent(self):
+        """The double-click guard must survive the orphan fix: a ts that WAS
+        tracked and consumed by a first click stays a no-op on the second."""
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        adapter._approval_resolved["5555.0001"] = False
+        ack = AsyncMock()
+        action = {"action_id": "hermes_approve_once", "value": "sess-key"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval", return_value=1) as mock_resolve:
+            await adapter._handle_approval_action(ack, self._click_body("5555.0001"), action)
+            first_updates = mock_client.chat_update.call_count
+            await adapter._handle_approval_action(ack, self._click_body("5555.0001"), action)
+
+        assert mock_resolve.call_count == 1, "double-click resolved twice"
+        assert mock_client.chat_update.call_count == first_updates, (
+            "second click re-rendered the message"
+        )
+
+
+class TestUnauthorizedClickFeedback:
+    """An unauthorized clicker must receive ephemeral feedback, not silence."""
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_click_gets_ephemeral_notice(self, monkeypatch):
+        adapter = _make_adapter()
+        adapter._approval_resolved["1234.5678"] = False
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_OWNER")
+
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "1234.5678", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_ATTACKER"},
+        }
+        action = {"action_id": "hermes_approve_once", "value": "sess-key"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postEphemeral = AsyncMock()
+
+        with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
+            await adapter._handle_approval_action(ack, body, action)
+
+        mock_resolve.assert_not_called()  # auth boundary unchanged
+        assert mock_client.chat_postEphemeral.called, (
+            "unauthorized click produced zero user feedback"
+        )
+        eph = mock_client.chat_postEphemeral.call_args[1]
+        assert eph["user"] == "U_ATTACKER"
+        assert "not authorized" in eph["text"].lower()
+
+
+class TestSiblingLanesNeverSilent:
+    """The same two contracts hold for clarify (and slash-confirm auth)."""
+
+    @pytest.mark.asyncio
+    async def test_restart_orphaned_clarify_click_renders_expired(self):
+        adapter = _make_adapter()
+        _attach_auth_runner(adapter)
+        # No _clarify_resolved entry — restart-orphaned prompt.
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "7777.0001", "blocks": [
+                {"type": "section", "text": {"type": "mrkdwn", "text": "which one?"}},
+            ]},
+            "channel": {"id": "C1"},
+            "user": {"name": "flong", "id": "U_FLONG"},
+        }
+        action = {"action_id": "hermes_clarify_choice_0", "value": "cl-1|0"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_update = AsyncMock()
+
+        with patch("tools.clarify_gateway.resolve_gateway_clarify", return_value=False):
+            await adapter._handle_clarify_action(ack, body, action)
+
+        assert mock_client.chat_update.called, (
+            "restart-orphaned clarify click silently swallowed"
+        )
+        rendered = mock_client.chat_update.call_args[1]["text"]
+        assert "expired" in rendered.lower()
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_slash_confirm_click_gets_ephemeral(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.delenv("SLACK_ALLOWED_USERS", raising=False)
+        monkeypatch.delenv("SLACK_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+        monkeypatch.setenv("GATEWAY_ALLOWED_USERS", "U_OWNER")
+        ack = AsyncMock()
+        body = {
+            "message": {"ts": "2222.3333", "blocks": []},
+            "channel": {"id": "C1"},
+            "user": {"name": "mallory", "id": "U_ATTACKER"},
+        }
+        action = {"action_id": "hermes_confirm_once", "value": "sess|cid"}
+        mock_client = adapter._team_clients["T1"]
+        mock_client.chat_postEphemeral = AsyncMock()
+
+        await adapter._handle_slash_confirm_action(ack, body, action)
+
+        assert mock_client.chat_postEphemeral.called
+        assert "not authorized" in mock_client.chat_postEphemeral.call_args[1]["text"].lower()


### PR DESCRIPTION
An enterprise Slack fleet reported approval buttons that "often do nothing" — presses on a visible prompt produced no reaction at all. Two silent-swallow mechanisms in the Block Kit click handlers, both fixed here under one contract: **a button click is never silently ignored.**

## What changed

**1. Restart-orphaned prompts ate their first click** (`_handle_approval_action`, `_handle_clarify_action`)

The double-click guard popped the message ts from an in-process dict with a default of True — so any prompt sent before the current gateway process started (routine upgrade, redeploy, any restart) was unknown to the new process and its *first legitimate click* returned silently. The prompts are durable Slack messages; the guard state is not.

The guard now distinguishes *consumed* keys (marker set to True and kept, instead of popped) from *never-seen* keys. Unknown ts falls through to resolution, where zero pending approvals already renders the honest "expired — command was not run" outcome. Genuine double-clicks stay a no-op — pinned by a dedicated test, which earned its keep by catching the first version of this fix re-resolving on second click.

**2. Unauthorized clickers got zero feedback** (all three handlers: approval, slash-confirm, clarify)

Approval prompts post where multiple people can see them. A viewer outside the authorized set who pressed a button got a server-side log line and nothing else — indistinguishable from a broken button. All three handlers now send an ephemeral "not authorized" notice via a shared helper. The authorization boundary itself is unchanged: unauthorized clicks still never resolve anything, and the ephemeral send is best-effort (its failure never blocks the rejection).

The clarify handler had both flaws and receives both fixes; slash-confirm resolution is already idempotent by confirm_id, so only the auth-feedback lane applied there.

## Not in this PR

- The same in-memory guard shape exists in other platform adapters' button handlers — kept this PR Slack-only for reviewability; happy to file the sweep issue.
- Persisting pending-approval state across restarts (or proactively editing orphaned prompts to "expired" at startup) would eliminate the orphan class entirely rather than making it honest — bigger design, worth its own discussion given prompt coalescing means one message can represent several waiters.

## Verification

- 5 new tests: orphaned-click renders expired (approval + clarify), genuine double-click stays silent, unauthorized click gets ephemeral (approval + slash-confirm) — all through the real handlers with the module's established mock harness.
- Mutation checks: restoring the treat-unknown-as-resolved behavior fails the orphan test; short-circuiting the ephemeral helper fails both auth-feedback tests.
- Full gates via `scripts/run_tests.sh tests/gateway/ tests/conformance/`: exit 0.

## Review-caught hazard (second commit)

An adversarial review of the first version caught a real hazard: the orphan branch resolved via `resolve_gateway_approval(session_key, choice)`, which is FIFO within the session — a click on a stale pre-restart prompt could have approved the oldest *live* pending approval for a *different* command. The orphan's waiter died with the old process, so there is nothing correct to resolve: the branch now renders the "expired" outcome directly (shared `_render_approval_outcome`, extracted from the resolved path) and never touches the queue. A new test drives the **real** approval queue — no mocked resolver — and asserts a live pending entry survives an orphaned click in the same session. Clarify's own orphan fall-through was checked against the same hazard and is safe as-is (`resolve_gateway_clarify` targets by clarify_id, not FIFO).

Also from that review: clarify's unauthorized notice derives `team_id` via `_event_team_id` instead of passing None (multi-workspace), the notice wording covers clarify prompts, and two stale comments describing the retired atomic-pop guard were updated.
