### PR TITLE
fix(skills): ledger write_file and patch hits on live skill trees

### DIFF
--- a/tests/tools/test_skill_ledger.py
+++ b/tests/tools/test_skill_ledger.py
@@ -558,3 +558,100 @@ def test_backup_fill_ignores_tar_path_traversal(ledger_env):
     )
     # Malicious members are not.
     assert not any(p.endswith("evil.md") or p.endswith("outside.md") for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# File-tool skill-tree writes (observability for write_file / patch bypass)
+# ---------------------------------------------------------------------------
+
+
+def test_classify_skill_tree_write_same_profile(ledger_env):
+    from tools import skill_ledger
+
+    skill_md = ledger_env["skills"] / "obs-gap" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text(VALID_SKILL_CONTENT.replace("my-skill", "obs-gap"), encoding="utf-8")
+    hit = skill_ledger.classify_skill_tree_write(str(skill_md))
+    assert hit is not None
+    assert hit["skill"] == "obs-gap"
+    assert hit["path"] == str(skill_md.resolve())
+
+
+def test_classify_skill_tree_write_skips_sidecars_and_outsiders(ledger_env, tmp_path):
+    from tools import skill_ledger
+
+    usage = ledger_env["skills"] / ".usage.json"
+    usage.write_text("{}", encoding="utf-8")
+    assert skill_ledger.classify_skill_tree_write(str(usage)) is None
+
+    hub = ledger_env["skills"] / ".hub" / "lock.json"
+    hub.parent.mkdir()
+    hub.write_text("{}", encoding="utf-8")
+    assert skill_ledger.classify_skill_tree_write(str(hub)) is None
+
+    outsider = tmp_path / "notes.txt"
+    outsider.write_text("hi", encoding="utf-8")
+    assert skill_ledger.classify_skill_tree_write(str(outsider)) is None
+
+
+def test_write_file_to_skills_is_ledgered(ledger_env, monkeypatch):
+    """write_file landing in ~/.hermes/skills must leave an apply event
+    even when skills.write_approval is on (the gate only covers skill_manage)."""
+    from tools import skill_ledger, write_approval as wa
+    from tools.file_tools import write_file_tool
+
+    monkeypatch.setenv("HERMES_HOME", str(ledger_env["home"]))
+    monkeypatch.setattr(wa, "write_approval_enabled", lambda subsystem: True)
+
+    target = ledger_env["skills"] / "obs-gap" / "SKILL.md"
+    content = VALID_SKILL_CONTENT.replace("name: my-skill", "name: obs-gap")
+    result = json.loads(write_file_tool(str(target), content))
+    assert not result.get("error"), result
+    assert target.exists()
+    assert wa.pending_count("skills") == 0
+
+    rows = [r for r in skill_ledger.list_entries() if r.get("skill") == "obs-gap"]
+    assert rows, "write_file to a skills tree must append a ledger apply event"
+    entry = rows[0]
+    assert entry["action"] == "write_file"
+    assert entry["evidence"].get("source") == "write_file"
+    assert entry["evidence"].get("path", "").endswith("SKILL.md")
+
+
+def test_patch_to_skills_is_ledgered(ledger_env, monkeypatch):
+    from tools import skill_ledger
+    from tools.file_tools import patch_tool, write_file_tool
+
+    monkeypatch.setenv("HERMES_HOME", str(ledger_env["home"]))
+    target = ledger_env["skills"] / "obs-gap" / "SKILL.md"
+    content = VALID_SKILL_CONTENT.replace("name: my-skill", "name: obs-gap")
+    assert not json.loads(write_file_tool(str(target), content)).get("error")
+
+    patched = json.loads(
+        patch_tool(
+            mode="replace",
+            path=str(target),
+            old_string="Original body.",
+            new_string="Patched body.",
+        )
+    )
+    assert not patched.get("error"), patched
+    assert "Patched body." in target.read_text(encoding="utf-8")
+
+    patch_rows = [
+        r for r in skill_ledger.list_entries(skill="obs-gap") if r["action"] == "patch"
+    ]
+    assert patch_rows
+    assert patch_rows[0]["evidence"].get("source") == "patch"
+
+
+def test_write_file_outside_skills_is_not_ledgered(ledger_env, tmp_path, monkeypatch):
+    from tools import skill_ledger
+    from tools.file_tools import write_file_tool
+
+    monkeypatch.setenv("HERMES_HOME", str(ledger_env["home"]))
+    outsider = tmp_path / "notes.txt"
+    result = json.loads(write_file_tool(str(outsider), "hello"))
+    assert not result.get("error"), result
+    assert outsider.exists()
+    assert skill_ledger.list_entries() == []

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2236,6 +2236,21 @@ def _check_binary_document_write(filepath: str, task_id: str = "default") -> str
     return None
 
 
+def _record_skill_tree_write(
+        source: str, paths: list[str], session_id: str | None = None) -> None:
+    """Best-effort ledger entry when a generic file tool hits a skills tree.
+
+    ``write_file`` / ``patch`` bypass ``skill_manage`` (and its approval
+    gate). Recording the write is observability only — never raises.
+    """
+    try:
+        from tools.skill_ledger import record_file_tool_skill_write
+
+        record_file_tool_skill_write(source, paths, session_id=session_id)
+    except Exception:
+        logger.debug("skill-tree write ledger failed", exc_info=True)
+
+
 def write_file_tool(path: str, content: str, task_id: str = "default",
                     cross_profile: bool = False,
                     session_id: str | None = None) -> str:
@@ -2286,6 +2301,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
                 result_dict["_warning"] = stale_warning
             if not result_dict.get("error"):
                 _mark_verification_stale(task_id, [path], session_id=session_id)
+                _record_skill_tree_write("write_file", [path], session_id=session_id)
             _update_read_timestamp(path, task_id)
             return json.dumps(result_dict, ensure_ascii=False)
 
@@ -2318,6 +2334,9 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
+                _record_skill_tree_write(
+                    "write_file", [_resolved], session_id=session_id
+                )
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -2507,6 +2526,9 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                 _reset_patch_failures(task_id, [
                     _r for _r in (_path_to_resolved.get(_p) for _p in _paths_to_check) if _r
                 ])
+                _record_skill_tree_write(
+                    "patch", _resolved_modified, session_id=session_id
+                )
         # Hint when old_string not found — saves iterations where the agent
         # retries with stale content instead of re-reading the file.
         # Suppressed when patch_replace already attached a rich "Did you mean?"

--- a/tools/skill_ledger.py
+++ b/tools/skill_ledger.py
@@ -5,6 +5,11 @@ Every skill mutation — regardless of actor — appends one JSONL entry to
 before/after file manifests whose contents are stored content-addressed
 (sha256-deduped) under ``~/.hermes/.curator_backups/blobs/``.
 
+``skill_manage`` is the primary writer. Generic file tools (``write_file``,
+``patch``) that land in a live skills tree also append here so a later
+integrity check can tell an attributed bypass from an unlogged one. Raw
+shell / editor / MCP filesystem writes stay out of this ledger on purpose.
+
 Design decisions (Teknium-approved):
   - JSONL, not the state DB: the ledger is a durable, human-greppable audit
     trail that survives DB resets and is trivially rsync/backup friendly.
@@ -411,6 +416,17 @@ def append_entry(
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+        path_hint = ""
+        if isinstance(evidence, dict):
+            path_hint = str(evidence.get("path") or evidence.get("file_path") or "")
+        logger.info(
+            "skill apply event: action=%s skill=%s actor=%s id=%s%s",
+            action,
+            skill,
+            entry["actor"],
+            entry["id"],
+            f" path={path_hint}" if path_hint else "",
+        )
         return entry["id"]
     except Exception as e:
         logger.warning("skill_ledger: failed to append entry (%s) — mutation unaffected", e)
@@ -450,6 +466,156 @@ def record_mutation(
     except Exception as e:
         logger.warning("skill_ledger: record_mutation failed (%s) — mutation unaffected", e)
         return None
+
+
+# --------------------------------------------------------------------------------------
+# File-Tool Skill-Tree Writes
+# --------------------------------------------------------------------------------------
+
+_SKILL_SIDECAR_DIRS = {".hub", ".archive", ".org", ".curator_backups"}
+
+
+def _frontmatter_name(skill_md: Path) -> Optional[str]:
+    """Best-effort ``name:`` from a SKILL.md frontmatter block."""
+    try:
+        text = skill_md.read_text(encoding="utf-8")[:2048]
+    except OSError:
+        return None
+    if not text.lstrip().startswith("---"):
+        return None
+    for line in text.splitlines()[1:]:
+        stripped = line.strip()
+        if stripped == "---":
+            break
+        if stripped.startswith("name:"):
+            return stripped.split(":", 1)[1].strip().strip("'\"") or None
+    return None
+
+
+def _match_under_skills(target: Path, skills_root: Path) -> Optional[Dict[str, Any]]:
+    """If *target* is under *skills_root*, return skill identity metadata."""
+    try:
+        root = skills_root.resolve()
+        rel = target.relative_to(root)
+    except (ValueError, OSError):
+        return None
+    if not rel.parts:
+        return None
+    first = rel.parts[0]
+    if first.startswith(".") or first in _SKILL_SIDECAR_DIRS:
+        return None
+
+    if target.name == "SKILL.md":
+        skill_dir = target.parent
+    else:
+        skill_dir = target.parent
+        current = skill_dir
+        while current != root and current.parent != current:
+            if (current / "SKILL.md").exists():
+                skill_dir = current
+                break
+            current = current.parent
+        else:
+            skill_dir = root / first
+
+    skill_name = _frontmatter_name(skill_dir / "SKILL.md") or skill_dir.name
+    return {
+        "skill": skill_name,
+        "skill_dir": str(skill_dir),
+        "path": str(target),
+    }
+
+
+def classify_skill_tree_write(path: str) -> Optional[Dict[str, Any]]:
+    """Return skill identity when *path* lands in a live Hermes skills tree.
+
+    Covers ``<HERMES_HOME>/skills/**``, ``<root>/profiles/<name>/skills/**``,
+    and configured external skill dirs. Sidecar files (``.usage.json``,
+    ``.curator_ledger.jsonl``, ``.hub``, ``.archive``) return None.
+    """
+    try:
+        target = Path(os.path.expanduser(str(path))).resolve()
+    except OSError:
+        return None
+
+    homes: List[Path] = []
+    try:
+        homes.append(Path(get_hermes_home()).resolve())
+    except (OSError, RuntimeError):
+        pass
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = Path(get_default_hermes_root()).resolve()
+        if root not in homes:
+            homes.append(root)
+    except (OSError, RuntimeError):
+        pass
+
+    for home in homes:
+        hit = _match_under_skills(target, home / "skills")
+        if hit:
+            return hit
+        try:
+            rel = target.relative_to(home / "profiles")
+        except ValueError:
+            rel = None
+        if rel is not None and len(rel.parts) >= 3 and rel.parts[1] == "skills":
+            hit = _match_under_skills(
+                target, home / "profiles" / rel.parts[0] / "skills"
+            )
+            if hit:
+                return hit
+
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        for ext in get_external_skills_dirs():
+            hit = _match_under_skills(target, Path(ext))
+            if hit:
+                return hit
+    except Exception:
+        pass
+    return None
+
+
+def record_file_tool_skill_write(
+    source: str,
+    paths: List[str],
+    session_id: Optional[str] = None,
+) -> None:
+    """Ledger a ``write_file`` / ``patch`` hit on a live skills tree.
+
+    Observability only: does not stage, approve, or block the write.
+    ``evidence.source`` is the file tool name so a later audit can tell
+    these apart from ``skill_manage`` apply events.
+    """
+    if not paths:
+        return
+    seen: set[str] = set()
+    for raw in paths:
+        if not raw or raw in seen:
+            continue
+        seen.add(raw)
+        info = classify_skill_tree_write(raw)
+        if not info:
+            continue
+        evidence: Dict[str, Any] = {
+            "source": source,
+            "path": info["path"],
+            "tool": source,
+        }
+        if session_id:
+            evidence["session_id"] = session_id
+        after_root = Path(info["skill_dir"])
+        if not after_root.exists():
+            after_root = Path(info["path"])
+        record_mutation(
+            source,
+            info["skill"],
+            after_root=after_root,
+            evidence=evidence,
+        )
 
 
 def capture_before(

--- a/website/docs/user-guide/features/curator.md
+++ b/website/docs/user-guide/features/curator.md
@@ -149,7 +149,7 @@ The same subcommands are available as the `/curator` slash command inside a runn
 
 ## Audit ledger and single-edit rollback
 
-Whole-run snapshots answer "undo everything the last curator pass did" — but sometimes you want to know *who changed what* and undo exactly one mutation. Every skill mutation — curator auto-transitions, agent `skill_manage` calls, and your own CLI archive/restore/purge — appends one entry to the append-only JSONL ledger at `~/.hermes/skills/.curator_ledger.jsonl`:
+Whole-run snapshots answer "undo everything the last curator pass did" — but sometimes you want to know *who changed what* and undo exactly one mutation. Every attributed skill mutation — curator auto-transitions, agent `skill_manage` calls, generic `write_file` / `patch` hits on a live skills tree, and your own CLI archive/restore/purge — appends one entry to the append-only JSONL ledger at `~/.hermes/skills/.curator_ledger.jsonl`. Raw shell, editor, and MCP filesystem writes are **not** ledgered (see [Which writes are attributed](/user-guide/features/skills#which-writes-are-attributed-and-which-are-not)):
 
 - **actor** — `curator` (background review fork / auto-transitions), `agent` (foreground agent tool calls), or `user` (CLI commands)
 - **action** — `create`, `edit`, `patch`, `delete`, `write_file`, `remove_file`, `archive`, `restore`, `purge`, `rollback`

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -630,6 +630,24 @@ in the pending JSON file). Memory writes have the same gate under
 > (dangerous-pattern heuristics), not an approval gate — the two are
 > independent. See [Guard on agent-created skill writes](/user-guide/configuration#guard-on-agent-created-skill-writes).
 
+### Which writes are attributed (and which are not)
+
+The write-approval gate applies only to `skill_manage`. Generic file tools
+can still land content in `~/.hermes/skills/` (and each profile's
+`skills/` directory) without staging. Those writes are **not** blocked —
+that is the current trust model — but they **are** attributed:
+
+| Write path | Approval gate | Audit ledger (`~/.hermes/skills/.curator_ledger.jsonl`) | `agent.log` apply line |
+|---|---|---|---|
+| `skill_manage` (create / edit / patch / write_file / remove_file / delete) | Yes, when `skills.write_approval` is on | Yes (`action` is the skill_manage verb) | Yes |
+| `write_file` / `patch` targeting a live skills tree | No | Yes (`action` is `write_file` or `patch`; `evidence.source` names the file tool) | Yes |
+| `terminal`, a raw editor, MCP filesystem, or any other out-of-process write | No | **No — intentionally unlogged** | No |
+
+`hermes curator ledger` lists the attributed events. A drift detector
+that only correlates against this ledger will correctly flag a
+shell/`cat` write as unattributed; it should not treat a `write_file`
+bypass as "no apply event."
+
 ## Skills Hub
 
 Browse, search, install, and manage skills from online registries, `skills.sh`, direct well-known skill endpoints, and official optional skills.


### PR DESCRIPTION
## What does this PR do?

`skills.write_approval` only stages `skill_manage` writes. The generic `write_file` and `patch` tools can still land live content under `~/.hermes/skills/` (and each profile's `skills/` directory) with no pending-approval artifact and no apply event.

That left an observability hole: the skills-integrity / curator ledger correlation could not tell a `write_file` bypass from a raw filesystem write. This PR records those file-tool hits on the existing `~/.hermes/skills/.curator_ledger.jsonl` path (the same apply-event mechanism `skill_manage` already uses), emits an INFO `skill apply event` line so `agent.log` can be grepped by skill name and path, and documents that `terminal` / editor / MCP filesystem writes stay unlogged.

This does not turn `write_file`/`patch` into an approval gate. The trust model (file tools are not a security boundary) is unchanged.

## Related Issue

Fixes #100449

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/skill_ledger.py` — classify writes under a live skills tree (`HERMES_HOME/skills`, `profiles/*/skills`, external skill dirs); skip sidecars (`.hub`, `.archive`, `.usage.json`); `record_file_tool_skill_write()` appends a ledger entry with `evidence.source` of `write_file` or `patch`; `append_entry()` logs `skill apply event: action=… skill=… path=…` at INFO.
- `tools/file_tools.py` — after a successful `write_file` / `patch`, call the ledger hook (best-effort; never blocks the write).
- `website/docs/user-guide/features/skills.md` — coverage table: which paths are gated, ledgered, or intentionally unlogged.
- `website/docs/user-guide/features/curator.md` — ledger description now includes file-tool hits.
- `tests/tools/test_skill_ledger.py` — classify + write_file/patch attribution tests, including a negative control that an unrelated path is not ledgered.

## How to Test

1. Isolated `HERMES_HOME` with `skills.write_approval: true`.
2. Call `write_file` (not `skill_manage`) on `$HERMES_HOME/skills/obs-gap-repro/SKILL.md`. Confirm the file exists, `pending/skills/` is empty, and `hermes curator ledger` (or `.curator_ledger.jsonl`) has an entry with `action=write_file`, `skill=obs-gap-repro`, and `evidence.source=write_file`.
3. Negative control: `skill_manage(action=create)` with the gate on still stages and does not write a live skill. `write_file` to a path outside any skills tree does not append a ledger row.
4. `scripts/run_tests.sh tests/tools/test_skill_ledger.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
write_file error: None
file exists: True
pending: 0
ledger entries:
  action=write_file skill=obs-gap-repro
  evidence.source=write_file
  evidence.path=.../.hermes/skills/obs-gap-repro/SKILL.md
skill apply event: action=write_file skill=obs-gap-repro actor=agent path=.../SKILL.md
skill_manage create: staged=True live file=False
patch: action=patch evidence.source=patch
```

`scripts/run_tests.sh tests/tools/test_skill_ledger.py` — 24 passed.
