### PR TITLE
fix(slack): avoid mixed native task-card payloads

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -2858,13 +2858,15 @@ class SlackAdapter(BasePlatformAdapter):
                         }
                     )
 
+                # Slack rejects an appendStream request containing both
+                # structured task-card chunks and markdown_text.  The chunks
+                # are the native card payload; text belongs solely to the
+                # editable fallback path in the caller.
                 append_payload: Dict[str, Any] = {
                     "channel": chat_id,
                     "ts": stream.stream_ts,
                     "chunks": chunks,
                 }
-                if fallback_text:
-                    append_payload["markdown_text"] = fallback_text
                 await client.api_call("chat.appendStream", json=append_payload)
                 return SendResult(success=True, message_id=stream.stream_ts)
             except Exception as exc:  # pragma: no cover - defensive logging

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -5078,6 +5078,12 @@ class TestNativeTaskCardProgress:
             "recipient_team_id": "T1",
             "recipient_user_id": "U1",
         }
+        # Slack rejects an appendStream payload that mixes its structured
+        # task-card chunks with markdown_text. Keep the card protocol pure.
+        for call in calls[1:]:
+            payload = call.kwargs["json"]
+            assert payload["chunks"]
+            assert "markdown_text" not in payload
         adapter._app.client.api_call.assert_not_awaited()
 
         await adapter.stop_native_task_card_progress("C1", metadata=metadata)


### PR DESCRIPTION
## Summary
- omit `markdown_text` from Slack native task-card `chat.appendStream` payloads when sending structured task chunks
- add a regression assertion that native task-card appends contain chunks but no markdown text

Slack rejects the mixed payload with `cannot_provide_both_markdown_text_and_chunks`, forcing every native-card turn to fall back to the editable text progress bubble.

## Validation
- `uv run --extra dev pytest tests/gateway/test_slack.py::TestNativeTaskCardProgress -q` (4 passed)
- Live verification on Hermes v0.21.0 / macOS: native plan/task cards rendered successfully after this change.

Fixes #87743