### PR TITLE
fix(approval): honor unattended policy for API sessions

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -853,6 +853,7 @@ class TestWebhookApprovalExclusion:
         assert result["approved"] is False
         assert "api_server" in result["message"]
         smart_approve.assert_not_called()
+        assert "test-api-session" not in approval_mod._pending
 
     def test_api_server_unattended_approve_overrides_process_ask_mode(
         self, monkeypatch

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -831,19 +831,54 @@ class TestWebhookApprovalExclusion:
         assert result["approved"] is True
 
     def test_api_server_dangerous_command_denies_by_default(self, monkeypatch):
-        """api_server sessions get the same instant deny (#87509)."""
+        """api_server sessions deny despite a process-global ask marker."""
+        import tools.approval as approval_mod
         from tools.approval import check_all_command_guards
 
         self._isolate(monkeypatch)
         monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
         monkeypatch.setenv("HERMES_SESSION_PLATFORM", "api_server")
         monkeypatch.setenv("HERMES_SESSION_KEY", "test-api-session")
 
-        result = check_all_command_guards("sudo systemctl restart nginx", "local")
+        with mock_patch.object(
+            approval_mod, "_smart_approve", return_value="escalate"
+        ) as smart_approve:
+            result = check_all_command_guards(
+                "sudo systemctl restart nginx", "local"
+            )
+
         assert result["approved"] is False
         assert "api_server" in result["message"]
+        smart_approve.assert_not_called()
+
+    def test_api_server_unattended_approve_overrides_process_ask_mode(
+        self, monkeypatch
+    ):
+        """A listener-less API turn must not inherit process-global ask mode."""
+        import tools.approval as approval_mod
+        from tools.approval import check_all_command_guards
+
+        self._isolate(monkeypatch)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.setenv("HERMES_EXEC_ASK", "1")
+        monkeypatch.setenv("HERMES_SESSION_PLATFORM", "api_server")
+        monkeypatch.setenv("HERMES_SESSION_KEY", "test-api-session")
+        monkeypatch.setattr(
+            approval_mod, "_get_unattended_approval_mode", lambda: "approve"
+        )
+        with mock_patch.object(
+            approval_mod, "_smart_approve", return_value="escalate"
+        ) as smart_approve:
+            result = check_all_command_guards("pkill -9 -f soffice", "local")
+
+        assert result["approved"] is True
+        smart_approve.assert_not_called()
+        assert "test-api-session" not in approval_mod._pending
 
     def test_execute_code_denied_on_unattended_platform(self, monkeypatch):
         """execute_code is denied instantly on unattended platforms (parity with cron)."""

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4791,10 +4791,10 @@ def check_all_command_guards(command: str, env_type: str,
 
     # HERMES_EXEC_ASK is a legacy process-global routing hint. It must not
     # turn a session-scoped unattended API/webhook request back into an
-    # interactive approval context with no responder. A future unattended
-    # surface that registers an exact approval transport remains interactive
-    # through is_gateway; only listener-less sessions ignore the leaked hint.
-    if _is_unattended_platform_approval_context() and not is_gateway:
+    # interactive approval context with no responder. Every platform in
+    # _UNATTENDED_APPROVAL_PLATFORMS is listener-less by contract; a surface
+    # with an approval transport must not be classified as unattended.
+    if _is_unattended_platform_approval_context():
         is_ask = False
 
     # Single-query (-q) sessions export HERMES_INTERACTIVE=1 but have no user

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -4789,6 +4789,14 @@ def check_all_command_guards(command: str, env_type: str,
     is_gateway = _is_gateway_approval_context()
     is_ask = env_var_enabled("HERMES_EXEC_ASK")
 
+    # HERMES_EXEC_ASK is a legacy process-global routing hint. It must not
+    # turn a session-scoped unattended API/webhook request back into an
+    # interactive approval context with no responder. A future unattended
+    # surface that registers an exact approval transport remains interactive
+    # through is_gateway; only listener-less sessions ignore the leaked hint.
+    if _is_unattended_platform_approval_context() and not is_gateway:
+        is_ask = False
+
     # Single-query (-q) sessions export HERMES_INTERACTIVE=1 but have no user
     # to answer approval prompts — an unanswered prompt just waits the full
     # timeout then fails closed. Treat them as a deterministic non-interactive


### PR DESCRIPTION
## Summary

- honor `approvals.unattended_mode` for listener-less API-server sessions even when the gateway process has `HERMES_EXEC_ASK=1`
- resolve unattended allow/deny policy before invoking the smart-approval guardian
- cover both fail-closed default-deny and explicit auto-approve behavior

## Root cause

The API server correctly binds `HERMES_SESSION_PLATFORM=api_server`, and the approval core correctly classifies that platform as unattended. However, `check_all_command_guards()` also read the gateway's process-global `HERMES_EXEC_ASK=1`. That legacy marker kept `is_ask` true after the session-scoped unattended classification, skipped the unattended policy branch, and routed smart `ESCALATE` results into a pending approval path that OpenAI-compatible clients cannot answer.

The fix makes the session-scoped unattended classification override the process-global ask hint when no exact gateway approval transport exists. Interactive gateway sessions remain unchanged.

## Verification

- `scripts/run_tests.sh tests/tools/test_approval.py -k 'api_server_dangerous_command_denies_by_default or api_server_unattended_approve_overrides_process_ask_mode' -q` — 2 passed
- Full `tests/tools/test_approval.py` run reached 117 passed with 2 unrelated pre-existing Windows temp-path failures (`test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, `test_symlinked_temp_dir_only_exempts_canonical_target`)

## Related Issue

Closes #100532
