### PR TITLE
fix(auth): isolate Codex singleton sync by principal

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -808,6 +808,52 @@ def _write_through_provider_state_to_global_root(
         )
 
 
+def _codex_principal_identity(
+    access_token: Any,
+) -> Optional[Tuple[str, str]]:
+    """Return the local routing identity for a Codex access token.
+
+    Claims are decoded without signature verification. This identity is used
+    only to decide whether two already-loaded credentials may share singleton
+    runtime state; it is not an authentication or authorization proof.
+    """
+    claims = _decode_jwt_claims(access_token)
+    if not isinstance(claims, dict):
+        return None
+    auth_claims = claims.get("https://api.openai.com/auth")
+    if not isinstance(auth_claims, dict):
+        return None
+    account_id = auth_claims.get("chatgpt_account_id")
+    subject = claims.get("sub")
+    if not isinstance(account_id, str) or not isinstance(subject, str):
+        return None
+    account_id = account_id.strip()
+    subject = subject.strip()
+    if not account_id or not subject:
+        return None
+    return account_id, subject
+
+
+def _codex_entry_tracks_singleton(
+    entry: PooledCredential,
+    singleton_tokens: Dict[str, Any],
+) -> bool:
+    """Whether a Codex pool entry is allowed to follow singleton state."""
+    if entry.source == "device_code":
+        return True
+    if entry.source != SOURCE_MANUAL_DEVICE_CODE:
+        return False
+    entry_identity = _codex_principal_identity(entry.access_token)
+    singleton_identity = _codex_principal_identity(
+        singleton_tokens.get("access_token")
+    )
+    return bool(
+        entry_identity
+        and singleton_identity
+        and entry_identity == singleton_identity
+    )
+
+
 def _singleton_target_for_entry(pool: "CredentialPool", entry: "PooledCredential") -> Optional[Path]:
     """Root ``.anthropic_oauth.json`` when *entry* is a borrowed hermes_pkce row, else None."""
     if entry.source != "hermes_pkce" or entry.id not in getattr(pool, "_borrowed_root_ids", ()):
@@ -1104,6 +1150,7 @@ class CredentialPool:
         *,
         persist: bool = True,
         failure_reason: Optional[str] = None,
+        force_terminal: bool = False,
     ) -> PooledCredential:
         normalized_error = _normalize_error_context(error_context)
         # Permanent OAuth failures (token_invalidated, token_revoked, etc.)
@@ -1113,7 +1160,9 @@ class CredentialPool:
         # removes it (issue #32849).  DEAD entries are excluded from rotation
         # unconditionally and only clear via an explicit re-auth write-side
         # sync (``_save_codex_tokens`` after a fresh device-code login).
-        if self._is_terminal_auth_failure(status_code, normalized_error):
+        if force_terminal or self._is_terminal_auth_failure(
+            status_code, normalized_error
+        ):
             terminal_status = STATUS_DEAD
         else:
             terminal_status = STATUS_EXHAUSTED
@@ -1271,11 +1320,12 @@ class CredentialPool:
         though fresh credentials are sitting on disk — and every request
         fails with "no available entries (all exhausted or empty)".
 
