### PR TITLE
fix(gateway): stop macOS custom TLS gateways from failing certificate checks

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -610,6 +610,30 @@ def _common_betas_for_base_url(
     return betas
 
 
+def _resolve_custom_provider_httpx_verify(base_url: str):
+    """Resolve a route-scoped TLS override for an Anthropic HTTP client."""
+    if not base_url:
+        return None
+    try:
+        from agent.ssl_verify import resolve_httpx_verify
+        from hermes_cli.config import get_custom_provider_tls_settings
+
+        tls = get_custom_provider_tls_settings(base_url)
+        if not tls:
+            return None
+        return resolve_httpx_verify(
+            ca_bundle=tls.get("ssl_ca_cert"),
+            ssl_verify=tls.get("ssl_verify"),
+            base_url=base_url,
+        )
+    except Exception:
+        logger.debug(
+            "custom-provider TLS resolution skipped for Anthropic client",
+            exc_info=True,
+        )
+        return None
+
+
 def _build_anthropic_client_with_bearer_hook(
     token_provider,
     base_url: str = None,
@@ -654,7 +678,11 @@ def _build_anthropic_client_with_bearer_hook(
         import re as _re
         normalized_base_url = _re.sub(r"/v1/?$", "", normalized_base_url.rstrip("/"))
 
-    http_client = build_bearer_http_client(token_provider, timeout=timeout_obj)
+    httpx_kwargs = {"timeout": timeout_obj}
+    httpx_verify = _resolve_custom_provider_httpx_verify(base_url)
+    if httpx_verify is not None:
+        httpx_kwargs["verify"] = httpx_verify
+    http_client = build_bearer_http_client(token_provider, **httpx_kwargs)
 
     kwargs = {
         "timeout": timeout_obj,
@@ -741,7 +769,7 @@ def build_anthropic_client(
 
     normalize_proxy_env_vars()
 
-    from httpx import Timeout
+    from httpx import Client, Timeout
 
     normalized_base_url = _normalize_base_url_text(base_url)
     if normalized_base_url:
@@ -757,6 +785,12 @@ def build_anthropic_client(
         # refill for minutes. (#26293)
         "max_retries": 0,
     }
+    httpx_verify = _resolve_custom_provider_httpx_verify(base_url)
+    if httpx_verify is not None:
+        kwargs["http_client"] = Client(
+            timeout=kwargs["timeout"],
+            verify=httpx_verify,
+        )
     if normalized_base_url:
         # Azure Anthropic endpoints require an ``api-version`` query parameter.
         # Pass it via default_query so the SDK appends it to every request URL

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2217,6 +2217,29 @@ def _collect_history_media_paths(agent_history: List[Dict[str, Any]]) -> set:
 # SSL certificate auto-detection for NixOS and other non-standard systems.
 # Must run BEFORE any HTTP library (discord, aiohttp, etc.) is imported.
 # ---------------------------------------------------------------------------
+_COMMON_CA_BUNDLE_PATHS = (
+    "/etc/ssl/certs/ca-certificates.crt",               # Debian/Ubuntu/Gentoo
+    "/etc/pki/tls/certs/ca-bundle.crt",                 # RHEL/CentOS 7
+    "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", # RHEL/CentOS 8+
+    "/etc/ssl/ca-bundle.pem",                            # SUSE/OpenSUSE
+    "/etc/ssl/cert.pem",                                 # Alpine / macOS
+    "/etc/pki/tls/cert.pem",                             # Fedora
+    "/usr/local/etc/openssl@1.1/cert.pem",               # macOS Homebrew Intel
+    "/opt/homebrew/etc/openssl@1.1/cert.pem",            # macOS Homebrew ARM
+)
+
+
+def _ordered_ca_bundle_candidates(platform_name, default_paths, certifi_bundle):
+    """Return CA candidates in host-appropriate preference order."""
+    compiled_defaults = [default_paths.cafile, default_paths.openssl_cafile]
+    if platform_name == "darwin":
+        candidates = [certifi_bundle, *compiled_defaults]
+    else:
+        candidates = [*compiled_defaults, certifi_bundle]
+    candidates.extend(_COMMON_CA_BUNDLE_PATHS)
+    return tuple(dict.fromkeys(candidate for candidate in candidates if candidate))
+
+
 def _ensure_ssl_certs() -> None:
     """Set SSL_CERT_FILE if the system doesn't expose CA certs to Python.
 
@@ -2238,32 +2261,15 @@ def _ensure_ssl_certs() -> None:
 
     import ssl
 
-    # 1. Python's compiled-in defaults
-    paths = ssl.get_default_verify_paths()
-    for candidate in (paths.cafile, paths.openssl_cafile):
-        if candidate and os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
-
-    # 2. certifi (ships its own Mozilla bundle)
+    certifi_bundle = None
     try:
         import certifi
-        os.environ["SSL_CERT_FILE"] = certifi.where()
-        return
+        certifi_bundle = certifi.where()
     except ImportError:
         pass
 
-    # 3. Common distro / macOS locations
-    for candidate in (
-        "/etc/ssl/certs/ca-certificates.crt",               # Debian/Ubuntu/Gentoo
-        "/etc/pki/tls/certs/ca-bundle.crt",                 # RHEL/CentOS 7
-        "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem", # RHEL/CentOS 8+
-        "/etc/ssl/ca-bundle.pem",                            # SUSE/OpenSUSE
-        "/etc/ssl/cert.pem",                                 # Alpine / macOS
-        "/etc/pki/tls/cert.pem",                             # Fedora
-        "/usr/local/etc/openssl@1.1/cert.pem",               # macOS Homebrew Intel
-        "/opt/homebrew/etc/openssl@1.1/cert.pem",            # macOS Homebrew ARM
-    ):
+    paths = ssl.get_default_verify_paths()
+    for candidate in _ordered_ca_bundle_candidates(sys.platform, paths, certifi_bundle):
         if os.path.exists(candidate):
             os.environ["SSL_CERT_FILE"] = candidate
             return

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -48,6 +48,37 @@ class TestIsOAuthToken:
 class TestBuildAnthropicClient:
 
 
+    def test_custom_provider_ca_bundle_is_applied_to_http_client(self):
+        verify_context = object()
+        http_client = MagicMock(name="custom_ca_http_client")
+        tls_settings = {"ssl_ca_cert": "/custom/provider-ca.pem"}
+
+        with (
+            patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk,
+            patch(
+                "hermes_cli.config.get_custom_provider_tls_settings",
+                return_value=tls_settings,
+            ),
+            patch(
+                "agent.ssl_verify.resolve_httpx_verify",
+                return_value=verify_context,
+            ) as mock_resolve_verify,
+            patch("httpx.Client", return_value=http_client) as mock_httpx_client,
+        ):
+            build_anthropic_client(
+                "custom-key",
+                base_url="https://gateway.example/anthropic/v1",
+            )
+
+        mock_resolve_verify.assert_called_once_with(
+            ca_bundle="/custom/provider-ca.pem",
+            ssl_verify=None,
+            base_url="https://gateway.example/anthropic/v1",
+        )
+        assert mock_httpx_client.call_args.kwargs["verify"] is verify_context
+        assert mock_sdk.Anthropic.call_args.kwargs["http_client"] is http_client
+
+
     def test_api_key_uses_api_key(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client("sk-ant-api03-something")

--- a/tests/gateway/test_ssl_cert_detection.py
+++ b/tests/gateway/test_ssl_cert_detection.py
@@ -3,6 +3,42 @@
 from types import SimpleNamespace
 
 
+def test_macos_ca_candidates_prefer_certifi_over_compiled_default():
+    from gateway.run import _ordered_ca_bundle_candidates
+
+    candidates = _ordered_ca_bundle_candidates(
+        "darwin",
+        SimpleNamespace(
+            cafile="/etc/ssl/cert.pem",
+            openssl_cafile="/etc/ssl/cert.pem",
+        ),
+        "/python/site-packages/certifi/cacert.pem",
+    )
+
+    assert candidates[:2] == (
+        "/python/site-packages/certifi/cacert.pem",
+        "/etc/ssl/cert.pem",
+    )
+
+
+def test_non_macos_ca_candidates_keep_compiled_default_first():
+    from gateway.run import _ordered_ca_bundle_candidates
+
+    candidates = _ordered_ca_bundle_candidates(
+        "linux",
+        SimpleNamespace(
+            cafile="/etc/ssl/certs/ca-certificates.crt",
+            openssl_cafile=None,
+        ),
+        "/python/site-packages/certifi/cacert.pem",
+    )
+
+    assert candidates[:2] == (
+        "/etc/ssl/certs/ca-certificates.crt",
+        "/python/site-packages/certifi/cacert.pem",
+    )
+
+
 def test_ensure_ssl_certs_ignores_stale_ssl_cert_file(monkeypatch, tmp_path):
     """A missing SSL_CERT_FILE should be treated as unset, not trusted."""
     import ssl


### PR DESCRIPTION
## What does this PR do?

Hermes gateways on macOS can fail against otherwise valid TLS endpoints when Python selects the frozen `/etc/ssl/cert.pem` bundle before certifi. This change prefers certifi on macOS while preserving explicit `SSL_CERT_FILE` settings and non-macOS system bundle precedence. It also applies each custom provider's `ssl_ca_cert` or `ssl_verify` setting when the provider uses the native Anthropic Messages transport.

### Symptom

An affected custom OpenAI/Anthropic-compatible gateway fails with `CERTIFICATE_VERIFY_FAILED`, surfaced to the user as a connection failure, even though the certificate chain validates against certifi. Setting `ssl_ca_cert` repairs OpenAI-wire requests but was ignored by `anthropic_messages` requests.

### Impact

macOS users whose endpoint chains to a root present in certifi but absent from `/etc/ssl/cert.pem` cannot use that endpoint without a process-wide `SSL_CERT_FILE` workaround. Custom CA configuration also did not work consistently across provider transports.

### Bug Cause

**Trigger:** `gateway/run.py:_ensure_ssl_certs` and `agent/anthropic_adapter.py:build_anthropic_client`

**Causal chain:**
1. Gateway startup sees an existing Python-compiled CA path on macOS and returns before considering certifi.
2. The selected system PEM can lag current Mozilla roots, so TLS chain construction fails for newer roots.
3. The native Anthropic client is built directly by the SDK and never receives the matching custom provider TLS policy, so route-scoped configuration cannot repair that transport.

**Why it is wrong:** Existence of a macOS PEM file does not establish that it is the maintained trust source, and transport choice must not silently change whether route-scoped TLS configuration is honored.

**Working sibling / contrast:** OpenAI-wire clients already resolve `ssl_ca_cert` through `resolve_httpx_verify`, and non-macOS hosts intentionally retain their compiled system bundle precedence for distribution and enterprise trust stores.

**Ruled out:** Current main already classifies certificate verification failures and emits TLS-specific guidance, so this is not caused solely by generic error formatting.

### Fix

- Order CA candidates by host policy: certifi first on macOS, compiled defaults first elsewhere, with existing common-path fallbacks retained.
- Resolve custom-provider TLS settings by the original route URL before Anthropic strips its wire-level `/v1` suffix.
- Supply the resulting verification context to both static-key and callable-bearer Anthropic HTTP clients.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - make macOS prefer certifi without changing explicit or non-macOS precedence.
- `agent/anthropic_adapter.py` - apply route-scoped TLS settings to Anthropic HTTP clients.
- `tests/gateway/test_ssl_cert_detection.py` - cover macOS and non-macOS CA ordering.
- `tests/agent/test_anthropic_adapter.py` - cover custom CA propagation through an Anthropic route ending in `/v1`.

## How to Test

1. Configure a custom Anthropic Messages provider with `ssl_ca_cert` and a `/v1` base URL.
2. Confirm client construction uses the resolved verification context while the SDK still normalizes its request base URL.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_ssl_cert_detection.py tests/gateway/test_ssl_certs.py tests/agent/test_anthropic_adapter.py tests/agent/test_ssl_verify.py tests/agent/test_error_classifier.py tests/agent/test_error_surface.py -q
scripts/run_tests.sh tests/agent/test_anthropic_request_client_reuse.py tests/run_agent/test_switch_model_rollback.py tests/run_agent/test_anthropic_third_party_oauth_guard.py tests/agent/test_auxiliary_client_anthropic_custom.py tests/hermes_cli/test_custom_provider_tls.py -q
```

Result: 262 passed, 1 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11; host-policy ordering is covered as a pure platform-input contract

### Documentation & Housekeeping

- [x] Documentation changes are N/A; existing configuration fields and user guidance are unchanged
- [x] `cli-config.yaml.example` changes are N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; no workflow changed
- [x] I've considered cross-platform impact and preserved non-macOS CA precedence
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A; this is transport and startup certificate-selection behavior.
