### PR TITLE
fix(file-tools): match bare words as substrings in search_files (#77423)

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -479,6 +479,58 @@ class TestSearchFilesFallbackHiddenPaths:
         assert set(result.files) == {str(visible_file), str(visible_nested_file)}
 
 
+class TestSearchFilesBareWordSubstring:
+    """Bare words without wildcards must match filenames as substrings (#77423).
+
+    Before the fix, `readme` / CJK names like `品目39.23.md` (no leading `*`)
+    returned 0 results on both rg and find paths — agents silently degraded
+    to shell find/ls.
+    """
+
+    def _make_env(self):
+        return make_real_subprocess_env("/")
+
+    def _make_tree(self, tmp_path):
+        root = tmp_path / "tree"
+        (root / "nested").mkdir(parents=True)
+        root.joinpath("品目39.23.md").write_text("x")
+        root.joinpath("readme.txt").write_text("x")
+        root.joinpath("readme-old.txt").write_text("x")
+        root.joinpath("nested", "品目39.23.md").write_text("x")
+        root.joinpath("app.py").write_text("x")
+        return root
+
+    def test_bare_word_matches_as_substring_rg(self, tmp_path):
+        root = self._make_tree(tmp_path)
+        ops = ShellFileOperations(self._make_env())
+        result = ops._search_files("readme", str(root), limit=50, offset=0)
+        assert result.error is None
+        names = {Path(f).name for f in result.files}
+        assert {"readme.txt", "readme-old.txt"} <= names
+
+    def test_cjk_full_name_no_wildcard_found(self, tmp_path):
+        root = self._make_tree(tmp_path)
+        ops = ShellFileOperations(self._make_env())
+        result = ops._search_files("品目39.23", str(root), limit=50, offset=0)
+        assert result.error is None
+        assert len(result.files) == 2
+
+    def test_bare_word_matches_as_substring_find_fallback(self, tmp_path, monkeypatch):
+        root = self._make_tree(tmp_path)
+        ops = ShellFileOperations(self._make_env())
+        monkeypatch.setattr(ops, "_has_command", lambda command: command == "find")
+        result = ops._search_files("品目39.23", str(root), limit=50, offset=0)
+        assert result.error is None
+        assert len(result.files) == 2
+
+    def test_wildcard_pattern_unchanged(self, tmp_path):
+        root = self._make_tree(tmp_path)
+        ops = ShellFileOperations(self._make_env())
+        result = ops._search_files("*.py", str(root), limit=50, offset=0)
+        assert result.error is None
+        assert {Path(f).name for f in result.files} == {"app.py"}
+
+
 class TestShellFileOpsWriteDenied:
     def test_write_file_denied_path(self, file_ops):
         result = file_ops.write_file("~/.ssh/authorized_keys", "evil key")

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -3042,6 +3042,10 @@ class ShellFileOperations(FileOperations):
             search_pattern = pattern
         else:
             search_pattern = pattern.split('/')[-1]
+        # Bare words (no wildcard) become substring globs so `find` parity
+        # with the rg path holds for partial-name lookups (#77423).
+        if search_pattern and '*' not in search_pattern and '?' not in search_pattern:
+            search_pattern = f"*{search_pattern}*"
 
         search_root = Path(path)
         has_hidden_path_ancestor = any(
@@ -3143,9 +3147,14 @@ class ShellFileOperations(FileOperations):
         (most recently edited first) when rg >= 13.0 supports --sortr.
         """
         # rg --files -g uses glob patterns; wrap bare names so they match
-        # at any depth (equivalent to find -name).
-        if '/' not in pattern and not pattern.startswith('*'):
-            glob_pattern = f"*{pattern}"
+        # at any depth (equivalent to find -name). Bare words without a
+        # leading wildcard get substring semantics (`*name*`) — filename
+        # search by partial name is the common case, and a silent 0-result
+        # for `readme` / CJK names like `品目39.23` (no leading `*`) is a
+        # usability trap (#77423). Patterns that already carry a wildcard
+        # (`*.py`, `foo?.txt`) are passed through unchanged.
+        if '/' not in pattern and '*' not in pattern and '?' not in pattern:
+            glob_pattern = f"*{pattern}*"
         else:
             glob_pattern = pattern
 


### PR DESCRIPTION
## Summary
- Bare words without any wildcard (`readme`, `品目39.23`) now compile to `*name*` globs on **both** the ripgrep and find paths of `search_files(target="files")`, so partial-name lookups match at any position in the filename instead of only as a suffix.
- Patterns that already carry a wildcard (`*.py`, `foo?.txt`) or a path separator are passed through unchanged.
- Fixes the remaining hole identified in #77423: extension-bearing patterns were recovered by #77439's dot normalization, but bare words without extensions (`readme`, `39.23`, CJK names) still returned a silent 0-result set on current main.

## Why substring semantics for bare words
A filename search with a bare word is almost always a partial-name lookup ("find the file whose name contains this"). The previous suffix-only wrap (`*name`) made `readme` miss `readme-old.txt` and made CJK full names without a leading `*` (`品目39.23.md`) return nothing, which in our multi-agent production deployment silently degraded every CJK filename lookup (agents fell back to shelling out to `find`/`ls`). As @HenryNova-X noted in #77423, bare patterns becoming substring matches is "probably the right default for a filename search" — this PR implements exactly that, with the behavior note called out.

## Behavior table
| Pattern | Before (main) | After |
|:--|:--|:--|
| `readme` | matches `readme.txt` only if filename *ends with* `readme` → typically 0 results | matches `readme.txt`, `readme-old.txt`, `my-readme.md` |
| `品目39.23` | 0 results | matches `品目39.23.md` |
| `*.py` | pass-through | pass-through (unchanged) |
| `foo?.txt` | pass-through | pass-through (unchanged) |
| `dir/name` | last segment used | unchanged |

## Test plan
- [x] New regression class `TestSearchFilesBareWordSubstring` (4 tests): rg path substring match, CJK full-name lookup, find-fallback parity, wildcard pass-through
- [x] Full existing suite for the file: 70 passed; the 2 failures are pre-existing `windows_only`-marked tests that run on this Linux box only because the marker isn't registered locally (untouched by this change)
- [x] Verified both code paths on a tree with CJK filenames, bare words, and wildcard patterns (rg 14 + GNU find)

Closes #77423 (together with the dot-pattern recovery already in #77439)

cc @HenryNova-X (offered to test against the repro table in #77423)