### PR TITLE
fix(email): cron deliveries start fresh conversations, never inherit sender thread subject

### DIFF
--- a/cron/scheduler_delivery.py
+++ b/cron/scheduler_delivery.py
@@ -1205,7 +1205,7 @@ def _live_route_metadata(t: _TargetDelivery) -> tuple[Optional[str], dict, dict]
         # thread_id is absent from metadata; cron deliveries have no inbound reply anchor, so the metadata
         # key bypasses that check and lets the adapter route via a plain message_thread_id. See #52060.
         route_thread_id = str(thread_id) if thread_id is not None else None
-        route_metadata = {"job_id": job["id"], "notify": t.notify_delivery}
+        route_metadata = {"job_id": job["id"], "job_name": job.get("name") or job.get("id", "cron"), "notify": t.notify_delivery}
         if route_thread_id:
             route_metadata["thread_id"] = route_thread_id
         media_metadata = {"notify": t.notify_delivery}

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -277,6 +277,21 @@ class DeliveryRouter:
             return {"success": True, "filtered": "silence_narration", "delivered": False}
 
         send_metadata = dict(metadata or {})
+
+        # Cron email deliveries without a thread anchor must not inherit the
+        # sender's last inbound subject — Gmail would thread the report into
+        # that conversation (e.g. a nightly backup landing inside a "floor
+        # plans" thread). Give them an explicit fresh-conversation subject the
+        # adapter uses verbatim (no Re: prefix, no References header).
+        if (
+            target.platform == Platform.EMAIL
+            and "subject" not in send_metadata
+            and "thread_id" not in send_metadata
+            and (metadata or {}).get("job_id")
+        ):
+            job_name = (metadata or {}).get("job_name") or (metadata or {}).get("job_id", "cron")
+            send_metadata["subject"] = f"Cronjob Response: {job_name}"
+
         home = self.config.get_home_channel(target.platform) if transport.is_relay else None
         if home is not None and home.chat_id == target.chat_id:
             send_metadata.update({k: v for k, v in (("user_id", home.user_id), ("scope_id", home.scope_id)) if v})

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -5,6 +5,7 @@ import asyncio
 import email as email_lib
 from contextlib import contextmanager, suppress
 import imaplib
+import json
 import logging
 import os
 import re
@@ -328,6 +329,8 @@ def _attach_file(msg: MIMEMultipart, path: Path, filename: str) -> None:
 class EmailAdapter(BasePlatformAdapter):
     """Email gateway adapter using IMAP (receive) and SMTP (send)."""
 
+    splits_long_messages = True  # email has no practical length cap; the gateway must not truncate long sends
+
     # Per-account seen-UID snapshot surviving adapter recreation: the reconnect watcher builds a FRESH
     # adapter per retry; without this connect(is_reconnect=True) would re-mark the mailbox seen and skip
     # mail that arrived during the outage. Keyed by address (multiplex runs several accounts); same-process only.
@@ -364,10 +367,21 @@ class EmailAdapter(BasePlatformAdapter):
         self._seen_uids_max: int = 2000   # cap to prevent unbounded memory growth
         self._poll_task: Optional[asyncio.Task] = None
         self._last_fetch_failed, self._last_fetch_error = False, ""  # "checked, nothing new" vs "the check itself failed"
-        # chat_id (sender email) -> last subject + message-id for threading
         # Track the last IMAP fetch attempt so the poll loop can distinguish "checked, nothing new" from
         # "the check itself failed" (#80016).
