### PR TITLE
fix(desktop): never lose HERMES_BACKEND_READY emitted before the port wait attaches

### DIFF
--- a/apps/desktop/electron/backend-ready.test.ts
+++ b/apps/desktop/electron/backend-ready.test.ts
@@ -260,3 +260,57 @@ test('exit-before-announcement error stays clean when no output was buffered', a
     return true
   })
 })
+
+// ---------------------------------------------------------------------------
+// bufferedOutput (#60323): a sentinel consumed BEFORE the wait attaches must
+// still resolve. main.ts attaches an output tail at spawn, then awaits
+// claimBackendChild/advanceBootProgress before calling this wait; flowing-mode
+// stdout never replays consumed chunks to late listeners.
+// ---------------------------------------------------------------------------
+
+test('resolves from bufferedOutput when the sentinel was consumed before the wait attached (#60323)', async () => {
+  const child = makeFakeChild()
+
+  // Simulate the spawn-time output tail: it consumed the READY line already,
+  // and no further stdout data will ever arrive.
+  const alreadyConsumed = 'boot noise\nHERMES_BACKEND_READY port=43211\n'
+
+  const port = await waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => alreadyConsumed,
+    timeoutMs: 500
+  })
+
+  assert.equal(port, 43211)
+})
+
+test('bufferedOutput accepts the legacy HERMES_DASHBOARD_READY sentinel too', async () => {
+  const child = makeFakeChild()
+
+  const port = await waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => 'HERMES_DASHBOARD_READY port=43212\n',
+    timeoutMs: 500
+  })
+
+  assert.equal(port, 43212)
+})
+
+test('bufferedOutput without a sentinel still resolves from later live stdout', async () => {
+  const child = makeFakeChild()
+
+  const wait = waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => 'uvicorn still importing...\n',
+    timeoutMs: 1000
+  })
+
+  child.stdout.emit('data', Buffer.from('HERMES_BACKEND_READY port=43213\n'))
+
+  assert.equal(await wait, 43213)
+})
+
+test('bufferedOutput without a sentinel still times out (no false positive)', async () => {
+  const child = makeFakeChild()
+
+  const wait = waitForDashboardPort(child, 50, () => '', () => 'no sentinel here\n')
+
+  await assert.rejects(wait, /Timed out waiting/)
+})

