### PR TITLE
fix(cron): skip running secondary gateways in desktop cron ticker (#100489)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -298,9 +298,14 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     start_kwargs: dict = {"interval": interval}
     if isinstance(provider, InProcessCronScheduler):
         try:
-            from hermes_cli.profiles import profiles_to_serve
+            from hermes_cli.profiles import profiles_to_serve, _check_gateway_running
 
-            profile_homes = list(profiles_to_serve(multiplex=True))
+            all_profile_homes = list(profiles_to_serve(multiplex=True))
+            profile_homes = [
+                (name, home)
+                for name, home in all_profile_homes
+                if name == "default" or not _check_gateway_running(home)
+            ]
             if len(profile_homes) > 1:
                 start_kwargs["profile_homes"] = profile_homes
                 from hermes_logging import enable_profile_log_routing

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -70,6 +70,40 @@ def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path
     assert builtin.start_kwargs["profile_homes"] == homes
 
 
+
+def test_secondary_profile_with_running_gateway_excluded_from_desktop_ticker(
+    monkeypatch, _providers, tmp_path
+):
+    """Secondary profiles running their own live gateway must not be ticked by Desktop (#100489)."""
+    _sp, builtin = _providers
+    root_home = tmp_path / "root"
+    coder_home = tmp_path / "profiles" / "coder"
+    idle_home = tmp_path / "profiles" / "idle"
+    homes = [
+        ("default", root_home),
+        ("coder", coder_home),
+        ("idle", idle_home),
+    ]
+    import hermes_cli.profiles as profiles_mod
+
+    monkeypatch.setattr(profiles_mod, "profiles_to_serve", lambda **_kw: list(homes))
+    # coder has a live independent gateway running; idle does not
+    monkeypatch.setattr(
+        profiles_mod,
+        "_check_gateway_running",
+        lambda home: home == coder_home,
+    )
+
+    ws._start_desktop_cron_ticker(threading.Event(), interval=7)
+
+    assert builtin.start_kwargs is not None
+    assert builtin.start_kwargs["interval"] == 7
+    # "coder" is excluded because its own gateway ticks its store; "default" and "idle" are kept
+    assert builtin.start_kwargs["profile_homes"] == [
+        ("default", root_home),
+        ("idle", idle_home),
+    ]
+
 def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
     _sp, builtin = _providers
     import hermes_cli.profiles as profiles_mod


### PR DESCRIPTION
## What does this PR do?

When `HERMES_DESKTOP=1` is active, `hermes_cli/web_server.py::_start_desktop_cron_ticker()` starts an in-process multiplex cron ticker across all profile homes. This ticker exists as a fallback for secondary profiles whose desktop backends were reaped after idle timeout (#69377).

However, when a secondary profile is already running its own dedicated gateway daemon (e.g. `hermes gateway run` via LaunchAgent/systemd with its own Telegram/Discord bot credentials), the Desktop multiplex ticker was still ticking that profile. When Desktop won the `.tick.lock`, it executed deliveries with `adapters={}` via the standalone delivery path, causing the job to be delivered using the **default profile's bot token** instead of the secondary profile's live bot.

This PR filters out secondary profiles that have an active running gateway (`not _check_gateway_running(home)`) from the desktop ticker's `profile_homes`, allowing secondary profiles with dedicated gateway daemons to reliably tick and deliver their own cron jobs with their own bot identities.

## Related Issue

Fixes #100489

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py`: In `_start_desktop_cron_ticker()`, filter `profile_homes` with `not _check_gateway_running(home)` for secondary profiles so running gateway daemons maintain full authority over their own cron ticks and deliveries.
- `tests/hermes_cli/test_desktop_cron_ticker_profiles.py`: Added regression test `test_secondary_profile_with_running_gateway_excluded_from_desktop_ticker`.

## How to Test

1. Run the regression test:
   `python -m pytest tests/hermes_cli/test_desktop_cron_ticker_profiles.py -k test_secondary_profile_with_running_gateway_excluded_from_desktop_ticker`
2. Run the desktop cron ticker suite:
   `python -m pytest tests/hermes_cli/test_desktop_cron_ticker_profiles.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_desktop_cron_ticker_profiles.py` and tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
