### PR TITLE
fix: honor yolo for computer use and bound vision fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7506,11 +7506,42 @@ class AIAgent:
         try:
             from tools.vision_tools import vision_analyze_tool
 
+            # This preprocessing happens before the main provider request is
+            # opened, so the normal API TTFB watchdog cannot protect it. The
+            # auxiliary vision client receives its own timeout, but a provider
+            # adapter or blocking recovery path can fail to unwind promptly.
+            # Add an outer wall-clock bound so one historical screenshot cannot
+            # leave the turn at "starting API call" until the 10-minute turn
+            # liveness watchdog kills the whole session.
+            fallback_timeout = 120.0
+            try:
+                from hermes_cli.config import cfg_get, load_config
+
+                vision_cfg = cfg_get(
+                    load_config(), "auxiliary", "vision", default={}
+                )
+                configured_timeout = float(vision_cfg.get("timeout", 120.0))
+                if configured_timeout > 0:
+                    fallback_timeout = configured_timeout
+            except Exception:
+                pass
+
             result_json = asyncio.run(
-                vision_analyze_tool(image_url=vision_source, user_prompt=analysis_prompt)
+                asyncio.wait_for(
+                    vision_analyze_tool(
+                        image_url=vision_source,
+                        user_prompt=analysis_prompt,
+                    ),
+                    timeout=fallback_timeout,
+                )
             )
             result = json.loads(result_json) if isinstance(result_json, str) else {}
             description = (result.get("analysis") or "").strip()
+        except asyncio.TimeoutError:
+            description = (
+                "Image analysis timed out after "
+                f"{fallback_timeout:g}s; continuing without a visual description."
+            )
         except Exception as e:
             description = f"Image analysis failed: {e}"
         finally:

--- a/tests/run_agent/test_vision_aware_preprocessing.py
+++ b/tests/run_agent/test_vision_aware_preprocessing.py
@@ -13,6 +13,8 @@ Covers:
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import MagicMock, patch
 
 
@@ -133,6 +135,32 @@ class TestPrepareMessagesForNonVision:
         assert out[1]["content"] == "ack"
         assert isinstance(out[2]["content"], str)
         assert "[Image: thing]" in out[2]["content"]
+
+
+class TestImageFallbackLiveness:
+    def test_auxiliary_vision_has_outer_wall_clock_timeout(self, tmp_path):
+        """A stuck pre-API image fallback must not reach turn liveness abort."""
+        agent = _make_agent()
+        image_path = tmp_path / "screen.png"
+        image_path.write_bytes(b"not-read-by-mock")
+
+        async def stuck_vision(**_kwargs):
+            await asyncio.sleep(60)
+
+        started = time.monotonic()
+        with patch(
+            "tools.vision_tools.vision_analyze_tool", side_effect=stuck_vision
+        ), patch(
+            "hermes_cli.config.load_config",
+            return_value={"auxiliary": {"vision": {"timeout": 0.01}}},
+        ):
+            result = agent._describe_image_for_anthropic_fallback(
+                str(image_path), "tool"
+            )
+
+        assert time.monotonic() - started < 1.0
+        assert "Image analysis timed out after 0.01s" in result
+        assert "continuing without a visual description" in result
 
 
 # ─── _model_supports_vision ──────────────────────────────────────────────────

--- a/tests/tools/test_computer_use_cua_0_10_permissions.py
+++ b/tests/tools/test_computer_use_cua_0_10_permissions.py
@@ -38,6 +38,39 @@ def test_any_explicit_hermes_bypass_maps_to_unrestricted_mode():
         assert computer_use._cua_permission_mode("session-a") == "unrestricted"
 
 
