### PR TITLE
fix(desktop): render direct bot-to-bot DM replies visible (not collapsed)

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -161,11 +161,15 @@ const InterAgentCollapsedNotice: FC<{ sender: string }> = ({ sender }) => (
  */
 const InterAgentAssistantMessage: FC<AssistantMessageProps & { sender: string }> = ({ sender, ...props }) => {
   const isRunning = useAuiState(s => s.message.status?.type === 'running')
+  // Collapse a bot-to-bot reply behind a "Replied to X" notice ONLY when the
+  // thread opts in. Direct Bot Chat DMs have no other surface to show the
+  // reply, so collapsing it hides the receiving bot's activity entirely.
+  const collapse = useAuiState(s => s.message.metadata?.custom?.interAgentCollapse === true)
 
   return (
     <AssistantMessageBody
       {...props}
-      collapsedNotice={isRunning ? null : <InterAgentCollapsedNotice sender={sender} />}
+      collapsedNotice={collapse && !isRunning ? <InterAgentCollapsedNotice sender={sender} /> : null}
     />
   )
 }

--- a/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/inter-agent-collapse.test.tsx
@@ -1,17 +1,15 @@
-// Two contracts with no coverage before the invalidation-scoping work split
-// AssistantMessage into InterAgentAssistantMessage + AssistantMessageBody:
+// Two contracts for the split of AssistantMessage into
+// InterAgentAssistantMessage + AssistantMessageBody:
 //
 // 1. The collapse gate. A reply to an inter-agent delivery renders collapsed
-//    ("Replied to <sender>", expandable) ONLY once it settles — never while it
-//    streams, because the user should see progress. That gate is the sole
-//    remaining root-level `isRunning` subscription, so it is the thing most
-//    likely to break if the split is revisited.
-// 2. The streaming marker. `data-message-streaming` moved off the message root
-//    onto a permanently-mounted hidden leaf, and
-//    scripts/run-short-session-hang-repro.mjs derives its settled-row count by
-//    subtracting `[data-message-streaming="true"]` markers from message roots.
-//    Nothing in the app itself reads it, so without this test a delete would
-//    look free and would silently regress that repro's response gate.
+//    ("Replied to <sender>", expandable) ONLY when the thread opts in via
+//    `message.metadata.custom.interAgentCollapse === true` AND the turn has
+//    settled. Direct bot-to-bot DMs (no opt-in) render the reply expanded and
+//    visible — the receiving bot's activity is the whole point of the chat.
+//    The streaming marker (`data-message-streaming`) stays on a
+//    permanently-mounted hidden leaf regardless, so a delete looks free and
+//    would silently regress scripts/run-short-session-hang-repro.mjs, which
+//    derives settled-row count by subtracting those markers from roots.
 import { AssistantRuntimeProvider, type ThreadMessage, useExternalStoreRuntime } from '@assistant-ui/react'
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
@@ -42,7 +40,9 @@ afterEach(() => {
   cleanup()
 })
 
-const assistantMetadata = { unstable_state: null, unstable_annotations: [], unstable_data: [], steps: [], custom: {} }
+function baseCustom(): Record<string, unknown> {
+  return {}
+}
 
 function user(id: string, text: string): ThreadMessage {
   return {
@@ -51,18 +51,18 @@ function user(id: string, text: string): ThreadMessage {
     content: [{ type: 'text', text }],
     attachments: [],
     createdAt,
-    metadata: { custom: {} }
+    metadata: { custom: baseCustom() }
   } as ThreadMessage
 }
 
-function assistant(id: string, text: string, running: boolean): ThreadMessage {
+function assistant(id: string, text: string, running: boolean, custom: Record<string, unknown> = baseCustom()): ThreadMessage {
   return {
     id,
     role: 'assistant',
     content: text ? [{ type: 'text', text }] : [],
     status: running ? { type: 'running' } : { type: 'complete', reason: 'stop' },
     createdAt,
-    metadata: assistantMetadata
+    metadata: { custom }
   } as ThreadMessage
 }
 
@@ -83,20 +83,37 @@ function Harness({ messages }: { messages: ThreadMessage[] }) {
 const DELIVERY = 'Message from 🤖 Hermes (@hermes): please check the build'
 
 describe('inter-agent collapse gate', () => {
-  it('collapses a settled reply to an inter-agent delivery', async () => {
-    render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'build is green', false)]} />)
+  it('shows a settled direct-DM reply inline (not collapsed/hidden)', async () => {
+    render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'the build is green', false)]} />)
 
-    expect(await screen.findByText(/Replied to/)).toBeTruthy()
-    expect(screen.getByText('show reply')).toBeTruthy()
+    await screen.findByText('the build is green')
+    expect(screen.queryByText(/Replied to/)).toBeNull()
+    expect(screen.queryByText('show reply')).toBeNull()
   })
 
   it('does NOT collapse while that reply is still streaming', async () => {
     const { container } = render(<Harness messages={[user('u1', DELIVERY), assistant('a1', 'working on it', true)]} />)
 
     await screen.findByText('working on it')
+    expect(screen.queryByText(/Replied to/)).toBeNull()
     expect(screen.queryByText('show reply')).toBeNull()
     // Expanded => the full body root, which carries the streaming marker.
     expect(container.querySelector('[data-message-streaming="true"]')).toBeTruthy()
+  })
+
+  it('collapses a settled reply ONLY when the thread opts in', async () => {
+    render(
+      <Harness
+        messages={[user('u1', DELIVERY), assistant('a1', 'build is green', false, { interAgentCollapse: true })]}
+      />
+    )
+
+    expect(await screen.findByText(/Replied to/)).toBeTruthy()
+    expect(screen.getByText('show reply')).toBeTruthy()
+    // A closed <details> keeps its content in the DOM (hidden, not removed).
+    const summary = screen.getByText('show reply').closest('details')
+    expect(summary).toBeTruthy()
+    expect(summary?.hasAttribute('open')).toBe(false)
   })
 
   it('leaves an ordinary reply expanded', async () => {

--- a/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/status-invalidation-scope.test.tsx
@@ -142,10 +142,12 @@ describe('streaming-status invalidation scope', () => {
   })
 
   it('keeps the same root DOM node across the settle transition', async () => {
-    // The inter-agent reply collapses once it settles. Rendering that as a
-    // competing root swapped the element type at this position, so React
-    // unmounted the row and mounted a fresh one — discarding the DOM the
-    // scroll anchor was holding.
+    // A direct bot-to-bot reply now renders EXPANDED (visible) on settle, not
+    // collapsed behind a "Replied to" toggle. Rendering that as a competing
+    // root previously swapped the element type at this position, so React
+    // unmounted the row and mounted a fresh one — discarding the DOM the scroll
+    // anchor was holding. Same root, updated in place: settle is now a prop
+    // change React applies without a remount.
     const delivery = 'Message from 🤖 Hermes (@hermes): please check the build'
     const messages = [user('u1', delivery), assistant('a1', 'working on it', true)]
     const { container, findByText, rerender } = render(<Harness messages={messages} />)
@@ -156,10 +158,11 @@ describe('streaming-status invalidation scope', () => {
     expect(before).toBeTruthy()
 
     rerender(<Harness messages={[messages[0], assistant('a1', 'working on it', false)]} />)
-    await findByText(/Replied to/)
+    // Settled reply stays visible inline; no collapse / no remount.
+    await findByText('working on it')
+    expect(container.querySelector('[data-slot="aui_assistant-message-root"] [data-slot="aui_assistant-message-content"]')).toBeTruthy()
 
     const after = container.querySelector('[data-slot="aui_assistant-message-root"]')
-
     // Same element, updated in place — not a remount.
     expect(after).toBe(before)
   })


### PR DESCRIPTION
## Summary

When one bot messages another bot directly (a 1:1 Bot Chat DM, **not** in a
shared group), the messages pass and the receiving bot's inbound "Message
from X" notice updates the left-panel headline — but the **responding bot's
messages/activity never render in the main chat view.**

## Root cause

`apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx` —
`InterAgentAssistantMessage` unconditionally collapsed every reply to a
`Message from X` delivery into a closed `<details>` (`Replied to X` / `show
reply`). In a direct bot-to-bot DM that reply is the *only* place the responding
bot's output appears, so collapsing it hid the reply (and the streaming
activity) entirely. The text is still in the DOM inside the closed `<details>`,
which is why the left-panel notice updates but the main view looks empty.

Group rooms render through a separate room view and never hit
`InterAgentAssistantMessage`, which is why groups looked fine while direct DMs
did not — matching the report ("not the same group"). Verified against the
original bundle (`dist/assets/index-kukO7Y0p.js` contained `show reply` but no
`interAgentCollapse` gate).

## Fix

Gate the collapse on an **opt-in** flag: `message.metadata.custom.interAgentCollapse === true`.
- Direct bot-to-bot DMs → reply renders expanded/visible, like a normal turn.
- A shared-group surface that wants the compact "Replied to X" event style keeps
  it by setting `interAgentCollapse` on its inter-agent replies.

One component, one root — settling is a prop change React applies in place, so
the prior no-remount invariant is preserved.

## Verification (single-machine, @hermes ↔ @merlin)

### Component / build (automated)
- `apps/desktop` vitest `ui` project — full `assistant-ui/` suite:
  **52 files / 461 tests pass**.
- `apps/desktop/src/components/assistant-ui/thread/` subset:
  **28 files / 170 tests pass**.
- Added regression test `shows a settled direct-DM reply inline (not collapsed)`
  (failed before the fix, passes after) — asserts `findByText('the build is
  green')` visible and `show reply`/`Replied to` absent.
- `tsc --build tsconfig.electron.json`: clean.
- Production bundle rebuilt (`npx vite build --mode production`):
  `dist/assets/index-BHVOXi-o.js` contains `interAgentCollapse===!0` and still
  contains the `show reply` opt-in notice. (Note: the rebuild overwrote the
  old `index-kukO7Y0p.js` on disk.)

### Live bot-to-bot DM — CONFIRMED (end-to-end through the Electron renderer)
- Launched the app fresh from the rebuilt bundle (backend `HERMES_BACKEND_READY
  port=58269`; profile @merlin backend on 58305).
- Delivered a `Message from 🤖 hermes (@hermes): …` delivery into @merlin's
  Bot Chat via the desktop Bots plugin relay.
- @merlin's backend accepted and routed the delivery (active session
  `bg_124055_f35df0` on `inclusionai/ling-3.0-flash-fin:free`).
- **Empirical confirmation from the GUI:** "I can see bot-to-bot work now" —
  @merlin's reply renders **visible** in the Bot Chat main view (no longer
  hidden behind the collapsed `show reply`), instead of showing only the
  left-panel "replied" notice with an empty main view.

## Provisional / residual gaps
- Bundle was rebuilt from source and the app relaunched to pick it up; a
  **packaged release build** (`hermes update` / installer) has not been cut.
- Cross-connection relay e2e (bot A on gateway 1 → bot B on gateway 2 over the
  relay) was not exercised (single local connection topology only).
- The `interAgentCollapse` opt-in is not yet wired by any group surface; group
  rooms are behaviorally unchanged (they don't render via this component).