### PR TITLE
fix(skills): expose plugin skills to interactive commands

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -577,6 +577,76 @@ def get_skill_commands() -> Dict[str, Dict[str, Any]]:
     return scan_skill_commands()
 
 
+def get_plugin_skill_commands() -> Dict[str, Dict[str, Any]]:
+    """Return qualified plugin skills as interactive slash commands.
+
+    This stays separate from the filesystem mapping used by native messaging
+    command menus, where ``:`` is not a portable command character.
+    """
+    commands: Dict[str, Dict[str, Any]] = {}
+    try:
+        from agent.skill_utils import get_disabled_skill_names
+        from hermes_cli.plugins import (
+            _get_disabled_plugins,
+            discover_plugins,
+            get_plugin_manager,
+        )
+        from tools.skills_tool import (
+            _parse_frontmatter,
+            skill_matches_environment,
+            skill_matches_platform,
+        )
+
+        discover_plugins()
+        manager = get_plugin_manager()
+        disabled = get_disabled_skill_names()
+        disabled_plugins = _get_disabled_plugins()
+        for metadata in manager.list_plugin_skill_metadata():
+            qualified = str(metadata.get("name") or "").strip()
+            if (
+                not qualified
+                or ":" not in qualified
+                or qualified in disabled
+                or metadata.get("plugin_key") in disabled_plugins
+            ):
+                continue
+            skill_md = manager.find_plugin_skill(qualified)
+            if skill_md is None or not skill_md.is_file():
+                continue
+            try:
+                parsed, _ = _parse_frontmatter(
+                    skill_md.read_text(encoding="utf-8-sig", errors="replace")
+                )
+            except Exception:
+                parsed = {}
+            frontmatter = metadata.get("frontmatter") or parsed
+            if not skill_matches_platform(frontmatter):
+                continue
+            if not skill_matches_environment(frontmatter):
+                continue
+            description = str(
+                metadata.get("description")
+                or parsed.get("description")
+                or f"Invoke the {qualified} plugin skill"
+            ).strip()
+            commands[f"/{qualified.lower()}"] = {
+                "name": qualified,
+                "description": description,
+                "skill_identifier": qualified,
+                "skill_md_path": str(skill_md),
+                "skill_dir": str(skill_md.parent),
+                "source": "plugin",
+            }
+    except Exception:
+        logger.warning("Plugin skill slash-command discovery failed", exc_info=True)
+    return commands
+
+
+def get_interactive_skill_commands() -> Dict[str, Dict[str, Any]]:
+    """Return filesystem and namespaced plugin skills for CLI/TUI use."""
+    return {**get_skill_commands(), **get_plugin_skill_commands()}
+
+
 def reload_skills() -> Dict[str, Any]:
     """Re-scan the skills directory and return a diff of what changed.
 
@@ -642,7 +712,9 @@ def reload_skills() -> Dict[str, Any]:
     }
 
 
-def resolve_skill_command_key(command: str) -> Optional[str]:
+def resolve_skill_command_key(
+    command: str, *, interactive: bool = True
+) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
     Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
@@ -652,13 +724,20 @@ def resolve_skill_command_key(command: str) -> Optional[str]:
     (which disallow hyphens, so ``/claude-code`` is registered as
     ``/claude_code`` and comes back in the underscored form).
 
-    Returns the matching ``/slug`` key from ``get_skill_commands()`` or
-    ``None`` if no match.
+    Interactive callers also resolve namespaced plugin skills. Native messaging
+    gateways pass ``interactive=False`` because ``:`` is not a portable command
+    character and their command menus use the filesystem-only mapping.
     """
     if not command:
         return None
