### PR TITLE
fix(desktop): use canonical profile name for rail prewarm and reorder

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -73,8 +73,13 @@ vi.mock('@/store/profile-share', () => ({
   runImportProfileFlow: vi.fn()
 }))
 
+const prewarmStarted = vi.fn()
+
 vi.mock('./use-profile-prewarm', () => ({
-  useProfilePrewarm: () => ({ cancelPrewarm: vi.fn(), startPrewarm: vi.fn() })
+  useProfilePrewarm: (profile?: null | string) => ({
+    cancelPrewarm: vi.fn(),
+    startPrewarm: () => prewarmStarted(profile)
+  })
 }))
 
 vi.mock('@/hermes', () => ({
@@ -94,6 +99,7 @@ const profiles = $profiles as ReturnType<typeof atom<Array<{ is_default: boolean
 
 afterEach(() => {
   cleanup()
+  prewarmStarted.mockClear()
   hasMultipleConnections.set(false)
   profiles.set([{ is_default: true, name: 'default' }])
 })
@@ -115,6 +121,19 @@ describe('ProfileRail multi-gateway entry point', () => {
     // gated behind multiProfile the way the default↔all toggle is.
     expect(screen.getByRole('button', { name: 'Manage gateways…' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'Manage profiles…' })).toBeTruthy()
+  })
+
+  it('prewarms the canonical profile name, not the display label (#100330)', () => {
+    profiles.set([
+      { is_default: true, name: 'default' },
+      { display_name: 'Forge · Eng Lead', is_default: false, name: 'forge' }
+    ] as never)
+    render(<ProfileRail />)
+
+    fireEvent.pointerEnter(screen.getByRole('button', { name: 'Forge · Eng Lead' }))
+
+    expect(prewarmStarted).toHaveBeenCalledWith('forge')
+    expect(prewarmStarted).not.toHaveBeenCalledWith('Forge · Eng Lead')
   })
 
   it('keeps the active profile explicit when gateway identity moves to the statusbar', () => {

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -371,6 +371,7 @@ export function ProfileRail() {
                   color={resolveProfileColor(profile.name, colors)}
                   key={profile.name}
                   label={profileLabel(profile)}
+                  name={profile.name}
                   // The legacy per-profile remote override predates the
                   // gateway registry; once the rail shows machines directly
                   // it only confuses, so it is offered on single-gateway
@@ -1132,6 +1133,9 @@ function RestSquare({
 interface ProfileSquareProps {
   active: boolean
   color: null | string
+  /** Canonical profile key — routing, prewarm, and drag-reorder identity. */
+  name: string
+  /** Presentation label only (display_name). Never used for routing. */
   label: string
   onSelect: () => void
   onRecolor: (color: null | string) => void
@@ -1161,6 +1165,7 @@ function ProfileSquare({
   active,
   color,
   label,
+  name,
   onConnectRemote,
   onDelete,
   onEditSoul,
@@ -1176,11 +1181,12 @@ function ProfileSquare({
   const pressTimer = useRef<null | number>(null)
   const suppressClick = useRef(false)
   // Hovering a square telegraphs the switch — start that profile's backend
-  // spawn now so a cold click doesn't pay the full boot.
-  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(label)
+  // spawn now so a cold click doesn't pay the full boot. Identity is the
+  // canonical name, never display_name (#100330).
+  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
-    id: label,
+    id: name,
     transition: RAIL_TRANSITION
   })
 


### PR DESCRIPTION
## What does this PR do?

`ProfileSquare` used the presentation label (`display_name`) as the identity for hover-prewarm and drag-reorder. Every other prop on the square already uses `profile.name`; `profileLabel()` is documented as display-only.

Hovering a renamed profile (key `forge`, label `Forge · Eng Lead`) therefore called `getConnection("Forge · Eng Lead")` and failed with "Profile no longer exists". `useSortable({ id: label })` also missed `SortableContext`'s `profile.name` list, so drag-reorder silently no-op'd.

Pass `name={profile.name}` into the square and use it for `useProfilePrewarm` and `useSortable`. The label stays on the button for aria/display.

## Related Issue

Fixes #100330

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`: `ProfileSquare` takes canonical `name` for prewarm + sortable id
- `profile-rail-connect.test.tsx`: hover a `display_name` square, assert prewarm is called with `forge` not the label

## How to Test

```text
cd apps/desktop
npx vitest run src/app/chat/sidebar/profile-rail-connect.test.tsx
# 6 passed
```

Not click-tested in a live Desktop window (no display here).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (identity string; covered by the prewarm spy)
