### PR TITLE
fix(desktop): upload SSH attachments across stale routes

### DIFF
--- a/apps/desktop/src/store/session-states.test.ts
+++ b/apps/desktop/src/store/session-states.test.ts
@@ -1228,4 +1228,18 @@ describe('isSessionRemote (#94640)', () => {
 
     expect(isSessionRemote('stored-2')).toBe(true)
   })
+
+  it('uploads bytes when the ambient SSH tunnel is remote but a stale owner route is local', () => {
+    $connection.set({ mode: 'remote', remoteKind: 'ssh' } as never)
+    $sessionTiles.set([
+      {
+        ownerRoute: { connectionId: 'stale-local', mode: 'local', profile: 'default' },
+        runtimeId: 'rt-ssh',
+        storedSessionId: 'stored-ssh'
+      }
+    ])
+
+    expect(isSessionRemote('rt-ssh')).toBe(true)
+    expect(isSessionRemote('stored-ssh')).toBe(true)
+  })
 })

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -988,24 +988,27 @@ export function knownOwnerForSession(sessionId: null | string | undefined): Sess
 }
 
 /**
- * Whether the connection that OWNS `sessionId` is remote — never the ambient
- * `$connection`. A session tied to a registered secondary connection (Bot
+ * Whether attachment bytes may need to cross a machine boundary for
+ * `sessionId`. A session tied to a registered secondary connection (Bot
  * Mode, the unified Sessions list) can differ from whichever connection the
  * window currently shows; its RPCs already route to their own owner via
  * `requestForSessionProfile`, but a caller that instead reads ambient mode to
  * decide image.attach vs image.attach_bytes ships a client-local path to a
  * remote backend that can't resolve it (#94640). A bare profile name (no
  * connectionId) is a pool profile of the ambient connection, so ambient mode
- * still applies there.
+ * still applies there. If either route is remote, uploading bytes is safe and
+ * avoids sending a client-local path when a stale local owner route survives
+ * an SSH/remote re-home.
  */
 export function isSessionRemote(sessionId: null | string | undefined): boolean {
   const owner = knownOwnerForSession(sessionId)
+  const ambientRemote = $connection.get()?.mode === 'remote'
 
   if (owner && typeof owner === 'object' && owner.mode) {
-    return owner.mode === 'remote'
+    return owner.mode === 'remote' || ambientRemote
   }
 
-  return $connection.get()?.mode === 'remote'
+  return ambientRemote
 }
 
 /**


### PR DESCRIPTION
## Summary
- stage attachments as bytes whenever either the session owner or ambient connection is remote
- prevent stale local owner routes after an SSH/remote re-home from sending client-local paths to the gateway
- add a regression test for the SSH tunnel case

## Reproduction
Attaching a Mac file to a Desktop session backed by an SSH-connected VPS could call `file.attach` without `data_url`. The gateway then returned `file not found on gateway and no data_url provided`.

## Verification
- `npm --workspace apps/desktop test -- --project ui src/store/session-states.test.ts` (74 passed)
- six `session-states*.test.ts` suites (115 passed)
- `npm --workspace apps/desktop run typecheck`
- `npx eslint apps/desktop/src/store/session-states.ts apps/desktop/src/store/session-states.test.ts`
- independent review: no security or logic findings