### PR TITLE
fix(update): warn surviving pre-update serve and dashboard runtimes on success (#100479)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10703,6 +10703,15 @@ def _cmd_update_impl(args, gateway_mode: bool):
             node_failures, already_restarted_units=set(restarted_services)
         )
 
+        # Check if any pre-update serve/dashboard runtimes survived on
+        # pre-update code generations (#100479).
+        try:
+            _stale_serve_rows = _surviving_pre_update_serve_runtimes(_pre_update_plan)
+            if _stale_serve_rows:
+                _warn_stale_serve_runtimes(_stale_serve_rows)
+        except Exception as _serve_warn_exc:
+            logger.debug("Failed to check for surviving serve runtimes: %s", _serve_warn_exc)
+
         print()
         print("Tip: You can now select a provider and model:")
         print("  hermes model              # Select provider and model")

--- a/tests/hermes_cli/test_update_fleet_restart_pending.py
+++ b/tests/hermes_cli/test_update_fleet_restart_pending.py
@@ -102,16 +102,21 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(
         hermes_main, "_finish_dashboard_update_cleanup", lambda *a, **k: None
     )
+    monkeypatch.setattr(
+        update_cmd, "_finish_dashboard_update_cleanup", lambda *a, **k: None
+    )
     monkeypatch.setattr(hermes_main, "_build_web_ui", lambda *a, **k: None)
     monkeypatch.setattr(
         update_cmd, "_venv_core_imports_healthy", lambda: (True, "")
     )
     monkeypatch.setattr(update_cmd, "_update_node_dependencies", lambda: [])
+    monkeypatch.setattr(update_cmd, "_purge_stale_hermes_modules", lambda: None)
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
 
     import hermes_cli.gateway as hermes_gateway
 
     monkeypatch.setattr(
-        hermes_gateway, "find_gateway_pids", lambda all_profiles=False: []
+        hermes_gateway, "find_gateway_pids", lambda **_kwargs: []
     )
     monkeypatch.setattr(hermes_gateway, "supports_systemd_services", lambda: False)
     monkeypatch.setattr(
@@ -300,6 +305,33 @@ def test_marker_written_after_pull_cleared_after_successful_restart(
     assert not update_cmd._fleet_restart_pending_marker_path().exists()
     out = capsys.readouterr().out
     assert "✓ Code updated!" in out
+
+
+def test_clean_update_warns_about_surviving_pre_update_serve_runtime(
+    monkeypatch, tmp_path, capsys
+):
+    """The successful update path must surface an inventoried stale serve."""
+    args = _update_args()
+    _patch_update_deps(monkeypatch, tmp_path, _make_head_moved_side_effect())
+    monkeypatch.setattr(
+        update_cmd,
+        "_surviving_pre_update_serve_runtimes",
+        lambda _plan: [
+            {
+                "pid": 5555,
+                "kind": "serve",
+                "profile": "default",
+                "supervisor": "manual-serve",
+            }
+        ],
+    )
+
+    hermes_main.cmd_update(args)
+
+    out = capsys.readouterr().out
+    assert "pid 5555" in out
+    assert "serve" in out
+    assert "pre-update code" in out
 
 
 def test_interrupt_between_pull_and_restart_leaves_marker(


### PR DESCRIPTION
## What does this PR do?

On the clean success path of `hermes update`, `_surviving_pre_update_serve_runtimes(_pre_update_plan)` and `_warn_stale_serve_runtimes()` were never called (they were only wired into the abort recovery `except Exception:` block).

As a result, non-unit `serve` and `dashboard` runtimes (such as Desktop SSH `serve --isolated` or manual CLI `serve` sessions with no systemd unit) that survived the update continue running on pre-update `sys.modules` graphs without warning the user. Because these serve processes run cron tickers, later agent-mode cron runs fail with `ImportError` on symbols added in the update.

This PR adds the check for surviving serve/dashboard runtimes on the normal update path after dashboard cleanup, reporting any stale processes and the commands to restart them.

## Related Issue

Fixes #100479

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/update_cmd.py`: Call `_surviving_pre_update_serve_runtimes(_pre_update_plan)` and `_warn_stale_serve_runtimes()` on the normal update path so non-unit serve/dashboard runtimes surviving an update are reported.
- `tests/hermes_cli/test_update_fleet_restart_pending.py`: Added an update-path regression test that drives `cmd_update` through a successful mocked pull and asserts the stale-runtime warning.

## How to Test

1. Run the update-path regression test:
   `python -m pytest tests/hermes_cli/test_update_fleet_restart_pending.py::test_clean_update_warns_about_surviving_pre_update_serve_runtime`
2. Run the relevant suites in separate pytest processes:
   `python -m pytest tests/hermes_cli/test_update_serve_generation_recovery.py`
   `python -m pytest tests/hermes_cli/test_update_fleet_restart_pending.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_update_serve_generation_recovery.py` and tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
