### PR TITLE
fix(desktop): disable Vulkan on Linux Wayland ozone

### DIFF
--- a/apps/desktop/electron/bootstrap-platform.test.ts
+++ b/apps/desktop/electron/bootstrap-platform.test.ts
@@ -7,6 +7,8 @@ import {
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
+  linuxWaylandVulkanDisableFeatures,
+  mergeDisableFeatures,
   resolveLinuxPasswordStore
 } from './bootstrap-platform'
 
@@ -122,4 +124,48 @@ test('resolveLinuxPasswordStore warns on unknown values instead of applying them
 
   assert.equal(result.store, null)
   assert.match(String(result.warning), /keychain-of-wonders/)
+})
+
+test('linuxWaylandVulkanDisableFeatures is linux+wayland ozone only', () => {
+  const wayland = { XDG_SESSION_TYPE: 'wayland', WAYLAND_DISPLAY: 'wayland-0', DISPLAY: ':0' }
+
+  assert.equal(linuxWaylandVulkanDisableFeatures({ platform: 'darwin', env: wayland }), null)
+  assert.equal(linuxWaylandVulkanDisableFeatures({ platform: 'win32', env: wayland }), null)
+  assert.equal(
+    linuxWaylandVulkanDisableFeatures({ platform: 'linux', env: { DISPLAY: ':0' } }),
+    null
+  )
+  assert.equal(
+    linuxWaylandVulkanDisableFeatures({
+      platform: 'linux',
+      env: wayland,
+      argv: ['--ozone-platform=x11']
+    }),
+    null
+  )
+  assert.equal(
+    linuxWaylandVulkanDisableFeatures({ platform: 'linux', env: wayland }),
+    'Vulkan'
+  )
+  assert.equal(
+    linuxWaylandVulkanDisableFeatures({
+      platform: 'linux',
+      env: { DISPLAY: ':0', ELECTRON_OZONE_PLATFORM_HINT: 'wayland' }
+    }),
+    'Vulkan'
+  )
+})
+
+test('linuxWaylandVulkanDisableFeatures merges existing disable-features', () => {
+  const wayland = { XDG_SESSION_TYPE: 'wayland', WAYLAND_DISPLAY: 'wayland-0' }
+
+  assert.equal(
+    linuxWaylandVulkanDisableFeatures({
+      platform: 'linux',
+      env: wayland,
+      existingDisableFeatures: 'UseOzonePlatform,Vulkan'
+    }),
+    'UseOzonePlatform,Vulkan'
+  )
+  assert.equal(mergeDisableFeatures('Foo, Bar', ['Vulkan', 'foo']), 'Foo,Bar,Vulkan')
 })