-        Mirrors the Nous/Anthropic resync paths above.  Only applies to
-        device_code-sourced entries; env/API-key-sourced entries have no
-        auth.json shadow to sync from.
+        Mirrors the Nous/Anthropic resync paths above. Canonical
+        ``device_code`` entries track the singleton. Legacy
+        ``manual:device_code`` entries do so only when both access tokens
+        identify the same Codex principal; unknown identity fails closed.
         """
-        if self.provider != "openai-codex" or entry.source not in ("device_code", "manual:device_code"):
+        if self.provider != "openai-codex":
             return entry
         try:
             with _auth_store_lock():
@@ -1285,6 +1335,8 @@ class CredentialPool:
                 return entry
             tokens = state.get("tokens")
             if not isinstance(tokens, dict):
+                return entry
+            if not _codex_entry_tracks_singleton(entry, tokens):
                 return entry
             store_access = tokens.get("access_token", "")
             store_refresh = tokens.get("refresh_token", "")
@@ -2158,6 +2210,39 @@ class CredentialPool:
                 # remove all singleton-seeded (device_code) entries from the
                 # in-memory pool.  Mirrors the xAI and Nous quarantine paths.
                 if auth_mod._is_terminal_codex_oauth_refresh_error(exc):
+                    # ``manual:device_code`` is historically ambiguous: it can
+                    # be a legacy alias of the singleton or an independent
+                    # account. Never quarantine singleton state unless the
+                    # manual row can be proven to track the same principal.
+                    if entry.source == SOURCE_MANUAL_DEVICE_CODE:
+                        try:
+                            with _auth_store_lock():
+                                auth_store = _load_auth_store()
+                                state = _load_provider_state(
+                                    auth_store, "openai-codex"
+                                )
+                            singleton_tokens = (
+                                state.get("tokens")
+                                if isinstance(state, dict)
+                                else None
+                            )
+                        except Exception:
+                            singleton_tokens = None
+                        if not isinstance(
+                            singleton_tokens, dict
+                        ) or not _codex_entry_tracks_singleton(
+                            entry, singleton_tokens
+                        ):
+                            self._mark_exhausted(
+                                entry,
+                                401,
+                                {
+                                    "reason": getattr(exc, "code", None),
+                                    "message": str(exc),
+                                },
+                                force_terminal=True,
+                            )
+                            return None
                     logger.debug(
                         "Codex OAuth refresh token is terminally invalid; clearing local token state"
                     )

--- a/tests/agent/test_codex_singleton_account_isolation.py
+++ b/tests/agent/test_codex_singleton_account_isolation.py
@@ -11,7 +11,9 @@ import pytest
 def _write_auth_store(tmp_path, payload: dict) -> None:
     hermes_home = tmp_path / "hermes"
     hermes_home.mkdir(parents=True, exist_ok=True)
-    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+    (hermes_home / "auth.json").write_text(
+        json.dumps(payload, indent=2), encoding="utf-8"
+    )
 
 
 def _jwt_with_claims(claims: dict) -> str:
@@ -249,7 +251,9 @@ def test_independent_manual_refresh_uses_own_pair_and_leaves_singleton_unchanged
     assert refreshed.access_token == refreshed_manual_access
     assert refreshed.refresh_token == "refresh-b2"
 
-    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = json.loads(
+        (tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8")
+    )
     assert persisted["providers"]["openai-codex"]["tokens"] == {
         "access_token": singleton_access,
         "refresh_token": "refresh-a",
@@ -316,7 +320,9 @@ def test_independent_manual_terminal_refresh_persists_dead_without_quarantining_
     assert by_id["manual-b"].last_status == STATUS_DEAD
     assert by_id["manual-b"].last_error_reason == reason
 
-    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = json.loads(
+        (tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8")
+    )
     assert persisted["providers"]["openai-codex"]["tokens"] == {
         "access_token": singleton_access,
         "refresh_token": "refresh-a",
@@ -388,7 +394,9 @@ def test_429_rotation_does_not_rewrite_fallback_manual_token_pair(
     assert next_entry.access_token == access_b
     assert next_entry.refresh_token == "refresh-b"
 
-    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted = json.loads(
+        (tmp_path / "hermes" / "auth.json").read_text(encoding="utf-8")
+    )
     persisted_b = next(
         entry
         for entry in persisted["credential_pool"]["openai-codex"]

--- a/tests/agent/test_codex_singleton_account_isolation.py
+++ b/tests/agent/test_codex_singleton_account_isolation.py
@@ -1,0 +1,398 @@
+"""Regression coverage for Codex singleton/manual credential isolation."""
+
+from __future__ import annotations
+
+import base64
+import json
+
+import pytest
+
+
+def _write_auth_store(tmp_path, payload: dict) -> None:
+    hermes_home = tmp_path / "hermes"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "auth.json").write_text(json.dumps(payload, indent=2))
+
+
+def _jwt_with_claims(claims: dict) -> str:
+    def _part(payload: dict) -> str:
+        raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+    return f"{_part({'alg': 'none', 'typ': 'JWT'})}.{_part(claims)}.sig"
+
+
+def _codex_jwt(
+    account_id: str,
+    *,
+    subject: str,
+    token_id: str | None = None,
+) -> str:
+    claims: dict[str, object] = {
+        "sub": subject,
+        "https://api.openai.com/auth": {
+            "chatgpt_account_id": account_id,
+        },
+    }
+    if token_id is not None:
+        claims["jti"] = token_id
+    return _jwt_with_claims(claims)
+
+
+def _pool_entry(
+    *,
+    entry_id: str,
+    source: str,
+    access_token: str,
+    refresh_token: str,
+    priority: int = 0,
+):
+    from agent.credential_pool import PooledCredential
+
+    return PooledCredential(
+        provider="openai-codex",
+        id=entry_id,
+        label=entry_id,
+        auth_type="oauth",
+        priority=priority,
+        source=source,
+        access_token=access_token,
+        refresh_token=refresh_token,
+    )
+
+
+def _singleton_store(access_token: str, refresh_token: str, pool_entries: list[dict] | None = None) -> dict:
+    payload: dict = {
+        "version": 1,
+        "active_provider": "openai-codex",
+        "providers": {
+            "openai-codex": {
+                "tokens": {
+                    "access_token": access_token,
+                    "refresh_token": refresh_token,
+                }
+            }
+        },
+    }
+    if pool_entries is not None:
+        payload["credential_pool"] = {"openai-codex": pool_entries}
+    return payload
+
+
+def test_manual_different_principal_does_not_adopt_singleton(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    singleton_access = _codex_jwt("workspace-a", subject="user-a")
+    manual_access = _codex_jwt("workspace-b", subject="user-b")
+    _write_auth_store(tmp_path, _singleton_store(singleton_access, "refresh-a"))
+
+    from agent.credential_pool import CredentialPool
+
+    manual = _pool_entry(
+        entry_id="manual-b",
+        source="manual:device_code",
+        access_token=manual_access,
+        refresh_token="refresh-b",
+    )
+    pool = CredentialPool("openai-codex", [manual])
+
+    synced = pool._sync_codex_entry_from_auth_store(manual)
+
+    assert synced is manual
+    assert synced.access_token == manual_access
+    assert synced.refresh_token == "refresh-b"
+
+
+def test_manual_same_principal_adopts_rotated_singleton(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    stale_access = _codex_jwt("workspace-a", subject="user-a", token_id="stale")
+    fresh_access = _codex_jwt("workspace-a", subject="user-a", token_id="fresh")
+    _write_auth_store(tmp_path, _singleton_store(fresh_access, "refresh-a2"))
+
+    from agent.credential_pool import CredentialPool, STATUS_EXHAUSTED
+
+    manual = _pool_entry(
+        entry_id="manual-a",
+        source="manual:device_code",
+        access_token=stale_access,
+        refresh_token="refresh-a1",
+    )
+    manual.last_status = STATUS_EXHAUSTED
+    manual.last_error_code = 401
+    pool = CredentialPool("openai-codex", [manual])
+
+    synced = pool._sync_codex_entry_from_auth_store(manual)
+
+    assert synced is not manual
+    assert synced.access_token == fresh_access
+    assert synced.refresh_token == "refresh-a2"
+    assert synced.last_status is None
+    assert synced.last_error_code is None
+
+
+def test_manual_same_workspace_different_subject_does_not_adopt_singleton(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    singleton_access = _codex_jwt("shared-workspace", subject="user-a")
+    manual_access = _codex_jwt("shared-workspace", subject="user-b")
+    _write_auth_store(tmp_path, _singleton_store(singleton_access, "refresh-a"))
+
+    from agent.credential_pool import CredentialPool
+
+    manual = _pool_entry(
+        entry_id="manual-b",
+        source="manual:device_code",
+        access_token=manual_access,
+        refresh_token="refresh-b",
+    )
+    pool = CredentialPool("openai-codex", [manual])
+
+    assert pool._sync_codex_entry_from_auth_store(manual) is manual
+    assert manual.access_token == manual_access
+    assert manual.refresh_token == "refresh-b"
+
+
+@pytest.mark.parametrize(
+    "manual_access",
+    [
+        "not-a-jwt",
+        _jwt_with_claims(
+            {"https://api.openai.com/auth": {"chatgpt_account_id": "workspace-a"}}
+        ),
+        _jwt_with_claims({"sub": "user-a", "https://api.openai.com/auth": {}}),
+        _jwt_with_claims(
+            {
+                "sub": " ",
+                "https://api.openai.com/auth": {"chatgpt_account_id": "workspace-a"},
+            }
+        ),
+    ],
+)
+def test_manual_unknown_principal_fails_closed(tmp_path, monkeypatch, manual_access):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    singleton_access = _codex_jwt("workspace-a", subject="user-a")
+    _write_auth_store(tmp_path, _singleton_store(singleton_access, "refresh-a"))
+
+    from agent.credential_pool import CredentialPool
+
+    manual = _pool_entry(
+        entry_id="manual-unknown",
+        source="manual:device_code",
+        access_token=manual_access,
+        refresh_token="refresh-manual",
+    )
+    pool = CredentialPool("openai-codex", [manual])
+
+    assert pool._sync_codex_entry_from_auth_store(manual) is manual
+    assert manual.access_token == manual_access
+    assert manual.refresh_token == "refresh-manual"
+
+
+def test_canonical_device_code_still_tracks_singleton_without_identity(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, _singleton_store("fresh-non-jwt", "fresh-refresh"))
+
+    from agent.credential_pool import CredentialPool
+
+    canonical = _pool_entry(
+        entry_id="canonical",
+        source="device_code",
+        access_token="stale-non-jwt",
+        refresh_token="stale-refresh",
+    )
+    pool = CredentialPool("openai-codex", [canonical])
+
+    synced = pool._sync_codex_entry_from_auth_store(canonical)
+
+    assert synced.access_token == "fresh-non-jwt"
+    assert synced.refresh_token == "fresh-refresh"
+
+
+def test_independent_manual_refresh_uses_own_pair_and_leaves_singleton_unchanged(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    singleton_access = _codex_jwt("workspace-a", subject="user-a")
+    manual_access = _codex_jwt("workspace-b", subject="user-b", token_id="old")
+    refreshed_manual_access = _codex_jwt(
+        "workspace-b", subject="user-b", token_id="new"
+    )
+    _write_auth_store(tmp_path, _singleton_store(singleton_access, "refresh-a"))
+    refresh_calls: list[tuple[str, str]] = []
+
+    def _refresh(access_token, refresh_token):
+        refresh_calls.append((access_token, refresh_token))
+        return {
+            "access_token": refreshed_manual_access,
+            "refresh_token": "refresh-b2",
+            "last_refresh": "2026-09-04T00:00:00+00:00",
+        }
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _refresh)
+
+    from agent.credential_pool import CredentialPool
+
+    manual = _pool_entry(
+        entry_id="manual-b",
+        source="manual:device_code",
+        access_token=manual_access,
+        refresh_token="refresh-b1",
+    )
+    pool = CredentialPool("openai-codex", [manual])
+
+    refreshed = pool._refresh_entry(manual, force=True)
+
+    assert refreshed is not None
+    assert refresh_calls == [(manual_access, "refresh-b1")]
+    assert refreshed.access_token == refreshed_manual_access
+    assert refreshed.refresh_token == "refresh-b2"
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["providers"]["openai-codex"]["tokens"] == {
+        "access_token": singleton_access,
+        "refresh_token": "refresh-a",
+    }
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        "refresh_token_reused",
+        "codex_refresh_failed",
+        "codex_auth_missing_refresh_token",
+    ],
+)
+def test_independent_manual_terminal_refresh_persists_dead_without_quarantining_singleton(
+    tmp_path, monkeypatch, reason
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    singleton_access = _codex_jwt("workspace-a", subject="user-a")
+    manual_access = _codex_jwt("workspace-b", subject="user-b")
+    seeded = _pool_entry(
+        entry_id="seeded-a",
+        source="device_code",
+        access_token=singleton_access,
+        refresh_token="refresh-a",
+        priority=0,
+    )
+    manual = _pool_entry(
+        entry_id="manual-b",
+        source="manual:device_code",
+        access_token=manual_access,
+        refresh_token="refresh-b",
+        priority=1,
+    )
+    _write_auth_store(
+        tmp_path,
+        _singleton_store(
+            singleton_access,
+            "refresh-a",
+            [seeded.to_dict(), manual.to_dict()],
+        ),
+    )
+
+    from hermes_cli.auth import AuthError
+
+    def _terminal_refresh(*_args, **_kwargs):
+        raise AuthError(
+            "synthetic terminal Codex refresh failure",
+            provider="openai-codex",
+            code=reason,
+            relogin_required=True,
+        )
+
+    monkeypatch.setattr("hermes_cli.auth.refresh_codex_oauth_pure", _terminal_refresh)
+
+    from agent.credential_pool import CredentialPool, STATUS_DEAD, load_pool
+
+    pool = CredentialPool("openai-codex", [seeded, manual])
+    assert pool._refresh_entry(manual, force=True) is None
+
+    by_id = {entry.id: entry for entry in pool.entries()}
+    assert "seeded-a" in by_id
+    assert by_id["manual-b"].last_status == STATUS_DEAD
+    assert by_id["manual-b"].last_error_reason == reason
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    assert persisted["providers"]["openai-codex"]["tokens"] == {
+        "access_token": singleton_access,
+        "refresh_token": "refresh-a",
+    }
+    persisted_by_id = {
+        entry["id"]: entry
+        for entry in persisted["credential_pool"]["openai-codex"]
+    }
+    assert "seeded-a" in persisted_by_id
+    assert persisted_by_id["manual-b"]["last_status"] == STATUS_DEAD
+    assert persisted_by_id["manual-b"]["last_error_reason"] == reason
+
+    reloaded = load_pool("openai-codex")
+    reloaded_manual = next(
+        entry for entry in reloaded.entries() if entry.id == "manual-b"
+    )
+    assert reloaded_manual.last_status == STATUS_DEAD
+    assert reloaded_manual.last_error_reason == reason
+
+
+def test_429_rotation_does_not_rewrite_fallback_manual_token_pair(
+    tmp_path, monkeypatch
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    access_a = _codex_jwt("workspace-a", subject="user-a")
+    access_b = _codex_jwt("workspace-b", subject="user-b")
+    entry_a = _pool_entry(
+        entry_id="manual-a",
+        source="manual:device_code",
+        access_token=access_a,
+        refresh_token="refresh-a",
+        priority=0,
+    )
+    entry_b = _pool_entry(
+        entry_id="manual-b",
+        source="manual:device_code",
+        access_token=access_b,
+        refresh_token="refresh-b",
+        priority=1,
+    )
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [entry_a.to_dict(), entry_b.to_dict()]
+            },
+        },
+    )
+
+    from agent.credential_pool import CredentialPool
+
+    pool = CredentialPool("openai-codex", [entry_a, entry_b])
+    assert pool.select().id == "manual-a"
+
+    next_entry = pool.mark_exhausted_and_rotate(
+        status_code=429,
+        credential_id="manual-a",
+        api_key_hint=access_a,
+        error_context={
+            "reason": "rate_limit_exceeded",
+            "message": "synthetic rate limit",
+        },
+    )
+
+    assert next_entry is not None
+    assert next_entry.id == "manual-b"
+    assert next_entry.access_token == access_b
+    assert next_entry.refresh_token == "refresh-b"
+
+    persisted = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    persisted_b = next(
+        entry
+        for entry in persisted["credential_pool"]["openai-codex"]
+        if entry["id"] == "manual-b"
+    )
+    assert persisted_b["access_token"] == access_b
+    assert persisted_b["refresh_token"] == "refresh-b"


### PR DESCRIPTION
## Summary

Codex runtime synchronization could replace an independent `manual:device_code` credential with the active singleton token pair. The labels remained distinct, but both entries could then authenticate as the same ChatGPT principal.

This revision re-cuts the fix on current `main` and makes singleton adoption principal-aware:

- Canonical `device_code` entries continue to track the singleton.
- `manual:device_code` entries adopt singleton tokens only when both access-token JWTs identify the same non-empty Codex principal: `(chatgpt_account_id, sub)`.
- Missing, malformed, or incomplete identity fails closed.
- A terminal refresh failure for an independent manual account marks only that account `DEAD`; it no longer removes or quarantines an unrelated singleton entry.
- The Codex terminal predicate is propagated explicitly to the pool status writer, so local terminal reasons such as `codex_refresh_failed` and `codex_auth_missing_refresh_token` cannot be downgraded to transient `EXHAUSTED` state.

JWT claims are decoded here only as a local routing/equality discriminator between credentials Hermes already loaded. They are **not** used as an authentication or authorization proof.

## Motivation

`manual:device_code` carries two historical meanings: a legacy alias for the singleton, and an independent account created by the credential-pool flow. Source-label synchronization alone cannot distinguish them.

`chatgpt_account_id` alone is also insufficient: distinct users can belong to the same ChatGPT workspace/account and share that value while having different JWT subjects. Comparing both `chatgpt_account_id` and `sub` preserves same-principal recovery without permitting cross-user adoption inside a shared workspace and without adding persistent lineage metadata.

This remains a narrow runtime alternative to the source-only restriction in #92198 and the persisted-lineage approach in #95297. It intentionally does not depend on the broader source canonicalization proposed by #20075.

## Regression coverage

The focused regression suite in `tests/agent/test_codex_singleton_account_isolation.py` covers:

- different principals do not adopt each other's singleton tokens;
- same-principal legacy aliases still adopt rotated singleton tokens;
- same `chatgpt_account_id` with different JWT `sub` does **not** adopt;
- missing/malformed/incomplete identity fails closed;
- canonical `device_code` recovery still works without usable identity claims;
- an independent manual refresh uses its own token pair and leaves the singleton unchanged;
- `refresh_token_reused`, `codex_refresh_failed`, and `codex_auth_missing_refresh_token` persist the independent manual entry as `DEAD` and leave the singleton intact;
- the `DEAD` state survives reload;
- 429 rotation to a fallback manual credential does not rewrite that fallback credential's access/refresh token pair.

## Validation

Fresh local validation was run against PR head `db67dafba050a1cc56b2aeba122052471fc6b0d8` in an isolated worktree:

- focused isolation suite: **13 passed**;
- adjacent credential/auth suites: **102 passed**;
- wider Codex selection: **208 passed**;
- Ruff on the changed production/test files: **passed**;
- `py_compile`: **passed**;
- Windows footgun check against upstream `main`: **passed**;
- `git diff --check`: **passed**.

The Windows check initially found four locale-dependent `Path.read_text()` / `Path.write_text()` calls in the new regression file. Follow-up commit `db67dafba0` now specifies `encoding="utf-8"`; the complete focused, adjacent, and wider Codex matrices were rerun after that edit.

The upstream PR workflows for this head still report `action_required`, with no CI jobs dispatched. This is an authorization state rather than a test failure; once approved, upstream CI remains authoritative for the repository-required gates and OS matrix.

## Scope

This PR intentionally does **not** fix the separate sole-credential 429 rotation-to-self behavior tracked in #97315, nor does it introduce persisted lineage/schema changes or broader account-selector behavior.
