### PR TITLE
fix(web): pass terminal/series/swatch keys through user theme normaliser

### DIFF
--- a/hermes_cli/web_server_dashboard.py
+++ b/hermes_cli/web_server_dashboard.py
@@ -397,6 +397,37 @@ def _normalise_theme_definition(data: Dict[str, Any]) -> Optional[Dict[str, Any]
         result["customCSS"] = custom_css
     if component_styles:
         result["componentStyles"] = component_styles
+
+    # Terminal pane colors, chart accents, and picker swatch. The frontend
+    # reads these from the applied theme definition and falls back to
+    # #000000/#f0e6d2 when absent (web/src/themes/context.tsx,
+    # ChatPage.tsx, HermesConsoleModal.tsx). Built-ins define them in
+    # presets.ts; without this passthrough user themes silently dropped
+    # them — e.g. the embedded terminal rendered as a black pane inside
+    # a light/pastel theme.
+    for key in ("terminalBackground", "terminalForeground"):
+        val = data.get(key)
+        if isinstance(val, str) and val.strip():
+            result[key] = val.strip()
+    series_src = data.get("seriesColors")
+    if isinstance(series_src, dict):
+        series_out = {
+            k: v.strip()
+            for k, v in series_src.items()
+            if k in ("inputTokenAccent", "outputTokenAccent")
+            and isinstance(v, str)
+            and v.strip()
+        }
+        if series_out:
+            result["seriesColors"] = series_out
+    swatch_src = data.get("swatchColors")
+    if isinstance(swatch_src, list):
+        # Frontend contract is exactly three entries (web/src/themes/types.ts
+        # swatchColors: [string, string, string]); clamp longer lists instead
+        # of dropping the whole theme's swatch.
+        swatch_clamped = [c.strip() for c in swatch_src if isinstance(c, str) and c.strip()][:3]
+        if len(swatch_clamped) == 3:
+            result["swatchColors"] = swatch_clamped
     return result
 
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3996,7 +3996,46 @@ class TestNormaliseThemeExtensions:
         assert r["componentStyles"]["header"]["background"].startswith("linear-gradient")
         assert "rogueBucket" not in r["componentStyles"]
 
+    def test_passthrough_terminal_series_swatch(self):
+        """terminalBackground/Foreground, seriesColors, swatchColors survive
+        normalisation — the frontend needs them to color the embedded
+        terminal pane and token charts (falls back to #000000 otherwise)."""
+        from hermes_cli.web_server_dashboard import _normalise_theme_definition
+        result = _normalise_theme_definition({
+            "name": "pastel",
+            "terminalBackground": "  #1e1e2e ",
+            "terminalForeground": "#cdd6f4",
+            "seriesColors": {
+                "inputTokenAccent": "  #89b4fa ",
+                "outputTokenAccent": "#a6e3a1",
+                "bogusKey": "ignored",
+            },
+            "swatchColors": ["#1e1e2e", "#cdd6f4", "#a6e3a1", "#extra-ignored"],
+        })
+        assert result is not None
+        assert result["terminalBackground"] == "#1e1e2e"
+        assert result["terminalForeground"] == "#cdd6f4"
+        assert result["seriesColors"] == {
+            "inputTokenAccent": "#89b4fa",
+            "outputTokenAccent": "#a6e3a1",
+        }
+        assert result["swatchColors"] == ["#1e1e2e", "#cdd6f4", "#a6e3a1"]
 
+    def test_passthrough_drops_garbage(self):
+        """Non-string / wrong-length values don't leak into the wire format."""
+        from hermes_cli.web_server_dashboard import _normalise_theme_definition
+        result = _normalise_theme_definition({
+            "name": "messy",
+            "terminalBackground": 42,
+            "terminalForeground": "   ",
+            "seriesColors": "not-a-dict",
+            "swatchColors": ["#111111", "#222222"],
+        })
+        assert result is not None
+        assert "terminalBackground" not in result
+        assert "terminalForeground" not in result
+        assert "seriesColors" not in result
+        assert "swatchColors" not in result
 
 
 class TestDeleteSessionEndpoint:


### PR DESCRIPTION
## Problem

User-authored dashboard themes (`~/.hermes/dashboard-themes/*.yaml`) silently lose `terminalBackground`, `terminalForeground`, `seriesColors`, and `swatchColors`: `_normalise_theme_definition()` in `hermes_cli/web_server.py` never copies these keys into the wire format.

The frontend reads them from the applied theme definition and falls back to `#000000` / `#f0e6d2` when absent (`web/src/themes/context.tsx`, `ChatPage.tsx`, `HermesConsoleModal.tsx`). Consequences:

- the embedded terminal pane renders as an unstyled black box inside a light/pastel user theme
- Analytics/Models token charts lose their accent colors
- the theme picker ignores the theme's swatch override

Only built-in themes (defined in `web/src/themes/presets.ts`, e.g. `nous-blue` sets all four) could use these keys — user themes had to fall back to a `customCSS` `!important` override hack targeting `.xterm-screen` to fix the terminal pane.

## Fix

Copy the four keys through `_normalise_theme_definition()` with the same shape validation style as the rest of the function:

- `terminalBackground` / `terminalForeground`: non-empty strings
- `seriesColors`: dict restricted to the two known accents (`inputTokenAccent`, `outputTokenAccent`)
- `swatchColors`: exactly 3 non-empty string entries

Garbage values are dropped, keeping the wire format clean.

## Verification

- RED→GREEN: new tests fail without the fix, pass with it.
- `pytest tests/hermes_cli/test_web_server.py -k "Normalise or Discover" -o 'addopts=' -q` → **9 passed** (7 pre-existing + 2 new).
- Live check on my deployment (v0.21.0, docker): a user Catppuccin Mocha theme with `terminalBackground: #1e1e2e` now colors the terminal pane correctly via the theme key alone — the `customCSS` `!important` workaround block can be deleted from the theme YAML.

## Environment

Hermes 0.21.0, Docker s6 container.