### PR TITLE
fix(streaming): complete Portal/vLLM streams no longer misread as mid-stream drops (#90848, #91373; salvages #91189, #91376, #96333)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4309,7 +4309,9 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     extra = getattr(chunk, "model_extra", None)
                     if isinstance(extra, dict):
                         last_one = extra.get("lastOne")
-                if last_one is True and finish_reason is None:
+                # Integer/string-truthy sentinels included — relabelled
+                # upstreams have been seen sending 1 / "true".
+                if last_one in (True, 1, "true") and finish_reason is None:
                     finish_reason = "stop"
                 continue
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4301,6 +4301,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         ),
                         raw_text=f"{_err_type}: {_err_msg}",
                     )
+                # Nous Portal usage frames often have choices=[] plus
+                # lastOne=true and no [DONE]. Treat that as a clean
+                # terminal, not a mid-stream drop (#90848).
+                last_one = getattr(chunk, "lastOne", None)
+                if last_one is None:
+                    extra = getattr(chunk, "model_extra", None)
+                    if isinstance(extra, dict):
+                        last_one = extra.get("lastOne")
+                if last_one is True and finish_reason is None:
+                    finish_reason = "stop"
                 continue
 
             delta = chunk.choices[0].delta

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4609,10 +4609,16 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # text content but no tool calls.  Without this guard the partial
         # text is silently stamped finish_reason="stop" and the turn ends as
         # if complete — the model's intended next step is lost (#32086).
