### PR TITLE
fix(tools): clamp default-derived foreground terminal timeouts to FOREGROUND_MAX_TIMEOUT

### DIFF
--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -90,15 +90,17 @@ class TestForegroundTimeoutCap:
         assert call_kwargs[0][0] == "pnpm dev --help"
 
 
-    def test_config_default_above_cap_not_rejected(self):
-        """When config default timeout > cap but model passes no timeout, execute normally.
+    def test_config_default_above_cap_clamped_for_foreground(self):
+        """When config default timeout > cap and model passes no timeout, clamp.
 
-        Only the model's explicit timeout parameter triggers rejection,
-        not the user's configured default.
+        A raised TERMINAL_TIMEOUT default serves dispatcher-owned background
+        workflows (#100451); the model expressed no timeout intent, so the
+        call is not rejected, but the foreground wait is still bounded by
+        FOREGROUND_MAX_TIMEOUT instead of inheriting the raised default.
         """
-        from tools.terminal_tool import terminal_tool
+        from tools.terminal_tool import terminal_tool, FOREGROUND_MAX_TIMEOUT
 
-        # User configured TERMINAL_TIMEOUT=900 in their env
+        # Profile raised TERMINAL_TIMEOUT=900 for background workflows
         with patch("tools.terminal_tool._get_env_config",
                     return_value=_make_env_config(timeout=900)), \
              patch("tools.terminal_tool._start_cleanup_thread"):
@@ -111,10 +113,68 @@ class TestForegroundTimeoutCap:
                  patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
                 result = json.loads(terminal_tool(command="make build"))
 
-        # Should execute with the config default, NOT be rejected
+        # Executes (not rejected) with the wait clamped to the cap
         call_kwargs = mock_env.execute.call_args
-        assert call_kwargs[1]["timeout"] == 900
+        assert call_kwargs[1]["timeout"] == FOREGROUND_MAX_TIMEOUT
         assert "error" not in result or result["error"] is None
+
+
+    def test_config_default_at_or_below_cap_untouched(self):
+        """A config default at or below the cap must pass through unchanged."""
+        from tools.terminal_tool import terminal_tool
+
+        with patch("tools.terminal_tool._get_env_config",
+                    return_value=_make_env_config(timeout=300)), \
+             patch("tools.terminal_tool._start_cleanup_thread"):
+
+            mock_env = MagicMock()
+            mock_env.execute.return_value = {"output": "done", "returncode": 0}
+
+            with patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+                 patch("tools.terminal_tool._last_activity", {"default": 0}), \
+                 patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}):
+                result = json.loads(terminal_tool(command="make build"))
+
+        call_kwargs = mock_env.execute.call_args
+        assert call_kwargs[1]["timeout"] == 300
+        assert "error" not in result or result["error"] is None
+
+
+    def test_background_spawn_keeps_raised_default(self):
+        """Background spawns are not clamped by the foreground cap.
+
+        The raised TERMINAL_TIMEOUT default exists for dispatcher-owned
+        background workflows; a background spawn must keep using it.
+        """
+        from types import SimpleNamespace
+
+        from tools.terminal_tool import terminal_tool
+        import tools.process_registry as process_registry_mod
+
+        spawn_calls = []
+
+        class FakeRegistry:
+            pending_watchers = []
+
+            def spawn_local(self, **kwargs):
+                spawn_calls.append(kwargs)
+                return SimpleNamespace(id="sess-1", pid=4321)
+
+        mock_env = SimpleNamespace(env={})
+
+        with patch("tools.terminal_tool._get_env_config",
+                    return_value=_make_env_config(timeout=900)), \
+             patch("tools.terminal_tool._start_cleanup_thread"), \
+             patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
+             patch("tools.terminal_tool._last_activity", {"default": 0}), \
+             patch("tools.terminal_tool._task_env_overrides", {}), \
+             patch("tools.terminal_tool._resolve_container_task_id", lambda value: value or "default"), \
+             patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}), \
+             patch.object(process_registry_mod, "process_registry", FakeRegistry()):
+            result = json.loads(terminal_tool(command="long-runner", background=True))
+
+        assert result["exit_code"] == 0
+        assert len(spawn_calls) == 1
 
 
     def test_exactly_at_max_not_rejected(self):

--- a/tests/tools/test_terminal_foreground_timeout_cap.py
+++ b/tests/tools/test_terminal_foreground_timeout_cap.py
@@ -152,6 +152,7 @@ class TestForegroundTimeoutCap:
         import tools.process_registry as process_registry_mod
 
         spawn_calls = []
+        create_env_calls = []
 
         class FakeRegistry:
             pending_watchers = []
@@ -162,19 +163,29 @@ class TestForegroundTimeoutCap:
 
         mock_env = SimpleNamespace(env={})
 
+        def _fake_create_environment(**kwargs):
+            create_env_calls.append(kwargs)
+            return mock_env
+
+        # Empty environment cache so the spawn runs through _create_environment,
+        # the consumer of the raised default on the background path.
         with patch("tools.terminal_tool._get_env_config",
                     return_value=_make_env_config(timeout=900)), \
              patch("tools.terminal_tool._start_cleanup_thread"), \
-             patch("tools.terminal_tool._active_environments", {"default": mock_env}), \
-             patch("tools.terminal_tool._last_activity", {"default": 0}), \
+             patch("tools.terminal_tool._active_environments", {}), \
+             patch("tools.terminal_tool._last_activity", {}), \
              patch("tools.terminal_tool._task_env_overrides", {}), \
              patch("tools.terminal_tool._resolve_container_task_id", lambda value: value or "default"), \
+             patch("tools.terminal_tool._create_environment", side_effect=_fake_create_environment), \
              patch("tools.terminal_tool._check_all_guards", return_value={"approved": True}), \
              patch.object(process_registry_mod, "process_registry", FakeRegistry()):
             result = json.loads(terminal_tool(command="long-runner", background=True))
 
         assert result["exit_code"] == 0
         assert len(spawn_calls) == 1
+        # The raised default survives into the environment the background
+        # process runs in — the cap only bounds foreground waits.
+        assert create_env_calls[0]["timeout"] == 900
 
 
     def test_exactly_at_max_not_rejected(self):

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2967,6 +2967,12 @@ def terminal_tool(
             and timeout is None
             and effective_timeout > FOREGROUND_MAX_TIMEOUT
         ):
+            logger.info(
+                "Clamping default-derived foreground timeout %ss to "
+                "FOREGROUND_MAX_TIMEOUT=%ss (raise TERMINAL_MAX_FOREGROUND_TIMEOUT "
+                "for a longer wait). Task: %s",
+                default_timeout, FOREGROUND_MAX_TIMEOUT, effective_task_id,
+            )
             effective_timeout = FOREGROUND_MAX_TIMEOUT
 
         # Guardrail: long-lived server/watch commands should run as managed

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -2957,6 +2957,18 @@ def terminal_tool(
                 f"notify_on_complete=true for long-running commands."
             )
 
+        # A raised TERMINAL_TIMEOUT default exists for dispatcher-owned
+        # background workflows; a foreground call that omits ``timeout`` must
+        # not inherit it past the foreground cap. The caller expressed no
+        # timeout intent, so clamp instead of rejecting (raise
+        # TERMINAL_MAX_FOREGROUND_TIMEOUT for a longer legitimate wait).
+        if (
+            not background
+            and timeout is None
+            and effective_timeout > FOREGROUND_MAX_TIMEOUT
+        ):
+            effective_timeout = FOREGROUND_MAX_TIMEOUT
+
         # Guardrail: long-lived server/watch commands should run as managed
         # background sessions, not foreground shell hacks.
         if not background:


### PR DESCRIPTION
## What does this PR do?

A foreground terminal call that omits `timeout` inherits the configured `TERMINAL_TIMEOUT` default without passing through the `FOREGROUND_MAX_TIMEOUT` cap: the reject branch in `tools/terminal_tool.py` only fires when `timeout` was explicitly requested (`if not background and timeout and timeout > FOREGROUND_MAX_TIMEOUT`), while the effective value is computed as `effective_timeout = timeout or default_timeout`.

A profile can legitimately raise `TERMINAL_TIMEOUT` for dispatcher-owned background workflows (e.g. a Kanban Game Worker whose dispatcher injects a Task-sized timeout). In such a profile, any unrelated foreground call that omits `timeout` then waits for the full raised default — setting the profile default to 50,400 seconds made omitted-timeout foreground calls eligible to wait 14 hours, far past the documented 600s foreground cap.

This PR clamps the default-derived value to `FOREGROUND_MAX_TIMEOUT` for foreground calls. Clamping (not rejecting) is the right move because the caller expressed no timeout intent, so an error would be unjustified; `TERMINAL_MAX_FOREGROUND_TIMEOUT` remains the supported way to raise the cap itself when a longer foreground wait is genuinely wanted. Explicit-timeout rejection and background-process behavior are unchanged.

## Related Issue

Fixes #100451

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/terminal_tool.py`: after the explicit foreground-timeout reject branch, clamp `effective_timeout` to `FOREGROUND_MAX_TIMEOUT` when the call is foreground, `timeout` was omitted, and the configured default exceeds the cap.
- `tests/tools/test_terminal_foreground_timeout_cap.py`: updated `test_config_default_above_cap_not_rejected` — it previously asserted the exact passthrough (`timeout == 900`) that #100451 reports as the bug; it now asserts the foreground wait is clamped to the cap while the call still executes (not rejected).
- `tests/tools/test_terminal_foreground_timeout_cap.py`: added `test_config_default_at_or_below_cap_untouched` (a default at/below the cap passes through unchanged) and `test_background_spawn_keeps_raised_default` (background spawns keep the raised default and are not clamped).

## How to Test

1. `pytest tests/tools/test_terminal_foreground_timeout_cap.py -v` — Observed result: 10 passed.
2. `pytest tests/tools/test_terminal_*.py -q` (bounded_execute, compound_background, config_env_sync, degraded_mode, error_redaction, exit_semantics, foreground_timeout_cap, none_command_guard, timeout_output, tool) — Observed result: 84 passed.
3. Manual: with `TERMINAL_TIMEOUT=900` set, a foreground `terminal_tool` call omitting `timeout` now executes with a 600s wait bound instead of 900s; with `background=true` the spawn path is unchanged.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A (the existing schema text "Foreground timeout above {cap}s is rejected" still describes the model-facing contract; the default-derived path is not part of the schema)