### PR TITLE
fix(cron): keep the profile scope across the delivery worker thread

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3856,7 +3856,18 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        # Copy the caller's context into the worker thread.
+                        # ContextVars do NOT propagate into a fresh thread, and
+                        # the multiplex cron ticker scopes each profile with
+                        # set_hermes_home_override() — a ContextVar. Submitting
+                        # bare meant _send_to_platform's load_gateway_config()
+                        # resolved get_hermes_home() back to the process-level
+                        # HERMES_HOME (the default profile) and delivered a
+                        # secondary profile's job with the DEFAULT profile's
+                        # bot token (#100489). Same guard the agent-run
+                        # submission already uses at :6160.
+                        _delivery_context = contextvars.copy_context()
+                        future = pool.submit(_delivery_context.run, asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/tests/cron/test_cron_delivery_profile_scope.py
+++ b/tests/cron/test_cron_delivery_profile_scope.py
@@ -1,0 +1,94 @@
+"""Cron delivery must keep the profile scope across the worker thread (#100489).
+
+The multiplex cron ticker scopes each profile with
+``set_hermes_home_override(home)`` — a ContextVar. ``_deliver_result``'s
+standalone send path submits into a fresh ``ThreadPoolExecutor``, and
+ContextVars do NOT propagate into new threads, so ``_send_to_platform`` ->
+``load_gateway_config()`` resolved ``get_hermes_home()`` back to the
+process-level ``HERMES_HOME`` (the default profile) and delivered a secondary
+profile's job with the DEFAULT profile's bot token.
+"""
+
+import concurrent.futures
+import contextvars
+import inspect
+import threading
+
+import pytest
+
+_scope = contextvars.ContextVar("probe_home_override", default="DEFAULT-PROFILE")
+
+
+def _read_scope():
+    return _scope.get()
+
+
+def _submit_bare():
+    """The pre-fix shape: submit straight into a fresh pool thread."""
+    _scope.set("link-ss")
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(_read_scope).result(timeout=5)
+    finally:
+        pool.shutdown(wait=False)
+
+
+def _submit_with_context():
+    """The fix: copy the caller's context into the worker thread."""
+    _scope.set("link-ss")
+    ctx = contextvars.copy_context()
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    try:
+        return pool.submit(ctx.run, _read_scope).result(timeout=5)
+    finally:
+        pool.shutdown(wait=False)
+
+
+def _in_fresh_thread(fn):
+    """Run fn in its own thread so ContextVar sets don't leak between cases."""
+    box = {}
+    t = threading.Thread(target=lambda: box.__setitem__("v", fn()))
+    t.start()
+    t.join(10)
+    return box.get("v")
+
+
+class TestContextVarThreadSemantics:
+    """Pin the mechanism itself, so the reason for the fix stays documented."""
+
+    def test_bare_submit_loses_the_profile_scope(self):
+        assert _in_fresh_thread(_submit_bare) == "DEFAULT-PROFILE"
+
+    def test_copy_context_preserves_the_profile_scope(self):
+        assert _in_fresh_thread(_submit_with_context) == "link-ss"
+
+
+class TestDeliveryUsesCopiedContext:
+    """The real call site must use the copy_context form."""
+
+    def test_deliver_result_copies_context_into_the_send_thread(self):
+        from cron import scheduler
+
+        source = inspect.getsource(scheduler._deliver_result)
+        assert "contextvars.copy_context()" in source, (
+            "the standalone send path must copy the caller's context so the "
+            "multiplex profile scope survives the worker thread (#100489)"
+        )
+        # The submit must go through the copied context, not bare asyncio.run.
+        assert "submit(_delivery_context.run, asyncio.run" in source
+
+    def test_no_bare_asyncio_run_submit_remains(self):
+        from cron import scheduler
+
+        source = inspect.getsource(scheduler._deliver_result)
+        assert "submit(asyncio.run," not in source, (
+            "a bare submit would silently drop the profile scope again"
+        )
+
+    def test_context_copy_precedes_the_submit(self):
+        from cron import scheduler
+
+        source = inspect.getsource(scheduler._deliver_result)
+        copy_at = source.index("contextvars.copy_context()")
+        submit_at = source.index("submit(_delivery_context.run")
+        assert copy_at < submit_at


### PR DESCRIPTION
Fixes #100489

## Problem

The multiplex cron ticker scopes each profile with `set_hermes_home_override(home)` — a **ContextVar**. `_deliver_result`'s standalone send path submits into a fresh `ThreadPoolExecutor`, and ContextVars do **not** propagate into new threads. So `_send_to_platform` → `load_gateway_config()` resolved `get_hermes_home()` back to the process-level `HERMES_HOME` (the default profile) and delivered a secondary profile's job with the **default profile's bot token**.

The delivery identity was nondeterministic — it flipped depending on which process won `cron/.tick.lock`. The reporter's evidence shows exactly that: the same `link-ss` job delivered via the default bot when the desktop multiplex ticker won the tick (logged on the default side, no `via live adapter`), and via `link-ss`'s own bot when triggered inside that profile's session.

This leaks the wrong identity across a boundary `cron/jobs.py:68` documents as per-profile by design (#4707).

## Mechanism, verified before fixing

With a ContextVar set to `link-ss` in the caller:

```
ticker sets scope to      : link-ss
delivery thread sees (now): DEFAULT-PROFILE   <- the bug
delivery thread sees (fix): link-ss
```

## Fix

`contextvars.copy_context()` around the submit — the same guard the agent-run submission at `scheduler.py:6160` already uses:

```python
_delivery_context = contextvars.copy_context()
future = pool.submit(_delivery_context.run, asyncio.run, _send_to_platform(...))
```

This is the reporter's **option 2** (propagate the scope) rather than option 1 (skip profiles that run their own gateway), because it fixes the delivery path for *every* caller rather than only the desktop-ticker overlap — an explicit `hermes cron run` under a scoped profile had the same defect, and option 1 would have left it.

## Verification

New `tests/cron/test_cron_delivery_profile_scope.py` — **5/5 pass**:

- **mechanism**: bare `pool.submit` loses the scope (`DEFAULT-PROFILE`); `submit(ctx.run, ...)` preserves it (`link-ss`) — each in its own thread so ContextVar sets can't leak between cases
- **call site**: `_deliver_result` contains `contextvars.copy_context()` and submits through it
- **regression guard**: asserts no bare `submit(asyncio.run,` remains, so a revert fails loudly
- **ordering**: the copy precedes the submit

Sibling suites green: `test_cron_relay_delivery_guards.py` + `test_cron_created_delivery.py` 22/22.