+        # When `include_usage` is requested, OpenAI-compliant providers (e.g.
+        # vLLM, OpenAI, DeepSeek) emit a final usage-only chunk with empty
+        # choices and no finish_reason. Receiving a valid usage object proves
+        # the provider completed generation and closed the stream cleanly
+        # (#91373), so it is not a mid-stream drop.
         _text_only_dropped_no_finish = (
             finish_reason is None
             and content_parts
             and not tool_calls_acc
+            and usage_obj is None
         )
         if _text_only_dropped_no_finish:
             logger.warning(

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4317,6 +4317,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if hasattr(chunk, "model") and chunk.model:
                 model_name = chunk.model
 
+            # Extract terminal chunk fields BEFORE any content-shape `continue`.
+            # Backends that merge finish_reason into the final content chunk
+            # (e.g. vLLM >= 0.1.dev20051) can have that chunk swallowed by the
+            # SSE-echo guard below when the tokenizer emits standalone ':'
+            # tokens — the finish chunk would never register and the response
+            # would be falsely flagged as truncated (#94614).
+            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
+            if chunk_finish_reason:
+                finish_reason = chunk_finish_reason
+            if hasattr(chunk, "usage") and chunk.usage:
+                usage_obj = chunk.usage
+
             # Accumulate reasoning content
             reasoning_text = getattr(delta, "reasoning_content", None) or getattr(delta, "reasoning", None)
             if reasoning_text:
@@ -4452,13 +4464,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                         # discarding the attempted action.
                         result["partial_tool_names"].append(name)
 
-            chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
-            if chunk_finish_reason:
-                finish_reason = chunk_finish_reason
-
-            # Usage in the final chunk
-            if hasattr(chunk, "usage") and chunk.usage:
-                usage_obj = chunk.usage
+            # (finish_reason/usage are now extracted at the top of the loop
+            # body. The old tail-side extraction sat after the SSE-echo
+            # guard's `continue` paths, so a merged finish chunk that tripped
+            # the guard never registered — false "stream truncated".)
 
         _close_managed_stream()
 

--- a/contributors/emails/jon@cromulent.dk
+++ b/contributors/emails/jon@cromulent.dk
@@ -1,0 +1,1 @@
+jon-nielsen

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -248,8 +248,11 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
                         done_tracker.feed(chunk)
                     await resp.write(chunk)
             if done_tracker is not None and done_tracker.should_append_done():
-                await resp.write(DONE_SSE_FRAME)
-        except (aiohttp.ClientError, asyncio.CancelledError) as exc:
+                try:
+                    await resp.write(DONE_SSE_FRAME)
+                except Exception as exc:  # client hung up at EOF — harmless
+                    logger.debug("proxy: DONE append skipped: %s", exc)
+        except (aiohttp.ClientError, asyncio.CancelledError, OSError) as exc:
             if done_tracker is not None:
                 done_tracker.mark_interrupted()
             logger.warning("proxy: streaming interrupted: %s", exc)

--- a/hermes_cli/proxy/server.py
+++ b/hermes_cli/proxy/server.py
@@ -3,10 +3,18 @@
 Listens on ``http://<host>:<port>/v1/<path>`` and forwards each request to
 ``<upstream-base-url>/<path>`` with the client's ``Authorization`` header
 replaced by a freshly-resolved bearer from the configured adapter. The
-response is streamed back unmodified, preserving SSE.
+response body is streamed through unchanged (SSE deltas preserved).
 
-The server is intentionally minimal: it does NOT mediate, log, transform,
-or rewrite request/response bodies. It's a credential-attaching forwarder.
+One narrow SSE compatibility shim applies after a *clean* upstream EOF:
+when a ``text/event-stream`` response carries a terminal ``finish_reason``
+or ``lastOne: true`` but omits the OpenAI ``data: [DONE]`` sentinel, the
+proxy appends a single ``[DONE]`` frame. It never rewrites earlier frames,
+never duplicates an upstream ``[DONE]``, and never synthesizes ``[DONE]``
+after an error event or a mid-stream interrupt (see
+:mod:`hermes_cli.proxy.sse_done`, issue #90848).
+
+Otherwise the server does not mediate, log, or rewrite request/response
+bodies — it is a credential-attaching forwarder.
 """
 
 from __future__ import annotations
@@ -26,6 +34,11 @@ except ImportError:
     AIOHTTP_AVAILABLE = False
 
 from hermes_cli.proxy.adapters.base import UpstreamAdapter, UpstreamCredential
+from hermes_cli.proxy.sse_done import (
+    DONE_SSE_FRAME,
+    SseDoneTracker,
+    content_type_is_sse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -222,11 +235,23 @@ def create_app(adapter: UpstreamAdapter) -> "web.Application":
         )
         await resp.prepare(request)
 
+        # Track SSE terminal markers so we can append a missing [DONE]
+        # after clean EOF without rewriting any earlier frames.
+        done_tracker: Optional[SseDoneTracker] = None
+        if content_type_is_sse(upstream_resp.headers):
+            done_tracker = SseDoneTracker()
+
         try:
             async for chunk in upstream_resp.content.iter_any():
                 if chunk:
+                    if done_tracker is not None:
+                        done_tracker.feed(chunk)
                     await resp.write(chunk)
+            if done_tracker is not None and done_tracker.should_append_done():
+                await resp.write(DONE_SSE_FRAME)
         except (aiohttp.ClientError, asyncio.CancelledError) as exc:
+            if done_tracker is not None:
+                done_tracker.mark_interrupted()
             logger.warning("proxy: streaming interrupted: %s", exc)
         finally:
             upstream_resp.release()

--- a/hermes_cli/proxy/sse_done.py
+++ b/hermes_cli/proxy/sse_done.py
@@ -1,0 +1,132 @@
+"""SSE ``[DONE]`` sentinel normalization for OpenAI-compatible proxies.
+
+Some upstreams (notably Nous Portal for certain free models) deliver a
+complete chat-completions stream — content deltas, a non-null
+``finish_reason``, and often a ``lastOne: true`` usage frame — then close
+the connection without the conventional OpenAI terminal event::
+
+    data: [DONE]
+
+Strict OpenAI-compatible clients treat that shape as a truncated stream.
+This module watches the forwarded SSE byte stream and reports whether the
+proxy should append a single ``data: [DONE]`` frame after a *clean*
+upstream EOF.
+
+Rules (issue #90848):
+- Retain every original delta unchanged (this helper never rewrites bytes).
+- Append ``[DONE]`` only after a complete terminal choice
+  (``finish_reason`` non-null) **or** an upstream ``lastOne: true`` marker.
+- Never synthesize ``[DONE]`` after an error event, or when the stream was
+  interrupted before clean EOF.
+- Never emit a second ``[DONE]`` when the upstream already sent one.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+
+
+DONE_SSE_FRAME = b"data: [DONE]\n\n"
+
+
+@dataclass
+class SseDoneTracker:
+    """Incremental scanner over forwarded SSE chunks."""
+
+    saw_done: bool = False
+    saw_terminal_finish: bool = False
+    saw_last_one: bool = False
+    saw_error_event: bool = False
+    saw_malformed_event: bool = False
+    interrupted: bool = False
+    _buf: bytearray = field(default_factory=bytearray, repr=False)
+
+    def feed(self, chunk: bytes) -> None:
+        """Observe a forwarded chunk (bytes are not modified)."""
+        if not chunk:
+            return
+        self._buf.extend(chunk)
+        while True:
+            nl = self._buf.find(b"\n")
+            if nl < 0:
+                break
+            line = bytes(self._buf[:nl])
+            del self._buf[: nl + 1]
+            self._consume_line(line)
+
+    def mark_interrupted(self) -> None:
+        """Upstream stream ended via error/cancel — do not synthesize DONE."""
+        self.interrupted = True
+
+    def should_append_done(self) -> bool:
+        """True when a single terminal ``[DONE]`` should be appended."""
+        if (
+            self.interrupted
+            or self.saw_done
+            or self.saw_error_event
+            or self.saw_malformed_event
+        ):
+            return False
+        # Flush any trailing line without a final newline (rare but valid).
+        if self._buf:
+            self._consume_line(bytes(self._buf))
+            self._buf.clear()
+        if self.saw_done or self.saw_error_event or self.saw_malformed_event:
+            return False
+        return self.saw_terminal_finish or self.saw_last_one
+
+    def _consume_line(self, line: bytes) -> None:
+        # Strip CR from CRLF-delimited SSE.
+        if line.endswith(b"\r"):
+            line = line[:-1]
+        if not line.startswith(b"data:"):
+            return
+        payload = line[5:].strip()
+        if payload == b"[DONE]":
+            self.saw_done = True
+            return
+        if not payload:
+            return
+        try:
+            text = payload.decode("utf-8")
+        except UnicodeDecodeError:
+            self.saw_malformed_event = True
+            return
+        try:
+            event = json.loads(text)
+        except json.JSONDecodeError:
+            self.saw_malformed_event = True
+            return
+        if not isinstance(event, dict):
+            return
+        if event.get("error") is not None:
+            self.saw_error_event = True
+            return
+        if event.get("lastOne") is True:
+            self.saw_last_one = True
+        for choice in event.get("choices") or []:
+            if not isinstance(choice, dict):
+                continue
+            if choice.get("finish_reason") is not None:
+                self.saw_terminal_finish = True
+            # OpenAI error-shaped finish reasons should not unlock DONE.
+            fr = choice.get("finish_reason")
+            if isinstance(fr, str) and fr.lower() in {"error", "provider_error"}:
+                self.saw_error_event = True
+
+
+def content_type_is_sse(headers) -> bool:
+    """Return True when response headers advertise an SSE body."""
+    try:
+        value = headers.get("Content-Type") or headers.get("content-type") or ""
+    except Exception:
+        value = ""
+    return "text/event-stream" in str(value).lower()
+
+
+__all__ = [
+    "DONE_SSE_FRAME",
+    "SseDoneTracker",
+    "content_type_is_sse",
+]

--- a/hermes_cli/proxy/sse_done.py
+++ b/hermes_cli/proxy/sse_done.py
@@ -41,6 +41,7 @@ class SseDoneTracker:
     saw_malformed_event: bool = False
     interrupted: bool = False
     _buf: bytearray = field(default_factory=bytearray, repr=False)
+    _data_lines: list = field(default_factory=list, repr=False)
 
     def feed(self, chunk: bytes) -> None:
         """Observe a forwarded chunk (bytes are not modified)."""
@@ -68,10 +69,12 @@ class SseDoneTracker:
             or self.saw_malformed_event
         ):
             return False
-        # Flush any trailing line without a final newline (rare but valid).
+        # Flush any trailing line without a final newline (rare but valid),
+        # then dispatch a final event that never saw its blank-line boundary.
         if self._buf:
             self._consume_line(bytes(self._buf))
             self._buf.clear()
+        self._dispatch_event()
         if self.saw_done or self.saw_error_event or self.saw_malformed_event:
             return False
         return self.saw_terminal_finish or self.saw_last_one
@@ -80,9 +83,24 @@ class SseDoneTracker:
         # Strip CR from CRLF-delimited SSE.
         if line.endswith(b"\r"):
             line = line[:-1]
+        if not line:
+            # Blank line = SSE event boundary: dispatch accumulated data.
+            self._dispatch_event()
+            return
         if not line.startswith(b"data:"):
             return
-        payload = line[5:].strip()
+        # Per the SSE spec one event may span several consecutive ``data:``
+        # lines whose payloads are joined with "\n" at dispatch time.
+        # Parsing each line independently would misread a split JSON event
+        # as two malformed fragments.
+        self._data_lines.append(line[5:].strip())
+
+    def _dispatch_event(self) -> None:
+        if not self._data_lines:
+            return
+        payload = b"\n".join(self._data_lines)
+        self._data_lines = []
+        payload = payload.strip()
         if payload == b"[DONE]":
             self.saw_done = True
             return
@@ -103,7 +121,9 @@ class SseDoneTracker:
         if event.get("error") is not None:
             self.saw_error_event = True
             return
-        if event.get("lastOne") is True:
+        # Accept integer-truthy sentinels too — relabelled upstreams have
+        # been observed sending ``"lastOne": 1`` / ``"true"``.
+        if event.get("lastOne") in (True, 1, "true"):
             self.saw_last_one = True
         for choice in event.get("choices") or []:
             if not isinstance(choice, dict):

--- a/tests/hermes_cli/test_proxy.py
+++ b/tests/hermes_cli/test_proxy.py
@@ -365,6 +365,139 @@ def test_server_strips_client_auth_header():
     asyncio.run(run())
 
 
+def _build_sse_upstream(
+    frames: list[bytes],
+    *,
+    path: str = "/v1/chat/completions",
+) -> "web.Application":
+    async def sse(request):
+        _ = await request.read()
+        resp = web.StreamResponse(
+            status=200, headers={"Content-Type": "text/event-stream"},
+        )
+        await resp.prepare(request)
+        for chunk in frames:
+            await resp.write(chunk)
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_route("*", path, sse)
+    return app
+
+
+def test_proxy_appends_done_when_upstream_omits_sentinel():
+    """#90848: complete Portal-shaped SSE without [DONE] gets one appended."""
+    async def run():
+        frames = [
+            b'data: {"choices":[{"delta":{"content":"LONGCAT_OK"}}]}\n\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+            b'data: {"choices":[],"lastOne":true,"usage":{"prompt_tokens":1}}\n\n',
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_sse_upstream(frames)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"stream": True},
+                ) as resp:
+                    body = await resp.read()
+            text = body.decode("utf-8")
+            assert 'data: {"choices":[{"delta":{"content":"LONGCAT_OK"}}]}' in text
+            assert '"finish_reason":"stop"' in text
+            assert '"lastOne":true' in text
+            assert text.count("data: [DONE]") == 1
+            assert text.rstrip().endswith("data: [DONE]")
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_proxy_does_not_duplicate_existing_done():
+    async def run():
+        frames = [
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+            b"data: [DONE]\n\n",
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_sse_upstream(frames)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"stream": True},
+                ) as resp:
+                    body = await resp.read()
+            assert body.decode("utf-8").count("data: [DONE]") == 1
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_proxy_does_not_append_done_after_error_event():
+    async def run():
+        frames = [
+            b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+            b'data: {"error":{"message":"boom","type":"api_error"}}\n\n',
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_sse_upstream(frames)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"stream": True},
+                ) as resp:
+                    body = await resp.read()
+            assert "data: [DONE]" not in body.decode("utf-8")
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
+def test_proxy_does_not_append_done_after_malformed_trailing_frame():
+    async def run():
+        frames = [
+            b'data: {"choices":[{"delta":{"content":"partial"}}]}\n\n',
+            b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
+            b'data: {"choices": [MALFORMED]}\n\n',
+        ]
+        upstream_runner, upstream_base = await _start_runner(
+            _build_sse_upstream(frames)
+        )
+        adapter = FakeAdapter(f"{upstream_base}/v1", bearer="ours")
+        proxy_runner, proxy_base = await _start_runner(create_app(adapter))
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    f"{proxy_base}/v1/chat/completions",
+                    json={"stream": True},
+                ) as resp:
+                    body = await resp.read()
+            assert "data: [DONE]" not in body.decode("utf-8")
+        finally:
+            await proxy_runner.cleanup()
+            await upstream_runner.cleanup()
+
+    asyncio.run(run())
+
+
 # ---------------------------------------------------------------------------
 # CLI handlers
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_sse_done.py
+++ b/tests/hermes_cli/test_sse_done.py
@@ -110,3 +110,36 @@ def test_content_type_is_sse():
     assert content_type_is_sse({"Content-Type": "text/event-stream"}) is True
     assert content_type_is_sse({"content-type": "text/event-stream; charset=utf-8"}) is True
     assert content_type_is_sse({"Content-Type": "application/json"}) is False
