### PR TITLE
fix(update): stop crediting unmanaged serve runtimes with a gateway's restart

### DIFF
--- a/hermes_cli/update_inventory.py
+++ b/hermes_cli/update_inventory.py
@@ -464,17 +464,31 @@ def match_runtime_outcomes(
             if r is None:
                 continue
             outcome = "unaccounted"
+            # The bare "hermes-gateway" unit name is gateway-specific: a
+            # serve/dashboard runtime that merely shares the default
+            # profile is a different process the gateway restart never
+            # touched, and must not borrow its outcome (#100479).
             if r.profile in relaunched or r.profile in external:
                 outcome = "restarted"
             elif r.pid is not None and r.pid in killed:
                 outcome = "stopped"
             elif any(
-                r.profile in unit or (r.profile == "default" and "hermes-gateway" in unit)
+                r.profile in unit
+                or (
+                    r.kind == "gateway"
+                    and r.profile == "default"
+                    and "hermes-gateway" in unit
+                )
                 for unit in failed_set
             ):
                 outcome = "failed"
             elif any(
-                r.profile in svc or (r.profile == "default" and "hermes-gateway" in svc)
+                r.profile in svc
+                or (
+                    r.kind == "gateway"
+                    and r.profile == "default"
+                    and "hermes-gateway" in svc
+                )
                 for svc in restarted_set
             ):
                 outcome = "restarted"

--- a/tests/hermes_cli/test_restart_plan_reconciliation.py
+++ b/tests/hermes_cli/test_restart_plan_reconciliation.py
@@ -159,6 +159,28 @@ def test_external_supervisor_counts_as_restarted():
     assert outcomes[0]["outcome"] == "restarted"
 
 
+def test_unmanaged_serve_runtime_under_default_profile_is_unaccounted():
+    """#100479: an sshd-spawned `serve --isolated` has no systemd unit and
+    shares the default profile with the gateway. A gateway-only restart
+    must not be read as covering it — it must trip the tripwire instead."""
+    serve_runtime = RuntimeRecord(
+        kind="serve",
+        profile="default",
+        pid=900,
+        supervisor="manual-serve",
+        restart_via=_restart_mechanism("manual-serve", "default"),
+    )
+    outcomes = match_runtime_outcomes(
+        _plan(_rt("default", 100, supervisor="systemd"), serve_runtime),
+        restarted_services=["hermes-gateway"], relaunched_profiles=[],
+        externally_supervised_profiles=[], killed_pids=set(), failed_units=[],
+    )
+    by_pid = {o["pid"]: o["outcome"] for o in outcomes}
+    assert by_pid[100] == "restarted"
+    assert by_pid[900] == "unaccounted"
+    assert report_unaccounted_runtimes(outcomes) is True
+
+
 def test_mixed_fleet_only_the_missed_one_escalates(capsys):
     outcomes = match_runtime_outcomes(
         _plan(


### PR DESCRIPTION
Fixes #100479.

## The bug

`match_runtime_outcomes()` (`hermes_cli/update_inventory.py`, added by
#91277 Phase 2 as the "unaccounted runtime" tripwire) is supposed to
flag any planned runtime that the restart phase's bookkeeping never
mentions. For a runtime under the `default` profile, it has a fallback
special case: if the bare `"hermes-gateway"` unit shows up in
`restarted_services`, the runtime is credited as `"restarted"`.

That special case doesn't check the runtime's `kind`. A `serve`/
`dashboard` runtime — e.g. an sshd-spawned `hermes serve --isolated`
backend with no systemd unit at all (`supervisor="manual-serve"`,
`restart_via="respawn-argv"`) — is recorded under `profile="default"`
in the ledger just like the gateway. When the `hermes-gateway` systemd
unit restarts, this unrelated serve process gets marked `"restarted"`
purely because it shares the default profile name, even though its own
PID was never touched.

Because of that, the #91277 Phase 2 tripwire (`report_unaccounted_runtimes`)
never fires for these processes, and a `hermes update` that leaves a
pre-update `serve --isolated` backend running (still on stale
`sys.modules`, still ticking its own cron scheduler) reports a clean
success. That backend then fails every agent-mode cron job with
`ImportError: cannot import name 'X'` for any symbol added during the
pulled range, while `no_agent` jobs at the same tick succeed — exactly
the alert-storm signature in #100479's report, traced there via
`cron/executions.db`'s per-tick PID column.

## The fix

Restrict the `"hermes-gateway"` fallback match (in both the `failed`
and `restarted` branches) to `r.kind == "gateway"`. A serve/dashboard
runtime under the same profile now falls through to `"unaccounted"`
when nothing in the restart bookkeeping actually names it, which is
what the tripwire is for.

This only closes the reporting gap (one of several independent fixes
suggested in the issue) — it does not stop, relaunch, or add
relaunch authority for these runtimes, since a manual/Desktop-owned
serve has none. It makes the existing "planned runtimes the restart
phase never touched" warning fire for this class instead of it being
silently swallowed.

## Test plan

Added `test_unmanaged_serve_runtime_under_default_profile_is_unaccounted`
to `tests/hermes_cli/test_restart_plan_reconciliation.py`, mirroring the
issue's real-world shape: a `gateway` runtime restarted via the
`hermes-gateway` systemd unit, plus a `serve` runtime on the same
`default` profile with `supervisor="manual-serve"` that the restart
phase's bookkeeping never mentions.

Confirmed the test fails without the fix (`git checkout HEAD~1 --
hermes_cli/update_inventory.py`, keeping the new test):

```
$ python -m pytest tests/hermes_cli/test_restart_plan_reconciliation.py -q -k test_unmanaged_serve
F
AssertionError: assert 'restarted' == 'unaccounted'
  - unaccounted
  + restarted
1 failed, 11 deselected in 0.29s
```

With the fix restored, the full reconciliation suite and its
neighbors pass:

```
$ python -m pytest tests/hermes_cli/test_restart_plan_reconciliation.py -q
............                                                             [100%]
12 passed in 0.31s

$ python -m pytest tests/hermes_cli/test_windows_update_restart_reconciliation.py \
    tests/hermes_cli/test_plan_reconciliation_windows_live.py \
    tests/hermes_cli/test_update_autostash.py -q
....s..............................                                      [100%]
34 passed, 1 skipped in 30.31s

$ python -m pytest tests/hermes_cli/test_serve_runtime_inventory.py \
    tests/hermes_cli/test_update_fleet_restart_pending.py \
    tests/hermes_cli/test_update_inventory.py -q
....................................                                     [100%]
36 passed in 4.09s
```

`ruff check hermes_cli/update_inventory.py tests/hermes_cli/test_restart_plan_reconciliation.py` passes clean.

This change was developed with AI assistance (Claude Code), with all
diagnosis, code, and test output verified by running the actual test
suite against this checkout.