--- a/apps/desktop/electron/bootstrap-platform.ts
+++ b/apps/desktop/electron/bootstrap-platform.ts
@@ -141,10 +141,101 @@ function resolveLinuxPasswordStore(options: { env?: NodeJS.ProcessEnv; platform?
   return { store: requested, warning: null }
 }
 
+function requestedOzonePlatform(env: NodeJS.ProcessEnv, argv: readonly string[]): string | null {
+  let explicit: string | null = null
+  let hint: string | null = null
+
+  for (const arg of argv) {
+    const match = /^--ozone-platform(-hint)?=(.+)$/.exec(arg)
+
+    if (!match) {
+      continue
+    }
+
+    if (match[1]) {
+      hint = match[2].toLowerCase()
+    } else {
+      explicit = match[2].toLowerCase()
+    }
+  }
+
+  return explicit ?? hint ?? env.ELECTRON_OZONE_PLATFORM_HINT?.toLowerCase() ?? null
+}
+
+function linuxSessionIsWayland(env: NodeJS.ProcessEnv): boolean {
+  return env.XDG_SESSION_TYPE === 'wayland' || (Boolean(env.WAYLAND_DISPLAY) && !env.DISPLAY)
+}
+
+/**
+ * Merge Chromium `--disable-features` lists without dropping caller values.
+ */
+function mergeDisableFeatures(existing: string | undefined, extra: readonly string[]): string {
+  const seen = new Set<string>()
+  const out: string[] = []
+
+  for (const part of [...String(existing || '').split(','), ...extra]) {
+    const name = part.trim()
+
+    if (!name) {
+      continue
+    }
+
+    const key = name.toLowerCase()
+
+    if (seen.has(key)) {
+      continue
+    }
+
+    seen.add(key)
+    out.push(name)
+  }
+
+  return out.join(',')
+}
+
+/**
+ * Chromium's Wayland ozone backend is incompatible with Vulkan. On that path
+ * the GPU process dies after ~30s (`GPU process isn't usable. Goodbye.`)
+ * even when `app.disableHardwareAcceleration()` / `HERMES_DESKTOP_DISABLE_GPU`
+ * already ran. `--disable-features=Vulkan` keeps GL acceleration and avoids
+ * the unsupported path.
+ *
+ * Returns the merged `--disable-features` value when Linux ozone will be
+ * Wayland, or null when the switch is not needed.
+ */
+function linuxWaylandVulkanDisableFeatures(
+  options: {
+    env?: NodeJS.ProcessEnv
+    platform?: NodeJS.Platform
+    argv?: readonly string[]
+    existingDisableFeatures?: string
+  } = {}
+): string | null {
+  const env = options.env ?? process.env
+  const platform = options.platform ?? process.platform
+  const argv = options.argv ?? []
+
+  if (platform !== 'linux') {
+    return null
+  }
+
+  const requested = requestedOzonePlatform(env, argv)
+  const ozoneIsWayland =
+    requested === 'wayland' || ((requested === null || requested === 'auto') && linuxSessionIsWayland(env))
+
+  if (!ozoneIsWayland) {
+    return null
+  }
+
+  return mergeDisableFeatures(options.existingDisableFeatures, ['Vulkan'])
+}
+
 export {
   bundledRuntimeImportCheck,
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
+  linuxWaylandVulkanDisableFeatures,
+  mergeDisableFeatures,
   resolveLinuxPasswordStore
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -77,6 +77,7 @@ import {
   detectRemoteDisplay,
   isWindowsBinaryPathInWsl,
   isWslEnvironment,
+  linuxWaylandVulkanDisableFeatures,
   resolveLinuxPasswordStore
 } from './bootstrap-platform'
 import { decideBootstrapRepair } from './bootstrap-repair-guard'
@@ -507,6 +508,23 @@ if (REMOTE_DISPLAY_REASON) {
   app.commandLine.appendSwitch('disable-gpu-compositing')
   console.log(
     `[hermes] remote display detected (${REMOTE_DISPLAY_REASON}); disabling GPU hardware acceleration to prevent flicker`
+  )
+}
+
+// Linux + Wayland ozone: Chromium's Vulkan backend is unsupported
+// (`--ozone-platform=wayland is not compatible with Vulkan`). The GPU
+// process then dies ~30s later even after disableHardwareAcceleration()
+// — HERMES_DESKTOP_DISABLE_GPU is not enough. Disable Vulkan only; GL
+// acceleration stays on. Must run before app `ready`.
+const WAYLAND_VULKAN_FEATURES = linuxWaylandVulkanDisableFeatures({
+  argv: process.argv,
+  existingDisableFeatures: app.commandLine.getSwitchValue('disable-features')
+})
+
+if (WAYLAND_VULKAN_FEATURES) {
+  app.commandLine.appendSwitch('disable-features', WAYLAND_VULKAN_FEATURES)
+  console.log(
+    `[hermes] Linux Wayland ozone: appending --disable-features=${WAYLAND_VULKAN_FEATURES} (Vulkan is incompatible with --ozone-platform=wayland)`
   )
 }
 

--- a/hermes_cli/main_desktop.py
+++ b/hermes_cli/main_desktop.py
@@ -1219,6 +1219,75 @@ def _desktop_launch_options() -> tuple[list[str], str, str, str]:
     return flags, disable_gpu, password_store, ozone_hint
 
 
+def _linux_session_is_wayland(env: dict | None = None) -> bool:
+    """True when the login session is native Wayland (HUD/ozone same rule)."""
+    environ = env if env is not None else os.environ
+    if environ.get("XDG_SESSION_TYPE") == "wayland":
+        return True
+    return bool(environ.get("WAYLAND_DISPLAY")) and not environ.get("DISPLAY")
+
+
+def _requested_ozone_platform(env: dict | None = None, argv: list[str] | None = None) -> str | None:
+    """Last explicit `--ozone-platform=` / hint, else `ELECTRON_OZONE_PLATFORM_HINT`."""
+    environ = env if env is not None else os.environ
+    explicit = None
+    hint = None
+    for arg in argv or []:
+        if arg.startswith("--ozone-platform="):
+            explicit = arg.split("=", 1)[1].strip().lower()
+        elif arg.startswith("--ozone-platform-hint="):
+            hint = arg.split("=", 1)[1].strip().lower()
+    env_hint = str(environ.get("ELECTRON_OZONE_PLATFORM_HINT") or "").strip().lower() or None
+    return explicit or hint or env_hint
+
+
+def _linux_wayland_needs_vulkan_disabled(
+    env: dict | None = None,
+    *,
+    platform: str | None = None,
+    argv: list[str] | None = None,
+) -> bool:
+    """Wayland ozone + Vulkan aborts the GPU process (~30s). Disable Vulkan only."""
+    if (platform or sys.platform) != "linux":
+        return False
+    requested = _requested_ozone_platform(env, argv)
+    if requested == "x11":
+        return False
+    if requested == "wayland":
+        return True
+    return requested in (None, "", "auto") and _linux_session_is_wayland(env)
+
+
+def _desktop_electron_argv(config_flags: list[str], env: dict | None = None) -> list[str]:
+    """User `desktop.electron_flags` plus Linux/Wayland Vulkan disable when needed."""
+    flags = list(config_flags)
+    if _linux_wayland_needs_vulkan_disabled(env, argv=flags):
+        return _merge_electron_disable_features(flags, "Vulkan")
+    return flags
+
+
+def _merge_electron_disable_features(flags: list[str], feature: str) -> list[str]:
+    """Append ``feature`` to an existing ``--disable-features=`` flag, or add one."""
+    name = (feature or "").strip()
+    if not name:
+        return list(flags)
+    prefix = "--disable-features="
+    out: list[str] = []
+    merged = False
+    for flag in flags:
+        if flag.startswith(prefix):
+            parts = [p.strip() for p in flag[len(prefix):].split(",") if p.strip()]
+            if name not in parts:
+                parts.append(name)
+            out.append(prefix + ",".join(parts))
+            merged = True
+        else:
+            out.append(flag)
+    if not merged:
+        out.append(f"{prefix}{name}")
+    return out
+
+
 def _register_linux_desktop_entry() -> None:
     """Install the XDG desktop entry for Hermes Desktop (Linux only, best-effort).
 
@@ -1425,7 +1494,9 @@ def _desktop_launch_env(args: argparse.Namespace) -> tuple[dict, list[str]]:
         )
         if password_store:
             env["HERMES_DESKTOP_PASSWORD_STORE"] = password_store
-    return env, config_electron_flags
+    # Packaged icon / `hermes desktop` / source `electron .` all need this
+    # on argv: Chromium may pick ozone before `appendSwitch` in main.ts.
+    return env, _desktop_electron_argv(config_electron_flags, env)
 
 
 def _check_desktop_skip_build(
@@ -1539,7 +1610,7 @@ def cmd_gui(args: argparse.Namespace):
 
     if source_mode:
         print("→ Launching Hermes Desktop from source build...")
-        launch_command = [npm, "exec", "--", "electron", "."]
+        launch_command = [npm, "exec", "--", "electron", ".", *config_electron_flags]
     else:
         if packaged_executable is None:
             print(f"✗ Desktop package build completed but no launchable app was found at: {desktop_dir / 'release'}")

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1236,7 +1236,8 @@ def test_gui_linux_source_launch_bridges_detected_password_store(tmp_path, monke
          pytest.raises(SystemExit):
         cli_main.cmd_gui(_ns(source=True))
 
-    assert mock_run.call_args_list[1].args[0] == ["/usr/bin/npm", "exec", "--", "electron", "."]
+    source_cmd = mock_run.call_args_list[1].args[0]
+    assert source_cmd[:5] == ["/usr/bin/npm", "exec", "--", "electron", "."]
     launch_env = mock_run.call_args_list[1].kwargs["env"]
     assert launch_env["HERMES_DESKTOP_PASSWORD_STORE"] == "kwallet6"
 
@@ -1490,3 +1491,59 @@ def test_gui_zero_exit_pack_without_artifact_keeps_previous_app(tmp_path, monkey
     assert live_exe.read_text(encoding="utf-8") == "good build"
     assert not list(desktop_dir.glob(".staging-*"))
     assert "produced no launchable app" in capsys.readouterr().out
+
+
+def test_linux_wayland_needs_vulkan_disabled_matches_ozone_backend():
+    wayland = {
+        "XDG_SESSION_TYPE": "wayland",
+        "WAYLAND_DISPLAY": "wayland-0",
+        "DISPLAY": ":0",
+    }
+    assert main_desktop._linux_wayland_needs_vulkan_disabled(wayland, platform="linux") is True
+    assert main_desktop._linux_wayland_needs_vulkan_disabled(wayland, platform="darwin") is False
+    assert (
+        main_desktop._linux_wayland_needs_vulkan_disabled(
+            {**wayland, "ELECTRON_OZONE_PLATFORM_HINT": "x11"},
+            platform="linux",
+        )
+        is False
+    )
+    assert (
+        main_desktop._linux_wayland_needs_vulkan_disabled(
+            {"DISPLAY": ":0"},
+            platform="linux",
+            argv=["--ozone-platform=wayland"],
+        )
+        is True
+    )
+    assert main_desktop._linux_wayland_needs_vulkan_disabled({"DISPLAY": ":0"}, platform="linux") is False
+
+
+def test_desktop_electron_argv_adds_vulkan_on_linux_wayland(monkeypatch):
+    wayland = {
+        "XDG_SESSION_TYPE": "wayland",
+        "WAYLAND_DISPLAY": "wayland-0",
+        "DISPLAY": ":0",
+    }
+    monkeypatch.setattr(main_desktop.sys, "platform", "linux")
+    assert main_desktop._desktop_electron_argv([], wayland) == ["--disable-features=Vulkan"]
+    assert main_desktop._desktop_electron_argv(["--disable-features=Foo"], wayland) == [
+        "--disable-features=Foo,Vulkan"
+    ]
+    assert main_desktop._desktop_electron_argv(["--ozone-platform=x11"], wayland) == [
+        "--ozone-platform=x11"
+    ]
+    monkeypatch.setattr(main_desktop.sys, "platform", "darwin")
+    assert main_desktop._desktop_electron_argv([], wayland) == []
+
+
+def test_merge_electron_disable_features_appends_or_extends():
+    assert main_desktop._merge_electron_disable_features([], "Vulkan") == ["--disable-features=Vulkan"]
+    assert main_desktop._merge_electron_disable_features(
+        ["--ozone-platform-hint=auto", "--disable-features=Foo"],
+        "Vulkan",
+    ) == ["--ozone-platform-hint=auto", "--disable-features=Foo,Vulkan"]
+    assert main_desktop._merge_electron_disable_features(
+        ["--disable-features=Vulkan"],
+        "Vulkan",
+    ) == ["--disable-features=Vulkan"]


### PR DESCRIPTION
## What does this PR do?

On Linux Wayland, Chromium's ozone backend is incompatible with Vulkan. The desktop app opens normally, then after about 30 seconds the GPU process dies (`GPU process isn't usable. Goodbye.`) and Chromium `__builtin_trap()`s. `app.disableHardwareAcceleration()` / `HERMES_DESKTOP_DISABLE_GPU` does not stop that GPU process.

This appends `--disable-features=Vulkan` when Linux ozone will be Wayland — the switch that keeps GL acceleration and avoids the unsupported path. It is applied in Electron before `ready` (icon / direct binary) and on `hermes desktop` argv (packaged and source) so Chromium sees it at launch. Explicit `--ozone-platform=x11` is left alone.

## Related Issue

Fixes #100549

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/bootstrap-platform.ts` — `linuxWaylandVulkanDisableFeatures()` using the same ozone/session rules as HUD windowing; merges into an existing `--disable-features` list
- `apps/desktop/electron/main.ts` — apply that switch before `app.whenReady()`
- `hermes_cli/main.py` — `_desktop_electron_argv()` adds `--disable-features=Vulkan` on Linux Wayland for packaged and source launches
- `apps/desktop/electron/bootstrap-platform.test.ts` and `tests/hermes_cli/test_gui_command.py` — ozone/x11/merge coverage

## How to Test

1. On a Wayland session with a Vulkan ICD (`vulkan-intel` or similar), launch Hermes Desktop from the app icon or `hermes desktop` without extra flags.
2. Confirm logs include `Linux Wayland ozone: appending --disable-features=Vulkan` (or argv contains `--disable-features=Vulkan`).
3. Leave the window open for more than 30 seconds (and through normal use). There should be no `GPU process launch failed` / `GPU process isn't usable. Goodbye.` and no SIGTRAP core dump.
4. Helpers (any host): `scripts/run_tests.sh tests/hermes_cli/test_gui_command.py -q -k "wayland_needs_vulkan or merge_electron_disable or desktop_electron_argv"` and from `apps/desktop`: `npx vitest run electron/bootstrap-platform.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (policy helpers + packaged app stay-up); Linux Wayland abort needs a Wayland host to confirm

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs