### PR TITLE
fix(gateway): apply personality config changes without restart

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9483,7 +9483,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
             if override and override.system_prompt:
                 return (override.system_prompt or "").strip()
-        return getattr(self, "_ephemeral_system_prompt", None) or ""
+        # The global overlay is user config, not session state.  Resolve it at
+        # turn time so ordinary config edits affect the next message just like
+        # /personality does.  The underlying raw-config reader is mtime-cached.
+        prompt = self._load_ephemeral_system_prompt()
+        self._ephemeral_system_prompt = prompt
+        return prompt
 
     @staticmethod
     def _load_reasoning_config(model: str = "") -> dict | None:

--- a/tests/gateway/test_channel_overrides.py
+++ b/tests/gateway/test_channel_overrides.py
@@ -105,6 +105,29 @@ class TestGetSystemPromptForChannel:
         prompt = runner._get_system_prompt_for_channel(Platform.DISCORD, "chan_1")
         assert prompt == "You are a coding assistant."
 
+    def test_reloads_global_personality_after_config_change(self, tmp_path, monkeypatch):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            "display:\n  personality: kawaii\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("gateway.run._hermes_home", tmp_path)
+
+        runner = object.__new__(GatewayRunner)
+        runner.config = GatewayConfig()
+        runner._ephemeral_system_prompt = runner._load_ephemeral_system_prompt()
+        assert runner._ephemeral_system_prompt
+
+        config_path.write_text(
+            "display:\n  personality: neutral\n",
+            encoding="utf-8",
+        )
+
+        prompt = runner._get_system_prompt_for_channel(Platform.SLACK, "chan_1")
+
+        assert prompt == ""
+        assert runner._ephemeral_system_prompt == ""
+
 
 class TestResolveSessionAgentRuntimePriority:
     """Model/runtime priority: session /model → channel_overrides → global."""


### PR DESCRIPTION
## What does this PR do?

A running messaging gateway now reloads the global personality overlay before each turn, so changes made through `hermes config set display.personality ...` or direct `config.yaml` edits affect subsequent messages without a process restart. The existing mtime-keyed raw-config cache keeps unchanged reads lightweight, while channel-specific system prompt overrides retain priority.

### Symptom

After a gateway starts with a named personality, changing `display.personality` does not affect later messages or newly created sessions. The startup personality remains in every model request until `/personality` updates the process-local field or the gateway restarts.

### Impact

Messaging users continue receiving responses under a personality they explicitly disabled or replaced. The stale overlay affects every subsequent gateway turn that does not have a channel-specific override.

### Bug Cause

**Trigger:** `gateway/run.py:9486` / `GatewayRunner._get_system_prompt_for_channel`

**Causal chain:**
1. Gateway startup resolves `display.personality` into `_ephemeral_system_prompt` once.
2. Each later turn falls back to that process-local snapshot instead of the existing runtime config loader.
3. Config changes cannot alter the model-facing overlay until another code path mutates the snapshot or the process restarts.

**Why it is wrong:** The global personality is user configuration rather than session state, but the gateway treated it as immutable process state.

**Working sibling / contrast:** `/personality` persists the same config value and then mutates `_ephemeral_system_prompt`, so it takes effect immediately. Channel-specific `channel_overrides.system_prompt` also resolves before the global fallback and remains unchanged.

**Ruled out:** Session persistence is not responsible because the overlay is appended while constructing each turn and is not stored in session system prompts.

### Fix

Resolve the global fallback through `_load_ephemeral_system_prompt()` on each turn and synchronize the compatibility field with the result. Add a regression test that starts with `kawaii`, edits the same config to `neutral`, and verifies that the next channel prompt is empty.

## Related Issue

Closes #100393

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - refresh the global personality fallback from live config for each turn.
- `tests/gateway/test_channel_overrides.py` - cover a running gateway observing a `kawaii` to `neutral` config change.

## How to Test

1. Configure `display.personality: kawaii` and start a gateway.
2. Change the setting to `display.personality: neutral` without restarting the gateway.
3. Send another messaging turn and confirm the stale personality overlay is absent.
4. Run the focused automated coverage:

```bash
scripts/run_tests.sh tests/gateway/test_channel_overrides.py -q
```

Result: 7 tests passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - behavior now matches the documented config setting
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the change uses existing profile-aware Python config loading
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

N/A - the regression is covered by the focused gateway test above.