+def test_explicit_bypass_skips_foreground_and_focus_approval_callbacks():
+    """The prompt gate and driver mode must honor the same bypass policy.
+
+    Regression: approvals.mode=off selected an unrestricted cua-driver but
+    computer_use still called the CLI approval callback for foreground input
+    (and again for bring_to_front), leaving the turn blocked until its approval
+    timeout and then the liveness watchdog fired.
+    """
+    from tools.computer_use import tool as computer_use
+
+    callback = Mock(return_value="deny")
+    computer_use.set_approval_callback(callback)
+    try:
+        with patch(
+            "tools.approval.is_approval_bypass_active_for_session",
+            return_value=True,
+        ):
+            args = {
+                "action": "type",
+                "text": "foreground approval probe",
+                "delivery_mode": "foreground",
+                "bring_to_front": True,
+            }
+            assert computer_use._request_approval("type", args, "session-a") is None
+            assert computer_use._request_approval(
+                "bring_to_front", args, "session-a"
+            ) is None
+    finally:
+        computer_use.set_approval_callback(None)
+
+    callback.assert_not_called()
+
+
 def test_gateway_session_key_yolo_maps_to_unrestricted_mode():
     """Gateway /yolo keys bypass off the gateway session_key contextvar,
     not the DB session_id the tool path passes. Mode resolution must consult
@@ -48,11 +81,14 @@ def test_gateway_session_key_yolo_maps_to_unrestricted_mode():
     gateway_key = "agent:main:telegram:private:12345"
     token = approval.set_current_session_key(gateway_key)
     try:
-        approval.enable_session_yolo(gateway_key)
-        # Tool dispatch passes the (different) DB session id.
-        assert computer_use._cua_permission_mode("db-sid-xyz") == "unrestricted"
-        approval.disable_session_yolo(gateway_key)
-        assert computer_use._cua_permission_mode("db-sid-xyz") == "standard"
+        with patch("tools.approval._get_approval_mode", return_value="manual"), patch(
+            "tools.approval._YOLO_MODE_FROZEN", False
+        ):
+            approval.enable_session_yolo(gateway_key)
+            # Tool dispatch passes the (different) DB session id.
+            assert computer_use._cua_permission_mode("db-sid-xyz") == "unrestricted"
+            approval.disable_session_yolo(gateway_key)
+            assert computer_use._cua_permission_mode("db-sid-xyz") == "standard"
     finally:
         approval.disable_session_yolo(gateway_key)
         try:

--- a/tests/tools/test_computer_use_cua_0_9.py
+++ b/tests/tools/test_computer_use_cua_0_9.py
@@ -370,17 +370,18 @@ def test_persistent_focus_has_a_separate_approval_scope():
 
     computer_use.set_approval_callback(approve)
     try:
-        result = json.loads(
-            computer_use.handle_computer_use(
-                {
-                    "action": "click",
-                    "element": 1,
-                    "delivery_mode": "foreground",
-                    "bring_to_front": True,
-                },
-                session_id="approval-session",
+        with patch.object(computer_use, "_approval_bypass_active", return_value=False):
+            result = json.loads(
+                computer_use.handle_computer_use(
+                    {
+                        "action": "click",
+                        "element": 1,
+                        "delivery_mode": "foreground",
+                        "bring_to_front": True,
+                    },
+                    session_id="approval-session",
+                )
             )
-        )
     finally:
         computer_use.set_approval_callback(None)
 

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -234,8 +234,8 @@ def _warn_bypass_escalation(session_id: str) -> None:
     )
 
 
-def _cua_permission_mode(session_id: str) -> str:
-    """Map Hermes's explicit approval bypass onto Cua's immutable mode.
+def _approval_bypass_active(session_id: str) -> bool:
+    """Resolve Hermes approval bypass across both session namespaces.
 
     Hermes has TWO session-identity namespaces: the tool-dispatch path passes
     the DB ``session_id`` (``agent.session_id``), while gateway ``/yolo``
@@ -245,7 +245,10 @@ def _cua_permission_mode(session_id: str) -> str:
     gateway ``/yolo`` toggle silently invisible to computer_use (works in
     CLI, dead on messaging platforms), so we consult both namespaces —
     bypass in either means the user explicitly opted out of approvals for
-    this run. Fails closed on any resolution error.
+    this run. This resolver is shared by BOTH the Hermes prompt gate and the
+    cua-driver permission-mode selection; otherwise ``approvals.mode: off``
+    can start an unrestricted driver while the CLI callback still opens a
+    computer-use prompt. Fails closed on any resolution error.
     """
     try:
         from tools.approval import (
@@ -254,15 +257,21 @@ def _cua_permission_mode(session_id: str) -> str:
         )
 
         if is_approval_bypass_active_for_session(session_id):
-            _warn_bypass_escalation(session_id)
-            return "unrestricted"
+            return True
         current_key = get_current_session_key(default="")
         if current_key and is_approval_bypass_active_for_session(current_key):
-            _warn_bypass_escalation(session_id)
-            return "unrestricted"
+            return True
     except Exception:
         # Approval state must fail closed if it cannot be resolved.
         pass
+    return False
+
+
+def _cua_permission_mode(session_id: str) -> str:
+    """Map Hermes's explicit approval bypass onto Cua's immutable mode."""
+    if _approval_bypass_active(session_id):
+        _warn_bypass_escalation(session_id)
+        return "unrestricted"
     try:
         # Without YOLO, honor the configured mode (standard | bounded).
         # bounded requires computer_use.capability_manifest; the backend
@@ -601,6 +610,14 @@ def _request_approval(action: str, args: Dict[str, Any],
     operation. State is keyed on session_id so concurrent runs don't leak
     unlocks into one another.
     """
+    # Keep computer-use aligned with the canonical Hermes approval policy.
+    # In particular, approvals.mode=off / --yolo / session /yolo must bypass
+    # the CLI callback for foreground escalation too. The driver permission
+    # mode already honored this policy; omitting it here produced a second,
+    # contradictory prompt which could then sit for the full approval timeout
+    # and trip the turn-liveness watchdog.
+    if _approval_bypass_active(session_id):
+        return None
     is_foreground = args.get("delivery_mode") == "foreground"
     scope_key = (action, "foreground" if is_foreground else "background")
     with _approval_lock:


### PR DESCRIPTION
Fixes two stalls observed in the CLI:\n\n- computer_use now uses the canonical approval-bypass resolver for both cua-driver permission mode and the CLI prompt gate, so approvals.mode=off / --yolo / session /yolo do not prompt again on foreground escalation or bring_to_front.\n- non-vision image fallback preprocessing now has an outer wall-clock timeout based on auxiliary.vision.timeout, preventing a stuck historical screenshot analysis from sitting at starting API call until the turn-liveness watchdog aborts the session.\n\nRegression tests cover foreground/focus bypass and the outer vision timeout.\n\nVerification: 42 relevant tests passed; one unrelated Windows MCP test was deselected because the local test interpreter lacks pywintypes.