### PR TITLE
fix(tools): persist managed "nous" pin for per-capability web picks

### DIFF
--- a/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.test.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
-import { cleanup, fireEvent, render as rtlRender, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render as rtlRender, screen, waitFor, within } from '@testing-library/react'
 import type { ReactElement } from 'react'
 import { MemoryRouter } from 'react-router'
 import type * as ReactRouterDom from 'react-router'
@@ -1068,6 +1068,93 @@ describe('ToolsetConfigPanel', () => {
       await screen.findByText('Microsoft Edge TTS')
       expect(screen.queryByText(/^Search: /)).toBeNull()
       expect(screen.queryByRole('button', { name: 'Use for Search' })).toBeNull()
+    })
+
+    it('lights only the managed row for a stored nous pin, not the BYOK rows sharing the vendor string', async () => {
+      // The managed Nous Subscription row and the BYOK Firecrawl row both
+      // carry web_backend 'firecrawl'; the stored 'nous' pin must match the
+      // managed row (via managed_nous_feature) and only that one.
+      getToolsetConfig.mockResolvedValue(
+        webConfig({
+          active_provider: 'Nous Subscription',
+          active_extract_backend: 'nous',
+          providers: [
+            {
+              name: 'Nous Subscription',
+              badge: 'subscription',
+              tag: 'Managed Firecrawl billed to your subscription',
+              env_vars: [],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: true,
+              status: 'ready',
+              web_backend: 'firecrawl',
+              capabilities: ['search', 'extract'],
+              managed_nous_feature: 'web'
+            },
+            {
+              name: 'Firecrawl Self-Hosted',
+              badge: 'free · self-hosted',
+              tag: 'Run your own Firecrawl instance',
+              env_vars: [],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'ready',
+              web_backend: 'firecrawl',
+              capabilities: ['search', 'extract']
+            }
+          ]
+        })
+      )
+
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
+
+      // Badges show the stored pin as reported by the endpoint.
+      expect(await screen.findByText('Extract: nous')).toBeTruthy()
+      // Exactly one "Extract backend" pill: on the managed row. The BYOK row
+      // sharing web_backend 'firecrawl' must stay dark.
+      expect(screen.getAllByText('Extract backend')).toHaveLength(1)
+      const managedRow = screen.getByRole('button', { name: /Nous Subscription/ })
+      expect(within(managedRow).getByText('Extract backend')).toBeTruthy()
+      const byokRow = screen.getByRole('button', { name: /Firecrawl Self-Hosted/ })
+      expect(within(byokRow).queryByText('Extract backend')).toBeNull()
+    })
+
+    it('mirrors the nous pin (not the vendor string) after a capability pick on the managed row', async () => {
+      getToolsetConfig.mockResolvedValue(
+        webConfig({
+          providers: [
+            {
+              name: 'Nous Subscription',
+              badge: 'subscription',
+              tag: 'Managed Firecrawl billed to your subscription',
+              env_vars: [],
+              post_setup: null,
+              requires_nous_auth: false,
+              is_active: false,
+              status: 'ready',
+              web_backend: 'firecrawl',
+              capabilities: ['search', 'extract'],
+              managed_nous_feature: 'web'
+            }
+          ]
+        })
+      )
+      selectToolsetProvider.mockResolvedValue({ ok: true, name: 'web', provider: 'Nous Subscription', capability: 'extract' })
+
+      const { ToolsetConfigPanel } = await import('./toolset-config-panel')
+      render(<ToolsetConfigPanel onConfiguredChange={vi.fn()} toolset="web" />)
+
+      // The sole provider row is auto-expanded by the panel's initializer —
+      // clicking it again would toggle it shut.
+      fireEvent.click(await screen.findByRole('button', { name: 'Use for Extract' }))
+
+      await waitFor(() => expect(selectToolsetProvider).toHaveBeenCalledWith('web', 'Nous Subscription', 'extract'))
+      // The optimistic badge mirrors the persisted 'nous' pin — writing the
+      // vendor 'firecrawl' here would light the BYOK rows until a refetch.
+      await waitFor(() => expect(screen.getByText('Extract: nous')).toBeTruthy())
     })
   })
 })

