### PR TITLE
fix(api): make runs session history fail closed

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -395,19 +395,19 @@ def _ensure_codex_session(agent) -> None:
     )
 
 
-def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> None:
+def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> bool:
     """Splice the projected messages into ``messages`` and flush them to the session DB.
 
     Bypasses conversation_loop's per-step _persist_session(); the flush dedups via _DB_PERSISTED_MARKER so
     only the new codex rows are written. The agent stays the sole persister (agent_persisted=True): a
     gateway re-write would re-INSERT the user turn."""
     if not turn.projected_messages:
-        return
+        return True
     from agent.message_metadata import append_message
     for projected_message in turn.projected_messages:
         append_message(messages, projected_message)
     if getattr(agent, "_session_db", None) is None:
-        return
+        return True
     flush_ok = False
     try:
         flush_ok = agent._flush_messages_to_session_db(messages)
@@ -417,6 +417,7 @@ def _persist_projected_messages(agent, turn, messages: List[Dict[str, Any]]) -> 
         # Output already streamed and agent_persisted cannot flip to False: surface the gap loudly.
         logger.warning("codex app-server turn was delivered but could NOT be persisted to the session DB "
                        "(session=%s) — this turn will be missing after restart/resume", getattr(agent, "session_id", None))
+    return flush_ok is not False
 
 
 def _finish_codex_turn(agent, turn, messages: List[Dict[str, Any]], *, original_user_message: Any,
@@ -469,7 +470,17 @@ def run_codex_app_server_turn(agent, *, user_message: str, original_user_message
     if getattr(turn, "should_retire", False):
         logger.warning("codex app-server session retired (turn error: %s)", turn.error)
         _close_codex_session(agent)
-    _persist_projected_messages(agent, turn, messages)
+    if not _persist_projected_messages(agent, turn, messages):
+        cause = getattr(agent, "_last_persistence_error_cause", None)
+        return _turn_result(
+            interrupt, messages, api_calls=1, completed=False,
+            error="Codex app-server turn could not be persisted to the session database.",
+            final_response="", failed=True,
+            failure_reason="session_persistence_failed:" + (cause or "unknown"),
+            # The inbound user row may already be durable. Never ask a gateway fallback to append
+            # the whole turn again.
+            agent_persisted=True,
+        )
     usage_result = _finish_codex_turn(
         agent, turn, messages, original_user_message=original_user_message, should_review_memory=should_review_memory,
     )

--- a/agent/turn_facade_lease.py
+++ b/agent/turn_facade_lease.py
@@ -242,12 +242,22 @@ def admit_durable_turn_lease(
     admission = TurnLeaseAdmission(conversation_history=conversation_history)
     if db is None or not session_id:
         return admission
+    server_history_authoritative = bool(
+        getattr(agent, "_reload_durable_history_after_lease", False)
+        and not getattr(agent, "_preserve_caller_history_on_lease_wait", False)
+    )
     # A fresh session id has no durable transcript to race over, and callers may supply an
     # in-memory seed before the row exists — reloading would erase it. Check the concrete type:
     # MagicMock-style shims accept any attribute without the protocol.
+    durable_session_exists = _durable_session_exists(db, session_id)
+    if server_history_authoritative and not durable_session_exists:
+        admission.early_result = _canonical_session_error(
+            session_id, conversation_history, unavailable=False
+        )
+        return admission
     if (
         getattr(agent, "_persist_disabled", False)
-        or not _durable_session_exists(db, session_id)
+        or not durable_session_exists
         or not callable(getattr(type(db), "acquire_session_turn_lease", None))
     ):
         return admission
@@ -281,17 +291,39 @@ def admit_durable_turn_lease(
     agent._active_session_turn_lease_holder = holder
     agent._active_session_turn_lease_ttl_seconds = LEASE_TTL_SECONDS
     try:
-        if waited:
-            agent._emit_status("Session is free; loading the latest transcript...")
-            # The holder may have compressed/rotated the session while we waited: reload only
-            # AFTER admission; an immediate acquisition skips this (needless prompt-cache miss).
+        refresh_history = waited or server_history_authoritative
+        if refresh_history:
+            if getattr(agent, "_preserve_caller_history_on_lease_wait", False):
+                agent._emit_status("Session is free; preserving caller-provided history...")
+            else:
+                agent._emit_status("Session is free; loading the latest transcript...")
+        if server_history_authoritative:
+            try:
+                canonical_session_still_exists = db.get_session(session_id) is not None
+            except Exception:
+                logger.warning("Could not revalidate canonical session after turn lease", exc_info=True)
+                lease.release()
+                admission.early_result = _canonical_session_error(
+                    session_id, conversation_history, unavailable=True
+                )
+                return admission
+            if not canonical_session_still_exists:
+                lease.release()
+                admission.early_result = _canonical_session_error(
+                    session_id, conversation_history, unavailable=False
+                )
+                return admission
+        if refresh_history:
+            # Another holder may append or rotate after an API handler's preload, including when it
+            # releases before our first acquire attempt. Resolve/reload only after admission.
             latest_session_id = db.resolve_resume_session_id(session_id)
             if latest_session_id:
                 agent.session_id = latest_session_id
                 task_context["session_id"] = latest_session_id
-            admission.conversation_history = db.get_messages_as_conversation(
-                agent.session_id, repair_alternation=True, include_row_ids=True
-            )
+            if not getattr(agent, "_preserve_caller_history_on_lease_wait", False):
+                admission.conversation_history = db.get_messages_as_conversation(
+                    agent.session_id, repair_alternation=True, include_row_ids=True
+                )
         lease.build_threads()
     except BaseException:
         # The façade never saw this lease; release here so an admitted row is not leaked.
@@ -299,6 +331,21 @@ def admit_durable_turn_lease(
         raise
     admission.lease = lease
     return admission
+
+
+def _canonical_session_error(
+    session_id: str, conversation_history, *, unavailable: bool
+) -> Dict[str, Any]:
+    reason = "unavailable" if unavailable else "no longer exists"
+    code = "session_db_unavailable" if unavailable else "session_not_found"
+    return {
+        "final_response": f"Canonical session {reason}; your message was not processed.",
+        "messages": list(conversation_history or []),
+        "api_calls": 0,
+        "completed": False,
+        "failed": True,
+        "error": f"{code}:{session_id}",
+    }
 
 
 def _lease_not_acquired_result(agent, session_id: str, conversation_history) -> Dict[str, Any]:

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -65,6 +65,7 @@ _BROWSER_CONTROL_PROTOCOL_VERSION = 1
 
 # /v1/capabilities static feature flags (order is part of the JSON shape).
 _STATIC_FEATURE_FLAGS = {
+    "runs_session_history": True,
     "run_status": True, "run_events_sse": True, "run_stop": True, "run_steer": True,
     "run_approval_response": True, "tool_progress_events": True, "approval_events": True,
     "session_resources": True, "model_options": True, "session_chat": True,
@@ -2732,6 +2733,27 @@ class APIServerAdapter(OpenAICompatRoutesMixin, BasePlatformAdapter):
         except Exception as exc:
             logger.warning("Failed to load session history for %s: %s", session_id, exc)
             return []
+
+    async def _conversation_history_for_existing_session(
+        self, session_id: str,
+    ) -> tuple[List[Dict[str, Any]], Optional["web.Response"]]:
+        """Load required canonical Runs history, failing before agent admission on uncertainty."""
+        try:
+            session, error = await self._get_existing_session_or_404(session_id)
+        except Exception as exc:
+            logger.warning("Failed to resolve session before run admission for %s: %s", session_id, exc)
+            return [], self._session_db_unavailable()
+        if error is not None:
+            return [], error
+        assert session is not None
+        db = await self._ensure_session_db_async()
+        if db is None:
+            return [], self._session_db_unavailable()
+        try:
+            return await asyncio.to_thread(db.get_messages_as_conversation, session_id), None
+        except Exception as exc:
+            logger.warning("Failed to load required run history for %s: %s", session_id, exc)
+            return [], self._session_db_unavailable()
 
     @_require_auth
     async def _handle_list_sessions(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -253,8 +253,9 @@ def _resolve_conversation_history(
     instructions = body.get("instructions")
     previous_response_id = body.get("previous_response_id")
     conversation_history: List[Dict[str, str]] = []
+    conversation_history_supplied = "conversation_history" in body
     raw_history = body.get("conversation_history")
-    if raw_history:
+    if conversation_history_supplied:
         if not isinstance(raw_history, list):
             return [], instructions, None, _json_error(
                 _openai_error, "'conversation_history' must be an array of message objects", status=400)
@@ -267,14 +268,21 @@ def _resolve_conversation_history(
         if previous_response_id:
             logger.debug("Both conversation_history and previous_response_id provided; using conversation_history")
     stored_session_id = None
-    if not conversation_history and previous_response_id:
+    if not conversation_history_supplied and not conversation_history and previous_response_id:
         stored = self._response_store.get(previous_response_id)
-        if stored:
-            conversation_history = list(stored.get("conversation_history", []))
-            stored_session_id = stored.get("session_id")
-            if instructions is None:
-                instructions = stored.get("instructions")
-    if not conversation_history and isinstance(raw_input, list) and len(raw_input) > 1:
+        if stored is None:
+            return [], instructions, None, _json_error(
+                _openai_error, f"Previous response not found: {previous_response_id}", status=404)
+        conversation_history = list(stored.get("conversation_history", []))
+        stored_session_id = stored.get("session_id")
+        if instructions is None:
+            instructions = stored.get("instructions")
+    if (
+        not conversation_history_supplied
+        and not conversation_history
+        and isinstance(raw_input, list)
+        and len(raw_input) > 1
+    ):
         for msg in raw_input[:-1]:
             if isinstance(msg, dict) and msg.get("role") and msg.get("content"):
                 content = msg["content"]
@@ -318,6 +326,8 @@ class _RunLaunch:
     declared_selected: bool
     user_message: str
     conversation_history: List[Dict[str, str]]
+    caller_history_authoritative: bool
+    server_history_authoritative: bool
     agent_kwargs: dict  # ``_create_agent`` keyword arguments (prompt, model overrides, route, room policy)
     request_profile: Any
     browser_control_principal: Any
@@ -395,7 +405,13 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     if history_err is not None:
         return history_err
     previous_response_id = body.get("previous_response_id")
+    caller_history_authoritative = bool(
+        "conversation_history" in body
+        or previous_response_id
+        or (isinstance(raw_input, list) and len(raw_input) > 1)
+    )
     session_id = body.get("session_id") or stored_session_id
+    server_history_authoritative = bool(session_id and not caller_history_authoritative)
     route = self._resolve_route(body.get("model"))
     agent_overrides = _api_server._request_agent_overrides(body, virtual_model=self._model_name)
     selection_error = self._request_route_conflict_error(
@@ -416,8 +432,17 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
     limited = self._concurrency_limited_response()
     if limited is not None:
         return limited
-    if not conversation_history and session_id and not previous_response_id:
-        conversation_history = await self._conversation_history_for_session(str(session_id))
+    if (
+        "conversation_history" not in body
+        and not conversation_history
+        and session_id
+        and not previous_response_id
+    ):
+        conversation_history, history_error = (
+            await self._conversation_history_for_existing_session(str(session_id))
+        )
+        if history_error is not None:
+            return history_error
     run_id = f"run_{uuid.uuid4().hex}"
     self._run_owners[run_id] = self._run_idempotency_scope(request)
     # Same precedence as /v1/responses: body session_id > response chain > X-Hermes-Session-Key
@@ -443,7 +468,7 @@ async def _handle_runs(self, request: "web.Request", *, _api_server) -> "web.Res
         self._run_idempotency_ids.add(run_id)
     launch = _RunLaunch(
         self, run_id, q, session_id, gateway_session_key, _declared_selected, user_message,
-        conversation_history,
+        conversation_history, caller_history_authoritative, server_history_authoritative,
         agent_kwargs=dict(
             ephemeral_system_prompt=instructions, session_id=session_id, gateway_session_key=gateway_session_key,
             route=route, room_dispatch=room_dispatch, room_execution_policy=room_execution_policy,
@@ -477,6 +502,13 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
     effective_task_id = session_id or run.run_id
     # (token, reset) pairs unwound in the finally block; bound only once each step succeeds.
     resets: list[tuple[Any, Callable]] = []
+    missing = object()
+    authority_attr = (
+        "_preserve_caller_history_on_lease_wait" if run.caller_history_authoritative
+        else "_reload_durable_history_after_lease" if run.server_history_authoritative
+        else None
+    )
+    previous_authority = agent.__dict__.get(authority_attr, missing) if authority_attr else missing
     with self._profile_scope(run.request_profile):
         try:
             # Contextvars, not process env: concurrent runs must not share identity.
@@ -496,12 +528,19 @@ def _run_agent_sync(self, run: _RunLaunch, agent, approval_notify, *, _api_serve
             # /v1/runs owns its agent lifecycle (no TurnRunner): record process ownership
             # so stop/cancel reaps only the background processes this run created.
             _api_server._publish_turn_process_ownership(agent, effective_task_id)
+            if authority_attr:
+                setattr(agent, authority_attr, True)
             r = agent.run_conversation(
                 user_message=run.user_message, conversation_history=run.conversation_history,
                 task_id=effective_task_id)
         finally:
             # Clear ownership now so a later stop can't reap work this run left running.
             _api_server._clear_turn_process_ownership(agent)
+            if authority_attr:
+                if previous_authority is missing:
+                    agent.__dict__.pop(authority_attr, None)
+                else:
+                    setattr(agent, authority_attr, previous_authority)
             # Declared-conversation binding, same precedence gate as _run_agent.
             if run.declared_selected:
                 self._bind_declared_conversation(

--- a/hermes_state_maintenance.py
+++ b/hermes_state_maintenance.py
@@ -95,6 +95,8 @@ class SessionMaintenanceMixin:
                       SELECT 1 FROM messages WHERE messages.session_id = sessions.id
                   )
             """, (cutoff,)).fetchall()]
+            ids = [sid for sid in ids if not self._write_guards_reject(
+                conn, sid, allow_closed_compression_parent=True)]
             if ids:
                 conn.execute(f"DELETE FROM sessions WHERE id IN ({_placeholders(ids)})", ids)
                 self._delete_unreferenced_system_prompts(conn)
@@ -280,6 +282,8 @@ class SessionMaintenanceMixin:
             if exclude_active_write_guards:
                 session_ids -= {sid for sid in session_ids
                                 if self._write_guards_reject(conn, sid, allow_closed_compression_parent=True)}
+            else:
+                self._check_session_delete_guards(conn, session_ids)
             if not session_ids:
                 return 0
             conn.execute(f"UPDATE sessions SET parent_session_id = NULL "

--- a/hermes_state_sessions.py
+++ b/hermes_state_sessions.py
@@ -1442,6 +1442,14 @@ class SessionSessionsMixin:
             delegate_ids = _collect_delegate_child_ids(conn, [session_id])
         return [session_id, *sorted(delegate_ids)]
 
+    def _check_session_delete_guards(self, conn, session_ids) -> None:
+        """Reject deletion under a live turn lease; reclaim stale holders in the delete txn."""
+        for sid in set(session_ids):
+            self._check_transcript_write_guards(
+                conn, sid, None, reject_active_turn_lease=True,
+                allow_closed_compression_parent=True,
+            )
+
     def delete_session(
         self, session_id: str, sessions_dir: Optional[Path] = None,
         expected_delete_ids: Optional[List[str]] = None,
@@ -1458,6 +1466,9 @@ class SessionSessionsMixin:
                 session_id, *_collect_delegate_child_ids(conn, [session_id])
             }:
                 return False
+            self._check_session_delete_guards(
+                conn, [session_id, *_collect_delegate_child_ids(conn, [session_id])]
+            )
             removed_ids.extend(_delete_delegate_children(conn, [session_id]))
             conn.execute(  # orphan remaining children (branches) so FK is satisfied
                 "UPDATE sessions SET parent_session_id = NULL WHERE parent_session_id = ?", (session_id,),
@@ -1476,6 +1487,24 @@ class SessionSessionsMixin:
         """Delete *session_id* only if it has no messages, no title and no children; check and delete
         share one transaction so a concurrent flush can't be lost."""
         def _do(conn):
+            candidate = conn.execute(
+                """
+                SELECT 1 FROM sessions
+                WHERE id = ?
+                  AND title IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM messages WHERE messages.session_id = sessions.id
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM sessions child
+                      WHERE child.parent_session_id = sessions.id
+                  )
+                """,
+                (session_id,),
+            ).fetchone()
+            if candidate is None:
+                return False
+            self._check_session_delete_guards(conn, [session_id])
             cursor = conn.execute(
                 """
                 DELETE FROM sessions
@@ -1513,6 +1542,9 @@ class SessionSessionsMixin:
             ).fetchall()]
             if not existing:
                 return 0
+            self._check_session_delete_guards(
+                conn, [*existing, *_collect_delegate_child_ids(conn, existing)]
+            )
             ph = _session_ids_placeholders(existing)
             removed_ids.extend(_delete_delegate_children(conn, existing))
             conn.execute(  # orphan children whose parent is in the kill list (FK)
@@ -1551,6 +1583,7 @@ class SessionSessionsMixin:
             ).fetchall()}
             if not session_ids:
                 return 0
+            self._check_session_delete_guards(conn, session_ids)
             conn.execute(
                 "UPDATE sessions SET parent_session_id = NULL "
                 f"WHERE parent_session_id IN ({_session_ids_placeholders(session_ids)})", list(session_ids),

--- a/tests/agent/test_codex_app_server_persist.py
+++ b/tests/agent/test_codex_app_server_persist.py
@@ -77,6 +77,27 @@ def test_codex_success_flushes_and_reports_persisted():
     assert result["agent_persisted"] is True
 
 
+def test_codex_projected_message_flush_failure_is_not_completed():
+    agent = _make_agent(session_db=MagicMock())
+    agent._flush_messages_to_session_db.return_value = False
+
+    result = run_codex_app_server_turn(
+        agent,
+        user_message="hello",
+        original_user_message="hello",
+        messages=[{"role": "user", "content": "hello"}],
+        effective_task_id="task-1",
+    )
+
+    assert result["completed"] is False
+    assert result["failed"] is True
+    assert result["failure_reason"].startswith("session_persistence_failed:")
+    assert "could not be persisted" in result["error"]
+    assert isinstance(result["messages"][-1]["timestamp"], float)
+    # With the agent as sole persister, the gateway must SKIP its DB write.
+    assert result["agent_persisted"] is True
+
+
 def test_codex_user_interrupt_is_reported_and_cleared():
     agent = _make_agent(session_db=None)
     turn = _make_turn()

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -875,6 +875,7 @@ class TestCapabilitiesEndpoint:
             assert data["features"]["chat_completions"] is True
             assert data["features"]["run_status"] is True
             assert data["features"]["run_events_sse"] is True
+            assert data["features"]["runs_session_history"] is True
             assert data["features"]["runs_idempotency"] == {
                 "supported": True,
                 "durable": True,

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -13,6 +13,7 @@ import asyncio
 import hashlib
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -27,6 +28,8 @@ from gateway.platforms.api_server import (
     cors_middleware,
     security_headers_middleware,
 )
+from hermes_state import SessionDB
+from run_agent import AIAgent
 from tools import approval as approval_mod
 from tools import approval_gateway_wait
 
@@ -138,6 +141,37 @@ def _make_slow_agent(**kwargs):
     return mock_agent, ready, interrupted
 
 
+def _make_production_codex_agent(db: SessionDB, session_id: str) -> AIAgent:
+    """Real AIAgent persistence with only the external Codex turn stubbed."""
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://openrouter.ai/api/v1",
+        api_mode="codex_app_server",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_db=db,
+        session_id=session_id,
+    )
+    agent._session_db_created = True
+    codex_session = MagicMock()
+    codex_session.run_turn.return_value = SimpleNamespace(
+        interrupted=False,
+        error=None,
+        thread_id="thread-api",
+        turn_id="turn-api",
+        projected_messages=[
+            {"role": "assistant", "content": "CODEX_API_ASSISTANT"}
+        ],
+        tool_iterations=0,
+        final_text="CODEX_API_ASSISTANT",
+        should_retire=False,
+    )
+    setattr(agent, "_codex_session", codex_session)
+    setattr(agent, "tool_progress_callback", None)
+    return agent
+
+
 @pytest.fixture
 def adapter():
     return _make_adapter()
@@ -205,12 +239,256 @@ class TestStartRun:
                 assert status["object"] == "hermes.run"
 
     @pytest.mark.asyncio
-    async def test_start_binds_chat_id_for_delegation_wake_target(self, adapter):
+    async def test_existing_body_session_must_exist_before_run_admission(
+        self, auth_adapter
+    ):
+        db = MagicMock()
+        db.get_session.return_value = None
+        auth_adapter._session_db = db
+        app = _create_runs_app(auth_adapter)
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "missing-session"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                payload = await response.json()
+
+        assert response.status == 404
+        assert payload["error"]["code"] == "session_not_found"
+        create_agent.assert_not_called()
+        assert auth_adapter._run_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_body_session_history_read_failure_blocks_run(self, auth_adapter):
+        db = MagicMock()
+        db.get_session.return_value = {"id": "broken-history"}
+        db.get_messages_as_conversation.side_effect = RuntimeError("db unreadable")
+        auth_adapter._session_db = db
+        app = _create_runs_app(auth_adapter)
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "broken-history"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                payload = await response.json()
+
+        assert response.status == 503
+        assert payload["error"]["code"] == "session_db_unavailable"
+        create_agent.assert_not_called()
+        assert auth_adapter._run_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_missing_previous_response_blocks_session_run_admission(
+        self, auth_adapter
+    ):
+        db = MagicMock()
+        db.get_session.return_value = {"id": "canonical-session"}
+        auth_adapter._session_db = db
+        auth_adapter._response_store.get = MagicMock(return_value=None)
+        app = _create_runs_app(auth_adapter)
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "canonical-session",
+                        "previous_response_id": "resp-missing",
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                payload = await response.json()
+
+        assert response.status == 404
+        assert "Previous response not found" in payload["error"]["message"]
+        create_agent.assert_not_called()
+        db.get_messages_as_conversation.assert_not_called()
+        assert auth_adapter._run_streams == {}
+
+    @pytest.mark.asyncio
+    async def test_explicit_empty_history_prevents_session_db_fallback(
+        self, auth_adapter
+    ):
+        db = MagicMock()
+        db.get_messages_as_conversation.side_effect = AssertionError(
+            "explicit empty history must remain authoritative"
+        )
+        auth_adapter._session_db = db
+        app = _create_runs_app(auth_adapter)
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            agent = MagicMock()
+            agent.run_conversation.return_value = {"final_response": "done"}
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+            create_agent.return_value = agent
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "caller-history",
+                        "conversation_history": [],
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+
+        assert response.status == 202
+        db.get_messages_as_conversation.assert_not_called()
+        assert agent.run_conversation.call_args.kwargs["conversation_history"] == []
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize("history_source", ["previous_response", "multi_input"])
+    async def test_explicit_empty_history_precedes_other_caller_sources(
+        self, auth_adapter, history_source
+    ):
+        auth_adapter._session_db = MagicMock()
+        app = _create_runs_app(auth_adapter)
+        body = {
+            "session_id": "caller-history",
+            "conversation_history": [],
+        }
+        if history_source == "previous_response":
+            body.update({"input": "hello", "previous_response_id": "resp-prior"})
+            auth_adapter._response_store.get = MagicMock(
+                return_value={
+                    "conversation_history": [
+                        {"role": "user", "content": "FROM_PREVIOUS"}
+                    ],
+                    "session_id": "caller-history",
+                }
+            )
+        else:
+            body["input"] = [
+                {"role": "user", "content": "FROM_INPUT"},
+                {"role": "user", "content": "hello"},
+            ]
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            agent = MagicMock()
+            agent.run_conversation.return_value = {"final_response": "done"}
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+            create_agent.return_value = agent
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json=body,
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if agent.run_conversation.called:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert agent.run_conversation.call_args.kwargs["conversation_history"] == []
+
+    @pytest.mark.asyncio
+    async def test_explicit_history_marks_agent_authority_for_lease_wait(
+        self, auth_adapter
+    ):
+        auth_adapter._session_db = MagicMock()
+        app = _create_runs_app(auth_adapter)
+        observed = {}
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            agent = MagicMock()
+
+            def capture_authority(**_kwargs):
+                observed["authoritative"] = getattr(
+                    agent,
+                    "_preserve_caller_history_on_lease_wait",
+                    False,
+                )
+                return {"final_response": "done"}
+
+            agent.run_conversation.side_effect = capture_authority
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+            create_agent.return_value = agent
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={
+                        "input": "hello",
+                        "session_id": "caller-history",
+                        "conversation_history": [],
+                    },
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if "authoritative" in observed:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert observed == {"authoritative": True}
+        assert "_preserve_caller_history_on_lease_wait" not in agent.__dict__
+
+    @pytest.mark.asyncio
+    async def test_server_history_marks_agent_for_post_lease_reload(
+        self, auth_adapter, tmp_path
+    ):
+        db = SessionDB(tmp_path / "post-lease-reload.db")
+        db.create_session("canonical-session", "api_server")
+        db.append_message("canonical-session", "user", "stale API preload")
+        auth_adapter._session_db = db
+        app = _create_runs_app(auth_adapter)
+        observed = {}
+
+        with patch.object(auth_adapter, "_create_agent") as create_agent:
+            agent = MagicMock()
+
+            def capture_reload(**_kwargs):
+                observed["reload"] = getattr(
+                    agent,
+                    "_reload_durable_history_after_lease",
+                    False,
+                )
+                return {"final_response": "done"}
+
+            agent.run_conversation.side_effect = capture_reload
+            agent.session_prompt_tokens = 0
+            agent.session_completion_tokens = 0
+            agent.session_total_tokens = 0
+            create_agent.return_value = agent
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": "canonical-session"},
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert response.status == 202
+                for _ in range(40):
+                    if "reload" in observed:
+                        break
+                    await asyncio.sleep(0.01)
+
+        assert observed == {"reload": True}
+        assert "_reload_durable_history_after_lease" not in agent.__dict__
+
+    @pytest.mark.asyncio
+    async def test_start_binds_chat_id_for_delegation_wake_target(
+        self, adapter, tmp_path
+    ):
         """/v1/runs must bind the raw session id as the api_server chat_id
         (like every other agent-entry route does via _run_agent): the async
         delegation dispatch reads HERMES_SESSION_CHAT_ID to pick its wake
         self-post target, and an empty binding forces background delegations
         on this route back to synchronous execution."""
+        adapter._session_db = SessionDB(tmp_path / "wake-target.db")
+        adapter._session_db.create_session("runs-raw-sid", "api_server")
         app = _create_runs_app(adapter)
         captured = {}
 
@@ -317,6 +595,83 @@ class TestStartRun:
         assert kwargs["requested_provider"] == "minimax"
         assert kwargs["model_options"] == model_options
 
+    @pytest.mark.asyncio
+    async def test_production_codex_turn_persists_for_restart_followup(self, tmp_path):
+        state_path = tmp_path / "state.db"
+        headers = {"Authorization": "Bearer sk-secret"}
+
+        first_adapter = _make_adapter(api_key="sk-secret")
+        first_db = SessionDB(state_path)
+        first_adapter._session_db = first_db
+        session_id = first_db.create_session("runs continuity", "api_server")
+        first_app = _create_runs_app(first_adapter)
+        async with TestClient(TestServer(first_app)) as cli:
+            with patch.object(
+                first_adapter,
+                "_create_agent",
+                side_effect=lambda **kwargs: _make_production_codex_agent(
+                    first_db, kwargs["session_id"]
+                ),
+            ):
+                started = await cli.post(
+                    "/v1/runs",
+                    json={"input": "turn one", "session_id": session_id},
+                    headers=headers,
+                )
+                assert started.status == 202
+                run_id = (await started.json())["run_id"]
+                status = None
+                for _ in range(80):
+                    status_response = await cli.get(
+                        f"/v1/runs/{run_id}", headers=headers
+                    )
+                    status = await status_response.json()
+                    if status["status"] in {"completed", "failed", "cancelled"}:
+                        break
+                    await asyncio.sleep(0.05)
+                assert status is not None
+                assert status["status"] == "completed", status
+
+        first_db.close()
+        first_adapter._session_db = None
+
+        second_adapter = _make_adapter(api_key="sk-secret")
+        second_db = SessionDB(state_path)
+        second_adapter._session_db = second_db
+        second_app = _create_runs_app(second_adapter)
+        try:
+            with patch.object(second_adapter, "_create_agent") as create_agent:
+                agent = MagicMock()
+                agent.run_conversation.return_value = {"final_response": "done"}
+                agent.session_prompt_tokens = 0
+                agent.session_completion_tokens = 0
+                agent.session_total_tokens = 0
+                create_agent.return_value = agent
+                async with TestClient(TestServer(second_app)) as cli:
+                    followup = await cli.post(
+                        "/v1/runs",
+                        json={"input": "turn two", "session_id": session_id},
+                        headers=headers,
+                    )
+                    assert followup.status == 202
+                    for _ in range(80):
+                        if agent.run_conversation.called:
+                            break
+                        await asyncio.sleep(0.05)
+
+            assert agent.run_conversation.called
+            loaded = agent.run_conversation.call_args.kwargs["conversation_history"]
+            assert [
+                (message["role"], message["content"])
+                for message in loaded
+            ] == [
+                ("user", "turn one"),
+                ("assistant", "CODEX_API_ASSISTANT"),
+            ]
+        finally:
+            second_db.close()
+            second_adapter._session_db = None
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id} — poll run status
@@ -326,7 +681,9 @@ class TestStartRun:
 class TestRunStatus:
 
     @pytest.mark.asyncio
-    async def test_status_reflects_explicit_session_id(self, adapter):
+    async def test_status_reflects_explicit_session_id(self, adapter, tmp_path):
+        adapter._session_db = SessionDB(tmp_path / "status-session.db")
+        adapter._session_db.create_session("space-session", "api_server")
         app = _create_runs_app(adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(adapter, "_create_agent") as mock_create:
@@ -390,10 +747,62 @@ class TestRunEvents:
                 assert "run.completed" in body
                 assert "Hello!" in body
 
+    @pytest.mark.asyncio
+    async def test_codex_persistence_failure_emits_failed_without_completed(
+        self, auth_adapter, tmp_path
+    ):
+        db = SessionDB(tmp_path / "codex-failure.db")
+        auth_adapter._session_db = db
+        session_id = db.create_session(
+            "codex persistence failure",
+            "api_server",
+        )
+        agent = _make_production_codex_agent(auth_adapter._session_db, session_id)
+        real_flush = agent._flush_messages_to_session_db
+
+        def fail_projected_assistant(messages, conversation_history=None):
+            if any(
+                isinstance(message, dict)
+                and message.get("content") == "CODEX_API_ASSISTANT"
+                for message in messages
+            ):
+                return False
+            return real_flush(messages, conversation_history)
+
+        agent._flush_messages_to_session_db = fail_projected_assistant
+        app = _create_runs_app(auth_adapter)
+        headers = {"Authorization": "Bearer sk-secret"}
+
+        with patch.object(auth_adapter, "_create_agent", return_value=agent):
+            async with TestClient(TestServer(app)) as cli:
+                response = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "session_id": session_id},
+                    headers=headers,
+                )
+                run_id = (await response.json())["run_id"]
+                events = await cli.get(
+                    f"/v1/runs/{run_id}/events",
+                    headers=headers,
+                )
+                body = await events.text()
+
+        assert body.count('"run.failed"') == 1
+        assert '"run.completed"' not in body
+        assert "session database" in body
+        durable = auth_adapter._session_db.get_messages_as_conversation(session_id)
+        assert [(message["role"], message["content"]) for message in durable] == [
+            ("user", "hello"),
+        ]
+
 
     @pytest.mark.asyncio
-    async def test_approval_resolve_all_is_scoped_to_target_run(self, auth_adapter):
+    async def test_approval_resolve_all_is_scoped_to_target_run(
+        self, auth_adapter, tmp_path
+    ):
         """Same client session_id must not let one run approve another run's queue."""
+        auth_adapter._session_db = SessionDB(tmp_path / "approval-session.db")
+        auth_adapter._session_db.create_session("shared-project", "api_server")
         app = _create_runs_app(auth_adapter)
         async with TestClient(TestServer(app)) as cli:
             with patch.object(auth_adapter, "_create_agent") as mock_create:

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -127,6 +127,112 @@ def test_run_conversation_acquires_then_reloads_latest_tip(monkeypatch):
     )
 
 
+def test_contended_lease_preserves_explicit_caller_history(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    setattr(agent, "_preserve_caller_history_on_lease_wait", True)
+
+    def acquire_with_wait(session_id, holder, **kwargs):
+        db.events.append(("acquire", session_id, holder))
+        kwargs["on_wait"](0.0)
+        return True
+
+    db.acquire_session_turn_lease = acquire_with_wait
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    explicit = []
+
+    AIAgent.run_conversation(agent, "new message", conversation_history=explicit)
+
+    assert observed == {"history": explicit, "session_id": "compressed-tip"}
+    assert [event[0] for event in db.events] == ["acquire", "resolve", "release"]
+
+
+def test_server_history_reloads_after_immediate_lease_admission(monkeypatch):
+    db = _DB()
+    agent = _agent_with_db(db)
+    setattr(agent, "_reload_durable_history_after_lease", True)
+    observed = {}
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        observed["history"] = history
+        observed["session_id"] = _agent.session_id
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale API preload"}],
+    )
+
+    assert observed == {
+        "history": [{"role": "user", "content": "durable latest"}],
+        "session_id": "compressed-tip",
+    }
+    assert [event[0] for event in db.events] == [
+        "acquire",
+        "resolve",
+        "reload",
+        "release",
+    ]
+
+
+def test_server_history_fails_if_session_is_deleted_before_lease_admission(
+    monkeypatch,
+):
+    db = _DB()
+    probes = iter(({"id": "stale-parent"}, None))
+    db.get_session = lambda session_id: next(probes)
+    agent = _agent_with_db(db)
+    setattr(agent, "_reload_durable_history_after_lease", True)
+
+    def must_not_run(*_args, **_kwargs):
+        raise AssertionError("deleted canonical session must not reach model work")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", must_not_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale API preload"}],
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["error"] == "session_not_found:stale-parent"
+    assert [event[0] for event in db.events] == ["acquire", "release"]
+
+
+def test_server_history_fails_if_session_is_deleted_before_initial_probe(monkeypatch):
+    db = _DB(session_exists=False)
+    agent = _agent_with_db(db)
+    setattr(agent, "_reload_durable_history_after_lease", True)
+
+    def must_not_run(*_args, **_kwargs):
+        raise AssertionError("deleted canonical session must not reach model work")
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", must_not_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale API preload"}],
+    )
+
+    assert result["failed"] is True
+    assert result["completed"] is False
+    assert result["error"] == "session_not_found:stale-parent"
+    assert db.events == []
+
+
 def test_run_conversation_acquires_lease_when_session_probe_raises(monkeypatch):
     """A locked / non-WAL get_session must not skip the durable lease."""
     db = _DB()

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 import threading
 import time
 from types import SimpleNamespace
 
+import pytest
+
 from agent import relay_runtime
 from hermes_state import SessionDB
+from hermes_state_errors import SessionTurnLeaseLostError
 from run_agent import AIAgent
 
 
@@ -209,6 +213,74 @@ def test_server_history_fails_if_session_is_deleted_before_lease_admission(
     assert result["completed"] is False
     assert result["error"] == "session_not_found:stale-parent"
     assert [event[0] for event in db.events] == ["acquire", "release"]
+
+
+@pytest.mark.parametrize("delete_stage", ["post_probe", "history_read", "model_work"])
+def test_live_turn_lease_fences_deletion_through_model_work(
+    tmp_path, monkeypatch, delete_stage
+):
+    """A delete racing any post-admission stage never removes or recreates the session."""
+    path = tmp_path / "state.db"
+    db = SessionDB(path)
+    deleting_db = SessionDB(path)
+    db.create_session("canonical", source="desktop")
+    db.append_message("canonical", role="user", content="durable history")
+    original_started_at = db.get_session("canonical")["started_at"]
+    agent = _agent_with_db(db, session_id="canonical")
+    setattr(agent, "_reload_durable_history_after_lease", True)
+    delete_errors = []
+    model_calls = []
+
+    def attempt_delete():
+        try:
+            deleting_db.delete_session("canonical")
+        except SessionTurnLeaseLostError as exc:
+            delete_errors.append(exc)
+
+    original_get_session = db.get_session
+    probe_count = 0
+
+    def get_session(session_id):
+        nonlocal probe_count
+        probe_count += 1
+        row = original_get_session(session_id)
+        if delete_stage == "post_probe" and probe_count == 2:
+            attempt_delete()
+        return row
+
+    original_history_read = db.get_messages_as_conversation
+
+    def get_history(session_id, **kwargs):
+        if delete_stage == "history_read":
+            attempt_delete()
+        return original_history_read(session_id, **kwargs)
+
+    db.get_session = get_session
+    db.get_messages_as_conversation = get_history
+
+    def fake_run(_agent, _message, _system, history, *_args, **_kwargs):
+        if delete_stage == "model_work":
+            attempt_delete()
+        session = deleting_db.get_session("canonical")
+        model_calls.append(session is not None)
+        return {"final_response": "ok", "messages": history, "failed": False}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+
+    result = AIAgent.run_conversation(
+        agent,
+        "new message",
+        conversation_history=[{"role": "user", "content": "stale preload"}],
+    )
+
+    assert result["final_response"] == "ok"
+    assert len(delete_errors) == 1
+    assert model_calls == [True]
+    surviving = deleting_db.get_session("canonical")
+    assert surviving is not None
+    assert surviving["started_at"] == original_started_at
+    assert deleting_db.delete_session("canonical") is True
+    assert deleting_db.get_session("canonical") is None
 
 
 def test_server_history_fails_if_session_is_deleted_before_initial_probe(monkeypatch):

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -148,6 +148,9 @@ def test_direct_session_db_flushes_share_marker_claim(agent):
                 self.rows.append(m["content"])
             return list(range(1, len(messages) + 1))
 
+        def flush_token_counts(self):
+            pass
+
     db = _BarrierDB()
     agent._session_db = db
     agent._session_db_created = True

--- a/tests/state/test_session_turn_lease.py
+++ b/tests/state/test_session_turn_lease.py
@@ -54,6 +54,54 @@ def test_turn_lease_serializes_separate_session_db_instances(tmp_path):
     second.release_session_turn_lease("shared", second_holder)
 
 
+@pytest.mark.parametrize(
+    ("delete", "raises_busy"),
+    [
+        (lambda db: db.delete_session("shared"), True),
+        (lambda db: db.delete_sessions(["shared"]), True),
+        (lambda db: db.delete_session_if_empty("shared"), True),
+        (lambda db: db.delete_empty_sessions(), True),
+        (lambda db: db.prune_sessions(older_than_days=None, include_pinned=True), True),
+        (lambda db: db.prune_empty_ghost_sessions(), False),
+    ],
+    ids=["single", "bulk", "if-empty", "empty-sweep", "prune", "ghost-sweep"],
+)
+def test_destructive_session_paths_fence_live_turn_leases_and_reclaim_stale(
+    tmp_path, delete, raises_busy
+):
+    """Every session-row delete shares the durable turn's admission fence."""
+    path = tmp_path / "state.db"
+    owner = SessionDB(path)
+    deleter = SessionDB(path)
+    old = time.time() - 2 * 86400
+    owner.create_session("shared", source="tui")
+    owner.end_session("shared", "test")
+    owner._conn.execute(
+        "UPDATE sessions SET started_at = ?, ended_at = ? WHERE id = ?",
+        (old, old, "shared"),
+    )
+    owner._conn.commit()
+    holder = f"pid={os.getpid()}:turn=live"
+    assert owner.try_acquire_session_turn_lease("shared", holder, ttl_seconds=30)
+
+    if raises_busy:
+        with pytest.raises(SessionTurnLeaseLostError):
+            delete(deleter)
+    else:
+        assert delete(deleter) == 0
+    assert deleter.get_session("shared") is not None
+
+    owner._conn.execute(
+        "UPDATE session_turn_leases SET expires_at = ? WHERE conversation_id = ?",
+        (time.time() - 1, "shared"),
+    )
+    owner._conn.commit()
+
+    assert delete(deleter)
+    assert deleter.get_session("shared") is None
+    assert not owner.refresh_session_turn_lease("shared", holder, ttl_seconds=30)
+
+
 def test_turn_lease_is_scoped_to_conversation_root(tmp_path):
     """Compression descendants share one durable serialization domain."""
     db = SessionDB(tmp_path / "state.db")

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -250,6 +250,7 @@ Returns a machine-readable description of the API server's stable surface for ex
     "chat_completions": true,
     "responses_api": true,
     "run_submission": true,
+    "runs_session_history": true,
     "run_status": true,
     "run_events_sse": true,
     "run_stop": true
@@ -258,6 +259,20 @@ Returns a machine-readable description of the API server's stable surface for ex
 ```
 
 Use this endpoint when integrating dashboards, browser UIs, or control planes so they can discover whether the running Hermes version supports runs, streaming, cancellation, and session continuity without depending on private Python internals.
+
+`runs_session_history` means that an authenticated `POST /v1/runs` with an
+existing body `session_id` loads that session's canonical server-side history
+when the request supplies no stronger history source, and a successful turn is
+persisted back to the same session. A later run can therefore continue the
+conversation after an API-server restart without the client reconstructing or
+resending the transcript.
+
+This flag describes Hermes's canonical SessionDB load/persist contract. The
+`codex_app_server` runtime also owns a separate provider-native thread; restoring
+that provider thread from SessionDB after a process restart is not yet covered
+by this capability. Clients that require model-visible restart continuity must
+use a runtime that consumes the supplied conversation history, or wait for
+durable Codex `thread/resume` integration.
 
 ## Browser-extension control
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/features/api-server.md
@@ -212,6 +212,7 @@ OpenAI Responses API 格式。通过 `previous_response_id` 支持服务端对�
     "chat_completions": true,
     "responses_api": true,
     "run_submission": true,
+    "runs_session_history": true,
     "run_status": true,
     "run_events_sse": true,
     "run_stop": true
@@ -220,6 +221,16 @@ OpenAI Responses API 格式。通过 `previous_response_id` 支持服务端对�
 ```
 
 在集成仪表板、浏览器 UI 或控制平面时使用此端点，以便它们能够发现当前运行的 Hermes 版本是否支持 runs、流式传输、取消和 session 连续性，而无需依赖私有 Python 内部实现。
+
+`runs_session_history` 表示：经过身份验证的 `POST /v1/runs` 在请求体中提供
+已有的 `session_id`，且请求没有提供优先级更高的历史来源时，会加载该会话的
+规范服务端历史；成功的轮次也会持久化回同一会话。因此，即使 API 服务器重启，
+后续 run 仍可继续该对话，客户端无需自行重建或重新发送完整记录。
+
+该标志描述 Hermes 规范 SessionDB 的加载/持久化契约。`codex_app_server`
+运行时还拥有独立的提供方原生线程；进程重启后从 SessionDB 恢复该线程尚不属于
+此能力的保证范围。需要模型可见重启连续性的客户端必须使用会消费所提供会话历史的
+运行时，或等待持久化 Codex `thread/resume` 集成。
 
 ### GET /health
 


### PR DESCRIPTION
## Summary

Completes the server-owned `/v1/runs` session-history contract already partially present on current `main`, then advertises it for external clients as `features.runs_session_history`.

A real consumer is waiting on this contract: Knosence9/Prano#282 needs accepted runs plus separately subscribable SSE while Hermes—not Android—owns canonical conversation history.

## What changed

- Require a body `session_id` continuation to name an existing SessionDB session.
- Reject an unresolved `previous_response_id` before it can suppress canonical history.
- Return controlled `404 session_not_found` or `503 session_db_unavailable` before admitting agent work when required canonical history cannot be loaded.
- Preserve explicit `conversation_history` field presence, including `[]`, ahead of SessionDB, `previous_response_id`, and multi-message-input fallbacks, including after a contended durable-lease wait.
- Re-resolve and reload server-owned SessionDB history after lease admission, closing the release-before-first-acquire stale-preload race.
- Revalidate canonical session existence before and after durable lease admission so concurrent deletion cannot run from stale preloaded history or recreate the deleted session.
- Convert a failed Codex projected-message flush into a structured persistence failure rather than reporting `run.completed` for a turn missing after restart.
- Advertise and document `features.runs_session_history` only after restart-spanning and failure-path coverage.

## TDD and verification

RED regressions first proved:

- missing body session previously returned 202;
- an unknown `previous_response_id` previously returned 202 and bypassed canonical history;
- deleting a canonical session before either AIAgent admission probe previously allowed stale model work;
- required history-read failure previously returned 202 with empty history;
- explicit `conversation_history: []` was overridden by SessionDB, response-chain, and multi-input histories;
- Codex projected-message flush failure previously still returned completed;
- the capability was absent.

Current exact candidate:

```text
202 relevant tests passed
Ruff: passed
git diff --check: passed
```

The restart test crosses `POST /v1/runs`, a real `AIAgent` Codex persistence path with only external Codex I/O stubbed, closes/reopens the same SQLite database, creates a new adapter/server, and proves the next handler receives the first turn's canonical SessionDB history.

This capability covers canonical SessionDB load/persist. Codex app-server also owns a separate provider-native thread; model-visible restart continuity for that runtime remains excluded pending durable `thread/resume`.

## Compatibility and risk

- Request/response route shapes are unchanged.
- Clients that omit body `session_id` keep existing one-off behavior.
- Explicit caller-owned history remains supported and authoritative.
- Existing best-effort history helper remains unchanged for compatibility callers; only explicit server-owned Runs continuation is fail-closed.
- A Codex durability failure may have already streamed deltas, but the terminal event is now honestly `run.failed`, never `run.completed`.

## Related

- Addresses #69204
- Addresses #84406
- Supersedes the remaining current-main gap discussed in #69205 after newer session-loading and agent persistence work landed independently.
- Follow-up #100531 tracks durable Codex app-server `thread/resume` for model-visible restart continuity.