### PR TITLE
fix(update): break the gateway restart vs auto-update three-way deadlock

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -9887,10 +9887,47 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             from hermes_cli.gateway import (
                                 GATEWAY_LOOP_WEDGED,
                                 _escalate_wedged_gateway,
+                                _is_pid_ancestor_of_current_process,
+                                _request_gateway_self_restart,
                                 probe_gateway_loop_liveness,
                             )
 
-                            if (
+                            if _is_pid_ancestor_of_current_process(_main_pid):
+                                # THREE-WAY DEADLOCK BREAK (#100179).
+                                #
+                                # When `hermes update` runs INSIDE the gateway's
+                                # own process tree — the hermes-auto-update cron
+                                # job is the canonical case — waiting for that
+                                # gateway to exit is a circular wait:
+                                #
+                                #   gateway  waits on all in-flight work units
+                                #            (#77184 don't-amputate-turns)
+                                #     └─ cron agent session waits on the
+                                #        `hermes update` process to exit
+                                #          └─ `hermes update` waits on the
+                                #             gateway to exit  ← back to A
+                                #
+                                # The wedged-loop probe cannot break it: the cron
+                                # session posts activity every ~180s (process-tool
+                                # poll return), so it is "actively waiting
+                                # forever" and never marked wedged. The gateway
+                                # then burns the full force-drain cap (1800s)
+                                # before killing its own updater's session.
+                                #
+                                # Fire-and-forget instead: signal the restart and
+                                # return immediately. The gateway's own restart
+                                # flow completes normally once THIS process (and
+                                # therefore the cron work unit holding it) exits.
+                                print(
+                                    f"  → {svc_name}: update is running inside "
+                                    "this gateway's process tree — signalling "
+                                    "restart and letting the gateway drain "
+                                    "itself (avoids the cron-update deadlock)"
+                                )
+                                _graceful_ok = _request_gateway_self_restart(
+                                    _main_pid
+                                )
+                            elif (
                                 probe_gateway_loop_liveness(_main_pid)
                                 == GATEWAY_LOOP_WEDGED
                             ):
@@ -10200,10 +10237,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 from hermes_cli.gateway import (
                     GATEWAY_LOOP_WEDGED,
                     _escalate_wedged_gateway,
+                    _is_pid_ancestor_of_current_process,
+                    _request_gateway_self_restart,
                     probe_gateway_loop_liveness,
                 )
 
-                if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+                if _is_pid_ancestor_of_current_process(pid):
+                    # Same three-way deadlock break as the systemd path
+                    # (#100179): this update is running inside that gateway's
+                    # process tree (hermes-auto-update cron), so waiting for it
+                    # to exit is a circular wait — the gateway waits on the
+                    # cron work unit, the cron session waits on this process,
+                    # this process waits on the gateway. Signal and return.
+                    print(
+                        f"  → {proc.profile}: update runs inside this gateway's "
+                        "process tree — signalling restart without waiting "
+                        "(avoids the cron-update deadlock)"
+                    )
+                    drained = _request_gateway_self_restart(pid)
+                elif probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
                     # Loop-liveness probe: this gateway's event loop is
                     # provably dead (#81642) — SIGUSR1/SIGTERM shutdown can
                     # never run, so the drain wait would burn the full budget

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7839,6 +7839,67 @@ def _refuse_update_if_venv_foreign_owned(project_root) -> None:
     sys.exit(1)
 
 
+def _drain_or_signal_gateway_for_update(
+    pid: int,
+    drain_budget: float,
+    label: str,
+) -> bool:
+    """Decide how ``hermes update`` hands a running gateway over to new code.
+
+    Three-way triage shared by the systemd and bare-process restart paths:
+
+    1. **Gateway is an ancestor of this process** — THREE-WAY DEADLOCK BREAK
+       (#100179). When ``hermes update`` runs INSIDE the gateway's own
+       process tree (the hermes-auto-update cron job is the canonical case),
+       waiting for that gateway to exit is a circular wait::
+
+           gateway  waits on all in-flight work units (#77184)
+             └─ cron agent session waits on the `hermes update` process
+                  └─ `hermes update` waits on the gateway to exit  ← back to A
+
+       The wedged-loop probe cannot break it: the cron session posts
+       activity every ~180s (process-tool poll return), so it is "actively
+       waiting forever" and never marked wedged — the gateway burns the full
+       force-drain cap (1800s) before killing its own updater's session.
+       Fire-and-forget instead: signal the restart and return immediately;
+       the gateway's own restart flow completes once THIS process (and
+       therefore the cron work unit holding it) exits.
+    2. **Event loop provably wedged** (#81642) — SIGUSR1 can never drain it;
+       bounded escalation (SIGTERM grace → SIGKILL) instead of burning the
+       full drain budget.
+    3. **Live, out-of-tree gateway** — the normal graceful SIGUSR1 drain,
+       waiting up to ``drain_budget`` for the process to exit (unchanged,
+       including the #86684 cron floor).
+
+    Returns True when the gateway was signalled/stopped successfully.
+    """
+    from hermes_cli.gateway import (
+        GATEWAY_LOOP_WEDGED,
+        _escalate_wedged_gateway,
+        _graceful_restart_via_sigusr1,
+        _is_pid_ancestor_of_current_process,
+        _request_gateway_self_restart,
+        probe_gateway_loop_liveness,
+    )
+
+    if _is_pid_ancestor_of_current_process(pid):
+        print(
+            f"  → {label}: update is running inside this gateway's "
+            "process tree — signalling restart and letting the gateway "
+            "drain itself (avoids the cron-update deadlock, #100179)"
+        )
+        return _request_gateway_self_restart(pid)
+    if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
+        print(
+            f"  ⚠ {label}: gateway event loop is unresponsive — "
+            "skipping drain, forcing a bounded stop..."
+        )
+        _escalate_wedged_gateway(pid)
+        return True
+    print(f"  → {label}: draining (up to {int(drain_budget)}s)...")
+    return _graceful_restart_via_sigusr1(pid, drain_timeout=drain_budget)
+
+
 def _cmd_update_impl(args, gateway_mode: bool):
     """Body of ``cmd_update`` — kept separate so the wrapper can always
     restore stdio even on ``sys.exit``."""
@@ -9884,77 +9945,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
                         _graceful_ok = False
                         if _main_pid > 0:
-                            from hermes_cli.gateway import (
-                                GATEWAY_LOOP_WEDGED,
-                                _escalate_wedged_gateway,
-                                _is_pid_ancestor_of_current_process,
-                                _request_gateway_self_restart,
-                                probe_gateway_loop_liveness,
+                            # Three-way triage (ancestor fire-and-forget
+                            # #100179 / wedged escalation #81642 / normal
+                            # graceful drain) — shared with the bare-process
+                            # path below.
+                            _graceful_ok = _drain_or_signal_gateway_for_update(
+                                _main_pid, _drain_budget, svc_name
                             )
-
-                            if _is_pid_ancestor_of_current_process(_main_pid):
-                                # THREE-WAY DEADLOCK BREAK (#100179).
-                                #
-                                # When `hermes update` runs INSIDE the gateway's
-                                # own process tree — the hermes-auto-update cron
-                                # job is the canonical case — waiting for that
-                                # gateway to exit is a circular wait:
-                                #
-                                #   gateway  waits on all in-flight work units
-                                #            (#77184 don't-amputate-turns)
-                                #     └─ cron agent session waits on the
-                                #        `hermes update` process to exit
-                                #          └─ `hermes update` waits on the
-                                #             gateway to exit  ← back to A
-                                #
-                                # The wedged-loop probe cannot break it: the cron
-                                # session posts activity every ~180s (process-tool
-                                # poll return), so it is "actively waiting
-                                # forever" and never marked wedged. The gateway
-                                # then burns the full force-drain cap (1800s)
-                                # before killing its own updater's session.
-                                #
-                                # Fire-and-forget instead: signal the restart and
-                                # return immediately. The gateway's own restart
-                                # flow completes normally once THIS process (and
-                                # therefore the cron work unit holding it) exits.
-                                print(
-                                    f"  → {svc_name}: update is running inside "
-                                    "this gateway's process tree — signalling "
-                                    "restart and letting the gateway drain "
-                                    "itself (avoids the cron-update deadlock)"
-                                )
-                                _graceful_ok = _request_gateway_self_restart(
-                                    _main_pid
-                                )
-                            elif (
-                                probe_gateway_loop_liveness(_main_pid)
-                                == GATEWAY_LOOP_WEDGED
-                            ):
-                                # Loop-liveness probe says the gateway's event
-                                # loop is provably dead (#81642): SIGUSR1 can
-                                # never drain it, so waiting the full budget
-                                # (180s default) only wedges the update too.
-                                # Bounded escalation (SIGTERM grace → SIGKILL,
-                                # ~10s) then restart the unit. A busy gateway
-                                # keeps a fresh heartbeat and never takes this
-                                # path — its drain (incl. the #86684 cron
-                                # floor) is untouched.
-                                print(
-                                    f"  ⚠ {svc_name}: gateway event loop is "
-                                    "unresponsive — skipping drain, forcing "
-                                    "a bounded stop..."
-                                )
-                                _escalate_wedged_gateway(_main_pid)
-                                _graceful_ok = True
-                            else:
-                                print(
-                                    f"  → {svc_name}: draining (up to {int(_drain_budget)}s)..."
-                                )
-                                _graceful_ok = _graceful_restart_via_sigusr1(
-                                    _main_pid,
-                                    drain_timeout=_drain_budget,
-                                )
 
                         if _graceful_ok:
                             # Gateway exited after a planned restart.
@@ -10226,54 +10223,16 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # gateway doesn't support SIGUSR1 or doesn't exit within
                 # the drain budget, fall back to SIGTERM — the watcher
                 # still sees the exit and relaunches either way.
-                # Announce the drain first: this wait can hold for the full
+                # Three-way triage (ancestor fire-and-forget #100179 /
+                # wedged escalation #81642 / normal graceful drain) — shared
+                # with the systemd path above.  The helper announces the
+                # chosen path first: a drain wait can hold for the full
                 # budget per gateway with no other output, and on surfaces
-                # that stream update progress (the desktop updater most of
-                # all) the silence reads as a hung update (#44515).
-                print(
-                    f"  → {proc.profile}: draining gateway PID {pid} "
-                    f"(up to {int(_drain_budget)}s)..."
+                # that stream update progress the silence reads as a hung
+                # update (#44515).
+                drained = _drain_or_signal_gateway_for_update(
+                    pid, _drain_budget, proc.profile
                 )
-                from hermes_cli.gateway import (
-                    GATEWAY_LOOP_WEDGED,
-                    _escalate_wedged_gateway,
-                    _is_pid_ancestor_of_current_process,
-                    _request_gateway_self_restart,
-                    probe_gateway_loop_liveness,
-                )
-
-                if _is_pid_ancestor_of_current_process(pid):
-                    # Same three-way deadlock break as the systemd path
-                    # (#100179): this update is running inside that gateway's
-                    # process tree (hermes-auto-update cron), so waiting for it
-                    # to exit is a circular wait — the gateway waits on the
-                    # cron work unit, the cron session waits on this process,
-                    # this process waits on the gateway. Signal and return.
-                    print(
-                        f"  → {proc.profile}: update runs inside this gateway's "
-                        "process tree — signalling restart without waiting "
-                        "(avoids the cron-update deadlock)"
-                    )
-                    drained = _request_gateway_self_restart(pid)
-                elif probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
-                    # Loop-liveness probe: this gateway's event loop is
-                    # provably dead (#81642) — SIGUSR1/SIGTERM shutdown can
-                    # never run, so the drain wait would burn the full budget
-                    # and stall the update. Bounded stop instead (SIGTERM
-                    # grace → SIGKILL, ~10s). A busy-but-alive gateway keeps
-                    # a fresh heartbeat and never takes this branch, so live
-                    # drains (incl. the #86684 cron floor) are unaffected.
-                    print(
-                        f"  ⚠ {proc.profile}: gateway event loop is "
-                        "unresponsive — skipping drain, forcing a bounded stop..."
-                    )
-                    _escalate_wedged_gateway(pid)
-                    drained = True
-                else:
-                    drained = _graceful_restart_via_sigusr1(
-                        pid,
-                        drain_timeout=_drain_budget,
-                    )
                 if not drained:
                     try:
                         os.kill(pid, _signal.SIGTERM)

--- a/tests/hermes_cli/test_update_cron_deadlock_guard.py
+++ b/tests/hermes_cli/test_update_cron_deadlock_guard.py
@@ -103,3 +103,65 @@ class TestSelfRestartFireAndForget:
 
         assert ok is True
         assert waited == [(4242, 7.0)], "drain path must still wait for exit"
+
+
+class TestDrainOrSignalTriage:
+    """_drain_or_signal_gateway_for_update routes the three cases correctly."""
+
+    def _patched(self, monkeypatch, *, ancestor, wedged):
+        from hermes_cli import gateway as gw
+
+        calls = {"self_restart": [], "escalate": [], "drain": []}
+        monkeypatch.setattr(
+            gw, "_is_pid_ancestor_of_current_process", lambda pid: ancestor
+        )
+        monkeypatch.setattr(
+            gw,
+            "probe_gateway_loop_liveness",
+            lambda pid: gw.GATEWAY_LOOP_WEDGED if wedged else "alive",
+        )
+        monkeypatch.setattr(
+            gw,
+            "_request_gateway_self_restart",
+            lambda pid: calls["self_restart"].append(pid) or True,
+        )
+        monkeypatch.setattr(
+            gw, "_escalate_wedged_gateway", lambda pid: calls["escalate"].append(pid)
+        )
+        monkeypatch.setattr(
+            gw,
+            "_graceful_restart_via_sigusr1",
+            lambda pid, drain_timeout: calls["drain"].append((pid, drain_timeout))
+            or True,
+        )
+        return calls
+
+    def test_ancestor_gateway_is_signalled_fire_and_forget(self, monkeypatch):
+        """In-tree gateway (#100179): SIGUSR1 request, NO drain wait."""
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=True, wedged=False)
+        assert _drain_or_signal_gateway_for_update(1234, 900.0, "svc") is True
+        assert calls["self_restart"] == [1234]
+        assert calls["drain"] == [], "drain-waiting on an ancestor IS the deadlock"
+        assert calls["escalate"] == []
+
+    def test_wedged_gateway_is_escalated(self, monkeypatch):
+        """Provably-dead loop (#81642): bounded escalation, no drain wait."""
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=False, wedged=True)
+        assert _drain_or_signal_gateway_for_update(1234, 900.0, "svc") is True
+        assert calls["escalate"] == [1234]
+        assert calls["drain"] == []
+        assert calls["self_restart"] == []
+
+    def test_live_out_of_tree_gateway_still_drain_waits(self, monkeypatch):
+        """Normal out-of-tree update keeps the full graceful drain semantics."""
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=False, wedged=False)
+        assert _drain_or_signal_gateway_for_update(1234, 900.0, "svc") is True
+        assert calls["drain"] == [(1234, 900.0)]
+        assert calls["self_restart"] == []
+        assert calls["escalate"] == []

