### PR TITLE
fix(desktop-update): self-heal a TCC-anchor-bricked venv in the posix hand-off (#95759)

### DIFF
--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -39,6 +39,7 @@ ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
 NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
+SELF_TEST_TCC_HEAL=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -52,6 +53,7 @@ while [ $# -gt 0 ]; do
     --no-marker-cleanup) NO_MARKER_CLEANUP=1; shift ;;
     --self-test-ui) SELF_TEST_UI=1; shift ;;
     --self-test-gate) SELF_TEST_GATE=1; shift ;;
+    --self-test-tcc-heal) SELF_TEST_TCC_HEAL=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
@@ -471,7 +473,151 @@ finish() {
 }
 trap finish EXIT
 
+# ── legacy macOS TCC anchor self-heal (#95759) ──────────────────────────────
+# The reverted TCC interpreter anchor (#95425/#95541) left some installs with
+# a real-file `venv/bin/python` copy plus a `.tcc-anchor-source` marker, and
+# `python3`/`python3.N` aliases that die at interpreter init ("No module
+# named 'encodings'"). On those installs EVERY normal CLI entrypoint is dead
+# (`venv/bin/hermes` has a `python3` shebang), so no Python-side heal —
+# doctor OR in-update — can ever run. This shell is the last surface that
+# still executes, so the heal lives here (recovery design after @aeonsong's
+# #96231; heal-point observation by @ahrazzle / @tokenfires on #95759).
+#
+# Ping-pong coherence with the re-landed forward anchor
+# (hermes_cli/macos_tcc_anchor.ensure_tcc_anchor, which re-anchors whenever
+# `venv/bin/python` is a uv-managed symlink): this heal is gated on the
+# interpreter FAILING its boot probe, so a healthy anchored install is never
+# touched; and when it does restore symlinks, the very `hermes update` run it
+# unblocks re-installs a boot-gated healthy anchor — a one-shot convergence,
+# not a loop.
+
+tcc_probe_python() { # interpreter path → 0 iff it boots a real stdlib.
+  # PYTHONHOME/PYTHONPATH are scrubbed: an inherited PYTHONHOME papers over
+  # exactly the prefix-resolution failure this probe exists to detect.
+  [ -x "$1" ] || return 1
+  env -u PYTHONHOME -u PYTHONPATH -u PYTHONSTARTUP -u __PYVENV_LAUNCHER__ \
+    "$1" -c 'import encodings' >/dev/null 2>&1
+}
+
+TCC_HEAL_STATE="not-run"
+
+tcc_heal_rollback() { # restore every .tcc-heal-old.$$ backup in a bin dir
+  local b
+  for b in "$1"/*.tcc-heal-old.$$; do
+    [ -e "$b" ] || [ -L "$b" ] || continue
+    mv -f "$b" "${b%.tcc-heal-old.$$}" 2>/dev/null || true
+  done
+}
+
+tcc_heal_cleanup() { # heal landed: drop the backups
+  local b
+  for b in "$1"/*.tcc-heal-old.$$; do
+    [ -e "$b" ] || [ -L "$b" ] || continue
+    rm -f "$b" 2>/dev/null || true
+  done
+}
+
+tcc_alias_names() { # existing python3 / python3.N entries in a bin dir
+  local a
+  for a in "$1"/python3 "$1"/python3.*; do
+    [ -e "$a" ] || [ -L "$a" ] || continue
+    case "${a##*/}" in
+      python3|python3.[0-9]|python3.[0-9][0-9]) printf '%s\n' "$a" ;;
+    esac
+  done
+}
+
+tcc_anchor_heal() { # $1 = venv bin dir. 0 iff python3 boots on exit.
+  local bin="$1" marker src alias staged
+  local py="$bin/python" py3="$bin/python3"
+  if tcc_probe_python "$py3"; then TCC_HEAL_STATE="healthy"; return 0; fi
+  marker="$bin/.tcc-anchor-source"
+  [ -f "$marker" ] || { TCC_HEAL_STATE="no-marker"; return 1; }
+  src="$(head -1 "$marker" 2>/dev/null)"
+  case "$src" in
+    "$bin"/*) TCC_HEAL_STATE="unsafe-source"; return 1 ;;
+    /*) ;;
+    *) TCC_HEAL_STATE="invalid-marker"; return 1 ;;
+  esac
+  if tcc_probe_python "$py"; then
+    # #95541 alias-brick: the anchored copy itself boots; only the aliases
+    # are dead. Aliases over a real-file anchor must be REAL FILES (hard
+    # link, else copy) — an alias *symlink* onto the copy is the exact
+    # crash shape being healed here.
+    TCC_HEAL_STATE="healed-aliases"
+    while IFS= read -r alias; do
+      [ -n "$alias" ] || continue
+      mv "$alias" "$alias.tcc-heal-old.$$" 2>/dev/null \
+        || { tcc_heal_rollback "$bin"; TCC_HEAL_STATE="failed"; return 1; }
+      if ! { ln "$py" "$alias" 2>/dev/null || cp -p "$py" "$alias" 2>/dev/null; }; then
+        tcc_heal_rollback "$bin"; TCC_HEAL_STATE="failed"; return 1
+      fi
+    done <<EOF_ALIASES
+$(tcc_alias_names "$bin")
+EOF_ALIASES
+  elif [ -x "$src" ] && tcc_probe_python "$src"; then
+    # Full restore to the pre-anchor layout: python → symlink to the
+    # marker-recorded store interpreter, aliases → symlinks to python.
+    TCC_HEAL_STATE="healed-symlinks"
+    mv "$py" "$py.tcc-heal-old.$$" 2>/dev/null \
+      || { TCC_HEAL_STATE="failed"; return 1; }
+    if ! ln -s "$src" "$py" 2>/dev/null; then
+      tcc_heal_rollback "$bin"; TCC_HEAL_STATE="failed"; return 1
+    fi
+    while IFS= read -r alias; do
+      [ -n "$alias" ] || continue
+      staged="$alias.tcc-heal-new.$$"
+      mv "$alias" "$alias.tcc-heal-old.$$" 2>/dev/null \
+        || { tcc_heal_rollback "$bin"; TCC_HEAL_STATE="failed"; return 1; }
+      if ! { ln -s python "$staged" 2>/dev/null && mv "$staged" "$alias" 2>/dev/null; }; then
+        rm -f "$staged" 2>/dev/null
+        tcc_heal_rollback "$bin"; TCC_HEAL_STATE="failed"; return 1
+      fi
+    done <<EOF_ALIASES
+$(tcc_alias_names "$bin")
+EOF_ALIASES
+  else
+    # Recorded source gone or itself unbootable (the vanished-uv-store
+    # class from #95759): fail closed, touch nothing.
+    TCC_HEAL_STATE="source-missing"; return 1
+  fi
+  if tcc_probe_python "$py3"; then
+    if [ "$TCC_HEAL_STATE" = "healed-symlinks" ]; then
+      # Marker asserts the anchored layout; the symlink layout is done
+      # with it. (The alias-heal branch KEEPS it: real-file python +
+      # real-file aliases is exactly the layout ensure_tcc_anchor marks.)
+      rm -f "$marker" 2>/dev/null || true
+    fi
+    tcc_heal_cleanup "$bin"
+    return 0
+  fi
+  tcc_heal_rollback "$bin"
+  TCC_HEAL_STATE="failed"
+  return 1
+}
+
+tcc_pick_update_invoke() { # sets UPDATE_INVOKE; safety net past a failed heal
+  # Last-resort class: aliases still dead but the anchored copy boots. The
+  # launchd gateway proves `venv/bin/python -m hermes_cli.main` works when
+  # every alias entrypoint is bricked — drive the update the same way.
+  local bin="$1"
+  UPDATE_INVOKE=("$bin/hermes")
+  if ! tcc_probe_python "$bin/python3" && tcc_probe_python "$bin/python"; then
+    UPDATE_INVOKE=("$bin/python" -m hermes_cli.main)
+  fi
+}
+
 # ── self-tests: no update, touch nothing ────────────────────────────────────
+if [ "$SELF_TEST_TCC_HEAL" -eq 1 ]; then
+  # Runs the REAL heal + invoke selection against --install-root and reports;
+  # tests/test_desktop_update_tcc_heal.py drives the state matrix through it.
+  trap - EXIT
+  tcc_anchor_heal "$INSTALL_ROOT/venv/bin" || true
+  tcc_pick_update_invoke "$INSTALL_ROOT/venv/bin"
+  echo "state=$TCC_HEAL_STATE invoke=${UPDATE_INVOKE[*]}"
+  exit 0
+fi
+
 if [ "$SELF_TEST_GATE" -eq 1 ]; then
   # Prints the gate decision for the given --install-root/--relaunch-target
   # and exits; scripts/desktop-update/repro.sh gate asserts the matrix.
@@ -568,6 +714,23 @@ start_ui
 HERMES_BIN="$INSTALL_ROOT/venv/bin/hermes"
 [ -x "$HERMES_BIN" ] || { FINAL_CODE=3 FINAL_MSG="Update aborted: $HERMES_BIN is missing. The install needs repair (run the Hermes installer or hermes doctor)."; log "$FINAL_MSG"; exit 3; }
 
+# Heal a venv the reverted TCC anchor left bricked BEFORE invoking the CLI:
+# venv/bin/hermes execs venv/bin/python3, so a dead alias kills every attempt
+# and its retry identically (#95759). macOS-only artifact; probe is cheap.
+if [ "$(uname)" = "Darwin" ]; then
+  if tcc_anchor_heal "$INSTALL_ROOT/venv/bin"; then
+    case "$TCC_HEAL_STATE" in
+      healed-*) log "TCC anchor self-heal repaired the venv interpreter ($TCC_HEAL_STATE)" ;;
+    esac
+  else
+    log "TCC anchor self-heal could not repair the venv ($TCC_HEAL_STATE)"
+  fi
+fi
+tcc_pick_update_invoke "$INSTALL_ROOT/venv/bin"
+if [ "${UPDATE_INVOKE[0]}" != "$HERMES_BIN" ]; then
+  log "venv/bin/python3 still unbootable; invoking the update via ${UPDATE_INVOKE[*]}"
+fi
+
 # Run FROM the install root: `hermes update` resolves the tree it mutates
 # from the working directory, and we inherit the Desktop's cwd (which can be
 # an unrelated repo — updating THAT instead of the install is the failure
@@ -584,14 +747,14 @@ export PYTHONUNBUFFERED=1
 # know the flag and argparse would abort with exit 2, which collides with the
 # "close all Hermes windows" sentinel.
 KEEP_STASH=""
-if "$HERMES_BIN" update --help 2>/dev/null | grep -q -- '--keep-stash'; then
+if "${UPDATE_INVOKE[@]}" update --help 2>/dev/null | grep -q -- '--keep-stash'; then
   KEEP_STASH="--keep-stash"
 else
   log "installed hermes predates --keep-stash; running without it"
 fi
-log "running: hermes update --yes --gateway $KEEP_STASH --branch $BRANCH"
+log "running: ${UPDATE_INVOKE[*]} update --yes --gateway $KEEP_STASH --branch $BRANCH"
 publish_stage "Updating code and dependencies"
-OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
+OUT="$("${UPDATE_INVOKE[@]}" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
 printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
 log "hermes update exit code: $CODE"
 
@@ -613,7 +776,7 @@ if [ "$CODE" -ne 0 ] && [ "$CODE" -ne 2 ]; then
   fi
   log "retrying once (freshly pulled fix loads on the second run)"
   publish_stage "Retrying update"
-  OUT="$("$HERMES_BIN" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
+  OUT="$("${UPDATE_INVOKE[@]}" update --yes --gateway $KEEP_STASH --branch "$BRANCH" 2>&1)"; CODE=$?
   printf '%s\n' "$OUT" >> "$LOG" 2>/dev/null
   log "retry exit code: $CODE"
 fi
@@ -625,12 +788,21 @@ trap 'on_signal TERM' TERM
 if [ "$CODE" -eq 0 ] && printf '%s' "$OUT" | grep -q "Desktop build failed"; then
   log "desktop build failed inside hermes update; retrying build"
   publish_stage "Rebuilding Desktop"
-  "$HERMES_BIN" desktop --force-build --build-only >> "$LOG" 2>&1 || {
+  "${UPDATE_INVOKE[@]}" desktop --force-build --build-only >> "$LOG" 2>&1 || {
     FINAL_CODE=6 FINAL_MSG="Code and dependencies updated, but the Desktop app rebuild failed - you are running the previous build. Run hermes desktop --force-build from a terminal to retry."
     exit 6
   }
 fi
 
 if [ "$CODE" -eq 0 ]; then FINAL_CODE=0 FINAL_MSG="Update complete."
-else FINAL_CODE="$CODE" FINAL_MSG="Update failed (exit $CODE). Run hermes debug share in a terminal to send a report."; fi
+else
+  FINAL_CODE="$CODE" FINAL_MSG="Update failed (exit $CODE). Run hermes debug share in a terminal to send a report."
+  # The bricked-venv class is fixable and must not read as a generic exit 1:
+  # a dead interpreter with a failed/impossible heal means retrying can never
+  # succeed — tell the user what is actually wrong (#95759).
+  if ! tcc_probe_python "$INSTALL_ROOT/venv/bin/python3" \
+      && ! tcc_probe_python "$INSTALL_ROOT/venv/bin/python"; then
+    FINAL_MSG="Update failed: the Python interpreter inside $INSTALL_ROOT/venv cannot start (heal state: $TCC_HEAL_STATE). Reinstall the runtime with the Hermes installer, or run hermes doctor --fix from a terminal if any hermes command still works."
+  fi
+fi
 exit "$FINAL_CODE"

--- a/tests/test_desktop_update_tcc_heal.py
+++ b/tests/test_desktop_update_tcc_heal.py
@@ -1,0 +1,246 @@
+"""Desktop hand-off self-heal for venvs bricked by the reverted macOS TCC
+anchor (#95759), exercised against the REAL ``posix.sh`` functions.
+
+The reverted anchor (#95425/#95541) left installs with a real-file
+``venv/bin/python`` copy, a ``.tcc-anchor-source`` marker, and ``python3*``
+aliases that die at interpreter init (``No module named 'encodings'``).
+``venv/bin/hermes`` execs ``venv/bin/python3``, so the desktop update
+hand-off — and every other CLI entrypoint, doctor included — dies before any
+Python-side heal can run.  The heal therefore lives in the hand-off shell.
+
+These tests drive ``posix.sh --self-test-tcc-heal`` (the script's real
+``tcc_anchor_heal`` / ``tcc_pick_update_invoke`` functions, no re-implementation)
+against synthetic venv trees on Linux.  macOS itself is NOT live-tested here —
+there is no mac runner — but the heal logic is platform-independent shell and
+the self-test path runs it without the ``uname`` gate.
+
+Interpreter stubs: the probe is ``<interpreter> -c 'import encodings'``; a
+stub that exits 0 stands in for a bootable interpreter and one that prints
+the real crash text and exits 1 stands in for a bricked one.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+POSIX_SH = REPO_ROOT / "scripts" / "desktop-update" / "posix.sh"
+
+GOOD_STUB = "#!/bin/bash\n# bootable interpreter stub\nexit 0\n"
+BAD_STUB = (
+    "#!/bin/bash\n"
+    "echo \"Fatal Python error: init_fs_encoding: failed to get the Python "
+    "codec of the filesystem encoding\" >&2\n"
+    "echo \"ModuleNotFoundError: No module named 'encodings'\" >&2\n"
+    "exit 1\n"
+)
+# Boots only when invoked via a path whose basename is exactly `python`:
+# used to force the post-heal verification probe to fail (rollback path).
+PICKY_STUB = (
+    "#!/bin/bash\n"
+    "[ \"$(basename \"$0\")\" = \"python\" ] && exit 0\n"
+    "exit 1\n"
+)
+
+requires_bash = pytest.mark.skipif(
+    not os.path.exists("/bin/bash"), reason="posix.sh needs /bin/bash"
+)
+
+
+def _write_exe(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+
+def make_venv(tmp_path: Path, *, python: str | None, python3: str | None,
+              marker: str | None, store_python: str | None = GOOD_STUB,
+              alias_symlinks: bool = False) -> Path:
+    """Build a synthetic install root with a venv/bin tree.
+
+    ``python``/``python3`` are stub bodies (None = absent). ``marker`` is the
+    ``.tcc-anchor-source`` content (None = absent, "STORE" = point it at the
+    created store interpreter). ``store_python`` is the store interpreter stub
+    body (None = do not create — the vanished-uv-store class).
+    """
+    root = tmp_path / "install"
+    bin_dir = root / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    store = tmp_path / "uv-store" / "bin" / "python3.11"
+    if store_python is not None:
+        store.parent.mkdir(parents=True)
+        _write_exe(store, store_python)
+    if python is not None:
+        _write_exe(bin_dir / "python", python)
+    for name in ("python3", "python3.11"):
+        if python3 is None:
+            continue
+        if alias_symlinks:
+            (bin_dir / name).symlink_to("python")
+        else:
+            _write_exe(bin_dir / name, python3)
+    if marker is not None:
+        (bin_dir / ".tcc-anchor-source").write_text(
+            str(store) if marker == "STORE" else marker, encoding="utf-8"
+        )
+    return root
+
+
+def run_selftest(root: Path) -> str:
+    proc = subprocess.run(
+        ["/bin/bash", str(POSIX_SH), "--self-test-tcc-heal", "--no-ui",
+         "--install-root", str(root)],
+        capture_output=True, text=True, encoding="utf-8",
+        errors="replace", timeout=60,
+    )
+    assert proc.returncode == 0, proc.stderr
+    return proc.stdout.strip().splitlines()[-1]
+
+
+@requires_bash
+class TestAnchorHeal:
+    def test_healthy_venv_untouched(self, tmp_path):
+        """A bootable python3 short-circuits the heal — nothing is examined."""
+        root = make_venv(tmp_path, python=GOOD_STUB, python3=GOOD_STUB,
+                         marker="STORE")
+        before = (root / "venv/bin/python3").read_text(encoding="utf-8")
+        out = run_selftest(root)
+        assert "state=healthy" in out
+        assert (root / "venv/bin/python3").read_text(encoding="utf-8") == before
+        assert (root / "venv/bin/.tcc-anchor-source").exists()
+
+    def test_alias_brick_healed_to_real_files(self, tmp_path):
+        """#95541 class: anchored copy boots, alias symlinks are dead.
+
+        The heal must replace the aliases with REAL FILES of the anchor (an
+        alias symlink onto the copy is the crash shape) and KEEP the marker so
+        ensure_tcc_anchor recognises the layout as active (no ping-pong).
+        """
+        root = make_venv(tmp_path, python=GOOD_STUB, python3=BAD_STUB,
+                         marker="STORE")
+        out = run_selftest(root)
+        assert "state=healed-aliases" in out
+        bin_dir = root / "venv/bin"
+        for name in ("python3", "python3.11"):
+            alias = bin_dir / name
+            assert not alias.is_symlink()
+            assert alias.read_text(encoding="utf-8") == GOOD_STUB
+        assert (bin_dir / ".tcc-anchor-source").exists()
+        assert not list(bin_dir.glob("*tcc-heal*"))
+        assert "invoke=" in out and out.endswith("/venv/bin/hermes")
+
+    def test_full_brick_restored_to_symlinks(self, tmp_path):
+        """Anchored copy AND aliases dead, marker source alive: restore the
+        pre-anchor symlink layout and drop the marker."""
+        root = make_venv(tmp_path, python=BAD_STUB, python3=BAD_STUB,
+                         marker="STORE")
+        out = run_selftest(root)
+        assert "state=healed-symlinks" in out
+        bin_dir = root / "venv/bin"
+        py = bin_dir / "python"
+        assert py.is_symlink()
+        assert py.resolve() == (tmp_path / "uv-store/bin/python3.11")
+        for name in ("python3", "python3.11"):
+            alias = bin_dir / name
+            assert alias.is_symlink()
+            assert os.readlink(alias) == "python"
+        assert not (bin_dir / ".tcc-anchor-source").exists()
+        assert not list(bin_dir.glob("*tcc-heal*"))
+
+    def test_missing_source_fails_closed(self, tmp_path):
+        """Vanished uv store (the #95759 comment class): touch nothing."""
+        root = make_venv(tmp_path, python=BAD_STUB, python3=BAD_STUB,
+                         marker="STORE", store_python=None)
+        out = run_selftest(root)
+        assert "state=source-missing" in out
+        bin_dir = root / "venv/bin"
+        assert (bin_dir / "python").read_text(encoding="utf-8") == BAD_STUB
+        assert (bin_dir / ".tcc-anchor-source").exists()
+
+    def test_no_marker_is_not_ours_to_heal(self, tmp_path):
+        root = make_venv(tmp_path, python=BAD_STUB, python3=BAD_STUB,
+                         marker=None)
+        out = run_selftest(root)
+        assert "state=no-marker" in out
+        assert (root / "venv/bin/python").read_text(encoding="utf-8") == BAD_STUB
+
+    def test_marker_inside_venv_is_unsafe(self, tmp_path):
+        root = make_venv(tmp_path, python=BAD_STUB, python3=BAD_STUB,
+                         marker="PLACEHOLDER")
+        bin_dir = root / "venv/bin"
+        inside = bin_dir / "recorded-python"
+        _write_exe(inside, GOOD_STUB)
+        (bin_dir / ".tcc-anchor-source").write_text(str(inside), encoding="utf-8")
+        out = run_selftest(root)
+        assert "state=unsafe-source" in out
+        assert (bin_dir / "python").read_text(encoding="utf-8") == BAD_STUB
+
+    def test_relative_marker_is_invalid(self, tmp_path):
+        root = make_venv(tmp_path, python=BAD_STUB, python3=BAD_STUB,
+                         marker="../python")
+        out = run_selftest(root)
+        assert "state=invalid-marker" in out
+
+    def test_failed_verification_rolls_back(self, tmp_path):
+        """If python3 still refuses to boot after the repair, every replaced
+        file is restored and no staging/backup litter remains."""
+        root = make_venv(tmp_path, python=PICKY_STUB, python3=BAD_STUB,
+                         marker="STORE")
+        out = run_selftest(root)
+        assert "state=failed" in out
+        bin_dir = root / "venv/bin"
+        assert (bin_dir / "python3").read_text(encoding="utf-8") == BAD_STUB
+        assert (bin_dir / "python3.11").read_text(encoding="utf-8") == BAD_STUB
+        assert (bin_dir / ".tcc-anchor-source").exists()
+        assert not list(bin_dir.glob("*tcc-heal*"))
+
+
+@requires_bash
+class TestUpdateInvokeFallback:
+    def test_dead_alias_no_marker_falls_back_to_module_invocation(self, tmp_path):
+        """No marker to heal from, but the venv python itself boots (the
+        launchd-gateway shape): drive the update as python -m hermes_cli.main."""
+        root = make_venv(tmp_path, python=GOOD_STUB, python3=BAD_STUB,
+                         marker=None)
+        out = run_selftest(root)
+        assert "state=no-marker" in out
+        assert out.endswith("/venv/bin/python -m hermes_cli.main")
+
+    def test_healthy_venv_keeps_hermes_entrypoint(self, tmp_path):
+        root = make_venv(tmp_path, python=GOOD_STUB, python3=GOOD_STUB,
+                         marker=None)
+        out = run_selftest(root)
+        assert out.endswith("/venv/bin/hermes")
+
+
+@requires_bash
+class TestHandoffSurvivesBrickAB:
+    """A/B analog of the reported loop: `venv/bin/hermes` execs python3."""
+
+    def _make_hermes(self, root: Path) -> Path:
+        hermes = root / "venv/bin/hermes"
+        _write_exe(
+            hermes,
+            "#!/bin/bash\n"
+            'exec "$(cd "$(dirname "$0")" && pwd)/python3" -c "import encodings"\n',
+        )
+        return hermes
+
+    def test_bricked_entrypoint_fails_before_and_boots_after_heal(self, tmp_path):
+        root = make_venv(tmp_path, python=GOOD_STUB, python3=BAD_STUB,
+                         marker="STORE")
+        hermes = self._make_hermes(root)
+        # BEFORE the heal: the entrypoint dies exactly like the field logs.
+        before = subprocess.run([str(hermes)], capture_output=True,
+                                text=True, encoding="utf-8", errors="replace")
+        assert before.returncode == 1
+        assert "No module named 'encodings'" in before.stderr
+        # Heal (real posix.sh function), then the same entrypoint boots.
+        assert "state=healed-aliases" in run_selftest(root)
+        after = subprocess.run([str(hermes)], capture_output=True,
+                               text=True, encoding="utf-8", errors="replace")
+        assert after.returncode == 0


### PR DESCRIPTION
## Summary

Fixes #95759 — on a macOS install whose venv was converted by the **reverted** TCC interpreter anchor (#95425/#95541), the desktop-driven update loops forever on "Update failed (exit 1)". Root cause: the bricked artifact is the `python3`/`python3.N` **aliases** (real-file copies/symlinks that die at interpreter init with `ModuleNotFoundError: No module named 'encodings'`), and `venv/bin/hermes` shebang-execs `venv/bin/python3` — so **every** Python entrypoint is dead: `hermes update`, `hermes doctor`, and both of the handoff's retry attempts. No Python-side heal can ever run on this class. The only surface that still executes is the hand-off shell itself (`scripts/desktop-update/posix.sh`), so that's where the heal now lives.

## What this does

`posix.sh` gains a probe-gated self-heal that runs after `HERMES_BIN` resolution, before the update invocation (macOS only):

- **`tcc_anchor_heal`** — fires only when `venv/bin/python3` fails a scrubbed-env (`PYTHONHOME`/`PYTHONPATH` removed) `import encodings` boot probe AND the `.tcc-anchor-source` marker is present and valid (absolute path, outside the venv). Two repair shapes, both staged with per-attempt backups and full rollback if the repaired interpreter still fails its verification probe:
  - **alias-brick (#95541 class)** — the anchored `venv/bin/python` copy itself boots: aliases are re-materialized as **real files** of the anchor (hardlink, else copy — an alias *symlink* onto the copy is the exact crash shape). The marker is **kept**: real-file python + real-file aliases is precisely the layout `ensure_tcc_anchor` marks "active", so the re-landed forward anchor sees a healthy install and does not re-anchor → **no anchor/heal ping-pong**.
  - **full brick** — the copy is dead too, but the marker-recorded store interpreter boots: `python` is restored to a symlink to it, aliases to symlinks to `python`, marker removed. The unblocked `hermes update` then re-installs a boot-gated healthy anchor — one-shot convergence.
  - **fail-closed** on missing marker, relative/in-venv marker path, and missing/unbootable recorded source (the vanished-uv-store class from the issue thread) — nothing is touched.
- **`tcc_pick_update_invoke`** — safety net: if aliases stay dead but `venv/bin/python` boots (the launchd-gateway shape proven working in the field reports), the update is driven via `venv/bin/python -m hermes_cli.main` instead of the dead `venv/bin/hermes` shim.
- **Honest failure text** — an unrecoverable dead interpreter now reports as a venv-repair problem (with the heal state) instead of a generic "Update failed (exit 1). Run hermes debug share…".
- **`--self-test-tcc-heal`** — runs the real heal + invoke selection against `--install-root` and reports `state=… invoke=…`; the test harness drives the state matrix through it (same pattern as the existing `--self-test-gate`).

## Salvage / attribution

- **#96231 (@aeonsong)** — the Electron-side pre-heal. Its recovery design (marker validation, source probe before touching anything, staged replacements with backups, post-repair verification probe, atomic rollback, fail-closed reason codes) is directly reflected in `tcc_anchor_heal`; credited in the commit body. The TS module itself couldn't be cherry-picked verbatim: it heals at Desktop *launch*, which doesn't cover the handoff path this issue is about, and (per @ahrazzle's thread analysis) as written it ping-pongs with the re-landed forward anchor on uv-managed installs because it restores symlinks even when the anchored interpreter is healthy. This heal is probe-gated and, for the alias-brick class, restores the anchor-compatible real-file layout, resolving that coherently. #96231 could still land as a complementary launch-time layer if a maintainer wants it — this PR does not conflict with it and closes neither PR.
- **#95775 (@liuhao1024)** — in-update heal intent credited in the commit body. Not cherry-pickable: its target function `check_macos_tcc_anchor_removed()` no longer exists on current main (doctor now runs the forward `ensure_tcc_anchor`), and per the thread its heal point is unreachable on every dead-CLI install (the CLI cannot boot far enough to reach `cmd_update`).
- Heal-point observation (the shell handoff survives a dead venv) and the ping-pong analysis: @ahrazzle and @tokenfires on #95759.

## Testing

**Live repro:** macOS not live-tested (no mac runner — the heal is platform-independent shell exercised via the self-test path without the `uname` gate); Linux synthetic-venv A/B + unit tests. A/B on the real handoff invoke surface (`venv/bin/hermes` shebang-execing `venv/bin/python3`, alias-bricked tree with marker): **before** — `hermes update` exit 1 with `ModuleNotFoundError: No module named 'encodings'`, retry exit 1, matching the field logs line for line; **after** — `posix.sh`'s real `tcc_anchor_heal` reports `state=healed-aliases`, aliases are real files, the same entrypoint exits 0.

- `tests/test_desktop_update_tcc_heal.py` (11 tests) drives the **real** `posix.sh` functions via `--self-test-tcc-heal` on synthetic venv trees: healthy no-op, alias heal (real files + marker kept), symlink restore (marker removed), fail-closed classes (no marker / in-venv marker / relative marker / vanished source), rollback on failed verification with zero staging litter, invoke fallback selection, and the A/B entrypoint test above.
- Sabotage-verified: re-introducing the alias-symlink bug into the heal fails 2 tests.
- `bash -n` clean; shellcheck: only the two pre-existing findings on untouched lines (SC2034 line 262, SC2071 line 688); new code clean. `ruff check` clean; Windows-footgun checker clean; mirror suite `tests/test_desktop_update_shim_progress.py` + new file: 16 passed.

## Infographic

![venv-self-heal](https://v3b.fal.media/files/b/0aa8b187/zWWYuaZn3lQIulm0Lkdo__VJiGceRZ.png)
