### PR TITLE
test(gateway): async goal tests no longer drop the goal write on slow CI runners

### DIFF
--- a/tests/gateway/test_goal_continuation_drain.py
+++ b/tests/gateway/test_goal_continuation_drain.py
@@ -87,6 +87,11 @@ def hermes_home(tmp_path, monkeypatch):
     from hermes_cli import goals
 
     goals._DB_CACHE.clear()
+    # Pre-warm the SessionDB cache from this sync (non-loop) context so the
+    # async tests' GoalManager.set() never races the bounded loop-thread
+    # bootstrap window on loaded CI runners (goal silently not persisted →
+    # continuation never enqueued; flaked on main run 33455779041).
+    goals._get_session_db()
     yield home
     goals._DB_CACHE.clear()
 

--- a/tests/gateway/test_goal_max_turns_config.py
+++ b/tests/gateway/test_goal_max_turns_config.py
@@ -59,6 +59,10 @@ async def test_gateway_goal_uses_goals_max_turns_from_full_config(tmp_path, monk
     (home / "config.yaml").write_text("goals:\n  max_turns: 7\n", encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(home))
     goals._DB_CACHE.clear()
+    # Pre-warm from sync context: the /goal handler runs on the event loop,
+    # where a cold cache only waits the bounded bootstrap window — under CI
+    # load the goal write can be dropped and the state assertion flakes.
+    goals._get_session_db()
 
     runner = _make_runner()
 

--- a/tests/gateway/test_goal_resume_restart.py
+++ b/tests/gateway/test_goal_resume_restart.py
@@ -46,6 +46,10 @@ def hermes_home(tmp_path, monkeypatch):
 
     token = set_hermes_home_override(str(home))
     goals._DB_CACHE.clear()
+    # Pre-warm the SessionDB cache from sync context so async GoalManager
+    # writes never race the bounded loop-thread bootstrap window on loaded
+    # CI runners (goal silently unpersisted; main run 33455779041).
+    goals._get_session_db()
     yield home
     try:
         reset_hermes_home_override(token)

--- a/tests/gateway/test_loop_command.py
+++ b/tests/gateway/test_loop_command.py
@@ -34,6 +34,13 @@ def loop_env(tmp_path, monkeypatch):
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
     goals._DB_CACHE.clear()
+    # Pre-warm the SessionDB cache from this sync (non-loop) context. Inside
+    # the async tests, a cold cache makes GoalManager.set() kick the bounded
+    # background bootstrap (loop-thread path) and wait only
+    # _DB_BOOTSTRAP_INIT_WAIT_S — on a loaded CI runner the init overruns the
+    # window, the goal is never persisted, and the active-goal assertion
+    # flakes (main run 33455779041). Warming here removes the race entirely.
+    goals._get_session_db()
     yield home
     goals._DB_CACHE.clear()
 


### PR DESCRIPTION
## Summary
Async gateway goal/loop tests no longer flake when the CI runner is slow: their fixtures now pre-warm the goals SessionDB cache from sync context, so the deliberately-bounded loop-thread bootstrap window can never drop the goal write mid-test.

Root cause: `GoalManager.set()` on an event-loop thread waits only `_DB_BOOTSTRAP_INIT_WAIT_S` (1.5s) for the background SessionDB bootstrap — intentional production behavior (an unbounded init starved the gateway loop watchdog → exit-75 crash loop). On a loaded CI runner the cold init overruns the window, the goal write is silently dropped, and the tests fail downstream with confusing symptoms: `/loop` shows no "active /goal" note; the goal continuation is enqueued under no key. Both flaked in main run [33455779041](https://github.com/NousResearch/hermes-agent/actions/runs/33455779041) (the captured log even shows the `bootstrap window exceeded` warning).

## Changes
- `tests/gateway/test_loop_command.py`, `tests/gateway/test_goal_continuation_drain.py`, `tests/gateway/test_goal_resume_restart.py`, `tests/gateway/test_goal_max_turns_config.py`: fixtures call `goals._get_session_db()` right after clearing `_DB_CACHE` (sync context = unbounded init path). Test-only; production bootstrap semantics untouched. Sync-only goal test files can't hit the window by construction and are left alone.

## Validation
| | Before | After |
|---|---|---|
| Live repro (SessionDB.__init__ slowed past the window, `set()` on loop thread) | goal write dropped, `state is None` | goal persisted |
| 4 files (18 tests) ×3 consecutive | 2 FLAKY frames on main | 18 passed ×3 |

**Live repro:** deterministic harness slows `SessionDB.__init__` beyond `_DB_BOOTSTRAP_INIT_WAIT_S` — reproduces the exact CI warning + dropped write without the pre-warm; never fires with it.

## Infographic

![Goal tests race squashed](https://v3b.fal.media/files/b/0aa8b312/cioVE9J7xyVjOQS-2TB29_5eYRoqIs.png)
