### PR TITLE
fix(discord): trace non-final text deliveries

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1078,9 +1078,11 @@ async def _send_or_update_status_coro(adapter, chat_id, status_key, content, met
     appending a new one. Adapters without the method fall back to plain send.
     """
     sender = getattr(adapter, "send_or_update_status", None)
+    delivery_metadata = dict(metadata or {})
+    delivery_metadata.setdefault("_gateway_delivery_surface", "status")
     if callable(sender):
-        return await sender(chat_id, status_key, content, metadata=metadata)
-    return await adapter.send(chat_id, content, metadata=metadata)
+        return await sender(chat_id, status_key, content, metadata=delivery_metadata)
+    return await adapter.send(chat_id, content, metadata=delivery_metadata)
 
 
 def _approval_send_outcome(future, timeout: float) -> str:
@@ -5938,11 +5940,13 @@ class TurnRunner:
                 return
             if already_streamed or not ctx._status_adapter or not str(display_text or "").strip():
                 return
+            interim_metadata = _interim_metadata(ctx._status_thread_metadata)
+            interim_metadata["_gateway_delivery_surface"] = "interim_assistant"
             safe_schedule_threadsafe(
                 ctx._status_adapter.send(
                     ctx._status_chat_id,
                     display_text,
-                    metadata=ctx._status_thread_metadata,
+                    metadata=interim_metadata,
                 ),
                 ctx._loop_for_step,
                 logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3488,6 +3488,23 @@ class DiscordAdapter(BasePlatformAdapter):
                 or ("interim_assistant" if (metadata or {}).get("_interim_send") else "unclassified")
             )
 
+            def log_nonfinal_delivery(result: SendResult) -> None:
+                if final_delivery or not result.success:
+                    return
+                message_ids = list(
+                    (result.raw_response or {}).get("message_ids")
+                    or ([result.message_id] if result.message_id else [])
+                )
+                logger.info(
+                    "[%s] Sent non-final Discord message surface=%s chat=%s reply_to=%s message_ids=%s chars=%d",
+                    self.name,
+                    delivery_surface,
+                    chat_id,
+                    reply_to or (metadata or {}).get("reply_to_message_id"),
+                    message_ids,
+                    len(content),
+                )
+
             if thread_id:
                 # Fetch the thread directly — threads are addressed by their own ID.
                 channel = self._client.get_channel(int(thread_id))
@@ -3506,6 +3523,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # Forum channels reject channel.send() — create a thread post instead.
             if self._is_forum_parent(channel):
                 result = await self._send_to_forum(channel, content)
+                log_nonfinal_delivery(result)
                 await asyncio.to_thread(
                     self._record_discord_response,
                     reply_to=reply_to,
@@ -3575,16 +3593,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 message_id=message_ids[0] if message_ids else None,
                 raw_response={"message_ids": message_ids}
             )
-            if not final_delivery:
-                logger.info(
-                    "[%s] Sent non-final Discord message surface=%s chat=%s reply_to=%s message_ids=%s chars=%d",
-                    self.name,
-                    delivery_surface,
-                    chat_id,
-                    reply_to or (metadata or {}).get("reply_to_message_id"),
-                    message_ids,
-                    len(content),
-                )
+            log_nonfinal_delivery(result)
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3483,6 +3483,10 @@ class DiscordAdapter(BasePlatformAdapter):
                 thread_id = metadata["thread_id"]
             nonconversational = _metadata_marks_nonconversational(metadata)
             final_delivery = bool(metadata and metadata.get("notify"))
+            delivery_surface = str(
+                (metadata or {}).get("_gateway_delivery_surface")
+                or ("interim_assistant" if (metadata or {}).get("_interim_send") else "unclassified")
+            )
 
             if thread_id:
                 # Fetch the thread directly — threads are addressed by their own ID.
@@ -3571,6 +3575,16 @@ class DiscordAdapter(BasePlatformAdapter):
                 message_id=message_ids[0] if message_ids else None,
                 raw_response={"message_ids": message_ids}
             )
+            if not final_delivery:
+                logger.info(
+                    "[%s] Sent non-final Discord message surface=%s chat=%s reply_to=%s message_ids=%s chars=%d",
+                    self.name,
+                    delivery_surface,
+                    chat_id,
+                    reply_to or (metadata or {}).get("reply_to_message_id"),
+                    message_ids,
+                    len(content),
+                )
             await asyncio.to_thread(
                 self._record_discord_response,
                 reply_to=reply_to,

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -82,6 +82,34 @@ async def test_send_rejects_whitespace_and_records_failed_final_reply(
     assert "Dropped empty message to chat=555" in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_send_records_nonfinal_delivery_provenance_without_content(
+    caplog, monkeypatch, tmp_path
+):
+    # Given: a live-looking Discord channel and a non-final status delivery.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    channel = SimpleNamespace(send=AsyncMock(return_value=SimpleNamespace(id=777)))
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=channel),
+        fetch_channel=AsyncMock(),
+    )
+
+    # When: the adapter successfully posts the non-final delivery.
+    with caplog.at_level("INFO"):
+        result = await adapter.send(
+            "555",
+            "private status payload",
+            metadata={"_gateway_delivery_surface": "status"},
+        )
+
+    # Then: operators can join the receipt to Discord without logging content.
+    assert result.success is True
+    assert "surface=status" in caplog.text
+    assert "message_ids=['777']" in caplog.text
+    assert "private status payload" not in caplog.text
+
+
 def _voice_adapter(reference_obj, *, native_result=None, native_error=None):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
@@ -416,5 +444,4 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-
 

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -110,6 +110,42 @@ async def test_send_records_nonfinal_delivery_provenance_without_content(
     assert "private status payload" not in caplog.text
 
 
+@pytest.mark.asyncio
+async def test_forum_send_records_nonfinal_delivery_provenance_without_content(
+    caplog, monkeypatch, tmp_path
+):
+    # Given: a Discord forum parent and a non-final status delivery.
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    forum_channel = _discord_mod.ForumChannel()
+    forum_channel.id = 555
+    forum_channel.create_thread = AsyncMock(
+        return_value=SimpleNamespace(
+            id=777,
+            message=SimpleNamespace(id=888),
+            thread=SimpleNamespace(id=777, send=AsyncMock()),
+        )
+    )
+    adapter._client = SimpleNamespace(
+        get_channel=MagicMock(return_value=forum_channel),
+        fetch_channel=AsyncMock(),
+    )
+
+    # When: the adapter creates a forum post for the non-final delivery.
+    with caplog.at_level("INFO"):
+        result = await adapter.send(
+            "555",
+            "private forum status payload",
+            metadata={"_gateway_delivery_surface": "status"},
+        )
+
+    # Then: the forum delivery has the same content-free provenance receipt.
+    assert result.success is True
+    assert "surface=status" in caplog.text
+    assert "message_ids=['888']" in caplog.text
+    assert "private forum status payload" not in caplog.text
+
+
 def _voice_adapter(reference_obj, *, native_result=None, native_error=None):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
     ref_msg = SimpleNamespace(id=99, to_reference=MagicMock(return_value=reference_obj))
@@ -444,4 +480,3 @@ async def test_send_file_attachment_forum_uses_files_kwarg(tmp_path, monkeypatch
     thread_kwargs = forum_channel.create_thread.await_args.kwargs
     assert thread_kwargs.get("file") is None
     assert isinstance(thread_kwargs.get("files"), list) and len(thread_kwargs["files"]) == 1
-

--- a/tests/gateway/test_interim_send_lanes.py
+++ b/tests/gateway/test_interim_send_lanes.py
@@ -22,7 +22,7 @@ wrap per call site (grep `_interim_metadata(` in gateway/run.py).
 
 import pytest
 
-from gateway.run import _interim_metadata
+from gateway.run import _interim_metadata, _send_or_update_status_coro
 from tests.gateway.relay.test_relay_live_cards import _connected_adapter
 
 
@@ -48,6 +48,33 @@ class TestInterimMetadataHelper:
         src = {"thread_id": "t1"}
         _interim_metadata(src)
         assert "_interim_send" not in src
+
+
+class RecordingStatusAdapter:
+    def __init__(self):
+        self.metadata = None
+
+    async def send(self, chat_id, content, metadata=None):
+        self.metadata = metadata
+        return {"success": True}
+
+
+@pytest.mark.asyncio
+async def test_status_delivery_adds_a_provenance_surface():
+    adapter = RecordingStatusAdapter()
+
+    await _send_or_update_status_coro(
+        adapter,
+        "chat-1",
+        "lifecycle",
+        "working",
+        {"thread_id": "thread-1"},
+    )
+
+    assert adapter.metadata == {
+        "thread_id": "thread-1",
+        "_gateway_delivery_surface": "status",
+    }
 
 
 class TestHeartbeatShapedSendDoesNotSeal:


### PR DESCRIPTION
## Summary
- add an explicit delivery surface to gateway status and interim-assistant text sends
- record successful non-final Discord text delivery receipts with surface, reply/message IDs, and character count, never message content
- cover normal and forum Discord text routes with regression tests

## Incident basis
A real Discord request produced two replies from the same Hermes bot. The durable session/ledger recorded only the later final response, so the earlier contradictory reply bypassed the normal final-delivery record. The historical caller cannot be reconstructed retroactively because that route had no delivery receipt. This PR makes a recurrence attributable while preserving status, warning, and failure delivery.

## Verification
- targeted Discord adapter and interim-lane tests: 18 passed
- Ruff, Python compilation, and diff check passed
- independent goal, code, security, QA, and context reviews passed for commit a04559d818b2f6b598fed0a0fb2918488152e4f9

## Manual QA limitation
No live Discord message was posted solely for this change, to avoid an unsolicited bot message. Existing incident records were verified against the real Discord API; the new receipt contract is covered by adapter-level tests.