### PR TITLE
fix(mcp): close leaked coroutine in stdio fast-fail gate (Closes #100472)

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6184,9 +6184,10 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         )
                     _call_coro = server.session.call_tool(tool_name, arguments=args)
                     _watch_children = getattr(server, "_watch_stdio_children", None)
+                    _watch_coro = _watch_children() if _watch_children is not None else None
                     _watch_ok = (
-                        _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        _watch_coro is not None
+                        and inspect.isawaitable(_watch_coro)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:
@@ -6194,6 +6195,8 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # non-awaitable, or there is no child-watcher to race
                         # against: plain await is exactly the pre-#81995
                         # semantics.
+                        if asyncio.iscoroutine(_watch_coro):
+                            _watch_coro.close()
                         result = (
                             await _call_coro
                             if asyncio.iscoroutine(_call_coro)
@@ -6205,7 +6208,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                         # the call immediately instead of riding out the full
                         # tool timeout.
                         rpc_task = asyncio.ensure_future(_call_coro)
-                        watch_task = asyncio.ensure_future(_watch_children())
+                        watch_task = asyncio.ensure_future(_watch_coro)
                         try:
                             done, _pending = await asyncio.wait(
                                 {rpc_task, watch_task},


### PR DESCRIPTION
Closes #100472