### PR TITLE
fix(kanban): refuse to complete a card whose declared files are absent

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -18,6 +18,7 @@ import argparse
 import contextlib
 import json
 import os
+import re
 import shlex
 import sys
 import time
@@ -25,6 +26,10 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_db import (
+    _declared_artifact_paths,
+    _missing_artifact_rejection,
+)
 from hermes_cli import kanban_swarm as ks
 
 
@@ -2379,6 +2384,23 @@ def _cmd_complete(args: argparse.Namespace) -> int:
             # to every terminal handoff so request-review cannot bypass the
             # acceptance contract that protects complete.
             task = kb.get_task(conn, tid)
+
+            # Cheapest evidence first: if the card named the files it must
+            # leave behind, they have to exist before it can close. A
+            # worker that exhausts its iteration budget can still reach
+            # this call, and without the check a review that produced no
+            # report closes exactly like one that produced three.
+            missing = _missing_artifact_rejection(task)
+            if missing is not None:
+                print(
+                    f"kanban: cannot complete {tid}: {missing}. "
+                    f"Write the deliverables the card declares, or edit the "
+                    f"card if the plan changed.",
+                    file=sys.stderr,
+                )
+                failed.append(tid)
+                continue
+
             rejection = _goal_mode_handoff_rejection(
                 task,
                 (summary or args.result or "").strip(),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -12148,3 +12148,125 @@ def latest_summaries(
         ids,
     ).fetchall()
     return {r["task_id"]: r["summary"] for r in rows}
+
+
+_ARTIFACT_HEADING_RE = re.compile(
+    r"^\s*(?:#{1,6}\s*|\*\*)\s*"
+    r"(?:deliverables?|output\s+files?|artifacts?|交付物|产出物|输出文件)"
+    r"\s*[:：]?\s*\*{0,2}\s*$",
+    re.IGNORECASE,
+)
+_NEXT_HEADING_RE = re.compile(r"^\s*(?:#{1,6}\s|\*\*\S)")
+_ARTIFACT_PATH_RE = re.compile(
+    r"^\s*[-*+]?\s*`?([^\s`,;()]+\.[A-Za-z0-9_]{1,8})`?\s*$"
+)
+# Prose declarations: a path introduced by a verb that means "produce
+# this". Read verbs are deliberately absent -- a card names the sources
+# it wants consulted far more often than the files it must leave, and
+# requiring an input to exist would fail every completion.
+_PROSE_ARTIFACT_RE = re.compile(
+    r"(?:"
+    r"写入|写到|输出到|保存到|存到|生成到|产出到|落盘到|"
+    r"writes?\s+(?:to\s+)?|saves?\s+(?:to\s+)?|outputs?\s+(?:to\s+)?|"
+    r"emits?\s+(?:to\s+)?|records?\s+(?:to\s+)?"
+    r")\s*[`'\"]?([^\s`'\",;()]+\.[A-Za-z0-9_]{1,8})",
+    re.IGNORECASE,
+)
+# A templated name cannot be resolved to a real file, so it cannot be
+# checked and must not block completion. This is the gate's real limit:
+# a card that says "write r<N>.md for each round" declares nothing this
+# can verify, which is why dispatch should enumerate the rounds instead
+# of templating them.
+_PLACEHOLDER_RE = re.compile(r"[<>{}*?]|\$\{|%s|\bN\b")
+
+
+def _declared_artifact_paths(body: Optional[str]) -> list[str]:
+    """Return the files a card says it must leave behind.
+
+    Two shapes count. A deliverables heading is the explicit form and is
+    what dispatch should write. Prose is the form cards actually use --
+    "每轮评审结果写入 docs/reviews/r1.md" sitting in a numbered
+    requirement -- and missing it was how a review card closed as done
+    with nothing on disk.
+
+    Paths the card merely references stay out: only write verbs promote
+    a path to a deliverable, and templated names are skipped because
+    nothing can verify them.
+    """
+    if not body:
+        return []
+    paths: list[str] = []
+
+    in_section = False
+    for line in body.splitlines():
+        if _ARTIFACT_HEADING_RE.match(line):
+            in_section = True
+            continue
+        if in_section:
+            if _NEXT_HEADING_RE.match(line):
+                # Section over; the line itself is a heading, nothing to
+                # scan, but later prose is back in play.
+                in_section = False
+                continue
+            match = _ARTIFACT_PATH_RE.match(line)
+            if match:
+                paths.append(match.group(1))
+                continue
+            if line.strip():
+                # A non-path line inside the section: the bullet list has
+                # ended even though no new heading started. Fall through
+                # so this line is read as prose.
+                in_section = False
+        for match in _PROSE_ARTIFACT_RE.finditer(line):
+            paths.append(match.group(1))
+
+    seen: set[str] = set()
+    unique: list[str] = []
+    for path in paths:
+        if path in seen or _PLACEHOLDER_RE.search(path):
+            continue
+        seen.add(path)
+        unique.append(path)
+    return unique
+
+
+def _missing_artifact_rejection(task: Optional[Task]) -> Optional[str]:
+    """Report declared deliverables that are not on disk.
+
+    A worker whose iteration budget runs out can still call complete, and
+    a review card that produced no report is then indistinguishable from
+    one that produced three. Checking the files the card itself named is
+    the cheapest evidence available, and it costs nothing on the cards
+    that name none.
+
+    An empty file counts as missing: a zero-byte report says as little as
+    an absent one.
+    """
+    if task is None:
+        return None
+    declared = _declared_artifact_paths(task.body)
+    if not declared:
+        return None
+    root = task.workspace_path
+    if not root:
+        # Nothing to resolve relative paths against; the check would be
+        # guessing at a location rather than verifying one.
+        return None
+
+    missing: list[str] = []
+    for rel in declared:
+        candidate = Path(rel)
+        if not candidate.is_absolute():
+            candidate = Path(root) / rel
+        try:
+            if not candidate.is_file() or candidate.stat().st_size == 0:
+                missing.append(rel)
+        except OSError:
+            missing.append(rel)
+    if not missing:
+        return None
+    return (
+        "declared deliverables are missing or empty: "
+        + ", ".join(missing)
+        + f" (resolved against {root})"
+    )

--- a/tests/hermes_cli/test_kanban_artifact_gate.py
+++ b/tests/hermes_cli/test_kanban_artifact_gate.py
@@ -1,0 +1,283 @@
+"""Tests for the declared-artifact gate on kanban completion.
+
+A worker that runs out of iteration budget can still mark its card done,
+and a review card that produced no report then looks indistinguishable
+from one that produced three. This gate closes that: when a card names
+the files it must leave behind, completion checks they are on disk.
+
+Two layers:
+
+1. Path extraction from the card body -- which shapes count as a
+   declared artifact and which are prose that merely mentions a file.
+2. The gate itself -- missing files are reported, present files pass,
+   and cards that declare nothing are unaffected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+# ---------------------------------------------------------------------------
+# Path extraction
+# ---------------------------------------------------------------------------
+
+
+def test_extracts_paths_from_artifacts_section():
+    """A section naming output files yields those paths."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = """
+## Review scope
+Branch feat/x, commits HEAD~2..HEAD
+
+## Deliverables
+- docs/reviews/round1.md
+- docs/reviews/round2.md
+"""
+    assert _declared_artifact_paths(body) == [
+        "docs/reviews/round1.md",
+        "docs/reviews/round2.md",
+    ]
+
+
+def test_ignores_prose_mentioning_files_outside_a_deliverables_section():
+    """A path in the background prose is not a deliverable."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = """
+## Background
+The link failure comes from tools/image-host.c referencing image-sig.c.
+Read configs/imx8qxp_defconfig for the current settings.
+"""
+    assert _declared_artifact_paths(body) == []
+
+
+def test_recognises_the_common_heading_spellings():
+    """Deliverable sections are written several ways in practice."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    for heading in (
+        "## Deliverables",
+        "### 交付物",
+        "## Output files",
+        "## 产出物",
+        "**Deliverable:**",
+    ):
+        body = f"{heading}\n- reports/out.md\n"
+        assert _declared_artifact_paths(body) == ["reports/out.md"], heading
+
+
+def test_deliverables_section_ends_at_the_next_heading():
+    """Paths under a later section are not pulled in."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = """
+## Deliverables
+- reports/wanted.md
+
+## Notes
+- reports/not_wanted.md
+"""
+    assert _declared_artifact_paths(body) == ["reports/wanted.md"]
+
+
+def test_accepts_backticked_and_bare_paths():
+    """Both `path` and bare path forms are picked up."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = "## Deliverables\n- `docs/a.md`\n- docs/b.md\n"
+    assert _declared_artifact_paths(body) == ["docs/a.md", "docs/b.md"]
+
+
+def test_empty_body_is_safe():
+    """No body, no declarations, no crash."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    assert _declared_artifact_paths(None) == []
+    assert _declared_artifact_paths("") == []
+
+
+# ---------------------------------------------------------------------------
+# Prose declarations
+#
+# Cards in the wild name their outputs mid-sentence rather than under a
+# heading. The card that motivated this gate said "每轮评审结果写入
+# /home/.../k4-uboot-fix-r<N>.md" in a numbered requirement, closed as
+# done, and left nothing on disk.
+# ---------------------------------------------------------------------------
+
+
+def test_prose_write_verb_declares_an_artifact():
+    """A path introduced by a write verb is an output, not a reference."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = "4. 每轮评审结果写入 /home/user/docs/reviews/round1.md\n"
+    assert _declared_artifact_paths(body) == ["/home/user/docs/reviews/round1.md"]
+
+
+def test_prose_english_write_verbs():
+    """The same shape in English."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    for verb in ("write to", "save to", "output to", "write"):
+        body = f"Please {verb} reports/out.md when finished.\n"
+        assert _declared_artifact_paths(body) == ["reports/out.md"], verb
+
+
+def test_prose_read_verbs_are_not_declarations():
+    """Files the worker must consult are inputs and must not be required."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    for line in (
+        "先读 docs/design/spec.md 再动手",
+        "Read configs/imx8qxp_defconfig for current settings",
+        "参考 tools/image-host.c 的实现",
+        "评审范围包括 src/main.py",
+    ):
+        assert _declared_artifact_paths(line) == [], line
+
+
+def test_prose_placeholder_paths_are_skipped():
+    """A templated name cannot be checked, so it must not block."""
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = "每轮结果写入 docs/reviews/k4-uboot-fix-r<N>.md\n"
+    assert _declared_artifact_paths(body) == []
+
+
+def test_prose_and_section_declarations_combine_without_duplicates():
+    from hermes_cli.kanban_db import _declared_artifact_paths
+
+    body = """
+## Deliverables
+- reports/a.md
+
+Also write reports/b.md, and write reports/a.md again.
+"""
+    assert _declared_artifact_paths(body) == ["reports/a.md", "reports/b.md"]
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+def _make_task(workspace_path, body):
+    """Build a minimal Task carrying just what the gate reads."""
+    import time
+
+    return kb.Task(
+        id="t_test",
+        title="Review: something",
+        body=body,
+        assignee="reviewer",
+        status="running",
+        priority=0,
+        created_by="user",
+        created_at=int(time.time()),
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=str(workspace_path),
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+
+def test_gate_rejects_when_declared_file_is_absent(tmp_path):
+    """The defect this exists for: card says done, disk says nothing."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    task = _make_task(tmp_path, "## Deliverables\n- reports/r1.md\n")
+    rejection = _missing_artifact_rejection(task)
+
+    assert rejection is not None
+    assert "reports/r1.md" in rejection
+
+
+def test_gate_passes_when_declared_file_exists(tmp_path):
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    (tmp_path / "reports").mkdir()
+    (tmp_path / "reports" / "r1.md").write_text("findings", encoding="utf-8")
+
+    task = _make_task(tmp_path, "## Deliverables\n- reports/r1.md\n")
+    assert _missing_artifact_rejection(task) is None
+
+
+def test_gate_names_every_missing_file(tmp_path):
+    """Reporting one at a time would mean three round trips."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    (tmp_path / "reports").mkdir()
+    (tmp_path / "reports" / "r1.md").write_text("x", encoding="utf-8")
+
+    task = _make_task(
+        tmp_path,
+        "## Deliverables\n- reports/r1.md\n- reports/r2.md\n- reports/r3.md\n",
+    )
+    rejection = _missing_artifact_rejection(task)
+
+    assert rejection is not None
+    assert "reports/r2.md" in rejection
+    assert "reports/r3.md" in rejection
+    assert "reports/r1.md" not in rejection
+
+
+def test_gate_is_silent_for_cards_declaring_nothing(tmp_path):
+    """Most cards do not name deliverables; they must be unaffected."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    task = _make_task(tmp_path, "Fix the thing and commit it.")
+    assert _missing_artifact_rejection(task) is None
+
+
+def test_gate_is_silent_without_a_workspace(tmp_path):
+    """A scratch card has nowhere to resolve relative paths against."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    task = _make_task(tmp_path, "## Deliverables\n- reports/r1.md\n")
+    task.workspace_path = None
+    assert _missing_artifact_rejection(task) is None
+
+
+def test_gate_accepts_absolute_paths(tmp_path):
+    """An absolute declaration is checked as given, not joined."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    target = tmp_path / "elsewhere" / "report.md"
+    target.parent.mkdir()
+    target.write_text("x", encoding="utf-8")
+
+    task = _make_task(tmp_path / "workspace", f"## Deliverables\n- {target}\n")
+    assert _missing_artifact_rejection(task) is None
+
+
+def test_gate_treats_an_empty_file_as_missing(tmp_path):
+    """A zero-byte report is the same evidence as no report."""
+    from hermes_cli.kanban_db import _missing_artifact_rejection
+
+    (tmp_path / "reports").mkdir()
+    (tmp_path / "reports" / "r1.md").write_text("", encoding="utf-8")
+
+    task = _make_task(tmp_path, "## Deliverables\n- reports/r1.md\n")
+    rejection = _missing_artifact_rejection(task)
+
+    assert rejection is not None
+    assert "reports/r1.md" in rejection

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -752,6 +752,22 @@ def _handle_complete(args: dict, **kw) -> str:
             # Only enforce when a judge is actually reachable — see
             # _goal_judge_available for why an unavailable judge fails open.
             task = kb.get_task(conn, tid)
+
+            # The card's own declared deliverables come first, and cost
+            # nothing on cards that declare none. A worker out of
+            # iteration budget still reaches this call, so without the
+            # check a review that wrote no report closes exactly like one
+            # that wrote three. This is separate from the artifacts=[...]
+            # argument below: that one is what the worker claims it
+            # produced, this one is what the card demanded up front.
+            missing = kb._missing_artifact_rejection(task)
+            if missing is not None:
+                return tool_error(
+                    f"Cannot complete: {missing}. Write the deliverables the "
+                    f"card declares, then complete again. If the plan changed, "
+                    f"edit the card body first so the record matches reality."
+                )
+
             rejection = _goal_mode_handoff_rejection(
                 task,
                 (summary or result or "").strip(),


### PR DESCRIPTION
A worker that exhausts its iteration budget still reaches `kanban_complete`, and nothing checked that the work left anything behind. Card `t_9f017d0a` closed as done carrying a comment claiming four review passes were written; `find` returned zero reports. From the board it was indistinguishable from a card that produced all three rounds.

The card already says what it owes. Completion now reads the paths back out of the body and refuses while any of them is missing or zero-byte, naming the ones that are absent so the worker knows what to write. Both entry points are covered: the CLI and the tool workers actually call.

## How declarations are recognised

Two ways:

- **Explicit** — a `## Deliverables` heading (or `交付物` / `产出物` / `Output files`).
- **Prose** — the form cards actually use. The card above said `每轮评审结果写入 <path>` inside a numbered requirement, so **write verbs** promote a path too.

**Read verbs deliberately do not.** Cards name sources to consult far more often than files to produce, and requiring an input to exist would fail every completion.

## Known limit

Templated names are skipped. `<round N>` cannot be resolved to a file, so it cannot be verified, and the gate stays quiet rather than guessing. That is its real limit, and why the dispatch skill now says to enumerate rounds instead of templating them.

Cards declaring nothing are unaffected, which is nearly all of them.

## Verification

Verified end to end against a real database and filesystem:

- zero reports → blocks, with both paths named
- one of two present → blocks, naming only the missing one
- both present → completes

Existing kanban suite unchanged at 15 pre-existing failures, 292 → 310 passed.

Rebased onto current `main` (`18a76be124`) before opening; `tests/hermes_cli/test_kanban_artifact_gate.py` — 18 passed.
