### PR TITLE
fix(compression): anchor codex app-server preflight on reported usage

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -102,7 +102,7 @@ def _coerce_usage_int(value: Any) -> int:
     return 0
 
 
-def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
+def _record_codex_app_server_usage(agent, turn, messages=None) -> dict[str, Any]:
     """Translate Codex app-server token usage into Hermes accounting.
 
     Codex app-server reports usage via thread/tokenUsage/updated as:
@@ -115,6 +115,12 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
 
     Even when Codex omits usage for a turn, Hermes should still count that turn
     as one API call for session/status accounting.
+
+    ``messages`` is the local transcript mirror for the turn. When real usage
+    is reported, it is snapshotted into ``agent._usage_anchor`` exactly like
+    the main loop's post-response capture (conversation_loop) — this runtime
+    bypasses that loop, so without this the anchor stays None forever and
+    every preflight estimate falls back to the rough mirror heuristic.
     """
     agent.session_api_calls += 1
 
@@ -190,6 +196,26 @@ def _record_codex_app_server_usage(agent, turn) -> dict[str, Any]:
                 compressor.context_length = context_window
         except Exception:
             logger.debug("codex app-server usage update failed", exc_info=True)
+
+    # Usage-anchored context accounting, mirroring the main loop's capture.
+    # The mirror transcript is deliberately never compacted on this runtime
+    # (native compaction preserves it — see _record_codex_app_server_compaction),
+    # so the heuristic estimate grows monotonically while the real thread may
+    # be tiny or freshly compacted. Without an anchor, hermes-mode preflight
+    # trusts that estimate alone and fires thread compaction on nearly every
+    # turn of a long-lived session (#100381). A usage-less turn keeps whatever
+    # anchor the last real reading produced.
+    if isinstance(messages, list):
+        from agent.model_metadata import capture_usage_anchor
+
+        try:
+            _new_anchor = capture_usage_anchor(
+                prompt_tokens, completion_tokens, messages
+            )
+        except Exception:
+            _new_anchor = None
+        if _new_anchor is not None:
+            agent._usage_anchor = _new_anchor
 
     agent.session_prompt_tokens += prompt_tokens
     agent.session_completion_tokens += completion_tokens
@@ -896,7 +922,7 @@ def run_codex_app_server_turn(
         getattr(agent, "_iters_since_skill", 0) + turn.tool_iterations
     )
     _record_codex_app_server_compaction(agent, turn)
