### PR TITLE
feat(plugins): add bounded state deletion

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1433,6 +1433,11 @@ class PluginState:
         with _locked_plugin_state(self.path):
             return self._read_unlocked().get(key, default)
 
+    def keys(self) -> tuple[str, ...]:
+        """Return a stable snapshot of stored keys for bounded plugin GC."""
+        with _locked_plugin_state(self.path):
+            return tuple(self._read_unlocked().keys())
+
     def set(self, key: str, value: Any) -> None:
         """Atomically set one JSON value without dropping concurrent updates."""
         self._validate_key(key)
@@ -1450,6 +1455,24 @@ class PluginState:
                     f"Plugin state quota exceeded: {len(encoded)} bytes is greater "
                     f"than the {self.quota_bytes}-byte per-plugin quota"
                 )
+            from utils import atomic_json_write
+
+            atomic_json_write(self.path, data, mode=0o600)
+
+    def delete(self, key: str) -> None:
+        """Atomically remove one key; remove the state file when it becomes empty."""
+        self._validate_key(key)
+        with _locked_plugin_state(self.path):
+            data = self._read_unlocked()
+            if key not in data:
+                return
+            del data[key]
+            if not data:
+                try:
+                    self.path.unlink()
+                except FileNotFoundError:
+                    pass
+                return
             from utils import atomic_json_write
 
             atomic_json_write(self.path, data, mode=0o600)

--- a/tests/hermes_cli/test_plugin_config_state_bridge.py
+++ b/tests/hermes_cli/test_plugin_config_state_bridge.py
@@ -203,6 +203,24 @@ def test_state_round_trip_is_atomic_and_aligned_with_plugin_data(
     assert not list(state_path.parent.glob("*.tmp"))
 
 
+def test_state_delete_removes_key_and_last_value_file(isolated_home: Path) -> None:
+    ctx = _context()
+    ctx.state.set("keep", 1)
+    ctx.state.set("remove", 2)
+    assert set(ctx.state.keys()) == {"keep", "remove"}
+
+    ctx.state.delete("remove")
+
+    assert ctx.state.get("remove") is None
+    assert ctx.state.get("keep") == 1
+    assert json.loads(ctx.state.path.read_text(encoding="utf-8")) == {"keep": 1}
+
+    ctx.state.delete("keep")
+    ctx.state.delete("already_missing")
+
+    assert not ctx.state.path.exists()
+
+
 def test_native_state_namespace_is_windows_safe_and_cannot_traverse(
     isolated_home: Path,
 ) -> None:

--- a/website/docs/developer-guide/plugins/index.md
+++ b/website/docs/developer-guide/plugins/index.md
@@ -556,7 +556,14 @@ than placing runtime bookkeeping in `config.yaml`:
 def register(ctx):
     cursor = ctx.state.get("cursor", default={"page": 0})
     ctx.state.set("cursor", {"page": cursor["page"] + 1})
+    stale_keys = [key for key in ctx.state.keys() if key.startswith("expired:")]
+    for key in stale_keys:
+        ctx.state.delete(key)
 ```
+
+`get()` reads one value, `set()` atomically replaces one value, `keys()` returns
+a stable key snapshot for bounded garbage collection, and `delete()` atomically
+removes a key. Deleting the last key also removes the empty `state.json` file.
 
 State is profile-scoped, atomically replaced, safe across concurrent writers,
 and limited to 10 MiB per plugin. Portable packages share the same directory as


### PR DESCRIPTION
## Summary
- add atomic `PluginState.keys()` for bounded garbage collection
- add atomic `PluginState.delete()` with empty-file cleanup
- document the API and cover deletion/idempotency with a regression test

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_plugin_config_state_bridge.py tests/hermes_cli/test_plugins.py -q` — 96 passed
- `ruff check hermes_cli/plugins.py tests/hermes_cli/test_plugin_config_state_bridge.py` — passed
- `git diff --check origin/main..HEAD` — passed
