### PR TITLE
fix(desktop): hand off gateway cookies when a connection registration changes its OAuth partition

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -90,6 +90,7 @@ import { detectBundleSkew } from './bundle-skew'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
+  AT_COOKIE_VARIANTS,
   authModeFromStatus,
   buildGatewayWsUrl,
   buildGatewayWsUrlWithTicket,
@@ -119,6 +120,7 @@ import {
   resolveProfileBackendRoute,
   resolveRemoteSshDashboardProfile,
   resolveTestWsUrl,
+  RT_COOKIE_VARIANTS,
   savedProfileSsh,
   tokenPreview,
   withTransientRetries
@@ -268,6 +270,7 @@ import { runNativeLogin } from './native-oauth-login'
 import { loadNativeTokenSet, type NativeTokenStoreIo, persistNativeTokenSet } from './native-token-store'
 import { serializeJsonBody, setJsonRequestHeaders } from './oauth-net-request'
 import { LEGACY_OAUTH_PARTITION, resolveOauthPartition } from './oauth-partition'
+import { handoffOauthCookies } from './oauth-cookie-handoff'
 import { createParentStartMarkerResolver, parentWatchdogEnv } from './parent-process-identity'
 import { registerPetOverlayIpc } from './pet-overlay-ipc'
 import {
@@ -7013,6 +7016,10 @@ function resolveOauthPartitionForUrl(url) {
 function getOauthSessionForUrl(url) {
   const partition = resolveOauthPartitionForUrl(url)
 
+  return getOauthSessionForPartition(partition)
+}
+
+function getOauthSessionForPartition(partition) {
   if (partition === OAUTH_SESSION_PARTITION) {
     return getOauthSession()
   }
@@ -9260,7 +9267,45 @@ async function saveRegistryConnection(input: any = {}) {
     managedConnectionUpdateGate.assertCanMutate(entry.id)
   }
 
-  writeDesktopConnectionsRegistry(upsertConnection(registry, entry))
+  const nextRegistry = upsertConnection(registry, entry)
+
+  // A new cookie-auth remote is commonly signed in while it is still an
+  // unsaved editor draft. At that point the single partition resolver must
+  // choose the legacy jar; after registration it chooses conn:<id>. Hand the
+  // gateway cookies to the new authoritative jar BEFORE publishing the
+  // registry, so every later REST/ws-ticket read follows policy without being
+  // stranded. Existing edits normally resolve to the same partition and skip.
+  if (entry.kind === 'remote' && entry.authMode === 'oauth') {
+    const sourcePartition = resolveOauthPartition(entry.url, {
+      registry,
+      v1RemoteUrl: readDesktopConnectionConfig()?.remote?.url
+    })
+    const targetPartition = resolveOauthPartition(entry.url, {
+      registry: nextRegistry,
+      v1RemoteUrl: readDesktopConnectionConfig()?.remote?.url
+    })
+
+    if (sourcePartition !== targetPartition) {
+      const source = getOauthSessionForPartition(sourcePartition)
+      const target = getOauthSessionForPartition(targetPartition)
+
+      if (!source || !target) {
+        throw new Error('OAuth session partition is unavailable during connection registration.')
+      }
+
+      await handoffOauthCookies({
+        source,
+        target,
+        url: entry.url,
+        cookieNames: [...AT_COOKIE_VARIANTS, ...RT_COOKIE_VARIANTS]
+      })
+      // The target has now been explicitly hydrated; do not let an older
+      // memoized warm-up describe its pre-handoff state.
+      oauthCookieWarmups.delete(targetPartition)
+    }
+  }
+
+  writeDesktopConnectionsRegistry(nextRegistry)
 
   // A dial-material edit (endpoint/auth/ssh routing — NOT a label rename)
   // leaves pooled backends under `conn:<id>::*` and renderer sockets pointing

--- a/apps/desktop/electron/oauth-cookie-handoff.test.ts
+++ b/apps/desktop/electron/oauth-cookie-handoff.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { handoffOauthCookies } from './oauth-cookie-handoff'
+
+function fakeSession(reads: any[][] = []) {
+  const get = vi.fn(async () => reads.shift() ?? [])
+  const set = vi.fn(async () => undefined)
+  const flushStorageData = vi.fn()
+
+  return { session: { cookies: { get, set }, flushStorageData }, get, set, flushStorageData }
+}
+
+describe('OAuth cookie partition handoff', () => {
+  it('copies HttpOnly gateway cookies before an unregistered URL is retargeted to its connection jar', async () => {
+    const source = fakeSession([[{ name: 'hermes_session_at', value: 'at', httpOnly: true, secure: true, path: '/' }]])
+    const target = fakeSession()
+
+    await expect(
+      handoffOauthCookies({
+        source: source.session,
+        target: target.session,
+        url: 'https://gw.example.com:8443',
+        cookieNames: ['hermes_session_at', 'hermes_session_rt']
+      })
+    ).resolves.toBe(1)
+
+    expect(target.set).toHaveBeenCalledWith(
+      expect.objectContaining({ url: 'https://gw.example.com:8443', name: 'hermes_session_at', value: 'at' })
+    )
+  })
+
+  it('warms and retries a cold persisted source jar before accepting an empty read', async () => {
+    const source = fakeSession([[], [{ name: 'hermes_session_rt', value: 'rt', path: '/' }]])
+    const target = fakeSession()
+    const wait = vi.fn(async () => undefined)
+
+    await expect(
+      handoffOauthCookies({
+        source: source.session,
+        target: target.session,
+        url: 'https://gw.example.com',
+        cookieNames: ['hermes_session_at', 'hermes_session_rt'],
+        delaysMs: [0, 30],
+        wait
+      })
+    ).resolves.toBe(1)
+
+    expect(source.flushStorageData).toHaveBeenCalledOnce()
+    expect(source.get).toHaveBeenCalledTimes(2)
+    expect(wait).toHaveBeenCalledWith(30)
+    expect(target.set).toHaveBeenCalledOnce()
+  })
+
+  it('surfaces a target write failure instead of silently registering against an empty jar', async () => {
+    const source = fakeSession([[{ name: 'hermes_session_at', value: 'at' }]])
+    const target = fakeSession()
+    target.set.mockRejectedValueOnce(new Error('cookie database write failed'))
+
+    await expect(
+      handoffOauthCookies({
+        source: source.session,
+        target: target.session,
+        url: 'https://gw.example.com',
+        cookieNames: ['hermes_session_at']
+      })
+    ).rejects.toThrow('cookie database write failed')
+  })
+})

--- a/apps/desktop/electron/oauth-cookie-handoff.ts
+++ b/apps/desktop/electron/oauth-cookie-handoff.ts
@@ -1,0 +1,85 @@
+/**
+ * Move gateway session cookies when a URL acquires a different authoritative
+ * OAuth partition (notably: an unsaved registry draft becomes a saved,
+ * per-connection remote). Electron's persisted cookie store hydrates lazily,
+ * so an empty first read is retried after an explicit warm-up.
+ */
+
+export interface CookieLike {
+  name: string
+  value: string
+  domain?: string
+  path?: string
+  secure?: boolean
+  httpOnly?: boolean
+  sameSite?: string
+  expirationDate?: number
+}
+
+export interface CookieSessionLike {
+  cookies: {
+    get(filter: { url: string }): Promise<CookieLike[]>
+    set(details: Record<string, unknown>): Promise<void>
+  }
+  flushStorageData?: () => void
+}
+
+export interface HandoffOauthCookiesOptions {
+  source: CookieSessionLike
+  target: CookieSessionLike
+  url: string
+  cookieNames: readonly string[]
+  delaysMs?: readonly number[]
+  wait?: (ms: number) => Promise<void>
+}
+
+export async function handoffOauthCookies({
+  source,
+  target,
+  url,
+  cookieNames,
+  delaysMs = [0, 30, 60, 90],
+  wait = ms => new Promise(resolve => setTimeout(resolve, ms))
+}: HandoffOauthCookiesOptions): Promise<number> {
+  source.flushStorageData?.()
+
+  let cookies: CookieLike[] = []
+
+  for (const delayMs of delaysMs) {
+    if (delayMs > 0) {
+      await wait(delayMs)
+    }
+
+    cookies = (await source.cookies.get({ url })).filter(
+      cookie => cookieNames.includes(cookie.name) && Boolean(cookie.value)
+    )
+
+    if (cookies.length > 0) {
+      break
+    }
+  }
+
+  for (const cookie of cookies) {
+    const details: Record<string, unknown> = {
+      url,
+      name: cookie.name,
+      value: cookie.value,
+      path: cookie.path || '/'
+    }
+
+    // Deliberately omit Domain: gateway cookies are host-only, and Chromium
+    // rejects __Host- cookies if a Domain attribute is supplied on set().
+    if (typeof cookie.secure === 'boolean') details.secure = cookie.secure
+    if (typeof cookie.httpOnly === 'boolean') details.httpOnly = cookie.httpOnly
+    if (cookie.sameSite) details.sameSite = cookie.sameSite
+    if (cookie.expirationDate) details.expirationDate = cookie.expirationDate
+
+    // This is an authoritative handoff. A failed write must reject the save;
+    // silently registering the connection would strand the source cookie.
+    await target.cookies.set(details)
+  }
+
+  target.flushStorageData?.()
+
+  return cookies.length
+}

--- a/apps/desktop/electron/oauth-partition.test.ts
+++ b/apps/desktop/electron/oauth-partition.test.ts
@@ -51,6 +51,18 @@ describe('resolveOauthPartition (#92183 per-connection cookie jars)', () => {
     expect(b).toContain('conn-b')
   })
 
+  it('changes authority exactly once across an unregistered-to-registered remote transition', () => {
+    const before = registry('local', [{ id: 'local', kind: 'local' }])
+    const after = registry('local', [{ id: 'local', kind: 'local' }, remote('mac', 'https://gw.example.com:8443')])
+
+    expect(resolveOauthPartition('https://gw.example.com:8443/login', { registry: before })).toBe(
+      LEGACY_OAUTH_PARTITION
+    )
+    expect(resolveOauthPartition('https://gw.example.com:8443/api/auth/ws-ticket', { registry: after })).toContain(
+      'conn:mac'
+    )
+  })
+
   it('keeps the v1 primary remote on the LEGACY partition so upgrades do not sign the user out', () => {
     const reg = registry('mig-1', [remote('mig-1', 'https://gw-a.example.com')])
 


### PR DESCRIPTION
## Symptom

Adding a remote gateway that uses dashboard auth (basic-auth dashboard behind a reverse proxy) from the desktop's **Add connection** flow: the probe passes, the in-app sign-in succeeds (the backend audit log even records `login_success`), but the connection test immediately fails with:

```
Remote Hermes gateway uses OAuth, but you are not signed in. Open Settings → Gateway and click "Sign in", or switch back to Local.
```

while the backend logs `401 {"reason":"no_cookie"}` on the `POST /api/auth/ws-ticket` — with **zero** `ws_ticket_minted` audit events. Repeating the sign-in does not help; the session cookie the SPA holds is live (subsequent dashboard visits auto-authenticate), yet every ws-ticket mint from the connection path goes out without a cookie.

## Root cause

The sign-in for a *new* remote happens while the connection is still an **unsaved editor draft**. At that point `resolveOauthPartition()` correctly routes both the login window and the SPA session to the legacy shared OAuth partition, where the gateway session cookies (`hermes_session_at`/`hermes_session_rt`) land.

The moment the connection is saved, the same resolver — now seeing the URL in the v2 connections registry — retargets the URL to its dedicated per-connection partition (`conn:<id>`, the #92183 isolation between gateways on one host). Every later REST/ws-ticket call for that URL reads the *new* jar, which is empty: the just-issued cookies are stranded in the legacy jar. Chromium cookie jars ignore ports, so no host-attr trick recovers this; the authority change happens exactly once, between draft and registered, and nothing migrates the cookies across it.

## Fix

In the connection-registration path, before publishing the new registry, re-resolve the partition for `entry.url` against both the previous and the next registry. If the authority changed, hand off the gateway session cookies from the source partition to the target partition via a new `handoffOauthCookies()` helper:

- warms the lazily-hydrated persisted store and retries the read before accepting an empty jar (documented cold-start false-negative),
- deliberately omits `Domain` on `cookies.set()` (host-only gateway cookies; Chromium rejects `__Host-` cookies with a Domain attribute),
- treats the write as authoritative: a failed cookie write **rejects the save** instead of silently registering a connection whose jar is empty.

This keeps the partition resolver as the single owner of authority policy, preserves per-connection isolation (cookies are *moved to* the connection's own jar, not shared), and surfaces failure instead of silently retargeting — the invariants called out in `apps/desktop/AGENTS.md`.

## Testing

- New behavior-contract tests: `oauth-cookie-handoff.test.ts` (copy of HttpOnly AT/RT cookies, cold-store warm + retry before accepting an empty read, failed target write rejects the save)
- New partition test: `oauth-partition.test.ts` — authority changes exactly once across the unregistered → registered transition (legacy before, `conn:<id>` after)
- `npx vitest run electron/oauth-cookie-handoff.test.ts electron/oauth-partition.test.ts electron/connection-config.test.ts` → **130/130 passed**

## Live verification (operator, two-host setup, v0.21.0 both ends)

Desktop repackaged with this fix; the remote gateway is a second Hermes host's dashboard behind Tailscale serve with basic-auth enabled. Re-adding the connection: sign-in → registration → connection test goes green in one pass. Server side, the audit log went from `login_success` + zero `ws_ticket_minted` (broken) to `refresh_success` + four `ws_ticket_minted`, and the gateway accepted the desktop's WebSocket from the remote host and held it open:

```
{"event":"refresh_success","provider":"basic","user_id":"yt"}
{"event":"ws_ticket_minted","provider":"basic","user_id":"yt"}
{"event":"ws_ticket_minted","provider":"basic","user_id":"yt"}
{"event":"ws_ticket_minted","provider":"basic","user_id":"yt"}
ws accepted peer=100.95.152.99
```

## Operator-facing fallout worth noting

During the broken window the error surfaced as "uses OAuth, but you are not signed in" even though the user *had* just signed in successfully — the 401 `no_cookie` on the ticket mint gets classified as a reauth (needs-login) error. With the handoff in place the classification becomes moot for this path, but the message string may deserve a follow-up to distinguish "no session" from "session not presented on this request".