### PR TITLE
fix(desktop): show all sessions in expanded projects

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -147,12 +147,13 @@ import type { SidebarNavItem } from '../../types'
 import { SidebarCronJobsSection } from './cron-jobs-section'
 import { SidebarFilterMenu } from './filter-menu'
 import { SidebarLoadMoreRow } from './load-more-row'
-import { orderByIds, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
+import { orderByIds, rankSessions, reconcileOrderIds, resolveManualSessionOrderIds, sameIds } from './order'
 import { filterSessionsByProfileScope } from './profile-scope'
 import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
+  latestProjectSessions,
   liveSessionProjectId,
   orderProjectsByIds,
   overlayLiveLanes,
@@ -941,6 +942,43 @@ export function ChatSidebar({
   // so scoping is consistent across views.
   const agentProjectTree = worktreeGroupingActive ? projectModel : undefined
 
+  // The overview tree intentionally carries only three lightweight preview
+  // rows per project. Expanding a project lazily hydrates its full authoritative
+  // session set and caches that raw node for as long as this profile/connection
+  // remains selected. The derived rows below re-apply live overlays, filters,
+  // pins, and tombstones on every relevant change instead of freezing a stale
+  // filtered snapshot in local state.
+  const [hydratedOverviewProjects, setHydratedOverviewProjects] = useState<Record<string, SidebarProjectTree>>({})
+  const hydratedOverviewProjectIdsRef = useRef(new Set<string>())
+
+  useEffect(() => {
+    hydratedOverviewProjectIdsRef.current.clear()
+    setHydratedOverviewProjects({})
+  }, [activeConnectionId, profileScope])
+
+  const loadOverviewProjectSessions = useCallback(async (projectId: string) => {
+    const hydrated = await fetchProjectSessions(projectId)
+
+    if (hydrated) {
+      hydratedOverviewProjectIdsRef.current.add(projectId)
+      setHydratedOverviewProjects(current => ({ ...current, [projectId]: hydrated }))
+    }
+  }, [])
+
+  // Keep already-expanded projects authoritative after an archive/delete or an
+  // out-of-band session change refreshes the lightweight tree. Otherwise the
+  // cached hydrated node could resurrect a row after its optimistic tombstone
+  // is pruned from the fresh overview snapshot.
+  useEffect(() => {
+    if (!gatewayReady) {
+      return
+    }
+
+    for (const projectId of hydratedOverviewProjectIdsRef.current) {
+      void loadOverviewProjectSessions(projectId)
+    }
+  }, [projectTree, gatewayReady, loadOverviewProjectSessions])
+
   // ── Project switcher (drill-in) ────────────────────────────────────────────
   // Grouped, single-profile view is a project switcher: ALL_PROJECTS shows the
   // overview (a list you click into); a concrete scope means you've "entered" a
@@ -1123,16 +1161,46 @@ export function ChatSidebar({
   // most-recent sessions), overlaid with live $sessions so a just-created
   // session shows under its project instantly (and with its working arc),
   // matching the flat Recents list. Keyed by project id for the rows.
-  const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(
-    () =>
-      overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, {
+  const hydratedOverviewSessions = useMemo<Record<string, SessionInfo[]>>(() => {
+    const rows: Record<string, SessionInfo[]> = {}
+
+    for (const [projectId, hydrated] of Object.entries(hydratedOverviewProjects)) {
+      const overview = projectModel.find(project => project.id === projectId)
+
+      if (!overview) {
+        continue
+      }
+
+      const filtered = excludeProjectSessions(
+        { ...hydrated, label: overview.label, repos: orderRepos(hydrated.repos) },
+        isHiddenFromProjects
+      )
+
+      const live = overlayLiveLanes(filtered, agentSessions, removedSessionIds)
+      rows[projectId] = rankSessions(latestProjectSessions(live, Number.MAX_SAFE_INTEGER), sortOrderIds)
+    }
+
+    return rows
+  }, [
+    hydratedOverviewProjects,
+    projectModel,
+    orderRepos,
+    isHiddenFromProjects,
+    agentSessions,
+    removedSessionIds,
+    sortOrderIds
+  ])
+
+  const overviewPreviews = useMemo<Record<string, SessionInfo[]>>(() => {
+    const previews = overlayLivePreviews(projectOverview ?? [], agentSessions, projects, PROJECT_PREVIEW_COUNT, {
         removed: removedSessionIds,
         // Rank before the trim, so "3 priciest in this project" isn't "3 most
         // recent, priciest first".
         rankIds: sortOrderIds
-      }),
-    [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds]
-  )
+      })
+
+    return { ...previews, ...hydratedOverviewSessions }
+  }, [projectOverview, agentSessions, projects, removedSessionIds, sortOrderIds, hydratedOverviewSessions])
 
   const onEnterProject = useCallback(
     (id: string) => {
@@ -1814,6 +1882,7 @@ export function ChatSidebar({
                   ) : undefined
                 }
                 liveSessions={inProject ? enteredProjectOverlaySessions : undefined}
+                loadProjectSessions={loadOverviewProjectSessions}
                 manualOrderIds={agentOrderManual ? agentOrderIds : sortOrderIds}
                 onArchiveSession={onArchiveSession}
                 onBranchSession={onBranchSession}

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -1,6 +1,7 @@
 // Public surface of the project/worktree sidebar, consumed by the sidebar root.
 export { EnteredProjectContent } from './entered-content'
 export {
+  latestProjectSessions,
   orderProjectsByIds,
   PROJECT_PREVIEW_COUNT,
   projectTreeCwd,

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.test.tsx
@@ -7,7 +7,14 @@ import type { SessionInfo } from '@/hermes'
 import { ProjectOverviewRow } from './overview-row'
 import type { SidebarProjectTree } from './workspace-groups'
 
-afterEach(cleanup)
+let workspaceNodeOpen = false
+const toggleWorkspaceNodeOpen = vi.fn()
+
+afterEach(() => {
+  cleanup()
+  workspaceNodeOpen = false
+  toggleWorkspaceNodeOpen.mockReset()
+})
 
 vi.mock('@/i18n', () => ({
   useI18n: () => ({
@@ -27,7 +34,7 @@ vi.mock('@/i18n', () => ({
 vi.mock('./model', () => ({
   PROJECT_PREVIEW_COUNT: 3,
   latestProjectSessions: () => [],
-  useWorkspaceNodeOpen: () => [false, vi.fn()]
+  useWorkspaceNodeOpen: () => [workspaceNodeOpen, toggleWorkspaceNodeOpen]
 }))
 
 // ProjectMenu (the kebab) has its own dedicated test file — stub it here so
@@ -39,7 +46,7 @@ vi.mock('./project-menu', () => ({
   ProjectMenu: () => null
 }))
 
-const project = { id: 'p1', label: 'Test D' } as unknown as SidebarProjectTree
+const project = { id: 'p1', label: 'Test D', sessionCount: 5 } as unknown as SidebarProjectTree
 
 const tipTrigger = (el: HTMLElement) => el.closest('[data-slot="tooltip-trigger"]')
 
@@ -69,6 +76,32 @@ describe('ProjectOverviewRow', () => {
     render(<ProjectOverviewRow project={project} />)
 
     expect(screen.queryByRole('button', { name: 'Show Test D sessions' })).toBeNull()
+  })
+
+  it('renders every hydrated session when the project is expanded', () => {
+    workspaceNodeOpen = true
+    const sessions = Array.from({ length: 5 }, (_, index) => ({ id: `s${index + 1}` }) as unknown as SessionInfo)
+    const renderRows = vi.fn(() => null)
+
+    render(<ProjectOverviewRow previewSessions={sessions} project={project} renderRows={renderRows} />)
+
+    expect(renderRows).toHaveBeenCalledWith(sessions)
+  })
+
+  it('lazily loads the full project when its preview is already expanded on first paint', () => {
+    workspaceNodeOpen = true
+    const loadProjectSessions = vi.fn().mockResolvedValue(undefined)
+
+    render(
+      <ProjectOverviewRow
+        loadProjectSessions={loadProjectSessions}
+        previewSessions={[{ id: 's1' } as unknown as SessionInfo]}
+        project={project}
+        renderRows={() => null}
+      />
+    )
+
+    expect(loadProjectSessions).toHaveBeenCalledWith('p1')
   })
 
   it('offers the "new session" add button on Home, which starts one with no folder', () => {

--- a/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/projects/overview-row.tsx
@@ -1,5 +1,5 @@
 import type * as React from 'react'
-import { useRef } from 'react'
+import { useEffect, useRef } from 'react'
 
 import { Codicon } from '@/components/ui/codicon'
 import type { SessionInfo } from '@/hermes'
@@ -64,6 +64,7 @@ interface ProjectOverviewRowProps {
   project: SidebarProjectTree
   onEnter?: (id: string) => void
   onNewSession?: (path: null | string) => void
+  loadProjectSessions?: (id: string) => Promise<void> | void
   renderRows?: (sessions: SessionInfo[]) => React.ReactNode
   activeProjectId?: null | string
   previewSessions?: SessionInfo[]
@@ -78,6 +79,7 @@ export function ProjectOverviewRow({
   project,
   onEnter,
   onNewSession,
+  loadProjectSessions,
   renderRows,
   activeProjectId,
   previewSessions,
@@ -94,8 +96,18 @@ export function ProjectOverviewRow({
   // The appearance popover anchors here (the full row) so it opens flush with
   // the sidebar's content edge regardless of which side the sidebar is on.
   const rowRef = useRef<HTMLDivElement>(null)
-  const fetched = (previewSessions ?? []).slice(0, PROJECT_PREVIEW_COUNT)
+  const fetched = previewSessions ?? []
   const preview = renderRows ? (fetched.length ? fetched : latestProjectSessions(project, PROJECT_PREVIEW_COUNT)) : []
+
+  // Projects default open, so loading only inside the disclosure click misses
+  // the exact first-paint case: the row already shows its three previews and no
+  // transition ever fires. Hydrate whenever this row is open; stable props keep
+  // the effect to one request per open transition.
+  useEffect(() => {
+    if (open && project.sessionCount > fetched.length) {
+      void loadProjectSessions?.(project.id)
+    }
+  }, [open, loadProjectSessions, project.id, project.sessionCount, fetched.length])
 
   const lead = reorderable ? (
     <SidebarRowGrab

--- a/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
+++ b/apps/desktop/src/app/chat/sidebar/sessions-section.tsx
@@ -132,6 +132,7 @@ interface SidebarSessionsSectionProps {
   // True while the backend project tree is loading (overview skeleton).
   projectsLoading?: boolean
   onEnterProject?: (id: string) => void
+  loadProjectSessions?: (id: string) => Promise<void> | void
   // The entered project's flattened content: main-checkout sessions render
   // directly (no redundant repo/branch header); only linked worktrees nest.
   projectContent?: SidebarProjectTree
@@ -203,6 +204,7 @@ export function SidebarSessionsSection({
   projectOverviewPreviews,
   projectsLoading = false,
   onEnterProject,
+  loadProjectSessions,
   projectContent,
   projectRepoWorktrees,
   liveSessions,
@@ -469,6 +471,7 @@ export function SidebarSessionsSection({
       <Component
         activeProjectId={activeProjectId}
         key={project.id}
+        loadProjectSessions={loadProjectSessions}
         onEnter={onEnterProject}
         onNewSession={onNewSessionInWorkspace}
         previewSessions={projectOverviewPreviews?.[project.id]}

--- a/apps/desktop/src/store/projects.test.ts
+++ b/apps/desktop/src/store/projects.test.ts
@@ -813,6 +813,27 @@ describe('project tree profile isolation', () => {
     expect($projects.get().map(project => project.id)).toEqual(['profile-b'])
   })
 
+  it('allows different projects to hydrate concurrently in the same context', async () => {
+    const first = deferred<unknown>()
+    const second = deferred<unknown>()
+
+    const request = vi.fn((_method: string, params: Record<string, unknown>) =>
+      params.project_id === 'p1' ? first.promise : second.promise
+    )
+
+    const gateway = { connectionState: 'open', request }
+    activeGateway.mockReturnValue(gateway as never)
+    gatewayAtom.set(gateway as never)
+
+    const pendingFirst = fetchProjectSessions('p1')
+    const pendingSecond = fetchProjectSessions('p2')
+    second.resolve({ project: { id: 'p2', label: 'Two', path: null, repos: [], sessionCount: 0 } })
+    first.resolve({ project: { id: 'p1', label: 'One', path: null, repos: [], sessionCount: 0 } })
+
+    await expect(pendingFirst).resolves.toMatchObject({ id: 'p1' })
+    await expect(pendingSecond).resolves.toMatchObject({ id: 'p2' })
+  })
+
   it('does not publish a late projects.tree response from the previous profile', async () => {
     const { promise: defaultResponse, resolve: resolveDefault } = deferred<unknown>()
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -575,12 +575,14 @@ async function refreshProjectTreeAcrossProfiles(): Promise<void> {
 }
 
 // Fully hydrated lanes (repo -> lane -> session rows) for one project, fetched
-// when the user enters it. Same backend grouping as `projects.tree`, so ids and
-// membership match exactly.
-let projectSessionsRefreshGeneration = 0
+// lazily when a project is expanded or entered. Same backend grouping as
+// `projects.tree`, so ids and membership match exactly. Generations are scoped
+// per project so expanding one row never cancels another row's in-flight load.
+const projectSessionsRefreshGenerations = new Map<string, number>()
 
 export async function fetchProjectSessions(projectId: string): Promise<SidebarProjectTree | null> {
-  const generation = ++projectSessionsRefreshGeneration
+  const generation = (projectSessionsRefreshGenerations.get(projectId) ?? 0) + 1
+  projectSessionsRefreshGenerations.set(projectId, generation)
 
   try {
     const context = await activeProjectsContext()
@@ -591,7 +593,7 @@ export async function fetchProjectSessions(projectId: string): Promise<SidebarPr
       projectParams({ project_id: projectId }, context.profile)
     )
 
-    if (generation !== projectSessionsRefreshGeneration || !stillOnProjectsContext(context)) {
+    if (generation !== projectSessionsRefreshGenerations.get(projectId) || !stillOnProjectsContext(context)) {
       return null
     }
 


### PR DESCRIPTION
## Summary

Fixes #70421 (also #83058 and #90527): expanding a project in the Desktop Projects overview now lazily loads and renders the project's complete active, unarchived session list instead of remaining capped at the three lightweight `projects.tree` previews.

This is an alternative to #90678 that addresses its review's scaling concern: the initial tree request remains capped at three previews. Full sessions are fetched only for projects that are actually expanded.

## Root cause

`projects.tree` intentionally returns only three preview sessions per project. `ProjectOverviewRow` reused that preview array after expansion, so there was no data available for rows 4…N and no load-more path.

## Changes

- Hydrate a project's authoritative lanes through `projects.project_sessions` when its overview row is expanded.
- Handle projects that are already open on first paint (the default state), not only disclosure-click transitions.
- Cache hydrated raw project nodes per connection/profile, then reapply existing live overlays, filtering, ordering, pin exclusion, and tombstones while rendering.
- Refresh already-hydrated projects when the lightweight tree changes so archive/delete/out-of-band updates remain authoritative.
- Scope request generations per project so two projects can hydrate concurrently without cancelling each other.
- Preserve the three-row lightweight preview for projects that do not need full hydration.

## Verification

- Focused Desktop tests: 50 passed
- ESLint on every touched source/test file: passed
- TypeScript app, Electron, and E2E configs: passed
- Production Desktop build: passed
- `git diff --check`: passed
- Isolated macOS Desktop QA: an expanded Home project rendered 4 sessions (more than the former cap) and the Projects sidebar scrolled through the complete project list

## Notes

No backend schema or protocol changes are required; the existing `projects.project_sessions` RPC is used. Archived sessions remain excluded by the authoritative backend query and existing frontend filters.

Closes #70421
Refs #83058, #90527, #90678
