### PR TITLE
fix(desktop): keep background responses and approvals connected

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/index.ts
@@ -12,6 +12,7 @@ import { $gateway, activeGatewayConnectionId } from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey } from '@/store/profile'
 import { replayPendingApproval } from '@/store/prompts'
 import { setSessionProviderWait } from '@/store/provider-wait'
+import { storedSessionIdForRuntimeId } from '@/store/session-states'
 import { setSessionDraftingTool } from '@/store/tool-drafting'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -198,7 +199,11 @@ export function useGatewayEventHandler(deps: GatewayEventDeps) {
       const replaySessionId = approvalReplaySessionId(event.type, activeSessionIdRef.current, sessionId)
 
       if (replaySessionId) {
-        void replayPendingApproval($gateway.get(), replaySessionId).catch(() => undefined)
+        void replayPendingApproval(
+          $gateway.get(),
+          replaySessionId,
+          storedSessionIdForRuntimeId(replaySessionId)
+        ).catch(() => undefined)
       }
 
       // Mid-turn compaction does not emit another message.start. The first

--- a/apps/desktop/src/components/assistant-ui/tool/approval.tsx
+++ b/apps/desktop/src/components/assistant-ui/tool/approval.tsx
@@ -28,7 +28,7 @@ import {
   sessionApprovalInlineVisible,
   sessionApprovalRequest
 } from '@/store/prompts'
-import { requestForOwnedSession } from '@/store/session-states'
+import { requestForOwnedSession, storedSessionIdForRuntimeId } from '@/store/session-states'
 
 import type { ToolPart } from './fallback-model'
 
@@ -157,7 +157,10 @@ const ApprovalBar: FC<{ request: ApprovalRequest; surface: 'floating' | 'inline'
           {
             choice,
             request_id: request.requestId,
-            session_id: request.sessionId ?? undefined
+            session_id: request.sessionId ?? undefined,
+            ...(request.sessionId && storedSessionIdForRuntimeId(request.sessionId)
+              ? { stored_session_id: storedSessionIdForRuntimeId(request.sessionId) }
+              : {})
           }
         )
         triggerHaptic(choice === 'deny' ? 'cancel' : 'submit')

--- a/apps/desktop/src/store/prompts.test.ts
+++ b/apps/desktop/src/store/prompts.test.ts
@@ -121,12 +121,13 @@ describe('approval prompt store', () => {
       }
     }
 
-    await replayPendingApproval(gateway, 's1')
+    await replayPendingApproval(gateway, 'stale-runtime', 'stored-s1')
 
+    $activeSessionId.set('stale-runtime')
     expect($approvalRequest.get()?.requestId).toBe('r1')
     expect(calls).toEqual([
-      ['approval.pending', { session_id: 's1' }],
-      ['approval.received', { request_id: 'r1', session_id: 's1' }]
+      ['approval.pending', { session_id: 'stale-runtime', stored_session_id: 'stored-s1' }],
+      ['approval.received', { request_id: 'r1', session_id: 'stale-runtime', stored_session_id: 'stored-s1' }]
     ])
   })
 })

--- a/apps/desktop/src/store/prompts.ts
+++ b/apps/desktop/src/store/prompts.ts
@@ -115,24 +115,34 @@ export const $approvalRequest = approval.$active
 export const setApprovalRequest = approval.set
 export const clearApprovalRequest = approval.clear
 
