### PR TITLE
fix(sessions): stop transient profile DB reads from breaking Desktop chat opens

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12410,6 +12410,12 @@ from hermes_cli.web_routers.sessions import (  # noqa: E402,F401 — legacy re-e
 # query raises "no such table: sessions".
 _session_db_bootstrap_lock = threading.Lock()
 
+# Read-only opens can briefly surface SQLITE_IOERR during concurrent writer
+# activity. Reopen the whole handle twice so a cleared transition succeeds,
+# while a persistent storage failure still reaches the caller after 100 ms.
+_SESSION_DB_READ_IO_RETRIES = 2
+_SESSION_DB_READ_IO_BACKOFF_S = 0.05
+
 
 def _session_db_read_probe_statements() -> tuple:
     """Stale-schema probes for read-only opens, derived from SCHEMA_SQL.
@@ -12463,6 +12469,21 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
     if not read_only:
         return SessionDB(db_path=db_path, read_only=False)
 
+    def _is_retryable_read_io_error(exc: BaseException) -> bool:
+        error_code = getattr(exc, "sqlite_errorcode", None)
+        if isinstance(error_code, int):
+            # Extended SQLite result codes retain the primary code in the low
+            # byte. Use the numeric fallback for Python builds that do not
+            # export SQLITE_IOERR as a module constant.
+            return error_code & 0xFF == getattr(sqlite3, "SQLITE_IOERR", 10)
+        # Older pysqlite builds expose no result code. Keep the compatibility
+        # path exact so disk-full, permissions, corruption, and generic read
+        # failures are never retried as if they were a WAL transition.
+        return (
+            isinstance(exc, sqlite3.OperationalError)
+            and str(exc).strip().lower() == "disk i/o error"
+        )
+
     def _needs_bootstrap() -> bool:
         try:
             return db_path.stat().st_size == 0
@@ -12490,8 +12511,20 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
                 raise
         return db
 
+    def _open_probed_with_io_retry():
+        for attempt in range(_SESSION_DB_READ_IO_RETRIES + 1):
+            try:
+                return _open_probed()
+            except sqlite3.DatabaseError as exc:
+                if (
+                    not _is_retryable_read_io_error(exc)
+                    or attempt == _SESSION_DB_READ_IO_RETRIES
+                ):
+                    raise
+                time.sleep(_SESSION_DB_READ_IO_BACKOFF_S)
+
     try:
-        return _open_probed()
+        return _open_probed_with_io_retry()
     except (sqlite3.DatabaseError, UnicodeDecodeError) as exc:
         message = str(exc).lower()
         stale_schema = "no such table" in message or "no such column" in message
@@ -12505,7 +12538,7 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
             raise
         SessionDB(db_path=db_path, read_only=False).close()
         try:
-            return _open_probed()
+            return _open_probed_with_io_retry()
         except (sqlite3.DatabaseError, UnicodeDecodeError) as still_stale:
             message = str(still_stale).lower()
             if "no such table" not in message and "no such column" not in message:
@@ -12525,7 +12558,7 @@ def _open_session_db_at_path(db_path: Path, *, read_only: bool):
                     db_path,
                     still_stale,
                 )
-            return _open_probed()
+            return _open_probed_with_io_retry()
 
 
 def _open_session_db_for_profile(profile: Optional[str], *, read_only: bool):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -628,6 +628,93 @@ class TestWebServerEndpoints:
 
         assert opens == [True]
 
+    def test_get_sessions_retries_transient_read_only_io_error(self, monkeypatch):
+        """A one-shot SQLITE_IOERR during the read-only probe must not 500."""
+        import sqlite3
+
+        import hermes_state
+        from hermes_constants import get_hermes_home
+        from hermes_state import SessionDB
+
+        db_path = get_hermes_home() / "state.db"
+        seed = SessionDB(db_path=db_path)
+        try:
+            seed.create_session("io-retry", source="cli")
+        finally:
+            seed.close()
+
+        original_session_db = hermes_state.SessionDB
+        read_only_opens = 0
+
+        def flaky_open(*args, **kwargs):
+            nonlocal read_only_opens
+            if kwargs.get("read_only", False):
+                read_only_opens += 1
+                if read_only_opens == 1:
+                    exc = sqlite3.OperationalError("disk I/O error")
+                    exc.sqlite_errorcode = 10  # SQLITE_IOERR
+                    raise exc
+            return original_session_db(*args, **kwargs)
+
+        monkeypatch.setattr(hermes_state, "SessionDB", flaky_open)
+
+        response = self.client.get("/api/sessions?limit=50&offset=0")
+
+        assert response.status_code == 200
+        assert [row["id"] for row in response.json()["sessions"]] == ["io-retry"]
+        assert read_only_opens == 2
+
+    def test_persistent_read_only_io_error_is_bounded_and_propagated(
+        self, tmp_path, monkeypatch
+    ):
+        """Retrying a read must not mask a persistent storage failure."""
+        import sqlite3
+
+        import hermes_state
+        from hermes_cli import web_server
+
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"not-empty")
+        opens = []
+        sleeps = []
+
+        def io_error(*_args, **kwargs):
+            opens.append(kwargs.get("read_only", False))
+            exc = sqlite3.OperationalError("disk I/O error")
+            exc.sqlite_errorcode = 10  # SQLITE_IOERR
+            raise exc
+
+        monkeypatch.setattr(hermes_state, "SessionDB", io_error)
+        monkeypatch.setattr(web_server.time, "sleep", sleeps.append)
+
+        with pytest.raises(sqlite3.OperationalError, match="disk I/O error"):
+            web_server._open_session_db_at_path(db_path, read_only=True)
+
+        assert opens == [True, True, True]
+        assert sleeps == [0.05, 0.05]
+
+    def test_non_io_read_error_is_not_retried(self, tmp_path, monkeypatch):
+        """The retry classifier must stay narrower than generic read failures."""
+        import sqlite3
+
+        import hermes_state
+        from hermes_cli import web_server
+
+        db_path = tmp_path / "state.db"
+        db_path.write_bytes(b"not-empty")
+        opens = []
+
+        def full_disk(*_args, **kwargs):
+            opens.append(kwargs.get("read_only", False))
+            raise sqlite3.OperationalError("database or disk is full")
+
+        monkeypatch.setattr(hermes_state, "SessionDB", full_disk)
+
+        with pytest.raises(sqlite3.OperationalError, match="disk is full"):
+            web_server._open_session_db_at_path(db_path, read_only=True)
+
+        assert opens == [True]
+
     def test_decode_error_triggers_writable_heal(self, tmp_path, monkeypatch):
         """UnicodeDecodeError — pysqlite failing to decode SQLite's own error
         message over corrupt file bytes (#98924) — must route through the


### PR DESCRIPTION
## What does this PR do?

Prevents a one-shot SQLite I/O error on a read-only profile database from turning Desktop session listing into an HTTP 500. The read-only open path now retries the complete probed handle twice with a short fixed backoff, while persistent storage failures still propagate unchanged.

### Symptom

During concurrent bot profile activity, opening a bot chat can intermittently show "Couldn't open <bot>'s chat - try again". The corresponding `GET /api/sessions` request fails while `SessionDB(read_only=True)` probes an FTS table with `sqlite3.OperationalError: disk I/O error`.

### Impact

Affected Desktop users temporarily cannot open the selected bot chat. Retrying the action succeeds, and the issue report's integrity checks found no database corruption.

### Bug Cause

**Trigger:** `hermes_cli/web_server.py` / `_open_session_db_at_path()` opening and probing a profile database read-only during concurrent writer activity.

**Causal chain:**
1. A read-only `SessionDB` open or schema probe receives `SQLITE_IOERR` during concurrent database activity.
2. `_open_session_db_at_path()` only routes stale or malformed schemas through recovery and immediately re-raises the I/O error.
3. `/api/sessions` converts the unhandled exception into HTTP 500, so Desktop cannot resolve the selected chat.

**Why it is wrong:** A read that succeeds after reopening proves the first failure was transient, but the existing path gave it no bounded retry opportunity. SQLite's busy timeout does not handle `SQLITE_IOERR`.

**Working sibling / contrast:** The same database opens normally on the user's next click after the transient condition clears.

**Ruled out:** The fix does not treat generic database failures as transient. Tests prove disk-full errors are not retried and persistent `SQLITE_IOERR` is re-raised after the bounded retry budget. The issue reporter also verified `PRAGMA integrity_check` and FTS integrity successfully.

### Fix

- Classify only SQLite primary result code `SQLITE_IOERR`, with an exact legacy message fallback for Python builds without exception result codes.
- Reopen the entire read-only probed handle up to two times at 50 ms intervals.
- Preserve the existing writable schema-heal behavior and propagate the final error if all attempts fail.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` - add narrowly classified, bounded retries around probed read-only session database opens.
- `tests/hermes_cli/test_web_server.py` - cover API recovery after a transient I/O error, bounded persistent failure, and no retry for unrelated storage errors.

## How to Test

1. Run the Desktop session endpoint regression tests, including injected transient and persistent SQLite failures.
2. Run read-only FTS and concurrent session database reader tests.

```bash
scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/test_98924_readonly_fts_decode_error.py tests/test_session_db_read_conn_pool.py -q
scripts/run_tests.sh tests/test_hermes_state.py -k 'read_only_connection_keeps_fts_search_available or concurrent_connect' -q
```

Result: 190 passed, 22 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on all relevant tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update: N/A - no user-facing interface or configuration changed
- [x] `cli-config.yaml.example`: N/A - no configuration keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md`: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered - the SQLite primary-code classifier and fallback are platform-independent
- [x] Tool descriptions/schemas: N/A - no model tool behavior changed

## Screenshots / Logs

N/A - automated endpoint and database regression tests exercise the failure and success paths.
