### PR TITLE
fix(kanban): resume explicitly requeued active PR tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9397,6 +9397,35 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _event_resumes_active_pr(kind: str, payload_raw: Optional[str]) -> bool:
+    """Return whether a later lifecycle event deliberately resumes PR work.
+
+    Keep this allowlist narrow: ordinary comments and automatic recovery events
+    are not operator intent and must not weaken duplicate-PR prevention.
+    """
+    try:
+        payload = json.loads(payload_raw) if payload_raw else {}
+    except (json.JSONDecodeError, TypeError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    if kind == "status":
+        return (
+            payload.get("status") == "ready"
+            or payload.get("requested_status") == "ready"
+        )
+    if kind in {"promoted_manual", "unblocked"}:
+        return True
+    if kind == "reclaimed":
+        return payload.get("manual") is True
+    if kind == "changes_requested":
+        return bool(str(payload.get("reason") or "").strip())
+    if kind == "review_reopened":
+        return payload.get("status", "ready") == "ready"
+    return False
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -9448,7 +9477,10 @@ def check_respawn_guard(
     ``"active_pr"``
         A GitHub PR URL appears in a recent task comment (within
         ``_RESPAWN_GUARD_PR_WINDOW`` seconds).  A prior worker already
-        opened a PR; re-spawning risks a duplicate PR on the same task.
+        opened a PR; re-spawning risks a duplicate PR on the same task. A later
+        explicit ready requeue, manual promote/unblock/reclaim, or first-class
+        changes-requested/review-reopened event proves deliberate continuation
+        and bypasses this guard. Comments alone never bypass it.
 
     Stale / dead claim locks are NOT a guard reason — they are handled
     by ``release_stale_claims`` and ``detect_crashed_workers`` which
@@ -9537,12 +9569,30 @@ def check_respawn_guard(
             return "recent_success"
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
+    #    Only a trusted lifecycle transition *after the latest matching PR
+    #    comment* proves deliberate continuation. This preserves duplicate-PR
+    #    prevention for stale comments and automatic recovery churn.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
     for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+        "SELECT body, created_at FROM task_comments "
+        "WHERE task_id = ? AND created_at >= ? "
+        "ORDER BY created_at DESC, id DESC",
         (task_id, pr_cutoff),
     ).fetchall():
         if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+            continuation_events = conn.execute(
+                "SELECT kind, payload FROM task_events "
+                "WHERE task_id = ? AND created_at > ? "
+                "AND kind IN ('status', 'promoted_manual', 'unblocked', "
+                "'reclaimed', 'changes_requested', 'review_reopened') "
+                "ORDER BY id DESC",
+                (task_id, int(c["created_at"])),
+            ).fetchall()
+            if any(
+                _event_resumes_active_pr(event["kind"], event["payload"])
+                for event in continuation_events
+            ):
+                return None
             return "active_pr"
 
     return None

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -510,6 +510,137 @@ def test_delete_task_removes_task_and_cascades(kanban_home):
 # ---------------------------------------------------------------------------
 
 
+def _add_pr_comment_at(conn, task_id: str, created_at: int) -> None:
+    conn.execute(
+        "INSERT INTO task_comments (task_id, author, body, created_at) "
+        "VALUES (?, 'worker', ?, ?)",
+        (
+            task_id,
+            "Opened https://github.com/example/hermes-agent/pull/123",
+            created_at,
+        ),
+    )
+
+
+def test_respawn_guard_active_pr_requires_later_continuation_event(
+    kanban_home, monkeypatch,
+):
+    """A fresh PR comment alone remains duplicate-work proof.
+
+    An older lifecycle event must not launder it into a continuation, while a
+    later explicit ready requeue is trusted as deliberate resumption.
+    """
+    monkeypatch.setattr(kb.time, "time", lambda: 1_200)
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="finish active PR", assignee="alice")
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (task_id, '{"status":"ready"}', 1_000),
+        )
+        _add_pr_comment_at(conn, task_id, 1_100)
+
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (task_id, '{"status":"ready","requested_status":"ready"}', 1_200),
+        )
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+@pytest.mark.parametrize("transition", ["promote", "unblock", "reclaim"])
+def test_respawn_guard_active_pr_allows_explicit_lifecycle_continuations(
+    kanban_home, monkeypatch, transition,
+):
+    """First-class operator promote/unblock/reclaim events resume an active PR."""
+    now = [2_000]
+    monkeypatch.setattr(kb.time, "time", lambda: now[0])
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="continue PR", assignee="alice")
+
+        if transition == "promote":
+            conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (task_id,))
+        elif transition == "unblock":
+            assert kb.block_task(conn, task_id, reason="operator check")
+        else:
+            assert kb.claim_task(conn, task_id) is not None
+
+        _add_pr_comment_at(conn, task_id, now[0])
+        assert kb.check_respawn_guard(conn, task_id) == "active_pr"
+
+        now[0] += 1
+        if transition == "promote":
+            assert kb.promote_task(conn, task_id, actor="operator") == (True, None)
+        elif transition == "unblock":
+            assert kb.unblock_task(conn, task_id)
+        else:
+            assert kb.reclaim_task(conn, task_id, reason="resume existing PR")
+
+        task = kb.get_task(conn, task_id)
+        assert task is not None
+        assert task.status == "ready"
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_respawn_guard_active_pr_allows_changes_requested_instruction(
+    kanban_home, monkeypatch,
+):
+    """A later first-class changes-requested reason is concrete rework proof."""
+    now = [3_000]
+    monkeypatch.setattr(kb.time, "time", lambda: now[0])
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="address review", assignee="implementer")
+        implementation = kb.claim_task(conn, task_id)
+        assert implementation is not None
+        _add_pr_comment_at(conn, task_id, 3_000)
+        assert kb.request_review(
+            conn,
+            task_id,
+            reviewer="reviewer",
+            expected_run_id=implementation.current_run_id,
+        )
+        now[0] += 1
+        review = kb.claim_review_task(conn, task_id)
+        assert review is not None
+        assert kb.request_changes(
+            conn,
+            task_id,
+            reason="Fix the failing Windows assertion",
+            expected_run_id=review.current_run_id,
+        ) == (True, "implementer")
+
+        assert kb.check_respawn_guard(conn, task_id) is None
+
+
+def test_dispatch_active_pr_continuation_spawns_but_duplicate_stays_guarded(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Dispatch honors a later explicit requeue without weakening duplicates."""
+    monkeypatch.setattr(kb.time, "time", lambda: 4_001)
+    with kb.connect() as conn:
+        continuation = kb.create_task(conn, title="continue PR", assignee="alice")
+        duplicate = kb.create_task(conn, title="duplicate PR", assignee="alice")
+        for task_id in (continuation, duplicate):
+            _add_pr_comment_at(conn, task_id, 4_000)
+        conn.execute(
+            "INSERT INTO task_events (task_id, kind, payload, created_at) "
+            "VALUES (?, 'status', ?, ?)",
+            (
+                continuation,
+                '{"status":"ready","requested_status":"ready"}',
+                4_001,
+            ),
+        )
+
+        result = kb.dispatch_once(conn, dry_run=True)
+
+    assert continuation in [task_id for task_id, _assignee, _workspace in result.spawned]
+    assert (duplicate, "active_pr") in result.respawn_guarded
+
+
 
 
 


### PR DESCRIPTION
## Summary
- preserve the active-PR duplicate-spawn guard for stale PR comments
- allow only explicit lifecycle continuations strictly newer than the latest PR comment
- cover ready requeue, manual promote/unblock/reclaim, review remediation, stale events, and dispatch behavior

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_db.py` (37 passed, 1 skipped on macOS)
- `scripts/run_tests.sh tests/hermes_cli/test_kanban_review_lifecycle.py tests/hermes_cli/test_kanban_promote.py tests/hermes_cli/test_kanban_reclaim_claim_lock_guard.py tests/plugins/test_kanban_board_lifecycle_api.py` (27 passed)
- `uv run --no-sync ruff check hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_db.py`
- `git diff --check origin/main...HEAD`

The release head is a byte-identical cherry-pick of independently reviewed commit `902e1851fd59f13dff2efe55a81d77e64cee6944` onto current `origin/main`; the fresh immutable head is `93089d26aec65d8b2ee068965809e6bc8301ed33`.