-export async function receiveApprovalRequest(gateway: ApprovalGateway | null, request: ApprovalRequest): Promise<void> {
+export async function receiveApprovalRequest(
+  gateway: ApprovalGateway | null,
+  request: ApprovalRequest,
+  storedSessionId?: string | null
+): Promise<void> {
   setApprovalRequest(request)
 
   if (gateway && request.requestId && request.sessionId) {
     await gateway.request('approval.received', {
       request_id: request.requestId,
-      session_id: request.sessionId
+      session_id: request.sessionId,
+      ...(storedSessionId ? { stored_session_id: storedSessionId } : {})
     })
   }
 }
 
-export async function replayPendingApproval(gateway: ApprovalGateway | null, sessionId: string | null): Promise<void> {
+export async function replayPendingApproval(
+  gateway: ApprovalGateway | null,
+  sessionId: string | null,
+  storedSessionId?: string | null
+): Promise<void> {
   if (!gateway || !sessionId) {
     return
   }
 
   const rawResult = await gateway.request('approval.pending', {
-    session_id: sessionId
+    session_id: sessionId,
+    ...(storedSessionId ? { stored_session_id: storedSessionId } : {})
   })
 
   const result =
@@ -144,15 +154,19 @@ export async function replayPendingApproval(gateway: ApprovalGateway | null, ses
     return
   }
 
-  await receiveApprovalRequest(gateway, {
-    allowPermanent: pending.allow_permanent !== false,
-    choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
-    command: typeof pending.command === 'string' ? pending.command : '',
-    description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
-    requestId: pending.request_id,
-    sessionId,
-    smartDenied: pending.smart_denied === true
-  })
+  await receiveApprovalRequest(
+    gateway,
+    {
+      allowPermanent: pending.allow_permanent !== false,
+      choices: Array.isArray(pending.choices) ? pending.choices.filter(choice => typeof choice === 'string') : undefined,
+      command: typeof pending.command === 'string' ? pending.command : '',
+      description: typeof pending.description === 'string' ? pending.description : 'dangerous command',
+      requestId: pending.request_id,
+      sessionId,
+      smartDenied: pending.smart_denied === true
+    },
+    storedSessionId
+  )
 }
 
 /** The prompt request for one specific session — the tile counterpart of the

--- a/apps/desktop/src/store/session-states-scopes.test.ts
+++ b/apps/desktop/src/store/session-states-scopes.test.ts
@@ -45,6 +45,13 @@ describe('liveSessionScopes', () => {
     expect(liveSessionScopes()).toEqual(new Set(['conn:local::default']))
   })
 
+  it('keeps an awaiting-response session before the backend reports busy', () => {
+    recordSessionEventScope({ connectionId: 'local', profile: 'chiefy', session_id: 'rt-awaiting' })
+    publishSessionState('rt-awaiting', state({ busy: false, awaitingResponse: true }))
+
+    expect(liveSessionScopes()).toEqual(new Set(['conn:local::chiefy']))
+  })
+
   it('includes needs-input sessions and drops settled ones', () => {
     recordSessionEventScope({ connectionId: 'homelab', profile: 'default', session_id: 'rt-1' })
     publishSessionState('rt-1', state({ busy: false, needsInput: true }))

--- a/apps/desktop/src/store/session-states.ts
+++ b/apps/desktop/src/store/session-states.ts
@@ -89,14 +89,15 @@ export function recordSessionEventScope(event: { connectionId?: string; profile?
   }
 }
 
-/** Composite scopes of registry-sourced sessions that are live (busy or
- * waiting on input) — the (connectionId, profile) half of the gateway
- * keep-set. Local-source live work keeps flowing through profile names. */
+/** Composite scopes of registry-sourced sessions that are live (busy,
+ * awaiting the backend's first response, or waiting on input) — the
+ * (connectionId, profile) half of the gateway keep-set. Local-source live
+ * work keeps flowing through profile names. */
 export function liveSessionScopes(): Set<string> {
   const scopes = new Set<string>()
 
   for (const [runtimeId, state] of Object.entries($sessionStates.get())) {
-    if (!state || (!state.busy && !state.needsInput)) {
+    if (!state || (!state.busy && !state.awaitingResponse && !state.needsInput)) {
       continue
     }
 
@@ -646,7 +647,7 @@ export const $workingSessionIds = computed(
   (states, sessions) =>
     (workingIds = stableArray(
       workingIds,
-      storedIds(states, sessions, s => s.busy)
+      storedIds(states, sessions, s => s.busy || s.awaitingResponse)
     ))
 )
 

--- a/apps/desktop/src/store/session-watchdog.test.ts
+++ b/apps/desktop/src/store/session-watchdog.test.ts
@@ -216,6 +216,15 @@ describe('computed $workingSessionIds', () => {
     expect($workingSessionIds.get()).toEqual([])
   })
 
+  it('treats an awaiting response as working before busy arrives', () => {
+    publishSessionState(
+      'rt-awaiting',
+      state({ awaitingResponse: true, busy: false, storedSessionId: 's-awaiting' })
+    )
+
+    expect($workingSessionIds.get()).toContain('s-awaiting')
+  })
+
   it('reflects busy sessions under the id their surfaces key on', () => {
     publishSessionState('rt1', state({ busy: true, storedSessionId: 's1' }))
     publishSessionState('rt2', state({ busy: false, storedSessionId: 's2' }))

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -173,6 +173,70 @@ def test_session_context_uses_session_cwd(monkeypatch, tmp_path):
         server._sessions.pop(sid, None)
 
 
+def test_approval_pending_uses_durable_session_id_after_runtime_reap(monkeypatch):
+    """Reconnect replay must not depend on a stale runtime id."""
+    monkeypatch.setattr(
+        "tools.approval.list_gateway_approvals",
+        lambda session_key: [{"request_id": "approval-1", "session_key": session_key}],
+    )
+
+    result = server._methods["approval.pending"](
+        "r1",
+        {"session_id": "stale-runtime", "stored_session_id": "stored-session"},
+    )
+
+    assert result["result"]["approvals"] == [
+        {"request_id": "approval-1", "session_key": "stored-session"}
+    ]
+
+
+def test_approval_received_uses_durable_session_id_after_runtime_reap(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        "tools.approval.ack_gateway_approval",
+        lambda session_key, request_id: seen.append((session_key, request_id)) or True,
+    )
+
+    result = server._methods["approval.received"](
+        "r1",
+        {
+            "session_id": "stale-runtime",
+            "stored_session_id": "stored-session",
+            "request_id": "approval-1",
+        },
+    )
+
+    assert result["result"]["acknowledged"] is True
+    assert seen == [("stored-session", "approval-1")]
+
+
+def test_approval_respond_uses_durable_session_id_after_runtime_reap(monkeypatch):
+    seen = []
+    monkeypatch.setattr(
+        "tools.approval.resolve_gateway_approval",
+        lambda session_key, choice, **kwargs: seen.append((session_key, choice, kwargs)) or 1,
+    )
+
+    result = server._methods["approval.respond"](
+        "r1",
+        {
+            "session_id": "stale-runtime",
+            "stored_session_id": "stored-session",
+            "request_id": "approval-1",
+            "choice": "once",
+        },
+    )
+
+    assert result["result"]["resolved"] == 1
+    assert seen == [
+        (
+            "stored-session",
+            "once",
+            {"resolve_all": False, "request_id": "approval-1"},
+        )
+    ]
+
+
 def test_handoff_fail_marks_only_inflight_rows(monkeypatch):
     class DbContext:
         def __init__(self, db):

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -1790,22 +1790,36 @@ def _(rid, params: dict) -> dict:
     return _respond(rid, params, "value", allow_expired=True)
 
 
+def _approval_session_key(params: dict, rid):
+    """Resolve an approval queue by live runtime or durable stored identity."""
+    sid = str(params.get("session_id") or "")
+    session = _sessions.get(sid)
+    if session is not None:
+        return (str(session["session_key"]), None)
+    stored = str(params.get("stored_session_id") or "").strip()
+    if stored:
+        return (stored, None)
+    _session, err = _sess_nowait(params, rid)
+    return (None, err)
+
+
 @method("approval.pending")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session_key, err = _approval_session_key(params, rid)
     if err:
         return err
     try:
         from tools.approval import list_gateway_approvals
 
-        return _ok(rid, {"approvals": list_gateway_approvals(session["session_key"])})
+        assert session_key is not None
+        return _ok(rid, {"approvals": list_gateway_approvals(session_key)})
     except Exception as e:
         return _err(rid, 5004, str(e))
 
 
 @method("approval.received")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session_key, err = _approval_session_key(params, rid)
     if err:
         return err
     request_id = params.get("request_id")
@@ -1814,9 +1828,10 @@ def _(rid, params: dict) -> dict:
     try:
         from tools.approval import ack_gateway_approval
 
+        assert session_key is not None
         return _ok(
             rid,
-            {"acknowledged": ack_gateway_approval(session["session_key"], request_id)},
+            {"acknowledged": ack_gateway_approval(session_key, request_id)},
         )
     except Exception as e:
         return _err(rid, 5004, str(e))
@@ -1869,7 +1884,7 @@ def _approval_respond_session_fallback(params: dict):
 
 @method("approval.respond")
 def _(rid, params: dict) -> dict:
-    session, err = _sess(params, rid)
+    session_key, err = _approval_session_key(params, rid)
     if err:
         # Session-not-found (4001) only: the client may hold a stale live
         # sid for a session whose runtime was re-minted after a reconnect.
@@ -1880,14 +1895,16 @@ def _(rid, params: dict) -> dict:
         session = _approval_respond_session_fallback(params)
         if session is None:
             return err
+        session_key = session["session_key"]
     try:
         from tools.approval import resolve_gateway_approval
 
+        assert session_key is not None
         return _ok(
             rid,
             {
                 "resolved": resolve_gateway_approval(
-                    session["session_key"],
+                    session_key,
                     params.get("choice", "deny"),
                     resolve_all=params.get("all", False),
                     request_id=params.get("request_id"),
@@ -1915,6 +1932,7 @@ def register(server) -> None:
         _coerce_truncate_int,
         _reconcile_client_ordinal,
         _pending_reaction_notes,
+        _approval_session_key,
         _approval_respond_session_fallback,
     ):
         setattr(


### PR DESCRIPTION
## Summary
- treat `awaitingResponse` sessions as active work in the working-state and gateway/socket keep-sets
- route approval replay, acknowledgement, and response with the durable stored session identity
- preserve approval cards when a runtime id is detached or reaped during a bot/profile switch
- add regressions for both lifecycle paths

## Why
Switching to another bot immediately after sending could prune the first bot's secondary socket during the optimistic `awaitingResponse` window. A separate reconnect path also replayed approvals using a stale runtime id, leaving protected operations blocked until their five-minute timeout.

## Verification
- 47/47 existing session/gateway regression tests passed
- 36/36 approval and gateway-event Desktop tests passed
- 3/3 durable approval identity gateway tests passed
- `npm run typecheck` passed
- `npm run lint` passed with zero errors; pre-existing warnings remain
- signed macOS Desktop package build completed successfully