### PR TITLE
fix(retry): apply the adaptive long backoff to Cloudflare capacity 429s

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -81,9 +81,9 @@ from agent.prompt_caching import (
 )
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
-    is_zai_coding_overload_error,
+    capacity_overload_policy,
+    capacity_overload_retry_ceiling,
     jittered_backoff,
-    zai_coding_overload_retry_ceiling,
 )
 from agent.trajectory import has_incomplete_scratchpad
 # Bind before the turn starts so a source-tree swap cannot load a skewed
@@ -4798,18 +4798,22 @@ def run_conversation(
                     FailoverReason.timeout,
                     FailoverReason.overloaded,
                 }
-                # Z.AI Coding Plan GLM-5.2 overload 429s classify as
-                # `overloaded` (to spare the credential pool), but `overloaded`
-                # is excluded from `is_rate_limited` — the gate for the adaptive
-                # Z.AI backoff below. Detect the overload directly so its
-                # long-backoff schedule runs, and raise the retry ceiling so the
-                # long tier (30/60/90/120s) is reachable. See
-                # zai_coding_overload_retry_ceiling() for the ceiling rationale.
-                _is_zai_coding_overload = is_zai_coding_overload_error(
+                # Provider capacity overloads (Z.AI Coding Plan GLM-5.2 1305s,
+                # Cloudflare Workers AI 3040s) need the adaptive long backoff:
+                # the account/endpoint needs time to drain, so the default 2-5s
+                # schedule just burns all three attempts against the same
+                # window. Z.AI overloads additionally classify as `overloaded`,
+                # which is excluded from `is_rate_limited` — the gate for the
+                # adaptive backoff below — so detect the capacity shape directly
+                # and raise the retry ceiling so the long tier (30/60/90/120s)
+                # is reachable. See capacity_overload_retry_ceiling() for the
+                # ceiling rationale.
+                _capacity_policy = capacity_overload_policy(
                     base_url=str(_base), model=_model, error=api_error
                 )
-                if _is_zai_coding_overload:
-                    max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                _is_capacity_overload = _capacity_policy is not None
+                if _is_capacity_overload:
+                    max_retries = max(max_retries, capacity_overload_retry_ceiling())
                 _should_fallback = (
                     is_rate_limited
                     or (_is_transport_failure and retry_count >= 2)
@@ -5912,7 +5916,7 @@ def run_conversation(
                                 pass
                 wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
                 _backoff_policy = None
-                if (is_rate_limited or _is_zai_coding_overload) and not _retry_after:
+                if (is_rate_limited or _is_capacity_overload) and not _retry_after:
                     wait_time, _backoff_policy = adaptive_rate_limit_backoff(
                         retry_count,
                         base_url=str(_base),
@@ -5920,18 +5924,23 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                if is_rate_limited or _is_capacity_overload:
+                    _policy_label = {
+                        "zai_coding_overload": "Z.AI Coding overload",
+                        "cloudflare_capacity": "Cloudflare capacity",
+                    }.get(_capacity_policy or "", "")
                     _policy_note = ""
-                    if _backoff_policy == "zai_coding_overload_long":
-                        _policy_note = " (Z.AI Coding overload adaptive long backoff)"
-                    elif _backoff_policy == "zai_coding_overload_short":
-                        _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    if _backoff_policy and _policy_label:
+                        if _backoff_policy.endswith("_long"):
+                            _policy_note = f" ({_policy_label} adaptive long backoff)"
+                        elif _backoff_policy.endswith("_short"):
+                            _policy_note = f" ({_policy_label} short retry)"
+                    _wait_reason = "Provider overloaded" if _is_capacity_overload and not is_rate_limited else "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
-                    # Z.AI Coding waits are different: they can last minutes, so surface
+                    # capacity waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
+                    if _backoff_policy and _backoff_policy.endswith("_long"):
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -18,21 +18,27 @@ from typing import Any, Optional
 _jitter_counter = 0
 _jitter_lock = threading.Lock()
 
-# Z.AI Coding Plan's GLM-5.2 endpoint often returns HTTP 429 code 1305
-# ("The service may be temporarily overloaded...") for otherwise valid
-# Hermes requests. Short retries tend to hammer the same overloaded window;
-# after a few normal retries, progressively widen the wait window. Keep the
-# cap interactive-friendly: a simple TUI message should fail visibly in minutes,
+# Some providers report transient *capacity* pressure as a 429 that a short
+# retry cannot clear: Z.AI Coding Plan's GLM-5.2 endpoint returns code 1305
+# ("The service may be temporarily overloaded..."), and Cloudflare Workers AI
+# returns code 3040 ("Capacity temporarily exceeded, please try again") under
+# account contention. Short retries just hammer the same window; after a few
+# normal retries, progressively widen the wait. Keep the cap
+# interactive-friendly: a simple TUI message should fail visibly in minutes,
 # not sit silent for 20+ minutes.
-_ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
+_CAPACITY_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 
 # Number of initial short retries before the adaptive long-backoff tier kicks
 # in. Shared by ``adaptive_rate_limit_backoff`` (which walks the long table
 # starting at attempt ``short_attempts + 1``) and
-# ``zai_coding_overload_retry_ceiling`` (which sizes the retry loop so every
+# ``capacity_overload_retry_ceiling`` (which sizes the retry loop so every
 # long-tier entry is reachable). Keeping it a single module constant prevents
 # the two from silently desyncing if the short-retry count is ever tuned.
-_ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
+_CAPACITY_OVERLOAD_SHORT_ATTEMPTS = 3
+
+# Back-compat aliases for the Z.AI-only names these constants shipped under.
+_ZAI_CODING_OVERLOAD_LONG_BACKOFF = _CAPACITY_OVERLOAD_LONG_BACKOFF
+_ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS
 
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
@@ -159,6 +165,43 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     )
 
 
+def is_cloudflare_capacity_error(*, base_url: str | None, error: Any) -> bool:
+    """Return True for Cloudflare Workers AI transient capacity 429s.
+
+    Workers AI reports account-level contention as HTTP 429 with body code
+    3040 and message "Capacity temporarily exceeded, please try again"
+    (surfaced as ``AiError``). Like the Z.AI overload shape, retrying against
+    the same short window rarely helps — the account needs time to drain.
+
+    The match is deliberately narrow (Cloudflare host + that one message/code)
+    so ordinary quota/billing 429s keep failing fast through the existing
+    classifier. Unlike the Z.AI check there is no model constraint: every
+    ``@cf/...`` model on the account shares the same capacity pool.
+    """
+    base = (base_url or "").lower()
+    status = getattr(error, "status_code", None)
+    text = _error_text(error)
+    return (
+        status == 429
+        and "api.cloudflare.com" in base
+        and ("3040" in text or "capacity temporarily exceeded" in text)
+    )
+
+
+def capacity_overload_policy(*, base_url: str | None, model: str | None, error: Any) -> str | None:
+    """Name the provider capacity-overload policy an error qualifies for.
+
+    Returns ``"zai_coding_overload"``, ``"cloudflare_capacity"``, or ``None``
+    when no provider-specific long-backoff policy applies. Callers use this to
+    gate both the adaptive backoff and the extended retry ceiling.
+    """
+    if is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+        return "zai_coding_overload"
+    if is_cloudflare_capacity_error(base_url=base_url, error=error):
+        return "cloudflare_capacity"
+    return None
+
+
 def adaptive_rate_limit_backoff(
     attempt: int,
     *,
@@ -166,33 +209,39 @@ def adaptive_rate_limit_backoff(
     model: str | None,
     error: Any,
     default_wait: float,
-    short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS,
+    short_attempts: int = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS,
 ) -> tuple[float, str | None]:
     """Provider-aware rate-limit backoff.
 
-    For most providers this returns ``default_wait`` unchanged. For Z.AI
-    Coding Plan GLM-5.2 overloads, keep the first ``short_attempts`` retries on
-    the normal short exponential schedule, then switch to progressively longer
-    waits (30s → 60s → 90s → 120s, capped) plus light jitter.
+    For most providers this returns ``default_wait`` unchanged. For provider
+    capacity overloads (Z.AI Coding Plan GLM-5.2 1305s, Cloudflare Workers AI
+    3040s), keep the first ``short_attempts`` retries on the normal short
+    exponential schedule, then switch to progressively longer waits
+    (30s → 60s → 90s → 120s, capped) plus light jitter.
 
     ``attempt`` is 1-based, matching the retry loop's logged attempt number.
-    Returns ``(wait_seconds, reason_label)`` where ``reason_label`` is suitable
-    for status/log decoration when a provider-specific policy fired.
+    Returns ``(wait_seconds, reason_label)`` where ``reason_label`` is
+    ``"<policy>_short"`` / ``"<policy>_long"`` and is suitable for status/log
+    decoration when a provider-specific policy fired.
     """
-    if not is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+    policy = capacity_overload_policy(base_url=base_url, model=model, error=error)
+    if policy is None:
         return default_wait, None
     if attempt <= short_attempts:
-        return default_wait, "zai_coding_overload_short"
+        return default_wait, f"{policy}_short"
 
-    idx = min(attempt - short_attempts - 1, len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) - 1)
-    base_delay = _ZAI_CODING_OVERLOAD_LONG_BACKOFF[idx]
+    idx = min(attempt - short_attempts - 1, len(_CAPACITY_OVERLOAD_LONG_BACKOFF) - 1)
+    base_delay = _CAPACITY_OVERLOAD_LONG_BACKOFF[idx]
     # A smaller jitter ratio keeps long waits readable while still avoiding
     # synchronized retry storms across concurrent Hermes sessions.
-    return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+    return (
+        jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2),
+        f"{policy}_long",
+    )
 
 
-def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS) -> int:
-    """Retry-loop ceiling needed for the full Z.AI overload backoff schedule.
+def capacity_overload_retry_ceiling(short_attempts: int = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS) -> int:
+    """Retry-loop ceiling needed for the full capacity-overload backoff schedule.
 
     The adaptive policy runs ``short_attempts`` short retries, then walks the
     long-backoff table one entry per subsequent attempt. The retry loop gives
@@ -200,9 +249,15 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     attempt's backoff is computed — so the ceiling must sit one past the final
     long-backoff entry for every long tier to actually execute.
 
-    With the default ``api_max_retries`` (3) equal to ``short_attempts`` (3),
-    the loop always gave up before reaching the long tier, leaving the whole
-    long-backoff schedule as dead code. Callers extend the ceiling to this
-    value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
+    With the default ``agent.api_max_retries`` (3) equal to ``short_attempts``
+    (3), the loop always gave up before reaching the long tier, leaving the
+    whole long-backoff schedule as dead code. Callers extend the ceiling to
+    this value for capacity-overload 429s (Z.AI 1305, Cloudflare 3040) so the
+    30/60/90/120s waits run.
     """
-    return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+    return short_attempts + len(_CAPACITY_OVERLOAD_LONG_BACKOFF) + 1
+
+
+# Back-compat alias for the Z.AI-only name this helper shipped under. The
+# ceiling is schedule-derived, so both policies share one value.
+zai_coding_overload_retry_ceiling = capacity_overload_retry_ceiling

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -903,6 +903,13 @@ agent:
   # to 1 if you use fallback providers and want fast failover on flaky
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
+  #
+  # Provider *capacity* 429s (Z.AI Coding Plan code 1305, Cloudflare Workers AI
+  # code 3040 "Capacity temporarily exceeded") are the exception: those get an
+  # adaptive long backoff (30s → 60s → 90s → 120s) after the first
+  # api_max_retries short attempts, and the retry ceiling is raised
+  # automatically so the long tier is reachable. Lowering api_max_retries only
+  # shortens the fast-retry phase before that schedule starts.
   # api_max_retries: 3
 
   # After the agent edits code without fresh passing verification, nudge it to

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,12 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_cloudflare_capacity_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+)
 
 
 def test_backoff_is_exponential():
@@ -167,6 +172,143 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
 
     assert long_waits, "long-backoff tier never reached within the retry ceiling"
     assert long_waits == [30.0, 60.0, 90.0, 120.0]
+
+
+# ---------------------------------------------------------------------------
+# Cloudflare Workers AI capacity 429s (code 3040)
+# ---------------------------------------------------------------------------
+
+_CF_BASE_URL = "https://api.cloudflare.com/client/v4/accounts/acct/ai/v1"
+
+
+def _cf_capacity_error():
+    return SimpleNamespace(
+        status_code=429,
+        body={
+            "errors": [
+                {
+                    "code": 3040,
+                    "message": "AiError: Capacity temporarily exceeded, please try again",
+                }
+            ]
+        },
+    )
+
+
+def test_cf_capacity_error_detected():
+    """The narrow CF capacity shape (429 + cloudflare host + 3040) matches."""
+    assert is_cloudflare_capacity_error(base_url=_CF_BASE_URL, error=_cf_capacity_error())
+
+
+def test_cf_capacity_error_matches_any_cf_model():
+    """Capacity is account-scoped, so detection must not depend on the model."""
+    _wait, policy = adaptive_rate_limit_backoff(
+        1,
+        base_url=_CF_BASE_URL,
+        model="@cf/zai-org/glm-5.3-flash",
+        error=_cf_capacity_error(),
+        default_wait=2.0,
+    )
+    assert policy == "cloudflare_capacity_short"
+
+
+def test_cf_capacity_ignores_other_hosts():
+    """The same body from a non-Cloudflare host is not a CF capacity error."""
+    assert not is_cloudflare_capacity_error(
+        base_url="https://api.deepseek.com/v1", error=_cf_capacity_error()
+    )
+
+
+def test_cf_ordinary_429_still_fails_fast():
+    """Quota/billing 429s from Cloudflare keep the default short backoff."""
+    quota_error = SimpleNamespace(
+        status_code=429,
+        body={"errors": [{"code": 10000, "message": "Daily request limit exceeded"}]},
+    )
+    assert not is_cloudflare_capacity_error(base_url=_CF_BASE_URL, error=quota_error)
+    wait, policy = adaptive_rate_limit_backoff(
+        5,
+        base_url=_CF_BASE_URL,
+        model="@cf/deepseek-ai/deepseek-v4-flash-0731",
+        error=quota_error,
+        default_wait=2.0,
+    )
+    assert (wait, policy) == (2.0, None)
+
+
+def test_cf_capacity_non_429_is_not_capacity():
+    """A 500 carrying the same text is not the capacity 429 shape."""
+    err = SimpleNamespace(
+        status_code=500,
+        body={"errors": [{"code": 3040, "message": "Capacity temporarily exceeded"}]},
+    )
+    assert not is_cloudflare_capacity_error(base_url=_CF_BASE_URL, error=err)
+
+
+def test_cf_capacity_long_tier_reachable_within_ceiling(monkeypatch):
+    """With the extended ceiling, CF capacity 429s walk the full
+    30/60/90/120s schedule — the same tiers the Z.AI path uses."""
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    from agent.retry_utils import capacity_overload_retry_ceiling
+
+    err = _cf_capacity_error()
+    ceiling = capacity_overload_retry_ceiling()
+
+    long_waits = []
+    for attempt in range(1, ceiling):
+        _wait, policy = adaptive_rate_limit_backoff(
+            attempt,
+            base_url=_CF_BASE_URL,
+            model="@cf/deepseek-ai/deepseek-v4-flash-0731",
+            error=err,
+            default_wait=1.0,
+        )
+        if policy == "cloudflare_capacity_long":
+            long_waits.append(_wait)
+
+    assert long_waits, "long-backoff tier never reached within the retry ceiling"
+    assert long_waits == [30.0, 60.0, 90.0, 120.0]
+
+
+def test_zai_and_cf_share_one_ceiling():
+    """Both policies walk the same table, so one ceiling covers both. The
+    Z.AI-era name stays exported for callers that still import it."""
+    from agent.retry_utils import (
+        capacity_overload_retry_ceiling,
+        zai_coding_overload_retry_ceiling,
+    )
+
+    assert zai_coding_overload_retry_ceiling() == capacity_overload_retry_ceiling()
+
+
+def test_capacity_policy_prefers_matching_provider():
+    """capacity_overload_policy names the provider that actually matched."""
+    from agent.retry_utils import capacity_overload_policy
+
+    assert (
+        capacity_overload_policy(
+            base_url="https://api.z.ai/api/coding/paas/v4",
+            model="glm-5.2",
+            error=_zai_overload_error(),
+        )
+        == "zai_coding_overload"
+    )
+    assert (
+        capacity_overload_policy(
+            base_url=_CF_BASE_URL,
+            model="@cf/deepseek-ai/deepseek-v4-flash-0731",
+            error=_cf_capacity_error(),
+        )
+        == "cloudflare_capacity"
+    )
+    assert (
+        capacity_overload_policy(
+            base_url="https://api.openai.com/v1",
+            model="gpt-5",
+            error=SimpleNamespace(status_code=429, body={"error": "rate limit"}),
+        )
+        is None
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

### Symptom

Running Hermes against Cloudflare Workers AI, turns die outright when the
account is under contention. Workers AI returns:

```
HTTP 429  AiError: Capacity temporarily exceeded, please try again   (code 3040)
```

The conversation loop classifies it as an ordinary rate limit and retries on the
short default schedule — roughly 2–5s, three attempts. All three land inside the
same congested window, the retries are exhausted in under fifteen seconds, and
the turn fails. The capacity almost always frees up shortly after; the agent just
never waits long enough to find out.

### Root cause

The agent already has exactly the right mechanism. `agent/retry_utils.py`
implements an adaptive long backoff — three short attempts, then 30s → 60s →
90s → 120s with light jitter — plus `zai_coding_overload_retry_ceiling()`, which
raises the retry ceiling so the long tier is actually reachable (with the default
`api_max_retries = 3`, the loop would otherwise give up before ever entering it).

But that mechanism is gated on `is_zai_coding_overload_error`, which requires
`api.z.ai/api/coding/paas/v4` in the base URL *and* `glm-5.2` in the model name.
Cloudflare capacity 429s are the same class of failure — a provider-side
capacity window that only time clears — and get none of it.

### Change

Generalize the gate instead of duplicating the schedule:

- **`is_cloudflare_capacity_error(base_url, error)`** — matches only HTTP 429 +
  `api.cloudflare.com` in the base URL + `3040` / "capacity temporarily
  exceeded" in the error text. Deliberately narrow, so ordinary Cloudflare quota
  and billing 429s keep failing fast through the existing classifier. Unlike the
  Z.AI check it has **no model constraint**: Workers AI capacity is
  account-scoped and shared by every `@cf/...` model.
- **`capacity_overload_policy(base_url, model, error)`** — returns
  `"zai_coding_overload"`, `"cloudflare_capacity"`, or `None`. One gate for both
  the backoff and the retry ceiling.
- The long-backoff table, the short-attempt count, and the retry ceiling are now
  provider-neutral (`_CAPACITY_OVERLOAD_LONG_BACKOFF`,
  `_CAPACITY_OVERLOAD_SHORT_ATTEMPTS`, `capacity_overload_retry_ceiling`). The
  previous Z.AI-only names are kept as aliases, so any caller still importing
  them keeps working.
- `adaptive_rate_limit_backoff` returns `"<policy>_short"` / `"<policy>_long"`.
  The Z.AI labels are byte-identical to before (`zai_coding_overload_long`), so
  existing assertions and log greps are unaffected.
- `agent/conversation_loop.py` detects the policy once, raises `max_retries` to
  the shared ceiling for either provider, and derives the status/log decoration
  from the matched policy instead of hardcoded Z.AI strings. Long waits are
  still emitted immediately rather than buffered, so the TUI does not look
  frozen for two minutes.

**No behavior changes for any other provider or error shape.** The whole change
is additive: one more error shape enters an existing, already-tested path.

### Change to configuration

None required. `agent.api_max_retries` (default 3) already governs the short
phase; the note in `cli-config.yaml.example` now records that capacity 429s get
the long schedule on top of it, and that lowering `api_max_retries` shortens the
fast-retry phase rather than disabling the long backoff.

## Related Issue

No existing issue found for this — I searched open and closed issues and PRs for
the Cloudflare capacity 429 / code 3040 shape and turned up nothing. Happy to
open one first and link it if the project prefers issue-first.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/retry_utils.py` — add `is_cloudflare_capacity_error` and
  `capacity_overload_policy`; rename the backoff table / short-attempt count /
  ceiling to provider-neutral names with back-compat aliases; make
  `adaptive_rate_limit_backoff` policy-driven.
- `agent/conversation_loop.py` — detect the capacity policy once, apply the
  shared retry ceiling, derive status decoration from the matched policy.
- `tests/test_retry_utils.py` — Cloudflare-path tests mirroring the Z.AI coverage.
- `cli-config.yaml.example` — note how `agent.api_max_retries` pairs with the
  long backoff for capacity errors.

## How to Test

1. `pytest tests/test_retry_utils.py -q` → 19 passed.
2. Detection, in isolation:
   ```python
   from agent.retry_utils import capacity_overload_policy
   from types import SimpleNamespace
   err = SimpleNamespace(status_code=429, body={"errors": [
       {"code": 3040, "message": "AiError: Capacity temporarily exceeded, please try again"}]})
   capacity_overload_policy(
       base_url="https://api.cloudflare.com/client/v4/accounts/acct/ai/v1",
       model="@cf/deepseek-ai/deepseek-v4-flash-0731", error=err)
   # -> 'cloudflare_capacity'
   ```
3. Against a live Workers AI route under contention: instead of exhausting
   three ~2s retries and killing the turn, the loop now runs those three short
   attempts and then emits a `(Cloudflare capacity adaptive long backoff)`
   status line for each of the 30/60/90/120s waits.

### Tests added

Mirroring the existing Z.AI coverage, for the Cloudflare path:

- capacity 429 is detected;
- detection is model-independent (a `@cf/zai-org/...` model matches too);
- the same body from a non-Cloudflare host does **not** match;
- a non-429 carrying the same text does **not** match;
- an ordinary Cloudflare quota 429 still returns the default wait and no policy
  (i.e. still fails fast);
- an end-to-end walk over the attempt range the retry loop actually executes,
  asserting the full `[30.0, 60.0, 90.0, 120.0]` schedule is reachable within
  the ceiling;
- both policies resolve to the same ceiling, and the Z.AI-era name is still
  exported.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — see note below
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 27.0 (arm64), Python 3.14

> **Note on the full suite:** `tests/test_retry_utils.py` passes (19/19) and both
> touched modules import cleanly. I was not able to run the full `pytest tests/`
> on this machine — the environment I have available is missing some runtime
> dependencies (`dotenv`), which breaks collection of the `tests/run_agent/`
> modules for reasons unrelated to this change. Worth a CI run before merge.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings in the touched module) — the
      rationale for the narrow match and the shared ceiling lives next to the code
- [x] I've updated `cli-config.yaml.example` (note on `agent.api_max_retries`)
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure-Python retry logic, no platform-specific behavior
- [x] N/A — no tool behavior changed
