### PR TITLE
fix(bot-mode): keep DMs until a live Desktop owner detaches

### DIFF
--- a/tests/tools/test_bot_retry_policy.py
+++ b/tests/tools/test_bot_retry_policy.py
@@ -198,6 +198,42 @@ def test_run_delivery_retries_transient_and_reemits_stdout(monkeypatch, tmp_path
     assert not dm.exists(), "dm file must be cleaned up"
 
 
+def test_run_delivery_retries_while_recipient_has_live_owner(monkeypatch, tmp_path, capsys):
+    """#100523: a Desktop-owned Bot Chat must not drop the DM."""
+    from tools import bot_mode_dm
+
+    dm = tmp_path / "dm.txt"
+    dm.write_text("hello")
+    calls = []
+    clock = {"t": 0.0}
+
+    def _fake_run(argv, **kwargs):
+        calls.append(list(argv))
+        if len(calls) < 3:
+            return _Proc(
+                1,
+                stderr=(
+                    "Session 20260831_213314_60cda6 already has a live owner "
+                    "(desktop, pid 695663, running 11m)."
+                ),
+            )
+        return _Proc(0, stdout="queued-then-delivered")
+
+    monkeypatch.setattr(bot_mode_dm, "_live_owner_wait_seconds", lambda: 30.0)
+    monkeypatch.setattr(bot_mode_dm, "_LIVE_OWNER_POLL_SECONDS", 1.0)
+    monkeypatch.setattr(bot_mode_dm.time, "monotonic", lambda: clock["t"])
+    monkeypatch.setattr(bot_mode_dm.time, "sleep", lambda s: clock.__setitem__("t", clock["t"] + s))
+    monkeypatch.setattr(bot_mode_dm.subprocess, "run", _fake_run)
+
+    rc = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "ops", "chat"], str(dm), stdin_file=False
+    )
+    assert rc == 0
+    assert len(calls) == 3
+    assert "queued-then-delivered" in capsys.readouterr().out
+    assert not dm.exists()
+
+
 def test_run_delivery_no_retry_for_missing_config(monkeypatch, tmp_path):
     from tools import bot_mode_dm
 

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -562,6 +562,48 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
     return acquire_turn_lock(_hermes_root(home), argv[2])
 
 
+def _is_live_owner_error(text: str) -> bool:
+    return "already has a live owner" in (text or "").lower()
+
+
+def _live_owner_wait_seconds() -> float:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config() or {}
+        bot = cfg.get("bot_mode") if isinstance(cfg.get("bot_mode"), dict) else {}
+        raw = bot.get("envelope_ttl_seconds", 900)
+        return max(0.0, float(raw))
+    except (TypeError, ValueError):
+        return 900.0
+    except Exception:
+        return 900.0
+
+
+_LIVE_OWNER_POLL_SECONDS = 5.0
+
+
+def _wait_out_live_owner(argv: list[str], dm_file: str):
+    """Re-run the local chat until the recipient session is free or TTL."""
+    deadline = time.monotonic() + _live_owner_wait_seconds()
+    proc = None
+    while time.monotonic() < deadline:
+        time.sleep(_LIVE_OWNER_POLL_SECONDS)
+        proc = subprocess.run(
+            [*argv, "--query-file", dm_file],
+            check=False,
+            stdin=subprocess.DEVNULL,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            return proc
+        detail = (proc.stderr or proc.stdout or "").strip()[-500:]
+        if not _is_live_owner_error(detail):
+            return proc
+    return proc
+
+
 def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     """Run one DM transport and remove its plaintext file after consumption.
 
@@ -607,6 +649,13 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                         capture_output=True,
                         text=True,
                     )
+                    detail = (proc.stderr or proc.stdout or "").strip()[-500:]
+                # Desktop owns Bot Chat: don't drop the DM. Poll until the
+                # lease is gone or the envelope TTL expires (#100523).
+                if proc.returncode != 0 and _is_live_owner_error(detail):
+                    waited = _wait_out_live_owner(argv, dm_file)
+                    if waited is not None:
+                        proc = waited
             # Re-emit the transport's streams: stdout is the reply text the
             # completion notification carries back to the sending agent.
             if proc.stdout:


### PR DESCRIPTION
## What does this PR do?

`message_agent` already acks "sent" and then runs `hermes chat --query-file` in the background. If the recipient's canonical Bot Chat is attached to Desktop, that subprocess hits the single-owner lock, exits 1, and the DM is gone. The sender never sees a real failure — only a background-process exit notification.

The lock itself is correct (two surfaces must not reason from different transcripts). This keeps the payload and retries until the Desktop lease is gone, or until `bot_mode.envelope_ttl_seconds` (default 900s) expires. It does not inject into the live transcript.

## Related Issue

Fixes #100523

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `tools/bot_mode_dm.py`: on "already has a live owner", poll and re-run the local chat until free or TTL
- `tests/tools/test_bot_retry_policy.py`: two live-owner failures then success

## How to Test

```text
uv run --extra dev python -m pytest tests/tools/test_bot_retry_policy.py::test_run_delivery_retries_while_recipient_has_live_owner tests/tools/test_bot_retry_policy.py::test_run_delivery_retries_transient_and_reemits_stdout tests/tools/test_bot_retry_policy.py::test_run_delivery_no_retry_for_missing_config -q
# 3 passed
```

Not runtime-tested against a live Desktop Bot Chat owner.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
