### PR TITLE
fix(streaming): superseded streams keep their completion marker — no more false drops (#94614, salvage #94625)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -4130,6 +4130,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                     provider_tool_in_flight["yes"] = True
             except Exception:
                 pass
+            # Payload-empty terminal chunk: the provider completed the
+            # stream (`finish_reason` set, no further writable delta). The
+            # attempt/writer fence exists to stop a superseded stream from
+            # writing *more* text. Fending this marker-only chunk discards
+            # the only completion signal, which the drop-guard then
+            # mislabels as a mid-stream drop. A finish chunk that still
+            # carries content/tool_calls remains gated.
+            try:
+                _choices = getattr(_chunk, "choices", None)
+                if _choices:
+                    _choice = _choices[0]
+                    if getattr(_choice, "finish_reason", None):
+                        _delta = getattr(_choice, "delta", None)
+                        _has_write = bool(
+                            getattr(_delta, "content", None)
+                            or getattr(_delta, "tool_calls", None)
+                            or getattr(_delta, "reasoning_content", None)
+                            or getattr(_delta, "reasoning", None)
+                        )
+                        if not _has_write:
+                            return True
+            except Exception:
+                pass
             if not _stream_attempt_is_active(stream_attempt_id):
                 return False
             token = _writer_token["value"]

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -91,6 +91,95 @@ class TestPartialStreamStubFinishReason:
         assert response.choices[0].message.tool_calls is None
 
 
+class TestTerminalChunkFenceException:
+    """A superseded writer must still accept the provider's terminal
+    finish_reason chunk. Fending that chunk leaves finish_reason None
+    after real text was delivered, which the drop-guard mislabels as a
+    mid-stream drop even though the provider completed the stream.
+    """
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_superseded_writer_accepts_finish_reason_chunk(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent_box = {}
+
+        class SupersedeBeforeFinish:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                yield _make_stream_chunk(content="Long prose that is complete.")
+                agent_box["agent"]._claim_stream_writer()
+                # Marker-only terminal chunk (empty delta), as vLLM emits.
+                yield _make_stream_chunk(finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SupersedeBeforeFinish()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent_box["agent"] = agent
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == "stop"
+        assert response.choices[0].message.content == "Long prose that is complete."
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_superseded_writer_still_fences_further_content(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+        agent_box = {}
+
+        class SupersedeBeforeMoreText:
+            response = SimpleNamespace(headers={})
+
+            def __iter__(self):
+                yield _make_stream_chunk(content="kept ")
+                agent_box["agent"]._claim_stream_writer()
+                # A False accept_chunk ends consumption; this text must
+                # never reach the accumulator, and the later finish chunk
+                # is never seen (the fence still stops *further* content).
+                yield _make_stream_chunk(content="must-not-append")
+                yield _make_stream_chunk(finish_reason="stop")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.return_value = SupersedeBeforeMoreText()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        agent_box["agent"] = agent
+        response = agent._interruptible_streaming_api_call({})
+
+        content = response.choices[0].message.content or ""
+        assert "must-not-append" not in content
+        assert "kept" in content
+        assert response.id == PARTIAL_STREAM_STUB_ID
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_genuine_truncation_without_finish_still_drops(
+        self, _mock_close, mock_create, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")
+
+        def _truncated():
+            yield _make_stream_chunk(content="cut off with no terminal chunk")
+
+        mock_client = MagicMock()
+        mock_client.chat.completions.create.side_effect = lambda *a, **kw: _truncated()
+        mock_create.return_value = mock_client
+
+        agent = _make_agent()
+        response = agent._interruptible_streaming_api_call({})
+
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+
 
 # ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
 


### PR DESCRIPTION
## Summary
A superseded stream writer now still accepts the provider's marker-only terminal chunk, so a complete response is no longer relabeled a mid-stream drop when supersession lands between the last content delta and the finish chunk. Closes the remaining half of #94614 — salvage of #94625 (@rainbowgore), complementing the loop-body fixes merged in #100515.

Root cause: the single-writer fence in `_accept_stream_chunk` rejects every chunk once a newer stream claims the writer token. That is correct for content (a stale stream must not append text), but the marker-only `finish_reason` chunk carries no writable payload — fending it discards the stream's only completion signal, and the drop-guard then flags delivered-and-complete text as truncated.

## Changes
- `agent/chat_completion_helpers.py`: in `_accept_stream_chunk`, accept a chunk whose `finish_reason` is set **and** whose delta carries no content/tool_calls/reasoning; finish chunks that still carry payload remain gated
- Tests: superseded writer accepts marker-only finish (fails on main — sabotage-verified); superseded writer still fences further content; genuine truncation without a terminal chunk still returns the partial-stream stub

## Validation
| | Before (main) | After |
|---|---|---|
| Marker-only finish after supersession | partial-stream stub (false drop) | `finish_reason=stop`, content intact |
| Content chunk after supersession | fenced | fenced (unchanged) |
| Real truncation, no terminal chunk | partial-stream stub | partial-stream stub (unchanged) |
| `test_partial_stream_finish_reason.py` | — | 25/25 pass |

**Live repro:** mock stream delivering complete prose, then `_claim_stream_writer()` supersession, then a marker-only `finish_reason:stop` chunk — before: response comes back as `PARTIAL_STREAM_STUB_ID`; after: clean stop with full content. Negative controls (stale content still fenced, genuine truncation still stubbed) verified both ways.

Note: competing PR #94624 (@fangliquanflq) covers the same trigger with a wider contract (also accepts finish-bearing chunks carrying payload + suppresses their callbacks). We took the narrower fence exception: stale payload stays discarded, only the completion marker survives.

## Infographic

![Terminal chunk crosses the fence](https://v3b.fal.media/files/b/0aa8b40b/MkhJdjyhON1777yxIu3fp_3At3Hlhz.png)
