### PR TITLE
feat(credentials): opaque per-profile credential store + masked CLI entry

### DIFF
--- a/agent/credential_store.py
+++ b/agent/credential_store.py
@@ -1,0 +1,359 @@
+"""Profile-scoped opaque credential store for agent-safe secret use.
+
+The model may request and pass credential references, but plaintext is only
+resolved inside trusted execution code. Secret values are encrypted on disk and
+redacted from model/tool/log boundaries.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import re
+import secrets
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, Optional
+
+from cryptography.fernet import Fernet, InvalidToken
+
+from hermes_constants import get_hermes_home
+from utils import atomic_json_write
+
+_REF_PREFIX = "cred_"
+_REF_RE = re.compile(r"^cred_[A-Za-z0-9_-]{16,80}$")
+_STORE_VERSION = 1
+_REDACTION = "«redacted-credential»"
+_MIN_REDACT_SECRET_LEN = 4
+
+
+class CredentialStoreError(RuntimeError):
+    """Raised for credential-store failures safe to show after sanitization."""
+
+
+@dataclass(frozen=True)
+class CredentialRecord:
+    ref: str
+    name: str
+    type: str
+    status: str
+    created_at: float
+    updated_at: float
+    revoked_at: Optional[float] = None
+
+    def public_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "ref": self.ref,
+            "name": self.name,
+            "type": self.type,
+            "status": self.status,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+        if self.revoked_at is not None:
+            data["revoked_at"] = self.revoked_at
+        return data
+
+
+def _credentials_dir() -> Path:
+    path = get_hermes_home() / "credentials"
+    path.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _key_path() -> Path:
+    return _credentials_dir() / "master.key"
+
+
+def _store_path() -> Path:
+    return _credentials_dir() / "store.json"
+
+
+def _ensure_file_private(path: Path) -> None:
+    if os.name == "posix":
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
+def _load_or_create_key() -> bytes:
+    path = _key_path()
+    if path.exists():
+        key = path.read_bytes().strip()
+        if not key:
+            raise CredentialStoreError("credential master key file is empty")
+        _ensure_file_private(path)
+        return key
+    key = Fernet.generate_key()
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    fd = os.open(path, flags, 0o600)
+    try:
+        os.write(fd, key + b"\n")
+    finally:
+        os.close(fd)
+    _ensure_file_private(path)
+    return key
+
+
+def _fernet() -> Fernet:
+    return Fernet(_load_or_create_key())
+
+
+def _empty_store() -> Dict[str, Any]:
+    return {"version": _STORE_VERSION, "credentials": {}}
+
+
+def _load_store() -> Dict[str, Any]:
+    path = _store_path()
+    if not path.exists():
+        return _empty_store()
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        raise CredentialStoreError(f"credential store is unreadable: {type(exc).__name__}") from exc
+    if not isinstance(data, dict):
+        raise CredentialStoreError("credential store has invalid format")
+    creds = data.get("credentials")
+    if not isinstance(creds, dict):
+        data["credentials"] = {}
+    data.setdefault("version", _STORE_VERSION)
+    return data
+
+
+def _save_store(data: Dict[str, Any]) -> None:
+    path = _store_path()
+    atomic_json_write(path, data, indent=2)
+    _ensure_file_private(path)
+
+
+def _validate_name(name: str) -> str:
+    value = (name or "").strip()
+    if not value:
+        raise CredentialStoreError("credential name is required")
+    if len(value) > 160:
+        raise CredentialStoreError("credential name is too long")
+    return value
+
+
+def _validate_type(credential_type: str) -> str:
+    value = (credential_type or "secret").strip().lower()
+    if not re.match(r"^[a-z][a-z0-9_.:-]{0,63}$", value):
+        raise CredentialStoreError("credential type must be a short lowercase identifier")
+    return value
+
+
+def _validate_ref(ref: str) -> str:
+    value = (ref or "").strip()
+    if not _REF_RE.match(value):
+        raise CredentialStoreError("invalid credential reference")
+    return value
+
+
+def _new_ref(name: str, credential_type: str) -> str:
+    digest = hashlib.sha256(
+        f"{credential_type}\0{name}\0{secrets.token_urlsafe(32)}".encode("utf-8")
+    ).digest()
+    return _REF_PREFIX + base64.urlsafe_b64encode(digest[:24]).decode("ascii").rstrip("=")
+
+
+def _encrypt(value: str) -> str:
+    if not isinstance(value, str) or value == "":
+        raise CredentialStoreError("credential value cannot be empty")
+    return _fernet().encrypt(value.encode("utf-8")).decode("ascii")
+
+
+def _decrypt(token: str) -> str:
+    try:
+        return _fernet().decrypt(token.encode("ascii")).decode("utf-8")
+    except (InvalidToken, UnicodeDecodeError, ValueError) as exc:
+        raise CredentialStoreError("credential value could not be decrypted") from exc
+
+
+def request_credential(name: str, credential_type: str = "secret") -> Dict[str, Any]:
+    """Create or return a pending opaque reference; never accepts a secret value."""
+    name = _validate_name(name)
+    credential_type = _validate_type(credential_type)
+    data = _load_store()
+    now = time.time()
+    for ref, record in data["credentials"].items():
+        if (
+            isinstance(record, dict)
+            and record.get("name") == name
+            and record.get("type") == credential_type
+            and record.get("status") != "deleted"
+        ):
+            return _public_record(ref, record, pending_secret=("ciphertext" not in record))
+    ref = _new_ref(name, credential_type)
+    data["credentials"][ref] = {
+        "name": name,
+        "type": credential_type,
+        "status": "pending",
+        "created_at": now,
+        "updated_at": now,
+    }
+    _save_store(data)
+    result = _public_record(ref, data["credentials"][ref], pending_secret=True)
+    result["entry_ui"] = "Run `hermes credentials set %s --type %s` in a terminal; input is masked and never sent to chat." % (name, credential_type)
+    return result
+
+
+def set_credential_value(name: str, credential_type: str, value: str) -> Dict[str, Any]:
+    """Store/update a value entered outside chat and return only public metadata."""
+    name = _validate_name(name)
+    credential_type = _validate_type(credential_type)
+    data = _load_store()
+    now = time.time()
+    ref = None
+    record = None
+    for candidate_ref, candidate in data["credentials"].items():
+        if (
+            isinstance(candidate, dict)
+            and candidate.get("name") == name
+            and candidate.get("type") == credential_type
+            and candidate.get("status") != "deleted"
+        ):
+            ref = candidate_ref
+            record = candidate
+            break
+    if record is None:
+        ref = _new_ref(name, credential_type)
+        record = {"name": name, "type": credential_type, "created_at": now}
+        data["credentials"][ref] = record
+    record["ciphertext"] = _encrypt(value)
+    record["status"] = "active"
+    record["updated_at"] = now
+    record.pop("revoked_at", None)
+    _save_store(data)
+    return _public_record(str(ref), record, pending_secret=False)
+
+
+def update_credential_value(ref: str, value: str) -> Dict[str, Any]:
+    ref = _validate_ref(ref)
+    data = _load_store()
+    record = data["credentials"].get(ref)
+    if not isinstance(record, dict) or record.get("status") == "deleted":
+        raise CredentialStoreError("credential reference not found")
+    record["ciphertext"] = _encrypt(value)
+    record["status"] = "active"
+    record["updated_at"] = time.time()
+    record.pop("revoked_at", None)
+    _save_store(data)
+    return _public_record(str(ref), record, pending_secret=False)
+
+
+def revoke_credential(ref: str) -> Dict[str, Any]:
+    ref = _validate_ref(ref)
+    data = _load_store()
+    record = data["credentials"].get(ref)
+    if not isinstance(record, dict) or record.get("status") == "deleted":
+        raise CredentialStoreError("credential reference not found")
+    now = time.time()
+    record["status"] = "revoked"
+    record["revoked_at"] = now
+    record["updated_at"] = now
+    _save_store(data)
+    return _public_record(str(ref), record, pending_secret=False)
+
+
+def delete_credential(ref: str) -> Dict[str, Any]:
+    ref = _validate_ref(ref)
+    data = _load_store()
+    record = data["credentials"].get(ref)
+    if not isinstance(record, dict):
+        raise CredentialStoreError("credential reference not found")
+    public = _public_record(ref, record, pending_secret=False)
+    del data["credentials"][ref]
+    _save_store(data)
+    public["status"] = "deleted"
+    return public
+
+
+def list_credentials() -> list[Dict[str, Any]]:
+    data = _load_store()
+    rows = []
+    for ref, record in sorted(data["credentials"].items(), key=lambda item: str(item[1].get("name", ""))):
+        if isinstance(record, dict) and record.get("status") != "deleted":
+            rows.append(_public_record(ref, record, pending_secret=("ciphertext" not in record)))
+    return rows
+
+
+def resolve_credential_value(ref: str, *, expected_type: Optional[str] = None) -> str:
+    """Resolve plaintext for trusted execution code only.
+
+    Do not expose this as a model tool. Callers must inject the returned value
+    directly into an outbound API/client operation and redact any output.
+    """
+    ref = _validate_ref(ref)
+    data = _load_store()
+    record = data["credentials"].get(ref)
+    if not isinstance(record, dict):
+        raise CredentialStoreError("credential reference not found")
+    if record.get("status") != "active":
+        raise CredentialStoreError(f"credential is not active: {record.get('status', 'unknown')}")
+    if expected_type and record.get("type") != _validate_type(expected_type):
+        raise CredentialStoreError("credential type mismatch")
+    ciphertext = record.get("ciphertext")
+    if not isinstance(ciphertext, str) or not ciphertext:
+        raise CredentialStoreError("credential has no stored secret value")
+    return _decrypt(ciphertext)
+
+
+def _public_record(ref: str, record: Dict[str, Any], *, pending_secret: bool) -> Dict[str, Any]:
+    out = CredentialRecord(
+        ref=ref,
+        name=str(record.get("name") or ""),
+        type=str(record.get("type") or "secret"),
+        status=str(record.get("status") or "pending"),
+        created_at=float(record.get("created_at") or 0),
+        updated_at=float(record.get("updated_at") or 0),
+        revoked_at=(float(record["revoked_at"]) if record.get("revoked_at") else None),
+    ).public_dict()
+    out["has_secret"] = not pending_secret
+    return out
+
+
+def iter_active_secret_values() -> Iterable[str]:
+    """Yield active secret plaintexts for forced redaction boundaries only."""
+    try:
+        data = _load_store()
+    except Exception:
+        return []
+    values = []
+    for record in data.get("credentials", {}).values():
+        if not isinstance(record, dict) or record.get("status") != "active":
+            continue
+        ciphertext = record.get("ciphertext")
+        if not isinstance(ciphertext, str):
+            continue
+        try:
+            value = _decrypt(ciphertext)
+        except Exception:
+            continue
+        if len(value) >= _MIN_REDACT_SECRET_LEN:
+            values.append(value)
+    return values
+
+
+def redact_registered_secrets(text: str) -> str:
+    """Redact exact stored secret values from any output string."""
+    if text is None:
+        return text
+    if not isinstance(text, str):
+        text = str(text)
+    if not text:
+        return text
+    try:
+        for value in iter_active_secret_values():
+            if value and value in text:
+                text = text.replace(value, _REDACTION)
+    except Exception:
+        pass
+    return text

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -822,6 +822,11 @@ def redact_sensitive_text(
         text = str(text)
     if not text:
         return text
+    try:
+        from agent.credential_store import redact_registered_secrets
+        text = redact_registered_secrets(text)
+    except Exception:
+        pass
     if not (force or _REDACT_ENABLED):
         return text
 

--- a/hermes_cli/credential_commands.py
+++ b/hermes_cli/credential_commands.py
@@ -1,0 +1,108 @@
+"""Masked credential-entry CLI for opaque agent credential refs."""
+
+from __future__ import annotations
+
+import argparse
+import getpass
+import json
+import sys
+from typing import Any
+
+from agent.credential_store import (
+    CredentialStoreError,
+    delete_credential,
+    list_credentials,
+    request_credential,
+    revoke_credential,
+    set_credential_value,
+    update_credential_value,
+)
+
+
+def _print_public(record: dict[str, Any]) -> None:
+    print(json.dumps(record, ensure_ascii=False, indent=2, sort_keys=True))
+
+
+def _prompt_secret(confirm: bool = True) -> str:
+    first = getpass.getpass("Credential value: ")
+    if not first:
+        raise CredentialStoreError("credential value cannot be empty")
+    if confirm:
+        second = getpass.getpass("Confirm credential value: ")
+        if first != second:
+            raise CredentialStoreError("credential values did not match")
+    return first
+
+
+def cmd_credentials(args: argparse.Namespace) -> int:
+    try:
+        command = getattr(args, "credentials_command", None)
+        if command == "request":
+            _print_public(request_credential(args.name, args.type))
+            return 0
+        if command == "set":
+            value = _prompt_secret(confirm=not args.no_confirm)
+            _print_public(set_credential_value(args.name, args.type, value))
+            return 0
+        if command == "update":
+            value = _prompt_secret(confirm=not args.no_confirm)
+            _print_public(update_credential_value(args.credential_ref, value))
+            return 0
+        if command in {"list", "ls"}:
+            _print_public({"credentials": list_credentials()})
+            return 0
+        if command == "revoke":
+            _print_public(revoke_credential(args.credential_ref))
+            return 0
+        if command in {"delete", "rm"}:
+            _print_public(delete_credential(args.credential_ref))
+            return 0
+    except CredentialStoreError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 1
+    print("Run `hermes credentials --help`.", file=sys.stderr)
+    return 1
+
+
+def build_credentials_parser(subparsers) -> argparse.ArgumentParser:  # noqa: ANN001
+    parser = subparsers.add_parser(
+        "credentials",
+        aliases=["credential"],
+        help="Enter and manage opaque agent credentials via masked terminal UI",
+        description=(
+            "Secure credential entry for agent workflows. The model receives "
+            "only opaque credential refs; values are entered with getpass in a "
+            "separate masked terminal prompt and stored encrypted per profile."
+        ),
+    )
+    subs = parser.add_subparsers(dest="credentials_command")
+
+    request = subs.add_parser("request", help="Create/return a pending opaque credential ref")
+    request.add_argument("name", help="Credential name, e.g. github-pat")
+    request.add_argument("--type", default="secret", help="Credential type, e.g. api_key/token/password")
+    request.set_defaults(func=cmd_credentials)
+
+    set_cmd = subs.add_parser("set", help="Set a credential value using masked input")
+    set_cmd.add_argument("name", help="Credential name")
+    set_cmd.add_argument("--type", default="secret", help="Credential type")
+    set_cmd.add_argument("--no-confirm", action="store_true", help="Skip second masked confirmation prompt")
+    set_cmd.set_defaults(func=cmd_credentials)
+
+    update = subs.add_parser("update", help="Update an existing credential by opaque ref")
+    update.add_argument("credential_ref", help="Opaque credential ref")
+    update.add_argument("--no-confirm", action="store_true", help="Skip second masked confirmation prompt")
+    update.set_defaults(func=cmd_credentials)
+
+    list_cmd = subs.add_parser("list", aliases=["ls"], help="List refs and metadata only")
+    list_cmd.set_defaults(func=cmd_credentials)
+
+    revoke = subs.add_parser("revoke", help="Revoke a credential; future resolution fails")
+    revoke.add_argument("credential_ref", help="Opaque credential ref")
+    revoke.set_defaults(func=cmd_credentials)
+
+    delete = subs.add_parser("delete", aliases=["rm"], help="Delete a credential record")
+    delete.add_argument("credential_ref", help="Opaque credential ref")
+    delete.set_defaults(func=cmd_credentials)
+
+    parser.set_defaults(func=cmd_credentials)
+    return parser

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -13379,6 +13379,13 @@ def main():
     secrets_parser.set_defaults(func=_dispatch_secrets)
 
     # =========================================================================
+    # credentials command — masked opaque credential entry for agents
+    # =========================================================================
+    from hermes_cli.credential_commands import build_credentials_parser
+
+    build_credentials_parser(subparsers)
+
+    # =========================================================================
     # egress command — iron-proxy outbound credential-injection firewall
     # =========================================================================
     # NOTE: this is the OUTBOUND egress firewall (ironsh/iron-proxy).

--- a/tests/test_opaque_credentials.py
+++ b/tests/test_opaque_credentials.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+
+def test_opaque_credential_e2e_no_plaintext_context_logs_auth_and_revoke(tmp_path, monkeypatch):
+    secret = "dummy-secret-never-visible-1234567890"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-a"))
+
+    from hermes_logging import setup_logging
+    from agent.credential_store import (
+        request_credential,
+        resolve_credential_value,
+        revoke_credential,
+        set_credential_value,
+    )
+    from agent.redact import redact_sensitive_text
+    from model_tools import handle_function_call
+
+    log_dir = setup_logging(hermes_home=Path(os.environ["HERMES_HOME"]), force=True)
+
+    requested = request_credential("dummy-api", "api_key")
+    ref = requested["ref"]
+    assert secret not in json.dumps(requested)
+
+    stored = set_credential_value("dummy-api", "api_key", secret)
+    assert stored["ref"] == ref
+    assert stored["has_secret"] is True
+    assert secret not in json.dumps(stored)
+
+    # Per-profile isolation: the same opaque ref is not resolvable from another
+    # Hermes home/profile.
+    original_home = os.environ["HERMES_HOME"]
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profile-b"))
+    try:
+        resolve_credential_value(ref, expected_type="api_key")
+        raise AssertionError("credential ref resolved across profiles")
+    except Exception as exc:
+        assert "not found" in str(exc)
+    monkeypatch.setenv("HERMES_HOME", original_home)
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self):  # noqa: N802
+            if self.headers.get("Authorization") == f"Bearer {secret}":
+                self.send_response(200)
+                self.end_headers()
+                self.wfile.write(b"authenticated")
+            else:
+                self.send_response(401)
+                self.end_headers()
+                self.wfile.write(b"unauthorized")
+
+        def log_message(self, format, *args):  # noqa: ANN001,A002
+            logging.getLogger("tests.credential_e2e.server").info(format, *args)
+
+    server = HTTPServer(("127.0.0.1", 0), Handler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        # Authenticated action: a tool resolves plaintext only inside execution
+        # code, injects it into the HTTP header, and never returns it to model
+        # context.
+        import urllib.request
+        from tools.registry import registry
+
+        def _authenticated_get(args, **kwargs):  # noqa: ANN001,ARG001
+            token = resolve_credential_value(args["credential_ref"], expected_type="api_key")
+            req = urllib.request.Request(f"http://127.0.0.1:{port}/")
+            req.add_header("Authorization", f"Bearer {token}")
+            with urllib.request.urlopen(req, timeout=5) as response:  # noqa: S310
+                return json.dumps({"success": True, "status": response.status, "body": response.read().decode("utf-8")})
+
+        registry.register(
+            name="credential_e2e_authenticated_get",
+            toolset="credentials",
+            schema={
+                "name": "credential_e2e_authenticated_get",
+                "description": "test-only authenticated request",
+                "parameters": {
+                    "type": "object",
+                    "properties": {"credential_ref": {"type": "string"}},
+                    "required": ["credential_ref"],
+                },
+            },
+            handler=_authenticated_get,
+            override=True,
+        )
+        auth_result = handle_function_call(
+            "credential_e2e_authenticated_get",
+            {"credential_ref": ref},
+            enabled_toolsets=["credentials"],
+        )
+        assert secret not in auth_result
+        auth_payload = json.loads(auth_result)
+        assert auth_payload == {"success": True, "status": 200, "body": "authenticated"}
+
+        # Model-facing credential surface sees only opaque refs and public metadata.
+        tool_result = handle_function_call(
+            "credential",
+            {"operation": "status", "credential_ref": ref},
+            enabled_toolsets=["credentials"],
+        )
+        assert ref in tool_result
+        assert secret not in tool_result
+
+        # Simulated model context: user prompt + assistant tool request + tool result.
+        model_context = json.dumps(
+            [
+                {"role": "user", "content": "Use dummy-api"},
+                {"role": "assistant", "tool_calls": [{"name": "credential", "arguments": {"operation": "status", "credential_ref": ref}}]},
+                {"role": "tool", "name": "credential", "content": tool_result},
+            ],
+            ensure_ascii=False,
+        )
+        assert secret not in model_context
+
+        # Logging redacts registered credentials even if a buggy caller logs one.
+        logging.getLogger("tests.credential_e2e").warning("leaked? %s", secret)
+        from hermes_logging import flush_log_queue
+        flush_log_queue()
+        log_text = "\n".join(
+            p.read_text(encoding="utf-8", errors="replace")
+            for p in log_dir.glob("*.log")
+        )
+        assert secret not in log_text
+        assert "«redacted-credential»" in log_text
+
+        # Generic redactor also catches the exact stored value in tool-like output.
+        assert secret not in redact_sensitive_text(f"token={secret}", force=True)
+
+        revoked = revoke_credential(ref)
+        assert revoked["status"] == "revoked"
+        revoked_result = handle_function_call(
+            "credential_e2e_authenticated_get",
+            {"credential_ref": ref},
+            enabled_toolsets=["credentials"],
+        )
+        assert secret not in revoked_result
+        revoked_payload = json.loads(revoked_result)
+        assert "error" in revoked_payload
+        assert "not active" in revoked_payload["error"]
+    finally:
+        server.shutdown()
+        server.server_close()

--- a/tools/credential_tool.py
+++ b/tools/credential_tool.py
@@ -1,0 +1,93 @@
+"""Opaque credential request/management tool.
+
+This tool intentionally never accepts or returns plaintext credential values.
+Users enter/update values through `hermes credentials set/update`, which uses a
+masked terminal prompt outside model chat.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+from agent.credential_store import (
+    CredentialStoreError,
+    delete_credential,
+    list_credentials,
+    request_credential,
+    revoke_credential,
+)
+from tools.registry import registry, tool_error
+
+
+SCHEMA = {
+    "name": "credential",
+    "description": (
+        "Request and manage opaque credential references without seeing secret "
+        "values. Use operation=request when a password/token/API key is needed; "
+        "never ask the user to paste secrets in chat. Values are entered via a "
+        "separate masked `hermes credentials set` UI. Returns only credential refs."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "operation": {
+                "type": "string",
+                "enum": ["request", "list", "revoke", "delete", "status"],
+                "description": "request creates/returns a pending opaque ref; revoke/delete/status operate by credential_ref.",
+            },
+            "name": {
+                "type": "string",
+                "description": "Human-readable credential name for request, e.g. github-pat or client-api-token.",
+            },
+            "credential_type": {
+                "type": "string",
+                "description": "Short type identifier such as api_key, token, password, oauth_refresh_token. Defaults to secret.",
+            },
+            "credential_ref": {
+                "type": "string",
+                "description": "Opaque credential reference returned by request/list. Never contains plaintext.",
+            },
+        },
+        "required": ["operation"],
+        "additionalProperties": False,
+    },
+}
+
+
+def _handle(args: Dict[str, Any], **_: Any) -> str:
+    op = str(args.get("operation") or "").strip().lower()
+    try:
+        if op == "request":
+            record = request_credential(
+                str(args.get("name") or ""),
+                str(args.get("credential_type") or "secret"),
+            )
+            return json.dumps({"success": True, "credential": record}, ensure_ascii=False)
+        if op == "list":
+            return json.dumps({"success": True, "credentials": list_credentials()}, ensure_ascii=False)
+        if op == "status":
+            ref = str(args.get("credential_ref") or "")
+            for record in list_credentials():
+                if record.get("ref") == ref:
+                    return json.dumps({"success": True, "credential": record}, ensure_ascii=False)
+            return tool_error("credential reference not found")
+        if op == "revoke":
+            record = revoke_credential(str(args.get("credential_ref") or ""))
+            return json.dumps({"success": True, "credential": record}, ensure_ascii=False)
+        if op == "delete":
+            record = delete_credential(str(args.get("credential_ref") or ""))
+            return json.dumps({"success": True, "credential": record}, ensure_ascii=False)
+        return tool_error("operation must be one of request, list, status, revoke, delete")
+    except CredentialStoreError as exc:
+        return tool_error(str(exc))
+
+
+registry.register(
+    name="credential",
+    toolset="credentials",
+    schema=SCHEMA,
+    handler=_handle,
+    requires_env=[],
+    emoji="🔐",
+)

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -1095,6 +1095,28 @@ class ToolRegistry:
     # ------------------------------------------------------------------
 
     @staticmethod
