### PR TITLE
fix(desktop): refresh the project tree on external session changes

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -91,12 +91,14 @@ function useSyncHarness({
   activeIsMessaging = false,
   activeSessionId,
   activeStoredSessionId,
-  refreshActiveTranscript
+  refreshActiveTranscript,
+  refreshProjectTree = vi.fn()
 }: {
   activeIsMessaging?: boolean
   activeSessionId: string | null
   activeStoredSessionId: string | null
   refreshActiveTranscript: () => Promise<void>
+  refreshProjectTree?: () => Promise<void>
 }) {
   const updateSessionState: Parameters<typeof useBackgroundSync>[0]['updateSessionState'] = vi.fn(
     (sessionId, updater) => {
@@ -119,6 +121,7 @@ function useSyncHarness({
     refreshCurrentModel: vi.fn(),
     refreshHermesConfig: vi.fn(),
     refreshMessagingSessions: vi.fn(),
+    refreshProjectTree,
     refreshSessions: vi.fn(),
     updateSessionState,
     requestGateway: vi.fn(async () => ({ sessions: [] })) as never
@@ -127,7 +130,12 @@ function useSyncHarness({
 
 function renderSync(
   refreshActiveTranscript: () => Promise<void>,
-  options: { activeIsMessaging?: boolean; activeSessionId?: null | string; activeStoredSessionId?: null | string } = {}
+  options: {
+    activeIsMessaging?: boolean
+    activeSessionId?: null | string
+    activeStoredSessionId?: null | string
+    refreshProjectTree?: () => Promise<void>
+  } = {}
 ) {
   return renderHook(() =>
     useSyncHarness({
@@ -413,6 +421,17 @@ describe('active transcript refresh', () => {
 
     expect(refresh).toHaveBeenCalledTimes(1)
   })
+
+  it('refreshes the authoritative project tree on the same coalesced sessions.changed pass (#100354)', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshProjectTree = vi.fn(async () => undefined)
+
+    renderSync(async () => undefined, { refreshProjectTree })
+
+    act(() => notifySessionsChanged())
+    expect(refreshProjectTree).toHaveBeenCalledTimes(1)
+  })
 })
 
 describe('reconcileActiveTranscript', () => {
@@ -653,6 +672,7 @@ describe('typing-aware sessions.changed deferral', () => {
       refreshCurrentModel: vi.fn(),
       refreshHermesConfig: vi.fn(),
       refreshMessagingSessions: vi.fn(),
+      refreshProjectTree: vi.fn(),
       requestGateway: vi.fn(async () => ({ sessions: [] })) as never,
       // Required by the hook's params. This harness never drives the
       // transcript path, so the updater just runs against a throwaway state —

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.tsx
@@ -25,6 +25,7 @@ function render(activeGatewayProfile: string, activeConnectionId: string, refres
         refreshCurrentModel: noop,
         refreshHermesConfig: noop,
         refreshMessagingSessions: noop,
+        refreshProjectTree: noop,
         refreshSessions,
         requestGateway
       })

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -461,6 +461,7 @@ interface BackgroundSyncParams {
   refreshCurrentModel: (force?: boolean) => Promise<unknown> | unknown
   refreshHermesConfig: () => Promise<unknown> | unknown
   refreshMessagingSessions: () => Promise<unknown> | unknown
+  refreshProjectTree: () => Promise<unknown> | unknown
   refreshSessions: () => Promise<unknown> | unknown
   requestGateway: GatewayRequester
   updateSessionState: (
@@ -534,6 +535,7 @@ export function useBackgroundSync({
   refreshCurrentModel,
   refreshHermesConfig,
   refreshMessagingSessions,
+  refreshProjectTree,
   refreshSessions,
   requestGateway,
   updateSessionState
@@ -691,6 +693,12 @@ export function useBackgroundSync({
       lastRunAt = Date.now()
       void refreshSessions()
       void refreshMessagingSessions()
+      // The authoritative project tree is a separate cache from the flat
+      // session list (#100354): an external create/rename/delete/cwd-move
+      // advances $sessionsChangeTick but never touched projects.tree without
+      // this, so Home/Project membership, counts, and preview rows went stale
+      // until Desktop restarted.
+      void refreshProjectTree()
       requestActiveTranscriptRefresh(true)
       // Bot canonical chats live in workspace tiles, never in the main-pane
       // selection — without this they never see background deliveries
@@ -766,6 +774,7 @@ export function useBackgroundSync({
     changeEventsAvailable,
     gatewayState,
     refreshMessagingSessions,
+    refreshProjectTree,
     refreshSessions,
     requestActiveTranscriptRefresh,
     updateSessionState

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -58,7 +58,7 @@ import {
   normalizeProfileKey,
   refreshActiveProfile
 } from '@/store/profile'
-import { $startWorkSessionRequest, followActiveSessionCwd } from '@/store/projects'
+import { $startWorkSessionRequest, followActiveSessionCwd, refreshProjectTree } from '@/store/projects'
 import {
   $activeSessionId,
   $connection,
@@ -832,6 +832,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     refreshCurrentModel,
     refreshHermesConfig,
     refreshMessagingSessions,
+    refreshProjectTree,
     refreshSessions,
     requestGateway,
     updateSessionState


### PR DESCRIPTION
## Problem

Fixes #100354.

Hermes Desktop's sidebar shows two things that are supposed to stay in sync: the flat session list, and the authoritative project tree (`projects.tree`, which drives Home vs. Project membership, per-project counts, and preview rows). Both are backend-owned caches invalidated by the renderer's `sessions.changed` handling.

The coalesced `sessions.changed` pass in `apps/desktop/src/app/contrib/hooks/use-background-sync.ts` already refreshed the flat list (`refreshSessions`, `refreshMessagingSessions`) and reconciled open transcripts on every throttled tick — but never called `refreshProjectTree()`. So a session created, renamed, deleted, or cwd-moved from outside the renderer (CLI, another Desktop window, a gateway/platform session) advanced the flat list while the project tree stayed cached, until Desktop was restarted.

## Fix

Add `refreshProjectTree()` to the same throttled/coalesced `run()` pass that already handles `refreshSessions()` and `refreshMessagingSessions()`, threaded through as a new required prop on `useBackgroundSync` (mirroring how every other refresh callback here is injected) and wired from `wiring.tsx` to the existing `refreshProjectTree` export in `@/store/projects`.

`refreshProjectTree()` already carries its own generation guard, tombstone preservation, and best-effort failure handling, so no new invalidation logic was needed. The entered-project drill-in view (`apps/desktop/src/app/chat/sidebar/index.tsx`) already re-hydrates its full lanes whenever `$projectTree` changes (its effect lists `projectTree` as a dependency), so wiring the tick into `refreshProjectTree()` fixes that surface too, for free.

## Test

Added a regression test in `use-background-sync.test.ts`:

```
refreshes the authoritative project tree on the same coalesced sessions.changed pass (#100354)
```

Confirmed RED without the fix (reverted only the two source files with `git stash`, keeping the new test):

```
❯ |ui| src/app/contrib/hooks/use-background-sync.test.ts (25 tests | 1 failed)
    × refreshes the authoritative project tree on the same coalesced sessions.changed pass (#100354)
AssertionError: expected "vi.fn()" to be called 1 times, but got 0 times
Test Files  1 failed | 1 passed (2)
     Tests  1 failed | 26 passed (27)
```

Confirmed GREEN with the fix restored:

```
 Test Files  2 passed (2)
      Tests  27 passed (27)
```

Also ran, all green:
- `npx vitest run src/app/contrib/hooks/use-background-sync.test.ts src/app/contrib/hooks/use-background-sync.test.tsx` — 27 passed
- `npx vitest run src/store/projects.test.ts src/store/gateway-switch.test.ts` — 52 passed
- `npx tsc -p . --noEmit` — clean
- `npx eslint src/app/contrib/hooks/use-background-sync.ts src/app/contrib/hooks/use-background-sync.test.ts src/app/contrib/hooks/use-background-sync.test.tsx src/app/contrib/wiring.tsx` — clean

## Disclosure

This contribution was developed with AI assistance (Claude) and checked against the current code and test suite before being opened.
