### PR TITLE
fix(mcp): tolerate Google issuer slash drift

### DIFF
--- a/tests/tools/test_mcp_oauth_manager.py
+++ b/tests/tools/test_mcp_oauth_manager.py
@@ -365,6 +365,85 @@ def test_bridge_forwards_requests_and_poisons_on_token_endpoint_400(
     assert not (d / "srv.client.json").exists()
     assert provider._initialized is False
     assert provider.context.client_info is None
+
+
+def _drive_google_issuer_discovery(provider, monkeypatch, *, server_url):
+    """Run the provider bridge across the SDK's strict issuer validator."""
+    from mcp.client.auth.oauth2 import OAuthClientProvider
+    from mcp.client.auth.utils import validate_metadata_issuer
+    from mcp.shared.auth import OAuthMetadata
+
+    discovery_request = SimpleNamespace(
+        url="https://accounts.google.com/.well-known/oauth-authorization-server"
+    )
+    metadata = OAuthMetadata.model_validate({
+        "issuer": "https://accounts.google.com",
+        "authorization_endpoint": "https://accounts.google.com/o/oauth2/v2/auth",
+        "token_endpoint": "https://oauth2.googleapis.com/token",
+        "response_types_supported": ["code"],
+    })
+
+    async def fake_base_flow(self, request):
+        self.context.auth_server_url = "https://accounts.google.com/"
+        response = yield discovery_request
+        validate_metadata_issuer(metadata, self.context.auth_server_url)
+
+    monkeypatch.setattr(OAuthClientProvider, "async_auth_flow", fake_base_flow)
+    provider.context.server_url = server_url
+    provider.context.oauth_metadata = metadata
+
+    metadata_response = _fake_response(
+        200,
+        str(discovery_request.url),
+        metadata.model_dump_json().encode(),
+    )
+
+    async def drive():
+        gen = provider.async_auth_flow(object())
+        assert await gen.__anext__() is discovery_request
+        try:
+            await gen.asend(metadata_response)
+        except StopAsyncIteration:
+            pass
+
+    asyncio.run(drive())
+
+
+def test_google_mcp_trailing_slash_issuer_is_accepted(tmp_path, monkeypatch):
+    """Google MCP's PRM/ASM slash disagreement must not break reconnect auth."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://oauth2.googleapis.com/token", monkeypatch
+    )
+
+    _drive_google_issuer_discovery(
+        provider,
+        monkeypatch,
+        server_url="https://drivemcp.googleapis.com/mcp/v1",
+    )
+
+    assert provider.context.auth_server_url == "https://accounts.google.com"
+
+
+def test_non_google_mcp_trailing_slash_issuer_stays_rejected(tmp_path, monkeypatch):
+    """The compatibility exception must not weaken issuer checks generally."""
+    from mcp.client.auth import OAuthFlowError
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    provider = _provider_with_token_endpoint(
+        tmp_path, {}, "https://oauth2.googleapis.com/token", monkeypatch
+    )
+
+    with pytest.raises(OAuthFlowError, match="issuer mismatch"):
+        _drive_google_issuer_discovery(
+            provider,
+            monkeypatch,
+            server_url="https://mcp.example.com/mcp",
+        )
+
+    assert provider.context.auth_server_url == "https://accounts.google.com/"
+
+
 @pytest.mark.asyncio
 async def test_manager_provider_token_exchange_includes_dcr_secret(tmp_path, monkeypatch):
     """The manager provider path applies the same Supabase DCR secret fix."""

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -421,6 +421,63 @@ def _make_hermes_provider_class() -> Optional[type]:
             ):
                 storage.save_oauth_metadata(meta)
 
+        async def _apply_google_issuer_compat(
+            self, discovery_request: Any, response: Any
+        ) -> None:
+            """Reconcile Google's MCP PRM/ASM trailing-slash disagreement.
+
+            Google Drive and Calendar currently advertise
+            ``https://accounts.google.com/`` in protected-resource metadata,
+            while the corresponding authorization-server metadata declares
+            ``https://accounts.google.com``. MCP SDK 2.x correctly compares
+            those strings exactly, so reconnect-time discovery otherwise
+            raises ``OAuthFlowError`` before a cached token can be refreshed.
+
+            Keep the exception vendor- and endpoint-specific: only the two
+            Google MCP hosts, Google's well-known metadata response, and this
+            exact slash-only pair qualify. Every other issuer mismatch still
+            reaches the SDK's strict validator unchanged.
+            """
+            from urllib.parse import urlsplit
+
+            if getattr(self.context, "auth_server_url", None) != (
+                "https://accounts.google.com/"
+            ):
+                return
+
+            try:
+                server_host = urlsplit(str(self.context.server_url)).hostname
+                request_url = urlsplit(str(discovery_request.url))
+            except (AttributeError, ValueError):
+                return
+            if server_host not in {
+                "drivemcp.googleapis.com",
+                "calendarmcp.googleapis.com",
+            }:
+                return
+            if request_url.hostname != "accounts.google.com" or request_url.path not in {
+                "/.well-known/oauth-authorization-server",
+                "/.well-known/openid-configuration",
+            }:
+                return
+            if getattr(response, "status_code", None) != 200:
+                return
+
+            try:
+                import json
+
+                payload = json.loads(await response.aread())
+            except (AttributeError, TypeError, ValueError):
+                return
+            if payload.get("issuer") != "https://accounts.google.com":
+                return
+
+            self.context.auth_server_url = "https://accounts.google.com"
+            logger.debug(
+                "MCP OAuth '%s': normalized Google's slash-only issuer mismatch",
+                self._hermes_server_name,
+            )
+
         async def _maybe_flag_poisoned_client(self, response: Any) -> None:
             """Detect a dead client registration and force re-registration.
 
@@ -579,6 +636,7 @@ def _make_hermes_provider_class() -> Optional[type]:
                         break
                     # Sniff the response for a dead-client-registration signal
                     # before handing it back to the SDK (best-effort, GH#36767).
+                    await self._apply_google_issuer_compat(outgoing, incoming)
                     await self._maybe_flag_poisoned_client(incoming)
                     outgoing = await inner.asend(incoming)
             except StopAsyncIteration:


### PR DESCRIPTION
## Summary
- reconcile the exact Google Drive/Calendar PRM issuer trailing-slash mismatch before MCP SDK validation
- retain strict issuer rejection for all other providers and mismatch shapes
- add bridge-level regression coverage for both the compatible and rejected cases

## Root cause
Google MCP protected-resource metadata advertises `https://accounts.google.com/`, while Google authorization-server metadata declares `https://accounts.google.com`. MCP SDK 2.0.0 compares these strings exactly, so reconnect-time OAuth discovery raises `OAuthFlowError` and can park the MCP transport even though cached-token probes remain green.

## Verification
- `scripts/run_tests.sh tests/tools/test_mcp_oauth_manager.py tests/tools/test_mcp_oauth_metadata.py tests/tools/test_mcp_oauth_bidirectional.py tests/tools/test_mcp_tool_401_handling.py` - 26 passed
- live public metadata read reproduced the slash disagreement and the compatibility path normalized it to an exact match
- post-restart Google Drive and Google Calendar MCP probes connected; no new critical MCP/auth/storage log entries