### PR TITLE
fix(compression): stop stalled auxiliary streams from hanging large sessions

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9782,8 +9782,7 @@ def _consume_request_local_stream(
             progress_hook()
 
     def _run() -> None:
-        if progress_hook is not None:
-            _aux_progress.hook = _progress
+        _aux_progress.hook = _progress
         if response_hook is not None:
             _aux_provider_response.hook = response_hook
         try:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9665,10 +9665,15 @@ def _create_with_progress_once(
     stream_kwargs["stream_options"] = {"include_usage": True}
     stream_client, owns_stream_client = _copy_request_local_streaming_client(client)
     try:
+        if owns_stream_client:
+            return _consume_request_local_stream(
+                stream_client,
+                stream_kwargs,
+                model=str(kwargs.get("model") or ""),
+                total_ceiling=total_ceiling,
+            )
         chunks = stream_client.chat.completions.create(**stream_kwargs)
     except Exception as exc:
-        if owns_stream_client:
-            _close_cached_client(stream_client)
         # Genuine provider failures (auth, credit, rate limit, network) are
         # not streaming's fault — surface them unchanged so the existing
         # recovery chains (credential refresh, pool rotation, provider
@@ -9700,19 +9705,12 @@ def _create_with_progress_once(
     # as provider response progress (TTFP) and forward progress alike.
     if hasattr(chunks, "choices"):
         _notify_aux_provider_response()
-        if owns_stream_client:
-            _close_cached_client(stream_client)
         return chunks
-    try:
-        return _aggregate_chat_stream(
-            chunks,
-            model=str(kwargs.get("model") or ""),
-            total_ceiling=total_ceiling,
-            request_client=stream_client if owns_stream_client else None,
-        )
-    finally:
-        if owns_stream_client:
-            _close_cached_client(stream_client)
+    return _aggregate_chat_stream(
+        chunks,
+        model=str(kwargs.get("model") or ""),
+        total_ceiling=total_ceiling,
+    )
 
 
 def _copy_request_local_streaming_client(client: Any) -> Tuple[Any, bool]:
@@ -9725,8 +9723,15 @@ def _copy_request_local_streaming_client(client: Any) -> Tuple[Any, bool]:
     Non-OpenAI adapters do not expose the required copy seam and retain their
     transport-specific ownership logic.
     """
+    # ``MagicMock`` and other dynamic adapters fabricate arbitrary attributes;
+    # only use the copy seam when the concrete object or its class declares it.
+    if (
+        inspect.getattr_static(client, "copy", None) is None
+        or inspect.getattr_static(client, "_client", None) is None
+    ):
+        return client, False
     copy_fn = getattr(client, "copy", None)
-    if not callable(copy_fn) or not hasattr(client, "_client"):
+    if not callable(copy_fn):
         return client, False
     base_url = str(getattr(client, "base_url", "") or "")
     http_client = _openai_http_client_kwargs(base_url).get("http_client")
@@ -9743,12 +9748,123 @@ def _copy_request_local_streaming_client(client: Any) -> Tuple[Any, bool]:
         return client, False
 
 
+def _consume_request_local_stream(
+    client: Any,
+    stream_kwargs: Dict[str, Any],
+    *,
+    model: str,
+    total_ceiling: float,
+) -> Any:
+    """Consume an isolated stream on its socket-owning daemon thread.
+
+    Windows cannot reliably wake httpx's blocked receive via a stranger-thread
+    socket shutdown. The caller therefore enforces the substantive-progress
+    deadline independently while this worker remains the sole owner of stream
+    iteration and client close. A timed-out worker can finish unwinding later,
+    but its request-local pool cannot poison retries or sibling tasks.
+    """
+    condition = threading.Condition()
+    state: Dict[str, Any] = {
+        "done": False,
+        "last_progress": time.monotonic(),
+        "result": None,
+        "error": None,
+    }
+    cancelled = threading.Event()
+    progress_hook = getattr(_aux_progress, "hook", None)
+    response_hook = getattr(_aux_provider_response, "hook", None)
+
+    def _progress() -> None:
+        with condition:
+            state["last_progress"] = time.monotonic()
+            condition.notify_all()
+        if progress_hook is not None:
+            progress_hook()
+
+    def _run() -> None:
+        if progress_hook is not None:
+            _aux_progress.hook = _progress
+        if response_hook is not None:
+            _aux_provider_response.hook = response_hook
+        try:
+            chunks = client.chat.completions.create(**stream_kwargs)
+            if hasattr(chunks, "choices"):
+                _notify_aux_provider_response()
+                result = chunks
+            else:
+                result = _aggregate_chat_stream(
+                    chunks,
+                    model=model,
+                    total_ceiling=total_ceiling,
+                    cancel_event=cancelled,
+                )
+            with condition:
+                state["result"] = result
+        except BaseException as exc:
+            with condition:
+                state["error"] = exc
+        finally:
+            _close_cached_client(client)
+            with condition:
+                state["done"] = True
+                condition.notify_all()
+
+    started = time.monotonic()
+    worker = threading.Thread(target=_run, daemon=True)
+    worker.start()
+    while True:
+        with condition:
+            if state["done"]:
+                break
+            now = time.monotonic()
+            idle_deadline = state["last_progress"] + _AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS
+            hard_deadline = started + total_ceiling
+            deadline = min(idle_deadline, hard_deadline)
+            remaining = deadline - now
+            if remaining > 0:
+                condition.wait(timeout=remaining)
+                continue
+            elapsed = now - started
+            saw_progress = state["last_progress"] > started
+            hard_expired = now >= hard_deadline
+        cancelled.set()
+        try:
+            from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+            force_close_tcp_sockets(client)
+        except Exception:
+            logger.debug(
+                "Auxiliary stream: socket abort on no-progress timeout failed",
+                exc_info=True,
+            )
+        if hard_expired:
+            raise TimeoutError(
+                f"Auxiliary streamed call timed out after {total_ceiling:.0f}s hard ceiling"
+            )
+        if not saw_progress:
+            raise TimeoutError(
+                "Auxiliary streamed call produced no output within "
+                f"{_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS:.1f}s "
+                f"(no-progress timeout, {elapsed:.1f}s elapsed)"
+            )
+        raise TimeoutError(
+            "Auxiliary streamed call stalled with no new output for "
+            f"{_AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS:.1f}s "
+            f"({elapsed:.1f}s elapsed)"
+        )
+
+    if state["error"] is not None:
+        raise state["error"]
+    return state["result"]
+
+
 def _aggregate_chat_stream(
     chunks: Any,
     *,
     model: str = "",
     total_ceiling: Optional[float] = None,
     request_client: Any = None,
+    cancel_event: Optional[threading.Event] = None,
 ) -> Any:
     """Consume a chat.completions chunk stream into a complete response.
 
@@ -9838,6 +9954,8 @@ def _aggregate_chat_stream(
     try:
         for chunk in chunks:
             made_progress = acc.feed(chunk)
+            if cancel_event is not None and cancel_event.is_set():
+                raise TimeoutError("Auxiliary streamed call cancelled after caller timeout")
             if watchdog_expired.is_set():
                 raise TimeoutError(_timeout_message())
             if made_progress:

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9663,9 +9663,12 @@ def _create_with_progress_once(
     stream_kwargs = dict(kwargs)
     stream_kwargs["stream"] = True
     stream_kwargs["stream_options"] = {"include_usage": True}
+    stream_client, owns_stream_client = _copy_request_local_streaming_client(client)
     try:
-        chunks = client.chat.completions.create(**stream_kwargs)
+        chunks = stream_client.chat.completions.create(**stream_kwargs)
     except Exception as exc:
+        if owns_stream_client:
+            _close_cached_client(stream_client)
         # Genuine provider failures (auth, credit, rate limit, network) are
         # not streaming's fault — surface them unchanged so the existing
         # recovery chains (credential refresh, pool rotation, provider
@@ -9697,10 +9700,47 @@ def _create_with_progress_once(
     # as provider response progress (TTFP) and forward progress alike.
     if hasattr(chunks, "choices"):
         _notify_aux_provider_response()
+        if owns_stream_client:
+            _close_cached_client(stream_client)
         return chunks
-    return _aggregate_chat_stream(
-        chunks, model=str(kwargs.get("model") or ""), total_ceiling=total_ceiling,
-    )
+    try:
+        return _aggregate_chat_stream(
+            chunks,
+            model=str(kwargs.get("model") or ""),
+            total_ceiling=total_ceiling,
+            request_client=stream_client if owns_stream_client else None,
+        )
+    finally:
+        if owns_stream_client:
+            _close_cached_client(stream_client)
+
+
+def _copy_request_local_streaming_client(client: Any) -> Tuple[Any, bool]:
+    """Give an OpenAI streamed attempt its own httpx connection pool.
+
+    ``OpenAI.copy()`` reuses the source client's pool unless an ``http_client``
+    override is supplied. Build that override through Hermes' normal TLS/proxy
+    path so a timed-out stream can be aborted and closed without poisoning the
+    process-cached auxiliary client used by later retries or sibling tasks.
+    Non-OpenAI adapters do not expose the required copy seam and retain their
+    transport-specific ownership logic.
+    """
+    copy_fn = getattr(client, "copy", None)
+    if not callable(copy_fn) or not hasattr(client, "_client"):
+        return client, False
+    base_url = str(getattr(client, "base_url", "") or "")
+    http_client = _openai_http_client_kwargs(base_url).get("http_client")
+    if http_client is None:
+        return client, False
+    try:
+        return copy_fn(http_client=http_client), True
+    except Exception:
+        _close_cached_client(http_client)
+        logger.debug(
+            "Auxiliary stream: request-local client copy failed; using cached client",
+            exc_info=True,
+        )
+        return client, False
 
 
 def _aggregate_chat_stream(
@@ -9708,6 +9748,7 @@ def _aggregate_chat_stream(
     *,
     model: str = "",
     total_ceiling: Optional[float] = None,
+    request_client: Any = None,
 ) -> Any:
     """Consume a chat.completions chunk stream into a complete response.
 
@@ -9720,10 +9761,101 @@ def _aggregate_chat_stream(
     :class:`_ChatStreamAccumulator`.
     """
     acc = _ChatStreamAccumulator(model=model, total_ceiling=total_ceiling)
+    started = time.monotonic()
+    idle_timeout = _AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS
+    hard_deadline = (
+        started + total_ceiling if total_ceiling is not None else None
+    )
+    watchdog_lock = threading.Lock()
+    watchdog_timer: List[Optional[threading.Timer]] = [None]
+    watchdog_generation = [0]
+    watchdog_expired = threading.Event()
+    stream_finished = threading.Event()
+    saw_progress = threading.Event()
+    timeout_reason = [""]
+
+    def _timeout_message() -> str:
+        elapsed = time.monotonic() - started
+        if timeout_reason[0] == "hard ceiling":
+            return (
+                "Auxiliary streamed call timed out after "
+                f"{float(total_ceiling or elapsed):.0f}s hard ceiling"
+            )
+        if not saw_progress.is_set():
+            return (
+                "Auxiliary streamed call produced no output within "
+                f"{idle_timeout:.1f}s (no-progress timeout, {elapsed:.1f}s elapsed)"
+            )
+        return (
+            "Auxiliary streamed call stalled with no new output for "
+            f"{idle_timeout:.1f}s ({elapsed:.1f}s elapsed)"
+        )
+
+    def _arm_watchdog() -> None:
+        if request_client is None:
+            return
+        now = time.monotonic()
+        delay = idle_timeout
+        if hard_deadline is not None:
+            delay = min(delay, max(hard_deadline - now, 0.0))
+        with watchdog_lock:
+            watchdog_generation[0] += 1
+            generation = watchdog_generation[0]
+            previous = watchdog_timer[0]
+            if previous is not None:
+                previous.cancel()
+
+            def _expire() -> None:
+                with watchdog_lock:
+                    if (
+                        generation != watchdog_generation[0]
+                        or stream_finished.is_set()
+                    ):
+                        return
+                    timeout_reason[0] = (
+                        "hard ceiling"
+                        if hard_deadline is not None
+                        and time.monotonic() >= hard_deadline
+                        else "no progress"
+                    )
+                    watchdog_expired.set()
+                try:
+                    from agent.agent_runtime_helpers import force_close_tcp_sockets
+
+                    force_close_tcp_sockets(request_client)
+                except Exception:
+                    logger.debug(
+                        "Auxiliary stream: socket abort on no-progress timeout failed",
+                        exc_info=True,
+                    )
+
+            timer = threading.Timer(delay, _expire)
+            timer.daemon = True
+            watchdog_timer[0] = timer
+            timer.start()
+
+    _arm_watchdog()
     try:
         for chunk in chunks:
-            acc.feed(chunk)
+            made_progress = acc.feed(chunk)
+            if watchdog_expired.is_set():
+                raise TimeoutError(_timeout_message())
+            if made_progress:
+                saw_progress.set()
+                _arm_watchdog()
+        if watchdog_expired.is_set():
+            raise TimeoutError(_timeout_message())
+    except Exception as exc:
+        if watchdog_expired.is_set() and not isinstance(exc, TimeoutError):
+            raise TimeoutError(_timeout_message()) from exc
+        raise
     finally:
+        stream_finished.set()
+        with watchdog_lock:
+            watchdog_generation[0] += 1
+            timer = watchdog_timer[0]
+        if timer is not None:
+            timer.cancel()
         close_fn = getattr(chunks, "close", None)
         if callable(close_fn):
             try:
@@ -9753,7 +9885,7 @@ class _ChatStreamAccumulator:
         self.resp_id = ""
         self.resp_model = model or ""
 
-    def feed(self, chunk: Any) -> None:
+    def feed(self, chunk: Any) -> bool:
         # Every provider frame records transport-level timing (TTFP
         # telemetry, first-frame-wins); only a substantive payload below
         # ticks the forward-progress hook that keeps compression alive.
@@ -9774,12 +9906,12 @@ class _ChatStreamAccumulator:
             self.usage = chunk_usage
         choices = getattr(chunk, "choices", None) or []
         if not choices:
-            return
+            return False
         choice = choices[0]
         self.finish_reason = getattr(choice, "finish_reason", None) or self.finish_reason
         delta = getattr(choice, "delta", None)
         if delta is None:
-            return
+            return False
         piece = getattr(delta, "content", None)
         if piece:
             self.content_parts.append(piece)
@@ -9830,6 +9962,7 @@ class _ChatStreamAccumulator:
 
         if made_progress:
             _notify_aux_progress()
+        return made_progress
 
     def finish(self) -> Any:
         tool_calls = None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9952,9 +9952,9 @@ def _aggregate_chat_stream(
     _arm_watchdog()
     try:
         for chunk in chunks:
-            made_progress = acc.feed(chunk)
             if cancel_event is not None and cancel_event.is_set():
                 raise TimeoutError("Auxiliary streamed call cancelled after caller timeout")
+            made_progress = acc.feed(chunk)
             if watchdog_expired.is_set():
                 raise TimeoutError(_timeout_message())
             if made_progress:

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -4,7 +4,8 @@ Slow summary models must not be punished like hung ones (#see PR): when a
 forward-progress hook is installed (context compression), the primary
 auxiliary call streams and ticks the hook only for substantive payloads, so
 outer watchdogs (gateway session hygiene) can extend their deadline on
-liveness. Without a hook, behavior is byte-for-byte the old non-streaming call.
+liveness. Without a hook, behavior stays non-streaming unless the provider
+explicitly requires the streamed path.
 """
 
 import threading
@@ -370,6 +371,40 @@ class TestAggregateChatStream:
         result = _aggregate_chat_stream(
             _SlowHealthyStream(), request_client=object(), total_ceiling=1.0
         )
+        assert result.choices[0].message.content == "abc"
+
+    def test_force_stream_without_hook_rearms_request_local_watchdog(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.04
+        )
+
+        class _SlowLocalClient(_FakeClient):
+            def _create(self, **kwargs):
+                self.calls.append(kwargs)
+
+                def _chunks():
+                    for text in ("a", "b", "c"):
+                        time.sleep(0.025)
+                        yield _chunk(content=text)
+
+                return _chunks()
+
+        cached_client = _FakeClient(stream_chunks=[])
+        local_client = _SlowLocalClient()
+        local_client.close = lambda: None
+        monkeypatch.setattr(
+            "agent.auxiliary_client._copy_request_local_streaming_client",
+            lambda client: (local_client, True),
+        )
+
+        result = _create_with_progress(
+            cached_client,
+            {"model": "m1", "messages": [], "timeout": 1.0},
+            force_stream=True,
+        )
+
+        assert cached_client.calls == []
+        assert local_client.calls[0]["stream"] is True
         assert result.choices[0].message.content == "abc"
 
     def test_stream_attempt_uses_and_closes_request_local_client(self, monkeypatch):

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -9,6 +9,7 @@ liveness. Without a hook, behavior is byte-for-byte the old non-streaming call.
 
 import threading
 import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -286,6 +287,71 @@ class TestAggregateChatStream:
 
         assert time.monotonic() - started < 0.5
         assert aborted == [request_client]
+
+    @pytest.mark.windows_only
+    def test_no_progress_watchdog_interrupts_real_openai_socket(self, monkeypatch):
+        """The watchdog must wake the actual Windows SDK receive, not a mock."""
+        peer_release = threading.Event()
+
+        class _StalledSSE(BaseHTTPRequestHandler):
+            protocol_version = "HTTP/1.1"
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", "0"))
+                self.rfile.read(length)
+                self.send_response(200)
+                self.send_header("Content-Type", "text/event-stream")
+                self.send_header("Connection", "close")
+                self.end_headers()
+                self.wfile.flush()
+                peer_release.wait(timeout=2.0)
+
+            def log_message(self, format, *args):
+                pass
+
+        server = HTTPServer(("127.0.0.1", 0), _StalledSSE)
+        server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+        server_thread.start()
+        monkeypatch.setattr(
+            "agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.1
+        )
+
+        from openai import OpenAI
+
+        client = OpenAI(
+            api_key="test",
+            base_url=f"http://127.0.0.1:{server.server_address[1]}/v1",
+            max_retries=0,
+        )
+        result = []
+        started = time.monotonic()
+
+        def _request():
+            try:
+                with aux_progress_hook(lambda: None):
+                    _create_with_progress(
+                        client,
+                        {"model": "m1", "messages": [], "timeout": 5.0},
+                    )
+            except Exception as exc:
+                result.append(exc)
+
+        worker = threading.Thread(target=_request)
+        worker.start()
+        worker.join(timeout=1.0)
+        elapsed = time.monotonic() - started
+        peer_release.set()
+        worker.join(timeout=3.0)
+        client.close()
+        server.shutdown()
+        server.server_close()
+        server_thread.join(timeout=1.0)
+
+        assert not worker.is_alive(), "stalled SDK receive ignored the watchdog"
+        assert elapsed < 1.0
+        assert len(result) == 1
+        assert isinstance(result[0], TimeoutError)
+        assert "no-progress timeout" in str(result[0])
 
     def test_substantive_chunks_rearm_no_progress_watchdog(self, monkeypatch):
         monkeypatch.setattr(
@@ -578,10 +644,8 @@ class TestContentBearingProgress:
             for _ in range(5):
                 accumulator.feed(keepalive)
                 accumulator.feed(empty_role_chunk)
-        # No substantive payload arrived: the fence must have stayed stale.
-        # Let coarse Windows monotonic clocks advance before observing age.
-        time.sleep(0.01)
-        assert fence.seconds_since_progress() > 0.0
+        # No substantive payload arrived: the fence must not report progress.
+        assert fence.progress_observed is False
 
         with aux_progress_hook(fence.touch_progress):
             accumulator.feed(_chunk(content="token"))

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -407,6 +407,64 @@ class TestAggregateChatStream:
         assert local_client.calls[0]["stream"] is True
         assert result.choices[0].message.content == "abc"
 
+    def test_request_local_worker_discards_chunks_after_caller_timeout(self, monkeypatch):
+        from agent.auxiliary_client import _aux_provider_response, _aux_timing_hook
+
+        peer_release = threading.Event()
+        worker_closed = threading.Event()
+        caller_returned = threading.Event()
+        late_callbacks = []
+        close_threads = []
+
+        class _LateLocalClient(_FakeClient):
+            def _create(self, **kwargs):
+                self.calls.append(kwargs)
+
+                def _chunks():
+                    peer_release.wait(timeout=1.0)
+                    yield _chunk(content="stale")
+
+                return _chunks()
+
+            def close(self):
+                close_threads.append(threading.get_ident())
+                worker_closed.set()
+
+        cached_client = _FakeClient(stream_chunks=[])
+        local_client = _LateLocalClient()
+        monkeypatch.setattr(
+            "agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.02
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._copy_request_local_streaming_client",
+            lambda client: (local_client, True),
+        )
+        monkeypatch.setattr(
+            "agent.agent_runtime_helpers.force_close_tcp_sockets", lambda client: 0
+        )
+
+        def _record_callback(kind):
+            if caller_returned.is_set():
+                late_callbacks.append(kind)
+
+        caller_thread = threading.get_ident()
+        with (
+            aux_progress_hook(lambda: _record_callback("progress")),
+            _aux_timing_hook(
+                _aux_provider_response, lambda: _record_callback("timing")
+            ),
+            pytest.raises(TimeoutError, match="no-progress timeout"),
+        ):
+            _create_with_progress(
+                cached_client, {"model": "m1", "messages": [], "timeout": 1.0}
+            )
+
+        caller_returned.set()
+        peer_release.set()
+        assert worker_closed.wait(timeout=1.0)
+        assert late_callbacks == []
+        assert close_threads and close_threads[0] != caller_thread
+
     def test_stream_attempt_uses_and_closes_request_local_client(self, monkeypatch):
         cached_client = _FakeClient(stream_chunks=[])
         local_client = _FakeClient(

--- a/tests/agent/test_aux_progress_streaming.py
+++ b/tests/agent/test_aux_progress_streaming.py
@@ -24,6 +24,7 @@ from agent.auxiliary_client import (
     _anthropic_event_has_content,
     _aux_stream_total_ceiling,
     _codex_event_has_content,
+    _copy_request_local_streaming_client,
     _create_with_progress,
     _notify_aux_progress,
     _provider_requires_stream,
@@ -195,6 +196,26 @@ class TestCreateWithProgress:
 # ---------------------------------------------------------------------------
 
 class TestAggregateChatStream:
+    def test_request_local_copy_overrides_the_cached_http_pool(self, monkeypatch):
+        shared_pool = object()
+        request_pool = object()
+        local_client = object()
+        source = SimpleNamespace(
+            _client=shared_pool,
+            base_url="https://proxy.example/v1",
+            copy=MagicMock(return_value=local_client),
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._openai_http_client_kwargs",
+            lambda base_url: {"http_client": request_pool},
+        )
+
+        copied, owned = _copy_request_local_streaming_client(source)
+
+        assert copied is local_client
+        assert owned is True
+        source.copy.assert_called_once_with(http_client=request_pool)
+
     def test_tool_call_deltas_are_reassembled(self):
         tc0 = SimpleNamespace(
             index=0, id="call_1",
@@ -229,6 +250,82 @@ class TestAggregateChatStream:
 
         result = _aggregate_chat_stream(_Stream())
         assert result.choices[0].message.content == "ok"
+        assert closed == [True]
+
+    def test_no_progress_watchdog_aborts_request_client_and_times_out(self, monkeypatch):
+        release = threading.Event()
+        aborted = []
+
+        class _BlockedStream:
+            def __iter__(self):
+                release.wait(timeout=1.0)
+                return iter(())
+
+            def close(self):
+                pass
+
+        request_client = object()
+
+        def _abort(client):
+            aborted.append(client)
+            release.set()
+            return 1
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.02
+        )
+        monkeypatch.setattr(
+            "agent.agent_runtime_helpers.force_close_tcp_sockets", _abort
+        )
+
+        started = time.monotonic()
+        with pytest.raises(TimeoutError, match="no-progress timeout"):
+            _aggregate_chat_stream(
+                _BlockedStream(), request_client=request_client, total_ceiling=1.0
+            )
+
+        assert time.monotonic() - started < 0.5
+        assert aborted == [request_client]
+
+    def test_substantive_chunks_rearm_no_progress_watchdog(self, monkeypatch):
+        monkeypatch.setattr(
+            "agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.04
+        )
+
+        class _SlowHealthyStream:
+            def __iter__(self):
+                for text in ("a", "b", "c"):
+                    time.sleep(0.025)
+                    yield _chunk(content=text)
+
+            def close(self):
+                pass
+
+        result = _aggregate_chat_stream(
+            _SlowHealthyStream(), request_client=object(), total_ceiling=1.0
+        )
+        assert result.choices[0].message.content == "abc"
+
+    def test_stream_attempt_uses_and_closes_request_local_client(self, monkeypatch):
+        cached_client = _FakeClient(stream_chunks=[])
+        local_client = _FakeClient(
+            stream_chunks=[_chunk(content="isolated", finish_reason="stop")]
+        )
+        closed = []
+        local_client.close = lambda: closed.append(True)
+        monkeypatch.setattr(
+            "agent.auxiliary_client._copy_request_local_streaming_client",
+            lambda client: (local_client, True),
+        )
+
+        with aux_progress_hook(lambda: None):
+            result = _create_with_progress(
+                cached_client, {"model": "m1", "messages": [], "timeout": 30}
+            )
+
+        assert cached_client.calls == []
+        assert local_client.calls[0]["stream"] is True
+        assert result.choices[0].message.content == "isolated"
         assert closed == [True]
 
 
@@ -482,6 +579,8 @@ class TestContentBearingProgress:
                 accumulator.feed(keepalive)
                 accumulator.feed(empty_role_chunk)
         # No substantive payload arrived: the fence must have stayed stale.
+        # Let coarse Windows monotonic clocks advance before observing age.
+        time.sleep(0.01)
         assert fence.seconds_since_progress() > 0.0
 
         with aux_progress_hook(fence.touch_progress):

--- a/tests/agent/test_fast_compression_lane.py
+++ b/tests/agent/test_fast_compression_lane.py
@@ -106,9 +106,11 @@ def test_summary_model_override_is_certified_against_the_effective_model():
 def test_compression_latency_records_delayed_first_provider_chunk():
     from agent.auxiliary_client import _notify_aux_progress, call_llm
 
+    now = [100.0]
+
     class _DelayedSemaphore:
         def acquire(self):
-            time.sleep(0.01)
+            now[0] += 0.01
 
         def release(self):
             pass
@@ -119,7 +121,7 @@ def test_compression_latency_records_delayed_first_provider_chunk():
     client.base_url = "http://127.0.0.1:11434/v1"
 
     def _chunks():
-        time.sleep(0.02)
+        now[0] += 0.02
         yield SimpleNamespace(
             id="chunk-1",
             model="qwen3:8b",
@@ -140,6 +142,7 @@ def test_compression_latency_records_delayed_first_provider_chunk():
     client.chat.completions.create.side_effect = lambda **_kwargs: _chunks()
 
     with (
+        patch("agent.auxiliary_client.time.monotonic", side_effect=lambda: now[0]),
         patch("agent.auxiliary_client._acquire_sync_aux_semaphore", return_value=_DelayedSemaphore()),
         patch("agent.auxiliary_client._get_cached_client", side_effect=_resolve_client),
     ):


### PR DESCRIPTION
## What does this PR do?

Compression can currently remain stuck until its full stream ceiling when a custom OpenAI-compatible endpoint stops producing chunks. This change gives each streamed auxiliary attempt its own connection pool and adds a progress-aware watchdog that aborts a silent request, allowing the existing retry and provider fallback chain to recover without poisoning the cached client.

### Symptom

Large-context compression can stop receiving stream chunks, emit transport errors such as `Bad file descriptor`, and remain blocked until the full auxiliary stream ceiling.

### Impact

Affected users cannot continue an oversized session until compression finishes or aborts. Reported stalls lasted up to approximately 3,800 seconds.

### Bug Cause

**Trigger:** `agent/auxiliary_client.py:_aggregate_chat_stream` while consuming a streamed compression response from an OpenAI-compatible endpoint.

**Causal chain:**
1. Compression enables auxiliary streaming so substantive chunks can refresh its progress fence.
2. `_aggregate_chat_stream` blocks inside the iterator when the endpoint stops sending chunks, so its existing ceiling check cannot run until another chunk arrives.
3. The stream uses the process-cached OpenAI client, so a failed transport can also leave stale sockets available to later auxiliary calls.

**Why it is wrong:** Timeout enforcement depended on receiving the next chunk, and streamed attempts did not own an isolated connection pool that could be safely aborted.

**Working sibling / contrast:** The Codex Responses adapter already uses a progress-aware timeout and transport-specific cleanup. The generic chat-completions auxiliary stream lacked equivalent recovery.

**Ruled out:** The existing total ceiling alone does not solve the stall because `_ChatStreamAccumulator.feed()` is only called after iterator progress.

### Fix

- Copy OpenAI clients with a fresh Hermes-configured httpx pool for each aggregated streaming attempt.
- Arm a 60-second first-token and between-token watchdog that re-arms only for substantive content, reasoning, or tool-call fragments.
- On expiry, shut down only the request-local sockets from the timer thread, then let the consuming thread close the stream and client.
- Normalize watchdog expiry to `TimeoutError` so the established same-provider retry and fallback logic remains the single recovery policy.

## Related Issue

Closes #100501

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/auxiliary_client.py` - isolate streamed attempts and recover first-token, mid-stream, and hard-ceiling stalls.
- `tests/agent/test_aux_progress_streaming.py` - cover request-local pools, watchdog aborts, progress re-arming, and owner-thread cleanup.

## How to Test

1. Run the targeted auxiliary client and streaming suites.
2. Confirm a blocked fake stream is released by request-local socket shutdown and raises a no-progress timeout.
3. Confirm slow streams with regular substantive chunks complete past one idle-window duration.

```bash
scripts/run_tests.sh tests/agent/test_aux_progress_streaming.py tests/agent/test_auxiliary_client.py -q
```

Result: 243 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

Not applicable. The automated test output is summarized above.
