### PR TITLE
fix(cron): let pinned agent jobs use configured local Ollama context

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2887,18 +2887,70 @@ def init_agent(
         compression_idle_compact_after_seconds
     )
 
-    # Reject models whose context window is below the minimum required
-    # for reliable tool-calling workflows (64K tokens).
+    # Resolve Ollama's served context before enforcing the global context
+    # floor. The model metadata can be smaller than an explicit Modelfile or
+    # model.ollama_num_ctx runtime setting.
+    agent._ollama_num_ctx: int | None = None
+    _ollama_num_ctx_override = None
+    if isinstance(_model_cfg, dict):
+        _ollama_num_ctx_override = _model_cfg.get("ollama_num_ctx")
+    if _ollama_num_ctx_override is not None:
+        try:
+            agent._ollama_num_ctx = int(_ollama_num_ctx_override)
+        except (TypeError, ValueError):
+            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
+    if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
+        try:
+            # ``agent.api_key`` may be a callable (Entra token provider).
+            # Ollama detection makes a manual HTTP request and expects a
+            # string — Azure Foundry isn't a local endpoint so this branch
+            # never fires for Entra, but guard defensively.
+            _key_for_ollama = agent.api_key if isinstance(agent.api_key, str) else ""
+            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key_for_ollama or "")
+            if _detected and _detected > 0:
+                agent._ollama_num_ctx = _detected
+        except Exception as exc:
+            _ra().logger.debug("Ollama num_ctx detection failed: %s", exc)
+    # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
+    # Without this, GGUF metadata can advertise 256K+ which Ollama honours
+    # by allocating that much VRAM — blowing up small GPUs even though the
+    # user explicitly set a smaller context_length in config.yaml.
+    if (
+        agent._ollama_num_ctx
+        and _config_context_length
+        and _ollama_num_ctx_override is None  # don't override explicit ollama_num_ctx
+        and agent._ollama_num_ctx > _config_context_length
+    ):
+        _ra().logger.info(
+            "Ollama num_ctx capped: %d -> %d (model.context_length override)",
+            agent._ollama_num_ctx, _config_context_length,
+        )
+        agent._ollama_num_ctx = _config_context_length
+
+    # Reject models whose effective context window is below the minimum
+    # required for reliable tool-calling workflows (64K tokens).
     _ctx = getattr(agent.context_compressor, "context_length", 0)
+    _validated_ctx = _ctx
+    if (
+        is_local_endpoint(agent.base_url)
+        and isinstance(agent._ollama_num_ctx, int)
+        and not isinstance(agent._ollama_num_ctx, bool)
+        and agent._ollama_num_ctx > 0
+    ):
+        _validated_ctx = max(_validated_ctx, agent._ollama_num_ctx)
     _allow_lmstudio_explicit_below_floor = (
         str(getattr(agent, "provider", "") or "").strip().lower() == "lmstudio"
         and isinstance(agent._config_context_length, int)
         and not isinstance(agent._config_context_length, bool)
         and agent._config_context_length > 0
     )
