### PR TITLE
fix(gateway): skip UNIX loop-tick witness on Windows instead of failing

### DIFF
--- a/gateway/shutdown_watchdog.py
+++ b/gateway/shutdown_watchdog.py
@@ -526,8 +526,8 @@ async def loop_heartbeat_forever(
     # disables the witness, and the payload flag tells probes that staleness is
     # no longer sufficient authority to escalate.
     #
-    # Windows: asyncio.start_unix_server raises (no AF_UNIX event-loop
-    # support), so the witness is PERMANENTLY absent there — the payload
+    # Windows: asyncio.start_unix_server is not attempted (no AF_UNIX
+    # event-loop support), so the witness is PERMANENTLY absent there — the payload
     # records loop_tick_socket=False and every stale-file probe classifies
     # UNKNOWN, never WEDGED. That is deliberate fail-safe: a wedged native
     # Windows gateway keeps the graceful-drain backstop instead of an
@@ -569,9 +569,15 @@ async def loop_heartbeat_forever(
                 logger.debug(
                     "stale loop-tick socket sweep failed", exc_info=True
                 )
-        tick_server = await asyncio.start_unix_server(
-            _tick_socket_handler, path=str(tick_socket_path)
-        )
+            tick_server = await asyncio.start_unix_server(
+                _tick_socket_handler, path=str(tick_socket_path)
+            )
+        else:
+            logger.info(
+                "Loop tick socket witness not armed on %s (no AF_UNIX) — "
+                "stale-loop probes will classify UNKNOWN, never WEDGED",
+                os.name,
+            )
     except Exception:
         tick_server = None
         logger.warning(

--- a/tests/gateway/test_loop_liveness_watchdog.py
+++ b/tests/gateway/test_loop_liveness_watchdog.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
-import pathlib
 import inspect
+import os
+import pathlib
 import threading
 import time
 from unittest.mock import MagicMock, patch
@@ -402,4 +403,31 @@ def test_loop_scheduling_witness_is_served_by_the_loop_itself():
     # thread, so an awaited start_unix_server is structurally loop-owned.
     assert "await asyncio.start_unix_server(" in body, (
         "the loop-scheduling witness socket is not armed by the loop task"
+    )
+
+
+def test_loop_scheduling_witness_skipped_on_windows(tmp_path, monkeypatch):
+    """Windows has no AF_UNIX event-loop support: the witness must be
+    skipped up front rather than attempted-and-failed, so gateway startup
+    logs carry no AttributeError traceback while the loop heartbeat still
+    runs and the payload still records loop_tick_socket=False."""
+    monkeypatch.setattr(os, "name", "nt")
+    info_messages = []
+
+    def _info(msg, *args, **kwargs):
+        info_messages.append(str(msg))
+
+    with patch("gateway.shutdown_watchdog.logger.warning") as warn, patch(
+        "gateway.shutdown_watchdog.logger.info", side_effect=_info
+    ):
+        asyncio.run(
+            loop_heartbeat_forever(
+                interval_s=1.0, home=tmp_path, should_continue=lambda: False
+            )
+        )
+    # The old code reached the failed-bind except path on Windows (the
+    # AttributeError traceback in gateway logs); the guarded code must not.
+    warn.assert_not_called()
+    assert any(
+        "Loop tick socket witness not armed" in m for m in info_messages
     )


### PR DESCRIPTION
## Summary

`asyncio.start_unix_server` is POSIX-only; on Windows the attribute does not exist. The loop-scheduling witness code in `loop_heartbeat_forever` nevertheless called it unconditionally, so **every gateway start on Windows logged an `AttributeError` traceback** through the failed-bind fallback path — even though graceful degradation (no witness; stale-loop probes classify UNKNOWN, never WEDGED) was already the documented, deliberate fail-safe design.

This PR guards the bind with the existing `os.name == "posix"` branch so the witness is simply *not attempted* on Windows, and logs the deliberate absence at info level instead of surfacing a traceback.

POSIX behavior is unchanged (stale-node sweep + bind + witness all still run there).

## Test Plan

- New regression test `test_loop_scheduling_witness_skipped_on_windows`: on `os.name == "nt"` the loop heartbeat still runs, the failed-bind warning path is never taken, and the deliberate skip is logged. **RED on the old code** (warning fired via the AttributeError fallback), GREEN with the fix.
- `tests/gateway/test_loop_liveness_watchdog.py`: 12/12 passed (Windows).
- `tests/gateway/test_shutdown_watchdog.py`: 2/2 passed.
- `ruff check` and `git diff --check`: clean.