### PR TITLE
fix(desktop): key profile rail sortable id by name, not display label

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-reorder.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-reorder.test.tsx
@@ -1,0 +1,120 @@
+import type * as DndKitSortable from '@dnd-kit/sortable'
+import { cleanup, render } from '@testing-library/react'
+import { atom } from 'nanostores'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ProfileRail } from './profile-switcher'
+
+// A profile square's sortable identity must track the canonical profile
+// name, not its display label -- SortableContext and handleDragEnd are both
+// keyed by name (profile-switcher.tsx), so a square registered under its
+// label falls out of that id space the moment display_name differs from
+// name, and dragging it silently does nothing (#100480).
+
+const sortableIds: string[] = []
+
+vi.mock('@dnd-kit/sortable', async () => {
+  const actual = await vi.importActual<typeof DndKitSortable>('@dnd-kit/sortable')
+
+  return {
+    ...actual,
+    useSortable: (args: Parameters<typeof actual.useSortable>[0]) => {
+      sortableIds.push(String(args.id))
+
+      return actual.useSortable(args)
+    }
+  }
+})
+
+vi.mock('react-router', () => ({
+  useNavigate: () => vi.fn()
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      common: { cancel: 'Cancel' },
+      profiles: {
+        allProfiles: 'All profiles',
+        connectGateway: 'Manage gateways…',
+        failedLoadSoul: 'Failed to load SOUL.md',
+        failedSaveSoul: 'Failed to save SOUL.md',
+        importProfile: 'Import profile…',
+        manageProfiles: 'Manage profiles…',
+        newProfile: 'New profile',
+        remoteOverride: {
+          badge: (host: string) => `Runs on ${host}`,
+          menuItem: 'Connect to a remote host…'
+        },
+        saveSoul: 'Save',
+        saving: 'Saving…',
+        showAllProfiles: 'Show all profiles',
+        soulSaved: 'SOUL.md saved',
+        switchToProfile: (name: string) => `Switch to ${name}`,
+        title: 'Profiles'
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/profile', () => ({
+  $activeGatewayProfile: atom('default'),
+  $profileColors: atom({}),
+  $profileCreateRequest: atom(0),
+  $profileOrder: atom([]),
+  $profiles: atom([
+    { is_default: true, name: 'default' },
+    { display_name: '薄荷', is_default: false, name: 'assistant' }
+  ]),
+  $profileScope: atom('default'),
+  ALL_PROFILES: '*',
+  normalizeProfileKey: (name: string) => name,
+  profileLabel: (profile: { display_name?: string; name: string }) =>
+    (profile.display_name ?? '').trim() || profile.name,
+  refreshActiveProfile: vi.fn().mockResolvedValue(undefined),
+  selectProfile: vi.fn(),
+  setProfileColor: vi.fn(),
+  setProfileOrder: vi.fn(),
+  setShowAllProfiles: vi.fn(),
+  sortByProfileOrder: (profiles: unknown[]) => profiles
+}))
+
+vi.mock('@/store/connections', () => ({
+  $activeConnectionId: atom(null),
+  $connectionsRegistry: atom(null),
+  $hasMultipleConnections: atom(false),
+  selectConnection: vi.fn()
+}))
+
+vi.mock('@/store/profile-share', () => ({
+  runExportProfileFlow: vi.fn(),
+  runImportProfileFlow: vi.fn()
+}))
+
+vi.mock('./use-profile-prewarm', () => ({
+  useProfilePrewarm: () => ({ cancelPrewarm: vi.fn(), startPrewarm: vi.fn() })
+}))
+
+vi.mock('@/hermes', () => ({
+  getProfileSoul: vi.fn().mockResolvedValue({ content: '' }),
+  updateProfileSoul: vi.fn()
+}))
+
+vi.mock('@/components/chat/code-editor', () => ({ CodeEditor: () => null }))
+vi.mock('../../profiles/create-profile-dialog', () => ({ CreateProfileDialog: () => null }))
+vi.mock('../../profiles/delete-profile-dialog', () => ({ DeleteProfileDialog: () => null }))
+vi.mock('../../profiles/rename-profile-dialog', () => ({ RenameProfileDialog: () => null }))
+
+afterEach(() => {
+  cleanup()
+  sortableIds.length = 0
+})
+
+describe('ProfileRail drag-to-reorder identity', () => {
+  it('registers a named profile square under its canonical name, not its display label', () => {
+    render(<ProfileRail />)
+
+    expect(sortableIds).toContain('assistant')
+    expect(sortableIds).not.toContain('薄荷')
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -371,6 +371,7 @@ export function ProfileRail() {
                   color={resolveProfileColor(profile.name, colors)}
                   key={profile.name}
                   label={profileLabel(profile)}
+                  name={profile.name}
                   // The legacy per-profile remote override predates the
                   // gateway registry; once the rail shows machines directly
                   // it only confuses, so it is offered on single-gateway
@@ -1133,6 +1134,11 @@ interface ProfileSquareProps {
   active: boolean
   color: null | string
   label: string
+  // The canonical profile id -- distinct from `label`, which is the display
+  // name and may be absent, non-ASCII, or renamed. Sortable identity must
+  // track this, not the label, or dnd-kit's id space diverges from the
+  // SortableContext/handleDragEnd id space (both keyed by name).
+  name: string
   onSelect: () => void
   onRecolor: (color: null | string) => void
   onRename: () => void
@@ -1161,6 +1167,7 @@ function ProfileSquare({
   active,
   color,
   label,
+  name,
   onConnectRemote,
   onDelete,
   onEditSoul,
@@ -1180,7 +1187,7 @@ function ProfileSquare({
   const { cancelPrewarm, startPrewarm } = useProfilePrewarm(label)
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
-    id: label,
+    id: name,
     transition: RAIL_TRANSITION
   })
 


### PR DESCRIPTION
Fixes #100480

## Root cause

In `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`, `ProfileSquare`
registered its dnd-kit sortable identity using the *display label*:

```tsx
const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
  id: label,          // profileLabel(profile) = display_name || name
  transition: RAIL_TRANSITION
})
```

but the surrounding `SortableContext` and `handleDragEnd` are both keyed by
the *canonical profile name*:

```tsx
<SortableContext items={named.map(profile => profile.name)} strategy={horizontalListSortingStrategy}>
...
const ids = named.map(profile => profile.name)
const from = ids.indexOf(String(active.id))
const to = ids.indexOf(String(over.id))
```

As long as a profile has no `display_name` (or one identical to its `name`),
`label === name` and the two id spaces happen to line up. The moment a
profile is given a non-empty, differing `display_name` (e.g. a Chinese
name), the square's sortable id no longer appears in `SortableContext`'s
`items`, so `ids.indexOf(active.id)` returns `-1` and `setProfileOrder` is
never called — the drag silently does nothing.

## Fix

Pass the profile's canonical `name` into `ProfileSquare` as its own prop and
use it for the sortable id, keeping `label` purely for display (aria-label,
avatar initial, tooltip).

```diff
                   color={resolveProfileColor(profile.name, colors)}
                   key={profile.name}
                   label={profileLabel(profile)}
+                  name={profile.name}
```

```diff
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
-    id: label,
+    id: name,
     transition: RAIL_TRANSITION
   })
```

## Test

Added `apps/desktop/src/app/chat/sidebar/profile-rail-reorder.test.tsx`,
which mocks `@dnd-kit/sortable`'s `useSortable` to record the `id` each
`ProfileSquare` registers with, renders `ProfileRail` with a profile whose
`display_name` ('薄荷') differs from its `name` ('assistant'), and asserts
the sortable id is the canonical name, not the label.

Confirmed the test fails without the fix:

```
$ git stash push -- apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
$ npx vitest run src/app/chat/sidebar/profile-rail-reorder.test.tsx --project ui
 ❯ |ui| src/app/chat/sidebar/profile-rail-reorder.test.tsx (1 test | 1 failed)
     × registers a named profile square under its canonical name, not its display label
AssertionError: expected [ '薄荷' ] to include 'assistant'
 Test Files  1 failed (1)
      Tests  1 failed (1)

$ git stash pop
```

And passes with it:

```
$ npx vitest run src/app/chat/sidebar/profile-rail-reorder.test.tsx --project ui
 Test Files  1 passed (1)
      Tests  1 passed (1)
```

Full sidebar suite (unaffected by the change) still green:

```
$ npx vitest run src/app/chat/sidebar/ --project ui
 Test Files  26 passed (26)
      Tests  227 passed (227)
```

Lint (`npx eslint src/app/chat/sidebar/profile-switcher.tsx src/app/chat/sidebar/profile-rail-reorder.test.tsx`)
and typecheck (`npx tsc -p . --noEmit`) both pass clean.

## AI assistance disclosure

This change (root-cause analysis, fix, and test) was written with the
assistance of an AI coding agent (Claude), reviewed and verified by running
the project's real lint/typecheck/test commands as shown above.