+
+
+def test_multiline_data_event_joins_per_sse_spec():
+    """One JSON event split across consecutive data: lines (spec-legal) must
+    parse as a single event, not two malformed fragments."""
+    tracker = SseDoneTracker()
+    tracker.feed(
+        b'data: {"choices":[{"delta":{},\n'
+        b'data: "finish_reason":"stop"}]}\n'
+        b"\n"
+    )
+    assert tracker.saw_malformed_event is False
+    assert tracker.should_append_done() is True
+
+
+def test_multiline_malformed_event_still_disables_synthesis():
+    tracker = SseDoneTracker()
+    tracker.feed(b"data: {broken\ndata: json!\n\n")
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    assert tracker.should_append_done() is False
+
+
+def test_truthy_integer_last_one_counts_as_terminal():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [], "lastOne": 1, "usage": {}}))
+    assert tracker.should_append_done() is True
+
+
+def test_final_event_without_trailing_blank_line_still_dispatches():
+    """Clean EOF right after the last data: line (no blank-line boundary)."""
+    tracker = SseDoneTracker()
+    tracker.feed(b'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n')
+    assert tracker.should_append_done() is True

--- a/tests/hermes_cli/test_sse_done.py
+++ b/tests/hermes_cli/test_sse_done.py
@@ -1,0 +1,112 @@
+"""Unit tests for SSE [DONE] sentinel tracking (issue #90848)."""
+
+from __future__ import annotations
+
+import json
+
+from hermes_cli.proxy.sse_done import DONE_SSE_FRAME, SseDoneTracker, content_type_is_sse
+
+
+def _data_line(obj) -> bytes:
+    if isinstance(obj, (bytes, bytearray)):
+        return b"data: " + bytes(obj) + b"\n\n"
+    if obj == "[DONE]":
+        return b"data: [DONE]\n\n"
+    return f"data: {json.dumps(obj)}\n\n".encode("utf-8")
+
+
+def test_complete_stream_without_done_appends():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {"content": "LONGCAT_OK"}}]}))
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    tracker.feed(
+        _data_line(
+            {
+                "choices": [],
+                "lastOne": True,
+                "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+            }
+        )
+    )
+    assert tracker.should_append_done() is True
+    assert tracker.saw_done is False
+    assert DONE_SSE_FRAME.startswith(b"data: [DONE]")
+
+
+def test_finish_reason_alone_is_enough_without_last_one():
+    """Solar-shaped stream: finish_reason present, no lastOne, no [DONE]."""
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {"content": "SOLAR_OK"}}]}))
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    assert tracker.should_append_done() is True
+
+
+def test_last_one_alone_is_enough_without_finish_reason():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {"content": "x"}}]}))
+    tracker.feed(_data_line({"choices": [], "lastOne": True}))
+    assert tracker.should_append_done() is True
+
+
+def test_existing_done_is_not_duplicated():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    tracker.feed(_data_line("[DONE]"))
+    assert tracker.should_append_done() is False
+    assert tracker.saw_done is True
+
+
+def test_error_event_blocks_done_synthesis():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {"content": "partial"}}]}))
+    tracker.feed(_data_line({"error": {"message": "upstream failed", "type": "api_error"}}))
+    assert tracker.should_append_done() is False
+
+
+def test_error_finish_reason_blocks_done_synthesis():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "error"}]}))
+    assert tracker.should_append_done() is False
+
+
+def test_malformed_event_blocks_done_synthesis():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    tracker.feed(b'data: {"choices": [MALFORMED]}\n\n')
+    assert tracker.should_append_done() is False
+
+
+def test_truncated_trailing_event_blocks_done_synthesis():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    tracker.feed(b'data: {"choices": [{"delta": {"content": "tail"}}]')
+    assert tracker.should_append_done() is False
+
+
+def test_interrupted_stream_never_appends_done():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]}))
+    tracker.mark_interrupted()
+    assert tracker.should_append_done() is False
+
+
+def test_incomplete_stream_without_terminal_marker_does_not_append():
+    tracker = SseDoneTracker()
+    tracker.feed(_data_line({"choices": [{"delta": {"content": "mid"}}]}))
+    assert tracker.should_append_done() is False
+
+
+def test_feed_preserves_chunk_boundaries_across_split_lines():
+    """A finish_reason frame split across TCP chunks must still be detected."""
+    tracker = SseDoneTracker()
+    payload = _data_line({"choices": [{"delta": {}, "finish_reason": "stop"}]})
+    mid = len(payload) // 2
+    tracker.feed(payload[:mid])
+    tracker.feed(payload[mid:])
+    assert tracker.should_append_done() is True
+
+
+def test_content_type_is_sse():
+    assert content_type_is_sse({"Content-Type": "text/event-stream"}) is True
+    assert content_type_is_sse({"content-type": "text/event-stream; charset=utf-8"}) is True
+    assert content_type_is_sse({"Content-Type": "application/json"}) is False

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -820,3 +820,68 @@ class TestPortalLastOneWithoutDone:
         assert getattr(response, "id", None) != PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == "stop"
         assert response.choices[0].message.content == "LONGCAT_OK"
