### PR TITLE
fix(anthropic): serialize concurrent lazy SDK imports with thread lock (#100461)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -19,6 +19,7 @@ import re
 import secrets
 import stat
 import subprocess
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -129,25 +130,29 @@ except Exception:
 # paths. Access via the `_get_anthropic_sdk()` accessor below, which caches
 # the module after the first call and returns None on ImportError.
 _anthropic_sdk: Any = ...  # sentinel — None means "tried and missing"
+_anthropic_sdk_lock = threading.Lock()
 
 
 def _get_anthropic_sdk():
     """Return the ``anthropic`` SDK module, importing lazily. None if not installed."""
     global _anthropic_sdk
-    if _anthropic_sdk is ...:
-        try:
-            from tools.lazy_deps import ensure as _lazy_ensure
-            _lazy_ensure("provider.anthropic", prompt=False)
-        except ImportError:
-            pass
-        except Exception:
-            # FeatureUnavailable — fall through to ImportError handling below
-            pass
-        try:
-            import anthropic as _sdk
-            _anthropic_sdk = _sdk
-        except ImportError:
-            _anthropic_sdk = None
+    if _anthropic_sdk is not ...:
+        return _anthropic_sdk
+    with _anthropic_sdk_lock:
+        if _anthropic_sdk is ...:
+            try:
+                from tools.lazy_deps import ensure as _lazy_ensure
+                _lazy_ensure("provider.anthropic", prompt=False)
+            except ImportError:
+                pass
+            except Exception:
+                # FeatureUnavailable — fall through to ImportError handling below
+                pass
+            try:
+                import anthropic as _sdk
+                _anthropic_sdk = _sdk
+            except ImportError:
+                _anthropic_sdk = None
     return _anthropic_sdk
 
 logger = logging.getLogger(__name__)

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -45,6 +45,32 @@ class TestIsOAuthToken:
 
 
 
+class TestAnthropicSdkLazyImport:
+    def test_get_anthropic_sdk_is_thread_safe(self, monkeypatch):
+        """Concurrent calls to _get_anthropic_sdk must be serialized by lock (#100461)."""
+        import concurrent.futures
+        import agent.anthropic_adapter as adapter
+
+        mock_module = SimpleNamespace(Anthropic=MagicMock())
+        monkeypatch.setitem(sys.modules, "anthropic", mock_module)
+        # Reset sentinel to simulate cold start
+        monkeypatch.setattr(adapter, "_anthropic_sdk", ...)
+
+        def worker():
+            return adapter._get_anthropic_sdk()
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+            futures = [executor.submit(worker) for _ in range(10)]
+            results = [f.result() for f in futures]
+
+        assert all(r is mock_module for r in results)
+        assert adapter._anthropic_sdk is mock_module
+    def test_get_anthropic_sdk_has_thread_lock(self):
+        """_anthropic_sdk_lock must exist to serialize concurrent cold-start imports (#100461)."""
+        import agent.anthropic_adapter as adapter
+        assert hasattr(adapter, "_anthropic_sdk_lock")
+
+
 class TestBuildAnthropicClient:
 
 


### PR DESCRIPTION
## What does this PR do?

In v0.21.0, `_get_anthropic_sdk()` in `agent/anthropic_adapter.py` imports the `anthropic` SDK module lazily on first access. However, during concurrent cold-starts (e.g. across multiple daemon profiles or multi-threaded worker pools starting simultaneously), multiple threads execute `import anthropic as _sdk` concurrently.

Under CPython 3.12 (such as cpython-3.12.13), concurrent module imports of generic classes (such as `Generic[_APIResponseT]` in `anthropic._response`) race during `typing._generic_class_getitem` cache initialization and cause `RecursionError` / typing-recursion crashes.

This PR wraps the lazy import in `_get_anthropic_sdk()` with a dedicated `threading.Lock()` using double-checked locking, serializing the initial import so concurrent cold-starts safely share the cached module without race conditions.

## Related Issue

Fixes #100461

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/anthropic_adapter.py`: Added `_anthropic_sdk_lock = threading.Lock()` and double-checked locking in `_get_anthropic_sdk()` to ensure concurrent callers serialize during initial import.
- `tests/agent/test_anthropic_adapter.py`: Added regression tests in `TestAnthropicSdkLazyImport` verifying thread-safety and lock presence across concurrent worker threads.

## How to Test

1. Run the regression tests:
   `python -m pytest tests/agent/test_anthropic_adapter.py -k TestAnthropicSdkLazyImport`
2. Run the anthropic adapter test suite:
   `python -m pytest tests/agent/test_anthropic_adapter.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_anthropic_adapter.py` and tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