--- a/tests/hermes_cli/test_update_cron_deadlock_guard.py
+++ b/tests/hermes_cli/test_update_cron_deadlock_guard.py
@@ -1,0 +1,105 @@
+"""Regression tests for #100179: cron-update three-way restart deadlock.
+
+When `hermes update` runs INSIDE the gateway's own process tree (the
+hermes-auto-update cron job), waiting for that gateway to exit is a
+circular wait:
+
+  gateway waits on all in-flight work units (#77184)
+    -> cron agent session waits on the `hermes update` process
+      -> `hermes update` waits on the gateway to exit  [back to A]
+
+The wedged-loop probe cannot break it: the cron session posts activity
+every ~180s (process-tool poll return), so it is never marked wedged and
+the gateway burns the full 1800s force-drain cap.
+
+The fix: when the target gateway PID is an ancestor of this process,
+fire-and-forget (SIGUSR1 + return) instead of drain-waiting.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+linux_only = pytest.mark.linux_only
+
+
+class TestAncestorDetectionGuard:
+    """_is_pid_ancestor_of_current_process is the deadlock discriminator."""
+
+    def test_own_pid_is_ancestor(self):
+        import os
+
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+
+        assert _is_pid_ancestor_of_current_process(os.getpid()) is True
+
+    def test_parent_pid_is_ancestor(self):
+        import os
+
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+
+        ppid = os.getppid()
+        if ppid <= 1:
+            pytest.skip("no meaningful parent in this environment")
+        assert _is_pid_ancestor_of_current_process(ppid) is True
+
+    def test_unrelated_pid_is_not_ancestor(self):
+        from hermes_cli.gateway import _is_pid_ancestor_of_current_process
+
+        # PID 0 / negative are never ancestors; a very high unlikely PID isn't
+        # either. Use the documented zero/negative contract for determinism.
+        assert _is_pid_ancestor_of_current_process(0) is False
+        assert _is_pid_ancestor_of_current_process(-5) is False
+
+
+@linux_only
+class TestSelfRestartFireAndForget:
+    """_request_gateway_self_restart signals without waiting for exit."""
+
+    def test_refuses_non_ancestor_pid(self):
+        from hermes_cli.gateway import _request_gateway_self_restart
+
+        # A non-ancestor must be refused — signalling an unrelated gateway
+        # and returning immediately would skip its drain entirely.
+        assert _request_gateway_self_restart(0) is False
+
+    def test_signals_ancestor_and_returns_immediately(self):
+        """The ancestor path sends SIGUSR1 and does NOT poll for exit."""
+        import os
+        import signal as _signal
+
+        from hermes_cli import gateway as gw
+
+        sent = []
+
+        def _fake_kill(pid, sig):
+            sent.append((pid, sig))
+
+        with patch.object(gw.os, "kill", side_effect=_fake_kill), patch.object(
+            gw, "_wait_for_pid_exit",
+            side_effect=AssertionError(
+                "fire-and-forget must NOT wait for the gateway to exit — "
+                "that wait is the #100179 deadlock"
+            ),
+        ):
+            ok = gw._request_gateway_self_restart(os.getpid())
+
+        assert ok is True
+        assert sent == [(os.getpid(), _signal.SIGUSR1)]
+
+    def test_graceful_restart_does_wait(self):
+        """Contrast: the non-ancestor path DOES drain-wait (unchanged)."""
+        import signal as _signal
+
+        from hermes_cli import gateway as gw
+
+        waited = []
+
+        with patch.object(gw.os, "kill"), patch.object(
+            gw, "_wait_for_pid_exit",
+            side_effect=lambda pid, t: waited.append((pid, t)) or True,
+        ):
+            ok = gw._graceful_restart_via_sigusr1(4242, drain_timeout=7.0)
+
+        assert ok is True
+        assert waited == [(4242, 7.0)], "drain path must still wait for exit"


### PR DESCRIPTION
## Problem (#100179)

`hermes-auto-update` cron replays after gateway downtime and runs `hermes update` **inside** the gateway's own process tree. The update succeeds, but the gateway then loops `Restart deferred: waiting on 1 active work unit(s)` every 30s until the 1800s force-drain cap fires.

Root cause — three-way circular wait (as diagnosed by the reporter):

| Role | Waits for |
|------|-----------|
| **Gateway** | all in-flight work units (`_await_active_work_before_restart`, #77184) — the cron update session IS a work unit |
| **Cron agent session** | the `hermes update` process to exit (process-tool polling every ~180s) |
| **`hermes update`** | the gateway to exit (`_graceful_restart_via_sigusr1`, drain_timeout≈1875s) |

A → B → C → A. The wedged-loop probe (#81642) can't break it: the ~180s process-tool polls count as activity, so the cron session is never marked wedged.

## Fix — the issue's recommended option 1 (salvage of PR #100207 by @salch-cred + follow-up refactor)

- **Commit 1 (cherry-picked from #100207, @salch-cred's authorship preserved):** at both drain sites in `update_cmd.py` (systemd path + bare-process/launchd path), check `_is_pid_ancestor_of_current_process(pid)` first. When the target gateway is an ancestor of this updater, call `_request_gateway_self_restart(pid)` — SIGUSR1 fire-and-forget, **no exit-wait** — and return; the gateway's own restart flow completes once the updater (and thus the cron work unit) exits. `_request_gateway_self_restart` already refuses non-ancestor PIDs, so out-of-tree updates keep full drain semantics (incl. the #86684 cron floor) untouched. Includes 6 regression tests (`tests/hermes_cli/test_update_cron_deadlock_guard.py`). The unrelated `test_psutil_android.py` file from #100207 was **not** picked.
- **Commit 2 (follow-up):** the two call sites carried duplicated copies of the same three-way decision. Extracted into one shared helper `_drain_or_signal_gateway_for_update(pid, drain_budget, label)` (ancestor fire-and-forget #100179 / wedged escalation #81642 / normal graceful drain) + 3 direct unit tests covering each branch. No behavior change.

**Live repro:** two-process harness (real OS parent/child tree, gateway-shaped SIGUSR1 handler + work-unit wait loop; update child imports the REAL `hermes_cli` code from the tree under test) — before: on pristine `origin/main` code, the update child (a descendant of the "gateway") called `_graceful_restart_via_sigusr1` and drain-waited the full budget while the gateway looped `Restart deferred: waiting on 1 active work unit(s)` until the watchdog declared DEADLOCK (exit 1, would burn the full 1800s cap in production); after: on this branch, `_drain_or_signal_gateway_for_update` detects the ancestor gateway, signals SIGUSR1 and returns in 0.19s, the work unit exits, and the gateway proceeds to its own restart — CLEAN (exit 0, ~2s total).

## Tests

- `tests/hermes_cli/test_update_cron_deadlock_guard.py`: 9 passed (6 from #100207 + 3 new triage-branch tests). Sabotage-verified: reverting the ancestor branch to a drain-wait makes `test_ancestor_gateway_is_signalled_fire_and_forget` fail; #100207's `test_signals_ancestor_and_returns_immediately` fails on pristine main.
- Targeted neighbors (`test_update_gateway_restart_aborted/fallback`, `test_update_fleet_restart_pending/timeout`, `test_update_restart_recovery`, `test_gateway_restart_loop`): 359 passed, 1 failed — `test_marker_written_after_pull_cleared_after_successful_restart`, **proven pre-existing** on a pristine `origin/main` archive (fails identically there; unrelated to this diff).
- `ruff check` clean; Windows-footgun checker clean on both touched files.

Fixes #100179
Closes #100207 (salvaged; @salch-cred credited via preserved commit authorship)

## Infographic

![three-way-deadlock-break](https://v3b.fal.media/files/b/0aa8b17e/PfWWKgZQ8iecU40gxJ25-_E94srqPU.png)
