### PR TITLE
fix(gateway): skip macOS frozen system CA so certifi can run

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2237,13 +2237,30 @@ def _ensure_ssl_certs() -> None:
         os.environ.pop("SSL_CERT_FILE", None)
 
     import ssl
+    import sys
 
-    # 1. Python's compiled-in defaults
+    # 1. Python's compiled-in defaults. On macOS those paths are always
+    #    /etc/ssl/cert.pem (and the /private/etc alias) — a frozen, incomplete
+    #    root set. Returning here made the certifi fallback unreachable, so
+    #    providers whose chain lives in Mozilla's bundle but not Apple's
+    #    failed with an opaque Connection error (#100414).
     paths = ssl.get_default_verify_paths()
+    _macos_system_ca = {
+        "/etc/ssl/cert.pem",
+        "/private/etc/ssl/cert.pem",
+    }
     for candidate in (paths.cafile, paths.openssl_cafile):
-        if candidate and os.path.exists(candidate):
-            os.environ["SSL_CERT_FILE"] = candidate
-            return
+        if not candidate or not os.path.exists(candidate):
+            continue
+        if sys.platform == "darwin":
+            try:
+                if os.path.realpath(candidate) in _macos_system_ca:
+                    continue
+            except OSError:
+                if candidate in _macos_system_ca:
+                    continue
+        os.environ["SSL_CERT_FILE"] = candidate
+        return
 
     # 2. certifi (ships its own Mozilla bundle)
     try:

--- a/tests/gateway/test_ssl_certs.py
+++ b/tests/gateway/test_ssl_certs.py
@@ -14,16 +14,25 @@ def _load_ensure_ssl():
     import textwrap, ssl as _ssl  # noqa: F401
 
     code = textwrap.dedent("""\
-    import os, ssl
+    import os, ssl, sys
 
     def _ensure_ssl_certs():
         if "SSL_CERT_FILE" in os.environ:
             return
         paths = ssl.get_default_verify_paths()
+        _macos_system_ca = {"/etc/ssl/cert.pem", "/private/etc/ssl/cert.pem"}
         for candidate in (paths.cafile, paths.openssl_cafile):
-            if candidate and os.path.exists(candidate):
-                os.environ["SSL_CERT_FILE"] = candidate
-                return
+            if not candidate or not os.path.exists(candidate):
+                continue
+            if sys.platform == "darwin":
+                try:
+                    if os.path.realpath(candidate) in _macos_system_ca:
+                        continue
+                except OSError:
+                    if candidate in _macos_system_ca:
+                        continue
+            os.environ["SSL_CERT_FILE"] = candidate
+            return
         try:
             import certifi
             os.environ["SSL_CERT_FILE"] = certifi.where()
@@ -49,5 +58,23 @@ class TestEnsureSslCerts:
         with patch.dict(os.environ, {"SSL_CERT_FILE": "/custom/ca.pem"}):
             fn()
             assert os.environ["SSL_CERT_FILE"] == "/custom/ca.pem"
+
+    def test_macos_skips_frozen_system_bundle_for_certifi(self, tmp_path):
+        """#100414: /etc/ssl/cert.pem always exists on macOS and is incomplete."""
+        fn = _load_ensure_ssl()
+        certifi_path = str(tmp_path / "cacert.pem")
+        tmp_path.joinpath("cacert.pem").write_text("dummy", encoding="utf-8")
+        fake_paths = MagicMock(cafile="/etc/ssl/cert.pem", openssl_cafile="/etc/ssl/cert.pem")
+        fake_certifi = MagicMock()
+        fake_certifi.where.return_value = certifi_path
+        with patch.dict(os.environ, {}, clear=False), \
+             patch("sys.platform", "darwin"), \
+             patch("ssl.get_default_verify_paths", return_value=fake_paths), \
+             patch("os.path.exists", return_value=True), \
+             patch("os.path.realpath", side_effect=lambda p: p), \
+             patch.dict("sys.modules", {"certifi": fake_certifi}):
+            os.environ.pop("SSL_CERT_FILE", None)
+            fn()
+            assert os.environ["SSL_CERT_FILE"] == certifi_path
 
 


### PR DESCRIPTION
## What does this PR do?

On macOS, `_ensure_ssl_certs` takes the first existing path from `ssl.get_default_verify_paths()` and returns. Those paths are always `/etc/ssl/cert.pem` (and the `/private/etc` alias) — a frozen, incomplete root set — so the certifi fallback on the next lines never runs.

Providers whose chain lives in Mozilla's bundle but not Apple's then fail with an opaque Connection error, while other providers in the same process succeed.

Skip those two macOS system paths (via `realpath`) so certifi can supply the Mozilla bundle. Linux/Windows still take the compiled-in default when it exists. An explicit `SSL_CERT_FILE` is still honored first.

## Related Issue

Fixes #100414

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: on darwin, skip `/etc/ssl/cert.pem` and `/private/etc/ssl/cert.pem` in step 1
- `tests/gateway/test_ssl_certs.py`: keep the extracted helper in sync; assert darwin falls through to certifi

## How to Test

```text
uv run --extra dev python -m pytest tests/gateway/test_ssl_certs.py -q
# 2 passed
```

Not runtime-tested on a real macOS host (Linux here). The helper is a source copy of `_ensure_ssl_certs` — same pattern as the existing env-var test.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit). macOS path not runtime-tested here.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (CA path selection; covered by the darwin unit test)
