### PR TITLE
fix(desktop): isolate an OAuth cookie partition only on a real host collision

### DIFF
--- a/apps/desktop/electron/oauth-partition.test.ts
+++ b/apps/desktop/electron/oauth-partition.test.ts
@@ -69,9 +69,39 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
     ])
 
     expect(resolveOauthPartition('https://gw-a.example.com/api/status', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
-    expect(resolveOauthPartition('https://gw-b.example.com/api/status', { registry: reg })).not.toBe(
+    // conn-b is on a different HOST than the primary — no cookie-jar collision
+    // is possible, so it rides the legacy jar too rather than an isolated
+    // partition that would never persist its cookies to disk (#100373).
+    expect(resolveOauthPartition('https://gw-b.example.com/api/status', { registry: reg })).toBe(
       LEGACY_OAUTH_PARTITION
     )
+  })
+
+  it('isolates a non-primary connection that shares the PRIMARY connection\'s hostname (#100373)', () => {
+    const reg = registry('conn-a', [
+      remote('conn-a', 'https://10.0.0.20:9119'),
+      remote('conn-b', 'https://10.0.0.20:9220')
+    ])
+
+    expect(resolveOauthPartition('https://10.0.0.20:9119/api/status', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
+    expect(resolveOauthPartition('https://10.0.0.20:9220/api/status', { registry: reg })).not.toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+  })
+
+  it('rides the legacy jar for two non-colliding remotes on different hosts (#100373 repro)', () => {
+    // The exact reported topology: primary is the local device, two remote
+    // gateways registered on different LAN hosts. Neither can evict the
+    // other's cookie in a shared jar, so isolating either one only trades a
+    // real bug (per-connection partitions never persisted cookies) for a
+    // problem that could not occur.
+    const reg = registry('local', [
+      remote('hp', 'http://10.0.0.20:9119'),
+      remote('asus', 'http://10.0.0.30:9119')
+    ])
+
+    expect(resolveOauthPartition('http://10.0.0.20:9119/api/status', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
+    expect(resolveOauthPartition('http://10.0.0.30:9119/api/status', { registry: reg })).toBe(LEGACY_OAUTH_PARTITION)
   })
 
   it('keeps cloud connections on the legacy partition (silent portal cascade needs the shared jar)', () => {
@@ -113,7 +143,12 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
   })
 
   it('normalizes trailing slashes and default ports when matching entry URLs', () => {
-    const reg = registry('local', [remote('conn-a', 'https://gw-a.example.com:443/')])
+    const reg = registry('local', [
+      remote('conn-a', 'https://gw-a.example.com:443/'),
+      // A colliding same-host sibling so conn-a actually needs isolation —
+      // otherwise there is nothing to normalize into a match against.
+      remote('conn-a-2', 'https://gw-a.example.com:8443/')
+    ])
 
     const got = resolveOauthPartition('https://gw-a.example.com/api/auth/ws-ticket', { registry: reg })
 
@@ -122,7 +157,11 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
   })
 
   it('produces a deterministic, partition-safe name from hostile connection ids', () => {
-    const reg = registry('local', [remote('we ird/id:€', 'https://gw-a.example.com')])
+    const reg = registry('local', [
+      remote('we ird/id:€', 'https://gw-a.example.com'),
+      // A colliding same-host sibling so the hostile id actually gets isolated.
+      remote('other', 'https://gw-a.example.com:8443')
+    ])
 
     const got = resolveOauthPartition('https://gw-a.example.com', { registry: reg })
 

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -20,8 +20,14 @@
  *   - A NON-primary v2 registry `remote` entry with cookie auth
  *     (`authMode: 'oauth'`, which covers dashboard basic/password providers —
  *     they authenticate via session cookies too) gets its own partition
- *     derived from the connection id. Fail closed: its requests can never see
- *     another connection's cookies, and its login window can never evict them.
+ *     derived from the connection id, but ONLY when another cookie-auth entry
+ *     (including the primary) shares its hostname. Chromium cookie jars
+ *     ignore the port, so that shared-host case is the only one where two
+ *     entries can actually evict or read each other's session cookie in the
+ *     legacy jar. Isolating on a different host solves nothing and costs a
+ *     real regression instead (#100373): a freshly created per-connection
+ *     partition on Windows never wrote its `Cookies` database to disk, so an
+ *     isolated gateway silently lost its session on every restart.
  *   - The registry PRIMARY and the v1 single-connection remote stay on the
  *     LEGACY shared partition, so existing signed-in users are not signed out
  *     by the upgrade.
@@ -88,6 +94,19 @@ function sanitizePartitionComponent(id: string): string {
   return encodeURIComponent(id).replace(/%/g, '_')
 }
 
+/** Hostname only (port dropped) — Chromium's cookie jar ignores the port too. */
+function safeHostname(raw: unknown): string | null {
+  if (typeof raw !== 'string' || !raw.trim()) {
+    return null
+  }
+
+  try {
+    return new URL(raw.trim()).hostname.toLowerCase() || null
+  } catch {
+    return null
+  }
+}
+
 /**
  * Decide the Electron session partition a cookie-authenticated request against
  * `requestUrl` must ride. See the module header for the rules.
@@ -108,7 +127,7 @@ export function resolveOauthPartition(requestUrl: unknown, opts: ResolveOauthPar
   const primaryId = typeof registry.primary === 'string' ? registry.primary : ''
   const v1Norm = normalizeForMatch(opts.v1RemoteUrl)
 
-  let best: { baseNorm: string; id: string } | null = null
+  let best: { baseNorm: string; id: string; host: string | null } | null = null
 
   for (const entry of registry.connections) {
     if (!entry || typeof entry !== 'object') {
@@ -143,11 +162,39 @@ export function resolveOauthPartition(requestUrl: unknown, opts: ResolveOauthPar
     // identical URLs tie-break on the lexicographically smallest id so the
     // choice is deterministic across processes and launches.
     if (!best || baseNorm.length > best.baseNorm.length || (baseNorm.length === best.baseNorm.length && id < best.id)) {
-      best = { baseNorm, id }
+      best = { baseNorm, id, host: safeHostname((entry as any).url) }
     }
   }
 
   if (!best) {
+    return LEGACY_OAUTH_PARTITION
+  }
+
+  // Isolate only when the winning entry's hostname is shared by another
+  // cookie-auth entry (any kind of "other" — the primary or a different
+  // secondary). No collision means no port-eviction risk, so the legacy jar
+  // is both sufficient and the only one that reliably persists (#100373).
+  const collides =
+    best.host !== null &&
+    registry.connections.some(other => {
+      if (!other || typeof other !== 'object') {
+        return false
+      }
+
+      const otherId = typeof (other as any).id === 'string' ? (other as any).id.trim() : ''
+
+      if (!otherId || otherId === best!.id) {
+        return false
+      }
+
+      return (
+        (other as any).kind === 'remote' &&
+        (other as any).authMode === 'oauth' &&
+        safeHostname((other as any).url) === best!.host
+      )
+    })
+
+  if (!collides) {
     return LEGACY_OAUTH_PARTITION
   }
 

--- a/apps/desktop/electron/oauth-partition.ts
+++ b/apps/desktop/electron/oauth-partition.ts
@@ -20,8 +20,9 @@
  *   - A NON-primary v2 registry `remote` entry with cookie auth
  *     (`authMode: 'oauth'`, which covers dashboard basic/password providers —
  *     they authenticate via session cookies too) gets its own partition
- *     derived from the connection id, but ONLY when another cookie-auth entry
- *     (including the primary) shares its hostname. Chromium cookie jars
+ *     derived from the connection id, but ONLY when another cookie-auth
+ *     `remote` entry (including the primary, when it is itself a `remote`
+ *     entry) shares its hostname. Chromium cookie jars
  *     ignore the port, so that shared-host case is the only one where two
  *     entries can actually evict or read each other's session cookie in the
  *     legacy jar. Isolating on a different host solves nothing and costs a


### PR DESCRIPTION
## What does this PR do?

`resolveOauthPartition()` (added by #92183) hands out a per-connection
Electron session partition (`persist:hermes-remote-oauth:conn:<id>`) to
*every* non-primary v2 remote gateway with `authMode: 'oauth'`, regardless
of whether isolation is actually needed.

Per the root-cause writeup in #100373, those per-connection partitions never
write a `Cookies` database to disk on Windows — Local Storage, Session
Storage, `Network Persistent State`, and `Trust Tokens` all persist for the
partition, but `Network\Cookies` is never created. So a non-primary
cookie-auth gateway signs in successfully, works for the entire app
lifetime, and is signed out on every single restart — indefinitely. The
reporter reproduced this twice on the same machine with the roles swapped
(swapping which of two gateways was primary), which rules out the specific
gateway, host, and network as the cause and isolates it to "non-primary +
per-connection partition."

Per-connection isolation exists to solve exactly one problem: two gateways
on the **same host** (different port) evicting each other's session cookie,
because Chromium's cookie jar ignores the port. Gateways on **different**
hosts can never collide that way — a single cookie store already scopes
cookies per domain, the same way a normal browser's one cookie jar holds
sessions for many unrelated sites without conflict. So isolating two
different-host gateways bought nothing and cost reliable persistence
instead.

This PR makes `resolveOauthPartition()` isolate only when a real collision
is possible: another cookie-auth entry (including the primary) shares the
candidate connection's hostname. Otherwise the connection rides the legacy
shared partition, which is the one partition that has been reliably
persisting cookies to disk all along.

This addresses "Issue 1" from #100373 exactly as reproduced (two remote
gateways on different LAN hosts, primary = local device): both now resolve
to the legacy partition instead of one of them getting an isolated jar that
never saves cookies. It does not touch "Issue 2" from the same report (the
`connect-on-demand` roster state being mislabeled as "unreachable" in the
desktop UI) — that's a separate, unrelated UI defect in
`profile-switcher.tsx` / the roster builder, not a cookie-jar bug, and is
left for a follow-up.

## Related Issue

Fixes #100373 (Issue 1 only — the cookie-jar persistence regression)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/oauth-partition.ts` — `resolveOauthPartition()` now
  tracks the candidate connection's hostname and only returns a
  per-connection partition when another cookie-auth entry (`kind: 'remote'`,
  `authMode: 'oauth'`) — including the primary — shares that hostname
  (new `safeHostname()` helper). No collision → legacy shared partition.
- `apps/desktop/electron/oauth-partition.test.ts` — updated two existing
  tests whose registries had a non-colliding, non-primary remote and
  asserted it got isolated (that was exactly the buggy behavior); added
  same-host colliding siblings so they keep exercising the isolation branch
  for a real collision. Added two regression tests: a non-primary remote
  that *does* share the primary's hostname still gets isolated, and the
  exact reported topology (two different-host remotes, local primary) rides
  the legacy jar on both sides.

## How to Test

1. `npm install --workspace apps/desktop` (from repo root)
2. `npx vitest run electron/oauth-partition.test.ts` (from `apps/desktop`)
3. `npx tsc -p tsconfig.electron.json --noEmit` (from `apps/desktop`)
4. `npx eslint electron/oauth-partition.ts electron/oauth-partition.test.ts` (from `apps/desktop`)

### Test output

```
 Test Files  1 passed (1)
      Tests  13 passed (13)
```

Confirmed the 2 new/changed tests fail without the fix (temporarily
reverted `oauth-partition.ts` to HEAD while keeping the updated test file):

```
FAIL electron/oauth-partition.test.ts > resolveOauthPartition (#92183 per-connection cookie jars) > keeps the registry PRIMARY connection on the legacy partition
AssertionError: expected 'persist:hermes-remote-oauth:conn:conn-b' to be 'persist:hermes-remote-oauth'

FAIL electron/oauth-partition.test.ts > resolveOauthPartition (#92183 per-connection cookie jars) > rides the legacy jar for two non-colliding remotes on different hosts (#100373 repro)
AssertionError: expected 'persist:hermes-remote-oauth:conn:hp' to be 'persist:hermes-remote-oauth'

 Test Files  1 failed (1)
      Tests  2 failed | 11 passed (13)
```

Also ran the full electron vitest project (`npx vitest run --project
electron` from `apps/desktop`): **2015 passed, 6 skipped, 0 failed** — no
regressions. Typecheck (`tsc -p tsconfig.electron.json --noEmit`) and lint
(`eslint`) on the touched files are both clean.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains only changes related to this fix (2 files, both in
      `oauth-partition.{ts,test.ts}`; no dependency/lockfile/CI changes)
- [x] I've added tests for my change, and verified they fail without the fix
- [x] Ran typecheck and lint on touched files — clean
- [x] Full electron test suite (2015 tests) passes with no regressions

## AI assistance disclosure

This fix (investigation, patch, and tests) was authored with the assistance
of an AI coding agent (Claude), with the resulting diff reviewed before
opening this PR.
