### PR TITLE
fix(gateway): require voice input for global auto-TTS fallback (#100431)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -24087,7 +24087,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # ``voice.auto_tts`` is synced into the adapter on gateway startup.
             # It is the fallback only when the chat has no explicit mode;
             # otherwise the chat-level all/voice_only/off choice takes precedence.
-            or (voice_mode is None and adapter_auto_tts)
+            or (voice_mode is None and adapter_auto_tts and is_voice_input)
         )
         if not should:
             logger.debug(

--- a/tests/gateway/test_auto_voice_reply_format.py
+++ b/tests/gateway/test_auto_voice_reply_format.py
@@ -93,6 +93,16 @@ class TestAutoVoiceReplyFormat:
         voice_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.VOICE)
         assert runner._should_send_voice_reply(voice_event, "hello", [], already_sent=True) is True
 
+    def test_should_send_voice_reply_global_auto_tts_ignores_text_input(self):
+        """Global voice.auto_tts with no explicit chat mode must not send voice for text input (#100431)."""
+        runner = _make_runner()
+        adapter = _make_adapter(Platform.TELEGRAM)
+        adapter._should_auto_tts_for_chat = MagicMock(return_value=True)
+        runner.adapters[Platform.TELEGRAM] = adapter
+        text_event = _make_event(Platform.TELEGRAM, chat_id="123", message_type=MessageType.TEXT)
+
+        assert runner._should_send_voice_reply(text_event, "hello", []) is False
+
 def _make_runner() -> GatewayRunner:
     with patch("gateway.run.GatewayRunner._load_voice_modes", return_value={}):
         runner = GatewayRunner.__new__(GatewayRunner)


### PR DESCRIPTION
## What does this PR do?

When `voice.auto_tts: true` is configured globally in `config.yaml`, the messaging gateway was incorrectly sending TTS voice replies for normal typed `MessageType.TEXT` messages in chats that have no explicit per-chat `/voice` mode.

The contract of global auto-TTS is voice-to-voice (voice input -> text + voice reply; text input -> text reply only), while `/voice tts` (`voice_mode == "all"`) remains the explicit mode that speaks replies to all messages.

This PR fixes the fallback condition in `GatewayRunner._should_send_voice_reply()` by requiring `is_voice_input` when relying on the global `adapter_auto_tts` fallback for chats with default voice mode (`voice_mode is None`).

## Related Issue

Fixes #100431

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: In `_should_send_voice_reply()`, add `and is_voice_input` to the `voice_mode is None and adapter_auto_tts` fallback check so typed text messages do not trigger unsolicited TTS voice replies.
- `tests/gateway/test_auto_voice_reply_format.py`: Added regression test `test_should_send_voice_reply_global_auto_tts_ignores_text_input` asserting that text messages with global auto-TTS and default voice mode return `False`.

## How to Test

1. Run the regression test:
   `python -m pytest tests/gateway/test_auto_voice_reply_format.py -k test_should_send_voice_reply_global_auto_tts_ignores_text_input`
2. Run the voice reply suite:
   `python -m pytest tests/gateway/test_auto_voice_reply_format.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_auto_voice_reply_format.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
