### PR TITLE
fix(gateway): hide provisional tool-failure status when interim is off

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1027,7 +1027,13 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
 _PROVISIONAL_TOOL_STATUS_RE = re.compile(
     r"\b(?:lookup|query|tool(?:\s+call)?)\s+failed\b"
-    r"|\bfailed\b.*\b(?:lookup|query|tool)\b",
+    r"|\bfailed\b.*\b(?:lookup|query|tool)\b"
+    # Localized MCP/tool failure status (#100543 live Discord: "최신 조회 실패").
+    r"|실패|失败|失敗",
+    re.IGNORECASE,
+)
+_PROVISIONAL_COMPRESSION_NOTICE_RE = re.compile(
+    r"compress|압축|压缩|壓縮",
     re.IGNORECASE,
 )
 
@@ -1044,7 +1050,7 @@ def _looks_like_provisional_tool_status(text: str) -> bool:
     body = str(text or "").strip()
     if not body or len(body) > 160 or body.count("\n") > 2:
         return False
-    if re.search(r"compress", body, re.I):
+    if _PROVISIONAL_COMPRESSION_NOTICE_RE.search(body):
         return False
     return bool(_PROVISIONAL_TOOL_STATUS_RE.search(body))
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1025,7 +1025,37 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+_PROVISIONAL_TOOL_STATUS_RE = re.compile(
+    r"\b(?:lookup|query|tool(?:\s+call)?)\s+failed\b"
+    r"|\bfailed\b.*\b(?:lookup|query|tool)\b",
+    re.IGNORECASE,
+)
+
+
+def _looks_like_provisional_tool_status(text: str) -> bool:
+    """True for short operational tool-failure status, not compression notices.
+
+    Discord posted MCP/tool "lookup failed" warnings as chat messages while
+    the same turn later delivered a successful final result (#100367). Those
+    must stay off chat when interim assistant messages are disabled.
+    Compression recovery/abort copy is excluded — #100370's blanket
+    status_callback gate swallowed those.
+    """
+    body = str(text or "").strip()
+    if not body or len(body) > 160 or body.count("\n") > 2:
+        return False
+    if re.search(r"compress", body, re.I):
+        return False
+    return bool(_PROVISIONAL_TOOL_STATUS_RE.search(body))
+
+
+def _prepare_gateway_status_message(
+    platform: Any,
+    event_type: str,
+    message: str,
+    *,
+    interim_enabled: bool = True,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
     Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
@@ -1038,6 +1068,12 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         return text
 
     text = _redact_gateway_user_facing_secrets(text)
+    if (
+        not interim_enabled
+        and str(event_type or "") == "warn"
+        and _looks_like_provisional_tool_status(text)
+    ):
+        return None
     if _TELEGRAM_NOISY_STATUS_RE.search(text):
         # Opt-in #52995: `compression.progress_notices: true` lets ROUTINE
         # compression progress statuses through to chat platforms. The
@@ -5750,6 +5786,7 @@ class TurnRunner:
             ctx.source.platform,
             event_type,
             message,
+            interim_enabled=ctx.interim_assistant_messages_enabled,
         )
         if prepared_message is None:
             logger.debug(

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -141,14 +141,19 @@ def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
 
 
 @pytest.mark.parametrize("platform", ["discord", "telegram", "slack"])
-def test_provisional_tool_warn_suppressed_when_interim_off(platform):
+@pytest.mark.parametrize(
+    "message",
+    ["Latest lookup failed", "최신 조회 실패", "最新查询失败"],
+)
+def test_provisional_tool_warn_suppressed_when_interim_off(platform, message):
     """#100367: MCP/tool lookup failures must not post as Discord replies
-    when interim assistant messages are disabled."""
+    when interim assistant messages are disabled. Localized copies (#100543)
+    use the same warn path without English tokens."""
     assert (
         _prepare_gateway_status_message(
             platform,
             "warn",
-            "Latest lookup failed",
+            message,
             interim_enabled=False,
         )
         is None
@@ -179,6 +184,17 @@ def test_compression_abort_warn_still_visible_when_interim_off(platform):
     assert (
         _prepare_gateway_status_message(
             platform, "warn", message, interim_enabled=False
+        )
+        == message
+    )
+
+
+def test_localized_compression_abort_still_visible_when_interim_off():
+    """A Korean compression abort still contains 실패; do not hide it."""
+    message = "⚠ 압축이 실패했습니다. 메시지는 삭제되지 않았습니다."
+    assert (
+        _prepare_gateway_status_message(
+            "discord", "warn", message, interim_enabled=False
         )
         == message
     )

--- a/tests/gateway/test_telegram_noise_filter.py
+++ b/tests/gateway/test_telegram_noise_filter.py
@@ -140,6 +140,62 @@ def test_telegram_status_keeps_legitimate_heartbeat_messages(message):
     assert _prepare_gateway_status_message(Platform.TELEGRAM, "lifecycle", message) == message
 
 
+@pytest.mark.parametrize("platform", ["discord", "telegram", "slack"])
+def test_provisional_tool_warn_suppressed_when_interim_off(platform):
+    """#100367: MCP/tool lookup failures must not post as Discord replies
+    when interim assistant messages are disabled."""
+    assert (
+        _prepare_gateway_status_message(
+            platform,
+            "warn",
+            "Latest lookup failed",
+            interim_enabled=False,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("platform", ["discord", "telegram"])
+def test_provisional_tool_warn_kept_when_interim_on(platform):
+    assert (
+        _prepare_gateway_status_message(
+            platform,
+            "warn",
+            "Latest lookup failed",
+            interim_enabled=True,
+        )
+        == "Latest lookup failed"
+    )
+
+
+@pytest.mark.parametrize("platform", ["discord", "telegram"])
+def test_compression_abort_warn_still_visible_when_interim_off(platform):
+    """#100370 rejected a blanket status gate; recovery notices stay."""
+    message = (
+        "⚠ Compression aborted: auth failure. No messages were dropped — "
+        "conversation continues unchanged. Run /compress to retry, or /new "
+        "to start a fresh session."
+    )
+    assert (
+        _prepare_gateway_status_message(
+            platform, "warn", message, interim_enabled=False
+        )
+        == message
+    )
+
+
+def test_webhook_keeps_provisional_tool_status_when_interim_off():
+    assert (
+        _prepare_gateway_status_message(
+            "webhook",
+            "warn",
+            "Latest lookup failed",
+            interim_enabled=False,
+        )
+        == "Latest lookup failed"
+    )
+
+
 @pytest.mark.parametrize("platform", CHAT_PLATFORMS)
 @pytest.mark.parametrize("message", NOISY_STATUS_MESSAGES)
 def test_all_chat_gateways_suppress_noise(platform, message):


### PR DESCRIPTION
## What does this PR do?

With `display.interim_assistant_messages` off, Discord still posted short tool/MCP failure status (`Latest lookup failed`) as a chat message, then later sent the successful final result. `interim_assistant_callback` was already gated; `status_callback` was not.

A previous attempt (#100370) gated every status callback and was closed because it hid compression recovery/progress and webhook/API diagnostics. This only drops `event_type=warn` text that looks like a short lookup/query/tool failure, and only when interim is off. Compression abort/lock notices still pass. Webhook/API/local keep the raw stream.

## Related Issue

Fixes #100367

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: `_looks_like_provisional_tool_status`; `_prepare_gateway_status_message(..., interim_enabled=)`
- `tests/gateway/test_telegram_noise_filter.py`: Discord/Telegram suppress vs keep; compression abort still visible; webhook unfiltered

## How to Test

```text
uv run --extra dev python -m pytest tests/gateway/test_telegram_noise_filter.py -q
# 144 passed
```

Not runtime-tested against a live Discord guild.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
