### PR TITLE
fix(gateway): honor session model override in /status command (#100323)

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -676,6 +676,22 @@ class GatewaySlashCommandsMixin:
                 context_used = _int_value(getattr(ctx, "last_prompt_tokens", 0))
                 context_total = _int_value(getattr(ctx, "context_length", 0))
 
+        if not route_resolved:
+            override = (getattr(self, "_session_model_overrides", {}) or {}).get(session_key)
+            if not override and getattr(self, "session_store", None):
+                try:
+                    override = self.session_store.get_model_override(session_key)
+                except Exception:
+                    override = None
+            if isinstance(override, dict):
+                override_model = _clean_str(override.get("model"))
+                override_provider = _clean_str(override.get("provider"))
+                if override_model:
+                    model_name = override_model
+                    provider_name = override_provider
+                    base_url = _clean_str(override.get("base_url"))
+                    route_resolved = True
+
         persisted_model = _clean_str(persisted_route.get("model"))
         persisted_provider = _clean_str(persisted_route.get("billing_provider"))
         if not route_resolved and persisted_model and persisted_provider:

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -189,6 +189,50 @@ async def test_status_command_uses_dominant_persisted_model_route(tmp_path):
         db.close()
 
 
+
+@pytest.mark.asyncio
+async def test_status_command_honors_session_model_override_over_dominant_route(tmp_path):
+    """Session-level /model override must take precedence over historical dominant route (#100323)."""
+    source = _make_source()
+    session_key = build_session_key(source)
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    db = SessionDB(db_path=tmp_path / "state.db")
+    runner._session_db = AsyncSessionDB(db)
+    try:
+        db.create_session("sess-1", "telegram", model="old-model")
+        # Old model accumulated 50 calls
+        db.update_token_counts(
+            "sess-1",
+            model="old-model",
+            billing_provider="old-provider",
+            input_tokens=1000,
+            api_call_count=50,
+        )
+        # User ran /model new-model --provider new-provider (saved in session_store / _session_model_overrides)
+        runner.session_store.set_model_override(
+            session_key,
+            {"model": "new-model", "provider": "new-provider"},
+        )
+        runner._session_model_overrides[session_key] = {
+            "model": "new-model",
+            "provider": "new-provider",
+        }
+
+        result = await runner._handle_message(_make_event("/status"))
+
+        assert "**Model:** `new-model` (new-provider)" in result
+        assert "old-model" not in result
+    finally:
+        db.close()
+
 @pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())


### PR DESCRIPTION
## What does this PR do?

When a user switches models in a session via `/model <new_model> [--provider <provider>]`, `/status` between turns was ignoring the active session-scoped model override and instead reporting the historically dominant model from `SessionDB` (the model with the highest lifetime call count in that session).

This PR updates `GatewaySlashCommandsMixin._handle_status_command()` to check for an active session model override (in `_session_model_overrides` and `session_store.get_model_override()`) before falling back to the dominant historical route or global config.

## Related Issue

Fixes #100323

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/slash_commands.py`: In `_handle_status_command()`, resolve active session `/model` override from `_session_model_overrides` / `session_store.get_model_override()` before falling back to `get_dominant_session_model_route()`.
- `tests/gateway/test_status_command.py`: Added regression test `test_status_command_honors_session_model_override_over_dominant_route` ensuring `/status` reports the newly selected session model override even when a previous model has higher historical token/call counts.

## How to Test

1. Run the regression test:
   `python -m pytest tests/gateway/test_status_command.py -k test_status_command_honors_session_model_override_over_dominant_route`
2. Run the status test suite:
   `python -m pytest tests/gateway/test_status_command.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_status_command.py` and tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
