### PR TITLE
fix(web): configs pinned to a removed backend no longer fail silently (post-#99199)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2526,6 +2526,32 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
                 f"Move '{key}' under the appropriate section",
             ))
 
+    # ── web backends that no longer ship in-tree ─────────────────────────
+    # A stale selection (e.g. web.backend: tavily after the #99199 removal)
+    # otherwise fails only at the first web_search/web_extract call, with a
+    # generic "no registered provider" error. Warn at startup instead.
+    web_cfg = config.get("web")
+    if isinstance(web_cfg, dict):
+        try:
+            from tools.tool_backend_helpers import removed_backend_note
+        except Exception:
+            removed_backend_note = None
+        if removed_backend_note is not None:
+            seen: set = set()
+            for _key in ("backend", "search_backend", "extract_backend"):
+                _val = str(web_cfg.get(_key) or "").strip().lower()
+                if not _val or _val in seen:
+                    continue
+                seen.add(_val)
+                note = removed_backend_note("web", _val)
+                if note:
+                    issues.append(ConfigIssue(
+                        "warning",
+                        f"web.{_key} is set to '{_val}', but {note} — "
+                        "web_search/web_extract will fail until it is changed",
+                        "Run 'hermes tools' and pick a different Web Search & Extract provider",
+                    ))
+
     return issues
 
 

--- a/tests/tools/test_removed_backend_migration.py
+++ b/tests/tools/test_removed_backend_migration.py
@@ -1,0 +1,84 @@
+"""Removed-backend migration warnings (post-#99199 Tavily removal).
+
+A config still pointing at a backend that no longer ships in-tree
+(``web.backend: tavily``) must fail loudly and specifically:
+
+1. startup — ``validate_config_structure`` emits a warning naming the
+   removal, instead of staying silent until the first tool call;
+2. tool call — ``selection_error`` explains the backend was removed and
+   names alternatives, instead of the generic "no registered provider
+   has that name".
+
+Regression source: keyed Tavily users upgrading to v0.21.0 saw their
+config silently become invalid with no migration or startup notice
+(reported on PR #99731).
+"""
+
+from hermes_cli.config import validate_config_structure
+from tools.tool_backend_helpers import (
+    REMOVED_BACKENDS,
+    removed_backend_note,
+    selection_error,
+)
+
+
+class TestRemovedBackendNote:
+    def test_tavily_is_registered_as_removed_web_backend(self):
+        assert "tavily" in REMOVED_BACKENDS["web"]
+
+    def test_note_lookup_normalizes_quotes_and_case(self):
+        plain = removed_backend_note("web", "tavily")
+        assert plain is not None
+        assert removed_backend_note("web", "'Tavily'") == plain
+        assert removed_backend_note("web", '  "TAVILY" ') == plain
+
+    def test_unknown_names_and_sections_return_none(self):
+        assert removed_backend_note("web", "exa") is None
+        assert removed_backend_note("web", "") is None
+        assert removed_backend_note("stt", "tavily") is None
+
+
+class TestSelectionErrorRemovedBackend:
+    def test_removed_backend_gets_specific_explanation(self):
+        msg = selection_error("web", "'tavily'", "no registered web search provider has that name")
+        assert "removed" in msg
+        assert "tavily" in msg.lower()
+        # generic failure text replaced, not appended
+        assert "no registered web search provider" not in msg
+        # still ends with the uniform remediation contract
+        assert "Run 'hermes tools' to change it." in msg
+
+    def test_live_backend_keeps_caller_failure_text(self):
+        msg = selection_error("web", "'exa'", "no registered web search provider has that name")
+        assert "no registered web search provider has that name" in msg
+        assert "removed" not in msg
+
+
+class TestStartupWarningForRemovedWebBackend:
+    @staticmethod
+    def _removed_issues(config):
+        return [
+            i for i in validate_config_structure(config)
+            if "removed" in i.message and "tavily" in i.message
+        ]
+
+    def test_stale_web_backend_warns_at_startup(self):
+        issues = self._removed_issues({"web": {"backend": "tavily"}})
+        assert len(issues) == 1
+        assert issues[0].severity == "warning"
+        assert "hermes tools" in issues[0].hint
+
+    def test_per_capability_keys_are_checked(self):
+        assert len(self._removed_issues({"web": {"search_backend": "tavily"}})) == 1
+        assert len(self._removed_issues({"web": {"extract_backend": "tavily"}})) == 1
+
+    def test_same_stale_value_warns_once(self):
+        issues = self._removed_issues(
+            {"web": {"backend": "tavily", "search_backend": "tavily", "extract_backend": "tavily"}}
+        )
+        assert len(issues) == 1
+
+    def test_healthy_backend_produces_no_removed_warning(self):
+        assert self._removed_issues({"web": {"backend": "exa"}}) == []
+        assert self._removed_issues({"web": {}}) == []
+        assert self._removed_issues({}) == []

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from utils import is_truthy_value
 
