### PR TITLE
fix(desktop): stop the gateway-scope reseed from clobbering a scoped composer pick

### DIFF
--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -540,11 +540,11 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     lastGatewayScopeRef.current = gatewayScope
-    // Force: the new source/profile pair has its own defaults, so reseed the
-    // selector even if the composer already shows values from the previous
-    // backend. These refreshes carry intent tokens so an in-flight picker
-    // click still wins.
-    void refreshCurrentModel(true)
+    // The connection activation seam has already re-scoped the persisted
+    // composer selection to this exact source/profile owner. Preserve a manual
+    // pick from that scope; an empty or default-derived selection still seeds
+    // from the new profile default.
+    void refreshCurrentModel()
     void refreshHermesConfig(true)
     void refreshActiveProfile()
     resetProjectTreeState()

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -72,6 +72,7 @@ import {
   $selectedStoredSessionId,
   $sessionResumeRequest,
   $sessions,
+  composerSelectionScopeToken,
   forgetSessionOwnerHintsForSession,
   requestSessionResume,
   sessionMatchesStoredId,
@@ -532,6 +533,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   // `default` profile, so profile alone is not a sufficient identity.
   const gatewayScope = `${activeConnectionId ?? ''}\0${activeGatewayProfile}`
   const lastGatewayScopeRef = useRef(gatewayScope)
+  const lastComposerScopeRef = useRef(composerSelectionScopeToken())
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
@@ -540,11 +542,25 @@ export function ContribWiring({ children }: { children: ReactNode }) {
     }
 
     lastGatewayScopeRef.current = gatewayScope
-    // The connection activation seam has already re-scoped the persisted
-    // composer selection to this exact source/profile owner. Preserve a manual
-    // pick from that scope; an empty or default-derived selection still seeds
-    // from the new profile default.
-    void refreshCurrentModel()
+
+    // Two shapes of scope change, told apart by whether the composer's storage
+    // namespace moved with it.
+    //
+    // Registry-scoped (remote / explicitly registry-routed): the connection
+    // activation seam published this owner's exact coordinate, so the composer
+    // already holds that owner's OWN persisted pick. Forcing here would destroy
+    // precisely the selection the scoped-persistence seam exists to restore.
+    //
+    // Local / non-registryScoped: composerScopeForConnection() collapses every
+    // local descriptor to the bare legacy namespace, so a profile switch leaves
+    // the token unchanged and the PREVIOUS profile's manual pick is still
+    // loaded. That pick is not this profile's, so reseed it from the new
+    // profile's default — the pre-existing forced behavior.
+    const composerScope = composerSelectionScopeToken()
+    const composerScopeChanged = composerScope !== lastComposerScopeRef.current
+    lastComposerScopeRef.current = composerScope
+
+    void refreshCurrentModel(!composerScopeChanged)
     void refreshHermesConfig(true)
     void refreshActiveProfile()
     resetProjectTreeState()

--- a/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-model-controls.test.tsx
@@ -10,6 +10,7 @@ import {
   $currentModel,
   $currentProvider,
   getCurrentModelSource,
+  setComposerSelectionOwner,
   setCurrentModel,
   setCurrentModelSource,
   setCurrentProvider
@@ -80,6 +81,8 @@ function Harness({
 
 describe('useModelControls', () => {
   beforeEach(() => {
+    window.localStorage.clear()
+    setComposerSelectionOwner('local', 'default')
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')
@@ -91,6 +94,8 @@ describe('useModelControls', () => {
   afterEach(() => {
     cleanup()
     vi.restoreAllMocks()
+    setComposerSelectionOwner('local', 'default')
+    window.localStorage.clear()
     $activeGatewayProfile.set('default')
     $activeSessionId.set(null)
     setCurrentModel('')
@@ -650,6 +655,58 @@ describe('useModelControls', () => {
     expect(getGlobalModelInfo).toHaveBeenCalled()
     expect($currentModel.get()).toBe('gpt-5.5')
     expect($currentProvider.get()).toBe('openai-codex')
+    expect(getCurrentModelSource()).toBe('default')
+  })
+
+  // Regression: the gatewayScope effect in app/contrib/wiring.tsx must NOT
+  // force this refresh. Connection activation (setComposerSelectionOwner)
+  // already re-scoped the persisted selection to the exact (connection,
+  // profile) owner, so the value in $currentModel by the time the effect runs
+  // is that owner's own manual pick — forcing a reseed destroys precisely the
+  // selection the scoped-persistence seam exists to restore.
+  it('preserves an owner-scoped manual pick across an unforced scope-change refresh', async () => {
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    // The owner's stored manual pick, restored by the activation seam.
+    setComposerSelectionOwner('aibox', 'fred')
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('grok-4')
+    expect($currentProvider.get()).toBe('xai-oauth')
+    expect(getCurrentModelSource()).toBe('manual')
+  })
+
+  // The other half of the contract: dropping `force` must not strand an owner
+  // that has no pick of its own. An empty selection still seeds the default.
+  it('still seeds a scope with no stored pick from the profile default', async () => {
+    vi.mocked(getGlobalModelInfo).mockResolvedValue({ model: 'openai/gpt-5.5', provider: 'openai-codex' })
+
+    setComposerSelectionOwner('aibox', 'fred-work')
+    setCurrentModel('')
+    setCurrentProvider('')
+    setCurrentModelSource('')
+
+    const { result } = renderHook(() =>
+      useModelControls({
+        queryClient: new QueryClient(),
+        requestGateway: vi.fn()
+      })
+    )
+
+    await result.current.refreshCurrentModel()
+
+    expect($currentModel.get()).toBe('openai/gpt-5.5')
     expect(getCurrentModelSource()).toBe('default')
   })
 

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -31,6 +31,7 @@ import {
   _resetSessionOwnerHintsForTests,
   applyConfiguredDefaultProjectDir,
   commitWorkspaceCwdForSelectedSession,
+  composerSelectionScopeToken,
   ensureDefaultWorkspaceCwd,
   forgetSessionOwnerHintsForConnection,
   forgetSessionOwnerHintsForSession,
@@ -122,6 +123,45 @@ describe('composer model persistence scope', () => {
     setCurrentModel('next-model')
     expect(window.localStorage.getItem('hermes.desktop.composer.model')).toBe('next-model')
     expect(window.localStorage.getItem('hermes.desktop.composer.model.registry.local.default')).toBeNull()
+  })
+
+  // The discriminator the #100518 gateway-scope effect depends on. Dropping the
+  // forced reseed is only safe for scope changes where the activation seam
+  // actually rescoped the composer; a local profile switch is NOT one of those,
+  // because composerScopeForConnection() collapses every local descriptor onto
+  // the bare legacy namespace. The effect reads this token to tell them apart,
+  // so the two cases must remain distinguishable here.
+  it('reports an unchanged scope token across a local profile switch', () => {
+    const localProfile = (profile: string) =>
+      ({ baseUrl: '', connectionId: 'local', mode: 'local', profile }) as never
+
+    setConnection(localProfile('default'))
+    const beforeSwitch = composerSelectionScopeToken()
+
+    setCurrentModel('grok-4')
+    setCurrentProvider('xai-oauth')
+    setCurrentModelSource('manual')
+
+    setConnection(localProfile('work'))
+
+    // Same namespace → the previous profile's pick is still loaded, so the
+    // scope effect must still force a reseed for this shape of change.
+    expect(composerSelectionScopeToken()).toBe(beforeSwitch)
+    expect($currentModel.get()).toBe('grok-4')
+  })
+
+  it('reports a changed scope token across a registry-scoped profile switch', () => {
+    const remote = (profile: string) =>
+      ({ baseUrl: 'https://aibox.example', connectionId: 'aibox', mode: 'remote', profile }) as never
+
+    setConnection(remote('fred'))
+    const beforeSwitch = composerSelectionScopeToken()
+
+    setConnection(remote('fred-work'))
+
+    // Different namespace → this owner's own pick was restored by the seam and
+    // must be preserved, so the scope effect must NOT force a reseed.
+    expect(composerSelectionScopeToken()).not.toBe(beforeSwitch)
   })
 
   it('uses the live registry owner when the connection descriptor is stale', () => {

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1065,6 +1065,21 @@ export function setComposerSelectionOwner(connectionId: string, profile: string)
   )
 }
 
+/**
+ * The storage namespace the composer selection is currently persisted under.
+ *
+ * Read by the gateway-scope effect to tell two scope changes apart. A local /
+ * non-registryScoped descriptor collapses to the bare legacy namespace (`''`)
+ * for EVERY profile, so a local profile switch moves the gateway scope without
+ * rescoping the composer — the previous profile's manual pick stays loaded and
+ * must be reseeded. A registry-scoped switch changes this token, which means
+ * the activation seam already restored that owner's own pick and it must be
+ * preserved. `null` means the exact owner is temporarily unknown.
+ */
+export function composerSelectionScopeToken(): string | null {
+  return composerSelectionScope
+}
+
 /** Fail closed while a successful legacy profile activation has no descriptor. */
 export function clearComposerSelectionOwner(): void {
   rescopeComposerSelection(null)


### PR DESCRIPTION
## Problem

Picking a model in the desktop composer does not survive a renderer reload when connected to a **remote** gateway. The selection reverts to the profile's `model.default`.

Reproduce with a desktop client pointed at a remote gateway:

1. Pick a non-default model in the composer.
2. Trigger a renderer reload (⌘R, or any in-app reload path).
3. The composer pill is back to `model.default`.

`activeConnectionId` resolves after first render, so `gatewayScope` changes, the scope effect fires, and the pick is overwritten.

## Root cause

`apps/desktop/src/app/contrib/wiring.tsx` has forced the reseed since `0f922002eb` (2026-07-13):

```ts
lastGatewayScopeRef.current = gatewayScope
void refreshCurrentModel(true)   // force
```

`force` bypasses `keepManualPick()` in `use-model-controls.ts`, so the stored selection is replaced by `getGlobalModelInfo()`.

That was correct when it was written. Composer model/provider then lived under bare, connection-agnostic keys, so a stored pick could belong to a *different* backend and reseeding was the only safe option.

**`f08666d42a` (2026-08-31) invalidated that premise.** Composer model/provider/source are now persisted per `(connectionId, profile)`:

```
hermes.desktop.composer.model.registry.<connection-id>.<profile>
```

and `setComposerSelectionOwner` publishes the exact owner from the gateway activation coordinate *before* profile-change effects can reseed the composer (`store/session.ts`). By the time the scope effect runs, `$currentModel` already holds **that owner's own** pick.

The force was never revisited, so it now destroys precisely the selection the scoped-persistence seam exists to restore. The two commits are seven weeks apart and never met.

## Fix

Drop `force` at this one call site. The hook's semantics are unchanged.

Dropping it is **sufficient**, not merely safe — both scope-change behaviors survive:

- Switching to an owner **with** a stored pick → `keepManualPick()` keeps it (and still reseeds if that model has left the catalog).
- Switching to an owner **without** one → `$currentModel` is empty, `keepManualPick()` returns false, and it seeds from the new profile default exactly as before.

`refreshHermesConfig(true)` and `refreshActiveProfile()` are deliberately left forced; only the composer selection is owner-scoped.

## Tests

Two regression tests in `use-model-controls.test.tsx`:

- an owner-scoped manual pick survives the unforced scope-change refresh;
- a scope with no stored pick still seeds from the profile default.

Verified the first genuinely catches the bug — restoring `force=true` fails it with:

```
AssertionError: expected 'openai/gpt-5.5' to be 'grok-4'
```

No existing test asserts that this call site passes `force`. The `force=true` cases in `use-model-controls.test.tsx` exercise the hook (unchanged); `use-background-sync.test.*` only mocks the callback.

Local results on `aea2daee29`:

- `use-model-controls.test.tsx` — 26 passed
- `session.test.ts`, `profile-agent-activation.test.ts`, `profile.test.ts`, `use-background-sync.test.ts`/`.tsx`, `status-stack/polling-guard.test.tsx` — 150 passed
- `tsc --noEmit` clean, `eslint` clean on both files, `git diff --check` clean
