### PR TITLE
fix(cron): don't treat a busy fire fence as lost claim ownership

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3621,13 +3621,37 @@ def _sweep_completed_oneshots(
 
 
 def heartbeat_fire_claim(job_id: str, *, expected_owner: str) -> bool:
+    """Refresh this owner's ``fire_claim`` lease.
+
+    A heartbeat is not an external side effect: it only compare-and-swaps
+    ``fire_claim["at"]`` when ``fire_claim["by"]`` still equals
+    ``expected_owner``.  ``_jobs_lock()`` already serializes that CAS with both
+    an in-process lock and a cross-process flock, so it is safe on its own.
+
+    Taking the fire fence here is actively harmful.  The run thread holds the
+    per-job fence across its whole side effect (see ``_fire_job_lock``), and the
+    fence's reentrancy is thread-local, so it does not extend to the heartbeat
+    thread.  Any execution outliving ``_RUN_CLAIM_HEARTBEAT_SECONDS`` therefore
+    blocked here for ``_JOBS_LOCK_TIMEOUT_SECONDS`` and returned False, which
+    the scheduler reads as "ownership lost" and uses to interrupt a perfectly
+    healthy run -- reported to the operator as "Interrupted by shutdown before
+    terminal completion."
+
+    So: prefer the fence to keep the common path serialized with other owner
+    mutations, but when it is unavailable fall back to the CAS instead of
+    reporting a loss of ownership we have not actually observed.  A genuine
+    takeover still returns False, because ``by`` no longer matches.
+    """
     with _fire_job_lock(job_id) as acquired:
-        if not acquired:
-            return False
-        return _heartbeat_fire_claim_locked(
-            job_id,
-            expected_owner=expected_owner,
-        )
+        if acquired:
+            return _heartbeat_fire_claim_locked(
+                job_id,
+                expected_owner=expected_owner,
+            )
+
+    # Fence unavailable (held by this job's own run thread, or contended
+    # cross-process). The owner check below is authoritative either way.
+    return _heartbeat_fire_claim_locked(job_id, expected_owner=expected_owner)
 
 
 def _heartbeat_fire_claim_locked(job_id: str, *, expected_owner: str) -> bool:

--- a/tests/cron/test_claim_job_for_fire.py
+++ b/tests/cron/test_claim_job_for_fire.py
@@ -263,3 +263,47 @@ def test_same_thread_fire_fence_reentrancy_preserves_ownership(temp_home):
     assert result == {"outer": True, "inner": True}
     thread.join(timeout=2)
     assert thread.is_alive() is False
+
+
+def test_heartbeat_survives_fence_held_by_its_own_run(temp_home, monkeypatch):
+    """A heartbeat must not report ownership lost merely because the fence is busy.
+
+    Regression for the false "Interrupted by shutdown before terminal
+    completion." that killed every cron job outliving the heartbeat interval:
+    the run thread holds the per-job fence across its side effect, the
+    heartbeat thread (a different thread, so the fence's thread-local
+    reentrancy does not apply) could not acquire it, and that timeout was
+    reported to the scheduler as a lost claim.
+    """
+    import cron.jobs as jobs
+
+    job = jobs.create_job(prompt="x", schedule="every 5m", name="long-run")
+    assert jobs.claim_job_for_fire(job["id"]) is True
+    owner = jobs.get_job(job["id"])["fire_claim"]["by"]
+
+    # Keep the failing path fast; the real value is 30s.
+    monkeypatch.setattr(jobs, "_JOBS_LOCK_TIMEOUT_SECONDS", 0.2)
+
+    fence_held = threading.Event()
+    release = threading.Event()
+
+    def hold_fence():
+        with jobs.fire_claim_fence(job["id"], expected_owner=owner) as owns:
+            assert owns is True
+            fence_held.set()
+            release.wait(timeout=5)
+
+    holder = threading.Thread(target=hold_fence, daemon=True)
+    holder.start()
+    try:
+        assert fence_held.wait(timeout=5)
+        # The run thread owns the fence; the heartbeat still confirms ownership.
+        assert jobs.heartbeat_fire_claim(job["id"], expected_owner=owner) is True
+        # A genuine takeover is still detected while the fence is busy.
+        assert (
+            jobs.heartbeat_fire_claim(job["id"], expected_owner="replacement-owner")
+            is False
+        )
+    finally:
+        release.set()
+        holder.join(timeout=5)


### PR DESCRIPTION
Fixes #100401.

## Problem

`heartbeat_fire_claim()` takes the per-job fire fence. The run thread already holds that fence around its side effects — `save_job_output()` and `_deliver_result()` (`_side_effect_fence()`). The heartbeat runs on a *different* thread, so `_fire_job_lock`'s thread-local reentrancy bookkeeping (`_fire_fence_lock_state = threading.local()`) does not apply and the `RLock` is genuinely contended.

So a delivery slower than `_JOBS_LOCK_TIMEOUT_SECONDS` (30s) makes the heartbeat block, time out, and return `False`. The scheduler cannot tell that apart from a real takeover:

```python
if not heartbeat_fire_claim(job_id, expected_owner=owner):
    lost_ownership.set()
    logger.warning("Job '%s': fire claim ownership lost; interrupting stale run", job_id)
```

and interrupts a perfectly healthy run, which operators see as:

```
failed     Interrupted by shutdown before terminal completion.
```

Nothing has shut down, and the work itself already succeeded — in my case a nightly backup that had committed *and* pushed before being reported as failed.

Production timeline (`deliver: bot-chat:default`), the two constants adding to exactly 90s:

```
03:45:00.49  run starts
03:46:30.55  Timed out waiting for local fire fence <dir>::<job_id>; failing closed   (t+90s)
             Job '<job_id>': fire claim ownership lost; interrupting stale run
03:47:33.32  Job '<job_id>': delivered to Bot Chat of profile 'default'               (t+153s)
```

Delivery was still in flight, holding the fence, when the heartbeat tried to renew.

## Fix

A heartbeat is not an external side effect. It only compare-and-swaps `fire_claim["at"]` when `fire_claim["by"]` still equals `expected_owner`, and `_heartbeat_fire_claim_locked()` already performs that CAS under `_jobs_lock()` — which holds **both** an in-process lock and a cross-process flock on `.jobs.lock`. The fence adds nothing to its correctness.

So: prefer the fence to keep the common path serialized with other owner mutations, but when it is unavailable, fall back to the CAS instead of reporting a loss of ownership that was never observed. A genuine takeover still returns `False`, because `by` no longer matches.

No change to the scheduler, no change to the constants, no new public API.

## Scope

Only jobs whose delivery is slow enough to span a heartbeat tick are affected. `--deliver local` never reproduces it — I confirmed with a 115s job that completes on both patched and unpatched builds. Every job I have seen fail delivers to `bot-chat`, which may make this worth a look alongside #95307 (also `bot-chat`, also a spurious lost fire claim).

## Testing

- New regression test reproduces the production log line and fails without the fix:
  `tests/cron/test_claim_job_for_fire.py::test_heartbeat_survives_fence_held_by_its_own_run`
- It also asserts that a real takeover is still detected while the fence is busy, so the fix does not weaken the ownership guarantee.
- Full `tests/cron/` suite: **1081 passed, 1 skipped**.
- One pre-existing unrelated failure, `test_repeated_heartbeat_errors_cancel_after_bounded_grace`, fails identically with and without this change (5/5 runs each) — it asserts `calls >= 3` against a 0.01s/0.03s timing window.

Verified against `main @ 18a76be12`; both touched files are byte-identical between that revision and current `main`.