@@ -402,8 +402,38 @@ def selection_exists(section: str) -> bool:
     return any(str(raw.get(key) or "").strip() for key in extra)
 
 
+# Backends that once shipped in-tree but were removed. A config that still
+# points at one otherwise fails silently at the FIRST tool call with a
+# generic "no registered provider has that name" — no migration, no startup
+# notice (reported after the Tavily removal in #99199). Both the startup
+# config check (hermes_cli.config.validate_config_structure) and
+# selection_error() consult this map so the user learns what actually
+# happened and what to do. Declared data, one policy — add future removals
+# here, never as one-off string checks at call sites.
+REMOVED_BACKENDS: Dict[str, Dict[str, str]] = {
+    "web": {
+        "tavily": (
+            "the Tavily backend was removed in v0.21.0 "
+            "(keyless alternatives: exa, parallel, firecrawl, keenable)"
+        ),
+    },
+}
+
+
+def removed_backend_note(section: str, name: str) -> Optional[str]:
+    """Explanation for a backend that used to ship in-tree, or None.
+
+    ``name`` tolerates the quoted form callers pass to selection_error().
+    """
+    normalized = (name or "").strip().strip("'\"").lower()
+    return REMOVED_BACKENDS.get(section, {}).get(normalized)
+
+
 def selection_error(section: str, selection_name: str, failure: str) -> str:
     """The uniform honest-error contract for a selected-but-broken provider."""
+    note = removed_backend_note(section, selection_name)
+    if note:
+        failure = note
     return (
         f"{section} is configured to use {selection_name} (set via hermes "
         f"tools), but {failure}. Run 'hermes tools' to change it."


### PR DESCRIPTION
# fix(web): stale removed-backend config warns at startup and errors by name

## Summary
A config still pointing at a removed web backend (`web.backend: tavily` after #99199) now warns at startup and errors by name at tool-call time, instead of failing silently with a generic "no registered web search provider has that name" only at the first `web_search`/`web_extract` call.

Root cause: #99199 removed the Tavily backend but existing configs kept the now-invalid selection — no migration, no deprecation notice (reported by keyed Tavily users on PR #99731).

## Changes
- `tools/tool_backend_helpers.py`: `REMOVED_BACKENDS` registry + `removed_backend_note()`; `selection_error()` swaps in the specific removal explanation (removed in v0.21.0, keyless alternatives named) while keeping the uniform "Run 'hermes tools'" remediation.
- `hermes_cli/config.py`: `validate_config_structure()` checks `web.backend`/`search_backend`/`extract_backend` against the registry and emits a startup warning (deduped per stale value) via the existing `print_config_warnings()` path in CLI and gateway.
- `tests/tools/test_removed_backend_migration.py`: startup warning, per-capability keys, dedupe, healthy-config negative, live-backend failure text preserved.

Declared-data, one-policy shape: future backend removals add one registry entry — both surfaces pick it up.

## Validation
| | Before | After |
|---|---|---|
| Startup with `web.backend: tavily` | silent | `⚠ web.backend is set to 'tavily', but the Tavily backend was removed in v0.21.0 (keyless alternatives: exa, parallel, firecrawl, keenable)…` |
| `web_search` error | "no registered web search provider has that name" | names the removal + alternatives |
| `web_extract` error | same generic | names the removal + alternatives |
| Healthy config (`exa`) | — | no warning (negative case verified) |
| Targeted tests | — | 121 passed / 4 skipped (`test_removed_backend_migration.py` + `test_config.py`); keyless-fallback suite green |

**Live repro:** isolated temp `HERMES_HOME` with `web.backend: tavily` on origin/main — `print_config_warnings()` emitted nothing and `web_search_tool` returned the generic error; after the fix, both surfaces show the specific removal message (real imports, real config file, both sync search and async extract paths).

## Infographic

![Stale backend warning mission patch](https://v3b.fal.media/files/b/0aa8b42e/y9ntYh2WR_cmYRoMfj0gB_tWCkT7bl.png)