+    def _redact_handler_result(result):
+        try:
+            from agent.redact import redact_sensitive_text
+        except Exception:
+            return result
+        if isinstance(result, str):
+            return redact_sensitive_text(result, force=True, redact_url_credentials=True)
+        if isinstance(result, dict) and result.get("_multimodal") is True:
+            redacted = dict(result)
+            content = []
+            for item in result.get("content", []):
+                if isinstance(item, dict) and isinstance(item.get("text"), str):
+                    item = dict(item)
+                    item["text"] = redact_sensitive_text(
+                        item["text"], force=True, redact_url_credentials=True
+                    )
+                content.append(item)
+            redacted["content"] = content
+            return redacted
+        return result
+
+    @staticmethod
     def _normalize_handler_result(name: str, result):
         """Enforce the result shapes supported by the agent tool pipeline.
 
@@ -1103,6 +1125,7 @@ class ToolRegistry:
         other value as a string error keeps logging, hooks, budgeting, and
         persistence from receiving values they cannot safely slice or size.
         """
+        result = ToolRegistry._redact_handler_result(result)
         if isinstance(result, str):
             return _bound_json_error_result(result)
         if (

--- a/toolsets.py
+++ b/toolsets.py
@@ -172,6 +172,12 @@ TOOLSETS = {
         "tools": ["terminal", "process"],
         "includes": []
     },
+
+    "credentials": {
+        "description": "Opaque credential request/revoke/list tools; values entered via masked CLI and resolved only at execution time",
+        "tools": ["credential"],
+        "includes": []
+    },
     
     "skills": {
         "description": "Access, create, edit, and manage skill documents with specialized instructions and knowledge",


### PR DESCRIPTION
## What

Lets Hermes reference secrets by opaque ref (`cred_xxxx`) without the model
ever seeing plaintext or secrets passing through chat/context:

- `agent/credential_store.py`: Fernet-encrypted store under
  `~/.hermes/credentials/`, one `master.key` (0600) + `store.json` per
  profile (`get_hermes_home()`-scoped, so refs never resolve across
  profiles). `request`/`set`/`update`/`revoke`/`delete`/`list` +
  `resolve_credential_value()` for trusted execution code only (never
  exposed as a model tool).
- `tools/credential_tool.py`: model-facing tool
  (`request`/`list`/`status`/`revoke`/`delete`) — returns refs and
  metadata only, never values.
- `hermes_cli/credential_commands.py`: `hermes credentials set/update` with
  `getpass` masked prompts, entered outside chat.
- `agent/redact.py`: `redact_registered_secrets()` wired into the general
  redaction path so any active stored secret value is scrubbed from
  logs/tool output even if a caller accidentally logs it.
- `tools/registry.py`: force-redact tool handler results with
  `redact_url_credentials=True` as a defense-in-depth boundary.
- `toolsets.py` / `hermes_cli/main.py`: register the `credentials` toolset
  and CLI subcommand.

## Why

Today the only way to hand Hermes a secret is either pasting it in chat
(lands in model context/logs) or hand-editing `.env` (fine for static
provider keys, awkward for ad-hoc per-task credentials like a client API
token). This gives agent workflows a third option: request an opaque ref,
have the human enter the value via a masked terminal prompt, and let
execution code resolve/use it without the value ever touching model
context.

## Verification

Real E2E test (`tests/test_opaque_credentials.py`, not mocked):
request -> set via masked input -> resolve only inside execution code ->
real Bearer-auth HTTP call to a local test server -> 200 -> asserts the
secret never appears in model context, tool output, or logs -> revoke ->
post-revoke call fails closed. Cross-profile isolation is asserted
directly (same ref does not resolve under a different `HERMES_HOME`).

```
1 passed in 1.52s   # tests/test_opaque_credentials.py
```

Also manually re-verified end-to-end against an isolated `HERMES_HOME`
(request/set/resolve/list/revoke) before opening this PR.