### PR TITLE
fix(agent): preserve invalid reasoning effort errors without compression

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1666,6 +1666,23 @@ def _classify_400(
             should_fallback=False,
         )
 
+    # Invalid reasoning configuration is a deterministic request-validation
+    # failure, not context overflow. Some OpenAI-compatible Responses
+    # providers return only structured fields (no message), so the generic
+    # large-request heuristic below otherwise treats the empty message as a
+    # bare overflow and enters a compression loop that cannot repair the
+    # rejected parameter.
+    error_param_lower = _extract_error_param(body).lower()
+    if (
+        error_code_lower == "invalid_reasoning_effort"
+        or error_param_lower in {"reasoning.effort", "reasoning_effort"}
+    ):
+        return result_fn(
+            FailoverReason.format_error,
+            retryable=False,
+            should_fallback=True,
+        )
+
     # Server-injected parameter rejection: a 400 blaming a request field the
     # client never sent.  MUST be checked BEFORE the request-validation branch
     # below, which would otherwise class it as a deterministic format_error and
@@ -2145,7 +2162,13 @@ def _extract_error_code(body: dict) -> str:
 
     error_obj = body.get("error", {})
     if isinstance(error_obj, dict):
-        code = error_obj.get("code") or error_obj.get("type") or ""
+        code = (
+            error_obj.get("code")
+            or error_obj.get("error_code")
+            or error_obj.get("errorCode")
+            or error_obj.get("type")
+            or ""
+        )
         if isinstance(code, str) and code.strip() and code.strip() != "400":
             return code.strip()
 
@@ -2170,6 +2193,16 @@ def _extract_error_code(body: dict) -> str:
         if text and text != "400":
             return text
     return ""
+
+
+def _extract_error_param(body: dict) -> str:
+    """Extract a request parameter name from flat or nested error bodies."""
+    if not isinstance(body, dict):
+        return ""
+    error_obj = body.get("error")
+    payload = error_obj if isinstance(error_obj, dict) else body
+    param = payload.get("param")
+    return param.strip() if isinstance(param, str) else ""
 
 
 def _extract_message(error: Exception, body: dict) -> str:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -2144,33 +2144,29 @@ def _extract_error_code(body: dict) -> str:
     if not body:
         return ""
 
+    def _specific_code(payload) -> str:
+        """Return the first non-generic structured code from a payload."""
+        if not isinstance(payload, dict):
+            return ""
+        for key in ("code", "error_code", "errorCode", "type"):
+            candidate = payload.get(key)
+            if isinstance(candidate, (str, int)):
+                text = str(candidate).strip()
+                if text and text != "400":
+                    return text
+        return ""
+
     def _code_from_payload(payload) -> str:
         """Extract a code/type from a nested error payload dict (defensive)."""
         if not isinstance(payload, dict):
             return ""
-        payload_error = payload.get("error", {})
-        if isinstance(payload_error, dict):
-            nested = payload_error.get("code") or payload_error.get("type") or ""
-            if isinstance(nested, str) and nested.strip() and nested.strip() != "400":
-                return nested.strip()
-        code = payload.get("code") or payload.get("error_code") or ""
-        if isinstance(code, (str, int)):
-            text = str(code).strip()
-            if text and text != "400":
-                return text
-        return ""
+        return _specific_code(payload.get("error")) or _specific_code(payload)
 
     error_obj = body.get("error", {})
     if isinstance(error_obj, dict):
-        code = (
-            error_obj.get("code")
-            or error_obj.get("error_code")
-            or error_obj.get("errorCode")
-            or error_obj.get("type")
-            or ""
-        )
-        if isinstance(code, str) and code.strip() and code.strip() != "400":
-            return code.strip()
+        code = _specific_code(error_obj)
+        if code:
+            return code
 
         # Some providers wrap the real JSON error body as a string inside
         # error.message — peek into it for a nested code (e.g. Responses API
@@ -2186,13 +2182,7 @@ def _extract_error_code(body: dict) -> str:
             if nested_code:
                 return nested_code
 
