### PR TITLE
fix(mcp): keep tool errors out of connectivity breaker

### DIFF
--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,56 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_application_errors_do_not_trip_server_circuit_breaker(monkeypatch, tmp_path):
+    """Tool-domain failures prove the MCP transport is still reachable.
+
+    A threshold's worth of ``CallToolResult.isError`` responses from one tool
+    must not open the server-wide connectivity breaker and block an unrelated
+    healthy tool on the same server.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    calls = []
+
+    async def _call_tool(tool_name, **kwargs):
+        calls.append(tool_name)
+        result = MagicMock()
+        block = MagicMock()
+        if tool_name == "domain_error":
+            result.is_error = True
+            block.text = "document not found"
+        else:
+            result.is_error = False
+            block.text = "healthy response"
+        result.content = [block]
+        result.structured_content = None
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        failing_handler = _make_tool_handler("srv", "domain_error", 10.0)
+        healthy_handler = _make_tool_handler("srv", "unrelated_tool", 10.0)
+
+        for _ in range(mcp_tool._CIRCUIT_BREAKER_THRESHOLD):
+            parsed = json.loads(failing_handler({}))
+            assert parsed.get("error") == "document not found", parsed
+
+        parsed = json.loads(healthy_handler({}))
+        assert parsed.get("result") == "healthy response", parsed
+        assert calls == (
+            ["domain_error"] * mcp_tool._CIRCUIT_BREAKER_THRESHOLD
+            + ["unrelated_tool"]
+        )
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6142,7 +6142,14 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     )
                 return tool_error(f"MCP server '{server_name}' is not connected")
 
+        rpc_round_trip_completed = False
+
         async def _call():
+            nonlocal rpc_round_trip_completed
+            # ``_call`` may run twice after auth/session recovery. Classify
+            # each attempt independently so only the latest attempt informs
+            # the connectivity breaker.
+            rpc_round_trip_completed = False
             _mark_server_call_started(server)
             async with server._rpc_lock, _track_inflight_rpc(
                 server, server_name, f"tools/call {tool_name}"
@@ -6237,6 +6244,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                             )
                 finally:
                     server._pending_call_context = None
+            rpc_round_trip_completed = True
             # The RPC round-trip completed — the session is demonstrably
             # healthy at the transport level (even if the tool itself
             # returned isError). Clear the rapid-drop budget (#62212).
@@ -6372,15 +6380,20 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            if rpc_round_trip_completed:
+                # CallToolResult.isError is a tool/application-level failure,
+                # not evidence that the server transport is unreachable.
+                _reset_server_error(server_name)
+            else:
+                # Pre-RPC connectivity errors (for example dead stdio
+                # children with a stale session) still count as failures.
+                try:
+                    if "error" in json.loads(result):
+                        _bump_server_error(server_name)
+                    else:
+                        _reset_server_error(server_name)
+                except (json.JSONDecodeError, TypeError):
+                    _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
## Summary
- track whether an MCP `tools/call` completed an RPC round trip
- reset the server connectivity breaker after a completed round trip, including `CallToolResult.isError=true`
- continue counting pre-RPC connectivity errors, transport exceptions, and dead-session/dead-stdio failures

## Reproduction
Three legitimate application-level errors from one MCP tool previously opened the server-wide breaker and blocked a healthy, unrelated tool as `server unreachable`.

## Verification
- regression failed before the fix and passes afterward
- MCP circuit-breaker and tool-handler suites: 107 passed
- `git diff --check` passed
