### PR TITLE
fix(desktop/update): preserve active profile and config model settings across updates

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12473,11 +12473,12 @@ async function startHermes() {
   }
 
   // Seed active-profile.json from legacy signals BEFORE the first
-  // primaryProfileKey() / primaryBackendIsRemote() read. Without this,
+  // profile-dependent read (`primaryBackendIsRemote()` on the next line, then
+  // `primaryProfileKey()` inside the connection IIFE below). Without this,
   // remote-mode users whose preference file is missing (first boot after
-  // update) resolve primaryProfileKey() to 'default' inside the connection
-  // IIFE below, then the remote branch returns and never runs the migration.
-  // Runs once; no-op when the preference file already exists.
+  // update) resolve primaryProfileKey() to 'default' inside the IIFE, then
+  // the remote branch returns and never runs the migration. Runs once;
+  // no-op when the preference file already exists.
   migrateActiveProfileIfMissing()
 
   const connectionAttempt = backendConnectionState.startAttempt()

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9426,9 +9426,11 @@ function isHermesProcess(pid) {
   } catch {
     return false
   }
+
   // On macOS / Linux, check the command line to avoid PID recycling false positives.
   try {
     const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+
     return cmdline.includes('hermes')
   } catch {
     // /proc not available (macOS) — fall back to ps. Use -o args= to inspect
@@ -9437,6 +9439,7 @@ function isHermesProcess(pid) {
     try {
       const { execSync } = require('child_process')
       const out = execSync(`ps -p ${pid} -o args=`, { encoding: 'utf8', timeout: 2000 })
+
       return out.includes('hermes')
     } catch {
       return false

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -299,6 +299,7 @@ import {
   profileNameFromDeleteRequest,
   resolveRouteProfile
 } from './profile-delete-routing'
+import { migrateActiveProfileIfMissing as migrateActiveProfileIfMissingPure } from './profile-migration'
 import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
 import {
   buildSidebarSessionSliceParams,
@@ -9450,79 +9451,28 @@ function isHermesProcess(pid) {
 //   3. state.db heuristics (hybrid recency×size score picks the primary workspace)
 // The stored JSON includes _migrated:true so the renderer can optionally surface
 // a one-time notification that the profile was auto-detected.
+//
+// Decision logic lives in profile-migration.ts (pure + unit-tested). This wrapper
+// just wires Electron/Node fs into a MigrationDeps bag and delegates.
 function migrateActiveProfileIfMissing() {
-  if (fs.existsSync(DESKTOP_PROFILE_CONFIG_PATH)) return
-
-  // 1. Legacy CLI sticky file — highest confidence, no _migrated flag needed
-  //    (the user explicitly chose this profile via hermes profile use).
-  const legacyActive = path.join(HERMES_HOME, 'active_profile')
-  try {
-    const name = fs.readFileSync(legacyActive, 'utf8').trim()
-    if (name && PROFILE_NAME_RE.test(name)) {
-      return writeActiveDesktopProfile(name)
-    }
-  } catch { /* not found */ }
-
-  // Gather known profile names from the filesystem
-  const profilesRoot = path.join(HERMES_HOME, 'profiles')
-  let allProfiles = []
-  try {
-    allProfiles = fs.readdirSync(profilesRoot, { withFileTypes: true })
-      .filter(e => e.isDirectory() && (e.name === 'default' || PROFILE_NAME_RE.test(e.name)))
-      .map(e => e.name)
-  } catch { /* no profiles dir */ }
-  if (allProfiles.length === 0) return
-
-  // 2. Running gateway detection — liveness + hermes identity check.
-  //    Also high confidence (the gateway is actively running), so no
-  //    _migrated flag is written — same rationale as priority 1.
-  const running = []
-  for (const name of allProfiles) {
-    const pidFile = path.join(profilesRoot, name, 'gateway.pid')
-    try {
-      const raw = fs.readFileSync(pidFile, 'utf8')
-      const parsed = JSON.parse(raw)
-      if (parsed.pid && isHermesProcess(parsed.pid)) {
-        running.push(name)
-      }
-    } catch { /* pid file missing, malformed, or stale */ }
-  }
-
-  if (running.length === 1) {
-    return writeActiveDesktopProfile(running[0])
-  }
-
-  // 3. state.db heuristics — hybrid recency × size score.
-  //    Only runs for named profiles (not default), since the goal is to
-  //    migrate AWAY from \"default\" when a better candidate exists.
-  //    The default profile's state.db at ~/.hermes/state.db is deliberately
-  //    excluded — the function is a no-op for single-profile users.
-  const candidates = running.length > 1 ? running : allProfiles
-  let best = null
-  let maxScore = -1
-
-  for (const name of candidates) {
-    const dbPath = path.join(profilesRoot, name, 'state.db')
-    try {
-      const stat = fs.statSync(dbPath)
-      const daysSinceModified = Math.max(0, (Date.now() - stat.mtimeMs) / (1000 * 60 * 60 * 24))
-      const recencyWeight = Math.max(0.1, 30 - daysSinceModified)
-      const sizeWeight = Math.log10(Math.max(1024, stat.size))
-      const score = recencyWeight * sizeWeight
-      if (score > maxScore) {
-        maxScore = score
-        best = name
-      }
-    } catch { /* no state.db */ }
-  }
-
-  if (best && best !== 'default') {
-    fs.mkdirSync(path.dirname(DESKTOP_PROFILE_CONFIG_PATH), { recursive: true })
-    writeFileAtomic(
-      DESKTOP_PROFILE_CONFIG_PATH,
-      JSON.stringify({ profile: best, _migrated: true }, null, 2)
-    )
-  }
+  migrateActiveProfileIfMissingPure(DESKTOP_PROFILE_CONFIG_PATH, {
+    legacyActivePath: path.join(HERMES_HOME, 'active_profile'),
+    profilesRoot: path.join(HERMES_HOME, 'profiles'),
+    existsSync: p => fs.existsSync(p),
+    readFileSync: (p, enc) => fs.readFileSync(p, enc),
+    statSync: p => fs.statSync(p),
+    readdirSync: (p, opts) => fs.readdirSync(p, opts as { withFileTypes: true }),
+    isHermesProcess,
+    now: () => Date.now(),
+    writeJson: (target, decision) => {
+      // Mirror writeActiveDesktopProfile's atomic-write + parent-dir-create
+      // semantics so the migration produces a file indistinguishable from a
+      // user-driven profile switch.
+      fs.mkdirSync(path.dirname(target), { recursive: true })
+      writeFileAtomic(target, JSON.stringify(decision, null, 2))
+    },
+    isValidProfileName: p => PROFILE_NAME_RE.test(p)
+  })
 }
 
 // Sanitize a connection config into the renderer-facing shape. With no
@@ -12522,6 +12472,14 @@ async function startHermes() {
     return existingConnectionPromise
   }
 
+  // Seed active-profile.json from legacy signals BEFORE the first
+  // primaryProfileKey() / primaryBackendIsRemote() read. Without this,
+  // remote-mode users whose preference file is missing (first boot after
+  // update) resolve primaryProfileKey() to 'default' inside the connection
+  // IIFE below, then the remote branch returns and never runs the migration.
+  // Runs once; no-op when the preference file already exists.
+  migrateActiveProfileIfMissing()
+
   const connectionAttempt = backendConnectionState.startAttempt()
   const primaryProfile = primaryProfileKey()
 
@@ -12590,7 +12548,6 @@ async function startHermes() {
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
     // unset preference keeps the legacy launch so existing installs are
     // unaffected.
-    migrateActiveProfileIfMissing()
     const activeProfile = readActiveDesktopProfile()
 
     if (activeProfile) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9416,6 +9416,115 @@ function writeActiveDesktopProfile(name) {
   return value || null
 }
 
+// True when the given pid belongs to a running process whose command line
+// contains "hermes", avoiding false positives from stale gateway.pid files
+// whose PID was recycled by the OS to an unrelated process.
+function isHermesProcess(pid) {
+  try {
+    process.kill(pid, 0) // signal 0 = existence check, no signal sent
+  } catch {
+    return false
+  }
+  // On macOS / Linux, check the command line to avoid PID recycling false positives.
+  try {
+    const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
+    return cmdline.includes('hermes')
+  } catch {
+    // /proc not available (macOS) — fall back to ps. Use -o args= to inspect
+    // the full command line, not just the process name.  -o comm= would return
+    // "python3" for any Python process, creating false positives.
+    try {
+      const { execSync } = require('child_process')
+      const out = execSync(`ps -p ${pid} -o args=`, { encoding: 'utf8', timeout: 2000 })
+      return out.includes('hermes')
+    } catch {
+      return false
+    }
+  }
+}
+
+// Seed active-profile.json from the best available signal when the file does
+// not yet exist.  Runs exactly once (no-op once the file exists).  Priority:
+//   1. Legacy ~/.hermes/active_profile (explicit CLI choice via hermes profile use)
+//   2. Running gateway (gateway.pid with verified liveness + hermes identity)
+//   3. state.db heuristics (hybrid recency×size score picks the primary workspace)
+// The stored JSON includes _migrated:true so the renderer can optionally surface
+// a one-time notification that the profile was auto-detected.
+function migrateActiveProfileIfMissing() {
+  if (fs.existsSync(DESKTOP_PROFILE_CONFIG_PATH)) return
+
+  // 1. Legacy CLI sticky file — highest confidence, no _migrated flag needed
+  //    (the user explicitly chose this profile via hermes profile use).
+  const legacyActive = path.join(HERMES_HOME, 'active_profile')
+  try {
+    const name = fs.readFileSync(legacyActive, 'utf8').trim()
+    if (name && PROFILE_NAME_RE.test(name)) {
+      return writeActiveDesktopProfile(name)
+    }
+  } catch { /* not found */ }
+
+  // Gather known profile names from the filesystem
+  const profilesRoot = path.join(HERMES_HOME, 'profiles')
+  let allProfiles = []
+  try {
+    allProfiles = fs.readdirSync(profilesRoot, { withFileTypes: true })
+      .filter(e => e.isDirectory() && (e.name === 'default' || PROFILE_NAME_RE.test(e.name)))
+      .map(e => e.name)
+  } catch { /* no profiles dir */ }
+  if (allProfiles.length === 0) return
+
+  // 2. Running gateway detection — liveness + hermes identity check.
+  //    Also high confidence (the gateway is actively running), so no
+  //    _migrated flag is written — same rationale as priority 1.
+  const running = []
+  for (const name of allProfiles) {
+    const pidFile = path.join(profilesRoot, name, 'gateway.pid')
+    try {
+      const raw = fs.readFileSync(pidFile, 'utf8')
+      const parsed = JSON.parse(raw)
+      if (parsed.pid && isHermesProcess(parsed.pid)) {
+        running.push(name)
+      }
+    } catch { /* pid file missing, malformed, or stale */ }
+  }
+
+  if (running.length === 1) {
+    return writeActiveDesktopProfile(running[0])
+  }
+
+  // 3. state.db heuristics — hybrid recency × size score.
+  //    Only runs for named profiles (not default), since the goal is to
+  //    migrate AWAY from \"default\" when a better candidate exists.
+  //    The default profile's state.db at ~/.hermes/state.db is deliberately
+  //    excluded — the function is a no-op for single-profile users.
+  const candidates = running.length > 1 ? running : allProfiles
+  let best = null
+  let maxScore = -1
+
+  for (const name of candidates) {
+    const dbPath = path.join(profilesRoot, name, 'state.db')
+    try {
+      const stat = fs.statSync(dbPath)
+      const daysSinceModified = Math.max(0, (Date.now() - stat.mtimeMs) / (1000 * 60 * 60 * 24))
+      const recencyWeight = Math.max(0.1, 30 - daysSinceModified)
+      const sizeWeight = Math.log10(Math.max(1024, stat.size))
+      const score = recencyWeight * sizeWeight
+      if (score > maxScore) {
+        maxScore = score
+        best = name
+      }
+    } catch { /* no state.db */ }
+  }
+
+  if (best && best !== 'default') {
+    fs.mkdirSync(path.dirname(DESKTOP_PROFILE_CONFIG_PATH), { recursive: true })
+    writeFileAtomic(
+      DESKTOP_PROFILE_CONFIG_PATH,
+      JSON.stringify({ profile: best, _migrated: true }, null, 2)
+    )
+  }
+}
+
 // Sanitize a connection config into the renderer-facing shape. With no
 // `profile` this describes the global/default connection (the existing
 // behavior); with a `profile` it describes that profile's per-profile remote
@@ -12481,6 +12590,7 @@ async function startHermes() {
     // resolves HERMES_HOME the same way `hermes -p <name>` does on the CLI. An
     // unset preference keeps the legacy launch so existing installs are
     // unaffected.
+    migrateActiveProfileIfMissing()
     const activeProfile = readActiveDesktopProfile()
 
     if (activeProfile) {

--- a/apps/desktop/electron/profile-migration.test.ts
+++ b/apps/desktop/electron/profile-migration.test.ts
@@ -1,0 +1,444 @@
+/**
+ * Tests for electron/profile-migration.ts — pure migration-decision helpers for
+ * the active-profile.json first-boot seeding.
+ *
+ * Run with: `vitest run` (wired via the `electronNative` project in
+ * `apps/desktop/vitest.config.ts`, which discovers tests under `electron/`).
+ *
+ * These tests cover the four axes the maintainer explicitly required:
+ *   1. precedence — legacy > single-running-gateway > state.db heuristic
+ *   2. stale PID rejection — recycled PID must not pass as a running gateway
+ *   3. fallback behavior — single-profile installs and missing files are no-ops
+ *   4. remote-boot path — verified by code review (the migration is moved to the
+ *      top of startHermes() in main.ts, before primaryProfileKey() is read); the
+ *      pure decision logic that the function relies on is covered below.
+ */
+
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import type { Dirent } from 'node:fs'
+
+import {
+  decideMigration,
+  findRunningGatewayProfiles,
+  listProfileDirs,
+  migrateActiveProfileIfMissing,
+  PROFILE_SCORE_MIN_SIZE_BYTES,
+  readLegacyActiveProfile,
+  scoreStateDb
+} from './profile-migration'
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// Mirrors the production PROFILE_NAME_RE in main.ts (regex matches "default";
+// callers like readLegacyActiveProfile must reject "default" explicitly).
+const PROFILE_NAME_RE = /^[a-z0-9][a-z0-9_-]{0,63}$/
+
+// Production-shaped validator: regex matches, but 'default' is excluded because
+// it's the implicit fallback, never a user-chosen CLI value.
+const isValidProfileName = (n: string) => n !== 'default' && PROFILE_NAME_RE.test(n)
+
+const NOW = 1_700_000_000_000
+
+type FileFixture = { content?: string; size?: number; mtime?: number; dir?: boolean }
+
+function makeFs(files: Record<string, FileFixture>) {
+  const map = new Map(Object.entries(files))
+
+  const existsSync = (p: string) => map.has(p)
+
+  const readFileSync = (p: string, _enc: 'utf8') => {
+    const e = map.get(p)
+    if (!e || e.content === undefined) throw new Error(`ENOENT: ${p}`)
+    return e.content
+  }
+
+  const statSync = (p: string) => {
+    const e = map.get(p)
+    if (!e || e.size === undefined) throw new Error(`ENOENT: ${p}`)
+    return { size: e.size, mtimeMs: e.mtime ?? NOW - 86_400_000 }
+  }
+
+  const readdirSync = (p: string, _options?: { withFileTypes?: boolean }): Dirent[] => {
+    const names = new Set<string>()
+    // 1. Explicit dir markers at this exact level.
+    for (const [fullPath, fixture] of map.entries()) {
+      if (fullPath === p && fixture.dir) {
+        // This is the dir itself; not a child. Skip.
+        continue
+      }
+      if (fullPath.startsWith(p + '/')) {
+        const rest = fullPath.slice(p.length + 1)
+        if (!rest.includes('/') && fixture.dir) {
+          names.add(rest)
+        }
+      }
+    }
+    // 2. Implicit directories: any nested path under `p` implies the intermediate
+    // directory exists (mirrors how mkdir({recursive:true}) populates the tree).
+    for (const key of map.keys()) {
+      if (!key.startsWith(p + '/')) continue
+      const rest = key.slice(p.length + 1)
+      const parts = rest.split('/')
+      if (parts.length < 2) continue
+      names.add(parts[0])
+    }
+    const entries: Dirent[] = []
+    for (const name of names) {
+      entries.push({
+        name,
+        isDirectory: () => true,
+        isFile: () => false,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isSymbolicLink: () => false,
+        isFIFO: () => false,
+        isSocket: () => false
+      } as unknown as Dirent)
+    }
+    if (entries.length === 0 && !map.has(p)) throw new Error(`ENOENT: ${p}`)
+    return entries
+  }
+
+  return { existsSync, readFileSync, statSync, readdirSync }
+}
+
+function baseDeps(overrides: Record<string, unknown> = {}) {
+  const fs = makeFs({})
+  return {
+    legacyActivePath: '/home/u/.hermes/active_profile',
+    profilesRoot: '/home/u/.hermes/profiles',
+    existsSync: fs.existsSync,
+    readFileSync: fs.readFileSync,
+    statSync: fs.statSync,
+    readdirSync: fs.readdirSync,
+    isHermesProcess: () => true,
+    now: () => NOW,
+    writeJson: () => {},
+    isValidProfileName,
+    ...overrides
+  }
+}
+
+// ---------------------------------------------------------------------------
+// readLegacyActiveProfile
+// ---------------------------------------------------------------------------
+
+test('readLegacyActiveProfile returns null when file missing', () => {
+  assert.equal(
+    readLegacyActiveProfile('/missing', () => { throw new Error('ENOENT') }, isValidProfileName),
+    null
+  )
+})
+
+test('readLegacyActiveProfile returns trimmed name on success', () => {
+  assert.equal(
+    readLegacyActiveProfile('/p', () => '  coder  \n' as unknown as string, isValidProfileName),
+    'coder'
+  )
+})
+
+test('readLegacyActiveProfile returns undefined when present but invalid (special chars)', () => {
+  assert.equal(
+    readLegacyActiveProfile('/p', () => 'BAD NAME!' as unknown as string, isValidProfileName),
+    undefined
+  )
+})
+
+test('readLegacyActiveProfile rejects default as a legacy CLI choice', () => {
+  // "default" matches PROFILE_NAME_RE but is implicit; the explicit guard
+  // suppresses it so the heuristic rung still fires.
+  assert.equal(
+    readLegacyActiveProfile('/p', () => 'default' as unknown as string, isValidProfileName),
+    undefined
+  )
+})
+
+test('readLegacyActiveProfile returns null for empty/whitespace content', () => {
+  assert.equal(
+    readLegacyActiveProfile('/p', () => '   \n' as unknown as string, isValidProfileName),
+    null
+  )
+})
+
+// ---------------------------------------------------------------------------
+// findRunningGatewayProfiles
+// ---------------------------------------------------------------------------
+
+test('findRunningGatewayProfiles returns [] when no pid files exist', () => {
+  const fs = makeFs({ '/home/u/.hermes/profiles/coder': { dir: true } })
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder'], {
+      ...fs,
+      isHermesProcess: () => true
+    }),
+    []
+  )
+})
+
+test('findRunningGatewayProfiles drops stale (non-hermes) recycled PIDs', () => {
+  // Two profiles have pid files, but only coder's pid is a live hermes process.
+  // The recycled PID at 5678 belongs to an unrelated process (e.g. Chrome).
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":1234}' },
+    '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":5678}' }
+  })
+  const deps = {
+    ...fs,
+    isHermesProcess: (pid: number) => pid === 1234
+  }
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps),
+    ['coder']
+  )
+})
+
+test('findRunningGatewayProfiles tolerates malformed pid files', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{not json' }
+  })
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder'], {
+      ...fs,
+      isHermesProcess: () => true
+    }),
+    []
+  )
+})
+
+test('findRunningGatewayProfiles drops non-integer and non-positive PIDs', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":-1}' },
+    '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":1.5}' },
+    '/home/u/.hermes/profiles/extra/gateway.pid': { content: '{"pid":0}' }
+  })
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer', 'extra'], {
+      ...fs,
+      isHermesProcess: () => true
+    }),
+    []
+  )
+})
+
+test('findRunningGatewayProfiles preserves order of allProfiles', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":1}' },
+    '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":2}' }
+  })
+  const deps = { ...fs, isHermesProcess: () => true }
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps),
+    ['coder', 'writer']
+  )
+})
+
+// ---------------------------------------------------------------------------
+// scoreStateDb
+// ---------------------------------------------------------------------------
+
+test('scoreStateDb returns null on missing file', () => {
+  assert.equal(
+    scoreStateDb('/missing', NOW, () => { throw new Error('ENOENT') }),
+    null
+  )
+})
+
+test('scoreStateDb floors recency weight at 0.1 for ancient files', () => {
+  const ancient = scoreStateDb('/p', NOW, () => ({ size: 10 * 1024 * 1024, mtimeMs: 0 }))
+  const fresh = scoreStateDb('/p', NOW, () => ({ size: 10 * 1024 * 1024, mtimeMs: NOW - 86_400_000 }))
+  // Ancient still scores > 0 because recency is floored at 0.1.
+  assert.ok(ancient !== null && ancient > 0)
+  assert.ok(fresh !== null && fresh > ancient!)
+})
+
+test('scoreStateDb prefers larger DB at similar recency', () => {
+  // 409 MB primary workspace vs 28 MB secondary — primary wins even with a
+  // slightly newer mtime on the secondary.
+  const big = scoreStateDb('/big', NOW, () => ({ size: 409 * 1024 * 1024, mtimeMs: NOW - 86_400_000 }))
+  const small = scoreStateDb('/small', NOW, () => ({ size: 28 * 1024 * 1024, mtimeMs: NOW - 60_000 }))
+  assert.ok(big !== null && small !== null && big > small)
+})
+
+test('scoreStateDb floors size weight at log10(MIN_SIZE) for tiny files', () => {
+  // 100 bytes and PROFILE_SCORE_MIN_SIZE_BYTES score the same on the size axis
+  // (recency is the same here, so the score is identical).
+  const tiny = scoreStateDb('/tiny', NOW, () => ({ size: 100, mtimeMs: NOW - 86_400_000 }))
+  const min = scoreStateDb('/min', NOW, () => ({ size: PROFILE_SCORE_MIN_SIZE_BYTES, mtimeMs: NOW - 86_400_000 }))
+  assert.equal(tiny, min)
+})
+
+// ---------------------------------------------------------------------------
+// listProfileDirs
+// ---------------------------------------------------------------------------
+
+test('listProfileDirs returns [] for missing profiles root', () => {
+  const fs = makeFs({})
+  assert.deepEqual(listProfileDirs(baseDeps({ ...fs })), [])
+})
+
+test('listProfileDirs includes default and any name passing the regex', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/default': { dir: true },
+    '/home/u/.hermes/profiles/coder': { dir: true },
+    '/home/u/.hermes/profiles/writer': { dir: true }
+  })
+  assert.deepEqual(
+    listProfileDirs(baseDeps({ ...fs })),
+    ['default', 'coder', 'writer']
+  )
+})
+
+test('listProfileDirs skips files (not directories) and invalid names', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/default': { dir: true },
+    '/home/u/.hermes/profiles/some-file.txt': { dir: false },
+    '/home/u/.hermes/profiles/UPPERCASE': { dir: true } // regex rejects
+  })
+  assert.deepEqual(listProfileDirs(baseDeps({ ...fs })), ['default'])
+})
+
+// ---------------------------------------------------------------------------
+// decideMigration
+// ---------------------------------------------------------------------------
+
+test('decideMigration prefers legacy over everything else', () => {
+  const deps = baseDeps()
+  const d = decideMigration('coder', ['writer'], ['coder', 'writer'], deps, () => null)
+  assert.deepEqual(d, { profile: 'coder' })
+  assert.equal(d?._migrated, undefined)
+})
+
+test('decideMigration prefers a single running gateway profile', () => {
+  const deps = baseDeps()
+  const d = decideMigration(null, ['coder'], ['coder', 'writer'], deps, () => null)
+  assert.deepEqual(d, { profile: 'coder' })
+  assert.equal(d?._migrated, undefined)
+})
+
+test('decideMigration falls through to scoring when multiple gateways run', () => {
+  // When running.length > 1 the heuristic must score the running set, not all
+  // profiles, so a stopped profile can't win against two live ones.
+  const deps = baseDeps()
+  const d = decideMigration(null, ['coder', 'writer'], ['coder', 'writer'], deps, p =>
+    p.endsWith('/writer/state.db') ? 50 : 10
+  )
+  assert.deepEqual(d, { profile: 'writer', _migrated: true })
+})
+
+test('decideMigration returns null when no candidate scores and legacy is invalid', () => {
+  const deps = baseDeps()
+  assert.equal(
+    decideMigration(undefined, [], ['coder', 'writer'], deps, () => null),
+    null
+  )
+})
+
+test('decideMigration suppresses write when best is default (single-profile fallback)', () => {
+  // The whole point of the migration is to migrate AWAY from default when a
+  // better candidate exists. If 'default' wins the score, the install is
+  // single-profile and we leave it alone.
+  const deps = baseDeps()
+  const d = decideMigration(null, [], ['default', 'coder'], deps, p =>
+    p.endsWith('/default/state.db') ? 99 : 50
+  )
+  assert.equal(d, null)
+})
+
+test('decideMigration still flags _migrated when legacy is invalid (undefined) but a heuristic wins', () => {
+  // legacy === undefined means "file was present but malformed" — fall through to
+  // the heuristic and mark as migrated.
+  const deps = baseDeps()
+  const d = decideMigration(undefined, [], ['coder'], deps, () => 10)
+  assert.deepEqual(d, { profile: 'coder', _migrated: true })
+})
+
+// ---------------------------------------------------------------------------
+// migrateActiveProfileIfMissing (orchestrator)
+// ---------------------------------------------------------------------------
+
+test('migrateActiveProfileIfMissing is a no-op when the preference file exists', () => {
+  let written: unknown = null
+  const deps = baseDeps({
+    existsSync: (p: string) => p === '/cfg/active-profile.json',
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
+})
+
+test('migrateActiveProfileIfMissing writes legacy choice with no _migrated flag', () => {
+  let written: unknown = null
+  const fs = makeFs({
+    '/home/u/.hermes/active_profile': { content: 'coder' },
+    '/home/u/.hermes/profiles/coder': { dir: true },
+    '/home/u/.hermes/profiles/writer': { dir: true }
+  })
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
+  assert.deepEqual(written, { profile: 'coder' })
+})
+
+test('migrateActiveProfileIfMissing writes heuristic choice with _migrated=true', () => {
+  let written: unknown = null
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/state.db': { size: 50 * 1024 * 1024, mtime: NOW - 86_400_000 },
+    '/home/u/.hermes/profiles/writer/state.db': { size: 200 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
+  assert.deepEqual(written, { profile: 'writer', _migrated: true })
+})
+
+test('migrateActiveProfileIfMissing is a no-op for single-profile (default-only) installs', () => {
+  // No heuristic candidate can beat 'default', so the orchestrator must NOT
+  // write a file — preserves legacy launch behavior for the 99% case.
+  let written: unknown = null
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/default/state.db': { size: 10 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
+})
+
+test('migrateActiveProfileIfMissing is a no-op when no profiles directory exists', () => {
+  let written: unknown = null
+  const fs = makeFs({})
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
+})
+
+test('migrateActiveProfileIfMissing prefers a single running gateway over heuristics', () => {
+  // running=['coder'] regardless of what the heuristic would score — gateway
+  // ownership is the strongest signal we have for the active profile.
+  let written: unknown = null
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":42}' },
+    '/home/u/.hermes/profiles/writer/state.db': { size: 500 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+  const deps = baseDeps({
+    ...fs,
+    isHermesProcess: (pid: number) => pid === 42,
+    writeJson: (_p: string, payload: unknown) => { written = payload }
+  })
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
+  assert.deepEqual(written, { profile: 'coder' })
+})

--- a/apps/desktop/electron/profile-migration.test.ts
+++ b/apps/desktop/electron/profile-migration.test.ts
@@ -15,10 +15,9 @@
  */
 
 import assert from 'node:assert/strict'
+import type { Dirent } from 'node:fs'
 
 import { test } from 'vitest'
-
-import type { Dirent } from 'node:fs'
 
 import {
   decideMigration,
@@ -53,41 +52,62 @@ function makeFs(files: Record<string, FileFixture>) {
 
   const readFileSync = (p: string, _enc: 'utf8') => {
     const e = map.get(p)
-    if (!e || e.content === undefined) throw new Error(`ENOENT: ${p}`)
+
+    if (!e || e.content === undefined) {
+      throw new Error(`ENOENT: ${p}`)
+    }
+
     return e.content
   }
 
   const statSync = (p: string) => {
     const e = map.get(p)
-    if (!e || e.size === undefined) throw new Error(`ENOENT: ${p}`)
+
+    if (!e || e.size === undefined) {
+      throw new Error(`ENOENT: ${p}`)
+    }
+
     return { size: e.size, mtimeMs: e.mtime ?? NOW - 86_400_000 }
   }
 
   const readdirSync = (p: string, _options?: { withFileTypes?: boolean }): Dirent[] => {
     const names = new Set<string>()
+
     // 1. Explicit dir markers at this exact level.
     for (const [fullPath, fixture] of map.entries()) {
       if (fullPath === p && fixture.dir) {
         // This is the dir itself; not a child. Skip.
         continue
       }
+
       if (fullPath.startsWith(p + '/')) {
         const rest = fullPath.slice(p.length + 1)
+
         if (!rest.includes('/') && fixture.dir) {
           names.add(rest)
         }
       }
     }
+
     // 2. Implicit directories: any nested path under `p` implies the intermediate
     // directory exists (mirrors how mkdir({recursive:true}) populates the tree).
     for (const key of map.keys()) {
-      if (!key.startsWith(p + '/')) continue
+      if (!key.startsWith(p + '/')) {
+        continue
+      }
+
       const rest = key.slice(p.length + 1)
       const parts = rest.split('/')
-      if (parts.length < 2) continue
+
+      if (parts.length < 2) {
+        continue
+      }
+
       names.add(parts[0])
     }
+
     const entries: Dirent[] = []
+
     for (const name of names) {
       entries.push({
         name,
@@ -100,7 +120,11 @@ function makeFs(files: Record<string, FileFixture>) {
         isSocket: () => false
       } as unknown as Dirent)
     }
-    if (entries.length === 0 && !map.has(p)) throw new Error(`ENOENT: ${p}`)
+
+    if (entries.length === 0 && !map.has(p)) {
+      throw new Error(`ENOENT: ${p}`)
+    }
+
     return entries
   }
 
@@ -109,6 +133,7 @@ function makeFs(files: Record<string, FileFixture>) {
 
 function baseDeps(overrides: Record<string, unknown> = {}) {
   const fs = makeFs({})
+
   return {
     legacyActivePath: '/home/u/.hermes/active_profile',
     profilesRoot: '/home/u/.hermes/profiles',
@@ -130,7 +155,13 @@ function baseDeps(overrides: Record<string, unknown> = {}) {
 
 test('readLegacyActiveProfile returns null when file missing', () => {
   assert.equal(
-    readLegacyActiveProfile('/missing', () => { throw new Error('ENOENT') }, isValidProfileName),
+    readLegacyActiveProfile(
+      '/missing',
+      () => {
+        throw new Error('ENOENT')
+      },
+      isValidProfileName
+    ),
     null
   )
 })
@@ -187,20 +218,20 @@ test('findRunningGatewayProfiles drops stale (non-hermes) recycled PIDs', () => 
     '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":1234}' },
     '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":5678}' }
   })
+
   const deps = {
     ...fs,
     isHermesProcess: (pid: number) => pid === 1234
   }
-  assert.deepEqual(
-    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps),
-    ['coder']
-  )
+
+  assert.deepEqual(findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps), ['coder'])
 })
 
 test('findRunningGatewayProfiles tolerates malformed pid files', () => {
   const fs = makeFs({
     '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{not json' }
   })
+
   assert.deepEqual(
     findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder'], {
       ...fs,
@@ -216,6 +247,7 @@ test('findRunningGatewayProfiles drops non-integer and non-positive PIDs', () =>
     '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":1.5}' },
     '/home/u/.hermes/profiles/extra/gateway.pid': { content: '{"pid":0}' }
   })
+
   assert.deepEqual(
     findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer', 'extra'], {
       ...fs,
@@ -230,11 +262,12 @@ test('findRunningGatewayProfiles preserves order of allProfiles', () => {
     '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":1}' },
     '/home/u/.hermes/profiles/writer/gateway.pid': { content: '{"pid":2}' }
   })
+
   const deps = { ...fs, isHermesProcess: () => true }
-  assert.deepEqual(
-    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps),
-    ['coder', 'writer']
-  )
+  assert.deepEqual(findRunningGatewayProfiles('/home/u/.hermes/profiles', ['coder', 'writer'], deps), [
+    'coder',
+    'writer'
+  ])
 })
 
 // ---------------------------------------------------------------------------
@@ -243,7 +276,9 @@ test('findRunningGatewayProfiles preserves order of allProfiles', () => {
 
 test('scoreStateDb returns null on missing file', () => {
   assert.equal(
-    scoreStateDb('/missing', NOW, () => { throw new Error('ENOENT') }),
+    scoreStateDb('/missing', NOW, () => {
+      throw new Error('ENOENT')
+    }),
     null
   )
 })
@@ -287,10 +322,8 @@ test('listProfileDirs includes default and any name passing the regex', () => {
     '/home/u/.hermes/profiles/coder': { dir: true },
     '/home/u/.hermes/profiles/writer': { dir: true }
   })
-  assert.deepEqual(
-    listProfileDirs(baseDeps({ ...fs })),
-    ['default', 'coder', 'writer']
-  )
+
+  assert.deepEqual(listProfileDirs(baseDeps({ ...fs })), ['default', 'coder', 'writer'])
 })
 
 test('listProfileDirs skips files (not directories) and invalid names', () => {
@@ -299,6 +332,7 @@ test('listProfileDirs skips files (not directories) and invalid names', () => {
     '/home/u/.hermes/profiles/some-file.txt': { dir: false },
     '/home/u/.hermes/profiles/UPPERCASE': { dir: true } // regex rejects
   })
+
   assert.deepEqual(listProfileDirs(baseDeps({ ...fs })), ['default'])
 })
 
@@ -324,9 +358,11 @@ test('decideMigration falls through to scoring when multiple gateways run', () =
   // When running.length > 1 the heuristic must score the running set, not all
   // profiles, so a stopped profile can't win against two live ones.
   const deps = baseDeps()
+
   const d = decideMigration(null, ['coder', 'writer'], ['coder', 'writer'], deps, p =>
     p.endsWith('/writer/state.db') ? 50 : 10
   )
+
   assert.deepEqual(d, { profile: 'writer', _migrated: true })
 })
 