+
+
+# ── Trailing usage chunk with no finish_reason (#91373) ───────────────────
+
+class TestStreamIncludeUsageFinalChunk:
+    """OpenAI / vLLM streaming with stream_options={'include_usage': True} emits
+    a final usage-only chunk with empty choices (choices=[]) and no finish_reason.
+    Hermes must recognize that the presence of usage proves the stream completed
+    cleanly and must NOT misclassify it as a mid-stream network drop (#91373).
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_text_stream_with_final_usage_chunk_completes_as_stop(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """When text is streamed and the final chunk is a usage-only chunk
+        without finish_reason, the completion must complete with finish_reason='stop'
+        instead of returning PARTIAL_STREAM_STUB_ID."""
+        def _vllm_stream():
+            # Chunks 1 and 2: text deltas with finish_reason=None
+            yield _make_stream_chunk(content="The final answer is 42.")
+            # Chunk 3: trailing usage-only chunk (choices=[], usage present)
+            usage = SimpleNamespace(prompt_tokens=100, completion_tokens=10, total_tokens=110)
+            yield SimpleNamespace(choices=[], model="vllm/test-model", usage=usage)
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _vllm_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "The final answer is 42."
+        assert response.usage is not None
+        assert response.usage.prompt_tokens == 100
+        assert response.usage.completion_tokens == 10
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_text_stream_abrupt_drop_without_usage_still_returns_stub(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """When text is streamed but the connection is severed before any usage
+        chunk arrives (usage is None and finish_reason is None), it remains
+        correctly classified as a partial stream stub."""
+        def _dropped_stream():
+            yield _make_stream_chunk(content="Partial text before drop")
+            # Stream ends abruptly without finish_reason and without usage
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _dropped_stream()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._current_streamed_assistant_text = "Partial text before drop"
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response.choices[0].message.content == "Partial text before drop"

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -885,3 +885,67 @@ class TestStreamIncludeUsageFinalChunk:
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
         assert response.choices[0].message.content == "Partial text before drop"
+
+
+# ── Merged-finish content chunk swallowed by the SSE-echo guard (#94614) ──
+
+class TestMergedFinishChunkSurvivesSSEGuard:
+    """vLLM >= 0.1.dev20051 merges finish_reason into the final CONTENT
+    chunk instead of a separate marker-only chunk. When the SSE-echo guard
+    is engaged at that moment (GLM-family tokenizers emit standalone ':'
+    tokens mid-prose), the guard's content-shape continue paths swallow the
+    terminal chunk and finish_reason is never captured — a complete stream
+    is misclassified as a mid-stream drop. Terminal fields must be
+    extracted before any content-shape continue."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_merged_finish_chunk_after_sse_lookalike_prefix_completes(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        def _vllm_merged_finish_stream():
+            # ':' then ' uniform' engage the SSE-echo guard (may_be_sse True)
+            yield _make_stream_chunk(content=":")
+            yield _make_stream_chunk(content=" uniform")
+            # Merged-finish terminal content chunk, as the new vLLM emits
+            yield _make_stream_chunk(content=".", finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _vllm_merged_finish_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == ": uniform."
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_merged_finish_chunk_without_sse_trigger_still_completes(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        """Control: the same merged-finish shape without an SSE-lookalike
+        prefix must keep completing (guard never engages)."""
+
+        def _plain_merged_finish_stream():
+            yield _make_stream_chunk(content="Hello")
+            yield _make_stream_chunk(content=".", finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _plain_merged_finish_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "Hello."

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -789,3 +789,34 @@ class TestSendTimePadMultimodalSafety:
         assert out[2]["content"] == ""
         # input list untouched (repair is copy-on-write)
         assert api_messages[1]["content"] == ""
+
+
+class TestPortalLastOneWithoutDone:
+    """#90848: complete Portal streams can end with lastOne=true and no
+    finish_reason / [DONE]. That is a clean terminal, not a drop."""
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_last_one_usage_frame_is_a_clean_stop(self, _mock_close, mock_create):
+        def _portal_stream():
+            yield _make_stream_chunk(content="LONGCAT_OK")
+            yield SimpleNamespace(
+                choices=[],
+                model="meituan/longcat-2.0:free",
+                usage=SimpleNamespace(prompt_tokens=1, completion_tokens=1),
+                lastOne=True,
+            )
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = (
+            lambda *a, **kw: _portal_stream()
+        )
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent._fire_stream_delta = lambda text: None
+        response = agent._interruptible_streaming_api_call({})
+
+        assert getattr(response, "id", None) != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "LONGCAT_OK"


### PR DESCRIPTION
## Summary
Complete streams are no longer misread as mid-stream drops: the Nous proxy appends the SSE `[DONE]` sentinel when the Portal omits it, and the agent stream reader accepts three provider-legal terminal shapes it previously rejected. Fixes #90848, #91373, and the vLLM merged-finish half of #94614 — consolidated salvage of PRs #91189 (@rainbowgore), #91376 (@loulanyue), and #96333 (@jon-nielsen).

Root cause: the end-of-stream verdict required the strict OpenAI shape (`[DONE]` sentinel / standalone finish chunk). Portal streams that end with `lastOne: true` and clean EOF, spec-compliant `include_usage` streams whose final chunk is usage-only with no `finish_reason`, and vLLM streams that merge `finish_reason` into the last content chunk (swallowed by the SSE-echo guard's `continue` paths) were all classified as truncated.

## Changes
- `hermes_cli/proxy/sse_done.py` (new): `SseDoneTracker` — byte-exact pass-through scanner; appends one `data: [DONE]` only after clean upstream EOF **and** a seen `finish_reason`/`lastOne` terminal; never after errors, interrupts, malformed frames, or an existing `[DONE]` (#91189)
- `hermes_cli/proxy/server.py`: wire the tracker into the streaming forwarder; guard the append against client hangup at EOF; widen the interrupt tuple with `OSError`
- `agent/chat_completion_helpers.py`: treat `lastOne: true` usage frames as clean stop (#91189); usage object presence proves clean completion when `finish_reason` is absent (#91376); extract `finish_reason`/usage before the SSE-echo guard's content-shape `continue`s (#96333)
- Hardening on top: SSE spec multi-line `data:` joins at blank-line boundaries (split JSON events no longer read as malformed), truthy `lastOne` sentinels (`1`/`"true"`), EOF-without-blank-line dispatch
- Tests: 46 targeted tests across proxy + tracker + stream classifier, including TCP-split frames and negative controls (abrupt drop without usage still returns the partial-stream stub)

## Validation
| | Before (main) | After |
|---|---|---|
| Portal-shaped stream through real proxy (live A/B) | `saw_DONE=False` → strict client says TRUNCATED | `saw_DONE=True` → COMPLETE |
| Fix tests on main (sabotage run) | 3 failed | 46/46 pass |
| Abrupt drop, no usage/finish | partial-stream stub | partial-stream stub (unchanged) |

**Live repro:** fake upstream emitting the exact #90848 frame byte-shape (content delta → `finish_reason:stop` → `lastOne:true` usage frame → clean EOF, no `[DONE]`) through the real `create_app()` proxy — before: strict client verdict TRUNCATED; after: single `[DONE]` appended, verdict COMPLETE, earlier frames byte-identical.

## Infographic

![Stream completes its quest](https://v3b.fal.media/files/b/0aa8b35e/D-anv0UGi2YBolHy7GEfq_TY8AbJiB.png)
