### PR TITLE
fix(desktop): keep @hermes callable when the primary handle is default

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx
@@ -193,7 +193,7 @@ export function GroupMentionInput({ members, onChange, onSubmitDraft, value, ...
     }
 
     for (const member of members) {
-      const handle = String(member.handle || botHandle(member.name, member) || '').trim()
+      const handle = String(botHandle(member.name, member) || '').trim()
       const display = displayName(member, botRosterMeta(member, allMeta))
       // Renamed members complete on their friendly tag; parser resolves both.
       const tag = String(botMentionTag(member) || handle).trim()

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.test.ts
@@ -240,6 +240,16 @@ describe('seating a room', () => {
     expect(members[0].handle).toBe('spark-work')
   })
 
+  it('durableGroupChatMembers stores the primary profile as handle hermes, not default', () => {
+    const [primary, farmer] = modules.membership.durableGroupChatMembers([
+      { name: 'default', title: '主要助理／任務協調者' },
+      { name: 'code-farmer', title: 'Code Farmer' }
+    ])
+
+    expect(primary.handle).toBe('hermes')
+    expect(farmer.handle).toBe('code-farmer')
+  })
+
   it('durableGroupChatMembers retains active and remote source identities', () => {
     const members = modules.membership.durableGroupChatMembers([
       {

--- a/apps/desktop/src/plugins/hermes-bots/group-membership.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-membership.ts
@@ -4,7 +4,7 @@
  * the roster UI both read.
  */
 
-import { $botMeta, botFriendlyNames, botMetaKey, botRosterKey } from './data'
+import { $botMeta, botFriendlyNames, botHandle, botMetaKey, botRosterKey } from './data'
 import { $groupChats, groupChatRoomKey } from './group-chat'
 import { botConnectionRoute, botRosterMeta, resolveBotConnectionRoute } from './routing'
 import type { BotMeta, GroupChat, GroupMember, RosterRow } from './types'
@@ -316,7 +316,7 @@ export function durableGroupChatMembers(bots: RosterRow[]): GroupMember[] {
 
     return {
       name: bot.name,
-      handle: bot.handle || bot.name,
+      handle: botHandle(bot.name, bot) || bot.handle || bot.name,
       ...(title
         ? {
             title

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.primary-alias.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.primary-alias.test.ts
@@ -1,0 +1,127 @@
+/**
+ * Directional bot-to-bot handoff to the primary profile.
+ *
+ * The primary member's internal name is `default`; the user-facing alias is
+ * `@hermes`. Live roster union rows and durable room descriptors often stamp
+ * `handle: "default"` (same as the profile id). Using that handle as the
+ * mention form shadows `botHandle()` and drops `@hermes`, so
+ * code-farmer → @hermes never selects the primary bot while the reverse
+ * direction still works (it matches `code-farmer` by name).
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $groupChats } from './group-chat'
+import { durableGroupChatMembers } from './group-membership'
+import { parseGroupChatMentions, resolveGroupResponders, unaddressedGroupMentions } from './group-rounds'
+import type { GroupMember, GroupMessage } from './types'
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { atom } = await import('nanostores')
+
+  return {
+    atom,
+    host: {
+      request: vi.fn(),
+      state: { connectionId: { get: () => 'local' }, profile: { get: () => 'default' } }
+    },
+    queryClient: { invalidateQueries: vi.fn() },
+    useQuery: vi.fn(),
+    useValue: vi.fn()
+  }
+})
+
+vi.mock('./shared', () => ({ getPluginCtx: () => null, ID: 'hermes-bots' }))
+
+const handleless: GroupMember[] = [
+  { name: 'default', title: '' },
+  { name: 'code-farmer', title: 'Code Farmer' }
+]
+
+const persisted: GroupMember[] = [
+  { handle: 'default', name: 'default', title: '主要助理／任務協調者' },
+  { handle: 'code-farmer', name: 'code-farmer', title: 'Code Farmer' }
+]
+
+const fromUser = (text: string): GroupMessage =>
+  ({ at: 1, from: { kind: 'user', name: 'You' }, id: 'u1', text, thread: 't1' }) as GroupMessage
+
+const fromMember = (name: string, text: string, id: string): GroupMessage =>
+  ({ at: 2, from: { kind: 'member', name }, id, text, thread: 't1' }) as GroupMessage
+
+beforeEach(() => {
+  $groupChats.set({})
+})
+
+describe('primary @hermes alias in group mention parse', () => {
+  it('resolves @hermes when the member has no precomputed handle', () => {
+    const parsed = parseGroupChatMentions('@hermes Please reply with the letter B.', handleless)
+
+    expect(parsed.mentioned.has('default')).toBe(true)
+    expect(parsed.mentioned.size).toBe(1)
+  })
+
+  it('resolves @hermes when persist/union stamped handle: "default"', () => {
+    const parsed = parseGroupChatMentions('@hermes Please reply with the letter B.', persisted)
+
+    expect(parsed.mentioned.has('default')).toBe(true)
+    expect(parsed.mentioned.size).toBe(1)
+  })
+
+  it('resolves @hermes after durableGroupChatMembers writes the room descriptor', () => {
+    const durable = durableGroupChatMembers([
+      { name: 'default', title: '主要助理／任務協調者' } as never,
+      { name: 'code-farmer', title: 'Code Farmer' } as never
+    ])
+
+    expect(durable[0].handle).toBe('hermes')
+
+    const parsed = parseGroupChatMentions('@hermes Please reply with the letter B.', durable)
+    const keys = [...parsed.mentioned]
+
+    expect(keys.some(key => String(key).includes('default'))).toBe(true)
+  })
+
+  it('still resolves a device-qualified handle and keeps @hermes as an alias', () => {
+    const members: GroupMember[] = [
+      { handle: 'default-vera', name: 'default' },
+      { handle: 'code-farmer', name: 'code-farmer' }
+    ]
+
+    const byAlias = parseGroupChatMentions('@hermes take this', members)
+    const byDevice = parseGroupChatMentions('@default-vera take this', members)
+
+    expect(byAlias.mentioned.has('default')).toBe(true)
+    expect(byDevice.mentioned.has('default')).toBe(true)
+  })
+})
+
+describe('directional bot-to-bot continuation', () => {
+  it('selects the primary bot when code-farmer hands off with @hermes', () => {
+    const log = [
+      fromUser('@code-farmer Please reply with one line only: mention Hermes and ask Hermes to reply with the letter B.'),
+      fromMember('code-farmer', '@hermes Please reply with the letter B.', 'm1')
+    ]
+    const responders = resolveGroupResponders(log, persisted).map(member => member.name)
+
+    $groupChats.set({ g: { log, members: persisted, roomId: 'room-1' } as never })
+
+    expect(responders).toContain('default')
+    expect(unaddressedGroupMentions('g', persisted, 't1')).toContain('default')
+  })
+
+  it('still selects code-farmer when the primary bot hands off the other way', () => {
+    const log = [
+      fromUser(
+        '@hermes Please reply with one line only: mention Code Farmer and ask Code Farmer to reply with the letter D.'
+      ),
+      fromMember('default', '@code-farmer Please reply with the letter D.', 'm2')
+    ]
+    const responders = resolveGroupResponders(log, persisted).map(member => member.name)
+
+    $groupChats.set({ g: { log, members: persisted, roomId: 'room-1' } as never })
+
+    expect(responders).toContain('code-farmer')
+    expect(unaddressedGroupMentions('g', persisted, 't1')).toContain('code-farmer')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -53,7 +53,10 @@ export function parseGroupChatMentions(text: unknown, members: GroupMember[]) {
     // Cross-connection members are also addressable by their @name-device
     // handle (the roster's disambiguated form) — same-named agents on two
     // machines resolve to the right one.
-    const handle = String(member.handle || botHandle(member.name, member) || '').trim()
+    // Always go through botHandle — a persisted/union handle of "default"
+    // must not shadow the user-facing @hermes alias (member.handle ||
+    // botHandle(...) short-circuits when handle === name === "default").
+    const handle = String(botHandle(member.name, member) || '').trim()
 
     const forms = new Set([
       member.name.toLowerCase(),
@@ -63,6 +66,13 @@ export function parseGroupChatMentions(text: unknown, members: GroupMember[]) {
         ? [title.toLowerCase(), title.toLowerCase().replace(/[\s_-]+/g, ''), title.split(/\s+/)[0].toLowerCase()]
         : [])
     ])
+
+    // The primary profile stays callable as @hermes even when a device-
+    // qualified handle is precomputed (default-vera) or a stale persist
+    // stamped handle: "default".
+    if ((member.name || '').trim().toLowerCase() === 'default') {
+      forms.add('hermes')
+    }
 
     // Renamed members answer to their friendly names too (profile
     // display_name and Bot Mode title), in slugged and collapsed forms —


### PR DESCRIPTION
## What does this PR do?

Desktop Bot Mode group chat failed in one direction: a teammate could `@mention` the primary bot as `@hermes` and the room would settle without giving Hermes a turn. The reverse handoff (`@hermes` → `@code-farmer`) already worked, and a direct user `@hermes` send also appeared to work.

The primary profile’s internal name is `default`. Live roster union rows and durable room descriptors often stamp `handle: "default"`. Group mention parse used `member.handle || botHandle(...)`, so that stamped handle shadowed `botHandle()` and never registered the user-facing `@hermes` alias. After Code Farmer replied `@hermes Please reply with the letter B.`, responder selection stayed on Code Farmer only, `unaddressedGroupMentions` saw no pending handoff, and the drive settled.

This routes mention forms through `botHandle()`, always keeps `@hermes` callable for the `default` profile, and persists the alias on room descriptors so the continuation path uses one canonical internal member key (`default` / source-qualified) while `@hermes` stays the public tag.

## Related Issue

Fixes #100406

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-rounds.ts` — `parseGroupChatMentions` always uses `botHandle()` and adds the `hermes` form for `name === "default"` (including device-qualified handles such as `default-vera`).
- `apps/desktop/src/plugins/hermes-bots/group-membership.ts` — `durableGroupChatMembers` persists `botHandle()` so room descriptors no longer rewrite the primary handle to `default`.
- `apps/desktop/src/plugins/hermes-bots/group-chat-parts.tsx` — mention autocomplete uses the same `botHandle()` resolution.
- `apps/desktop/src/plugins/hermes-bots/group-rounds.primary-alias.test.ts` — both handoff directions, persisted `handle: "default"`, and `@hermes` plus `@default-vera`.
- `apps/desktop/src/plugins/hermes-bots/group-membership.test.ts` — durable persist of a handle-less primary stores `hermes`.

## How to Test

1. From `apps/desktop`, run:
   `npx vitest run src/plugins/hermes-bots/group-rounds.primary-alias.test.ts src/plugins/hermes-bots/group-membership.test.ts src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-rounds.unaddressed.test.ts src/plugins/hermes-bots/group-chat-parts.test.tsx`
2. Confirm the new cases pass: `@hermes` resolves when `handle` is `"default"`; Code Farmer → `@hermes` selects the primary member; Hermes → `@code-farmer` still selects Code Farmer.
3. In Desktop Bot Mode, open a two-member group (Hermes + Code Farmer). Send `@code-farmer Please reply with one line only: mention Hermes and ask Hermes to reply with the letter B. Do not answer B yourself.` Code Farmer should reply `@hermes Please reply with the letter B.` and Hermes should take the next turn. Then send the reverse prompt (`@hermes` ask Code Farmer for `D`) and confirm Code Farmer still replies.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu), Desktop Bot Mode group-chat engine via vitest

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
npx vitest run src/plugins/hermes-bots/group-rounds.primary-alias.test.ts \
  src/plugins/hermes-bots/group-membership.test.ts \
  src/plugins/hermes-bots/group-rounds.test.ts \
  src/plugins/hermes-bots/group-rounds.unaddressed.test.ts \
  src/plugins/hermes-bots/group-chat-parts.test.tsx \
  src/plugins/hermes-bots/data.identity.test.ts

 Test Files  6 passed (6)
      Tests  113 passed (113)
```
