### PR TITLE
fix(desktop): stop fleet-wide hover-prewarm without pointer movement

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -833,13 +833,14 @@ function ProfileDropdown({
 // One dropdown row per profile — its own component so each row can own a
 // hover-intent prewarm timer (see useProfilePrewarm).
 function ProfileDropdownItem({ color, label, name }: { color: null | string; label: string; name: string }) {
-  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(name)
+  const { cancelPrewarm, notePointerMove, startPrewarm } = useProfilePrewarm(name)
 
   return (
     <DropdownMenuRadioItem
       className="min-w-0"
       onPointerEnter={startPrewarm}
       onPointerLeave={cancelPrewarm}
+      onPointerMove={notePointerMove}
       value={name}
     >
       <span className="flex min-w-0 items-center gap-1.5">
@@ -1177,7 +1178,7 @@ function ProfileSquare({
   const suppressClick = useRef(false)
   // Hovering a square telegraphs the switch — start that profile's backend
   // spawn now so a cold click doesn't pay the full boot.
-  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(label)
+  const { cancelPrewarm, notePointerMove, startPrewarm } = useProfilePrewarm(label)
 
   const { attributes, isDragging, listeners, setNodeRef, transform, transition } = useSortable({
     id: label,
@@ -1272,6 +1273,7 @@ function ProfileSquare({
                       clearPress()
                       cancelPrewarm()
                     }}
+                    onPointerMove={notePointerMove}
                     onPointerUp={clearPress}
                   >
                     {label.replace(/[^a-z0-9]/gi, '').charAt(0) || '?'}

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -144,7 +144,7 @@ function SidebarSessionRowImpl({
 }: SidebarSessionRowProps) {
   const { t } = useI18n()
   const r = t.sidebar.row
-  const { cancelPrewarm, startPrewarm } = useProfilePrewarm(session.profile)
+  const { cancelPrewarm, notePointerMove, startPrewarm } = useProfilePrewarm(session.profile)
   const title = sessionTitle(session)
   const density = useStore($sessionListDensity)
   const fmt = t.sidebar
@@ -395,9 +395,12 @@ function SidebarSessionRowImpl({
         // Hovering a row from another profile (the all-profiles view) telegraphs
         // a cross-profile resume — start that backend's spawn now so the click
         // doesn't pay the full cold boot. Same-profile rows no-op inside
-        // prewarmProfileBackend.
+        // prewarmProfileBackend. Layout-only pointerenter (stationary cursor,
+        // row identity changing underneath) must not arm the spawn — dwell
+        // starts on a real pointermove for this visit (#100548).
         onPointerEnter={startPrewarm}
         onPointerLeave={cancelPrewarm}
+        onPointerMove={notePointerMove}
         ref={ref}
         style={style}
         {...rest}

--- a/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.test.ts
@@ -1,0 +1,102 @@
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { prewarmProfileBackend } = vi.hoisted(() => ({
+  prewarmProfileBackend: vi.fn()
+}))
+
+vi.mock('@/store/profile', () => ({ prewarmProfileBackend }))
+
+import { useProfilePrewarm } from './use-profile-prewarm'
+
+const DWELL_MS = 120
+
+describe('useProfilePrewarm (#100548 layout-only pointerenter)', () => {
+  beforeEach(() => {
+    prewarmProfileBackend.mockClear()
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('does not spawn on pointerenter without a real pointer move (layout shift under a stationary cursor)', () => {
+    const { result } = renderHook(() => useProfilePrewarm('scout'))
+
+    act(() => {
+      result.current.startPrewarm()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+
+    expect(prewarmProfileBackend).not.toHaveBeenCalled()
+  })
+
+  it('does not cascade when successive rows (distinct profiles) receive layout-only pointerenter', () => {
+    const first = renderHook(() => useProfilePrewarm('finance'))
+    act(() => {
+      first.result.current.startPrewarm()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+    first.unmount()
+
+    const second = renderHook(() => useProfilePrewarm('scout'))
+    act(() => {
+      second.result.current.startPrewarm()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+
+    expect(prewarmProfileBackend).not.toHaveBeenCalled()
+  })
+
+  it('still prewarms after enter + pointer move + dwell (genuine hover intent)', () => {
+    const { result } = renderHook(() => useProfilePrewarm('scout'))
+
+    act(() => {
+      result.current.startPrewarm()
+      result.current.notePointerMove()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+
+    expect(prewarmProfileBackend).toHaveBeenCalledTimes(1)
+    expect(prewarmProfileBackend).toHaveBeenCalledWith('scout')
+  })
+
+  it('cancels an in-flight dwell on pointerleave', () => {
+    const { result } = renderHook(() => useProfilePrewarm('scout'))
+
+    act(() => {
+      result.current.startPrewarm()
+      result.current.notePointerMove()
+    })
+    act(() => {
+      result.current.cancelPrewarm()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+
+    expect(prewarmProfileBackend).not.toHaveBeenCalled()
+  })
+
+  it('ignores pointermove that was not preceded by pointerenter on this visit', () => {
+    const { result } = renderHook(() => useProfilePrewarm('scout'))
+
+    act(() => {
+      result.current.notePointerMove()
+    })
+    act(() => {
+      vi.advanceTimersByTime(DWELL_MS)
+    })
+
+    expect(prewarmProfileBackend).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.ts
+++ b/apps/desktop/src/app/chat/sidebar/use-profile-prewarm.ts
@@ -8,16 +8,23 @@ import { prewarmProfileBackend } from '@/store/profile'
 const PREWARM_DWELL_MS = 120
 
 /**
- * pointerenter/pointerleave handlers that pre-warm `profile`'s pool backend
- * after a short hover dwell (see prewarmProfileBackend in store/profile).
+ * pointerenter/pointerleave/pointermove handlers that pre-warm `profile`'s
+ * pool backend after a short hover dwell (see prewarmProfileBackend).
+ *
+ * `pointerenter` alone is not intent: virtualized session lists and running-arc
+ * re-renders fire it when a *stationary* cursor sits over the sidebar and a
+ * different profile's row slides under the pointer (#100548). Arm on enter,
+ * start the dwell only after a real pointermove on that visit, cancel on leave.
  * Consumers merge these with their own pointer handlers.
  */
 export function useProfilePrewarm(profile: string | null | undefined) {
   const timer = useRef<null | number>(null)
+  const armed = useRef(false)
   const profileRef = useRef(profile)
   profileRef.current = profile
 
   const cancelPrewarm = useCallback(() => {
+    armed.current = false
     if (timer.current != null) {
       clearTimeout(timer.current)
       timer.current = null
@@ -28,11 +35,20 @@ export function useProfilePrewarm(profile: string | null | undefined) {
 
   const startPrewarm = useCallback(() => {
     cancelPrewarm()
-    timer.current = window.setTimeout(() => {
-      timer.current = null
-      prewarmProfileBackend(profileRef.current || 'default')
-    }, PREWARM_DWELL_MS)
+    armed.current = true
   }, [cancelPrewarm])
 
-  return { cancelPrewarm, startPrewarm }
+  const notePointerMove = useCallback(() => {
+    if (!armed.current || timer.current != null) {
+      return
+    }
+
+    timer.current = window.setTimeout(() => {
+      timer.current = null
+      armed.current = false
+      prewarmProfileBackend(profileRef.current || 'default')
+    }, PREWARM_DWELL_MS)
+  }, [])
+
+  return { cancelPrewarm, notePointerMove, startPrewarm }
 }


### PR DESCRIPTION
## What does this PR do?

Hover-intent profile prewarm treated layout-only `pointerenter` as a switch telegraph. In the all-profiles session list, virtualized rows and running-arc/timestamp re-renders fire `pointerenter` when a **stationary** cursor sits over the sidebar and a different profile's row slides underneath. Each visit started a full `hermes serve` + MCP tree; the per-profile 60s throttle never engaged across a fleet sweep, and LRU keepalive-fresh backends let the pool grow past the cap of 3 (reporter: ~750 MB/min, peak 19 live backends, overnight cycling with no input).

This keeps the hover-prewarm feature. `useProfilePrewarm` now arms on `pointerenter` and starts the 120ms dwell only after a real `pointermove` on that visit; `pointerleave` still cancels. The same hook is wired on session rows, profile squares, and the condensed profile dropdown.

Does not close Bot Mode stampede (#96810). Does not add a global prewarm QPS cap or skip-at-pool-cap.

## Related Issue

Fixes #100548

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/sidebar/use-profile-prewarm.ts` — arm on enter; dwell + `prewarmProfileBackend` only after `notePointerMove`.
- `apps/desktop/src/app/chat/sidebar/session-row.tsx` — `onPointerMove={notePointerMove}`.
- `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx` — same on `ProfileDropdownItem` and `ProfileSquare`.
- `apps/desktop/src/app/chat/sidebar/use-profile-prewarm.test.ts` — layout-only enter does not spawn; successive distinct profiles do not cascade; enter+move+dwell still prewarms; leave cancels; move without enter is ignored.

## How to Test

1. From `apps/desktop`:
   `npx vitest run src/app/chat/sidebar/use-profile-prewarm.test.ts src/store/profile.test.ts src/app/chat/sidebar/session-row.test.tsx`
   Expected: 3 files / 33 passed (5 intent-gate tests in `use-profile-prewarm.test.ts`).
2. RED-on-unfixed: the same layout-only enter assertions failed on origin/main (`prewarmProfileBackend` called with `scout` / `finance` after 120ms with no move).
3. Manual (optional, multi-profile Desktop): all-profiles session list, park the cursor over the sidebar, leave it. `~/.hermes/logs/desktop.log` must not cycle `Starting Hermes backend for profile` / `Evicting idle profile backend` through the roster. Moving onto a row and dwelling ~120ms should still pre-warm that one profile.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: Desktop/JS only; `scripts/run_tests.sh` / pytest not in this change. Verified with `npx vitest run` in `apps/desktop` (3 files / 33 passed)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (WSL2) via Desktop vitest; live 35-profile overnight N/A

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