-    usage_result = _record_codex_app_server_usage(agent, turn)
+    usage_result = _record_codex_app_server_usage(agent, turn, messages=messages)
     api_calls = 1
 
     # Now check the skill nudge AFTER iters were incremented — same

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -5552,7 +5552,7 @@ def _compress_context_via_codex_app_server(
         # Codex turn supplies usage. Minimal external test engines may not expose
         # the ContextEngine update hook; preserve their existing bookkeeping.
         if hasattr(agent.context_compressor, "update_from_response"):
-            _record_codex_app_server_usage(agent, result)
+            _record_codex_app_server_usage(agent, result, messages=messages)
     except Exception:
         logger.debug("codex compaction bookkeeping failed", exc_info=True)
 

--- a/tests/agent/test_usage_anchor.py
+++ b/tests/agent/test_usage_anchor.py
@@ -208,5 +208,116 @@ class TestCompressionTriggerUsesAnchor:
         assert anchored is not None and anchored < threshold
 
 
+class TestCodexAppServerAnchor:
+    """The codex_app_server runtime bypasses the conversation loop, so its
+    usage recording is the only site that can maintain agent._usage_anchor.
+    Without it, hermes-mode preflight falls back to the rough mirror-transcript
+    heuristic, which grows monotonically (native compaction preserves the
+    mirror) and fires thread compaction on tiny real threads (#100381)."""
+
+    def _agent(self, anchor=None):
+        return SimpleNamespace(
+            _usage_anchor=anchor,
+            session_api_calls=0,
+            session_prompt_tokens=0,
+            session_completion_tokens=0,
+            session_total_tokens=0,
+            session_input_tokens=0,
+            session_output_tokens=0,
+            session_cache_read_tokens=0,
+            session_cache_write_tokens=0,
+            session_reasoning_tokens=0,
+            context_compressor=None,
+            event_callback=None,
+            _session_db=None,
+            model="codex-test-model",
+            provider="openai",
+            base_url=None,
+        )
+
+    def _turn(self, usage):
+        return SimpleNamespace(token_usage_last=usage, model_context_window=None)
+
+    def _usage(self, input_tokens=12_000, output_tokens=100):
+        return {
+            "inputTokens": input_tokens,
+            "cachedInputTokens": 0,
+            "outputTokens": output_tokens,
+            "reasoningOutputTokens": 0,
+            "totalTokens": input_tokens + output_tokens,
+        }
+
+    def test_turn_usage_sets_anchor(self):
+        from agent.codex_runtime import _record_codex_app_server_usage
+
+        messages = _history_with_images(10)
+        agent = self._agent()
+
+        _record_codex_app_server_usage(
+            agent, self._turn(self._usage()), messages=messages
+        )
+
+        anchor = agent._usage_anchor
+        assert anchor is not None
+        assert anchor["prompt_tokens"] == 12_000
+        assert anchor["base_count"] == len(messages)
+
+        # The next turn's preflight estimate anchors on provider truth plus
+        # only the appended delta — not the flat-1500-per-image heuristic.
+        messages.append(_msg("user", "follow-up"))
+        got = _preflight_request_tokens(agent, messages, "")
+        assert 12_000 < got < 12_200
+
+    def test_usage_less_turn_keeps_previous_anchor(self):
+        from agent.codex_runtime import _record_codex_app_server_usage
+
+        messages = _history_with_images(2)
+        prior = capture_usage_anchor(9_000, 50, messages)
+        agent = self._agent(anchor=prior)
+
+        _record_codex_app_server_usage(agent, self._turn(None), messages=messages)
+
+        assert agent._usage_anchor is prior
+
+    def test_hermes_mode_preflight_no_longer_trips_on_mirror_estimate(self):
+        """Issue scenario: the local mirror is huge (heuristic well over a
+        15K threshold) while the provider-reported thread is small. With the
+        anchor captured from codex usage, preflight stays below the threshold
+        and thread compaction is not fired on a tiny thread."""
+        from agent.codex_runtime import _record_codex_app_server_usage
+
+        threshold = 15_000
+        messages = _history_with_images(10)
+        assert estimate_messages_tokens_rough(messages) >= threshold
+
+        agent = self._agent()
+        _record_codex_app_server_usage(
+            agent, self._turn(self._usage(input_tokens=2_000)), messages=messages
+        )
+
+        messages.append(_msg("user", "next turn"))
+        anchored = _preflight_request_tokens(agent, messages, "")
+        assert anchored is not None
+        assert anchored < threshold
+
+        # Control: without the anchor (pre-fix behavior) the same mirror
+        # estimate is over the threshold and would trigger compaction.
+        unanchored = _preflight_request_tokens(self._agent(), messages, "")
+        assert unanchored >= threshold
+
+    def test_missing_messages_argument_leaves_anchor_untouched(self):
+        """Legacy callers that pass no mirror (e.g. external engines hitting
+        the compaction bookkeeping) must not crash or clobber the anchor."""
+        from agent.codex_runtime import _record_codex_app_server_usage
+
+        messages = _history_with_images(2)
+        prior = capture_usage_anchor(9_000, 50, messages)
+        agent = self._agent(anchor=prior)
+
+        _record_codex_app_server_usage(agent, self._turn(self._usage()))
+
+        assert agent._usage_anchor is prior
+
+
 if __name__ == "__main__":
     raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What does this PR do?

On the `codex_app_server` runtime, `agent._usage_anchor` was never populated: the usage-anchored context accounting is captured after each main-loop response in `conversation_loop`, and this runtime hands the whole turn to the app-server subprocess and bypasses that loop. `_record_codex_app_server_usage()` fed the real thread usage into `compressor.update_from_response()` but never snapshotted an anchor.

As a result every preflight estimate fell back to the rough mirror-transcript heuristic. That mirror is deliberately never compacted on this runtime (native compaction preserves it — see `_record_codex_app_server_compaction`), so the estimate grows monotonically while the real thread may be tiny or freshly compacted. With `compression.codex_app_server_auto: hermes` the estimate alone tripped the threshold and Hermes fired `thread/compact/start` on nearly every turn of a long-lived session, compacting tiny threads and thrashing (#100381).

The fix mirrors the main loop's post-response capture: `_record_codex_app_server_usage()` now snapshots the provider-reported prompt/completion tokens into `agent._usage_anchor` against the transcript mirror, so the next preflight resolves to provider truth plus only the messages appended since. A usage-less turn keeps the previous anchor, and the existing post-compaction invalidation site is unchanged.

## Related Issue

Fixes #100381

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_runtime.py` — `_record_codex_app_server_usage()` takes the transcript mirror (`messages`) and, when real usage is reported, captures it via `capture_usage_anchor()` into `agent._usage_anchor` (same pattern as the main loop); the `run_codex_app_server_turn` call site passes the mirror.
- `agent/conversation_compression.py` — the post-compaction bookkeeping call passes the mirror so a compaction result that carries usage re-establishes the anchor right after the invalidation.
- `tests/agent/test_usage_anchor.py` — new `TestCodexAppServerAnchor` class: anchor set from codex usage, usage-less turn keeps the prior anchor, the issue scenario (mirror heuristic far over threshold + small reported thread stays below threshold, with a no-anchor control that trips it), and legacy callers without `messages` are unaffected.

## How to Test

1. `pytest tests/agent/test_usage_anchor.py -q` — 16 passed (12 existing + 4 new). Observed result: passed.
2. `pytest tests/agent/test_context_compressor.py tests/agent/test_codex_app_server_event_bridge.py tests/agent/test_pre_compress_checkpoint_contract.py tests/agent/test_codex_app_server_persist.py tests/run_agent/test_codex_app_server_compaction.py tests/gateway/test_codex_hygiene_compaction.py -q` — Observed result: 219 passed.
3. `test_hermes_mode_preflight_no_longer_trips_on_mirror_estimate` reproduces the issue shape end to end: an image-heavy mirror whose heuristic estimate is far over a 15K threshold, a codex turn reporting a 2K real prompt, and the assertion that the next preflight estimate stays below the threshold while the pre-fix control (no anchor) is over it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Not applicable — behavior change is covered by the regression tests above.