### PR TITLE
fix(managed_uv): run smoke test in project_root and preserve failure diagnostics (#100477)

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -826,7 +826,11 @@ def _install_safe_python_generation(
     return None
 
 
-def _smoke_candidate_venv(venv_dir: Path) -> tuple[bool, str, SQLiteRuntimeInfo | None]:
+def _smoke_candidate_venv(
+    venv_dir: Path,
+    *,
+    project_root: Path | None = None,
+) -> tuple[bool, str, SQLiteRuntimeInfo | None]:
     """Exercise the candidate interpreter and imports through its real path."""
     python = _venv_python(venv_dir)
     info = probe_sqlite_runtime(python)
@@ -854,10 +858,11 @@ def _smoke_candidate_venv(venv_dir: Path) -> tuple[bool, str, SQLiteRuntimeInfo 
         "VIRTUAL_ENV",
     ):
         env.pop(key, None)
+    run_cwd = project_root if project_root is not None else venv_dir.parent
     try:
         result = subprocess.run(
             [str(python), "-I", "-c", check],
-            cwd=venv_dir.parent,
+            cwd=run_cwd,
             env=env,
             capture_output=True,
             text=True,
@@ -914,18 +919,20 @@ def _stage_candidate_venv(
         check=False,
     )
     if created.returncode != 0:
+        detail = (created.stderr or created.stdout or "").strip()
+        last_line = detail.splitlines()[-1] if detail else f"candidate venv creation failed (rc={created.returncode})"
         logger.warning(
             "candidate venv creation failed (rc=%d): %s",
             created.returncode,
-            (created.stderr or created.stdout or "").strip(),
+            last_line,
         )
         _remove_tree(candidate, boundary=runtime_root)
-        return None
+        return None, last_line
 
     if not (project_root / "uv.lock").is_file():
         logger.warning("candidate dependency sync refused: uv.lock is missing")
         _remove_tree(candidate, boundary=runtime_root)
-        return None
+        return None, "uv.lock is missing"
     # Locked sync must see project [tool.uv] exclude-newer; --no-config /
     # UV_NO_CONFIG drops it and uv 0.12+ refuses --locked.
     sync_env = dict(env)
@@ -942,19 +949,23 @@ def _stage_candidate_venv(
         ],
         cwd=project_root,
         env=sync_env,
+        capture_output=True,
+        text=True,
         check=False,
     )
     if synced.returncode != 0:
-        logger.warning("candidate dependency sync failed (rc=%d)", synced.returncode)
+        detail = (synced.stderr or synced.stdout or "").strip()
+        last_line = detail.splitlines()[-1] if detail else f"candidate dependency sync failed (rc={synced.returncode})"
+        logger.warning("candidate dependency sync failed (rc=%d): %s", synced.returncode, last_line)
         _remove_tree(candidate, boundary=runtime_root)
-        return None
+        return None, last_line
 
-    healthy, detail, _ = _smoke_candidate_venv(candidate)
+    healthy, detail, _ = _smoke_candidate_venv(candidate, project_root=project_root)
     if not healthy:
         logger.warning("candidate venv smoke failed: %s", detail)
         _remove_tree(candidate, boundary=runtime_root)
-        return None
-    return candidate
+        return None, detail
+    return candidate, ""
 
 
 def _rename_with_retry(source: Path, destination: Path) -> None:
@@ -1010,7 +1021,7 @@ def _cut_over_candidate(
             )
 
         try:
-            healthy, detail, info = _smoke_candidate_venv(live)
+            healthy, detail, info = _smoke_candidate_venv(live, project_root=project_root)
         except Exception as exc:
             healthy, detail, info = False, f"candidate smoke raised: {exc}", None
         if healthy:
@@ -1430,17 +1441,29 @@ def repair_vulnerable_runtime(
             )
         generation, python, candidate_info = provisioned
 
-        candidate = _stage_candidate_venv(
+        staged = _stage_candidate_venv(
             uv_bin,
             project_root=root,
             generation=generation,
             python=python,
         )
+        candidate: Path | None = None
+        smoke_detail = ""
+        if isinstance(staged, tuple):
+            candidate = staged[0]
+            smoke_detail = staged[1] if len(staged) > 1 else ""
+        elif isinstance(staged, Path):
+            candidate = staged
         if candidate is None:
             _remove_tree(generation, boundary=managed_python_install_dir(root))
+            fail_detail = (
+                f"replacement environment did not pass dependency and import smoke tests: {smoke_detail}"
+                if smoke_detail
+                else "replacement environment did not pass dependency and import smoke tests"
+            )
             return RuntimeRepairResult(
                 "failed",
-                "replacement environment did not pass dependency and import smoke tests",
+                fail_detail,
                 sqlite_before=current.sqlite_version_string,
                 sqlite_after=candidate_info.sqlite_version_string,
             )

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -620,6 +620,62 @@ class TestRuntimeRepair:
         assert leftovers == [], f"no stale markers may remain: {leftovers}"
 
 
+class TestCandidateSmokeDiagnostics:
+    """Regression tests for issue #100477: candidate smoke diagnostics & cwd."""
+
+    def test_failed_candidate_smoke_reports_specific_detail(self, tmp_path):
+        """Repair failure must include actionable smoke-test diagnostics (#100477)."""
+        from hermes_cli.managed_uv import repair_vulnerable_runtime
+
+        root, live, sentinel = _make_runtime_install(tmp_path, windows=sys.platform == "win32")
+        generation = root / ".hermes-runtime" / "cpython-3.12-fixed"
+        generation.mkdir(parents=True)
+        bin_name = "Scripts" if sys.platform == "win32" else "bin"
+        py_name = "python.exe" if sys.platform == "win32" else "python"
+        candidate_python = generation / bin_name / py_name
+        candidate_python.parent.mkdir(parents=True, exist_ok=True)
+        candidate_python.write_text("fixed interpreter", encoding="utf-8")
+        current = _runtime_info(candidate_python, (3, 49, 1))
+        fixed = _runtime_info(candidate_python, (3, 53, 1))
+
+        with patch(
+                 "hermes_cli.managed_uv.probe_sqlite_runtime",
+                 side_effect=[current, current],
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._install_safe_python_generation",
+                 return_value=(generation, candidate_python, fixed),
+             ), \
+             patch(
+                 "hermes_cli.managed_uv._stage_candidate_venv",
+                 return_value=(None, "ModuleNotFoundError: No module named 'hermes_state'"),
+             ):
+            result = repair_vulnerable_runtime("uv", project_root=root)
+
+        assert result.status == "failed"
+        assert "ModuleNotFoundError: No module named 'hermes_state'" in result.detail
+
+    def test_smoke_candidate_venv_uses_project_root_cwd(self, tmp_path):
+        """_smoke_candidate_venv must execute inside project_root (#100477)."""
+        from hermes_cli.managed_uv import _smoke_candidate_venv
+
+        root = tmp_path / "checkout"
+        root.mkdir()
+        candidate = root / ".hermes-runtime" / "venv-candidate"
+        bin_name = "Scripts" if sys.platform == "win32" else "bin"
+        py_name = "python.exe" if sys.platform == "win32" else "python"
+        (candidate / bin_name).mkdir(parents=True)
+        (candidate / bin_name / py_name).write_text("py", encoding="utf-8")
+
+        observed_cwd = []
+        with patch("hermes_cli.managed_uv.probe_sqlite_runtime", return_value=_runtime_info(candidate / bin_name / py_name, (3, 53, 1))), \
+             patch("hermes_cli.managed_uv._venv_python", return_value=candidate / bin_name / py_name), \
+             patch("hermes_cli.managed_uv.subprocess.run") as mock_run:
+            mock_run.side_effect = lambda *args, **kwargs: (observed_cwd.append(kwargs.get("cwd")) or MagicMock(returncode=0))
+            _smoke_candidate_venv(candidate, project_root=root)
+
+        assert observed_cwd == [root]
+
 class TestRuntimeCutover:
     def test_os_lock_blocks_concurrent_repair_and_releases(self, tmp_path):
         from hermes_cli.managed_uv import _acquire_repair_lock, _release_repair_lock


### PR DESCRIPTION
## What does this PR do?

During SQLite runtime replacement (`repair_vulnerable_runtime` in `hermes_cli/managed_uv.py`), two issues occurred when testing replacement environments:
1. `_smoke_candidate_venv` executed the candidate python in isolated mode (`-I`) with `cwd=venv_dir.parent` (`.runtime`), preventing imports of root-level project modules (such as `hermes_state`) from resolving.
2. When candidate staging or smoke testing failed, `_stage_candidate_venv` swallowed the specific error detail and returned `None`, causing `repair_vulnerable_runtime` to report a generic `"replacement environment did not pass dependency and import smoke tests"` without any actionable diagnostic detail.

This PR passes `project_root` to `_smoke_candidate_venv` so the smoke test executes in `project_root`, and propagates the specific failure details (e.g. the exact failed import / stderr from `_smoke_candidate_venv` or `uv sync`) through `_stage_candidate_venv` into `RuntimeRepairResult.detail`.

## Related Issue

Fixes #100477

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/managed_uv.py`:
  - Update `_smoke_candidate_venv` to accept `project_root` and run the smoke subprocess with `cwd=project_root`.
  - Update `_stage_candidate_venv` to capture and return `(candidate, detail)` when venv creation, sync, or smoke tests fail.
  - Update `repair_vulnerable_runtime` and `_cut_over_candidate` to receive `project_root` and format the actionable smoke failure detail into `RuntimeRepairResult.detail`.
- `tests/hermes_cli/test_managed_uv.py`: Added regression tests `test_failed_candidate_smoke_reports_specific_detail` and `test_smoke_candidate_venv_uses_project_root_cwd`.

## How to Test

1. Run the regression tests:
   `python -m pytest tests/hermes_cli/test_managed_uv.py -k TestCandidateSmokeDiagnostics`
2. Run the update sqlite remediation suite:
   `python -m pytest tests/hermes_cli/test_sqlite_runtime.py tests/hermes_cli/test_update_sqlite_remediation.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_sqlite_runtime.py tests/hermes_cli/test_update_sqlite_remediation.py` and tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
