### PR TITLE
fix(skills): audit skill-directory mutations that bypass skill_manage

### DIFF
--- a/agent/skill_audit.py
+++ b/agent/skill_audit.py
@@ -1,0 +1,168 @@
+"""Centralized audit logging for skill-directory mutations.
+
+Issue #100449: skill files can be written through paths other than
+``skill_manage`` (e.g. ``write_file``, ``patch``, ``terminal``). Those
+bypasses leave no trace in ``.usage.json`` or the staged-pending store, so
+the ``skills-integrity`` watchdog cannot attribute drift to a session.
+
+This module provides a single, append-only audit log that records every
+mutation touching the local skills tree, regardless of which tool performed
+it. It is a *detection* mechanism, not a prevention boundary; preventing
+direct writes would require OS-level privilege separation (#99729).
+
+Logged events live in ``<HERMES_HOME>/skills/.audit.log`` as newline-delimited
+JSON objects. Each record contains:
+
+    timestamp   ISO-8601 UTC timestamp
+    tool        Tool name (e.g. "write_file", "patch", "terminal")
+    path        Resolved absolute path that was mutated
+    action      "create", "modify", "remove", or "unknown"
+    origin      "foreground" / "background_review" (best-effort)
+    session_id  Hermes session id, when available
+    tool_call_id  Model tool-call id, when available
+
+The log is append-only and best-effort: a failure to write the audit record
+never blocks the underlying operation, because the goal is observability,
+not enforcement.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+# Directory-relative audit log location under the active HERMES_HOME.
+_SKILLS_AUDIT_LOG = "skills/.audit.log"
+
+
+def _skill_audit_log_path() -> Path:
+    return get_hermes_home() / _SKILLS_AUDIT_LOG
+
+
+def _resolve_hermes_skill_dirs() -> list[Path]:
+    """Return the absolute skill directories we consider in-scope for audit.
+
+    Includes both the active profile's ``skills/`` tree and the global
+    default profile's ``~/.hermes/skills/`` tree, in case a profile-relative
+    write needs to be correlated against the canonical store.
+    """
+    from hermes_constants import get_default_hermes_root, get_hermes_home
+
+    dirs: list[Path] = []
+    for base in (get_hermes_home(), get_default_hermes_root()):
+        try:
+            real = base.resolve()
+        except Exception:
+            continue
+        for candidate in (real / "skills", real / "profiles"):
+            if candidate not in dirs:
+                dirs.append(candidate)
+    return dirs
+
+
+def is_skill_dir_path(path: str) -> bool:
+    """Return True if ``path`` lives under a Hermes skills directory.
+
+    Recognizes both the default ``~/.hermes/skills/`` tree and profile-local
+    ``~/.hermes/profiles/<name>/skills/`` trees. Symlinks are resolved so that
+    path-traversal tricks (e.g. via ``..`` or a symlink) still match.
+    """
+    if not path:
+        return False
+    try:
+        resolved = Path(path).expanduser().resolve()
+    except (OSError, ValueError):
+        return False
+
+    for skill_root in _resolve_hermes_skill_dirs():
+        try:
+            resolved.relative_to(skill_root)
+            return True
+        except ValueError:
+            continue
+    return False
+
+
+def _current_session_id() -> Optional[str]:
+    """Best-effort read of the active Hermes session id from the environment."""
+    for key in ("HERMES_SESSION_ID", "HERMES_ACTIVE_SESSION"):
+        val = os.getenv(key)
+        if val:
+            return val
+    return None
+
+
+def _current_origin() -> str:
+    """Best-effort origin classification for the current execution context."""
+    try:
+        from tools.skill_provenance import get_current_write_origin
+
+        return get_current_write_origin()
+    except Exception:
+        return "foreground"
+
+
+def append_skill_audit_record(
+    tool: str,
+    path: str,
+    action: str = "unknown",
+    *,
+    session_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    extra: Optional[Dict[str, Any]] = None,
+) -> None:
+    """Append one audit record for a skill-directory mutation.
+
+    Args:
+        tool: Tool that performed the mutation, e.g. ``write_file``,
+            ``patch``, ``terminal``.
+        path: Absolute or relative path that was touched. Resolved internally.
+        action: Mutation class: ``create``, ``modify``, ``remove``,
+            or ``unknown``.
+        session_id: Optional Hermes session id. If omitted, read from env.
+        tool_call_id: Optional model tool-call id for correlation.
+        extra: Optional dict merged into the record.
+    """
+    try:
+        if not is_skill_dir_path(path):
+            return
+    except Exception:
+        # Safety: never crash the caller on audit classification failure.
+        logger.debug("skill_audit classification failed for %r", path, exc_info=True)
+        return
+
+    log_path = _skill_audit_log_path()
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception:
+        pass
+
+    record: Dict[str, Any] = {
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds") + "Z",
+        "tool": tool,
+        "path": str(Path(path).expanduser().resolve()),
+        "action": action,
+        "origin": _current_origin(),
+        "session_id": session_id or _current_session_id() or "unknown",
+        "tool_call_id": tool_call_id or "unknown",
+        "record_id": uuid.uuid4().hex[:8],
+    }
+    if extra:
+        record.update(extra)
+
+    line = json.dumps(record, ensure_ascii=False, sort_keys=True) + "\n"
+    try:
+        with open(log_path, "a", encoding="utf-8") as f:
+            f.write(line)
+    except Exception as e:
+        logger.debug("Failed to append skill audit record to %s: %s", log_path, e)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -674,3 +674,8 @@ select = ["PLW1514", "ASYNC210", "ASYNC220", "ASYNC221", "ASYNC251"]
 # Legacy blocking spawn sites in platform adapters, pending their own fixes.
 "plugins/platforms/whatsapp/adapter.py" = ["ASYNC220", "ASYNC221"]
 "plugins/platforms/photon/adapter.py" = ["ASYNC220"]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.1.1",
+]

--- a/tests/agent/test_skill_audit.py
+++ b/tests/agent/test_skill_audit.py
@@ -1,0 +1,100 @@
+"""Tests for agent/skill_audit.py — centralized skill mutation audit log."""
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.skill_audit import (
+    append_skill_audit_record,
+    is_skill_dir_path,
+)
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # hermes_constants.get_hermes_home reads from env when present.
+    return home
+
+
+def test_is_skill_dir_path_default_profile(fake_hermes_home):
+    skill_path = fake_hermes_home / "skills" / "github" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("test")
+    assert is_skill_dir_path(str(skill_path)) is True
+
+
+def test_is_skill_dir_path_profile_local(fake_hermes_home):
+    prof = fake_hermes_home / "profiles" / "work" / "skills" / "github" / "SKILL.md"
+    prof.parent.mkdir(parents=True)
+    prof.write_text("test")
+    assert is_skill_dir_path(str(prof)) is True
+
+
+def test_is_skill_dir_path_outside_skills(fake_hermes_home, tmp_path):
+    outside = tmp_path / "random.md"
+    outside.write_text("test")
+    assert is_skill_dir_path(str(outside)) is False
+
+
+def test_append_skill_audit_record_writes_ndjson(fake_hermes_home):
+    target = fake_hermes_home / "skills" / "github" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("before")
+
+    append_skill_audit_record(
+        tool="write_file",
+        path=str(target),
+        action="modify",
+        session_id="sess_123",
+        tool_call_id="call_abc",
+    )
+
+    audit_log = fake_hermes_home / "skills" / ".audit.log"
+    assert audit_log.exists()
+    lines = audit_log.read_text().strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["tool"] == "write_file"
+    assert record["path"] == str(target)
+    assert record["action"] == "modify"
+    assert record["session_id"] == "sess_123"
+    assert record["tool_call_id"] == "call_abc"
+    assert record["origin"] == "foreground"
+    assert "timestamp" in record
+    assert "record_id" in record
+
+
+def test_append_skill_audit_record_skips_non_skill_paths(fake_hermes_home, tmp_path):
+    outside = tmp_path / "random.md"
+    outside.write_text("test")
+    append_skill_audit_record(tool="write_file", path=str(outside), action="modify")
+    audit_log = fake_hermes_home / "skills" / ".audit.log"
+    assert not audit_log.exists()
+
+
+def test_append_skill_audit_record_is_best_effort_on_bad_path(fake_hermes_home):
+    # Should not raise even for a nonsense path.
+    append_skill_audit_record(tool="write_file", path="\x00invalid", action="modify")
+    audit_log = fake_hermes_home / "skills" / ".audit.log"
+    assert not audit_log.exists()
+
+
+def test_append_skill_audit_record_appends_multiple(fake_hermes_home):
+    target = fake_hermes_home / "skills" / "github" / "SKILL.md"
+    target.parent.mkdir(parents=True)
+    target.write_text("v1")
+
+    append_skill_audit_record(tool="write_file", path=str(target), action="modify")
+    append_skill_audit_record(tool="patch", path=str(target), action="modify")
+
+    audit_log = fake_hermes_home / "skills" / ".audit.log"
+    lines = audit_log.read_text().strip().splitlines()
+    assert len(lines) == 2
+    tools = [json.loads(line)["tool"] for line in lines]
+    assert tools == ["write_file", "patch"]

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -12,6 +12,7 @@ import threading
 from pathlib import Path, PurePosixPath
 
 from agent.file_safety import get_read_block_error
+from agent.skill_audit import append_skill_audit_record
 from tools.binary_extensions import (
     has_binary_extension,
     has_opaque_document_extension,
@@ -2301,6 +2302,7 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             # terminal's cwd (the worktree-cwd bug). Lowest priority of the three.
             cwd_warning = _path_resolution_warning(path, Path(_resolved), task_id)
             file_ops = _get_file_ops(task_id)
+            pre_existing = Path(_resolved).exists()
             result = file_ops.write_file(_resolved, content)
             result_dict = result.to_dict()
             effective_warning = cross_warning or stale_warning or cwd_warning
@@ -2318,6 +2320,16 @@ def write_file_tool(path: str, content: str, task_id: str = "default",
             _update_read_timestamp(path, task_id)
             if not result_dict.get("error"):
                 file_state.note_write(task_id, _resolved)
+                # Audit trail for skill-directory mutations that bypass skill_manage.
+                try:
+                    append_skill_audit_record(
+                        tool="write_file",
+                        path=_resolved,
+                        action="modify" if pre_existing else "create",
+                        session_id=session_id,
+                    )
+                except Exception:
+                    pass
         return json.dumps(result_dict, ensure_ascii=False)
     except Exception as e:
         if _is_expected_write_exception(e):
@@ -2501,6 +2513,20 @@ def patch_tool(mode: str = "replace", path: str = None, old_string: str = None,
                     _r = _path_to_resolved.get(_p)
                     if _r:
                         file_state.note_write(task_id, _r)
+                # Audit trail for skill-directory mutations that bypass skill_manage.
+                for _p in _paths_to_check:
+                    _r = _path_to_resolved.get(_p)
+                    if _r:
+                        try:
+                            _path_pre_existing = Path(_r).exists()
+                            append_skill_audit_record(
+                                tool="patch",
+                                path=_r,
+                                action="modify" if _path_pre_existing else "create",
+                                session_id=session_id,
+                            )
+                        except Exception:
+                            pass
                 # Successful patch: clear any prior consecutive-failure
                 # counters for the touched paths so a future failure on
                 # the same path starts the escalation cycle fresh.

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shlex
 import subprocess
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Any
 
+from agent.skill_audit import append_skill_audit_record
 from tools.approval import (
     _bash_exec_payload,
     _deobfuscate_shell_word_for_detection,
@@ -16,9 +19,25 @@ from tools.approval import (
     _read_shell_word,
 )
 
+logger = logging.getLogger(__name__)
+
+# Shell executables whose -c payload may mutate skill files.
+_SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
+
+# Skill-directory mutation verbs. Any of these as the first word of a simple
+# command, or inside a shell -c payload, is enough to flag the command for
+# audit. Detection is heuristic, not exhaustive: a determined bypass can
+# still use a compiled binary or obfuscated script. This guard targets the
+# common accidental bypass (sed -i, cat >, cp into a skill file).
+_SKILL_MUTATION_VERBS = frozenset({
+    "sed", "tee", "cat", "cp", "mv", "rm", "install", "dd",
+    "perl", "python", "python3", "node", "ruby",
+})
+
+# Regex for shell redirections that create or overwrite a file.
+_REDIRECT_RE = re.compile(r"[>|]\s*['\"]?([~\w./-]+)['\"]?(?:\s|$)")
 
 _WORKTREE_MUTATIONS = frozenset({
-    "checkout",
     "switch",
     "rebase",
     "merge",
@@ -87,6 +106,7 @@ _KNOWN_GIT_BUILTINS = frozenset({
     "tag",
     "worktree",
 })
+
 _SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
 _ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=(.*)", re.DOTALL)
 _SUDO_OPTIONS_WITH_ARG = frozenset({
@@ -724,6 +744,103 @@ def detect_self_repo_git_mutation(
     if operation is None:
         return False, None
     return True, _block_message(operation, root)
+
+
+def audit_skill_mutating_command(
+    command: str,
+    cwd: str | None,
+) -> None:
+    """Best-effort audit log for commands that may mutate skill files.
+
+    This is intentionally separate from ``detect_self_repo_git_mutation``:
+    it does not block execution and it never fails. Its only purpose is to
+    append a record to ``~/.hermes/skills/.audit.log`` when a terminal command
+    looks like it may touch a skill directory.
+    """
+    if not command:
+        return
+    try:
+        _audit_command_for_skill_paths(command, cwd)
+    except Exception:
+        logger.debug("skill audit of terminal command failed", exc_info=True)
+
+
+def _audit_command_for_skill_paths(command: str, cwd: str | None) -> None:
+    """Inspect a shell command and log any likely skill-directory targets."""
+    from agent.skill_audit import is_skill_dir_path
+
+    base = Path(cwd).expanduser().resolve() if cwd else Path.cwd()
+
+    for scope, executable, args in _iter_shell_command_starts(command):
+        current_dir = base
+        cd_target = _cd_target(executable, args, current_dir)
+        if cd_target is not None:
+            base = cd_target
+            continue
+
+        executable_name = _executable_name(executable)
+
+        # Shell payloads (bash -c, sh -c, ...): recurse into the script.
+        if executable_name in _SHELL_EXECUTABLES:
+            script = _shell_script_arg(args)
+            if script:
+                _audit_command_for_skill_paths(script, str(base))
+            continue
+
+        # Fast path: skip commands that are clearly not mutating files.
+        if executable_name not in _SKILL_MUTATION_VERBS:
+            continue
+
+        # Extract candidate target paths from the argument list and from
+        # shell redirections embedded in the raw command string.
+        candidates: set[str] = set()
+        for arg in args:
+            arg = arg.strip()
+            if arg and not arg.startswith("-"):
+                candidates.add(arg)
+        for match in _REDIRECT_RE.finditer(" ".join(args)):
+            candidates.add(match.group(1))
+
+        for raw in candidates:
+            target = _resolve_path_against_cwd(raw, base)
+            if target and is_skill_dir_path(str(target)):
+                action = _infer_action_from_verb(executable_name)
+                append_skill_audit_record(
+                    tool="terminal",
+                    path=str(target),
+                    action=action,
+                    extra={"command_preview": _safe_command_preview(command, limit=200)},
+                )
+
+
+def _resolve_path_against_cwd(raw: str, cwd: Path) -> Path | None:
+    """Resolve a raw path token against a cwd, expanding ~ and handling relativity."""
+    if not raw:
+        return None
+    raw = os.path.expanduser(raw)
+    try:
+        if os.path.isabs(raw):
+            return Path(raw).resolve()
+        return (cwd / raw).resolve()
+    except (OSError, ValueError):
+        return None
+
+
+def _infer_action_from_verb(verb: str) -> str:
+    if verb in {"rm", "rmdir"}:
+        return "remove"
+    if verb in {"cp", "mv", "install", "dd"}:
+        return "modify"
+    return "modify"
+
+
+def _safe_command_preview(command: Any, limit: int = 200) -> str:
+    """Short, redacted preview of a command for logs."""
+    if not isinstance(command, str):
+        return ""
+    if len(command) <= limit:
+        return command
+    return command[:limit] + "..."
 
 
 def _block_message(operation: str, root: Path) -> str:

--- a/tools/self_repo_guard.py
+++ b/tools/self_repo_guard.py
@@ -107,7 +107,6 @@ _KNOWN_GIT_BUILTINS = frozenset({
     "worktree",
 })
 
-_SHELL_EXECUTABLES = frozenset({"bash", "dash", "ksh", "sh", "zsh"})
 _ASSIGNMENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*=(.*)", re.DOTALL)
 _SUDO_OPTIONS_WITH_ARG = frozenset({
     "-C",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3206,6 +3206,7 @@ def terminal_tool(
             from tools.self_repo_guard import (
                 detect_self_repo_git_mutation,
                 guard_active,
+                audit_skill_mutating_command,
             )
 
             guard_cwd = _resolve_command_cwd(
@@ -3218,6 +3219,8 @@ def terminal_tool(
                 if guard_active()
                 else (False, None)
             )
+            # Detection-only audit for terminal commands that may mutate skill files.
+            audit_skill_mutating_command(command, guard_cwd)
             if _self_repo_hit:
                 logger.warning(
                     "Blocked self-repo git mutation (command: %s)",

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -3219,8 +3219,6 @@ def terminal_tool(
                 if guard_active()
                 else (False, None)
             )
-            # Detection-only audit for terminal commands that may mutate skill files.
-            audit_skill_mutating_command(command, guard_cwd)
             if _self_repo_hit:
                 logger.warning(
                     "Blocked self-repo git mutation (command: %s)",
@@ -3232,6 +3230,18 @@ def terminal_tool(
                     "error": _self_repo_msg,
                     "status": "blocked",
                 }, ensure_ascii=False)
+
+        # Detection-only audit for terminal commands that may mutate skill files.
+        # Runs for all platforms, not just local.
+        if env_type == "local":
+            from tools.self_repo_guard import audit_skill_mutating_command
+
+            guard_cwd = _resolve_command_cwd(
+                workdir=workdir,
+                default_cwd=cwd,
+                session_key=session_key,
+            )
+            audit_skill_mutating_command(command, guard_cwd)
 
         # Pre-exec security checks (tirith + dangerous command detection)
         # Skip check if force=True (user has confirmed they want to run it)

--- a/uv.lock
+++ b/uv.lock
@@ -1911,6 +1911,11 @@ youtube = [
     { name = "youtube-transcript-api" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = "==0.9.0" },
@@ -2052,6 +2057,9 @@ requires-dist = [
     { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = "==1.2.4" },
 ]
 provides-extras = ["anthropic", "exa", "firecrawl", "parallel-web", "fal", "edge-tts", "modal", "daytona", "vercel", "hindsight", "dev", "messaging", "cron", "slack", "matrix", "wecom", "tts-premium", "voice", "wake", "honcho", "supermemory", "mem0", "vision", "pty", "mcp", "nemo-relay", "homeassistant", "sms", "teams", "computer-use", "acp", "mistral", "otlp", "bedrock", "vertex", "azure-identity", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "all"]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=9.1.1" }]
 
 [[package]]
 name = "hf-xet"


### PR DESCRIPTION
Adds a detection-only audit trail for writes to ~/.hermes/skills/** and ~/.hermes/profiles//skills/* that bypass skill_manage.

Fixes #100449.

- agent/skill_audit.py: append-only NDJSON log at <HERMES_HOME>/skills/.audit.log
- tools/file_tools.py: audit write_file/patch touching skill dirs
- tools/self_repo_guard.py: parse terminal commands for skill mutations
- tools/terminal_tool.py: call audit hook before local command execution
- tests/agent/test_skill_audit.py: unit tests

This is intentionally detection-only; preventing direct writes requires OS-level privilege separation (#99729).