### PR TITLE
fix(telegram): scope guest_mode and 7 sibling settings per profile

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -10949,7 +10949,15 @@ class TelegramAdapter(BasePlatformAdapter):
     # ── Message reactions (processing lifecycle) ──────────────────────────
 
     def _reactions_enabled(self) -> bool:
-        """Check if message reactions are enabled via config/env."""
+        """Check if message reactions are enabled via config/env.
+
+        Extra-first (mirrors ``_telegram_require_mention``/``_telegram_guest_mode``
+        etc.): a secondary multiplex profile's own ``extra.reactions`` must
+        not be shadowed by the default profile's bridged ``TELEGRAM_REACTIONS``.
+        """
+        configured = self.config.extra.get("reactions")
+        if configured is not None:
+            return str(configured).strip().lower() not in {"false", "0", "no"}
         return os.getenv("TELEGRAM_REACTIONS", "false").lower() not in {"false", "0", "no"}
 
     async def _set_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
@@ -11172,17 +11180,17 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         extras.setdefault("disable_topic_auto_rename", telegram_cfg["disable_topic_auto_rename"])
 
     _effective_rm = telegram_cfg.get("require_mention", yaml_cfg.get("require_mention"))
-    if _effective_rm is not None and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
+    if _effective_rm is not None and not _skip_env_bridge and not os.getenv("TELEGRAM_REQUIRE_MENTION"):
         os.environ["TELEGRAM_REQUIRE_MENTION"] = str(_effective_rm).lower()
-    if "mention_patterns" in telegram_cfg and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
+    if "mention_patterns" in telegram_cfg and not _skip_env_bridge and not os.getenv("TELEGRAM_MENTION_PATTERNS"):
         os.environ["TELEGRAM_MENTION_PATTERNS"] = _json.dumps(telegram_cfg["mention_patterns"])
-    if "exclusive_bot_mentions" in telegram_cfg and not os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS"):
+    if "exclusive_bot_mentions" in telegram_cfg and not _skip_env_bridge and not os.getenv("TELEGRAM_EXCLUSIVE_BOT_MENTIONS"):
         os.environ["TELEGRAM_EXCLUSIVE_BOT_MENTIONS"] = str(telegram_cfg["exclusive_bot_mentions"]).lower()
-    if "allow_bots" in telegram_cfg and not os.getenv("TELEGRAM_ALLOW_BOTS"):
+    if "allow_bots" in telegram_cfg and not _skip_env_bridge and not os.getenv("TELEGRAM_ALLOW_BOTS"):
         os.environ["TELEGRAM_ALLOW_BOTS"] = str(telegram_cfg["allow_bots"]).lower()
-    if "guest_mode" in telegram_cfg and not os.getenv("TELEGRAM_GUEST_MODE"):
+    if "guest_mode" in telegram_cfg and not _skip_env_bridge and not os.getenv("TELEGRAM_GUEST_MODE"):
         os.environ["TELEGRAM_GUEST_MODE"] = str(telegram_cfg["guest_mode"]).lower()
-    if "observe_unmentioned_group_messages" in telegram_cfg and not os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
+    if "observe_unmentioned_group_messages" in telegram_cfg and not _skip_env_bridge and not os.getenv("TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"):
         os.environ["TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES"] = str(telegram_cfg["observe_unmentioned_group_messages"]).lower()
     frc = telegram_cfg.get("free_response_chats")
     if frc is not None:
@@ -11220,8 +11228,15 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
             ignored_threads = ",".join(str(v) for v in ignored_threads)
         if not _skip_env_bridge and not os.getenv("TELEGRAM_IGNORED_THREADS"):
             os.environ["TELEGRAM_IGNORED_THREADS"] = str(ignored_threads)
-    if "reactions" in telegram_cfg and not os.getenv("TELEGRAM_REACTIONS"):
-        os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+    if "reactions" in telegram_cfg:
+        extras.setdefault("reactions", telegram_cfg["reactions"])
+        if not _skip_env_bridge and not os.getenv("TELEGRAM_REACTIONS"):
+            os.environ["TELEGRAM_REACTIONS"] = str(telegram_cfg["reactions"]).lower()
+    # proxy_url is deliberately NOT scoped here — resolve_proxy_url()
+    # (gateway/platforms/base.py, shared by Discord/Telegram/etc.) reads
+    # TELEGRAM_PROXY via raw os.environ regardless of this bridge; scoping
+    # only the write side would be an inconsistent partial fix. Left for a
+    # dedicated fix to that shared helper.
     if "proxy_url" in telegram_cfg and not os.getenv("TELEGRAM_PROXY"):
         os.environ["TELEGRAM_PROXY"] = str(telegram_cfg["proxy_url"]).strip()
     _telegram_extra = telegram_cfg.get("extra") if isinstance(telegram_cfg.get("extra"), dict) else {}