@@ -343,9 +379,9 @@ test('decideMigration suppresses write when best is default (single-profile fall
   // better candidate exists. If 'default' wins the score, the install is
   // single-profile and we leave it alone.
   const deps = baseDeps()
-  const d = decideMigration(null, [], ['default', 'coder'], deps, p =>
-    p.endsWith('/default/state.db') ? 99 : 50
-  )
+
+  const d = decideMigration(null, [], ['default', 'coder'], deps, p => (p.endsWith('/default/state.db') ? 99 : 50))
+
   assert.equal(d, null)
 })
 
@@ -363,39 +399,53 @@ test('decideMigration still flags _migrated when legacy is invalid (undefined) b
 
 test('migrateActiveProfileIfMissing is a no-op when the preference file exists', () => {
   let written: unknown = null
+
   const deps = baseDeps({
     existsSync: (p: string) => p === '/cfg/active-profile.json',
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
   assert.equal(written, null)
 })
 
 test('migrateActiveProfileIfMissing writes legacy choice with no _migrated flag', () => {
   let written: unknown = null
+
   const fs = makeFs({
     '/home/u/.hermes/active_profile': { content: 'coder' },
     '/home/u/.hermes/profiles/coder': { dir: true },
     '/home/u/.hermes/profiles/writer': { dir: true }
   })
+
   const deps = baseDeps({
     ...fs,
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
   assert.deepEqual(written, { profile: 'coder' })
 })
 
 test('migrateActiveProfileIfMissing writes heuristic choice with _migrated=true', () => {
   let written: unknown = null
+
   const fs = makeFs({
     '/home/u/.hermes/profiles/coder/state.db': { size: 50 * 1024 * 1024, mtime: NOW - 86_400_000 },
     '/home/u/.hermes/profiles/writer/state.db': { size: 200 * 1024 * 1024, mtime: NOW - 86_400_000 }
   })
+
   const deps = baseDeps({
     ...fs,
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
   assert.deepEqual(written, { profile: 'writer', _migrated: true })
 })
@@ -404,13 +454,18 @@ test('migrateActiveProfileIfMissing is a no-op for single-profile (default-only)
   // No heuristic candidate can beat 'default', so the orchestrator must NOT
   // write a file — preserves legacy launch behavior for the 99% case.
   let written: unknown = null
+
   const fs = makeFs({
     '/home/u/.hermes/profiles/default/state.db': { size: 10 * 1024 * 1024, mtime: NOW - 86_400_000 }
   })
+
   const deps = baseDeps({
     ...fs,
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
   assert.equal(written, null)
 })
@@ -418,10 +473,14 @@ test('migrateActiveProfileIfMissing is a no-op for single-profile (default-only)
 test('migrateActiveProfileIfMissing is a no-op when no profiles directory exists', () => {
   let written: unknown = null
   const fs = makeFs({})
+
   const deps = baseDeps({
     ...fs,
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
   assert.equal(written, null)
 })
@@ -430,15 +489,20 @@ test('migrateActiveProfileIfMissing prefers a single running gateway over heuris
   // running=['coder'] regardless of what the heuristic would score — gateway
   // ownership is the strongest signal we have for the active profile.
   let written: unknown = null
+
   const fs = makeFs({
     '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":42}' },
     '/home/u/.hermes/profiles/writer/state.db': { size: 500 * 1024 * 1024, mtime: NOW - 86_400_000 }
   })
+
   const deps = baseDeps({
     ...fs,
     isHermesProcess: (pid: number) => pid === 42,
-    writeJson: (_p: string, payload: unknown) => { written = payload }
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
   })
+
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
   assert.deepEqual(written, { profile: 'coder' })
 })

--- a/apps/desktop/electron/profile-migration.ts
+++ b/apps/desktop/electron/profile-migration.ts
@@ -1,0 +1,194 @@
+// Pure migration-decision helpers for active-profile.json first-boot seeding.
+// Extracted from main.ts so they're unit-testable without Electron.
+//
+// The helpers here are deliberately side-effect-free except for the orchestrator
+// (`migrateActiveProfileIfMissing`), which only writes the preference file when
+// every fs/path concern is funnelled through the injected `MigrationDeps` bag.
+// Tests inject synthetic fs maps; production wires real fs/path.
+
+import type { Dirent } from 'node:fs'
+
+// Floor for the size dimension of the hybrid score. A 100-byte file (effectively
+// empty) and a 1 KiB file score the same on the size axis — both are too small to
+// be the user's primary workspace on their own.
+export const PROFILE_SCORE_MIN_SIZE_BYTES = 1024
+
+export interface MigrationDeps {
+  legacyActivePath: string
+  profilesRoot: string
+  existsSync: (path: string) => boolean
+  readFileSync: (path: string, encoding: 'utf8') => string
+  statSync: (path: string) => { size: number; mtimeMs: number }
+  readdirSync: (path: string, options?: { withFileTypes?: boolean }) => Dirent[]
+  isHermesProcess: (pid: number) => boolean
+  now: () => number
+  writeJson: (path: string, payload: MigrationDecision) => void
+  isValidProfileName: (name: string) => boolean
+}
+
+export interface MigrationDecision {
+  profile: string
+  /** True when chosen from the state.db heuristic (auto-detected), undefined when explicit. */
+  _migrated?: boolean
+}
+
+/**
+ * Parse the legacy CLI-sticky file. Returns the trimmed name on success, null when
+ * missing/unreadable/empty, undefined when present but invalid (so the caller can
+ * distinguish "explicitly chose default" from "no legacy file at all"). The
+ * `'default'` profile is always rejected here — it's an implicit fallback, never a
+ * user-chosen CLI value, and accepting it would suppress the heuristic rung that
+ * is the whole point of this migration.
+ */
+export function readLegacyActiveProfile(
+  legacyActivePath: string,
+  readFile: MigrationDeps['readFileSync'],
+  isValid: MigrationDeps['isValidProfileName']
+): string | null | undefined {
+  let raw: string
+  try {
+    raw = readFile(legacyActivePath, 'utf8')
+  } catch {
+    return null
+  }
+  const name = raw.trim()
+  if (!name) return null
+  if (name === 'default') return undefined
+  return isValid(name) ? name : undefined
+}
+
+/**
+ * Return the profile names whose gateway.pid file points to a live hermes process.
+ * Tolerates missing/malformed pid files and stale-but-recycled PIDs (the latter is
+ * the whole reason we check both liveness AND cmdline identity).
+ */
+export function findRunningGatewayProfiles(
+  profilesRoot: string,
+  allProfiles: string[],
+  deps: Pick<MigrationDeps, 'existsSync' | 'readFileSync' | 'isHermesProcess'>
+): string[] {
+  const running: string[] = []
+  for (const name of allProfiles) {
+    const pidFile = `${profilesRoot}/${name}/gateway.pid`
+    if (!deps.existsSync(pidFile)) continue
+    let parsed: { pid?: unknown } | null = null
+    try {
+      parsed = JSON.parse(deps.readFileSync(pidFile, 'utf8'))
+    } catch {
+      continue
+    }
+    const pid = Number(parsed?.pid)
+    if (!Number.isInteger(pid) || pid < 1) continue
+    if (deps.isHermesProcess(pid)) {
+      running.push(name)
+    }
+  }
+  return running
+}
+
+/**
+ * Hybrid recency × size score for a state.db file. Returns null when the file is
+ * missing. The formula picks the primary workspace across profiles whose databases
+ * have been touched at similar times — a 409 MB DB beats a 28 MB one even with a
+ * slightly newer mtime. Floors the recency weight at 0.1 so a profile touched
+ * years ago but never deleted still scores > 0 if its DB is large.
+ */
+export function scoreStateDb(
+  dbPath: string,
+  now: number,
+  stat: MigrationDeps['statSync']
+): number | null {
+  let s: { size: number; mtimeMs: number }
+  try {
+    s = stat(dbPath)
+  } catch {
+    return null
+  }
+  const daysSinceModified = Math.max(0, (now - s.mtimeMs) / (1000 * 60 * 60 * 24))
+  const recencyWeight = Math.max(0.1, 30 - daysSinceModified)
+  const sizeWeight = Math.log10(Math.max(PROFILE_SCORE_MIN_SIZE_BYTES, s.size))
+  return recencyWeight * sizeWeight
+}
+
+/**
+ * Pure decision logic. Returns null when nothing migratable was found.
+ * - legacy non-null → always prefer (no _migrated flag, user-chosen)
+ * - running.length === 1 → prefer that profile (no flag, gateway-owned)
+ * - state.db heuristic → set _migrated=true (auto-detected)
+ * - best === 'default' → suppress write (single-profile fallback)
+ */
+export function decideMigration(
+  legacyActive: string | null | undefined,
+  running: string[],
+  candidates: string[],
+  deps: MigrationDeps,
+  score: (dbPath: string) => number | null
+): MigrationDecision | null {
+  if (legacyActive) return { profile: legacyActive }
+  if (running.length === 1) return { profile: running[0] }
+
+  let best: string | null = null
+  let maxScore = -Infinity
+  for (const name of candidates) {
+    const s = score(`${deps.profilesRoot}/${name}/state.db`)
+    if (s == null) continue
+    if (s > maxScore) {
+      maxScore = s
+      best = name
+    }
+  }
+  if (!best || best === 'default') return null
+  return { profile: best, _migrated: true }
+}
+
+/**
+ * List known profile directory names under `profilesRoot`. Accepts `default` and
+ * any name passing the injected validator. Returns [] on missing dir or empty.
+ */
+export function listProfileDirs(deps: MigrationDeps): string[] {
+  let entries: Dirent[]
+  try {
+    entries = deps.readdirSync(deps.profilesRoot, { withFileTypes: true })
+  } catch {
+    return []
+  }
+  return entries
+    .filter(e => e.isDirectory() && (e.name === 'default' || deps.isValidProfileName(e.name)))
+    .map(e => e.name)
+}
+
+/**
+ * Orchestrator. Idempotent: writes at most once when the preference file is
+ * missing. Thin on top of the decision helpers above; the testable surface is
+ * `decideMigration` + the individual rung helpers, this function just glues them
+ * to the deps bag.
+ */
+export function migrateActiveProfileIfMissing(
+  desktopProfileConfigPath: string,
+  deps: MigrationDeps
+): boolean {
+  if (deps.existsSync(desktopProfileConfigPath)) return false
+
+  const legacyActive = readLegacyActiveProfile(
+    deps.legacyActivePath,
+    deps.readFileSync,
+    deps.isValidProfileName
+  )
+
+  const allProfiles = listProfileDirs(deps)
+  if (allProfiles.length === 0) return false
+
+  const running = findRunningGatewayProfiles(deps.profilesRoot, allProfiles, deps)
+  const candidates = running.length > 1 ? running : allProfiles
+  const decision = decideMigration(
+    legacyActive,
+    running,
+    candidates,
+    deps,
+    dbPath => scoreStateDb(dbPath, deps.now(), deps.statSync)
+  )
+  if (!decision) return false
+
+  deps.writeJson(desktopProfileConfigPath, decision)
+  return true
+}

--- a/apps/desktop/electron/profile-migration.ts
+++ b/apps/desktop/electron/profile-migration.ts
@@ -46,14 +46,23 @@ export function readLegacyActiveProfile(
   isValid: MigrationDeps['isValidProfileName']
 ): string | null | undefined {
   let raw: string
+
   try {
     raw = readFile(legacyActivePath, 'utf8')
   } catch {
     return null
   }
+
   const name = raw.trim()
-  if (!name) return null
-  if (name === 'default') return undefined
+
+  if (!name) {
+    return null
+  }
+
+  if (name === 'default') {
+    return undefined
+  }
+
   return isValid(name) ? name : undefined
 }
 
@@ -68,21 +77,33 @@ export function findRunningGatewayProfiles(
   deps: Pick<MigrationDeps, 'existsSync' | 'readFileSync' | 'isHermesProcess'>
 ): string[] {
   const running: string[] = []
+
   for (const name of allProfiles) {
     const pidFile = `${profilesRoot}/${name}/gateway.pid`
-    if (!deps.existsSync(pidFile)) continue
+
+    if (!deps.existsSync(pidFile)) {
+      continue
+    }
+
     let parsed: { pid?: unknown } | null = null
+
     try {
       parsed = JSON.parse(deps.readFileSync(pidFile, 'utf8'))
     } catch {
       continue
     }
+
     const pid = Number(parsed?.pid)
-    if (!Number.isInteger(pid) || pid < 1) continue
+
+    if (!Number.isInteger(pid) || pid < 1) {
+      continue
+    }
+
     if (deps.isHermesProcess(pid)) {
       running.push(name)
     }
   }
+
   return running
 }
 
@@ -93,20 +114,19 @@ export function findRunningGatewayProfiles(
  * slightly newer mtime. Floors the recency weight at 0.1 so a profile touched
  * years ago but never deleted still scores > 0 if its DB is large.
  */
-export function scoreStateDb(
-  dbPath: string,
-  now: number,
-  stat: MigrationDeps['statSync']
-): number | null {
+export function scoreStateDb(dbPath: string, now: number, stat: MigrationDeps['statSync']): number | null {
   let s: { size: number; mtimeMs: number }
+
   try {
     s = stat(dbPath)
   } catch {
     return null
   }
+
   const daysSinceModified = Math.max(0, (now - s.mtimeMs) / (1000 * 60 * 60 * 24))
   const recencyWeight = Math.max(0.1, 30 - daysSinceModified)
   const sizeWeight = Math.log10(Math.max(PROFILE_SCORE_MIN_SIZE_BYTES, s.size))
+
   return recencyWeight * sizeWeight
 }
 
@@ -124,20 +144,34 @@ export function decideMigration(
   deps: MigrationDeps,
   score: (dbPath: string) => number | null
 ): MigrationDecision | null {
-  if (legacyActive) return { profile: legacyActive }
-  if (running.length === 1) return { profile: running[0] }
+  if (legacyActive) {
+    return { profile: legacyActive }
+  }
+
+  if (running.length === 1) {
+    return { profile: running[0] }
+  }
 
   let best: string | null = null
   let maxScore = -Infinity
+
   for (const name of candidates) {
     const s = score(`${deps.profilesRoot}/${name}/state.db`)
-    if (s == null) continue
+
+    if (s == null) {
+      continue
+    }
+
     if (s > maxScore) {
       maxScore = s
       best = name
     }
   }
-  if (!best || best === 'default') return null
+
+  if (!best || best === 'default') {
+    return null
+  }
+
   return { profile: best, _migrated: true }
 }
 
@@ -147,11 +181,13 @@ export function decideMigration(
  */
 export function listProfileDirs(deps: MigrationDeps): string[] {
   let entries: Dirent[]
+
   try {
     entries = deps.readdirSync(deps.profilesRoot, { withFileTypes: true })
   } catch {
     return []
   }
+
   return entries
     .filter(e => e.isDirectory() && (e.name === 'default' || deps.isValidProfileName(e.name)))
     .map(e => e.name)
@@ -163,32 +199,31 @@ export function listProfileDirs(deps: MigrationDeps): string[] {
  * `decideMigration` + the individual rung helpers, this function just glues them
  * to the deps bag.
  */
-export function migrateActiveProfileIfMissing(
-  desktopProfileConfigPath: string,
-  deps: MigrationDeps
-): boolean {
-  if (deps.existsSync(desktopProfileConfigPath)) return false
+export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, deps: MigrationDeps): boolean {
+  if (deps.existsSync(desktopProfileConfigPath)) {
+    return false
+  }
 
-  const legacyActive = readLegacyActiveProfile(
-    deps.legacyActivePath,
-    deps.readFileSync,
-    deps.isValidProfileName
-  )
+  const legacyActive = readLegacyActiveProfile(deps.legacyActivePath, deps.readFileSync, deps.isValidProfileName)
 
   const allProfiles = listProfileDirs(deps)
-  if (allProfiles.length === 0) return false
+
+  if (allProfiles.length === 0) {
+    return false
+  }
 
   const running = findRunningGatewayProfiles(deps.profilesRoot, allProfiles, deps)
   const candidates = running.length > 1 ? running : allProfiles
-  const decision = decideMigration(
-    legacyActive,
-    running,
-    candidates,
-    deps,
-    dbPath => scoreStateDb(dbPath, deps.now(), deps.statSync)
+
+  const decision = decideMigration(legacyActive, running, candidates, deps, dbPath =>
+    scoreStateDb(dbPath, deps.now(), deps.statSync)
   )
-  if (!decision) return false
+
+  if (!decision) {
+    return false
+  }
 
   deps.writeJson(desktopProfileConfigPath, decision)
+
   return true
 }

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -22,7 +22,7 @@ import zipfile
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import (
     _get_platform_default_hermes_home,
@@ -2057,6 +2057,172 @@ def create_pre_update_snapshots_all_profiles(
         except Exception as exc:
             logger.debug("Pre-update snapshot for profile %s failed: %s", name, exc)
     return results
+
+
+# Config paths that the update flow must never change (#64160): the model
+# routing keys and the Mixture-of-Agents section are consumed machine-wide
+# (gateway, cron, desktop), so an update/repair cycle that rewrites them
+# silently redirects paid inference. Each entry is a dotted path into the raw
+# config.yaml document; a single-element tuple protects the whole section.
+_PROTECTED_CONFIG_PATHS: Tuple[Tuple[str, ...], ...] = (
+    ("model", "provider"),
+    ("model", "default"),
+    ("model", "base_url"),
+    ("model", "api_key"),
+    ("moa",),
+)
+
+
+def _read_raw_yaml_dict(path: Path) -> Optional[Dict[str, Any]]:
+    """Parse ``path`` as a YAML mapping. ``None`` = missing/unreadable/non-dict."""
+    if not path.is_file():
+        return None
+    try:
+        import yaml
+
+        with open(path, "r", encoding="utf-8") as f:
+            data = yaml.safe_load(f)
+    except Exception:
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _get_config_path_value(data: Dict[str, Any], dotted: Tuple[str, ...]) -> Any:
+    node: Any = data
+    for key in dotted:
+        if not isinstance(node, dict):
+            return None
+        node = node.get(key)
+    return node
+
+
+def _set_config_path_value(data: Dict[str, Any], dotted: Tuple[str, ...], value: Any) -> None:
+    node = data
+    for key in dotted[:-1]:
+        child = node.get(key)
+        if not isinstance(child, dict):
+            child = {}
+            node[key] = child
+        node = child
+    node[dotted[-1]] = value
+
+
+def restore_config_model_settings_if_rewritten(
+    snapshot_id: str,
+    hermes_home: Optional[Path] = None,
+) -> Optional[Dict[str, Any]]:
+    """Safety net for silent config.yaml model/MoA loss across ``hermes update``.
+
+    Desktop update/repair cycles have been observed to rewrite user-set
+    ``model.provider``/``model.default`` and drop the ``moa:`` section
+    entirely (issue #64160; the macOS repair/relaunch variant rewrote a
+    pinned ``model.default`` to a transient composer pick). These keys are
+    consumed by the gateway and unattended cron jobs too, so a rewrite
+    silently changes paid inference behavior machine-wide.
+
+    Mirrors :func:`restore_cron_jobs_if_emptied`: compare the *current*
+    config against the pre-update snapshot taken minutes earlier by this
+    same update run, and restore only the protected keys — never the whole
+    file — when a value the user had set was changed or dropped. Everything
+    the update legitimately wrote (version stamps, new sections) is left in
+    place.
+
+    Args:
+        snapshot_id: The pre-update quick-snapshot id (from
+            :func:`create_quick_snapshot`).
+        hermes_home: Override for the Hermes home directory (tests/siblings).
+
+    Returns:
+        ``None`` when no action was taken (the common, healthy path). On a
+        successful restore, ``{"restored": True, "keys": [...],
+        "snapshot_id": ...}`` so the caller can warn the user.
+    """
+    if not snapshot_id:
+        return None
+
+    home = hermes_home or get_hermes_home()
+    live_path = home / "config.yaml"
+    snap_path = _quick_snapshot_root(home) / snapshot_id / "config.yaml"
+
+    snap = _read_raw_yaml_dict(snap_path)
+    if not snap:
+        return None  # no snapshot copy — nothing to compare against
+    live = _read_raw_yaml_dict(live_path)
+    if live is None:
+        # Missing or unparseable live config is a different failure mode the
+        # user should see rather than have papered over (matches the cron net).
+        return None
+
+    restored_keys: list[str] = []
+    for dotted in _PROTECTED_CONFIG_PATHS:
+        snap_val = _get_config_path_value(snap, dotted)
+        if snap_val in (None, "", {}, []):
+            continue  # user never set it — nothing to protect
+        live_val = _get_config_path_value(live, dotted)
+        if live_val == snap_val:
+            continue
+        _set_config_path_value(live, dotted, snap_val)
+        restored_keys.append(".".join(dotted))
+
+    if not restored_keys:
+        return None
+
+    try:
+        from utils import atomic_yaml_write
+
+        atomic_yaml_write(live_path, live)
+    except (OSError, PermissionError) as exc:
+        logger.error(
+            "config.yaml model settings were rewritten during update but "
+            "auto-restore failed: %s",
+            exc,
+        )
+        return None
+
+    logger.warning(
+        "Restored user config value(s) %s from pre-update snapshot %s — "
+        "the update flow rewrote them (#64160)",
+        ", ".join(restored_keys),
+        snapshot_id,
+    )
+    return {"restored": True, "keys": restored_keys, "snapshot_id": snapshot_id}
+
+
+def restore_config_model_settings_all_profiles(
+    profile_snapshots: Dict[str, str],
+    invoking_home: Optional[Path] = None,
+) -> list[Dict[str, Any]]:
+    """Run the config model-settings safety net for every sibling profile.
+
+    Same contract as :func:`restore_cron_jobs_all_profiles`: each profile's
+    live ``config.yaml`` is compared against ITS OWN same-generation
+    pre-update snapshot. Returns one result dict per restored profile, each
+    with a ``profile`` key added. Never raises.
+    """
+    restored: list[Dict[str, Any]] = []
+    if not profile_snapshots:
+        return restored
+    home = invoking_home or get_hermes_home()
+    by_name = dict(_sibling_profile_homes(home))
+    for name, snap_id in profile_snapshots.items():
+        profile_home = by_name.get(name)
+        if profile_home is None:
+            continue
+        try:
+            result = restore_config_model_settings_if_rewritten(
+                snap_id, hermes_home=profile_home
+            )
+        except Exception as exc:
+            logger.debug(
+                "Config model-settings restore check for profile %s failed: %s",
+                name,
+                exc,
+            )
+            continue
+        if result:
+            result["profile"] = name
+            restored.append(result)
+    return restored
 
 
 def restore_cron_jobs_all_profiles(

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -497,6 +497,28 @@ def _check_and_apply_config_migration(
         # Never let the cron safety net break an otherwise-good update.
         logger.debug("Cron jobs auto-restore check failed: %s", exc)
 
+    # #64160: config.yaml model/provider + MoA safety net. Desktop
+    # update/repair cycles have rewritten user-set model.provider /
+    # model.default and dropped the moa: section — settings the gateway
+    # and cron jobs also consume. Compare the live config against the
+    # same pre-update snapshot and restore only the protected keys.
+    try:
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        cfg_restore = restore_config_model_settings_if_rewritten(
+            pre_update_snapshot_id
+        )
+        if cfg_restore:
+            print()
+            print(
+                "  ⚠️  config.yaml user model settings were rewritten during "
+                f"this update — restored {', '.join(cfg_restore['keys'])} "
+                f"from pre-update snapshot {cfg_restore['snapshot_id']}."
+            )
+    except Exception as exc:
+        # Never let the config safety net break an otherwise-good update.
+        logger.debug("Config model-settings auto-restore check failed: %s", exc)
+
     # #66140: run the same cron-jobs safety net for every sibling
     # profile against ITS OWN pre-update snapshot (same-generation by
     # construction — both taken by this run).
@@ -515,6 +537,23 @@ def _check_and_apply_config_migration(
             )
     except Exception as exc:
         logger.debug("Sibling cron auto-restore check failed: %s", exc)
+
+    # #64160: same config model-settings safety net for sibling profiles.
+    try:
+        from hermes_cli.backup import restore_config_model_settings_all_profiles
+
+        for _cfg_restored in restore_config_model_settings_all_profiles(
+            _LAST_SIBLING_SNAPSHOTS
+        ):
+            print()
+            print(
+                f"  ⚠️  Profile '{_cfg_restored['profile']}': config.yaml "
+                f"user model settings were rewritten during this update — "
+                f"restored {', '.join(_cfg_restored['keys'])} from "
+                f"pre-update snapshot {_cfg_restored['snapshot_id']}."
+            )
+    except Exception as exc:
+        logger.debug("Sibling config auto-restore check failed: %s", exc)
 
 
 # Critical files that Hermes must be able to import immediately after an

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1777,6 +1777,161 @@ class TestRestoreCronJobsIfEmptied:
         assert len(restored["jobs"]) == 19
 
 
+# ---------------------------------------------------------------------------
+# config.yaml model/provider + MoA auto-restore after silent update rewrite
+# (issue #64160)
+# ---------------------------------------------------------------------------
+
+class TestRestoreConfigModelSettingsIfRewritten:
+    """Desktop update/repair cycles have rewritten user-set model.provider /
+    model.default and dropped the moa: section (#64160).
+    `restore_config_model_settings_if_rewritten` is the post-update safety net
+    that restores only the protected keys from the pre-update snapshot."""
+
+    USER_CONFIG = (
+        "_config_version: 39\n"
+        "model:\n"
+        "  provider: custom\n"
+        "  default: zyphra/zamba-3-large\n"
+        "  base_url: https://api.zyphra.example/v1\n"
+        "moa:\n"
+        "  enabled: true\n"
+        "  presets:\n"
+        "    council:\n"
+        "      aggregator: {provider: custom, model: zyphra/zamba-3-large}\n"
+        "custom_unknown_key:\n"
+        "  hello: world\n"
+    )
+
+    def _make_snapshot(self, hermes_home: Path, label="pre-update"):
+        from hermes_cli.backup import create_quick_snapshot
+        return create_quick_snapshot(label=label, hermes_home=hermes_home, keep=5)
+
+    def _seed(self, hermes_home: Path) -> Path:
+        hermes_home.mkdir(parents=True, exist_ok=True)
+        cfg = hermes_home / "config.yaml"
+        cfg.write_text(self.USER_CONFIG, encoding="utf-8")
+        return cfg
+
+    def test_restores_rewritten_provider_and_dropped_moa(self, tmp_path):
+        import yaml
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        hermes_home = tmp_path / ".hermes"
+        cfg = self._seed(hermes_home)
+        snap_id = self._make_snapshot(hermes_home)
+        assert snap_id
+
+        # The update flow rewrites config.yaml with defaults: provider flips
+        # to deepseek, MoA section is gone (the #64160 field report).
+        cfg.write_text(
+            "_config_version: 39\nmodel:\n  provider: deepseek\n  default: deepseek-chat\n",
+            encoding="utf-8",
+        )
+
+        result = restore_config_model_settings_if_rewritten(
+            snap_id, hermes_home=hermes_home
+        )
+        assert result is not None
+        assert result["restored"] is True
+        assert result["snapshot_id"] == snap_id
+        assert "model.provider" in result["keys"]
+        assert "model.default" in result["keys"]
+        assert "moa" in result["keys"]
+
+        after = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert after["model"]["provider"] == "custom"
+        assert after["model"]["default"] == "zyphra/zamba-3-large"
+        assert after["model"]["base_url"] == "https://api.zyphra.example/v1"
+        assert after["moa"]["enabled"] is True
+        assert after["moa"]["presets"]["council"]["aggregator"]["model"] == (
+            "zyphra/zamba-3-large"
+        )
+
+    def test_noop_when_config_untouched(self, tmp_path):
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        hermes_home = tmp_path / ".hermes"
+        cfg = self._seed(hermes_home)
+        snap_id = self._make_snapshot(hermes_home)
+        before = cfg.read_text(encoding="utf-8")
+
+        result = restore_config_model_settings_if_rewritten(
+            snap_id, hermes_home=hermes_home
+        )
+        assert result is None
+        assert cfg.read_text(encoding="utf-8") == before
+
+    def test_preserves_legitimate_update_writes(self, tmp_path):
+        """Only protected keys are restored — a version bump or a new section
+        the migration legitimately wrote must survive the restore."""
+        import yaml
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        hermes_home = tmp_path / ".hermes"
+        cfg = self._seed(hermes_home)
+        snap_id = self._make_snapshot(hermes_home)
+
+        cfg.write_text(
+            "_config_version: 40\n"      # legitimate migration bump
+            "new_section:\n  added: true\n"  # legitimate new default
+            "model:\n  provider: deepseek\n",  # illegitimate rewrite
+            encoding="utf-8",
+        )
+
+        result = restore_config_model_settings_if_rewritten(
+            snap_id, hermes_home=hermes_home
+        )
+        assert result is not None
+        after = yaml.safe_load(cfg.read_text(encoding="utf-8"))
+        assert after["model"]["provider"] == "custom"          # restored
+        assert after["_config_version"] == 40                   # kept
+        assert after["new_section"] == {"added": True}          # kept
+
+    def test_noop_when_user_never_set_protected_keys(self, tmp_path):
+        """A config that never had model.provider/moa set gets no restore even
+        if the update writes those keys fresh — nothing of the user's was lost."""
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir(parents=True)
+        cfg = hermes_home / "config.yaml"
+        cfg.write_text("_config_version: 39\nagent: {}\n", encoding="utf-8")
+        snap_id = self._make_snapshot(hermes_home)
+
+        cfg.write_text(
+            "_config_version: 39\nmodel:\n  provider: deepseek\n", encoding="utf-8"
+        )
+        result = restore_config_model_settings_if_rewritten(
+            snap_id, hermes_home=hermes_home
+        )
+        assert result is None
+
+    def test_noop_on_unreadable_live_config(self, tmp_path):
+        """An unparseable live config is a different failure the user must see;
+        the safety net leaves it alone (mirrors the cron net's posture)."""
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        hermes_home = tmp_path / ".hermes"
+        cfg = self._seed(hermes_home)
+        snap_id = self._make_snapshot(hermes_home)
+
+        cfg.write_text(": not [valid yaml", encoding="utf-8")
+        result = restore_config_model_settings_if_rewritten(
+            snap_id, hermes_home=hermes_home
+        )
+        assert result is None
+        assert cfg.read_text(encoding="utf-8") == ": not [valid yaml"
+
+    def test_noop_without_snapshot_id(self, tmp_path):
+        from hermes_cli.backup import restore_config_model_settings_if_rewritten
+
+        assert restore_config_model_settings_if_rewritten(
+            "", hermes_home=tmp_path / ".hermes"
+        ) is None
+
+
+
 
 
 


### PR DESCRIPTION
Fixes #64160 — after a Desktop update, the app boots into the "default" profile (hiding the user's sessions) and `config.yaml` model/provider settings are silently rewritten (custom provider → deepseek, `moa:` section dropped).

## Root cause

Two independent gaps, one per symptom:

1. **Active profile**: the Desktop's profile preference lives in `active-profile.json` (Electron userData), written ONLY by an explicit user profile switch (`writeActiveDesktopProfile()`). Nothing seeds it on first boot after an update, so `primaryProfileKey()` = `readActiveDesktopProfile() || 'default'` always resolves `'default'`, hiding every other profile's sessions.
2. **Config rewrite**: update/repair cycles can leave `config.yaml` rewritten with fresh defaults — user-set `model.provider` / `model.default` / `model.base_url` / `model.api_key` replaced and the `moa:` section dropped. These keys are consumed by the gateway and unattended cron too, so the rewrite silently redirects paid inference machine-wide. The update completion path (`_check_and_apply_config_migration`) had a safety net for cron jobs (#34600) but none for config model settings.

## Fix

**Desktop half** (salvaged from @DavidMetcalfe's PR #64195, authorship preserved — he reported #64160 and submitted the fix): first-boot migration seeds `active-profile.json` from a priority ladder — legacy `~/.hermes/active_profile` (explicit CLI choice) → running gateway (`gateway.pid` with liveness + hermes-identity check to defeat PID recycling) → `state.db` recency×size heuristic (writes `_migrated: true` for optional UI notice). Pure decision logic extracted to `apps/desktop/electron/profile-migration.ts` (unit-testable without Electron); wired in `main.ts` before the first `primaryProfileKey()` read. No-op once the file exists; single-profile users keep legacy behavior.

**Updater half**: `restore_config_model_settings_if_rewritten()` in `hermes_cli/backup.py` mirrors the cron safety net — after the config migration step, compare the live `config.yaml` against the pre-update quick snapshot taken by this same update run and restore ONLY the protected keys the user had set that were changed or dropped (`model.provider|default|base_url|api_key`, `moa.*`) — never the whole file, so version stamps and new sections the migration legitimately wrote survive. Runs on every update completion path plus the same net for every sibling profile against its own same-generation snapshot (#66140 pattern). Exception-swallowing: a safety-net failure never breaks an otherwise-good update.

**Live repro:** real-import harness against isolated temp HERMES_HOME, both halves, before/after on pristine `origin/main` archive vs this branch —
- Config half (real `create_quick_snapshot` → simulated update rewrite → real `_check_and_apply_config_migration`): before: `model.provider: 'deepseek'`, `model.default: 'deepseek-chat'`, `moa: None` — **LOST, #64160 reproduced**; after: all three restored (`custom` / `zyphra/zamba-3-large` / moa intact) with the update-output warning naming the restored keys — **PRESERVED**.
- Desktop half (tsx harness, real fs, legacy `active_profile` = `work`, no `active-profile.json`): before: boots `'default'` — **LOST, #64160 reproduced**; after: migration seeds the file, boots `'work'` — **PRESERVED**.

## Tests

- 6 new tests (`TestRestoreConfigModelSettingsIfRewritten`): restore-on-rewrite, no-op-on-untouched, preservation of legitimate migration writes (version bump + new sections kept), no-op when user never set protected keys, unreadable live config left alone, missing snapshot id. Full `tests/hermes_cli/test_backup.py`: **66/66 pass**.
- 29 desktop tests in `profile-migration.test.ts` (ladder rungs, PID-recycling guard, score floor, invalid-name rejection, write-once semantics): **29/29 pass**.
- Sabotage-verified both halves: fix disabled → 2 pytest failures / 3 vitest failures; restored → all green.
- `tsc --noEmit` clean, `eslint` clean on touched files, `ruff check` clean, `check-windows-footguns.py --all` clean (1055 files).
- Update-lane note: `test_update_head_moved_gate.py` / `test_update_receipt.py` direct-pytest failures are identical on a pristine `origin/main` archive — pre-existing, not from this diff.

## Infographic

![update-keeps-your-settings](https://v3b.fal.media/files/b/0aa8b35b/9b9gWlMQ0yL0PJ03RjwB7_JQUrgzVJ.png)