--- a/apps/desktop/src/app/settings/toolset-config-panel.tsx
+++ b/apps/desktop/src/app/settings/toolset-config-panel.tsx
@@ -98,6 +98,16 @@ function providerStatus(provider: ToolProvider, envState: Record<string, boolean
   return providerConfigured(provider, envState) ? 'ready' : 'needs_keys'
 }
 
+/**
+ * The config key a per-capability pick on this row writes (and the badge key
+ * it matches on): Nous-managed rows persist the 'nous' pin instead of their
+ * vendor `web_backend` (e.g. the Nous Subscription and BYOK firecrawl rows
+ * both carry web_backend 'firecrawl' — only the pin tells them apart).
+ */
+function webBackendKey(provider: ToolProvider): string {
+  return provider.managed_nous_feature ? 'nous' : (provider.web_backend ?? provider.name)
+}
+
 interface EnvVarFieldProps {
   envVar: ToolEnvVar
   isSet: boolean
@@ -705,14 +715,18 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: Too
     try {
       await selectToolsetProvider(toolset, provider.name, capability, profile)
       // Mirror the backend write locally so the Search:/Extract: badges track
-      // the new per-capability backend without a refetch.
+      // the new per-capability backend without a refetch. The managed Nous
+      // row persists the 'nous' pin (not its vendor web_backend), so mirror
+      // that pin — otherwise the badges would light the BYOK row sharing the
+      // vendor string until the next refetch.
+      const writtenPin = webBackendKey(provider)
       setCfg(current =>
         current
           ? {
               ...current,
               ...(capability === 'search'
-                ? { active_search_backend: provider.web_backend ?? provider.name }
-                : { active_extract_backend: provider.web_backend ?? provider.name })
+                ? { active_search_backend: writtenPin }
+                : { active_extract_backend: writtenPin })
             }
           : current
       )
@@ -768,8 +782,11 @@ export function ToolsetConfigPanel({ toolset, onConfiguredChange, profile }: Too
         const isBackendActive = provider.is_active || cfg?.active_provider === provider.name
         const status = providerStatus(provider, envState)
         const webCaps = toolset === 'web' ? (provider.capabilities ?? []) : []
-        const isSearchBackend = Boolean(provider.web_backend && cfg.active_search_backend === provider.web_backend)
-        const isExtractBackend = Boolean(provider.web_backend && cfg.active_extract_backend === provider.web_backend)
+        // Managed rows match the stored 'nous' pin; vendor rows match their
+        // web_backend (see webBackendKey).
+        const backendKey = webBackendKey(provider)
+        const isSearchBackend = Boolean(provider.web_backend && cfg.active_search_backend === backendKey)
+        const isExtractBackend = Boolean(provider.web_backend && cfg.active_extract_backend === backendKey)
 
         return (
           <div className="overflow-hidden rounded-xl bg-background/60" key={provider.name}>

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1074,6 +1074,10 @@ export interface ToolProvider {
   /** Web toolset only: the backend key written to web.*backend config
    *  (e.g. 'searxng'). Absent on other toolsets and older backends. */
   web_backend?: string
+  /** Web toolset only: set on Nous-managed rows (e.g. the Nous Subscription
+   *  row). Their web_backend is the vendor string shared with BYOK rows, so
+   *  a stored 'nous' per-capability pin matches on this flag instead. */
+  managed_nous_feature?: string
   /** TTS toolset only: the provider key written to tts.provider when this row
    *  is selected (e.g. 'openai'). Doubles as the config section that holds the
    *  provider's voice/model settings (tts.<key>.*). Absent on other toolsets

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -550,11 +550,22 @@ async def select_toolset_provider(
                             status_code=400,
                             detail=f"{body.provider} does not support {body.capability}",
                         )
+                    # The managed Nous Subscription row carries
+                    # web_backend="firecrawl" but is serviced through the
+                    # Tool Gateway — persist the "nous" pin (same as
+                    # apply_provider_selection's whole-provider path) so the
+                    # per-capability override isn't indistinguishable from a
+                    # BYOK firecrawl pick that demands FIRECRAWL_API_KEY.
+                    from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+
+                    managed_feature = bool(prov.get("managed_nous_feature"))
                     web_cfg = config.setdefault("web", {})
                     if not isinstance(web_cfg, dict):
                         web_cfg = {}
                         config["web"] = web_cfg
-                    web_cfg[f"{body.capability}_backend"] = backend
+                    web_cfg[f"{body.capability}_backend"] = (
+                        NOUS_MANAGED_PROVIDER if managed_feature else backend
+                    )
                 else:
                     try:
                         apply_provider_selection(name, body.provider, config)

--- a/hermes_cli/web_routers/tools.py
+++ b/hermes_cli/web_routers/tools.py
@@ -309,6 +309,12 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
                         # the GUI can offer per-capability selection.
                         row["web_backend"] = prov["web_backend"]
                         row["capabilities"] = web_provider_capabilities(prov["web_backend"])
+                        if prov.get("managed_nous_feature"):
+                            # The managed row's web_backend is the vendor string
+                            # ("firecrawl"), shared with BYOK rows — this flag is
+                            # what lets the GUI pills tell the two apart when a
+                            # stored "nous" pin is active.
+                            row["managed_nous_feature"] = prov["managed_nous_feature"]
                     if name == "tts" and prov.get("tts_provider"):
                         # The provider key written to tts.provider on selection.
                         # Doubles as the config section holding the provider's
@@ -320,12 +326,34 @@ async def get_toolset_config(name: str, profile: Optional[str] = None):
                 # Resolve the per-capability active backends exactly the way the
                 # web_search / web_extract dispatchers do (per-capability key →
                 # shared web.backend → credential auto-detect), so the GUI badges
-                # reflect what a tool call would actually hit right now.
+                # reflect what a tool call would actually hit right now. The one
+                # exception is a stored "nous" pin: dispatch remaps it onto the
+                # firecrawl provider, but the picker pills need the pin itself to
+                # distinguish the managed Nous row from a BYOK firecrawl pick
+                # (both rows carry web_backend="firecrawl").
                 try:
-                    from tools.web_tools import _get_extract_backend, _get_search_backend
+                    from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+                    from tools.web_tools import (
+                        _get_extract_backend,
+                        _get_search_backend,
+                        _load_web_config,
+                    )
 
-                    active_search_backend = _get_search_backend()
-                    active_extract_backend = _get_extract_backend()
+                    def _gui_capability_backend(capability: str, resolved: str) -> str:
+                        try:
+                            stored = (
+                                _load_web_config().get(f"{capability}_backend") or ""
+                            ).lower().strip()
+                        except Exception:
+                            return resolved
+                        return stored if stored == NOUS_MANAGED_PROVIDER else resolved
+
+                    active_search_backend = _gui_capability_backend(
+                        "search", _get_search_backend()
+                    )
+                    active_extract_backend = _gui_capability_backend(
+                        "extract", _get_extract_backend()
+                    )
                 except Exception:
                     active_search_backend = None
                     active_extract_backend = None

--- a/plugins/web/firecrawl/provider.py
+++ b/plugins/web/firecrawl/provider.py
@@ -334,12 +334,19 @@ def _get_firecrawl_client() -> Any:
     import tools.web_tools as _wt
     from tools.tool_backend_helpers import (
         NOUS_MANAGED_PROVIDER,
+        capability_pins_managed_nous,
         read_selection,
         selection_error,
         selection_exists,
     )
 
     selected = read_selection("web")
+    # Per-capability pins (Desktop "Use for search/extract" on the managed
+    # row) store "nous" in web.{search,extract}_backend while the shared
+    # web.backend stays empty — promote those onto the Tool Gateway too, or
+    # e.g. Brave-search + Nous-extract would demand BYOK firecrawl keys.
+    if selected is None and capability_pins_managed_nous():
+        selected = NOUS_MANAGED_PROVIDER
 
     direct_config = _get_direct_firecrawl_config()
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2951,6 +2951,22 @@ class TestNewEndpoints:
         from tools.web_tools import _get_extract_backend
         assert _get_extract_backend() == "firecrawl"
 
+        # The config endpoint reports the *stored* pin, not the dispatch
+        # remap — "firecrawl" here would light the picker pill on the BYOK
+        # rows too (they share the vendor web_backend).
+        data = self.client.get("/api/tools/toolsets/web/config").json()
+        assert data["active_extract_backend"] == "nous"
+        # And the managed row is flagged so the GUI can match the pin on it
+        # (vendor rows carry no such flag).
+        nous_row = next(
+            r for r in data["providers"] if r["name"] == "Nous Subscription"
+        )
+        assert nous_row["managed_nous_feature"] == "web"
+        byok_row = next(
+            r for r in data["providers"] if r["name"] == "Firecrawl Self-Hosted"
+        )
+        assert "managed_nous_feature" not in byok_row
+
 
     def test_select_web_extract_on_selfhosted_row_still_writes_vendor(self):
         """The BYOK/self-hosted firecrawl rows keep writing their vendor
@@ -2964,6 +2980,11 @@ class TestNewEndpoints:
         from hermes_cli.config import load_config
         cfg = load_config()
         assert cfg["web"]["extract_backend"] == "firecrawl"
+
+        # A vendor pin keeps the dispatch value in the config endpoint too
+        # (no remap involved — stored value and resolved backend agree).
+        data = self.client.get("/api/tools/toolsets/web/config").json()
+        assert data["active_extract_backend"] == "firecrawl"
 
 
     # -- Terminal execution backend picker ---------------------------------

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2924,6 +2924,48 @@ class TestNewEndpoints:
         assert data["active_extract_backend"] == "firecrawl"
 
 
+    def test_select_web_extract_on_nous_row_pins_managed_provider(self):
+        """PUT capability=extract on the managed Nous Subscription row must
+        persist the "nous" pin (not its underlying "firecrawl" vendor string),
+        matching apply_provider_selection's whole-provider path — otherwise
+        the pin is indistinguishable from a BYOK firecrawl pick that demands
+        FIRECRAWL_API_KEY (#100513)."""
+        resp = self.client.put(
+            "/api/tools/toolsets/web/provider",
+            json={"provider": "Nous Subscription", "capability": "extract"},
+        )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["ok"] is True
+        assert body["capability"] == "extract"
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        assert cfg["web"]["extract_backend"] == "nous"
+        # The shared backend stays untouched ("" is the schema default, not a
+        # write) — search keeps its own chain.
+        assert not (cfg["web"].get("backend") or "").strip()
+
+        # The runtime dispatcher maps the nous pin onto the firecrawl
+        # provider (serviced through the Tool Gateway).
+        from tools.web_tools import _get_extract_backend
+        assert _get_extract_backend() == "firecrawl"
+
+
+    def test_select_web_extract_on_selfhosted_row_still_writes_vendor(self):
+        """The BYOK/self-hosted firecrawl rows keep writing their vendor
+        string — only the managed row persists "nous"."""
+        resp = self.client.put(
+            "/api/tools/toolsets/web/provider",
+            json={"provider": "Firecrawl Self-Hosted", "capability": "extract"},
+        )
+        assert resp.status_code == 200
+
+        from hermes_cli.config import load_config
+        cfg = load_config()
+        assert cfg["web"]["extract_backend"] == "firecrawl"
+
+
     # -- Terminal execution backend picker ---------------------------------
 
 

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -13,6 +13,7 @@ import json
 import os
 import sys
 import types
+from types import SimpleNamespace
 import pytest
 from unittest.mock import patch, MagicMock, AsyncMock
 
@@ -86,6 +87,55 @@ class TestFirecrawlClientConfig:
 
 
     # ── Singleton caching ────────────────────────────────────────────
+
+    def test_capability_nous_pin_routes_client_to_gateway(self):
+        """A per-capability 'nous' pin with an empty shared backend (the
+        Brave-search + Nous-extract mix) must route the firecrawl client
+        through the managed Tool Gateway instead of demanding BYOK keys
+        (#100513)."""
+        raw = {"web": {"search_backend": "brave-free", "extract_backend": "nous"}}
+        token = "nous" + "-token"
+        with patch("hermes_cli.config.read_raw_config_readonly", return_value=raw), \
+             patch("tools.web_tools._load_web_config", return_value=raw["web"]), \
+             patch(
+                 "tools.web_tools.resolve_managed_tool_gateway",
+                 return_value=SimpleNamespace(
+                     nous_user_token=token,
+                     gateway_origin="https://gw.example.com",
+                 ),
+             ), \
+             patch("tools.web_tools._read_nous_access_token", return_value=token), \
+             patch("tools.web_tools.Firecrawl") as mock_fc:
+            from tools.web_tools import _get_firecrawl_client
+            result = _get_firecrawl_client()
+            mock_fc.assert_called_once_with(
+                api_key=token,
+                api_url="https://gw.example.com",
+            )
+            assert result is mock_fc.return_value
+
+    def test_capability_vendor_pin_keeps_direct_only_semantics(self):
+        """A BYOK per-capability pin (extract_backend: firecrawl, shared
+        backend empty) keeps the direct-only semantics: with no credentials
+        it serves the keyless cloud tier (the explicit-selection unlock) —
+        it must NOT silently route through the managed Tool Gateway billed
+        to Nous."""
+        import tools.web_tools
+        raw = {"web": {"extract_backend": "firecrawl"}}
+        with patch("hermes_cli.config.read_raw_config_readonly", return_value=raw), \
+             patch("tools.web_tools._load_web_config", return_value=raw["web"]), \
+             patch(
+                 "tools.web_tools.resolve_managed_tool_gateway",
+                 return_value=SimpleNamespace(
+                     nous_user_token="nous" + "-token",
+                     gateway_origin="https://gw.example.com",
+                 ),
+             ) as resolve_gateway, \
+             patch("tools.web_tools._read_nous_access_token", return_value=None):
+            from tools.web_tools import _get_firecrawl_client
+            _get_firecrawl_client()
+            resolve_gateway.assert_not_called()
+            assert tools.web_tools._firecrawl_client_config[0] == "direct-keyless"
 
 
     def test_constructor_failure_allows_retry(self):
@@ -380,6 +430,25 @@ class TestBackendSelection:
         with patch("tools.web_tools._load_web_config", return_value={}), \
              patch("tools.web_tools._is_tool_gateway_ready", return_value=True):
             assert _get_backend() == "firecrawl"
+
+    def test_nous_extract_pin_maps_to_firecrawl(self):
+        """The managed 'nous' per-capability pin (web.extract_backend, written
+        by the Desktop "Use for extract" pick on the Nous Subscription row)
+        is serviced by the firecrawl provider — the same dispatch mapping
+        _get_backend() applies to the shared web.backend (#100513)."""
+        from tools.web_tools import _get_extract_backend
+        with patch("tools.web_tools._load_web_config", return_value={
+            "search_backend": "brave-free", "extract_backend": "nous",
+        }):
+            assert _get_extract_backend() == "firecrawl"
+
+    def test_nous_search_pin_maps_to_firecrawl(self):
+        """Same mapping on the search side of the split."""
+        from tools.web_tools import _get_search_backend
+        with patch("tools.web_tools._load_web_config", return_value={
+            "search_backend": "nous", "extract_backend": "tavily",
+        }):
+            assert _get_search_backend() == "firecrawl"
 
 
 class TestParallelClientConfig:

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -427,6 +427,34 @@ def removed_backend_note(section: str, name: str) -> Optional[str]:
     return REMOVED_BACKENDS.get(section, {}).get(normalized)
 
 
+def capability_pins_managed_nous(section: str = "web") -> bool:
+    """True when a per-capability key pins the managed Nous row.
+
+    ``read_selection()`` only reads the shared name key (``web.backend``),
+    so a Desktop per-capability pick on the managed Nous Subscription row
+    (``web.search_backend`` / ``web.extract_backend`` storing ``"nous"``)
+    is invisible to it. Vendor-side resolvers use this to promote the
+    client onto the Tool Gateway when the capability being served is the
+    pinned one.
+    """
+    extra = _EXTRA_SELECTION_KEYS.get(section, ())
+    if not extra:
+        return False
+    try:
+        from hermes_cli.config import read_raw_config_readonly
+
+        cfg = read_raw_config_readonly() or {}
+        raw = cfg.get(section) if isinstance(cfg, dict) else None
+    except Exception:
+        return False
+    if not isinstance(raw, dict):
+        return False
+    return any(
+        str(raw.get(key) or "").strip().lower() == NOUS_MANAGED_PROVIDER
+        for key in extra
+    )
+
+
 def selection_error(section: str, selection_name: str, failure: str) -> str:
     """The uniform honest-error contract for a selected-but-broken provider."""
     note = removed_backend_note(section, selection_name)

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -355,6 +355,14 @@ def _get_capability_backend(capability: str) -> str:
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
     if specific:
+        # The managed "nous" pin (Desktop "Use for search/extract" on the
+        # Nous Subscription row) is serviced by the firecrawl provider
+        # through the Tool Gateway — the same dispatch mapping _get_backend()
+        # applies to the shared web.backend.
+        from tools.tool_backend_helpers import NOUS_MANAGED_PROVIDER
+
+        if specific == NOUS_MANAGED_PROVIDER:
+            return "firecrawl"
         return specific
     return _get_backend()
 


### PR DESCRIPTION
## What does this PR do?

Desktop Settings lets you assign search and extract independently, but clicking **Use for extract** (or **Use for search**) on the **Nous Subscription** row wrote the row's underlying `web_backend` string (`firecrawl`) verbatim into `web.{search,extract}_backend`. That made the managed pick indistinguishable from a BYOK firecrawl choice: the panel then demands `FIRECRAWL_API_KEY` (which the managed row never needs) and the Portal token is never used.

The whole-provider path (`apply_provider_selection`, used by the CLI `hermes tools` flow) already writes the `"nous"` pin for managed rows. This PR makes the per-capability path do the same, and adds the two follow-ups that keep the pin usable end to end:

1. **Per-capability write**: if the picker row has `managed_nous_feature`, persist `nous` instead of the vendor string — BYOK/self-hosted rows keep writing `firecrawl`.
2. **Dispatch mapping**: `_get_capability_backend()` maps a stored `nous` pin onto the `firecrawl` provider, mirroring what `_get_backend()` already does for the shared `web.backend`.
3. **Client routing**: the firecrawl client resolver consults the per-capability keys via the new `capability_pins_managed_nous()` helper, so Brave-search + Nous-extract (shared `web.backend` empty) routes through the managed Tool Gateway instead of failing on missing BYOK keys.

Strict-selection semantics are preserved: a BYOK `extract_backend: firecrawl` pin with no credentials still serves the keyless cloud tier and never silently routes to the managed gateway.

Scope note: the Desktop badge rendering (multiple extract rows lit at once, symptom 2 in the issue) is a separate UI-layer identity comparison; this PR fixes the config-write/provider-dispatch root cause (symptom 1). With the pin now stored as `nous`, the badge layer can distinguish managed vs BYOK rows, which the UI fix can build on.

## Related Issue

Fixes #100513

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_routers/tools.py` — per-capability provider select now writes the `"nous"` pin for `managed_nous_feature` rows (matches `apply_provider_selection`).
- `tools/web_tools.py` — `_get_capability_backend()` maps a `nous` per-capability pin to the `firecrawl` provider for dispatch.
- `tools/tool_backend_helpers.py` — new `capability_pins_managed_nous()` helper: true when `web.search_backend`/`web.extract_backend` stores `nous` while the shared name key is empty.
- `plugins/web/firecrawl/provider.py` — `_get_firecrawl_client()` promotes a per-capability `nous` pin onto the managed Tool Gateway.
- `tests/hermes_cli/test_web_server.py` — route-level regression: PUT with `capability=extract` on the Nous Subscription row persists `extract_backend: nous` (and the runtime resolves firecrawl); the self-hosted row still writes the vendor string.
- `tests/tools/test_web_tools_config.py` — dispatch mapping (search + extract), managed-gateway client routing for the Brave+Nous mix, and direct-only semantics for a BYOK pin.

## How to Test

1. `pytest tests/tools/test_web_tools_config.py tests/tools/test_strict_provider_selection.py -q` — should pass (47 + 60 passed on this branch; the two `TestParallelClientConfig` failures also fail on clean `main` — pre-existing environment issue with the lazy parallel SDK install).
2. `pytest tests/hermes_cli/test_web_server.py::TestNewEndpoints -q` — should pass (41 passed).
3. Observed result: the new tests fail on the pre-fix code (pin written as `firecrawl`, client demanding `FIRECRAWL_API_KEY`) and pass with this change; the BYOK row test passes both before and after, pinning the unchanged behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — config-write and provider-dispatch behavior, covered by the new tests.