-    if _ctx and _ctx < MINIMUM_CONTEXT_LENGTH and not _allow_lmstudio_explicit_below_floor:
+    if (
+        _validated_ctx
+        and _validated_ctx < MINIMUM_CONTEXT_LENGTH
+        and not _allow_lmstudio_explicit_below_floor
+    ):
         raise ValueError(
-            f"Model {agent.model} has a context window of {_ctx:,} tokens, "
+            f"Model {agent.model} has a context window of {_validated_ctx:,} tokens, "
             f"which is below the minimum {MINIMUM_CONTEXT_LENGTH:,} required "
             f"by Hermes Agent.  Choose a model with at least "
             f"{MINIMUM_CONTEXT_LENGTH // 1000}K context.  If your server "
@@ -3032,54 +3084,13 @@ def init_agent(
     agent._api_latency_history = _deque(maxlen=10)
     agent._api_output_history = _deque(maxlen=10)
     
-    # ── Ollama num_ctx injection ──
-    # Ollama defaults to 2048 context regardless of the model's capabilities.
-    # When running against an Ollama server, detect the model's max context
-    # and pass num_ctx on every chat request so the full window is used.
-    # User override: set model.ollama_num_ctx in config.yaml to cap VRAM use.
-    # If model.context_length is set, it caps num_ctx so the user's VRAM
-    # budget is respected even when GGUF metadata advertises a larger window.
-    agent._ollama_num_ctx: int | None = None
-    _ollama_num_ctx_override = None
-    if isinstance(_model_cfg, dict):
-        _ollama_num_ctx_override = _model_cfg.get("ollama_num_ctx")
-    if _ollama_num_ctx_override is not None:
-        try:
-            agent._ollama_num_ctx = int(_ollama_num_ctx_override)
-        except (TypeError, ValueError):
-            _ra().logger.debug("Invalid ollama_num_ctx config value: %r", _ollama_num_ctx_override)
-    if agent._ollama_num_ctx is None and agent.base_url and is_local_endpoint(agent.base_url):
-        try:
-            # ``agent.api_key`` may be a callable (Entra token provider).
-            # Ollama detection makes a manual HTTP request and expects a
-            # string — Azure Foundry isn't a local endpoint so this branch
-            # never fires for Entra, but guard defensively.
-            _key_for_ollama = agent.api_key if isinstance(agent.api_key, str) else ""
-            _detected = query_ollama_num_ctx(agent.model, agent.base_url, api_key=_key_for_ollama or "")
-            if _detected and _detected > 0:
-                agent._ollama_num_ctx = _detected
-        except Exception as exc:
-            _ra().logger.debug("Ollama num_ctx detection failed: %s", exc)
-    # Cap auto-detected ollama_num_ctx to the user's explicit context_length.
-    # Without this, GGUF metadata can advertise 256K+ which Ollama honours
-    # by allocating that much VRAM — blowing up small GPUs even though the
-    # user explicitly set a smaller context_length in config.yaml.
-    if (
-        agent._ollama_num_ctx
-        and _config_context_length
-        and _ollama_num_ctx_override is None  # don't override explicit ollama_num_ctx
-        and agent._ollama_num_ctx > _config_context_length
-    ):
-        _ra().logger.info(
-            "Ollama num_ctx capped: %d -> %d (model.context_length override)",
-            agent._ollama_num_ctx, _config_context_length,
-        )
-        agent._ollama_num_ctx = _config_context_length
+    # Report the Ollama num_ctx resolved before the context-floor check above.
     if agent._ollama_num_ctx and not agent.quiet_mode:
         _ra().logger.info(
             "Ollama num_ctx: will request %d tokens (model max from /api/show)",
             agent._ollama_num_ctx,
         )
+
     # ── Recalibrate the compressor to the served window (#57275 claim 3) ──
     # The compressor was constructed ABOVE this block from the probed model
     # window (GGUF metadata can advertise 256K+), but every request below

--- a/tests/cron/test_cron_provider_pin.py
+++ b/tests/cron/test_cron_provider_pin.py
@@ -436,3 +436,5 @@ class TestRuntimeResolutionTargetModel:
 
         assert captured.get("target_model") == "my-pinned-model"
         assert captured.get("requested") == "openrouter"
+        assert mock_agent_cls.call_args.kwargs["model"] == "my-pinned-model"
+        assert mock_agent_cls.call_args.kwargs["provider"] == "openrouter"

--- a/tests/test_ollama_num_ctx.py
+++ b/tests/test_ollama_num_ctx.py
@@ -187,3 +187,13 @@ class TestCompressorClampsToNumCtx:
         # num_ctx above the resolved window must not RAISE the compressor
         # window: the clamp is one-directional.
         assert agent.context_compressor.context_length == 65536
+
+    def test_runtime_num_ctx_can_satisfy_floor_above_model_metadata(self):
+        agent = self._build_agent(
+            {"agent": {}, "model": {"ollama_num_ctx": 65536}}, probed_ctx=40960
+        )
+
+        assert agent._ollama_num_ctx == 65536
+        # Compression remains conservative: the runtime override authorizes
+        # startup without pretending that the model metadata is larger.
+        assert agent.context_compressor.context_length == 40960


### PR DESCRIPTION
## What does this PR do?

Agent-backed cron jobs can now reach a configured local Ollama fallback when the served `num_ctx` is at least 64K even if the model metadata advertises a smaller native window. The cron regression coverage also pins the existing per-job provider/model propagation contract so future scheduler changes cannot silently replace the requested route.

### Symptom

A cron agent that reaches local Ollama can fail during `AIAgent` construction with a 40,960-token context error even when `model.ollama_num_ctx` or the Ollama Modelfile configures a 65,536-token runtime window.

### Impact

The job aborts before its first model request, so a valid local fallback cannot run. Per-job model/provider propagation is also now asserted end to end at the scheduler-to-agent boundary.

### Bug Cause

**Trigger:** `agent/agent_init.py` context-floor validation during `AIAgent` initialization.

**Causal chain:**
1. The compressor resolves the model metadata window, such as 40,960 tokens.
2. Initialization enforces the 64K floor before resolving the local Ollama runtime `num_ctx`.
3. The agent raises before it can observe and use the configured 65,536-token served window.

**Why it is wrong:** The validation orders static model metadata ahead of the authoritative local runtime setting, making the supported Ollama override ineffective precisely when metadata is below the floor.

**Working sibling / contrast:** A model whose metadata already reports at least 64K starts normally, and the request path already passes the resolved Ollama `num_ctx` on chat calls.

**Ruled out:** The exact v0.21.0 scheduler source does not drop `job.model` or `job.provider`: it passes the model into `AIAgent` and the provider into runtime resolution. The new scheduler assertion preserves that contract and distinguishes an auth fallback from a lost pin.

### Fix

Resolve and cap the local Ollama `num_ctx` before context-floor validation, then validate the effective served window. The global 64K requirement remains unchanged, non-local providers keep their existing behavior, and compression remains conservative when model metadata is smaller than the runtime override.

## Related Issue

Closes #100437

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` - resolve local Ollama runtime context before enforcing the 64K floor.
- `tests/test_ollama_num_ctx.py` - cover a 40,960-token metadata window with a configured 65,536-token runtime.
- `tests/cron/test_cron_provider_pin.py` - assert that pinned model/provider values reach the constructed cron agent.

## How to Test

1. Configure a local Ollama model with `model.ollama_num_ctx: 65536` while its metadata reports 40,960 tokens.
2. Construct or run an agent-backed cron job that resolves to that local runtime and confirm initialization succeeds.
3. Run the automated regression suites:

```bash
scripts/run_tests.sh tests/test_ollama_num_ctx.py tests/cron/test_cron_provider_pin.py tests/agent/test_meta_agent_init.py tests/run_agent/test_run_agent.py
```

Result: 316 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation changes are N/A; behavior and configuration names are unchanged
- [x] `cli-config.yaml.example` changes are N/A; no config keys were added or changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; architecture is unchanged
- [x] Cross-platform impact was considered; the change uses existing endpoint and integer helpers
- [x] Tool description/schema changes are N/A

## Screenshots / Logs

N/A
