### PR TITLE
fix(profiles): pin secondary api_server off under multiplex create

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1174,6 +1174,103 @@ def profiles_to_serve(
     return serve
 
 
+def launch_gateway_is_multiplexed() -> bool:
+    """Return True when the machine-level launch/default gateway is multiplexing.
+
+    Topology is owned by the default root, not the profile being created:
+    ``GATEWAY_MULTIPLEX_PROFILES`` (when recognized) wins, else
+    ``<default_root>/config.yaml`` ``gateway.multiplex_profiles``. Same
+    owner as the enroll warning and the multiplexer itself. CLI
+    ``create_profile()`` does not consult this — standalone CLI profiles
+    keep today's independent-gateway behavior.
+    """
+    from gateway.config import _env_multiplex_profiles_override
+    from hermes_cli.config import read_user_config_raw
+    from hermes_constants import get_default_hermes_root
+
+    env_multiplex = _env_multiplex_profiles_override()
+    if env_multiplex is True:
+        return True
+    if env_multiplex is False:
+        return False
+    cfg_path = Path(get_default_hermes_root()) / "config.yaml"
+    if not cfg_path.exists():
+        return False
+    cfg = read_user_config_raw(cfg_path) or {}
+    if not isinstance(cfg, dict):
+        return False
+    return bool(
+        cfg.get("multiplex_profiles")
+        or (cfg.get("gateway") or {}).get("multiplex_profiles")
+    )
+
+
+def pin_secondary_profile_api_server_disabled(profile_dir: Path) -> bool:
+    """Persist ``platforms.api_server.enabled: false`` on a named profile.
+
+    Keeps inherited ``API_SERVER_KEY`` / credential pool available for
+    authentication while refusing a second listener. Uses the canonical
+    config writer under a HERMES_HOME override so ``_enabled_explicit``
+    is set on the next gateway load. Returns True when a write happened.
+    """
+    from hermes_cli.config import read_user_config_raw, save_config
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    profile_dir = Path(profile_dir)
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"profile directory does not exist: {profile_dir}")
+
+    token = set_hermes_home_override(str(profile_dir))
+    try:
+        cfg = read_user_config_raw() or {}
+        if not isinstance(cfg, dict):
+            cfg = {}
+        platforms = cfg.get("platforms")
+        if not isinstance(platforms, dict):
+            platforms = {}
+            cfg["platforms"] = platforms
+        api = platforms.get("api_server")
+        if not isinstance(api, dict):
+            api = {}
+            platforms["api_server"] = api
+        if api.get("enabled") is False:
+            return False
+        api["enabled"] = False
+        save_config(
+            cfg,
+            preserve_keys={("platforms", "api_server", "enabled")},
+        )
+        return True
+    finally:
+        reset_hermes_home_override(token)
+
+
+def normalize_created_profile_for_launch_multiplex(
+    profile_dir: Path,
+    *,
+    name: Optional[str] = None,
+) -> dict:
+    """Post-create pin for machine-level create endpoints (RPC + REST).
+
+    When the launch/default gateway is multiplexing, persist the secondary
+    API-server disable so the multiplexer does not skip the new profile.
+    Does nothing when multiplexing is off. Never called from
+    ``create_profile()`` itself.
+
+    Returns a dict: ``applied`` (pin write), ``multiplex`` (launch topology),
+    ``served`` (name is in ``profiles_to_serve`` after the pin).
+    """
+    profile_dir = Path(profile_dir)
+    if not launch_gateway_is_multiplexed():
+        return {"applied": False, "multiplex": False, "served": None}
+    applied = pin_secondary_profile_api_server_disabled(profile_dir)
+    served = None
+    if name:
+        served_names = {n for n, _ in profiles_to_serve(multiplex=True)}
+        served = name in served_names
+    return {"applied": applied, "multiplex": True, "served": served}
+
+
 def create_profile(
     name: str,
     clone_from: Optional[str] = None,

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -827,8 +827,30 @@ async def create_profile_endpoint(body: ProfileCreate):
         collision = profiles_mod.check_alias_collision(body.name)
         if not collision:
             profiles_mod.create_wrapper_script(body.name)
+
+        # Same topology pin as tui_gateway profiles.create: a Bot created
+        # through the machine-level REST twin of New Agent must not inherit
+        # standalone API-server listener intent under multiplex.
+        try:
+            profiles_mod.normalize_created_profile_for_launch_multiplex(
+                path, name=body.name
+            )
+        except Exception as e:
+            try:
+                import shutil
+
+                shutil.rmtree(path, ignore_errors=True)
+            except Exception:
+                pass
+            _log.exception("POST /api/profiles multiplex pin failed; rolled back")
+            raise HTTPException(
+                status_code=500,
+                detail=f"profile create rolled back: multiplex API-server pin failed: {e}",
+            ) from e
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except HTTPException:
+        raise
     except Exception as e:
         _log.exception("POST /api/profiles failed")
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/hermes_cli/test_profiles_multiplex_create_pin.py
+++ b/tests/hermes_cli/test_profiles_multiplex_create_pin.py
@@ -1,0 +1,128 @@
+"""Machine-level Bot create must pin secondary API-server disable under multiplex.
+
+Desktop New Agent / ``profiles.create`` / POST /api/profiles can clone or
+mirror the launch profile's API-server credential. Without an explicit
+``platforms.api_server.enabled: false`` pin, the multiplexer treats the new
+profile as a second listener and skips it.
+
+CLI ``create_profile()`` must stay untouched so standalone named gateways
+keep working.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.profiles import (
+    create_profile,
+    launch_gateway_is_multiplexed,
+    normalize_created_profile_for_launch_multiplex,
+    pin_secondary_profile_api_server_disabled,
+)
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    return default_home
+
+
+def _write_launch_multiplex(home: Path, *, key: str = "repro-api-server-key-16+") -> None:
+    (home / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n"
+        "platforms:\n  api_server:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text(f"API_SERVER_KEY={key}\n", encoding="utf-8")
+
+
+def _api_server_enabled(cfg_path: Path):
+    if not cfg_path.is_file():
+        return None
+    data = yaml.safe_load(cfg_path.read_text(encoding="utf-8")) or {}
+    api = ((data.get("platforms") or {}).get("api_server") or {})
+    return api.get("enabled")
+
+
+def _port_binding_platforms(profile_home: Path) -> list[str]:
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from gateway.config import load_gateway_config, platform_binds_port
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(profile_home))
+    secret = set_secret_scope(build_profile_secret_scope(profile_home))
+    try:
+        cfg = load_gateway_config()
+    finally:
+        reset_secret_scope(secret)
+        reset_hermes_home_override(token)
+    return sorted(
+        platform.value
+        for platform, pcfg in cfg.platforms.items()
+        if pcfg.enabled and platform_binds_port(platform.value, pcfg.extra)
+    )
+
+
+def test_launch_gateway_is_multiplexed_reads_default_root(profile_env):
+    assert launch_gateway_is_multiplexed() is False
+    _write_launch_multiplex(profile_env)
+    assert launch_gateway_is_multiplexed() is True
+
+
+def test_launch_gateway_env_override_wins(profile_env, monkeypatch):
+    _write_launch_multiplex(profile_env)
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "0")
+    assert launch_gateway_is_multiplexed() is False
+    monkeypatch.setenv("GATEWAY_MULTIPLEX_PROFILES", "1")
+    assert launch_gateway_is_multiplexed() is True
+
+
+def test_pin_writes_explicit_false_and_stops_force_enable(profile_env):
+    _write_launch_multiplex(profile_env)
+    created = create_profile(
+        "clonebot", clone_from="default", clone_config=True, no_alias=True
+    )
+    assert _api_server_enabled(created / "config.yaml") is True
+    assert "api_server" in _port_binding_platforms(created)
+
+    wrote = pin_secondary_profile_api_server_disabled(created)
+    assert wrote is True
+    assert _api_server_enabled(created / "config.yaml") is False
+    assert _port_binding_platforms(created) == []
+    env_text = (created / ".env").read_text(encoding="utf-8")
+    assert "API_SERVER_KEY=" in env_text
+
+
+def test_normalize_pins_only_when_launch_is_multiplexed(profile_env):
+    (profile_env / "config.yaml").write_text(
+        "platforms:\n  api_server:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    created = create_profile(
+        "standalone", clone_from="default", clone_config=True, no_alias=True
+    )
+    result = normalize_created_profile_for_launch_multiplex(created, name="standalone")
+    assert result["multiplex"] is False
+    assert result["applied"] is False
+    assert _api_server_enabled(created / "config.yaml") is True
+
+
+def test_cli_create_profile_is_not_silently_rewritten(profile_env):
+    _write_launch_multiplex(profile_env)
+    created = create_profile("clibot", no_alias=True)
+    assert _api_server_enabled(created / "config.yaml") is None
+    env_text = (created / ".env").read_text(encoding="utf-8")
+    assert "API_SERVER_KEY=" not in env_text
+    assert _port_binding_platforms(created) == []

--- a/tests/tui_gateway/test_profiles_create_multiplex_pin.py
+++ b/tests/tui_gateway/test_profiles_create_multiplex_pin.py
@@ -1,0 +1,124 @@
+"""profiles.create (Desktop New Agent RPC) pins multiplex secondary API server."""
+
+from __future__ import annotations
+
+import os
+import types
+from pathlib import Path
+
+import pytest
+import yaml
+
+from tui_gateway.methods_profiles import _registry
+from utils import is_truthy_value
+
+
+@pytest.fixture()
+def profile_env(tmp_path, monkeypatch):
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(default_home))
+    monkeypatch.delenv("GATEWAY_MULTIPLEX_PROFILES", raising=False)
+    monkeypatch.delenv("API_SERVER_KEY", raising=False)
+    monkeypatch.delenv("API_SERVER_ENABLED", raising=False)
+    return default_home
+
+
+def _bind_profiles_create():
+    fn = next(f for n, f in _registry._pending if n == "profiles.create")
+
+    def _ok(rid, result):
+        return {"jsonrpc": "2.0", "id": rid, "result": result}
+
+    def _err(rid, code, msg, data=None):
+        error = {"code": code, "message": msg}
+        if data is not None:
+            error["data"] = data
+        return {"jsonrpc": "2.0", "id": rid, "error": error}
+
+    g = dict(fn.__globals__)
+    g.update({"_ok": _ok, "_err": _err, "is_truthy_value": is_truthy_value, "os": os})
+    return types.FunctionType(
+        fn.__code__, g, fn.__name__, fn.__defaults__, fn.__closure__
+    )
+
+
+def _write_launch(home: Path) -> None:
+    (home / "config.yaml").write_text(
+        "gateway:\n  multiplex_profiles: true\n"
+        "platforms:\n  api_server:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    (home / ".env").write_text("API_SERVER_KEY=repro-api-server-key-16+\n", encoding="utf-8")
+
+
+def _api_enabled(home: Path):
+    cfg = home / "config.yaml"
+    if not cfg.is_file():
+        return None
+    data = yaml.safe_load(cfg.read_text(encoding="utf-8")) or {}
+    return ((data.get("platforms") or {}).get("api_server") or {}).get("enabled")
+
+
+def _port_binding(home: Path) -> list[str]:
+    from agent.secret_scope import (
+        build_profile_secret_scope,
+        reset_secret_scope,
+        set_secret_scope,
+    )
+    from gateway.config import load_gateway_config, platform_binds_port
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    token = set_hermes_home_override(str(home))
+    secret = set_secret_scope(build_profile_secret_scope(home))
+    try:
+        cfg = load_gateway_config()
+    finally:
+        reset_secret_scope(secret)
+        reset_hermes_home_override(token)
+    return sorted(
+        platform.value
+        for platform, pcfg in cfg.platforms.items()
+        if pcfg.enabled and platform_binds_port(platform.value, pcfg.extra)
+    )
+
+
+def test_fresh_create_mirrors_key_but_pins_disable(profile_env):
+    _write_launch(profile_env)
+    handler = _bind_profiles_create()
+    result = handler(1, {"name": "freshbot"})["result"]
+    assert result["ok"] is True
+    home = Path(result["path"])
+    assert result["mirrored"]["env"] is True
+    assert result["multiplex"]["multiplex"] is True
+    assert result["multiplex"]["served"] is True
+    assert (home / ".env").read_text(encoding="utf-8").startswith("API_SERVER_KEY=")
+    assert _api_enabled(home) is False
+    assert _port_binding(home) == []
+
+
+def test_clone_from_default_does_not_keep_listener_intent(profile_env):
+    _write_launch(profile_env)
+    handler = _bind_profiles_create()
+    result = handler(2, {"name": "clonebot", "clone_from": "default"})["result"]
+    home = Path(result["path"])
+    assert _api_enabled(home) is False
+    assert _port_binding(home) == []
+    assert "API_SERVER_KEY=" in (home / ".env").read_text(encoding="utf-8")
+    assert result["multiplex"]["served"] is True
+
+
+def test_no_pin_when_launch_is_not_multiplexed(profile_env):
+    (profile_env / "config.yaml").write_text(
+        "platforms:\n  api_server:\n    enabled: true\n",
+        encoding="utf-8",
+    )
+    (profile_env / ".env").write_text(
+        "API_SERVER_KEY=repro-api-server-key-16+\n", encoding="utf-8"
+    )
+    handler = _bind_profiles_create()
+    result = handler(3, {"name": "lonely", "clone_from": "default"})["result"]
+    home = Path(result["path"])
+    assert result["multiplex"]["multiplex"] is False
+    assert _api_enabled(home) is True

--- a/tui_gateway/methods_profiles.py
+++ b/tui_gateway/methods_profiles.py
@@ -571,6 +571,29 @@ def _(rid, params: dict) -> dict:
         except Exception:
             pass
 
+    # Machine-level create (Desktop New Agent / this RPC) must bind the
+    # new named profile to the launch gateway's topology. Under multiplex
+    # the secondary profile keeps inherited API_SERVER_KEY but must pin
+    # platforms.api_server.enabled: false or the multiplexer skips it.
+    # CLI create_profile() is intentionally not rewritten.
+    multiplex_norm = {"applied": False, "multiplex": False, "served": None}
+    try:
+        multiplex_norm = profiles_mod.normalize_created_profile_for_launch_multiplex(
+            path, name=name
+        )
+    except Exception as e:
+        try:
+            import shutil
+
+            shutil.rmtree(path, ignore_errors=True)
+        except Exception:
+            pass
+        return _err(
+            rid,
+            5062,
+            f"profile create rolled back: multiplex API-server pin failed: {e}",
+        )
+
     return _ok(
         rid,
         {
@@ -580,6 +603,7 @@ def _(rid, params: dict) -> dict:
             "soul_written": soul_written,
             "model_set": model_set,
             "mirrored": mirrored,
+            "multiplex": multiplex_norm,
         },
     )
 


### PR DESCRIPTION
## What does this PR do?

Desktop Bot Mode **New Agent** (`profiles.create` and the dashboard REST twin `POST /api/profiles`) can create a secondary profile that inherits API-server **listener** intent: a cloned `config.yaml` with `platforms.api_server.enabled: true`, and/or a mirrored `API_SERVER_KEY` that force-enables the listener. Under `gateway.multiplex_profiles: true`, the multiplexer treats that as a second port-binding platform and skips the profile (`SecondaryPortBindingConfigError`). The roster lists the bot, but `/p/<name>/…` 404s.

This pins machine-level create to persist an explicit

```yaml
platforms:
  api_server:
    enabled: false
```

on the new named profile when the launch/default gateway is multiplexing. Inherited credentials stay in `.env` so the bot can still authenticate; only the second listener is refused. The pin is written with `save_config(..., preserve_keys={("platforms", "api_server", "enabled")})` so the explicit `false` survives default-stripping (needed so `_enabled_explicit` beats `API_SERVER_KEY` force-enable).

CLI `create_profile()` is unchanged: standalone named profiles keep independent-gateway behavior.

## Related Issue

Fixes #100397

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/profiles.py` — add `launch_gateway_is_multiplexed()`, `pin_secondary_profile_api_server_disabled()`, and `normalize_created_profile_for_launch_multiplex()`. Topology is read from the default root / `GATEWAY_MULTIPLEX_PROFILES`, not from the profile being created. `create_profile()` does not call these helpers.
- `tui_gateway/methods_profiles.py` — after create + credential mirror, run the multiplex pin. On pin failure, `rmtree` the new profile and return an error. Result includes a `multiplex` object (`applied`, `multiplex`, `served`).
- `hermes_cli/web_routers/profiles.py` — same pin + rollback on `POST /api/profiles`.
- `tests/hermes_cli/test_profiles_multiplex_create_pin.py` — pin write, multiplex gate, env override, and CLI standalone (no silent rewrite).
- `tests/tui_gateway/test_profiles_create_multiplex_pin.py` — live `profiles.create` handler: fresh create mirrors the key but pins disable; clone-from-default does not keep listener intent; no pin when multiplex is off.

## How to Test

1. Point an isolated `HERMES_HOME` at a temp default root with `gateway.multiplex_profiles: true`, `platforms.api_server.enabled: true`, and an `API_SERVER_KEY` in `.env`.
2. Reproduce the skip condition without the pin: clone-from-default (`create_profile(..., clone_from="default", clone_config=True)`) leaves `enabled: true` and `platform_binds_port` reports `api_server`. Fresh `profiles.create` with `mirror_credentials` copies `API_SERVER_KEY` and, without an explicit `enabled: false`, the same binding appears.
3. With this change, call `profiles.create` for a fresh name and again with `clone_from: "default"`. Both profiles keep `API_SERVER_KEY` in `.env`, persist `platforms.api_server.enabled: false`, report empty port-binding, and appear in `profiles_to_serve(multiplex=True)` (`result.multiplex.served` is true). CLI `create_profile("clibot")` alone still does not copy the key or write an api_server pin.
4. Targeted tests:

```
PYTHONPATH=. python3 -m pytest \
  tests/hermes_cli/test_profiles_multiplex_create_pin.py \
  tests/tui_gateway/test_profiles_create_multiplex_pin.py -q
```

```
........                                                                 [100%]
8 passed in 1.04s
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
........                                                                 [100%]
8 passed in 1.04s
```
