### PR TITLE
chore: case-colliding contributor email file no longer breaks macOS/Windows checkouts

### DIFF
--- a/contributors/emails/agent@Agents-Mac-mini.local
+++ b/contributors/emails/agent@Agents-Mac-mini.local
@@ -1,1 +1,0 @@
-skip-agent


### PR DESCRIPTION
## Summary
Checkouts on case-insensitive filesystems (macOS/Windows default) no longer break: the case-colliding contributor email file is removed.

`contributors/emails/agent@Agents-Mac-mini.local` and `agent@agents-Mac-mini.local` differ only by case — on a case-insensitive checkout git can only materialize one, leaving the tree permanently dirty. The identity is a local-machine artifact, not a real contributor address; its lowercase sibling remains.

Fixes #88168
Fixes #100047
Fixes #99966
Fixes #99821

## Changes
- delete `contributors/emails/agent@Agents-Mac-mini.local` (lowercase sibling kept)

## Validation
| | Before | After |
|---|---|---|
| case-insensitive checkout | permanently dirty tree | clean |

**Live repro:** `git ls-files | tr A-Z a-z | sort | uniq -d` on main shows the colliding pair; empty after this change.

## Infographic

![One file, four issues](https://v3b.fal.media/files/b/0aa8b0f9/FP8WLi9XlTjE4Jxohsp5E_eINCP3z5.png)
