### PR TITLE
fix(acp): fail closed on corrupt config.yaml before starting the ACP server

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -116,6 +116,30 @@ def _load_env() -> None:
         )
 
 
+def _guard_corrupt_user_config() -> None:
+    """Fail closed when the active profile's config.yaml cannot be parsed.
+
+    The ACP server is a fully non-interactive surface: it is driven by an
+    IDE/editor over stdio JSON-RPC, not a human at a terminal, so nobody is
+    present to repair a corrupt ``config.yaml``. Silently continuing on
+    built-in defaults lets provider auto-detection adopt credentials from
+    ``.env`` that the config never named (issue #81952) — every new ACP
+    session builds a fresh ``AIAgent`` (``acp_adapter/session.py``'s
+    ``create_session``/``_make_agent``) subject to exactly that risk. Same
+    policy and escape hatch (``HERMES_IGNORE_USER_CONFIG=1``) as the
+    non-interactive CLI guard (``hermes_cli/main.py``) and the gateway/serve/
+    cron surfaces (``gateway/run.py::_guard_corrupt_user_config``,
+    ``hermes_cli/main.py::cmd_dashboard``, ``cron/scheduler.py::run_job``).
+    """
+    from hermes_cli.config import InvalidUserConfigError, require_parseable_user_config
+
+    try:
+        require_parseable_user_config()
+    except InvalidUserConfigError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
         prog="hermes-acp",
@@ -237,6 +261,7 @@ def main(argv: list[str] | None = None) -> None:
 
     _setup_logging()
     _load_env()
+    _guard_corrupt_user_config()
 
     logger = logging.getLogger(__name__)
     logger.info("Starting hermes-agent ACP adapter")

--- a/tests/hermes_cli/test_config_guard_surfaces.py
+++ b/tests/hermes_cli/test_config_guard_surfaces.py
@@ -101,6 +101,62 @@ class TestCronRunJobGuard:
         assert "Refusing non-interactive startup" not in (error or "")
 
 
+class TestAcpGuard:
+    """`hermes acp` / `hermes-acp`: driven by an IDE over stdio JSON-RPC, no
+    human present to repair a corrupt config.yaml. Same policy as gateway/
+    serve/cron (issue #81952)."""
+
+    def test_acp_refuses_corrupt_config(self, tmp_path, capsys):
+        from acp_adapter.entry import _guard_corrupt_user_config
+
+        _write_corrupt_config(tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            _guard_corrupt_user_config()
+
+        assert exc_info.value.code == 2
+        assert "Refusing non-interactive startup" in capsys.readouterr().err
+
+    def test_acp_allows_valid_config(self, tmp_path):
+        from acp_adapter.entry import _guard_corrupt_user_config
+
+        (tmp_path / "config.yaml").write_text("model:\n  default: local/test\n")
+        _guard_corrupt_user_config()  # must not raise
+
+    def test_acp_allows_missing_config(self, tmp_path):
+        from acp_adapter.entry import _guard_corrupt_user_config
+
+        _guard_corrupt_user_config()  # first-run state: must not raise
+
+    def test_acp_escape_hatch(self, monkeypatch, tmp_path):
+        from acp_adapter.entry import _guard_corrupt_user_config
+
+        _write_corrupt_config(tmp_path)
+        monkeypatch.setenv("HERMES_IGNORE_USER_CONFIG", "1")
+        _guard_corrupt_user_config()  # must not raise
+
+    def test_acp_main_exits_before_agent_server_starts(self, tmp_path, monkeypatch, capsys):
+        """`main()` must fail closed before touching HermesACPAgent/asyncio."""
+        from acp_adapter import entry as entry_mod
+
+        _write_corrupt_config(tmp_path)
+        monkeypatch.setattr(entry_mod, "_setup_logging", lambda: None)
+        monkeypatch.setattr(entry_mod, "_load_env", lambda: None)
+
+        sentinel = RuntimeError("reached agent construction")
+
+        def _fail_if_reached(*args, **kwargs):
+            raise sentinel
+
+        monkeypatch.setattr(entry_mod.asyncio, "run", _fail_if_reached)
+
+        with pytest.raises(SystemExit) as exc_info:
+            entry_mod.main([])
+
+        assert exc_info.value.code == 2
+        assert "Refusing non-interactive startup" in capsys.readouterr().err
+
+
 class TestServeGuard:
     def test_serve_headless_refuses_corrupt_config(self, tmp_path, capsys):
         """The `hermes serve` headless path fails closed before startup."""


### PR DESCRIPTION
## What & why

`require_parseable_user_config()` was extended to the gateway, `hermes serve` headless path, and cron surfaces today (#100153, #100156 — issue #81952): a corrupt `config.yaml` must refuse startup on a non-interactive surface rather than silently fall back to defaults, where provider auto-detection can adopt unnamed `.env` credentials.

`acp_adapter/entry.py::main()` was missed. `hermes acp` / `hermes-acp` is a fully non-interactive surface — driven by an IDE/editor over stdio JSON-RPC, no human present to notice or repair a corrupt config — and every new ACP session builds a fresh `AIAgent` (`acp_adapter/session.py`'s `create_session`/`_make_agent`), subject to exactly the same risk the other three surfaces were just fixed for.

The existing `_guard_noninteractive_user_config()` in `hermes_cli/main.py` only fires when `args.oneshot`/`args.query` is set, which ACP never sets — so both entry paths start unguarded:
- `hermes acp` (routed through `cmd_acp` → `acp_adapter.entry.main`)
- the standalone `hermes-acp` console script, which bypasses `hermes_cli/main.py` entirely (`pyproject.toml`: `hermes-acp = "acp_adapter.entry:main"`)

## Fix

Adds `_guard_corrupt_user_config()` to `acp_adapter/entry.py`, mirroring `gateway/run.py`'s guard of the same name (same `require_parseable_user_config()` call, same `HERMES_IGNORE_USER_CONFIG=1` escape hatch, same `sys.exit(2)` on failure), called in `main()` right after logging/env setup and before MCP discovery or agent construction.

## Tests

Added `TestAcpGuard` to `tests/hermes_cli/test_config_guard_surfaces.py` (the file `#100153` itself added, covering the gateway/cron/serve surfaces), mirroring `TestGatewayGuard`'s exact structure: refuses a corrupt config, allows a valid one, allows a missing one (first-run state), and honors the escape hatch — plus one additional test driving `entry.main([])` end-to-end to confirm it exits before ever reaching `asyncio.run(acp.run_agent(...))`.

- `tests/acp/`, `tests/acp_adapter/`, `tests/hermes_cli/test_config_guard_surfaces.py`, `tests/hermes_cli/test_noninteractive_config_guard.py` — 183 passed (needed a temporary `uv pip install agent-client-protocol==0.9.0` per the standing optional-dependency gotcha; confirmed no regression in the existing `tests/acp/test_entry.py` suite, which relies on the global test-suite `HERMES_HOME` sandbox having no `config.yaml` by default — first-run state, guard correctly no-ops)
- Mutation-verify: reverting the fix makes all 5 new tests fail — 4 with `ImportError` (the guard function doesn't exist pre-fix) and the 5th end-to-end test confirms `main()` proceeds all the way to `asyncio.run(...)` on a corrupt config instead of exiting

## Competitor check

Searched `gh pr/issue list` for "acp corrupt config guard", "require_parseable_user_config", "81952", "acp non-interactive config" (all states) — no PR or issue targets this specific gap.