@@ -11229,7 +11244,7 @@ def _apply_yaml_config(yaml_cfg: dict, telegram_cfg: dict) -> dict | None:
         telegram_cfg["reply_to_mode"] if "reply_to_mode" in telegram_cfg
         else _telegram_extra.get("reply_to_mode")
     )
-    if _telegram_rtm is not None and not os.getenv("TELEGRAM_REPLY_TO_MODE"):
+    if _telegram_rtm is not None and not _skip_env_bridge and not os.getenv("TELEGRAM_REPLY_TO_MODE"):
         _rtm_str = "off" if _telegram_rtm is False else str(_telegram_rtm).lower()
         os.environ["TELEGRAM_REPLY_TO_MODE"] = _rtm_str
     allowed_users = telegram_cfg.get("allow_from")

--- a/tests/gateway/test_telegram_reactions.py
+++ b/tests/gateway/test_telegram_reactions.py
@@ -53,6 +53,25 @@ def test_reactions_enabled_when_set_true(monkeypatch):
     assert adapter._reactions_enabled() is True
 
 
+def test_reactions_extra_takes_precedence_over_env(monkeypatch):
+    """A secondary multiplex profile's own extra.reactions must not be
+    shadowed by the default profile's bridged TELEGRAM_REACTIONS (mirrors
+    _telegram_require_mention/_telegram_guest_mode's existing precedence)."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "false")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter.config = PlatformConfig(enabled=True, token="fake-token", extra={"reactions": True})
+    assert adapter._reactions_enabled() is True
+
+    monkeypatch.setenv("TELEGRAM_REACTIONS", "true")
+    adapter2 = object.__new__(TelegramAdapter)
+    adapter2.platform = Platform.TELEGRAM
+    adapter2.config = PlatformConfig(enabled=True, token="fake-token", extra={"reactions": False})
+    assert adapter2._reactions_enabled() is False
+
+
 # ── _set_reaction ────────────────────────────────────────────────────
 
 

--- a/tests/plugins/platforms/test_discord_gate_isolation.py
+++ b/tests/plugins/platforms/test_discord_gate_isolation.py
@@ -434,3 +434,68 @@ class TestTelegramGateIsolation:
         assert extras is None or "allowed_chats" not in extras
         assert os.getenv("TELEGRAM_ALLOWED_CHATS") is None
         assert os.getenv("TELEGRAM_ALLOWED_USERS") is None
+
+    def test_telegram_guest_mode_and_siblings_skip_env_bridge_when_scoped(self, monkeypatch):
+        """guest_mode, require_mention, mention_patterns,
+        exclusive_bot_mentions, allow_bots, observe_unmentioned_group_messages,
+        reactions, and reply_to_mode were the ONLY _apply_yaml_config writes
+        missing the _skip_env_bridge guard every other Telegram gate already
+        has — a secondary profile's own values must not pollute shared env
+        (guest_mode is an authorization gate: non-allowlisted groups can
+        trigger the bot via direct @mention when enabled)."""
+        from agent import secret_scope
+        from plugins.platforms.telegram.adapter import _apply_yaml_config
+
+        env_vars = (
+            "TELEGRAM_GUEST_MODE",
+            "TELEGRAM_REQUIRE_MENTION",
+            "TELEGRAM_MENTION_PATTERNS",
+            "TELEGRAM_EXCLUSIVE_BOT_MENTIONS",
+            "TELEGRAM_ALLOW_BOTS",
+            "TELEGRAM_OBSERVE_UNMENTIONED_GROUP_MESSAGES",
+            "TELEGRAM_REACTIONS",
+            "TELEGRAM_REPLY_TO_MODE",
+        )
+        for var in env_vars:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", True)
+        token = secret_scope.set_secret_scope({})
+        try:
+            seeded = _apply_yaml_config(
+                {},
+                {
+                    "guest_mode": True,
+                    "require_mention": False,
+                    "mention_patterns": ["^hey bot"],
+                    "exclusive_bot_mentions": True,
+                    "allow_bots": True,
+                    "observe_unmentioned_group_messages": True,
+                    "reactions": True,
+                    "reply_to_mode": "off",
+                },
+            )
+        finally:
+            secret_scope.reset_secret_scope(token)
+
+        for var in env_vars:
+            assert os.getenv(var) is None, f"{var} leaked into process env under scope"
+        # guest_mode/reactions still reach this profile's own extra.
+        assert seeded["guest_mode"] is True
+        assert seeded["reactions"] is True
+
+    def test_telegram_guest_mode_and_siblings_bridge_env_single_profile(self, monkeypatch):
+        """Unscoped (single-profile) behavior is unchanged: legacy env bridge
+        still fires."""
+        from agent import secret_scope
+        from plugins.platforms.telegram.adapter import _apply_yaml_config
+
+        env_vars = ("TELEGRAM_GUEST_MODE", "TELEGRAM_REACTIONS", "TELEGRAM_REPLY_TO_MODE")
+        for var in env_vars:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr(secret_scope, "_MULTIPLEX_ACTIVE", False)
+        _apply_yaml_config(
+            {}, {"guest_mode": True, "reactions": True, "reply_to_mode": "off"},
+        )
+        assert os.environ["TELEGRAM_GUEST_MODE"] == "true"
+        assert os.environ["TELEGRAM_REACTIONS"] == "true"
+        assert os.environ["TELEGRAM_REPLY_TO_MODE"] == "off"


### PR DESCRIPTION
## What & why

`_apply_yaml_config()`'s env writes for `guest_mode`, `require_mention`, `mention_patterns`, `exclusive_bot_mentions`, `allow_bots`, `observe_unmentioned_group_messages`, `reactions`, and `reply_to_mode` were the only ones missing the `_skip_env_bridge` guard every other Telegram gate (`free_response_chats`/`topics`, `allowed_chats`/`topics`, `ignored_threads`, `allow_from`, `group_allow_from`, `group_allowed_chats`) already has under issue #72348's fix. Under `gateway.multiplex_profiles`, a secondary profile's own `config.yaml` settings for these 8 fields leaked into process-global `os.environ` for every other Telegram adapter to inherit.

`guest_mode` is the highest-severity case: this adapter's own docstring describes it as "whether non-allowlisted groups may trigger via direct @mention" — a genuine authorization gate, not just a behavioral toggle.

## Fix

Most of these 8 fields' read sides (`_telegram_require_mention`, `_telegram_guest_mode`, `_telegram_exclusive_bot_mentions`, `_compile_mention_patterns`) already correctly prefer `self.config.extra` over raw env — only the `_apply_yaml_config` write side needed the guard. `allow_bots` is consumed via the separately-scoped `gateway/authz_mixin.py` chokepoint, so only its write side needed fixing too. `reply_to_mode` is resolved via `PlatformConfig.reply_to_mode` (set through `gateway/config.py`'s scope-aware `_getenv`), so gating its write closes the reverse-direction leak (a secondary profile's setting polluting the unscoped default profile's read) with no read-side change needed.

`_reactions_enabled()` was the one read site with no extra fallback at all (unlike its siblings) — fixed to check `self.config.extra["reactions"]` first, same precedence as `_telegram_require_mention`/`_telegram_guest_mode`, and seeded `reactions` into `PlatformConfig.extra` in `_apply_yaml_config` (it wasn't seeded before, so a scoped profile's own value had nowhere to go).

## Scope note

`proxy_url` is deliberately left unscoped: `resolve_proxy_url()` (shared by Discord/Telegram/etc. in `gateway/platforms/base.py`) reads `TELEGRAM_PROXY` via raw `os.environ` regardless of this bridge, so scoping only the write side here would be an inconsistent partial fix — left for a dedicated fix to that shared helper (also affects Discord's `DISCORD_PROXY` the same way).

## Tests

Extends the established test files for these bug classes: `tests/plugins/platforms/test_discord_gate_isolation.py`'s `TestTelegramGateIsolation` (`_apply_yaml_config` scoped-vs-single-profile writes) and `tests/gateway/test_telegram_reactions.py` (`_reactions_enabled` extra-vs-env precedence).

- `tests/plugins/platforms/test_discord_gate_isolation.py`, `tests/gateway/test_telegram_reactions.py` — 31 passed
- `tests/ -k telegram` (66 files) — 824 passed, 6 pre-existing failures in `tests/test_telegram_polling_progress_ptb.py` (python-telegram-bot MagicMock/await incompatibility) confirmed independent of this change via stash — same failures occur with or without the fix
- Mutation-verify: reverting the fix makes both new tests fail as expected (write-side leak reproduced, and read-side extra-precedence assertion fails)

## Competitor check

Searched `TELEGRAM_GUEST_MODE`, "telegram guest_mode multiplex", "telegram _apply_yaml_config skip_env_bridge", `TELEGRAM_REACTIONS`, `TELEGRAM_REQUIRE_MENTION` (all PR/issue states) — no PR targets this scoping bug. Existing hits are unrelated (docs, reaction-lifecycle features, ptb-compat fixes, closed require_mention feature PRs).