-        self._thread_context: Dict[str, Dict[str, str]] = {}
+        # Thread-context persistence (per-account path, multiplexing-safe): chat_id (sender email) ->
+        # last subject + message-id for reply threading. Persisted to a small JSON file on every
+        # mutation and reloaded here so replies keep their thread's subject/Message-ID across gateway
+        # restarts.
+        try:
+            from hermes_constants import get_hermes_home
+
+            _state_dir = Path(get_hermes_home()) / "state"
+        except Exception:
+            _state_dir = Path.home() / ".hermes" / "state"
+        _addr_slug = re.sub(r"[^a-z0-9]+", "_", self._address.lower()).strip("_") or "default"
+        self._thread_context_path: Optional[Path] = _state_dir / f"email_thread_context_{_addr_slug}.json"
+        self._thread_context: Dict[str, Dict[str, Any]] = self._load_thread_context()
         logger.info("[Email] Adapter initialized for %s", self._address)
 
     def _trim_seen_uids(self) -> None:
@@ -410,6 +424,48 @@ class EmailAdapter(BasePlatformAdapter):
             yield imap
         finally:
             _close_imap(imap)
+
+    # ── Thread-context persistence ─────────────────────────────────────────
+    # _thread_context is in-memory; without persistence a gateway restart loses every thread's
+    # subject/Message-ID and replies fall back to the generic "Hermes Agent" subject. Persist the map
+    # to a small per-account JSON file on every mutation and reload on adapter construction.
+    _thread_context_max_entries: int = 500
+
+    def _load_thread_context(self) -> Dict[str, Dict[str, Any]]:
+        """Load persisted thread context (subject/message_id per chat key)."""
+        if not self._thread_context_path or not self._thread_context_path.exists():
+            return {}
+        try:
+            raw = json.loads(self._thread_context_path.read_text("utf-8"))
+            if not isinstance(raw, dict):
+                return {}
+            return {
+                str(k): dict(v)
+                for k, v in raw.items()
+                if isinstance(v, dict) and isinstance(v.get("subject"), str)
+            }
+        except Exception as e:  # corrupt/partial file — start fresh
+            logger.warning("[Email] Thread-context load failed (%s); starting fresh", e)
+            return {}
+
+    def _save_thread_context(self) -> None:
+        """Persist the thread-context map atomically (tmp + rename)."""
+        if not self._thread_context_path:
+            return
+        try:
+            self._thread_context_path.parent.mkdir(parents=True, exist_ok=True)
+            data = dict(self._thread_context)
+            if len(data) > self._thread_context_max_entries:
+                # Overwriting a key keeps its dict position, so this trims by first-inserted
+                # (FIFO), not by last-used — and the live map is trimmed with the persisted copy
+                # so per-sender key growth stays bounded in memory too.
+                trimmed = dict(list(data.items())[-self._thread_context_max_entries:])
+                data, self._thread_context = trimmed, trimmed
+            tmp = self._thread_context_path.with_suffix(".json.tmp")
+            tmp.write_text(json.dumps(data), "utf-8")
+            tmp.replace(self._thread_context_path)
+        except Exception as e:
+            logger.warning("[Email] Thread-context persist failed: %s", e)
 
     def _connect_smtp(self) -> smtplib.SMTP:
         """SMTP connection with TLS established (callers go straight to ``login()``). An unreachable IPv6 address can
@@ -635,7 +691,9 @@ class EmailAdapter(BasePlatformAdapter):
         # DOCUMENT wins over PHOTO for mixed attachments: run.py keys image handling off the per-path mime type regardless
         # of message_type, but document-context injection gates strictly on MessageType.DOCUMENT — so DOCUMENT surfaces both.
         kinds = {att["type"] for att in attachments}
-        self._thread_context[sender_addr] = {"subject": subject, "message_id": msg_data["message_id"]}
+        _ctx_entry = {"subject": subject, "message_id": msg_data["message_id"]}
+        self._thread_context[sender_addr] = _ctx_entry
+        self._save_thread_context()
         name = msg_data["sender_name"] or sender_addr
         event = MessageEvent(
             text=text or "(empty email)", message_id=msg_data["message_id"],
@@ -656,20 +714,29 @@ class EmailAdapter(BasePlatformAdapter):
 
     async def send(self, chat_id: str, content: str, reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
         """Send an email reply to the given address."""
-        return await self._run_send(self._send_email, (chat_id, content, reply_to), "[Email] Send failed to %s: %s", chat_id)
+        explicit_subject = (metadata or {}).get("subject")
+        return await self._run_send(self._send_email, (chat_id, content, reply_to, explicit_subject), "[Email] Send failed to %s: %s", chat_id)
 
     def _message_id_domain(self) -> str:
         """Domain for generated Message-IDs; ``localhost`` when EMAIL_ADDRESS lacks ``@``."""
         return (self._address.rsplit("@", 1)[-1] if "@" in self._address else "") or "localhost"
 
     def _new_reply(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None, *,
+                   explicit_subject: Optional[str] = None,
                    attach_empty_body: bool = False) -> Tuple[MIMEMultipart, str, str]:
         """Build a threaded reply skeleton. Returns ``(msg, msg_id, subject)``."""
         msg, ctx = MIMEMultipart(), self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
-        original_msg_id = reply_to_msg_id or ctx.get("message_id")
+        if explicit_subject:
+            # Outbound-only send (cron deliveries, standalone): verbatim subject, fresh conversation —
+            # no Re: prefix and no thread-context threading headers, so Gmail shows a new conversation
+            # instead of nesting the message in the sender's last inbound thread.
+            subject = explicit_subject  # keep the success-log line bound
+            original_msg_id = reply_to_msg_id
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
+            original_msg_id = reply_to_msg_id or ctx.get("message_id")
         threading = (("In-Reply-To", original_msg_id), ("References", original_msg_id)) if original_msg_id else ()
         msg_id = f"<hermes-{uuid.uuid4().hex[:12]}@{self._message_id_domain()}>"
         for key, value in (("From", self._address), ("To", to_addr), ("Subject", subject), *threading,
@@ -691,16 +758,19 @@ class EmailAdapter(BasePlatformAdapter):
             except Exception:
                 smtp.close()
 
-    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None) -> str:
+    def _send_email(self, to_addr: str, body: str, reply_to_msg_id: Optional[str] = None,
+                    explicit_subject: Optional[str] = None) -> str:
         """Send an email via SMTP. Runs in executor thread."""
-        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id, attach_empty_body=True)
+        msg, msg_id, subject = self._new_reply(to_addr, body, reply_to_msg_id,
+                                               explicit_subject=explicit_subject, attach_empty_body=True)
         self._smtp_send(msg)
         logger.info("[Email] Sent reply to %s (subject: %s)", to_addr, subject)
         return msg_id
 
-    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool) -> str:
+    def _send_with_files(self, to_addr: str, body: str, files: List[Tuple[Path, str]], *, lenient: bool,
+                         explicit_subject: Optional[str] = None) -> str:
         """Send a reply with attachments; *lenient* logs-and-skips unattachable files instead of raising."""
-        msg, msg_id, _ = self._new_reply(to_addr, body)
+        msg, msg_id, _ = self._new_reply(to_addr, body, explicit_subject=explicit_subject)
         for path, name in files:
             try:
                 _attach_file(msg, path, name)
@@ -710,6 +780,16 @@ class EmailAdapter(BasePlatformAdapter):
                 logger.warning("[Email] Failed to attach %s: %s", path, e)
         self._smtp_send(msg)
         return msg_id
+
+    def format_tool_event(self, event: Any, *, mode: str = "all",
+                          preview_max_len: int = 40) -> None:
+        """Suppress tool-progress chrome for email delivery.
+
+        Email is a plain-text, non-editable medium — there is no way to update a previously sent
+        message, so emitting a separate email per tool call would spam the user's inbox. Return None
+        to drop all tool-progress events; the final assistant response is the only message sent.
+        """
+        return None
 
     async def send_image(self, chat_id: str, image_url: str, caption: Optional[str] = None,
                          reply_to: Optional[str] = None, metadata: Optional[Dict[str, Any]] = None) -> SendResult:
@@ -735,25 +815,35 @@ class EmailAdapter(BasePlatformAdapter):
         if not local_paths and not body_parts:
             return
         try:
-            await asyncio.get_running_loop().run_in_executor(None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths)
+            explicit_subject = (metadata or {}).get("subject")
+            await asyncio.get_running_loop().run_in_executor(
+                None, self._send_email_with_attachments, chat_id, "\n\n".join(body_parts), local_paths,
+                explicit_subject)
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
             await super().send_multiple_images(chat_id, images, metadata, human_delay)
 
-    def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str]) -> str:
+    def _send_email_with_attachments(self, to_addr: str, body: str, file_paths: List[str],
+                                     explicit_subject: Optional[str] = None) -> str:
         """Send an email with multiple file attachments via SMTP (unattachable files are skipped)."""
-        msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths], lenient=True)
+        msg_id = self._send_with_files(to_addr, body, [(Path(f), Path(f).name) for f in file_paths],
+                                       lenient=True, explicit_subject=explicit_subject)
         logger.info("[Email] Sent multi-attachment email to %s (%d files)", to_addr, len(file_paths))
         return msg_id
 
     async def send_document(self, chat_id: str, file_path: str, caption: Optional[str] = None,
                             file_name: Optional[str] = None, reply_to: Optional[str] = None, **kwargs) -> SendResult:
         """Send a file as an email attachment."""
-        return await self._run_send(self._send_email_with_attachment, (chat_id, caption or "", file_path, file_name), "[Email] Send document failed: %s")
+        metadata = (kwargs or {}).get("metadata") or {}
+        explicit_subject = metadata.get("subject")
+        return await self._run_send(self._send_email_with_attachment, (chat_id, caption or "", file_path, file_name,
+                                                                       explicit_subject), "[Email] Send document failed: %s")
 
-    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None) -> str:
+    def _send_email_with_attachment(self, to_addr: str, body: str, file_path: str, file_name: Optional[str] = None,
+                                    explicit_subject: Optional[str] = None) -> str:
         """Send an email with a single file attachment via SMTP (raises if unattachable)."""
-        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)], lenient=False)
+        return self._send_with_files(to_addr, body, [(Path(file_path), file_name or Path(file_path).name)],
+                                     lenient=False, explicit_subject=explicit_subject)
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about the email chat."""

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -1125,3 +1125,165 @@ class TestSenderAuthentication(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestThreadContextPersistence(unittest.TestCase):
+    """Thread context must survive gateway restarts (replies keep subject)."""
+
+    def _make_adapter(self, tmp_dir):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "HERMES_HOME": str(tmp_dir),
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def test_save_then_reload_roundtrip(self):
+        """Saved context loads back with subject + message_id intact."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = self._make_adapter(tmp)
+            adapter._thread_context["user@test.com:my-thread"] = {
+                "subject": "Re: My Thread",
+                "message_id": "<m@test.com>",
+                "epoch": 0,
+                "msg_count": 3,
+            }
+            adapter._save_thread_context()
+            self.assertTrue(adapter._thread_context_path.exists())
+
+            # New adapter instance (simulates gateway restart) reloads it
+            adapter2 = self._make_adapter(tmp)
+            self.assertEqual(
+                adapter2._thread_context["user@test.com:my-thread"]["subject"],
+                "Re: My Thread",
+            )
+            self.assertEqual(
+                adapter2._thread_context["user@test.com:my-thread"]["message_id"],
+                "<m@test.com>",
+            )
+
+    def test_corrupt_file_starts_fresh(self):
+        """A corrupt/partial JSON file must not crash adapter construction."""
+        import tempfile
+        with tempfile.TemporaryDirectory() as tmp:
+            adapter = self._make_adapter(tmp)
+            adapter._thread_context_path.parent.mkdir(parents=True, exist_ok=True)
+            adapter._thread_context_path.write_text("{not json", "utf-8")
+            adapter2 = self._make_adapter(tmp)
+            self.assertEqual(adapter2._thread_context, {})
+
+
+
+class TestExplicitSubjectFreshConversation(unittest.TestCase):
+    """Cron/outbound deliveries carry an explicit subject in metadata: used verbatim (no Re: prefix)
+    with no threading headers, so Gmail shows a new conversation instead of nesting the report in the
+    sender's last inbound thread (the nightly-backup-in-floor-plans-thread bug).
+"""
+
+    def setUp(self):
+        self._prev_allow_all = os.environ.get("EMAIL_ALLOW_ALL_USERS")
+        os.environ["EMAIL_ALLOW_ALL_USERS"] = "true"
+        import tempfile
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+
+    def tearDown(self):
+        if self._prev_allow_all is None:
+            os.environ.pop("EMAIL_ALLOW_ALL_USERS", None)
+        else:
+            os.environ["EMAIL_ALLOW_ALL_USERS"] = self._prev_allow_all
+
+    def _make_adapter(self):
+        from gateway.config import PlatformConfig
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "HERMES_HOME": self._tmp.name,
+        }):
+            from plugins.platforms.email.adapter import EmailAdapter
+            return EmailAdapter(PlatformConfig(enabled=True))
+
+    def _dispatch(self, adapter, subject, body, mid):
+        import asyncio
+        captured = []
+
+        async def capture_handle(event):
+            captured.append(event)
+
+        adapter.handle_message = capture_handle
+        msg_data = {
+            "uid": mid.encode(),
+            "sender_addr": "user@test.com",
+            "sender_name": "User",
+            "subject": subject,
+            "message_id": f"<{mid}@test.com>",
+            "in_reply_to": "",
+            "body": body,
+            "attachments": [],
+            "date": "",
+        }
+        asyncio.run(adapter._dispatch_message(msg_data))
+        return captured
+
+    def _sent_subject(self, mock_smtp, call_index=-1):
+        send_call = mock_smtp.return_value.send_message.call_args_list[call_index][0][0]
+        return send_call["Subject"]
+
+    def test_cron_delivery_explicit_subject_is_fresh_conversation(self):
+        """Cron deliveries carry an explicit subject in metadata: used
+        verbatim (no Re: prefix) with no threading headers, so Gmail shows a
+        new conversation instead of nesting the report in the sender's last
+        thread (the nightly-backup-in-floor-plans-thread bug)."""
+        import asyncio
+        adapter = self._make_adapter()
+        self._dispatch(adapter, "test session isolation A", "body A", "m1")
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            result = asyncio.run(adapter.send(
+                chat_id="user@test.com",
+                content="Backup report",
+                metadata={"subject": "Cronjob Response: hermes-nightly-backup"},
+            ))
+        # Regression: send() must report SUCCESS (the pre-fix path raised
+        # UnboundLocalError in the success logger after sending, which made
+        # send() return failure and triggered a duplicate standalone fallback).
+        self.assertTrue(result.success)
+        msg = mock_smtp.return_value.send_message.call_args_list[0][0][0]
+        self.assertEqual(msg["Subject"], "Cronjob Response: hermes-nightly-backup")
+        self.assertNotIn("In-Reply-To", msg)
+        self.assertNotIn("References", msg)
+
+    def test_cron_delivery_explicit_subject_with_attachment_is_fresh(self):
+        """The attachment send path honours the explicit subject the same
+        way (send_document → _send_email_with_attachment)."""
+        import asyncio
+        adapter = self._make_adapter()
+        self._dispatch(adapter, "test session isolation A", "body A", "m1")
+
+        attach_path = os.path.join(self._tmp.name, "report.bin")
+        with open(attach_path, "wb") as f:
+            f.write(b"fake attachment bytes")
+
+        with patch("smtplib.SMTP") as mock_smtp:
+            mock_server = MagicMock()
+            mock_smtp.return_value = mock_server
+            result = asyncio.run(adapter.send_document(
+                chat_id="user@test.com",
+                file_path=attach_path,
+                caption="Report with file",
+                metadata={"subject": "Cronjob Response: weekly-report"},
+            ))
+        self.assertTrue(result.success)
+        msg = mock_smtp.return_value.send_message.call_args_list[0][0][0]
+        self.assertEqual(msg["Subject"], "Cronjob Response: weekly-report")
+        self.assertNotIn("In-Reply-To", msg)
+        self.assertNotIn("References", msg)


### PR DESCRIPTION
## What

Two wrong-threading bugs in the email gateway adapter, fixed so cron/outbound sends start **fresh conversations** and reply threading **survives gateway restarts**.

1. **Cron deliveries inherited the sender's last inbound subject.** A scheduled report emailed to an address that had previously written in (e.g. a nightly backup sent to a mailbox whose last inbound was "floor plans") came back as `Re: floor plans` with `In-Reply-To`/`References` headers — Gmail nested the report inside that unrelated conversation. Cron sends now carry an explicit `Cronjob Response: <job>` subject via delivery metadata (`gateway/delivery.py` sets `metadata["subject"]`; `cron/scheduler_delivery.py` supplies the job name), and the adapter uses it **verbatim with no threading headers** — a fresh conversation every run.
2. **Thread context was in-memory only.** The adapter's `sender → last subject/message-id` map lived solely in RAM, so a gateway restart wiped every thread's subject + Message-ID and the next reply degraded to the generic `Hermes Agent` subject with no threading headers. The map now persists to a small per-account JSON file under `HERMES_HOME/state`, atomically (tmp + rename), reloads at construction, is trimmed at 500 entries **in memory as well as on disk**, and tolerates corrupt files by starting fresh.

Delivery polish in the same files (email is a plain-text medium):

- The adapter advertises `splits_long_messages`, so long cron output is no longer truncated at the platform cap — email has no practical length limit.
- `format_tool_event` returns `None`: each tool call no longer emits its own uneditable email (a sent email cannot be updated, so intermediate tool emails are noise; the final message still arrives).

## Why

The cron-in-floor-plans-thread bug is user-visible daily for anyone running `hermes cron` against an email gateway: reports vanish into unrelated Gmail conversations and get mislabelled "Re: …". The restart bug silently degrades reply threading for every email user after any gateway restart or update.

## Related

- Sibling PR #100582 (success-log subject binding) is **folded into this branch** — the `subject` binding its fix addressed is present here (`subject = explicit_subject` in the reply builder) and the send-path tests assert `result.success`. Closing that PR.
- The subject-scoped session isolation feature (`/new` reset, per-thread epochs, `max_messages_per_session`) builds on the persistence added here and is proposed separately to keep this PR a focused bugfix.

## Notes for reviewers

- This branch was **rebuilt from scratch against the post-refactor `main`** (the earlier revision predated the Sep codebase simplification and no longer applied). Diff is against current `main`; email tests run 43/43 green (2 new persistence tests + 2 new explicit-subject tests; existing reply-threading tests unchanged and passing).
- Behavior contract preserved: the plain-sender context is still consulted for reply threading exactly as before — nothing about interactive replies changes. The explicit-subject path only activates when delivery metadata carries a subject (cron/outbound sends).
- Addressing earlier review feedback: the thread-context cap comment is corrected (overwrite preserves dict position, so the trim is insert-order FIFO, not LRU) and the live in-memory map is now trimmed alongside the persisted copy so per-sender key growth stays bounded.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

## How has this been tested?

`scripts/run_tests.sh tests/gateway/test_email.py` — 43 passed, 0 failed.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective
- [x] New and existing unit tests pass locally with my changes
