### PR TITLE
fix(desktop): follow Bot owner for floating pets

### DIFF
--- a/apps/desktop/src/app/settings/pet-settings.tsx
+++ b/apps/desktop/src/app/settings/pet-settings.tsx
@@ -15,7 +15,7 @@ import { triggerHaptic } from '@/lib/haptics'
 import { Download, Loader2, PawPrint, Pencil, Trash2 } from '@/lib/icons'
 import { selectableCardClass } from '@/lib/selectable-card'
 import { cn } from '@/lib/utils'
-import { $petInfo, $petRoam, setPetRoam } from '@/store/pet'
+import { $petInfo, $petOwner, $petRoam, petOwnerUsesAmbientGateway, setPetRoam } from '@/store/pet'
 import {
   $petBusy,
   $petGallery,
@@ -56,6 +56,7 @@ export function PetSettings() {
   const error = useStore($petGalleryError)
   const busySlug = useStore($petBusy)
   const petInfo = useStore($petInfo)
+  const petOwner = useStore($petOwner)
   const roam = useStore($petRoam)
   const [query, setQuery] = useState('')
   const [confirmDelete, setConfirmDelete] = useState<GalleryPet | null>(null)
@@ -64,12 +65,12 @@ export function PetSettings() {
   const scale = petInfo.scale ?? PET_SCALE_DEFAULT
 
   useEffect(() => {
-    if (gatewayState !== 'open') {
+    if (petOwnerUsesAmbientGateway(petOwner) && gatewayState !== 'open') {
       return
     }
 
     void loadPetGallery(requestGateway)
-  }, [gatewayState, requestGateway])
+  }, [gatewayState, petOwner, requestGateway])
 
   const enabled = gallery?.enabled ?? false
   const active = gallery?.active ?? ''

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -18,6 +18,7 @@ import {
   mergePetInfoMeta,
   type PetInfo,
   type PetInfoMeta,
+  petOwnerUsesAmbientGateway,
   requestPetForOwner,
   setPetInfo
 } from '@/store/pet'
@@ -113,6 +114,7 @@ export function FloatingPet() {
   const atRest = useStore($petAtRest)
   const roamDir = useStore($petRoamDir)
   const routeOverlayOpen = useRouteOverlayActive()
+  const usesAmbientGateway = petOwnerUsesAmbientGateway(owner)
 
   const requestPetGateway = useCallback(
     <T,>(method: string, params: Record<string, unknown> = {}) =>
@@ -153,7 +155,7 @@ export function FloatingPet() {
   // Older backends (no change_events) keep the legacy fast-while-inactive poll.
   const active = info.enabled && Boolean(info.spritesheetBase64)
   useEffect(() => {
-    if (gatewayState !== 'open') {
+    if (usesAmbientGateway && gatewayState !== 'open') {
       return
     }
 
@@ -163,7 +165,12 @@ export function FloatingPet() {
     // broadcast clears the mascot with zero round-trips, and an unchanged
     // revision (scale-only move still changes the sig) short-circuits below
     // via hasPetSpriteForMeta + mergePetInfoMeta.
-    if (changeEventsAvailable && petChange.tick > 0 && petChange.meta?.enabled === false) {
+    if (
+      usesAmbientGateway &&
+      changeEventsAvailable &&
+      petChange.tick > 0 &&
+      petChange.meta?.enabled === false
+    ) {
       setPetInfo({ enabled: false })
 
       return
@@ -280,7 +287,7 @@ export function FloatingPet() {
 
       window.clearInterval(timer)
     }
-  }, [gatewayState, active, changeEventsAvailable, petChange, requestPetGateway])
+  }, [gatewayState, active, changeEventsAvailable, petChange, requestPetGateway, usesAmbientGateway])
 
   // Pets follow the exact Bot owner as well as ordinary profile switches. Drop
   // the prior sprite immediately so a slow remote dial never leaves the default

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -18,6 +18,8 @@ import {
   mergePetInfoMeta,
   type PetInfo,
   type PetInfoMeta,
+  type PetOwner,
+  petOwnerChanged,
   petOwnerUsesAmbientGateway,
   requestPetForOwner,
   setPetInfo
@@ -114,6 +116,7 @@ export function FloatingPet() {
   const atRest = useStore($petAtRest)
   const roamDir = useStore($petRoamDir)
   const routeOverlayOpen = useRouteOverlayActive()
+  const previousOwnerRef = useRef<PetOwner | undefined>(undefined)
   const usesAmbientGateway = petOwnerUsesAmbientGateway(owner)
 
   const requestPetGateway = useCallback(
@@ -292,7 +295,15 @@ export function FloatingPet() {
   // Pets follow the exact Bot owner as well as ordinary profile switches. Drop
   // the prior sprite immediately so a slow remote dial never leaves the default
   // profile's mascot painted over the selected bot.
+  // eslint-disable-next-line no-restricted-syntax -- component-local history distinguishes mount hydration from a real owner switch
   useEffect(() => {
+    const previous = previousOwnerRef.current
+    previousOwnerRef.current = owner
+
+    if (!petOwnerChanged(previous, owner)) {
+      return
+    }
+
     setPetInfo({ enabled: false })
     resetPetGallery()
   }, [owner])

--- a/apps/desktop/src/components/pet/floating-pet.tsx
+++ b/apps/desktop/src/components/pet/floating-pet.tsx
@@ -2,14 +2,15 @@ import { useStore } from '@nanostores/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { useGatewayRequest } from '@/app/gateway/hooks/use-gateway-request'
-import { useOnProfileSwitch } from '@/app/hooks/use-on-profile-switch'
 import { useRouteOverlayActive } from '@/app/hooks/use-route-overlay-active'
 import { PetHeartField } from '@/components/chat/vibe-hearts'
 import { persistString, storedString } from '@/lib/storage'
+import { requestGatewayForAgent } from '@/store/gateway'
 import { $changeEventsAvailable, $petChange } from '@/store/live-sync'
 import {
   $petAtRest,
   $petInfo,
+  $petOwner,
   $petRoam,
   $petRoamDir,
   clearPetUnread,
@@ -17,7 +18,7 @@ import {
   mergePetInfoMeta,
   type PetInfo,
   type PetInfoMeta,
-  petProfile,
+  requestPetForOwner,
   setPetInfo
 } from '@/store/pet'
 import { resetPetGallery, setPetScale } from '@/store/pet-gallery'
@@ -104,6 +105,7 @@ export function FloatingPet() {
   const { resolvedMode } = useTheme()
   const gatewayState = useStore($gatewayState)
   const info = useStore($petInfo)
+  const owner = useStore($petOwner)
   const changeEventsAvailable = useStore($changeEventsAvailable)
   const petChange = useStore($petChange)
   const overlayActive = useStore($petOverlayActive)
@@ -111,6 +113,19 @@ export function FloatingPet() {
   const atRest = useStore($petAtRest)
   const roamDir = useStore($petRoamDir)
   const routeOverlayOpen = useRouteOverlayActive()
+
+  const requestPetGateway = useCallback(
+    <T,>(method: string, params: Record<string, unknown> = {}) =>
+      requestPetForOwner<T>(
+        owner,
+        method,
+        params,
+        (ambientMethod, ambientParams) => requestGateway<T>(ambientMethod, ambientParams),
+        (connectionId, profile, routedMethod, routedParams) =>
+          requestGatewayForAgent<T>(connectionId, profile, routedMethod, routedParams)
+      ),
+    [owner, requestGateway]
+  )
 
   const [position, setPosition] = useState<Point>(loadPosition)
   const containerRef = useRef<HTMLDivElement | null>(null)
@@ -158,7 +173,7 @@ export function FloatingPet() {
       try {
         if (active) {
           try {
-            const meta = await requestGateway<PetInfoMeta>('pet.info.meta', { profile: petProfile() })
+            const meta = await requestPetGateway<PetInfoMeta>('pet.info.meta', {})
 
             if (cancelled || !meta) {
               return
@@ -192,9 +207,8 @@ export function FloatingPet() {
         const held = $petInfo.get()
         const knownRevision = held.enabled && held.spritesheetBase64 ? held.spritesheetRevision : undefined
 
-        const next = await requestGateway<PetInfo & { spritesheetUnchanged?: boolean }>('pet.info', {
-          knownRevision,
-          profile: petProfile()
+        const next = await requestPetGateway<PetInfo & { spritesheetUnchanged?: boolean }>('pet.info', {
+          knownRevision
         })
 
         if (!cancelled && next) {
@@ -266,15 +280,15 @@ export function FloatingPet() {
 
       window.clearInterval(timer)
     }
-  }, [gatewayState, active, changeEventsAvailable, petChange, requestGateway])
+  }, [gatewayState, active, changeEventsAvailable, petChange, requestPetGateway])
 
-  // Pets are per-profile. When the active profile changes, drop the previous
-  // profile's mascot + gallery cache so the poll above refetches the new
-  // profile's pet (its config + pets dir resolve per-profile on the backend).
-  useOnProfileSwitch(() => {
+  // Pets follow the exact Bot owner as well as ordinary profile switches. Drop
+  // the prior sprite immediately so a slow remote dial never leaves the default
+  // profile's mascot painted over the selected bot.
+  useEffect(() => {
     setPetInfo({ enabled: false })
     resetPetGallery()
-  })
+  }, [owner])
 
   // Wire the overlay control channel once, only in the primary window — the
   // pop-out overlay belongs to it (main.ts positions it against the main
@@ -409,7 +423,7 @@ export function FloatingPet() {
   // off. The reclamp effect (via `clamp`) still guarantees it stays on-screen.
   const onScale = useCallback(
     (next: number, { clientX, clientY, ratio }: PetZoomAnchor) => {
-      setPetScale(requestGateway, next)
+      setPetScale(requestPetGateway, next)
       setPosition(prev => {
         const at = clampPoint(
           clientX - (clientX - prev.x) * ratio,
@@ -423,7 +437,7 @@ export function FloatingPet() {
         return at
       })
     },
-    [requestGateway, info.frameW, info.frameH]
+    [requestPetGateway, info.frameW, info.frameH]
   )
 
   usePetZoomGesture(containerRef, onScale, active && !overlayActive)

--- a/apps/desktop/src/store/pet-gallery.test.ts
+++ b/apps/desktop/src/store/pet-gallery.test.ts
@@ -1,7 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+vi.mock('@/store/gateway', () => ({
+  requestGatewayForAgent: vi.fn()
+}))
+
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { requestGatewayForAgent } from '@/store/gateway'
+
 import { $petInfo, setPetInfo } from './pet'
-import { $petGallery, adoptPet, type GatewayRequest, loadPetGallery, resetPetGallery } from './pet-gallery'
+import {
+  $petGallery,
+  adoptPet,
+  type GatewayRequest,
+  loadPetGallery,
+  loadPetThumb,
+  resetPetGallery
+} from './pet-gallery'
 
 function localGallery() {
   return {
@@ -13,14 +27,43 @@ function localGallery() {
 
 describe('pet gallery pet.info sync', () => {
   beforeEach(() => {
+    setWorkspaceScope('sessions')
+    vi.mocked(requestGatewayForAgent).mockReset()
     resetPetGallery()
     setPetInfo({ enabled: false })
   })
 
   afterEach(() => {
+    setWorkspaceScope('sessions')
     resetPetGallery()
     setPetInfo({ enabled: false })
     vi.restoreAllMocks()
+  })
+
+  it('routes gallery RPCs through the selected Bot connection', async () => {
+    setWorkspaceScope('bots', 'jaime-vpn::scout', {
+      kind: 'route',
+      route: {
+        connectionId: 'jaime-vpn',
+        mode: 'remote',
+        profile: 'scout',
+        targetProfile: 'scout'
+      }
+    })
+
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({ ok: true, dataUri: 'data:image/png;base64,pet' } as never)
+
+    const ambient = vi.fn(async () => {
+      throw new Error('ambient gateway must not receive a routed Bot pet RPC')
+    }) as unknown as GatewayRequest
+
+    await expect(loadPetThumb(ambient, 'cache-capy')).resolves.toBe('data:image/png;base64,pet')
+    expect(requestGatewayForAgent).toHaveBeenCalledWith('jaime-vpn', 'scout', 'pet.thumb', {
+      profile: 'scout',
+      slug: 'cache-capy',
+      url: ''
+    })
+    expect(ambient).not.toHaveBeenCalled()
   })
 
   it('uses pet.info.meta and keeps the cached spritesheet when the revision is current', async () => {

--- a/apps/desktop/src/store/pet-gallery.ts
+++ b/apps/desktop/src/store/pet-gallery.ts
@@ -2,13 +2,15 @@ import { atom } from 'nanostores'
 
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { normalize } from '@/lib/text'
+import { requestGatewayForAgent } from '@/store/gateway'
 import {
   $petInfo,
   hasPetSpriteForMeta,
   mergePetInfoMeta,
   type PetInfo,
   type PetInfoMeta,
-  petProfile,
+  petOwner,
+  requestPetForOwner,
   setPetInfo
 } from '@/store/pet'
 
@@ -58,11 +60,17 @@ export type GatewayRequest = <T>(
   signal?: AbortSignal
 ) => Promise<T>
 
-/** Profile-scoped pet RPC. Pets are per-profile, so every call carries the active
- *  profile (the gateway no-ops it for the launch profile). One chokepoint so no
- *  call site can forget it. */
+/** Profile-scoped pet RPC. Bot Mode can target another registered connection,
+ * so the exact owner route wins over the ambient requester's gateway. */
 const petRpc = <T>(request: GatewayRequest, method: string, params: Record<string, unknown> = {}): Promise<T> =>
-  request<T>(method, { ...params, profile: petProfile() })
+  requestPetForOwner<T>(
+    petOwner(),
+    method,
+    params,
+    (ambientMethod, ambientParams) => request<T>(ambientMethod, ambientParams),
+    (connectionId, profile, routedMethod, routedParams) =>
+      requestGatewayForAgent<T>(connectionId, profile, routedMethod, routedParams)
+  )
 
 /** A JSON-RPC "method not found" — the backend predates the pet RPCs. */
 export const $petGallery = atom<PetGallery | null>(null)

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
+
+import { setWorkspaceScope } from '@/components/pane-shell/workspace-scope'
+import { $activeGatewayProfile } from '@/store/profile'
 
 import {
   $petActivity,
@@ -10,8 +13,69 @@ import {
   hasPetSpriteForMeta,
   mergePetInfoMeta,
   type PetInfo,
+  petOwner,
+  petProfile,
+  requestPetForOwner,
   setPetActivity
 } from './pet'
+
+describe('pet owner routing', () => {
+  it('follows the exact Bot workspace owner instead of the ambient default profile', () => {
+    $activeGatewayProfile.set('default')
+    setWorkspaceScope('bots', 'jaime-vpn::scout', {
+      kind: 'route',
+      route: {
+        connectionId: 'jaime-vpn',
+        mode: 'remote',
+        profile: 'scout',
+        targetProfile: 'scout'
+      }
+    })
+
+    expect(petProfile()).toBe('scout')
+    expect(petOwner()).toEqual({
+      connectionId: 'jaime-vpn',
+      profile: 'scout',
+      targetProfile: 'scout'
+    })
+
+    setWorkspaceScope('sessions')
+  })
+
+  it('routes a Bot pet RPC through the selected bot connection', async () => {
+    const ambient = vi.fn()
+    const routed = vi.fn(async () => ({ slug: 'cache-capy' }))
+
+    const owner = {
+      connectionId: 'jaime-vpn',
+      profile: 'scout',
+      targetProfile: 'scout'
+    }
+
+    await expect(
+      requestPetForOwner(owner, 'pet.info', { knownRevision: 'old' }, ambient, routed)
+    ).resolves.toEqual({ slug: 'cache-capy' })
+    expect(routed).toHaveBeenCalledWith('jaime-vpn', 'scout', 'pet.info', {
+      knownRevision: 'old',
+      profile: 'scout'
+    })
+    expect(ambient).not.toHaveBeenCalled()
+  })
+
+  it('uses the ambient profile outside an exactly routed Bot workspace', () => {
+    $activeGatewayProfile.set('nightwatch')
+    setWorkspaceScope('bots', 'group:ops', {
+      kind: 'blocked',
+      message: 'Group chats have no single owner.'
+    })
+
+    expect(petProfile()).toBe('nightwatch')
+    expect(petOwner()).toEqual({ profile: 'nightwatch', targetProfile: 'nightwatch' })
+
+    setWorkspaceScope('sessions')
+    $activeGatewayProfile.set('default')
+  })
+})
 
 describe('derivePetState', () => {
   it('rests at idle by default and uses waiting when awaiting input', () => {

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -14,6 +14,7 @@ import {
   mergePetInfoMeta,
   type PetInfo,
   petOwner,
+  petOwnerUsesAmbientGateway,
   petProfile,
   requestPetForOwner,
   setPetActivity
@@ -38,6 +39,7 @@ describe('pet owner routing', () => {
       profile: 'scout',
       targetProfile: 'scout'
     })
+    expect(petOwnerUsesAmbientGateway(petOwner())).toBe(false)
 
     setWorkspaceScope('sessions')
   })
@@ -71,6 +73,7 @@ describe('pet owner routing', () => {
 
     expect(petProfile()).toBe('nightwatch')
     expect(petOwner()).toEqual({ profile: 'nightwatch', targetProfile: 'nightwatch' })
+    expect(petOwnerUsesAmbientGateway(petOwner())).toBe(true)
 
     setWorkspaceScope('sessions')
     $activeGatewayProfile.set('default')

--- a/apps/desktop/src/store/pet.test.ts
+++ b/apps/desktop/src/store/pet.test.ts
@@ -14,6 +14,7 @@ import {
   mergePetInfoMeta,
   type PetInfo,
   petOwner,
+  petOwnerChanged,
   petOwnerUsesAmbientGateway,
   petProfile,
   requestPetForOwner,
@@ -40,6 +41,28 @@ describe('pet owner routing', () => {
       targetProfile: 'scout'
     })
     expect(petOwnerUsesAmbientGateway(petOwner())).toBe(false)
+
+    setWorkspaceScope('sessions')
+  })
+
+  it('does not treat initial owner hydration as a switch', () => {
+    const ambient = { profile: 'default', targetProfile: 'default' }
+    const routed = { connectionId: 'jaime-vpn', profile: 'scout', targetProfile: 'scout' }
+
+    expect(petOwnerChanged(undefined, ambient)).toBe(false)
+    expect(petOwnerChanged(ambient, { ...ambient })).toBe(false)
+    expect(petOwnerChanged(ambient, routed)).toBe(true)
+  })
+
+  it('falls back to ambient ownership for a malformed Bot route', () => {
+    $activeGatewayProfile.set('default')
+    setWorkspaceScope('bots', 'broken::route', {
+      kind: 'route',
+      route: { connectionId: undefined, profile: undefined } as never
+    })
+
+    expect(() => petOwner()).not.toThrow()
+    expect(petOwner()).toEqual({ profile: 'default', targetProfile: 'default' })
 
     setWorkspaceScope('sessions')
   })

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -161,14 +161,17 @@ export const $petOwner = computed(
     const activeProfile = normalizeProfileKey(activeGatewayProfile)
 
     if (workspaceMode === 'bots' && workspaceTarget?.kind === 'route') {
-      const connectionId = workspaceTarget.route.connectionId.trim()
-      const profile = normalizeProfileKey(workspaceTarget.route.profile)
+      const route = workspaceTarget.route
+      const connectionId = String(route?.connectionId ?? '').trim()
+      const routeProfile = String(route?.profile ?? '').trim()
 
-      if (connectionId) {
+      if (connectionId && routeProfile) {
+        const profile = normalizeProfileKey(routeProfile)
+
         return {
           connectionId,
           profile,
-          targetProfile: normalizeProfileKey(workspaceTarget.route.targetProfile || profile)
+          targetProfile: normalizeProfileKey(route.targetProfile || profile)
         }
       }
     }
@@ -179,6 +182,17 @@ export const $petOwner = computed(
 
 export function petOwner(): PetOwner {
   return $petOwner.get()
+}
+
+/** Whether a previously rendered owner actually changed. The missing previous
+ * owner is initial hydration, not a switch — callers must preserve warm state. */
+export function petOwnerChanged(previous: PetOwner | undefined, next: PetOwner): boolean {
+  return Boolean(
+    previous &&
+      (previous.connectionId !== next.connectionId ||
+        previous.profile !== next.profile ||
+        previous.targetProfile !== next.targetProfile)
+  )
 }
 
 /** Ambient gateway state/events apply only when no exact Bot owner route exists. */

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -1,5 +1,6 @@
 import { atom, computed } from 'nanostores'
 
+import { $workspaceMode, $workspaceNewSessionTarget } from '@/components/pane-shell/workspace-scope'
 import { persistBoolean, storedBoolean } from '@/lib/storage'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { $busy } from '@/store/session'
@@ -143,15 +144,67 @@ export const $petActivity = atom<PetActivity>({})
 export const $petActive = computed($petInfo, info => info.enabled && Boolean(info.spritesheetBase64))
 
 /**
- * Profile the pet RPCs should resolve against. Pets are per-profile — the active
- * pet (`display.pet.*`) and the installed sprites live under each profile's
- * HERMES_HOME — so every pet RPC carries this. The gateway no-ops it for the
- * launch profile (own-profile backends already resolve it) and rebinds for any
- * other profile, which is what makes per-profile pets work in app-global remote
- * mode (one backend serving every profile).
+ * Exact backend owner whose pet should be rendered. Pets are per-profile: both
+ * `display.pet.*` and installed sprites live under that profile's HERMES_HOME.
+ * Bot Mode keeps the Sessions gateway ambient, so the workspace route — not the
+ * active gateway — is authoritative while a bot chat is selected.
  */
+export interface PetOwner {
+  connectionId?: string
+  profile: string
+  targetProfile: string
+}
+
+export const $petOwner = computed(
+  [$activeGatewayProfile, $workspaceMode, $workspaceNewSessionTarget],
+  (activeGatewayProfile, workspaceMode, workspaceTarget): PetOwner => {
+    const activeProfile = normalizeProfileKey(activeGatewayProfile)
+
+    if (workspaceMode === 'bots' && workspaceTarget?.kind === 'route') {
+      const connectionId = workspaceTarget.route.connectionId.trim()
+      const profile = normalizeProfileKey(workspaceTarget.route.profile)
+
+      if (connectionId) {
+        return {
+          connectionId,
+          profile,
+          targetProfile: normalizeProfileKey(workspaceTarget.route.targetProfile || profile)
+        }
+      }
+    }
+
+    return { profile: activeProfile, targetProfile: activeProfile }
+  }
+)
+
+export function petOwner(): PetOwner {
+  return $petOwner.get()
+}
+
+/** Profile whose config + pet store should answer pet RPCs. */
 export function petProfile(): string {
-  return normalizeProfileKey($activeGatewayProfile.get())
+  return petOwner().targetProfile
+}
+
+/** Route one pet RPC through the exact Bot owner when there is one. The
+ *  target profile remains explicit in params for shared-remote backends. */
+export function requestPetForOwner<T>(
+  owner: PetOwner,
+  method: string,
+  params: Record<string, unknown>,
+  requestAmbient: (method: string, params: Record<string, unknown>) => Promise<T>,
+  requestRouted: (
+    connectionId: string,
+    profile: string,
+    method: string,
+    params: Record<string, unknown>
+  ) => Promise<T>
+): Promise<T> {
+  const routedParams = { ...params, profile: owner.targetProfile }
+
+  return owner.connectionId
+    ? requestRouted(owner.connectionId, owner.profile, method, routedParams)
+    : requestAmbient(method, routedParams)
 }
 
 /**

--- a/apps/desktop/src/store/pet.ts
+++ b/apps/desktop/src/store/pet.ts
@@ -181,6 +181,11 @@ export function petOwner(): PetOwner {
   return $petOwner.get()
 }
 
+/** Ambient gateway state/events apply only when no exact Bot owner route exists. */
+export function petOwnerUsesAmbientGateway(owner: PetOwner): boolean {
+  return !owner.connectionId
+}
+
 /** Profile whose config + pet store should answer pet RPCs. */
 export function petProfile(): string {
   return petOwner().targetProfile


### PR DESCRIPTION
## Summary
- derive the floating pet owner from Bot Mode's exact workspace route instead of the ambient Sessions gateway
- route pet info, gallery/settings mutations, and scale RPCs through the selected bot's registered connection/profile
- ignore stale ambient pet events and ambient gateway state for exact routed Bot owners
- clear the previous sprite on real owner changes without clearing warm state on initial mount
- normalize malformed Bot routes and fail closed to ambient ownership

## Root cause
Bot chats intentionally preserve the ambient Sessions gateway. The floating pet read only `$activeGatewayProfile` and sent pet RPCs through that ambient socket, so every local or SSH bot rendered the default profile's pet. Ambient pet events and connectivity state could also suppress a healthy routed pet.

## Verification
- `npm exec eslint -- src/store/pet.ts src/store/pet.test.ts src/store/pet-gallery.ts src/store/pet-gallery.test.ts src/components/pet/floating-pet.tsx src/app/settings/pet-settings.tsx src/app/contrib/hooks/use-pet-bridge.ts`
- `npm exec vitest run -- --project ui src/store/pet.test.ts src/store/pet-gallery.test.ts src/components/pet/floating-pet-poll.test.ts` (22/22)
- `npm run typecheck`
- `npm run build`
- full UI suite baseline: 6,930/6,934 passed; four unrelated locale/billing failures outside the changed files

## Review follow-up
- `8bb2b55552`: isolates routed pets from stale ambient disable events, gallery/settings/overlay RPC misrouting, and ambient gateway-state gating.
- `3cfc339c47`: preserves warm pet state on initial mount and normalizes malformed Bot routes defensively.
