### PR TITLE
fix(updater): rebuild desktop on Windows hand-off repair path (#100044 salvage)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -4126,6 +4126,7 @@ def _repair_node_deps_on_current_checkout(
     gateway_mode: bool = False,
     pre_update_snapshot_id: str | None = None,
     completion_message: str = "✓ Already up to date!",
+    had_desktop_app_before_update: bool = False,
 ) -> bool:
     """Repair Node deps on the ``commit_count == 0`` path (#77211).
 
@@ -4156,6 +4157,23 @@ def _repair_node_deps_on_current_checkout(
         gateway_mode=gateway_mode,
         pre_update_snapshot_id=pre_update_snapshot_id,
     )
+    # A current checkout can still owe a Desktop rebuild (#97343): the
+    # packaged app is built from source the pull already landed — or, on the
+    # Windows hand-off, by a child that never reaches the commits-pulled
+    # rebuild. Skipping it leaves a stale desktop app behind a
+    # successful-looking update. Self-gates on the build stamp, so this is a
+    # no-op when nothing changed.
+    if not _rebuild_desktop_after_update(
+        _m().PROJECT_ROOT / "apps" / "desktop",
+        had_desktop_app_before_update=had_desktop_app_before_update,
+    ):
+        # _rebuild_desktop_after_update already printed the retry hint; withhold
+        # success rather than claiming the update finished (#88251).
+        print_completion(
+            "⚠ Update partially complete — the desktop app was not rebuilt "
+            "and is still on the previous build."
+        )
+        return False
     return bool(print_completion(completion_message))
 
 
@@ -8647,9 +8665,24 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         gateway_mode=gateway_mode,
                         pre_update_snapshot_id=pre_update_snapshot_id,
                     )
-                    current_checkout_complete = _print_verified_update_completion(
-                        "✓ Update complete!"
-                    )
+                    # The Windows hand-off child lands here after doing the
+                    # sync its parent could not, and the commits-pulled
+                    # rebuild below is never reached — rebuild the Desktop
+                    # app here or it silently stays on the old build
+                    # (#97343).
+                    if _rebuild_desktop_after_update(
+                        desktop_dir,
+                        had_desktop_app_before_update=had_desktop_app_before_update,
+                    ):
+                        current_checkout_complete = _print_verified_update_completion(
+                            "✓ Update complete!"
+                        )
+                    else:
+                        current_checkout_complete = False
+                        _print_update_completion(
+                            "⚠ Update partially complete — the desktop app was "
+                            "not rebuilt and is still on the previous build."
+                        )
                 else:
                     current_checkout_complete = False
                     print(f"⚠ Venv still unhealthy after repair: {detail_after}")
@@ -8665,6 +8698,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         if upstream_checked
                         else "✓ Up to date with your fork (official repo not checked)."
                     ),
+                    had_desktop_app_before_update=had_desktop_app_before_update,
                 )
             if runtime_repaired is not None and not _m()._is_windows():
                 print()

--- a/tests/hermes_cli/test_update_config_migration_on_current_checkout.py
+++ b/tests/hermes_cli/test_update_config_migration_on_current_checkout.py
@@ -29,6 +29,7 @@ def test_repair_node_deps_runs_config_migration_on_version_bump(capsys):
             "_run_migrate_config_fresh",
             return_value={"env_added": [], "config_added": ["migrated to v38"], "warnings": []},
         ) as mock_migrate,
+        patch.object(update_cmd, "_rebuild_desktop_after_update", return_value=True),
     ):
         update_cmd._repair_node_deps_on_current_checkout(completion)
 
@@ -52,6 +53,7 @@ def test_repair_node_deps_up_to_date_config(capsys):
         patch("hermes_cli.config.get_missing_env_vars", return_value=[]),
         patch("hermes_cli.config.get_missing_config_fields", return_value=[]),
         patch.object(update_cmd, "_run_migrate_config_fresh") as mock_migrate,
+        patch.object(update_cmd, "_rebuild_desktop_after_update", return_value=True),
     ):
         update_cmd._repair_node_deps_on_current_checkout(completion)
 

--- a/tests/hermes_cli/test_update_current_node_repair.py
+++ b/tests/hermes_cli/test_update_current_node_repair.py
@@ -36,7 +36,9 @@ def test_current_checkout_healthy_node_deps_reports_up_to_date():
     completion = MagicMock()
     with patch.object(
         update_cmd, "_update_node_dependencies", return_value=[]
-    ), patch.object(update_cmd, "_m") as m:
+    ), patch.object(update_cmd, "_m") as m, patch.object(
+        update_cmd, "_rebuild_desktop_after_update", return_value=True
+    ):
         update_cmd._repair_node_deps_on_current_checkout(completion)
 
     # The refresh pairs with the web build like every other call site.

--- a/tests/hermes_cli/test_update_handoff_desktop_rebuild.py
+++ b/tests/hermes_cli/test_update_handoff_desktop_rebuild.py
@@ -1,0 +1,54 @@
+"""The current-checkout repair path must rebuild the Desktop app (#97343).
+
+A Windows git install runs `hermes update` from `hermes.exe`, which reexecs a
+venv-Python child to finish the dependency sync. That child completes through
+``_repair_node_deps_on_current_checkout`` / the hand-off repair branch, never
+through the commits-pulled path that owns the Desktop rebuild — so a
+successful-looking update left the packaged desktop app on the previous build.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import update_cmd
+
+
+def test_current_checkout_repair_rebuilds_desktop_under_project_root():
+    """The repair passes PROJECT_ROOT/apps/desktop and the pre-update flag."""
+    completion = MagicMock(return_value=True)
+    with (
+        patch.object(update_cmd, "_update_node_dependencies", return_value=[]),
+        patch.object(update_cmd, "_m") as m,
+        patch.object(update_cmd, "_check_and_apply_config_migration"),
+        patch.object(
+            update_cmd, "_rebuild_desktop_after_update", return_value=True
+        ) as rebuild,
+    ):
+        m.return_value.PROJECT_ROOT = update_cmd.Path("/fake/hermes")
+        complete = update_cmd._repair_node_deps_on_current_checkout(
+            completion, had_desktop_app_before_update=True
+        )
+
+    assert complete is True
+    rebuild.assert_called_once()
+    assert rebuild.call_args[0][0] == update_cmd.Path("/fake/hermes/apps/desktop")
+    assert rebuild.call_args[1]["had_desktop_app_before_update"] is True
+    completion.assert_called_once_with("✓ Already up to date!")
+
+
+def test_failed_desktop_rebuild_withholds_success_completion():
+    """A failed rebuild must not report success and must return False."""
+    completion = MagicMock(return_value=True)
+    with (
+        patch.object(update_cmd, "_update_node_dependencies", return_value=[]),
+        patch.object(update_cmd, "_m") as m,
+        patch.object(update_cmd, "_check_and_apply_config_migration"),
+        patch.object(update_cmd, "_rebuild_desktop_after_update", return_value=False),
+    ):
+        m.return_value.PROJECT_ROOT = update_cmd.Path("/fake/hermes")
+        complete = update_cmd._repair_node_deps_on_current_checkout(completion)
+
+    assert complete is False
+    for call in completion.call_args_list:
+        assert not call[0][0].startswith("✓")

--- a/tests/hermes_cli/test_update_sqlite_remediation.py
+++ b/tests/hermes_cli/test_update_sqlite_remediation.py
@@ -70,6 +70,11 @@ def test_current_checkout_completion_is_verified_before_success(capsys, monkeypa
 def test_current_checkout_repair_returns_verified_completion_result(monkeypatch):
     monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
     monkeypatch.setattr(update_cmd._m(), "_build_web_ui", lambda _path: None)
+    monkeypatch.setattr(
+        update_cmd,
+        "_rebuild_desktop_after_update",
+        lambda _dir, **_kwargs: True,
+    )
 
     complete = update_cmd._repair_node_deps_on_current_checkout(
         lambda _message: False


### PR DESCRIPTION
## What does this PR do?

Salvages PR #100044 by @jwilson411 onto current `main` (clean cherry-pick, authorship preserved). Credit: @jwilson411.

On Windows git installs, `hermes update` launched from `hermes.exe` reexecs a venv-Python child (`HERMES_UPDATE_REEXEC=1`) to finish the dependency sync. That child completes through the current-checkout / dependency-repair path in `_cmd_update_impl` and printed `✓ Update complete!` without ever calling `_rebuild_desktop_after_update()` — the commits-pulled path owns the rebuild, and the hand-off child never reaches it. Result: every console-launched Windows update silently left the packaged desktop app on the previous build whenever the pulled commits touched `apps/desktop/`.

Fix: add the same stamp-gated rebuild tail to both current-checkout completion sites (the hand-off repair branch in `_cmd_update_impl`, and `_repair_node_deps_on_current_checkout` via a new `had_desktop_app_before_update` kwarg). A failed rebuild withholds the success banner and returns False (aligned with #88251).

Fixes #97343

**Live repro:** windows-latest A/B lane (ephemeral `wine2e/100044-handoff-rebuild` branch, real-import harness of `_repair_node_deps_on_current_checkout`, isolated HERMES_HOME, no mocks of the code under test) —
- before (origin/main): https://github.com/NousResearch/hermes-agent/actions/runs/33524748418 — symptom FIRES: `✓ Already up to date!` printed with ZERO `_rebuild_desktop_after_update` calls.
- after (fix applied): https://github.com/NousResearch/hermes-agent/actions/runs/33524869093 — rebuild invoked on the repair path (`apps/desktop`, `had_desktop_app_before_update=True`), plus the 4 PR test files: 13 passed on windows-latest.
Same A/B also reproduced on Linux via real-import harness. wine2e branch deleted after the proof; the workflow yml is NOT in this diff.

## Related Issue

Fixes #97343. Original contribution: #100044 (@jwilson411). Earlier unmerged attempt: #97380.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py`: rebuild tail on the `HERMES_UPDATE_REEXEC` hand-off repair branch and in `_repair_node_deps_on_current_checkout` (new `had_desktop_app_before_update: bool = False` kwarg, live flag threaded from `_cmd_update_impl`); failed rebuild withholds the success banner.
- `tests/hermes_cli/test_update_handoff_desktop_rebuild.py` (new): rebuild args invariant + withhold-success-on-failure.
- Existing current-checkout tests updated to mock the new call.

## How to Test

1. `python3 -m pytest tests/hermes_cli/test_update_handoff_desktop_rebuild.py tests/hermes_cli/test_update_current_node_repair.py tests/hermes_cli/test_update_config_migration_on_current_checkout.py tests/hermes_cli/test_update_sqlite_remediation.py` → 13 passed (Linux + windows-latest).
2. Windows live A/B run URLs above.

## Checklist

### Code

- [x] Contributor commit cherry-picked with authorship preserved (`98612348+jwilson411@users.noreply.github.com` — CI auto-resolves, no contributors file needed)
- [x] Stale-base gate: merge-base count 0 vs origin/main; diff touches only the 5 intended files
- [x] Live repro before/after on windows-latest (run URLs above)
- [x] Targeted tests green under 8G memory cap

## Infographic

![windows-handoff-desktop-rebuild](https://v3b.fal.media/files/b/0aa8b156/s7bbww2Fn4W1Kl-bmdXtq_ia6VrpmZ.png)
