### PR TITLE
fix(telegram): promote connect success line to WARNING so healthy startup is terminal-visible

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -4997,7 +4997,15 @@ class TelegramAdapter(BasePlatformAdapter):
             
             self._mark_connected()
             mode = "webhook" if self._webhook_mode else "polling"
-            logger.info("[%s] Connected to Telegram (%s mode)", self.name, mode)
+            # WARNING, not INFO: the "Connecting to Telegram (attempt N/8)…"
+            # line above is emitted at WARNING and reaches the terminal (the
+            # gateway's default stderr handler is WARNING-only), but this
+            # success line was INFO and went to the log file only. A healthy
+            # startup therefore looked permanently stalled at "attempt 1/8"
+            # on the console — the logging illusion in #90835. Both sides of
+            # the connect transition must share a terminal-visible level so a
+            # real hang is the *absence* of this line, not ambiguity.
+            logger.warning("[%s] Connected to Telegram (%s mode)", self.name, mode)
 
             # Start the persistent heartbeat loop in polling mode. Webhook mode
             # receives updates via incoming pushes — there is no long-poll

--- a/tests/gateway/test_telegram_connect_success_visibility.py
+++ b/tests/gateway/test_telegram_connect_success_visibility.py
@@ -1,0 +1,62 @@
+"""Regression test for #90835 (logging-illusion half).
+
+The Telegram adapter's "Connecting to Telegram (attempt N/8)…" line is
+emitted at WARNING and therefore reaches the gateway's default stderr
+handler (WARNING-only at default verbosity). The matching
+"Connected to Telegram (… mode)" success line was INFO and went to the log
+file only, so a healthy startup looked permanently stalled at "attempt 1/8"
+on the terminal.
+
+This test pins the invariant that both sides of the connect transition are
+emitted at the same terminal-visible level, by inspecting the log calls in
+the adapter source (the connect path needs a live bot token to execute, so
+the levels are asserted at the AST level rather than by running it).
+"""
+
+import ast
+from pathlib import Path
+
+ADAPTER = (
+    Path(__file__).resolve().parents[2]
+    / "plugins"
+    / "platforms"
+    / "telegram"
+    / "adapter.py"
+)
+
+
+def _logger_call_level(tree: ast.AST, needle: str) -> str:
+    """Return the logger method name for the log call whose format string
+    contains *needle*."""
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "logger"
+            and node.args
+        ):
+            first = node.args[0]
+            if (
+                isinstance(first, ast.Constant)
+                and isinstance(first.value, str)
+                and needle in first.value
+            ):
+                return node.func.attr
+    raise AssertionError(f"no logger call containing {needle!r} found")
+
+
+def test_connect_success_line_matches_attempt_line_visibility():
+    tree = ast.parse(ADAPTER.read_text(encoding="utf-8"))
+    attempt_level = _logger_call_level(tree, "Connecting to Telegram (attempt")
+    success_level = _logger_call_level(tree, "Connected to Telegram")
+
+    # The attempt line is terminal-visible (WARNING at default verbosity).
+    assert attempt_level == "warning"
+    # The success line must reach the same console sink — otherwise a healthy
+    # connect is indistinguishable from a hang at "attempt 1/8" (#90835).
+    assert success_level == attempt_level, (
+        "Telegram connect success line logs at a different level "
+        f"({success_level!r}) than the attempt line ({attempt_level!r}); "
+        "a healthy startup will look hung on the terminal (#90835)"
+    )


### PR DESCRIPTION
## Problem

The Telegram adapter's `[Telegram] Connecting to Telegram (attempt 1/8)…` line is emitted at **WARNING** (`plugins/platforms/telegram/adapter.py:4770`), so it reaches the gateway's default stderr handler (WARNING-only at default verbosity in `start_gateway()`). The matching success line `[Telegram] Connected to Telegram (… mode)` was **INFO** and therefore went to the log file only.

Result: a perfectly healthy startup looked permanently hung at "attempt 1/8" on the terminal — the confirmed logging-illusion half of #90835 (the gateway had connected fine; the reporter's direct `GatewayRunner.start()` path only "worked" because it didn't install the WARNING-only stderr handler).

## Fix

Promote the success line to `logger.warning(...)` so both sides of the connect transition share the same terminal-visible sink. A genuine hang is now the *absence* of the success line rather than an ambiguous trailing attempt line. One log-level change + explanatory comment.

Sibling-site sweep: homeassistant and wecom adapters log both sides of their connect at INFO — no attempt-visible/success-hidden asymmetry there, so Telegram is the only site in this class.

## Test

`tests/gateway/test_telegram_connect_success_visibility.py` — AST-level regression test asserting the attempt and success log calls share the same level (WARNING). Sabotage-verified: with the fix reverted the test fails with `'info' == 'warning'` assertion; with the fix it passes.

**Live repro:** real-import harness replicating `start_gateway()`'s exact logging stack (`hermes_logging.setup_logging(mode="gateway")` + default-verbosity WARNING stderr handler, temp `HERMES_HOME`), emitting through the adapter module's real logger at the levels extracted from the live source via AST — before (origin/main): terminal shows `Connecting to Telegram` but never `Connected to Telegram` (attempt=warning, success=info; symptom fires); after: both lines reach the terminal and agent.log (clean).

Also ran: `ruff check` (clean), `scripts/check-windows-footguns.py` on both touched files (clean).

Related open PRs on the same symptom (for maintainer awareness, not duplicated here blindly): #100242 (same one-line promotion + a handler-level test) and #93868 (opposite approach — demotes attempt 1 to INFO + adds a printed "Gateway ready" banner). This PR takes the minimal promote-success approach confirmed by triage on #90835.

Fixes #90835

## Infographic

![telegram-connect-logging-illusion](https://v3b.fal.media/files/b/0aa8b13f/v1lIlUsbY73m_6atyY_l2_1r2ImDp9.png)
