### PR TITLE
fix(cli): propagate cron subcommand exit codes from cmd_cron

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5651,7 +5651,7 @@ def cmd_cron(args):
     """Cron job management."""
     from hermes_cli.cron import cron_command
 
-    cron_command(args)
+    return cron_command(args)
 
 
 def cmd_sync(args):


### PR DESCRIPTION
## Summary

`cmd_cron()` in `hermes_cli/main.py` called `cron_command(args)` but discarded its return value, so every `hermes cron` subcommand — including `cron doctor` — always exited 0 regardless of failures. This defeats scripted health sweeps that gate on the exit code.

One-line fix: `return cron_command(args)`, so the CLI dispatcher (which already propagates `args.func(args)` return values as the process exit code) sees the real result.

## Test plan

- Before: `hermes cron doctor` on a host with failing cron jobs → exit 0.
- After: same command → non-zero exit matching `cron_command`'s returned status; healthy hosts still exit 0.
- All other `cron` subcommands unchanged except their exit codes now reflect their return values.
