### PR TITLE
fix(desktop): load a hybrid plugin from only one scan door

### DIFF
--- a/apps/desktop/src/contrib/runtime-loader.test.ts
+++ b/apps/desktop/src/contrib/runtime-loader.test.ts
@@ -137,6 +137,57 @@ describe('scanDiskPlugins (#66899)', () => {
     expect(readDir).toHaveBeenCalledTimes(1)
   })
 
+  it('does not scan the unified desktop half when the standalone door already has that folder (#100412)', async () => {
+    desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
+    agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')
+    readDir.mockImplementation(async dir => {
+      if (dir === '/local/.hermes/desktop-plugins') {
+        return {
+          entries: [
+            {
+              isDirectory: true,
+              name: 'word-count',
+              path: '/local/.hermes/desktop-plugins/word-count'
+            }
+          ]
+        }
+      }
+
+      if (dir === '/local/.hermes/desktop-plugins/word-count') {
+        return {
+          entries: [
+            {
+              isDirectory: false,
+              name: 'plugin.js',
+              path: '/local/.hermes/desktop-plugins/word-count/plugin.js'
+            }
+          ]
+        }
+      }
+
+      if (dir === '/local/.hermes/plugins') {
+        return {
+          entries: [{ isDirectory: true, name: 'word-count', path: '/local/.hermes/plugins/word-count' }]
+        }
+      }
+
+      if (dir === '/local/.hermes/plugins/word-count') {
+        return {
+          entries: [
+            { isDirectory: true, name: 'desktop', path: '/local/.hermes/plugins/word-count/desktop' }
+          ]
+        }
+      }
+
+      return { entries: [] }
+    })
+
+    await discoverRuntimePlugins()
+
+    expect(readDir).not.toHaveBeenCalledWith('/local/.hermes/plugins/word-count')
+    expect(readDir).not.toHaveBeenCalledWith('/local/.hermes/plugins/word-count/desktop')
+  })
+
   it('loads a unified desktop half OPT-IN: inventoried but not activated by default', async () => {
     desktopPluginsRoot.mockResolvedValue('/local/.hermes/desktop-plugins')
     agentPluginsRoot.mockResolvedValue('/local/.hermes/plugins')

--- a/apps/desktop/src/contrib/runtime-loader.ts
+++ b/apps/desktop/src/contrib/runtime-loader.ts
@@ -431,6 +431,11 @@ async function scanDiskPlugins(): Promise<void> {
     }
 
     const seen = new Set<string>()
+    // Folder names are claimed across both doors. A hybrid install copies the
+    // desktop half into desktop-plugins/<name> AND leaves plugins/<name>/desktop
+    // in the agent tree; loading both registers the same plugin id twice
+    // (#100412). Standalone is scanned first and wins.
+    const claimedOrigins = new Set<string>()
 
     for (const root of roots) {
       let entries
@@ -442,6 +447,10 @@ async function scanDiskPlugins(): Promise<void> {
       }
 
       for (const dir of entries.filter(e => e.isDirectory)) {
+        if (claimedOrigins.has(dir.name)) {
+          continue
+        }
+
         let file: string | null
 
         try {
@@ -454,6 +463,7 @@ async function scanDiskPlugins(): Promise<void> {
           continue // Ordinary agent package with no Desktop half — not an error.
         }
 
+        claimedOrigins.add(dir.name)
         seen.add(file)
 
         if (disk.has(file)) {


### PR DESCRIPTION
## What does this PR do?

A hybrid plugin install copies the desktop half to `desktop-plugins/<name>/plugin.js` and also leaves `plugins/<name>/desktop/plugin.js` in the agent tree. `scanDiskPlugins` walks both doors and keys the live map by file path, so the same plugin id loads twice. Last registration wins; Settings inventory and hot-reload then flip between the two copies.

Folder names are now claimed across both roots. The standalone door is scanned first and wins; the unified half of the same folder is skipped.

## Related Issue

Fixes #100412

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/contrib/runtime-loader.ts`: `claimedOrigins` Set, skip a folder already seen from the other door
- `runtime-loader.test.ts`: word-count in both doors; do not walk `plugins/word-count`

## How to Test

```text
cd apps/desktop
npx vitest run src/contrib/runtime-loader.test.ts
# 12 passed
```

Not runtime-tested against a live hybrid Git install in Desktop.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (vitest)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A (scan skip; covered by the dual-door test)
