### PR TITLE
fix: dispatch one-shot plugin lifecycle hooks

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -382,6 +382,13 @@ class CLIAgentSetupMixin:
         self.finalize_preloaded_skills()
 
         _prepare_deferred_agent_startup()
+        # The launcher may only have started discovery in the background (and
+        # the deferred path is intentionally opt-in).  Join that work and
+        # synchronously discover against the active profile before the agent
+        # snapshots its hooks and tool registry.
+        from hermes_cli.plugins import discover_plugins
+
+        discover_plugins()
         self._install_tool_callbacks()
         self._ensure_tirith_security()
 

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -354,6 +354,54 @@ def _create_session_db_for_oneshot():
         return None
 
 
+def _run_oneshot_conversation(agent, prompt: str, lifecycle) -> dict:
+    """Run the turn while enriching the loop-owned session-start dispatch."""
+    original_invoke_hook = lifecycle.invoke_hook
+
+    def invoke_oneshot_lifecycle_hook(hook_name: str, **kwargs):
+        if hook_name == "on_session_start":
+            kwargs.setdefault("session_id", getattr(agent, "session_id", None))
+            kwargs.setdefault("platform", getattr(agent, "platform", None) or "cli")
+            kwargs.setdefault("model", getattr(agent, "model", None))
+            kwargs.setdefault("provider", getattr(agent, "provider", None))
+        return original_invoke_hook(hook_name, **kwargs)
+
+    lifecycle.invoke_hook = invoke_oneshot_lifecycle_hook
+    try:
+        return agent.run_conversation(prompt)
+    finally:
+        lifecycle.invoke_hook = original_invoke_hook
+
+
+def _notify_successful_oneshot_lifecycle(agent, result: dict, lifecycle) -> None:
+    """Emit the normal end/finalize pair only after a completed turn."""
+    if (
+        not result.get("final_response")
+        or result.get("failed")
+        or result.get("partial")
+        or result.get("interrupted")
+    ):
+        return
+
+    lifecycle_context = {
+        "session_id": getattr(agent, "session_id", None),
+        "platform": getattr(agent, "platform", None) or "cli",
+        "model": getattr(agent, "model", None),
+        "provider": getattr(agent, "provider", None),
+        "completed": True,
+        "interrupted": False,
+        "reason": "shutdown",
+    }
+    try:
+        lifecycle.invoke_hook("on_session_end", **lifecycle_context)
+    except Exception:
+        logging.debug("oneshot on_session_end hook failed", exc_info=True)
+    try:
+        lifecycle.finalize_session(**lifecycle_context)
+    except Exception:
+        logging.debug("oneshot on_session_finalize hook failed", exc_info=True)
+
+
 def _run_agent(
     prompt: str,
     model: Optional[str] = None,
@@ -366,11 +414,19 @@ def _run_agent(
     run a single conversation.  Returns ``(final_response, run_result)``."""
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
+    from hermes_cli.plugins import discover_plugins
     from hermes_cli.config import load_config
     from hermes_cli.models import detect_provider_for_model
     from hermes_cli.runtime_provider import resolve_runtime_provider
     from hermes_cli.tools_config import _get_platform_tools
     from run_agent import AIAgent
+    from hermes_cli import lifecycle
+
+    # One-shot bypasses HermesCLI._init_agent(), so establish the same
+    # synchronous discovery barrier before resolving toolsets or constructing
+    # the agent.  This joins any launcher background scan and targets the
+    # currently active profile manager.
+    discover_plugins()
 
     cfg = load_config()
 
@@ -523,7 +579,8 @@ def _run_agent(
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
 
-        result = agent.run_conversation(prompt)
+        result = _run_oneshot_conversation(agent, prompt, lifecycle)
+        _notify_successful_oneshot_lifecycle(agent, result, lifecycle)
         return (result.get("final_response") or "", result)
     finally:
         # Ordering deliberately mirrors gateway/run.py:_cleanup_agent_resources,

--- a/tests/hermes_cli/test_agent_plugin_startup.py
+++ b/tests/hermes_cli/test_agent_plugin_startup.py
@@ -1,0 +1,196 @@
+"""Regression coverage for plugin discovery at agent construction time."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_interactive_agent_discovers_plugins_before_credential_setup(monkeypatch):
+    import cli
+    import hermes_cli.cli_agent_setup_mixin as setup_mixin
+    import hermes_cli.plugins as plugins
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        cli,
+        "_prepare_deferred_agent_startup",
+        lambda: events.append("deferred"),
+    )
+    monkeypatch.setattr(
+        plugins,
+        "discover_plugins",
+        lambda: events.append("plugins"),
+    )
+
+    agent_setup = SimpleNamespace(
+        agent=None,
+        finalize_preloaded_skills=lambda: events.append("skills"),
+        _install_tool_callbacks=lambda: events.append("callbacks"),
+        _ensure_tirith_security=lambda: events.append("tirith"),
+        _ensure_runtime_credentials=lambda: False,
+    )
+
+    result = setup_mixin.CLIAgentSetupMixin._init_agent(agent_setup)
+
+    assert result is False
+    assert events == ["skills", "deferred", "plugins", "callbacks", "tirith"]
+
+
+def test_oneshot_discovers_plugins_before_agent_build(monkeypatch):
+    import hermes_cli.config
+    import hermes_cli.oneshot as oneshot
+    import hermes_cli.plugins as plugins
+    import run_agent  # noqa: F401 - warm imports before recording ordering
+
+    events: list[str] = []
+    monkeypatch.setattr(
+        plugins,
+        "discover_plugins",
+        lambda: events.append("plugins"),
+    )
+
+    def fail_config_load():
+        events.append("config")
+        raise RuntimeError("stop before provider setup")
+
+    monkeypatch.setattr(hermes_cli.config, "load_config", fail_config_load)
+
+    with pytest.raises(RuntimeError, match="stop before provider setup"):
+        oneshot._run_agent("test prompt")
+
+    assert events.index("plugins") < events.index("config", events.index("plugins"))
+
+
+def test_profile_manager_discovery_is_idempotent_and_isolated(tmp_path):
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    import hermes_cli.plugins as plugins
+
+    home_a = tmp_path / "profile-a"
+    home_b = tmp_path / "profile-b"
+    for home, marker in ((home_a, "a"), (home_b, "b")):
+        plugin_dir = home / "plugins" / "marker"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text(
+            "name: marker\nversion: '1.0.0'\n"
+        )
+        (plugin_dir / "__init__.py").write_text(
+            f"def register(ctx):\n    ctx._manager._plugin_skills['marker'] = {marker!r}\n"
+        )
+        (home / "config.yaml").write_text(
+            "plugins:\n  enabled:\n    - marker\n"
+        )
+
+    plugins._reset_plugin_managers_for_tests()
+
+    token_a = set_hermes_home_override(str(home_a))
+    try:
+        manager_a = plugins.get_plugin_manager()
+        manager_a.discover_and_load()
+        loaded_plugin_count = len(manager_a._plugins)
+        manager_a.discover_and_load()
+        assert manager_a._plugin_skills["marker"] == "a"
+        assert len(manager_a._plugins) == loaded_plugin_count
+    finally:
+        reset_hermes_home_override(token_a)
+
+    token_b = set_hermes_home_override(str(home_b))
+    try:
+        manager_b = plugins.get_plugin_manager()
+        manager_b.discover_and_load()
+        assert manager_b is not manager_a
+        assert manager_b._plugin_skills["marker"] == "b"
+    finally:
+        reset_hermes_home_override(token_b)
+
+    plugins._reset_plugin_managers_for_tests()
+
+
+def test_oneshot_session_start_is_once_before_turn_with_normalized_identity():
+    from hermes_cli import oneshot
+
+    events = []
+    lifecycle = SimpleNamespace(
+        invoke_hook=lambda name, **kwargs: events.append((name, kwargs)),
+        finalize_session=lambda **kwargs: events.append(("finalize", kwargs)),
+    )
+    agent = SimpleNamespace(
+        session_id="oneshot-session",
+        platform="cli",
+        model="normalized-model",
+        provider="normalized-provider",
+    )
+
+    def run_conversation(_prompt):
+        lifecycle.invoke_hook("on_session_start")
+        events.append(("turn", {}))
+        return {"final_response": "done"}
+
+    agent.run_conversation = run_conversation
+
+    result = oneshot._run_oneshot_conversation(agent, "hello", lifecycle)
+
+    assert result["final_response"] == "done"
+    assert [event[0] for event in events] == ["on_session_start", "turn"]
+    assert events[0][1] == {
+        "session_id": "oneshot-session",
+        "platform": "cli",
+        "model": "normalized-model",
+        "provider": "normalized-provider",
+    }
+
+
+def test_oneshot_success_emits_end_then_finalize_with_shutdown_reason():
+    from hermes_cli import oneshot
+
+    events = []
+    lifecycle = SimpleNamespace(
+        invoke_hook=lambda name, **kwargs: events.append((name, kwargs)),
+        finalize_session=lambda **kwargs: events.append(("on_session_finalize", kwargs)),
+    )
+    agent = SimpleNamespace(
+        session_id="oneshot-session",
+        platform="cli",
+        model="model",
+        provider="provider",
+    )
+
+    oneshot._notify_successful_oneshot_lifecycle(
+        agent, {"final_response": "done"}, lifecycle
+    )
+
+    assert [event[0] for event in events] == [
+        "on_session_end",
+        "on_session_finalize",
+    ]
+    assert all(event[1]["reason"] == "shutdown" for event in events)
+    assert all(event[1]["session_id"] == "oneshot-session" for event in events)
+
+
+@pytest.mark.parametrize(
+    "result",
+    [
+        {"final_response": "failed", "failed": True},
+        {"final_response": "partial", "partial": True},
+        {"final_response": "interrupted", "interrupted": True},
+    ],
+)
+def test_oneshot_failed_or_interrupted_run_does_not_finalize(result):
+    from hermes_cli import oneshot
+
+    events = []
+    lifecycle = SimpleNamespace(
+        invoke_hook=lambda name, **kwargs: events.append((name, kwargs)),
+        finalize_session=lambda **kwargs: events.append(("on_session_finalize", kwargs)),
+    )
+    agent = SimpleNamespace(
+        session_id="oneshot-session",
+        platform="cli",
+        model="model",
+        provider="provider",
+    )
+
+    oneshot._notify_successful_oneshot_lifecycle(agent, result, lifecycle)
+
+    assert events == []


### PR DESCRIPTION
## Summary
- synchronously discover user plugins before one-shot agent construction
- provide one-shot session identity to on_session_start
- emit clean end/finalize lifecycle hooks only after successful completion
- add regression coverage for ordering, identity, and failed-run behavior

## Verification
- `tests/hermes_cli/test_agent_plugin_startup.py`: 8 passed
- related plugin/lifecycle suites: 85 passed
- `git diff --check` passed

No unrelated files are included in the branch commit.