-    # Top-level code
-    code = body.get("code") or body.get("error_code") or body.get("errorCode") or ""
-    if isinstance(code, (str, int)):
-        text = str(code).strip()
-        if text and text != "400":
-            return text
-    return ""
+    return _specific_code(body)
 
 
 def _extract_error_param(body: dict) -> str:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -475,6 +475,11 @@ class TestClassifyApiError:
                 "retryable": False,
             },
             {
+                "code": 400,
+                "error_code": "invalid_reasoning_effort",
+                "retryable": False,
+            },
+            {
                 "param": "reasoning.effort",
                 "retryable": False,
             },

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -467,6 +467,40 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.format_error
         assert result.retryable is False
 
+    @pytest.mark.parametrize(
+        "error_payload",
+        [
+            {
+                "error_code": "invalid_reasoning_effort",
+                "retryable": False,
+            },
+            {
+                "param": "reasoning.effort",
+                "retryable": False,
+            },
+        ],
+    )
+    def test_400_invalid_reasoning_effort_never_compresses(self, error_payload):
+        """A reasoning-configuration rejection is not context overflow."""
+        e = MockAPIError(
+            "Error code: 400 - invalid request",
+            status_code=400,
+            body={"error": error_payload},
+        )
+
+        result = classify_api_error(
+            e,
+            provider="custom",
+            model="gpt-5.6-sol",
+            approx_tokens=750,
+            context_length=1024,
+        )
+
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+        assert result.should_compress is False
+        assert result.should_fallback is True
+
     def test_message_only_overloaded_without_status_is_overloaded(self):
         """Some Anthropic-compatible proxies surface 'overloaded' in the
         message with no 503/529 status_code. It must classify as overloaded


### PR DESCRIPTION
## What does this PR do?

Custom Responses providers can reject an unsupported reasoning effort with a structured HTTP 400 that contains no message. Hermes currently treats that body as a generic context overflow for requests above its size heuristic, compresses a healthy conversation, and hides the real validation failure. This change gives the structured reasoning validation signals priority and fails fast without compression.

### Symptom

A provider returns `error_code=invalid_reasoning_effort` or `param=reasoning.effort`, but Hermes enters context compression and eventually reports `Context length exceeded (... tokens). Cannot compress further.`

### Impact

Users of OpenAI-compatible Responses providers can lose useful conversation context to an unnecessary compression attempt and receive a misleading context-length error instead of the actual unsupported reasoning configuration.

### Bug Cause

**Trigger:** `agent/error_classifier.py` / `_classify_400` / a structured 400 with no message and a request above the generic size heuristic.

**Causal chain:**
1. The provider rejects `reasoning.effort` with a nested `error_code` or `param`, but no human-readable message.
2. `_extract_error_code` ignores nested `error.error_code`, and `_classify_400` does not inspect the structured parameter.
3. The empty message is considered generic, so the size heuristic classifies the response as `context_overflow` and starts compression with the invalid parameter unchanged.

**Why it is wrong:** Compression cannot make an unsupported request parameter valid, and it replaces the provider's deterministic validation failure with an unrelated context error.

**Working sibling / contrast:** Explicit context-window messages and context-specific error codes already take the real overflow path and continue to enable compression.

**Ruled out:** The failure is not caused by an exhausted context window. A focused classifier probe reproduces the wrong result from the structured 400 alone, and the regression test turns green when those structured validation fields are handled before the generic overflow heuristic.

### Fix

Extract nested `error_code` values, recognize both `invalid_reasoning_effort` and `reasoning.effort` as deterministic request-validation signals, and return a non-retryable `format_error` with compression disabled. Regression coverage includes both structured shapes at a request size that previously activated the bogus overflow path.

## Related Issue

Closes #100536

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py` - classify structured invalid reasoning effort responses before generic context-overflow recovery.
- `tests/agent/test_error_classifier.py` - cover nested error-code and parameter-only Responses error bodies.

## How to Test

1. Construct an HTTP 400 error body containing either `error.error_code=invalid_reasoning_effort` or `error.param=reasoning.effort` without a message.
2. Classify it with request usage above the generic 400 size heuristic.
3. Confirm the result is `format_error`, non-retryable, and has `should_compress=false`.

```bash
scripts/run_tests.sh tests/agent/test_error_classifier.py -q
```

Result: 124 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on the relevant test file and all 124 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the classifier logic is platform-independent
- [x] Tool description and schema updates are N/A because no tool behavior changed

## Screenshots / Logs

The focused classifier suite passed: 124 tests passed, 0 failed.