--- a/apps/desktop/electron/backend-ready.ts
+++ b/apps/desktop/electron/backend-ready.ts
@@ -51,8 +51,21 @@ function resolvePortAnnounceTimeoutMs(env = process.env) {
  * on every terminal path — resolve, reject, or timeout — so repeated
  * backend spawns don't leak listener slots on the child.
  */
-function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(), describeOutputTail = () => '') {
+function waitForDashboardPort(
+  child,
+  timeoutMs = resolvePortAnnounceTimeoutMs(),
+  describeOutputTail = () => '',
+  bufferedOutput: () => string = () => ''
+) {
   return new Promise((resolve, reject) => {
+    // Seed the line buffer with any output the spawn-time tail already
+    // consumed (#60323): main.ts attaches its output tail at spawn, then
+    // awaits claimBackendChild + advanceBootProgress BEFORE this listener
+    // attaches. child.stdout is in flowing mode from the tail's listener, so
+    // a READY line flushed during that window is emitted once and never
+    // replayed to late listeners — the wait then times out at 90s and a
+    // healthy backend is killed. Scanning the tail's buffer (and seeding any
+    // trailing partial line) makes the listener-attach ordering irrelevant.
     let buf = ''
     let done = false
 
@@ -104,6 +117,19 @@ function waitForDashboardPort(child, timeoutMs = resolvePortAnnounceTimeoutMs(),
     child.stdout.on('data', onData)
     child.on('exit', onExit)
     child.on('error', onError)
+
+    // Listener is live — now recover a sentinel that was already flushed and
+    // consumed before this promise existed. The snapshot is taken AFTER the
+    // listener attaches, so no chunk can fall between snapshot and listener.
+    if (!done) {
+      const alreadyBuffered = bufferedOutput()
+      const m = alreadyBuffered ? alreadyBuffered.match(_READY_RE) : null
+
+      if (m) {
+        cleanup()
+        resolve(parseInt(m[1], 10))
+      }
+    }
   })
 }
 
@@ -187,6 +213,14 @@ function waitForDashboardReadyFile(
 function waitForDashboardPortAnnouncement(
   child,
   options: {
+    /**
+     * Returns the child's output buffered since SPAWN (the output tail's
+     * accumulated text, #60323). Scanned for an already-emitted READY
+     * sentinel so attaching this wait AFTER other awaits (backend claim,
+     * boot-progress IPC) can never lose the announcement: flowing-mode
+     * stdout never replays chunks to late listeners.
+     */
+    bufferedOutput?: () => string
     /** Returns a formatted stdout/stderr tail suffix for exit errors (#93608). */
     describeOutputTail?: () => string
     readyFile?: fs.PathOrFileDescriptor | null
@@ -200,7 +234,7 @@ function waitForDashboardPortAnnouncement(
     return waitForDashboardReadyFile(options.readyFile, child, timeoutMs, describeOutputTail)
   }
 
-  return waitForDashboardPort(child, timeoutMs, describeOutputTail)
+  return waitForDashboardPort(child, timeoutMs, describeOutputTail, options.bufferedOutput ?? (() => ''))
 }
 
 export {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12177,6 +12177,21 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // the claim, and would miss anything printed before it.
   const outputTail = createBackendOutputTail()
   outputTail.attach(child)
+
+  // Start watching for the READY announcement BEFORE any await (#60323):
+  // stdout is already flowing into the tail, and Node streams never replay
+  // consumed chunks to late listeners — a sentinel printed while
+  // claimBackendChild runs would otherwise be lost forever, timing out a
+  // healthy backend. The tail-buffer accessor covers any residual gap.
+  const portAnnouncement = waitForDashboardPortAnnouncement(child, {
+    bufferedOutput: () => outputTail.text(),
+    describeOutputTail: () => outputTail.describe(),
+    readyFile
+  })
+
+  // Mark handled so an early rejection (child dies during the claim) can't
+  // surface as an unhandled rejection before the Promise.race below attaches.
+  portAnnouncement.catch(() => {})
   await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce, outputTail)
 
   child.stdout.on('data', rememberLog)
@@ -12210,10 +12225,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   })
 
   // Discover the ephemeral port the child bound to
-  const port = await Promise.race([
-    waitForDashboardPortAnnouncement(child, { describeOutputTail: () => outputTail.describe(), readyFile }),
-    startFailed
-  ])
+  const port = await Promise.race([portAnnouncement, startFailed])
 
   if (readyFile) {
     fs.unlink(readyFile, () => {})
@@ -12564,6 +12576,24 @@ async function startHermes() {
     // later, after the claim, and would miss anything printed before it.
     const primaryOutputTail = createBackendOutputTail()
     primaryOutputTail.attach(hermesProcess)
+
+    // Start watching for the READY announcement BEFORE any await (#60323):
+    // claimBackendChild can take seconds (its Windows Get-Process probe cold
+    // start alone runs 2-8s) and advanceBootProgress awaits renderer IPC.
+    // stdout is already flowing into the tail, and Node streams never replay
+    // consumed chunks to late listeners, so a sentinel printed during that
+    // window was lost forever — the wait then hit its 90s timeout and a
+    // healthy backend was killed (deterministic on Windows, racy on
+    // macOS/Linux). The tail-buffer accessor covers any residual gap.
+    const portAnnouncement = waitForDashboardPortAnnouncement(hermesProcess, {
+      bufferedOutput: () => primaryOutputTail.text(),
+      describeOutputTail: () => primaryOutputTail.describe(),
+      readyFile
+    })
+
+    // Mark handled so an early rejection (child dies during the claim) can't
+    // surface as an unhandled rejection before the Promise.race below attaches.
+    portAnnouncement.catch(() => {})
     await claimBackendChild(
       hermesProcess,
       `${backend.command} ${backend.args.join(' ')}`,
@@ -12650,13 +12680,7 @@ async function startHermes() {
     await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
 
     // Discover the ephemeral port the child bound to
-    const port = await Promise.race([
-      waitForDashboardPortAnnouncement(hermesProcess, {
-        describeOutputTail: () => primaryOutputTail.describe(),
-        readyFile
-      }),
-      backendStartFailed
-    ])
+    const port = await Promise.race([portAnnouncement, backendStartFailed])
 
     if (readyFile) {
       fs.unlink(readyFile, () => {})


### PR DESCRIPTION
Fixes #60323 — Desktop misses `HERMES_BACKEND_READY` and times out at 90s, killing a healthy backend (still reproducing on v0.21.0, incl. concurrent multi-profile boots).

## Root cause

The spawn-time output tail (#93608) attaches `data` listeners at spawn, putting `child.stdout` into **flowing mode** immediately. Both backend spawn paths in `main.ts` then `await claimBackendChild(...)` (whose Windows `Get-Process` probe cold-starts in 2.4–8s, 30s timeout) and `await advanceBootProgress('backend.port', ...)` **before** `waitForDashboardPortAnnouncement` attaches its own stdout listener. Node streams never replay already-emitted chunks to late listeners, so a READY sentinel printed during that window is permanently lost → the wait can only time out → the healthy backend is killed and respawned. Deterministic on Windows (PowerShell cold start is slower than a warm backend boot), a race on macOS/Linux.

## Fix (both spawn paths — primary and profile pool)

1. **Create the announcement promise immediately after spawn**, before `claimBackendChild` / `advanceBootProgress`, and `Promise.race` it later (approach from stale PR #60986 by @ParaWheeler — credited — rebased onto the output-tail/readyFile plumbing added since).
2. **New `bufferedOutput` option** on `waitForDashboardPortAnnouncement`: after attaching its live listener, `waitForDashboardPort` scans the output tail's already-buffered text for the sentinel. This makes listener-attach ordering irrelevant for any current or future call site — fixes the bug class, not one site. Snapshot is taken *after* the listener attaches, so no chunk can fall between the two.

The `readyFile` (`HERMES_DESKTOP_READY_FILE`) path is already ordering-safe — it polls a file, not the stream — so it needs no change. Early rejections of the pre-created promise are marked handled to avoid unhandled-rejection noise if the child dies during the claim.

**Live repro:** real `hermes serve --host 127.0.0.1 --port 0` child + real `createBackendOutputTail` + real `waitForDashboardPortAnnouncement` (tsx harness), sentinel provably in the tail buffer before the wait attaches — before: `RESULT: REJECTED after 8008ms: Timed out waiting for Hermes backend port announcement (8000ms)`; after: `RESULT: RESOLVED port=44379 in 0ms`.

## Tests

- 4 new tests in `backend-ready.test.ts` (buffered sentinel resolves; legacy `HERMES_DASHBOARD_READY` accepted; no-sentinel buffer still resolves from live stdout; no-sentinel buffer still times out — no false positive). File: **24/24 pass**.
- Sabotage-verified: with the fix reverted, the 2 buffered-sentinel tests fail (2 failed | 22 passed).
- Adjacent lanes green: `backend-claim.test.ts`, `backend-start-failure.test.ts`, `backend-health.test.ts` — 55/55.
- `tsc -p apps/desktop/tsconfig.json --noEmit` clean; `eslint` clean on all touched files.

## Notes

- Open PR #96347 also targets this family with a broader multi-channel redesign; this PR is the minimal race fix. Not closing it — flagged for maintainer triage. Stale PR #60986 pioneered the promise-before-await ordering.

## Infographic

![ready-sentinel-race-fixed](https://v3b.fal.media/files/b/0aa8b17a/hay8aHUiLeb0LmmLGGirA_VmkuILa5.png)