-    cmd_key = f"/{command.replace('_', '-')}"
-    return cmd_key if cmd_key in get_skill_commands() else None
+    commands = (
+        get_interactive_skill_commands() if interactive else get_skill_commands()
+    )
+    exact_key = f"/{command.lower()}"
+    if exact_key in commands:
+        return exact_key
+    normalized_key = f"/{command.replace('_', '-').lower()}"
+    return normalized_key if normalized_key in commands else None
 
 
 def build_skill_invocation_message(
@@ -676,12 +755,15 @@ def build_skill_invocation_message(
     Returns:
         The formatted message string, or None if the skill wasn't found.
     """
-    commands = get_skill_commands()
+    commands = get_interactive_skill_commands()
     skill_info = commands.get(cmd_key)
     if not skill_info:
         return None
 
-    loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
+    loaded = _load_skill_payload(
+        skill_info.get("skill_identifier") or skill_info["skill_dir"],
+        task_id=task_id,
+    )
     if not loaded:
         return None
 
@@ -772,7 +854,7 @@ def build_stacked_skill_invocation_message(
         ``(message, loaded_skill_names, missing_skill_names)`` or ``None``
         when no skill could be loaded at all.
     """
-    commands = get_skill_commands()
+    commands = get_interactive_skill_commands()
 
     loaded_names: list[str] = []
     missing: list[str] = []
@@ -789,7 +871,10 @@ def build_stacked_skill_invocation_message(
             missing.append(cmd_key.lstrip("/"))
             continue
 
-        loaded = _load_skill_payload(skill_info["skill_dir"], task_id=task_id)
+        loaded = _load_skill_payload(
+            skill_info.get("skill_identifier") or skill_info["skill_dir"],
+            task_id=task_id,
+        )
         if not loaded:
             missing.append(cmd_key.lstrip("/"))
             continue

--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -717,12 +717,13 @@ def resolve_skill_command_key(
 ) -> Optional[str]:
     """Resolve a user-typed /command to its canonical skill_cmds key.
 
-    Skills are always stored with hyphens — ``scan_skill_commands`` normalizes
-    spaces and underscores to hyphens when building the key. Hyphens and
-    underscores are treated interchangeably in user input: this matches
-    ``_check_unavailable_skill`` and accommodates Telegram bot-command names
-    (which disallow hyphens, so ``/claude-code`` is registered as
-    ``/claude_code`` and comes back in the underscored form).
+    Filesystem skills are stored with hyphens — ``scan_skill_commands``
+    normalizes spaces and underscores when building the key. Qualified plugin
+    keys preserve their registered spelling, so an exact lowercase match is
+    tried before filesystem underscore-to-hyphen normalization. The fallback
+    accommodates Telegram bot-command names (which disallow hyphens, so
+    ``/claude-code`` is registered as ``/claude_code`` and comes back in the
+    underscored form).
 
     Interactive callers also resolve namespaced plugin skills. Native messaging
     gateways pass ``interactive=False`` because ``:`` is not a portable command

--- a/cli.py
+++ b/cli.py
@@ -4952,9 +4952,9 @@ _skill_bundles = None
 def _ensure_skill_commands() -> dict:
     global _skill_commands
     if _skill_commands is None:
-        from agent.skill_commands import scan_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
 
-        _skill_commands = scan_skill_commands()
+        _skill_commands = get_interactive_skill_commands()
     return _skill_commands
 
 
@@ -14818,7 +14818,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         prompt caching intact.
         """
         try:
-            from agent.skill_commands import reload_skills, get_skill_commands
+            from agent.skill_commands import get_interactive_skill_commands, reload_skills
 
             if not self._command_running:
                 print("🔄 Reloading skills...")
@@ -14829,7 +14829,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # (help display, command dispatch, Tab-completion lambda) see the
             # updated dict without needing to restart the session.
             global _skill_commands
-            _skill_commands = get_skill_commands()
+            _skill_commands = get_interactive_skill_commands()
             added = result.get("added", [])      # [{"name", "description"}, ...]
             removed = result.get("removed", [])  # [{"name", "description"}, ...]
             total = result.get("total", 0)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -19475,7 +19475,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     resolve_skill_command_key,
                 )
                 skill_cmds = get_skill_commands()
-                cmd_key = resolve_skill_command_key(command)
+                cmd_key = resolve_skill_command_key(command, interactive=False)
                 if cmd_key is not None:
                     # Check per-platform disabled status before executing.
                     # get_skill_commands() only applies the *global* disabled

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -6110,6 +6110,7 @@ class PluginManager:
         return [
             {
                 "name": qualified,
+                "plugin_key": str(entry.get("plugin_key", entry.get("plugin", ""))),
                 "description": str(entry.get("description", "")),
                 "category": "plugin",
                 "frontmatter": dict(entry.get("frontmatter", {})),

--- a/tests/test_plugin_skills.py
+++ b/tests/test_plugin_skills.py
@@ -8,6 +8,7 @@ Covers:
 
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
@@ -102,6 +103,153 @@ class TestPluginSkillRegistry:
 
         # Removing non-existent key is a no-op
         pm.remove_plugin_skill("p:x")
+
+
+class TestRegisteredPluginSkillCommands:
+    @pytest.fixture(autouse=True)
+    def _native_plugin(self, tmp_path, monkeypatch):
+        from agent import skill_commands
+        from hermes_cli import plugins as plugins_mod
+
+        home = tmp_path / ".hermes"
+        plugin_dir = home / "plugins" / "slash-probe"
+        skill_dir = plugin_dir / "skills" / "guide"
+        skill_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: slash-probe\nversion: 0.1.0\n",
+            encoding="utf-8",
+        )
+        (plugin_dir / "__init__.py").write_text(
+            "from pathlib import Path\n"
+            "def register(ctx):\n"
+            "    ctx.register_skill(\n"
+            "        'guide', Path(__file__).parent / 'skills' / 'guide' / 'SKILL.md'\n"
+            "    )\n",
+            encoding="utf-8",
+        )
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: guide\ndescription: Native plugin command probe.\n"
+            "platforms: [linux]\n---\n\nFollow the native plugin guide.\n",
+            encoding="utf-8",
+        )
+        home.mkdir(exist_ok=True)
+        (home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - slash-probe\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr("agent.skill_utils.sys.platform", "linux")
+        plugins_mod._reset_plugin_managers_for_tests()
+        skill_commands._skill_commands = {}
+        skill_commands._skill_commands_platform = None
+        skill_commands._skill_commands_home = None
+        yield
+        plugins_mod._reset_plugin_managers_for_tests()
+        skill_commands._skill_commands = {}
+        skill_commands._skill_commands_platform = None
+        skill_commands._skill_commands_home = None
+
+    def test_registered_skill_is_completable_invokable_and_preloadable(self):
+        from agent.skill_commands import (
+            build_preloaded_skills_prompt,
+            build_skill_invocation_message,
+            get_interactive_skill_commands,
+        )
+        from tui_gateway import server
+
+        commands = get_interactive_skill_commands()
+        assert commands["/slash-probe:guide"]["name"] == "slash-probe:guide"
+
+        from agent.skill_commands import resolve_skill_command_key
+
+        assert resolve_skill_command_key("slash-probe:guide") == "/slash-probe:guide"
+        assert resolve_skill_command_key(
+            "slash-probe:guide", interactive=False
+        ) is None
+
+        completed = server.handle_request(
+            {
+                "id": "complete",
+                "method": "complete.slash",
+                "params": {"text": "/slash-probe:"},
+            }
+        )
+        assert any(
+            item["text"] == "slash-probe:guide"
+            and item["kind"] == "skill"
+            for item in completed["result"]["items"]
+        )
+
+        dispatched = server.handle_request(
+            {
+                "id": "dispatch",
+                "method": "command.dispatch",
+                "params": {"name": "slash-probe:guide", "arg": "apply it"},
+            }
+        )
+        assert isinstance(dispatched, dict)
+        dispatch_result = dispatched["result"]
+        assert isinstance(dispatch_result, dict)
+        assert dispatch_result["type"] == "skill"
+        assert dispatch_result["name"] == "slash-probe:guide"
+
+        invoked = build_skill_invocation_message(
+            "/slash-probe:guide", "apply it"
+        )
+        assert invoked is not None
+        assert "Follow the native plugin guide." in invoked
+        assert "apply it" in invoked
+
+        prompt, loaded, missing = build_preloaded_skills_prompt(
+            ["slash-probe:guide"]
+        )
+        assert loaded == ["slash-probe:guide"]
+        assert missing == []
+        assert "Follow the native plugin guide." in prompt
+        assert str(
+            Path(commands["/slash-probe:guide"]["skill_dir"])
+        ) in prompt
+
+    def test_registered_skill_keeps_disabled_and_platform_gates(
+        self, monkeypatch
+    ):
+        from agent.skill_commands import (
+            build_preloaded_skills_prompt,
+            get_interactive_skill_commands,
+        )
+        from hermes_cli.plugins import get_plugin_manager
+
+        get_interactive_skill_commands()
+        skill_md = get_plugin_manager().find_plugin_skill("slash-probe:guide")
+        assert skill_md is not None
+
+        with monkeypatch.context() as disabled_patch:
+            disabled_patch.setattr(
+                "agent.skill_utils.get_disabled_skill_names",
+                lambda: {"slash-probe:guide"},
+            )
+            assert "/slash-probe:guide" not in get_interactive_skill_commands()
+
+        with monkeypatch.context() as disabled_patch:
+            disabled_patch.setattr(
+                "hermes_cli.plugins._get_disabled_plugins",
+                lambda: {"slash-probe"},
+            )
+            assert "/slash-probe:guide" not in get_interactive_skill_commands()
+
+        skill_md.write_text(
+            "---\nname: guide\ndescription: Native plugin command probe.\n"
+            "platforms: [windows]\n---\n\nFollow the native plugin guide.\n",
+            encoding="utf-8",
+        )
+        assert "/slash-probe:guide" not in get_interactive_skill_commands()
+        prompt, loaded, missing = build_preloaded_skills_prompt(
+            ["slash-probe:guide"]
+        )
+        assert prompt == ""
+        assert loaded == []
+        assert missing == ["slash-probe:guide"]
 
 
 class TestPluginContextRegisterSkill:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1059,6 +1059,8 @@ def _serve_plugin_skill(
             "description": description,
             "linked_files": _plugin_skill_linked_files(skill_md.parent),
             "readiness_status": SkillReadinessStatus.AVAILABLE.value,
+            "skill_dir": str(skill_md.parent),
+            "_source_path": str(skill_md),
         },
         ensure_ascii=False,
     )

--- a/tui_gateway/methods_complete.py
+++ b/tui_gateway/methods_complete.py
@@ -338,11 +338,12 @@ def _(rid, params: dict) -> dict:
         from prompt_toolkit.document import Document
         from prompt_toolkit.formatted_text import to_plain_text
 
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
         from agent.skill_bundles import get_skill_bundles
 
+        interactive_skill_commands = get_interactive_skill_commands()
         completer = SlashCommandCompleter(
-            skill_commands_provider=lambda: get_skill_commands(),
+            skill_commands_provider=lambda: interactive_skill_commands,
             skill_bundles_provider=lambda: get_skill_bundles(),
         )
         doc = Document(text, len(text))
@@ -352,7 +353,7 @@ def _(rid, params: dict) -> dict:
         # uses — no sniffing the ⚡/▣ meta glyphs, which are display text.
         skill_names = {
             key.lstrip("/").lower()
-            for key in (*get_skill_commands(), *get_skill_bundles())
+            for key in (*interactive_skill_commands, *get_skill_bundles())
         }
         items = [
             {

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -580,12 +580,12 @@ def _(rid, params: dict) -> dict:
 
     try:
         from agent.skill_commands import (
-            scan_skill_commands,
             build_skill_invocation_message,
+            get_interactive_skill_commands,
         )
 
-        cmds = scan_skill_commands()
-        key = f"/{name}"
+        cmds = get_interactive_skill_commands()
+        key = f"/{name}".lower()
         if key in cmds:
             msg = build_skill_invocation_message(
                 key, arg, task_id=session.get("session_key", "") if session else ""
@@ -1233,11 +1233,11 @@ def _(rid, params: dict) -> dict:
         pass
 
     try:
-        from agent.skill_commands import get_skill_commands
+        from agent.skill_commands import get_interactive_skill_commands
         from hermes_constants import reset_hermes_home_override, set_hermes_home_override
 
-        # Re-bind HERMES_HOME to the session's profile so get_skill_commands()
-        # sees that profile's skills.external_dirs rather than whatever the
+        # Re-bind HERMES_HOME to the session's profile so interactive skill discovery
+        # sees that profile's skills.external_dirs and registered plugins rather
         # process-level env happens to carry (#88023): dispatch() runs this
         # handler on the pool with a copied context, and nothing upstream of
         # here binds the override for slash.exec.
@@ -1247,7 +1247,7 @@ def _(rid, params: dict) -> dict:
         )
         try:
             _cmd_key = f"/{_cmd_base}"
-            if _cmd_key in get_skill_commands():
+            if _cmd_key in get_interactive_skill_commands():
                 return _err(
                     rid, 4018, f"skill command: use command.dispatch for {_cmd_key}"
                 )


### PR DESCRIPTION
## Summary

- include `ctx.register_skill()` entries in CLI/TUI slash discovery and invocation as `/plugin:skill`
- keep qualified names through stacked invocation and compatible `-s/--skills` preload paths
- preserve disabled plugin/skill, platform, environment, profile, and native messaging command gates

The filesystem command map remains unchanged, so native messaging menus never receive `:` commands and the system prompt/cache boundary is untouched.

## Existing work

This uses and credits the qualified interactive-registry approach from #85725 by @kstawiski, updated for current `main` and extended with compatible preload, disabled-plugin, platform, and profile-safe coverage.

## Verification

- regression test failed on unmodified `main` because registered plugin skills had no interactive command registry
- `scripts/run_tests.sh tests/test_plugin_skills.py tests/agent/test_skill_commands.py tests/agent/test_skill_commands_reload.py tests/test_tui_gateway_server.py -q` — 688 passed
- `ruff check` on all changed Python files — passed
- exact staged diff reviewed fail-closed for security, scope, profile/platform/disabled gating, native gateway compatibility, and prompt caching

Closes #100403
