### PR TITLE
fix(gateway,desktop): suppress benign Darwin malloc-stack-logging stderr noise (#54833)

### DIFF
--- a/apps/desktop/electron/backend-claim.test.ts
+++ b/apps/desktop/electron/backend-claim.test.ts
@@ -130,3 +130,44 @@ test('attach tolerates a child with missing stdio streams', () => {
   tail.attach({ stderr: null, stdout: null })
   assert.equal(tail.text(), '')
 })
+
+// --- #54833: benign Darwin malloc noise filtered from stderr, never stdout ---
+
+const MALLOC_NOISE =
+  "MallocStackLogging: can't turn off malloc stack logging because it was not enabled."
+
+test('output tail suppresses the exact stderr noise line on darwin', () => {
+  const prev = process.platform
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  try {
+    const child = { stderr: new EventEmitter(), stdout: new EventEmitter() }
+    const tail = createBackendOutputTail(4096)
+
+    tail.attach(child)
+    child.stderr.emit('data', Buffer.from(`real boot error\nPython(12) ${MALLOC_NOISE}\n`))
+    child.stderr.emit('end')
+
+    assert.match(tail.text(), /real boot error/)
+    assert.doesNotMatch(tail.text(), /MallocStackLogging/)
+  } finally {
+    Object.defineProperty(process, 'platform', { value: prev, configurable: true })
+  }
+})
+
+test('output tail retains the literal sentence when it arrives on stdout', () => {
+  const prev = process.platform
+  Object.defineProperty(process, 'platform', { value: 'darwin', configurable: true })
+  try {
+    const child = { stderr: new EventEmitter(), stdout: new EventEmitter() }
+    const tail = createBackendOutputTail(4096)
+
+    tail.attach(child)
+    child.stdout.emit('data', Buffer.from(`tool printed: ${MALLOC_NOISE}\n`))
+    child.stderr.emit('data', Buffer.from(''))
+    child.stderr.emit('end')
+
+    assert.match(tail.text(), new RegExp(MALLOC_NOISE.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')))
+  } finally {
+    Object.defineProperty(process, 'platform', { value: prev, configurable: true })
+  }
+})

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -18,6 +18,7 @@
  */
 
 import { execFile } from 'node:child_process'
+import { createBenignStderrSink } from './subprocess-stderr-noise'
 import fs from 'node:fs'
 
 import { electronProcessStartMarker } from './parent-process-identity'
@@ -150,7 +151,9 @@ export interface BackendOutputTail {
   /** Attach stdout/stderr data listeners to a just-spawned child. */
   attach(child: {
     stdout?: { on: (event: 'data', listener: (chunk: unknown) => void) => unknown } | null
-    stderr?: { on: (event: 'data', listener: (chunk: unknown) => void) => unknown } | null
+    stderr?: {
+      on: (event: 'data' | 'end' | 'close', listener: (chunk?: unknown) => void) => unknown
+    } | null
   }): void
   append(chunk: unknown): void
   /** The buffered tail (most recent `limit` characters), or ''. */
@@ -182,7 +185,14 @@ export function createBackendOutputTail(limit: number = DEFAULT_OUTPUT_TAIL_LIMI
     append,
     attach(child) {
       child.stdout?.on('data', append)
-      child.stderr?.on('data', append)
+      // #54833: stderr goes through the benign-noise sink (Darwin-only exact
+      // line); stdout is never filtered. flush() is wired on stream end so
+      // the held-back tail still reaches the boot-failure tail.
+      const stderrSink = createBenignStderrSink(append)
+
+      child.stderr?.on('data', stderrSink)
+      child.stderr?.on('end', () => append(stderrSink.flush()))
+      child.stderr?.on('close', () => append(stderrSink.flush()))
     },
     text() {
       return buffer

--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -18,10 +18,10 @@
  */
 
 import { execFile } from 'node:child_process'
-import { createBenignStderrSink } from './subprocess-stderr-noise'
 import fs from 'node:fs'
 
 import { electronProcessStartMarker } from './parent-process-identity'
+import { createBenignStderrSink } from './subprocess-stderr-noise'
 import { hiddenWindowsChildOptions } from './windows-child-options'
 
 export function execText(command: string, args: string[], { timeout = 3000 } = {}): Promise<string> {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -44,6 +44,7 @@ import {
   probeStartMarker,
   processStartMarker
 } from './backend-claim'
+import { createBenignStderrSink } from './subprocess-stderr-noise'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
@@ -12079,7 +12080,16 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce, outputTail)
 
   child.stdout.on('data', rememberLog)
-  child.stderr.on('data', rememberLog)
+  // #54833: filter the known-benign Darwin libmalloc teardown line out of
+  // backend stderr before it reaches desktop.log; stdout is never filtered.
+  const stderrNoiseSink = createBenignStderrSink(rememberLog)
+  child.stderr?.on('data', stderrNoiseSink)
+  child.stderr?.on('end', () => {
+    const rest = stderrNoiseSink.flush()
+    if (rest) {
+      rememberLog(rest)
+    }
+  })
 
   let ready = false
   let rejectStart = null
@@ -12480,7 +12490,15 @@ async function startHermes() {
     }
 
     hermesProcess.stdout.on('data', rememberLog)
-    hermesProcess.stderr.on('data', rememberLog)
+    // #54833: same benign-stderr filter as the pooled backend path above.
+    const hermesStderrSink = createBenignStderrSink(rememberLog)
+    hermesProcess.stderr?.on('data', hermesStderrSink)
+    hermesProcess.stderr?.on('end', () => {
+      const rest = hermesStderrSink.flush()
+      if (rest) {
+        rememberLog(rest)
+      }
+    })
     let backendReady = false
     let rejectBackendStart = null
 

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -44,7 +44,6 @@ import {
   probeStartMarker,
   processStartMarker
 } from './backend-claim'
-import { createBenignStderrSink } from './subprocess-stderr-noise'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
@@ -350,6 +349,7 @@ import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstra
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
 import { createStreamThrottle } from './stream-throttle'
+import { createBenignStderrSink } from './subprocess-stderr-noise'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
 import {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12084,12 +12084,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // backend stderr before it reaches desktop.log; stdout is never filtered.
   const stderrNoiseSink = createBenignStderrSink(rememberLog)
   child.stderr?.on('data', stderrNoiseSink)
-  child.stderr?.on('end', () => {
+  const flushStderrTail = () => {
     const rest = stderrNoiseSink.flush()
     if (rest) {
       rememberLog(rest)
     }
-  })
+  }
+  child.stderr?.on('end', flushStderrTail)
+  child.stderr?.on('close', flushStderrTail)
 
   let ready = false
   let rejectStart = null
@@ -12493,12 +12495,14 @@ async function startHermes() {
     // #54833: same benign-stderr filter as the pooled backend path above.
     const hermesStderrSink = createBenignStderrSink(rememberLog)
     hermesProcess.stderr?.on('data', hermesStderrSink)
-    hermesProcess.stderr?.on('end', () => {
+    const flushHermesStderrTail = () => {
       const rest = hermesStderrSink.flush()
       if (rest) {
         rememberLog(rest)
       }
-    })
+    }
+    hermesProcess.stderr?.on('end', flushHermesStderrTail)
+    hermesProcess.stderr?.on('close', flushHermesStderrTail)
     let backendReady = false
     let rejectBackendStart = null
 

--- a/apps/desktop/electron/subprocess-stderr-noise.test.ts
+++ b/apps/desktop/electron/subprocess-stderr-noise.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import {
+  createBenignStderrSink,
+  filterBenignDarwinSubprocessStderr,
+  isBenignDarwinMallocStackLoggingLine
+} from './subprocess-stderr-noise'
+
+const EXACT =
+  "MallocStackLogging: can't turn off malloc stack logging because it was not enabled."
+
+const WITH_PID = `Python(12345) ${EXACT}`
+
+// --- predicate ---------------------------------------------------------------
+
+test('predicate matches the exact line and the Python(pid) variant on darwin', () => {
+  assert.equal(isBenignDarwinMallocStackLoggingLine(EXACT, 'darwin'), true)
+  assert.equal(isBenignDarwinMallocStackLoggingLine(WITH_PID, 'darwin'), true)
+  assert.equal(
+    isBenignDarwinMallocStackLoggingLine(`python(56273) ${EXACT}`, 'darwin'),
+    true
+  )
+})
+
+test('predicate is a no-op on linux and win32', () => {
+  assert.equal(isBenignDarwinMallocStackLoggingLine(EXACT, 'linux'), false)
+  assert.equal(isBenignDarwinMallocStackLoggingLine(EXACT, 'win32'), false)
+})
+
+test('predicate rejects near-misses', () => {
+  for (const line of [
+    `ERROR: ${EXACT}`,
+    `${EXACT} (see docs)`,
+    EXACT.slice(0, -1),
+    'MallocStackLogging: malloc stack logging enabled',
+    'Python(abc) ' + EXACT,
+    ''
+  ]) {
+    assert.equal(isBenignDarwinMallocStackLoggingLine(line, 'darwin'), false, line)
+  }
+})
+
+// --- whole-string filter -------------------------------------------------------
+
+test('string filter removes only the noise line', () => {
+  assert.equal(
+    filterBenignDarwinSubprocessStderr(`real\n${WITH_PID}\nelse\n`, 'darwin'),
+    'real\nelse\n'
+  )
+})
+
+test('string filter is a byte-identical no-op off darwin', () => {
+  const text = `real\n${WITH_PID}\nelse\n`
+  assert.equal(filterBenignDarwinSubprocessStderr(text, 'linux'), text)
+})
+
+// --- streaming sink: the Node-specific contract --------------------------------
+
+function collect(platform) {
+  const seen = []
+  const sink = createBenignStderrSink(chunk => seen.push(chunk), platform)
+
+  return { seen, sink }
+}
+
+test('sink drops a whole noise line delivered in one chunk', () => {
+  const { seen, sink } = collect('darwin')
+  sink(`real failure\n${EXACT}\nanother failure\n`)
+  sink.flush()
+  assert.equal(seen.join(''), 'real failure\nanother failure\n')
+})
+
+test('sink drops a noise line split across two chunks', () => {
+  const { seen, sink } = collect('darwin')
+  sink(`real\nPython(123) MallocStackLogging: can't turn off ma`)
+  sink(`lloc stack logging because it was not enabled.\nkeep\n`)
+  sink.flush()
+  assert.equal(seen.join(''), 'real\nkeep\n')
+})
+
+test('sink drops multiple noise lines in one chunk', () => {
+  const { seen, sink } = collect('darwin')
+  sink(`${EXACT}\nmid\n${WITH_PID}\n`)
+  sink.flush()
+  assert.equal(seen.join(''), 'mid\n')
+})
+
+test('sink flushes an unterminated non-matching tail on close', () => {
+  const { seen, sink } = collect('darwin')
+  sink('partial line without newline')
+  const rest = sink.flush()
+
+  assert.equal(rest, 'partial line without newline')
+})
+
+test('sink flush discards an unterminated pure noise tail', () => {
+  const { seen, sink } = collect('darwin')
+  sink(EXACT)
+  const rest = sink.flush()
+
+  assert.equal(rest, '')
+  assert.equal(seen.join(''), '')
+})
+
+test('sink passes everything through on linux with no line work', () => {
+  const { seen, sink } = collect('linux')
+  sink(`real\n${WITH_PID}\nno newline at end`)
+  sink.flush()
+  assert.equal(seen.join(''), `real\n${WITH_PID}\nno newline at end`)
+})
+
+test('sink keeps a line that merely contains the sentence inside a traceback', () => {
+  const { seen, sink } = collect('darwin')
+  sink(`ValueError: got "${EXACT}"\n`)
+  sink.flush()
+  assert.equal(seen.join(''), `ValueError: got "${EXACT}"\n`)
+})

--- a/apps/desktop/electron/subprocess-stderr-noise.ts
+++ b/apps/desktop/electron/subprocess-stderr-noise.ts
@@ -1,0 +1,110 @@
+/**
+ * Known-benign subprocess stderr noise for the Desktop backend spawner
+ * (issue #54833).
+ *
+ * macOS children of Hermes occasionally print the libmalloc teardown line
+ * "MallocStackLogging: can't turn off malloc stack logging because it was
+ * not enabled." on exit. It is harmless, but it was reaching desktop.log and
+ * boot-failure tails through the backend stderr listeners. This is the
+ * Electron mirror of hermes_cli/subprocess_noise.py — same exact-match
+ * contract, same Darwin-only rule, stdout is never filtered.
+ *
+ * Unlike the Python predicate, the sink here is stateful: Node delivers
+ * streams as byte chunks that do not align with lines, so a match can be
+ * split across two 'data' events. The sink holds back an unterminated
+ * trailing line until the next chunk or until the stream ends.
+ */
+
+const BENIGN_MALLOC_STACK_LOGGING =
+  /^(?:[Pp]ython\([0-9]+\) )?MallocStackLogging: can't turn off malloc stack logging because it was not enabled\.$/
+
+export function isBenignDarwinMallocStackLoggingLine(
+  line,
+  platform = process.platform
+) {
+  if (platform !== 'darwin') {
+    return false
+  }
+
+  return BENIGN_MALLOC_STACK_LOGGING.test(line)
+}
+
+/** Whole-line filter over a complete string (test/reference surface). */
+export function filterBenignDarwinSubprocessStderr(text, platform = process.platform) {
+  if (platform !== 'darwin' || !text || !text.includes('MallocStackLogging')) {
+    return text
+  }
+
+  return text
+    .split(/(?<=\n)/)
+    .filter(chunk => !isBenignDarwinMallocStackLoggingLine(chunk.replace(/\r?\n$/, ''), platform))
+    .join('')
+}
+
+/**
+ * Wrap a stderr 'data' consumer in a line-boundary-aware filter.
+ *
+ * Returns a listener to attach in place of the raw consumer. Lines that end
+ * within the delivered chunks are filtered exactly; the unterminated tail is
+ * buffered and prepended to the next chunk, and `.flush()` (wire to
+ * 'end'/'close') forwards whatever remains so nothing is ever swallowed.
+ */
+export function createBenignStderrSink(consumer, platform = process.platform) {
+  let pending = ''
+
+  const emit = text => {
+    if (text) {
+      consumer(text)
+    }
+  }
+
+  const listener = chunk => {
+    const text = pending + String(chunk)
+    pending = ''
+
+    if (platform !== 'darwin') {
+      // Non-Darwin is a byte-for-byte pass-through; skip line work entirely.
+      emit(text)
+      return
+    }
+
+    const lastBreak = Math.max(
+      text.lastIndexOf('\n'),
+      text.endsWith('\r') ? text.length - 1 : -1
+    )
+
+    if (lastBreak < 0) {
+      pending = text
+      return
+    }
+
+    const complete = text.slice(0, lastBreak + 1)
+    pending = text.slice(lastBreak + 1)
+
+    const lines = complete.split(/(?<=\n)/)
+    let out = ''
+
+    for (const line of lines) {
+      if (!isBenignDarwinMallocStackLoggingLine(line.replace(/\r?\n$/, ''), platform)) {
+        out += line
+      }
+    }
+
+    emit(out)
+  }
+
+  listener.flush = () => {
+    const rest = pending
+    pending = ''
+
+    if (rest && platform === 'darwin') {
+      const bare = rest.replace(/\r?\n$/, '')
+
+      return isBenignDarwinMallocStackLoggingLine(bare, platform) ? '' : rest
+    }
+
+    return rest
+  }
+
+  return listener
+}

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2701,9 +2701,12 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
                 filter_benign_darwin_subprocess_stderr,
             )
 
-            tail = filter_benign_darwin_subprocess_stderr(
-                (result.stderr or result.stdout or "").strip()
-            )[-500:]
+            # Never filter stdout: only the stderr source is sanitized before
+            # the fallback to stdout. (#54833)
+            stderr_clean = filter_benign_darwin_subprocess_stderr(
+                (result.stderr or "").strip()
+            )
+            tail = (stderr_clean or (result.stdout or "").strip())[-500:]
             msg = (
                 f"bot-chat delivery to profile "
                 f"'{profile or '(own)'}' failed (exit {result.returncode})"

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -46,6 +46,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.subprocess_noise import filter_benign_darwin_subprocess_stderr
 from hermes_cli.config import (
     _expand_env_vars,
     cron_model_drift_axes,
@@ -2697,10 +2698,6 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
-            from hermes_cli.subprocess_noise import (
-                filter_benign_darwin_subprocess_stderr,
-            )
-
             # Never filter stdout: only the stderr source is sanitized before
             # the fallback to stdout. (#54833)
             stderr_clean = filter_benign_darwin_subprocess_stderr(
@@ -4452,10 +4449,6 @@ def _run_job_script(
         stderr = (stderr_raw or "").strip()
         # #54833: benign Darwin libmalloc teardown noise must not become the
         # only reported error for a failing script (falls back to exit code).
-        from hermes_cli.subprocess_noise import (
-            filter_benign_darwin_subprocess_stderr,
-        )
-
         stderr = filter_benign_darwin_subprocess_stderr(stderr).strip()
 
         # Redact secrets from both stdout and stderr before any return path.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2697,7 +2697,13 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             creationflags=windows_hide_flags(),
         )
         if result.returncode != 0:
-            tail = (result.stderr or result.stdout or "").strip()[-500:]
+            from hermes_cli.subprocess_noise import (
+                filter_benign_darwin_subprocess_stderr,
+            )
+
+            tail = filter_benign_darwin_subprocess_stderr(
+                (result.stderr or result.stdout or "").strip()
+            )[-500:]
             msg = (
                 f"bot-chat delivery to profile "
                 f"'{profile or '(own)'}' failed (exit {result.returncode})"
@@ -4441,6 +4447,13 @@ def _run_job_script(
 
         stdout = (stdout_raw or "").strip()
         stderr = (stderr_raw or "").strip()
+        # #54833: benign Darwin libmalloc teardown noise must not become the
+        # only reported error for a failing script (falls back to exit code).
+        from hermes_cli.subprocess_noise import (
+            filter_benign_darwin_subprocess_stderr,
+        )
+
+        stderr = filter_benign_darwin_subprocess_stderr(stderr).strip()
 
         # Redact secrets from both stdout and stderr before any return path.
         try:

--- a/gateway/platforms/webhook_filters.py
+++ b/gateway/platforms/webhook_filters.py
@@ -267,6 +267,12 @@ class WebhookRouteProcessor:
 
         stdout = (result.stdout or "").strip()
         stderr = (result.stderr or "").strip()
+        # #54833: benign Darwin libmalloc teardown noise is not diagnostics.
+        from hermes_cli.subprocess_noise import (
+            filter_benign_darwin_subprocess_stderr,
+        )
+
+        stderr = filter_benign_darwin_subprocess_stderr(stderr).strip()
         try:
             from agent.redact import redact_sensitive_text
 

--- a/hermes_cli/stderr_timestamp.py
+++ b/hermes_cli/stderr_timestamp.py
@@ -34,10 +34,18 @@ def _write_timestamped_line(log_file: TextIO, line: str) -> None:
 
 
 def _copy_stderr_with_timestamps(stderr: BinaryIO, log_path: Path) -> None:
+    from hermes_cli.subprocess_noise import (
+        is_benign_darwin_malloc_stack_logging_line,
+    )
+
     log_path.parent.mkdir(parents=True, exist_ok=True)
     with log_path.open("a", encoding="utf-8", buffering=1) as log_file:
         for raw_line in iter(stderr.readline, b""):
             line = raw_line.decode("utf-8", errors="replace")
+            # #54833: drop the known-benign Darwin libmalloc teardown line
+            # before it can reach gateway.error.log (no-op on other OSes).
+            if is_benign_darwin_malloc_stack_logging_line(line):
+                continue
             _write_timestamped_line(log_file, line)
 
 

--- a/hermes_cli/subprocess_noise.py
+++ b/hermes_cli/subprocess_noise.py
@@ -1,0 +1,88 @@
+"""Filter for known-benign subprocess stderr noise (issue #54833).
+
+On macOS, short-lived children of the Hermes runtime occasionally print the
+libmalloc/MallocStackLogging teardown line
+
+    Python(123) MallocStackLogging: can't turn off malloc stack logging
+    because it was not enabled.
+
+to stderr as they exit.  The message is emitted by Apple's private
+MallocStackLogging framework during process teardown; it is harmless, but
+because every Hermes stderr boundary (launchd wrapper log, execute-code tool
+results, Desktop backend log, plain terminal inheritance) forwards child
+stderr verbatim, it pollutes ``gateway.error.log``, ``desktop.log``, user
+terminals, and model context.
+
+The root toggle lives inside macOS internals, not Hermes, so this module is a
+containment seam, not a source fix: it suppresses ONLY the exact whole line,
+ONLY on Darwin, at the capture boundaries that already own the text.  Every
+other byte — including other MallocStackLogging diagnostics, the same sentence
+embedded in a traceback or a tool payload, and all stdout — is preserved.
+
+Keep this module import-cheap (stdlib only) and free of logging so it can be
+used from the launchd stderr wrapper before the gateway is up.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from typing import Optional
+
+# The one known-benign sentence.  The optional "<name>(<pid>) " prefix is the
+# os.asprintf banner macOS prepends (seen both as "Python(56273) ..." from
+# Framework Python.app and "python(16414) ..." from console interpreters);
+# everything after it must match byte-for-byte.
+_BENIGN_MALLOC_STACK_LOGGING_RE = re.compile(
+    r"^(?:[Pp]ython\([0-9]+\) )?"
+    r"MallocStackLogging: can't turn off malloc stack logging "
+    r"because it was not enabled\.$"
+)
+
+
+def is_benign_darwin_malloc_stack_logging_line(
+    line: str,
+    *,
+    platform: Optional[str] = None,
+) -> bool:
+    """Return True only for the exact known-benign libmalloc teardown line.
+
+    ``platform`` is a test seam defaulting to ``sys.platform``; it is not a
+    user setting.  Matching is done after stripping line endings only, so a
+    line with any other prefix, suffix, or wording never matches.
+    """
+    if (platform if platform is not None else sys.platform) != "darwin":
+        return False
+    # splitlines() on the single line removes a trailing \r\n / \n / \r
+    # without touching inner content; strip() would eat meaningful whitespace.
+    core = line.splitlines()[0] if line else ""
+    return bool(_BENIGN_MALLOC_STACK_LOGGING_RE.match(core))
+
+
+def filter_benign_darwin_subprocess_stderr(
+    text: str,
+    *,
+    platform: Optional[str] = None,
+) -> str:
+    """Remove only whole benign-malloc-logging lines from captured stderr.
+
+    * Non-Darwin hosts return the input unchanged (same object — this sits on
+      hot paths for Linux/Windows users and must cost nothing).
+    * ``splitlines(keepends=True)`` guarantees that deleting one line can
+      never splice neighbouring diagnostics together.
+    """
+    if (platform if platform is not None else sys.platform) != "darwin":
+        return text
+    if not text:
+        return text
+    if "MallocStackLogging" not in text:
+        # Fast bail: the marker is present in every matchable line.
+        return text
+    kept = [
+        chunk
+        for chunk in text.splitlines(keepends=True)
+        if not is_benign_darwin_malloc_stack_logging_line(
+            chunk, platform=platform
+        )
+    ]
+    return "".join(kept)

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -367,3 +367,62 @@ def test_agent_job_provider_classification_unchanged(error, expected):
 
     job = {"name": "daily-digest", "no_agent": False}
     assert expected in _summarize_cron_failure_for_delivery(job, error)
+
+
+# ---------------------------------------------------------------------------
+# _run_job_script: #54833 benign Darwin malloc noise must not be the error
+# ---------------------------------------------------------------------------
+
+_MALLOC_NOISE_LINE = (
+    "python(16414) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+def _force_darwin_noise_filter(monkeypatch):
+    from types import SimpleNamespace
+
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+def test_run_job_script_noise_only_falls_back_to_exit_code(hermes_env, monkeypatch, tmp_path):
+    _force_darwin_noise_filter(monkeypatch)
+    import os
+    from pathlib import Path
+    script_dir = Path(os.environ["HERMES_HOME"]) / "scripts"
+    script = script_dir / "noise_only.py"
+    script.write_text(
+        "import sys\n"
+        f"sys.stderr.write({(_MALLOC_NOISE_LINE + chr(10))!r})\n"
+        "sys.exit(3)\n",
+        encoding="utf-8",
+    )
+    from cron.scheduler import _run_job_script
+
+    ok, output = _run_job_script(str(script))
+    assert ok is False
+    assert "MallocStackLogging" not in output
+    assert "exited with code 3" in output
+
+
+def test_run_job_script_real_stderr_survives_filtering(hermes_env, monkeypatch, tmp_path):
+    _force_darwin_noise_filter(monkeypatch)
+    import os
+    from pathlib import Path
+    script_dir = Path(os.environ["HERMES_HOME"]) / "scripts"
+    script = script_dir / "mixed.py"
+    script.write_text(
+        "import sys\n"
+        f"sys.stderr.write({(_MALLOC_NOISE_LINE + chr(10))!r})\n"
+        "sys.stderr.write('boom: real failure\\n')\n"
+        "sys.exit(4)\n",
+        encoding="utf-8",
+    )
+    from cron.scheduler import _run_job_script
+
+    ok, output = _run_job_script(str(script))
+    assert ok is False
+    assert "MallocStackLogging" not in output
+    assert "boom: real failure" in output

--- a/tests/gateway/test_webhook_route_script_noise.py
+++ b/tests/gateway/test_webhook_route_script_noise.py
@@ -1,0 +1,75 @@
+"""#54833: webhook route-script stderr must not carry the benign malloc line."""
+
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+_MALLOC_NOISE = (
+    "python(16414) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+@pytest.fixture
+def _scripts_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    (home / "scripts").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    import importlib
+
+    import hermes_constants
+
+    importlib.reload(hermes_constants)
+    yield home
+    importlib.reload(hermes_constants)
+
+
+@pytest.fixture
+def _darwin(monkeypatch):
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+def test_failing_route_script_log_drops_noise_keeps_real_stderr(
+    _scripts_home, _darwin, caplog
+):
+    from gateway.platforms.webhook_filters import WebhookRouteProcessor
+
+    script = _scripts_home / "scripts" / "boom.py"
+    script.write_text(
+        "import sys\n"
+        f"sys.stderr.write({(_MALLOC_NOISE + chr(10))!r})\n"
+        "sys.stderr.write('real script broke\\n')\n"
+        "sys.exit(9)\n",
+        encoding="utf-8",
+    )
+    proc = WebhookRouteProcessor()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.webhook_filters"):
+        should_continue, _ = proc.run_route_script("boom.py", {"a": 1})
+
+    assert should_continue is False
+    logged = "\n".join(r.message for r in caplog.records)
+    assert "real script broke" in logged
+    assert "MallocStackLogging" not in logged
+
+
+def test_noise_only_failure_still_logs_cleanly(_scripts_home, _darwin, caplog):
+    from gateway.platforms.webhook_filters import WebhookRouteProcessor
+
+    script = _scripts_home / "scripts" / "quiet.py"
+    script.write_text(
+        "import sys\n"
+        f"sys.stderr.write({(_MALLOC_NOISE + chr(10))!r})\n"
+        "sys.exit(2)\n",
+        encoding="utf-8",
+    )
+    proc = WebhookRouteProcessor()
+
+    with caplog.at_level(logging.INFO, logger="gateway.platforms.webhook_filters"):
+        should_continue, _ = proc.run_route_script("quiet.py", {})
+
+    assert should_continue is False  # exit code decides, not the emptied stderr
+    assert "code=2" in "\n".join(r.message for r in caplog.records)

--- a/tests/hermes_cli/test_stderr_timestamp.py
+++ b/tests/hermes_cli/test_stderr_timestamp.py
@@ -157,3 +157,53 @@ def test_main_does_not_mark_unsupervised_child(tmp_path, monkeypatch):
 
     assert rc == 0
     assert marker_path.read_text(encoding="utf-8") == "unset"
+
+
+def _fake_darwin(monkeypatch):
+    """Force the noise filter's platform seam to darwin on any CI host."""
+    from types import SimpleNamespace
+
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+# Exact line from #54833 (the optional Python(pid) prefix varies by build).
+_MALLOC_NOISE = (
+    "python(56273) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+def test_main_drops_benign_malloc_line_on_darwin(tmp_path, monkeypatch):
+    _fake_darwin(monkeypatch)
+    log_path = tmp_path / "gateway.error.log"
+    code = (
+        "import sys\n"
+        "sys.stderr.write('real failure\\n')\n"
+        f"sys.stderr.write({(_MALLOC_NOISE + chr(10))!r})\n"
+        "sys.stderr.write('another real failure\\n')\n"
+    )
+
+    rc = stderr_timestamp.main(["--error-log", str(log_path), "--", sys.executable, "-c", code])
+
+    assert rc == 0
+    body = log_path.read_text(encoding="utf-8")
+    assert "MallocStackLogging" not in body
+    assert "real failure" in body
+    assert "another real failure" in body
+
+
+def test_main_keeps_malloc_line_on_linux(tmp_path, monkeypatch):
+    from types import SimpleNamespace
+
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="linux"))
+    log_path = tmp_path / "gateway.error.log"
+    code = f"import sys\nsys.stderr.write({(_MALLOC_NOISE + chr(10))!r})\n"
+
+    rc = stderr_timestamp.main(["--error-log", str(log_path), "--", sys.executable, "-c", code])
+
+    assert rc == 0
+    assert "MallocStackLogging" in log_path.read_text(encoding="utf-8")

--- a/tests/hermes_cli/test_subprocess_noise.py
+++ b/tests/hermes_cli/test_subprocess_noise.py
@@ -1,0 +1,119 @@
+"""Tests for the benign Darwin malloc-stack-logging stderr filter (#54833).
+
+The libmalloc/MallocStackLogging teardown line is harmless but pollutes
+gateway.error.log, desktop.log, terminals, and model context.  The filter must
+match ONLY that exact whole line, ONLY on Darwin, and must leave every other
+byte of stderr alone.
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from hermes_cli.subprocess_noise import (
+    filter_benign_darwin_subprocess_stderr,
+    is_benign_darwin_malloc_stack_logging_line,
+)
+
+EXACT = (
+    "MallocStackLogging: can't turn off malloc stack logging because it was "
+    "not enabled."
+)
+WITH_PID = f"Python(12345) {EXACT}"
+
+# One observed on the reporter's machine and one on a plain launchd child:
+# process-name prefix varies ("Python", "python") — both are the same line.
+OBSERVED = [
+    EXACT,
+    WITH_PID,
+    f"python(56273) {EXACT}",
+]
+
+
+class TestPredicate:
+    def test_observed_variants_match_on_darwin(self):
+        for line in OBSERVED:
+            assert is_benign_darwin_malloc_stack_logging_line(
+                line, platform="darwin"
+            ), line
+
+    def test_crlf_and_missing_newline_tolerated(self):
+        assert is_benign_darwin_malloc_stack_logging_line(
+            EXACT + "\r\n", platform="darwin"
+        )
+        assert is_benign_darwin_malloc_stack_logging_line(
+            EXACT + "\n", platform="darwin"
+        )
+
+    def test_not_matched_on_linux_or_windows(self):
+        for plat in ("linux", "win32"):
+            assert not is_benign_darwin_malloc_stack_logging_line(
+                EXACT, platform=plat
+            )
+
+    def test_different_malloc_diagnostic_not_matched(self):
+        # Other MallocStackLogging diagnostics stay visible on purpose.
+        assert not is_benign_darwin_malloc_stack_logging_line(
+            "MallocStackLogging: malloc stack logging enabled", platform="darwin"
+        )
+
+    def test_embedded_or_prefixed_text_not_matched(self):
+        for line in (
+            f"ERROR: {EXACT}",
+            f"{EXACT} (see docs)",
+            f"prefix {EXACT}",
+            EXACT[:-1],  # truncated sentence
+            EXACT.replace("can't", "can t"),  # near-miss
+            "Python(abc) " + EXACT,  # malformed pid
+            "",
+        ):
+            assert not is_benign_darwin_malloc_stack_logging_line(
+                line, platform="darwin"
+            ), line
+
+
+class TestFilter:
+    def test_empty_input(self):
+        assert filter_benign_darwin_subprocess_stderr("", platform="darwin") == ""
+
+    def test_removes_only_the_noise_line_and_keeps_neighbors(self):
+        text = f"real error line\n{WITH_PID}\nanother real line\n"
+        out = filter_benign_darwin_subprocess_stderr(text, platform="darwin")
+        assert out == "real error line\nanother real line\n"
+
+    def test_no_final_newline_is_preserved(self):
+        text = f"noise\n{EXACT}"
+        out = filter_benign_darwin_subprocess_stderr(text, platform="darwin")
+        assert out == "noise\n"
+
+    def test_crlf_neighbors_survive(self):
+        text = f"keep me\r\n{EXACT}\r\nkeep me too\r\n"
+        out = filter_benign_darwin_subprocess_stderr(text, platform="darwin")
+        assert out == "keep me\r\nkeep me too\r\n"
+
+    def test_all_noise_collapses_to_empty(self):
+        text = "\n".join(OBSERVED)
+        assert (
+            filter_benign_darwin_subprocess_stderr(text, platform="darwin") == ""
+        )
+
+    def test_non_darwin_is_byte_identical_noop(self):
+        text = f"something\n{WITH_PID}\nelse\n"
+        assert (
+            filter_benign_darwin_subprocess_stderr(text, platform="linux") == text
+        )
+        assert (
+            filter_benign_darwin_subprocess_stderr(text, platform="win32") == text
+        )
+
+    def test_identity_fast_path_returns_same_object_off_darwin(self):
+        text = f"whatever\n{EXACT}\n"
+        out = filter_benign_darwin_subprocess_stderr(text, platform="linux")
+        assert out is text
+
+    def test_lines_are_never_joined_by_deletion(self):
+        # A removed middle line must not splice surrounding diagnostics.
+        text = f"AA\n{EXACT}\nBB\n"
+        out = filter_benign_darwin_subprocess_stderr(text, platform="darwin")
+        assert out == "AA\nBB\n"

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -402,3 +402,52 @@ class TestPerCellRpcAuthority(unittest.TestCase):
             _run("y = 2")
             self.assertIsNot(kernel.cell_authority, first_authority)
             self.assertFalse(kernel.cell_authority.active)
+
+
+# ── #54833: benign Darwin malloc-stack-logging noise ──────────────────────
+_MALLOC_NOISE = (
+    "python(16414) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+@pytest.fixture
+def _force_darwin_noise_filter(monkeypatch):
+    """Act as if on macOS so the filter fires on any CI host."""
+    from types import SimpleNamespace
+
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+def test_cell_written_malloc_noise_never_reaches_the_result(
+    _force_darwin_noise_filter,
+):
+    code = (
+        "import os, sys\n"
+        f"os.write(2, {(_MALLOC_NOISE + chr(10))!r}.encode())\n"
+        "sys.stderr.write('real diagnostic\\n')\n"
+    )
+    with _kernel_config():
+        result = _run(code)
+    assert result["status"] == "success", result
+    assert "MallocStackLogging" not in result["output"]
+    assert "real diagnostic" in result["output"]
+
+
+def test_malloc_noise_is_kept_when_not_on_darwin(monkeypatch):
+    """Non-Darwin no-op: the filter must not remove anything on Linux/CI."""
+    from types import SimpleNamespace
+
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="linux"))
+    code = (
+        "import os\n"
+        f"os.write(2, {(_MALLOC_NOISE + chr(10))!r}.encode())\n"
+    )
+    with _kernel_config():
+        result = _run(code)
+    assert result["status"] == "success", result
+    assert "MallocStackLogging" in result["output"]

--- a/tests/tools/test_tts_malloc_noise.py
+++ b/tests/tools/test_tts_malloc_noise.py
@@ -1,0 +1,59 @@
+"""#54833: TTS failure messages must not be built from the benign malloc line."""
+
+import subprocess
+from types import SimpleNamespace
+
+import pytest
+
+_MALLOC_NOISE = (
+    "python(16414) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+@pytest.fixture
+def _darwin(monkeypatch):
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+def _completed(stderr: str):
+    return subprocess.CompletedProcess(args=[], returncode=1, stdout="", stderr=stderr)
+
+
+def test_neutts_failure_error_excludes_noise(_darwin, monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _completed(f"{_MALLOC_NOISE}\nCUDA OOM\n"),
+    )
+    with pytest.raises(RuntimeError) as exc:
+        tts_tool._generate_neutts("hi", "/tmp/out.wav", {})
+    assert "CUDA OOM" in str(exc.value)
+    assert "MallocStackLogging" not in str(exc.value)
+
+
+def test_neutts_noise_only_failure_keeps_generic_message(_darwin, monkeypatch):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        subprocess, "run", lambda *a, **k: _completed(_MALLOC_NOISE)
+    )
+    with pytest.raises(RuntimeError) as exc:
+        tts_tool._generate_neutts("hi", "/tmp/out.wav", {})
+    assert "unknown error" in str(exc.value)
+
+
+def test_piper_download_failure_excludes_noise(_darwin, monkeypatch, tmp_path):
+    from tools import tts_tool
+
+    monkeypatch.setattr(
+        subprocess, "run",
+        lambda *a, **k: _completed(f"{_MALLOC_NOISE}\nHTTP 404 voice missing\n"),
+    )
+    with pytest.raises(RuntimeError) as exc:
+        tts_tool._resolve_piper_voice_path("some-voice", tmp_path)
+    assert "HTTP 404" in str(exc.value)
+    assert "MallocStackLogging" not in str(exc.value)

--- a/tests/tui_gateway/test_host_supervisor_stderr_noise.py
+++ b/tests/tui_gateway/test_host_supervisor_stderr_noise.py
@@ -1,0 +1,49 @@
+"""#54833: HostSupervisor stderr drain must skip the benign malloc line."""
+
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from tui_gateway.host_supervisor import HostSupervisor
+
+_MALLOC_NOISE = (
+    "python(16414) MallocStackLogging: can't turn off malloc stack logging "
+    "because it was not enabled."
+)
+
+
+def _bare_supervisor() -> HostSupervisor:
+    sup = HostSupervisor.__new__(HostSupervisor)
+    sup._stderr_tail = []
+    return sup
+
+
+@pytest.fixture
+def _darwin(monkeypatch):
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="darwin"))
+
+
+def test_drain_skips_noise_keeps_real_lines(_darwin):
+    sup = _bare_supervisor()
+    proc = SimpleNamespace(
+        stderr=io.StringIO(f"real line\n{_MALLOC_NOISE}\nsecond line\n")
+    )
+
+    sup._drain_stderr(proc)  # type: ignore[arg-type]
+
+    assert sup._stderr_tail == ["real line", "second line"]
+
+
+def test_drain_keeps_noise_off_darwin(monkeypatch):
+    from hermes_cli import subprocess_noise
+
+    monkeypatch.setattr(subprocess_noise, "sys", SimpleNamespace(platform="linux"))
+    sup = _bare_supervisor()
+    proc = SimpleNamespace(stderr=io.StringIO(f"{_MALLOC_NOISE}\n"))
+
+    sup._drain_stderr(proc)  # type: ignore[arg-type]
+
+    assert sup._stderr_tail == [_MALLOC_NOISE]

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1884,6 +1884,13 @@ def execute_code(
         stderr_reader.join(timeout=3)
 
         stderr_text = b"".join(stderr_chunks).decode("utf-8", errors="replace")
+        # #54833: drop the known-benign Darwin libmalloc teardown line before
+        # ANSI stripping/redaction/hint selection can bake it into the result.
+        from hermes_cli.subprocess_noise import (
+            filter_benign_darwin_subprocess_stderr,
+        )
+
+        stderr_text = filter_benign_darwin_subprocess_stderr(stderr_text)
 
         stdout_text, stdout_metadata = _assemble_stdout_result(
             b"".join(stdout_head_chunks),

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -739,10 +739,19 @@ def execute_in_session_kernel(
 
             raw_text = _drain_raw(kernel)
             stderr_raw = _drain_stderr(kernel)
+            # #54833: strip the known-benign Darwin libmalloc teardown line
+            # before it can enter the tool result / model context.
+            from hermes_cli.subprocess_noise import (
+                filter_benign_darwin_subprocess_stderr,
+            )
+
+            stderr_raw = filter_benign_darwin_subprocess_stderr(stderr_raw)
             stdout_text = str(payload.get("stdout", ""))
             if raw_text:
                 stdout_text = stdout_text + raw_text
-            cell_stderr = str(payload.get("stderr", ""))
+            cell_stderr = filter_benign_darwin_subprocess_stderr(
+                str(payload.get("stderr", ""))
+            )
             if stderr_raw:
                 cell_stderr = cell_stderr + stderr_raw
 

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -765,12 +765,26 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 if r.returncode == 0:
                     if target is not None:
                         _activate_target_on_syspath(target)
-                    return _InstallResult(True, r.stdout or "", r.stderr or "")
+                    from hermes_cli.subprocess_noise import (
+                        filter_benign_darwin_subprocess_stderr,
+                    )
+
+                    return _InstallResult(
+                        True, r.stdout or "",
+                        filter_benign_darwin_subprocess_stderr(r.stderr or ""),
+                    )
                 logger.debug("uv pip install failed: %s", r.stderr)
                 # A resolver failure is authoritative. Falling through to pip
                 # here would silently discard uv policy such as exclude-newer
                 # and could install a release that the project quarantined.
-                return _InstallResult(False, r.stdout or "", r.stderr or "")
+                from hermes_cli.subprocess_noise import (
+                    filter_benign_darwin_subprocess_stderr,
+                )
+
+                return _InstallResult(
+                    False, r.stdout or "",
+                    filter_benign_darwin_subprocess_stderr(r.stderr or ""),
+                )
             except subprocess.TimeoutExpired as e:
                 logger.debug("uv invocation failed: %s", e)
                 return _InstallResult(False, "", f"uv pip install timed out: {e}")

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -80,6 +80,7 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.subprocess_noise import filter_benign_darwin_subprocess_stderr
 
 logger = logging.getLogger(__name__)
 
@@ -765,10 +766,6 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 if r.returncode == 0:
                     if target is not None:
                         _activate_target_on_syspath(target)
-                    from hermes_cli.subprocess_noise import (
-                        filter_benign_darwin_subprocess_stderr,
-                    )
-
                     return _InstallResult(
                         True, r.stdout or "",
                         filter_benign_darwin_subprocess_stderr(r.stderr or ""),
@@ -777,10 +774,6 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
                 # A resolver failure is authoritative. Falling through to pip
                 # here would silently discard uv policy such as exclude-newer
                 # and could install a release that the project quarantined.
-                from hermes_cli.subprocess_noise import (
-                    filter_benign_darwin_subprocess_stderr,
-                )
-
                 return _InstallResult(
                     False, r.stdout or "",
                     filter_benign_darwin_subprocess_stderr(r.stderr or ""),
@@ -826,10 +819,6 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)
-            from hermes_cli.subprocess_noise import (
-                filter_benign_darwin_subprocess_stderr,
-            )
-
             return _InstallResult(
                 r.returncode == 0,
                 r.stdout or "",

--- a/tools/lazy_deps.py
+++ b/tools/lazy_deps.py
@@ -812,7 +812,15 @@ def _venv_pip_install(specs: tuple[str, ...], *, timeout: int = 300) -> _Install
             )
             if r.returncode == 0 and target is not None:
                 _activate_target_on_syspath(target)
-            return _InstallResult(r.returncode == 0, r.stdout or "", r.stderr or "")
+            from hermes_cli.subprocess_noise import (
+                filter_benign_darwin_subprocess_stderr,
+            )
+
+            return _InstallResult(
+                r.returncode == 0,
+                r.stdout or "",
+                filter_benign_darwin_subprocess_stderr(r.stderr or ""),
+            )
         except subprocess.TimeoutExpired as e:
             return _InstallResult(False, "", f"pip install timed out: {e}")
         except Exception as e:

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -58,6 +58,7 @@ from typing import Callable, Dict, Any, Iterator, List, Optional, Tuple
 from urllib.parse import urljoin, urlparse
 
 from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli.subprocess_noise import filter_benign_darwin_subprocess_stderr
 from hermes_constants import display_hermes_home
 
 logger = logging.getLogger(__name__)
@@ -2844,10 +2845,6 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
     result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
-        from hermes_cli.subprocess_noise import (
-            filter_benign_darwin_subprocess_stderr,
-        )
-
         stderr = filter_benign_darwin_subprocess_stderr(
             result.stderr.strip()
         ).strip()
@@ -2965,10 +2962,6 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
         ) from exc
 
     if result.returncode != 0:
-        from hermes_cli.subprocess_noise import (
-            filter_benign_darwin_subprocess_stderr,
-        )
-
         stderr = filter_benign_darwin_subprocess_stderr(
             (result.stderr or "").strip()
         ).strip() or "no stderr output"

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -2844,7 +2844,13 @@ def _generate_neutts(text: str, output_path: str, tts_config: Dict[str, Any]) ->
 
     result = subprocess.run(cmd, capture_output=True, text=True, encoding='utf-8', errors='replace', timeout=120, stdin=subprocess.DEVNULL)
     if result.returncode != 0:
-        stderr = result.stderr.strip()
+        from hermes_cli.subprocess_noise import (
+            filter_benign_darwin_subprocess_stderr,
+        )
+
+        stderr = filter_benign_darwin_subprocess_stderr(
+            result.stderr.strip()
+        ).strip()
         # Filter out the "OK:" line from stderr
         error_lines = [l for l in stderr.splitlines() if not l.startswith("OK:")]
         raise RuntimeError(f"NeuTTS synthesis failed: {chr(10).join(error_lines) or 'unknown error'}")
@@ -2959,7 +2965,13 @@ def _resolve_piper_voice_path(voice: str, download_dir: Path) -> str:
         ) from exc
 
     if result.returncode != 0:
-        stderr = (result.stderr or "").strip() or "no stderr output"
+        from hermes_cli.subprocess_noise import (
+            filter_benign_darwin_subprocess_stderr,
+        )
+
+        stderr = filter_benign_darwin_subprocess_stderr(
+            (result.stderr or "").strip()
+        ).strip() or "no stderr output"
         raise RuntimeError(
             f"Piper voice download failed for '{voice}': {stderr[:400]}"
         )

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -22,6 +22,7 @@ from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
+from hermes_cli.subprocess_noise import is_benign_darwin_malloc_stack_logging_line
 from hermes_constants import get_hermes_home
 from tools.environments.local import hermes_subprocess_env
 
@@ -427,10 +428,6 @@ class HostSupervisor:
 
     def _drain_stderr(self, proc: subprocess.Popen[str]) -> None:
         assert proc.stderr is not None
-        from hermes_cli.subprocess_noise import (
-            is_benign_darwin_malloc_stack_logging_line,
-        )
-
         for raw in proc.stderr:
             text = raw.rstrip("\n")
             if text and not is_benign_darwin_malloc_stack_logging_line(text):

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -427,9 +427,13 @@ class HostSupervisor:
 
     def _drain_stderr(self, proc: subprocess.Popen[str]) -> None:
         assert proc.stderr is not None
+        from hermes_cli.subprocess_noise import (
+            is_benign_darwin_malloc_stack_logging_line,
+        )
+
         for raw in proc.stderr:
             text = raw.rstrip("\n")
-            if text:
+            if text and not is_benign_darwin_malloc_stack_logging_line(text):
                 self._stderr_tail = (self._stderr_tail + [text])[-80:]
                 logger.warning("compute host stderr: %s", text)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -526,8 +526,13 @@ class _SlashWorker:
         self.stdout_queue.put(None)
 
     def _drain_stderr(self):
+        from hermes_cli.subprocess_noise import (
+            is_benign_darwin_malloc_stack_logging_line,
+        )
+
         for line in self.proc.stderr or []:
-            if text := line.rstrip("\n"):
+            text = line.rstrip("\n")
+            if text and not is_benign_darwin_malloc_stack_logging_line(text):
                 self.stderr_tail = (self.stderr_tail + [text])[-80:]
 
     def run(self, command: str) -> str:


### PR DESCRIPTION
Closes #54833

## What this changes

Stops the benign macOS line

```
Python(<pid>) MallocStackLogging: can't turn off malloc stack logging because it was not enabled.
```

from reaching `gateway.error.log`, `desktop.log`, user terminals, and — most importantly — model context via `execute_code` tool results.

**This is containment, not a root-cause fix, deliberately.** The investigation (summarized below) found the toggle that puts MallocStackLogging into the mismatched state lives in Apple's private MallocStackLogging framework / libmalloc teardown, not in Hermes. Since the message is harmless, suppressing exactly this one known-benign whole line — only on Darwin, only on child **stderr** — is the safe repair. If maintainers would rather chase the upstream toggle, this PR should not merge; the filter boundaries it adds are still useful as a noise contract.

## What was ruled out (why there is no source fix to make in this repo)

- The gateway has **no multiprocessing/fork worker path** — watchdog, heartbeat, cron ticker, housekeeping are threads/asyncio tasks. `import multiprocessing` exists only in `batch_runner.py` and an offline script. The issue's suggested "pin start method to spawn" would change nothing for the reported children.
- Hermes never sets, unsets, or calls native APIs for `Malloc*` variables, and no installed runtime dependency touches stack-logging APIs (`debugpy` is dev-only and not even installed in the release venv).
- The emitters are the many short-lived children that re-invoke `sys.executable` (stdio-MCP watchdog, execute-code session kernels, cron scripts, webhook helpers, dashboard workers). Each boundary routes child stderr differently — which is why the same native line appears in four sinks with no single logger behind it.
- The exact sentence is printed by libmalloc's teardown shim (`turn_off_stack_logging` without a matching enabled logger; see `stack_logging_early_finished` in apple-oss-distributions/libmalloc `src/malloc.c`). A clean environment observed later doesn't prove no native initializer ever saw a matching key, and an exec normally clears in-process state — so the initiating call is outside what's observable from Hermes code.

## The fix

Two new seams with one shared contract — match ONLY the exact whole line, ONLY on `darwin`, never stdout, preserve every other byte:

- `hermes_cli/subprocess_noise.py` — predicate + whole-string filter (stdlib-only, platform injectable for tests, non-Darwin returns the input object unchanged).
- `apps/desktop/electron/subprocess-stderr-noise.ts` — the same predicate plus a stateful, chunk-boundary-aware streaming sink (Node `data` events do not align with lines).

Applied at the existing stderr owners:

| Sink fixed | Boundary |
| --- | --- |
| `gateway.error.log` (launchd) | `hermes_cli/stderr_timestamp.py` wrapper |
| model context via `execute_code` | `tools/code_kernel.py` (session kernels) + `tools/code_execution_tool.py` (per-call assembly) |
| compute-host / Desktop backend logs | `tui_gateway/host_supervisor.py`, `tui_gateway/server.py` slash worker `_drain_stderr` |
| event-driven captured stderr | `cron/scheduler.py` (job script + bot-chat delivery), `gateway/platforms/webhook_filters.py`, `tools/tts_tool.py` (NeuTTS/Piper), `tools/lazy_deps.py` |
| `desktop.log` + boot-failure tails | `apps/desktop/electron/backend-claim.ts` output tail + both `main.ts` backend stderr listeners |

Intentionally NOT changed: MCP stderr quarantine (`mcp-stderr.log` keeps raw diagnostics by design), any spawn flags / start methods / environments, stdout of anything, and no per-suppressed-line logging or config flags. When filtering leaves a failing command's stderr empty, each site's existing exit-code fallback applies — a nonzero exit never becomes success or an empty error.

## Tests

- 27 new cases: table-driven predicate/filter units (exact line, `Python(pid)` and `python(pid)` prefixes, CRLF, missing final newline, near-misses, other MallocStackLogging diagnostics, Linux/Windows byte-identical no-ops), a real-subprocess wrapper test, real session-kernel cells writing the line to fd 2, cron script error-path tests, compute-host drain test, and vitest streaming-sink tests including a line split mid-word across chunks.
- Focused suites green; Desktop: `vitest run --project electron` 1993 passed (the one failure in `managed-ssh-update.test.ts` fails identically on clean main — sandbox PATH issue), all three `tsc` projects pass; `ruff`/`ty` clean on every edited line.
- Full `scripts/run_tests.sh` compared against a clean-`main` baseline worktree: identical failure sets (all pre-existing optional-dep/config-gated suites; the 4 delta files pass in isolation on both trees).
- Verified live on macOS 14.4.1 arm64: through the real `stderr_timestamp` wrapper the noise line is dropped and neighbouring diagnostics survive with timestamps intact. Note the reproduction does **not** require Framework Python as the issue assumed — a uv-standalone-Python gateway emits the same line, confirming it is the OS/libmalloc, not the interpreter build.

Fixes #54833
