### PR TITLE
feat(models): claude-fable-5.1 selectable on OpenRouter and Nous Portal

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -82,6 +82,7 @@ def _custom_provider_ssl_context(base_url: str):
 # (model_id, display description shown in menus)
 OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Anthropic
+    ("anthropic/claude-fable-5.1",             ""),
     ("anthropic/claude-fable-5",               ""),
     ("anthropic/claude-opus-5",                ""),
     ("anthropic/claude-opus-5-fast",           "2x price, higher output speed"),
@@ -266,6 +267,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "moa": ["default"],
     "nous": [
         # Anthropic
+        "anthropic/claude-fable-5.1",
         "anthropic/claude-fable-5",
         "anthropic/claude-opus-5",
         "anthropic/claude-opus-4.8",

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-08-29T02:38:32Z",
+  "updated_at": "2026-09-01T18:20:04Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -12,6 +12,10 @@
         "note": "Descriptions drive picker badges. Live /api/v1/models filters curated ids by tool-calling support and free pricing. The entry labeled \"default\": true is the model Hermes silently lands on when the user never picked one."
       },
       "models": [
+        {
+          "id": "anthropic/claude-fable-5.1",
+          "description": ""
+        },
         {
           "id": "anthropic/claude-fable-5",
           "description": ""
@@ -209,6 +213,9 @@
         "note": "Free-tier gating is determined live via Portal pricing (partition_nous_models_by_tier), not this manifest. The entry labeled \"default\": true is the model Hermes silently lands on when the user never picked one."
       },
       "models": [
+        {
+          "id": "anthropic/claude-fable-5.1"
+        },
         {
           "id": "anthropic/claude-fable-5"
         },


### PR DESCRIPTION
## Summary
`anthropic/claude-fable-5.1` is now selectable in the `/model` picker on OpenRouter and Nous Portal, slotted above `claude-fable-5` per the newest-first ordering convention.

## Changes
- `hermes_cli/models.py`: added `anthropic/claude-fable-5.1` to `OPENROUTER_MODELS` and `_PROVIDER_MODELS["nous"]` (top of the Anthropic block)
- `website/static/api/model-catalog.json`: regenerated via `scripts/build_model_catalog.py`

## Scope notes (scoped rollout — only the two named providers touched)
- `_PROVIDER_MODELS["anthropic"]`, bedrock ids, copilot aliases, and setup defaults deliberately untouched (not in scope).
- **Pricing snapshot skipped**: both routes bill via `official_models_api` (live pricing) — verified with `resolve_billing_route()` for both providers.
- **Context length**: `DEFAULT_CONTEXT_LENGTHS` fuzzy match resolves `claude-fable-5.1` via the `claude-fable-5` prefix → 1,000,000, matching models.dev / Anthropic-direct metadata for 5.1. No new entry needed.
- **Reasoning stale-timeout floor**: prefix entry fires for the 5.1 slug (600s). No new entry needed.
- **Liveness**: Nous Portal serves the 5.1 slug **live-verified** — a real chat completion against `inference-api.nousresearch.com` returned 200 with `model: anthropic/claude-fable-5.1` and billed at the expected $10/$50 per M rates; only the portal's `/v1/models` discovery endpoint lags (slug not listed yet, so the curated entry is what surfaces it in the picker). OpenRouter's `/api/v1/models` doesn't list 5.1 yet — its curated entry pre-positions for the rollout.

## Validation
| Check | Result |
|---|---|
| Targeted catalog gate (6 files) | 187 passed, 0 failed |
| E2E curated fallback (net denied, temp HERMES_HOME) | 5.1 present, above 5, no dupes — both providers |
| Live inference on Nous Portal | 200 OK, served as `claude-fable-5.1`, correct billing |
| AST duplicate-entry scan on curated lists | none |
| `build_model_catalog.py` regen matches lists | manifest test green |

## Infographic

![Claude Fable 5.1 joins the catalog](https://v3b.fal.media/files/b/0aa8b594/l6XcU3jpyz8MA26s_jhNi_mJ7tFKxu.png)
