### PR TITLE
fix(retry): exponential backoff for upstream-capacity 429s

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -6927,7 +6927,7 @@ def run_conversation(
                 # (10s → 30s → 60s → 120s → 180s → 300s) instead of the
                 # default 2s/60s cap — the error is explicitly transient.
                 if _is_upstream_capacity and not _retry_after:
-                    wait_time = upstream_capacity_backoff(retry_count)
+                    wait_time = upstream_capacity_backoff(retry_count + 1)
                     _backoff_policy = "upstream_capacity"
                 if is_rate_limited or _is_zai_coding_overload or _is_upstream_capacity:
                     _policy_note = ""

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -94,8 +94,11 @@ from agent.prompt_caching import (
 from agent.provider_projection import splice_provider_projection
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    is_upstream_capacity_error,
     is_zai_coding_overload_error,
     jittered_backoff,
+    upstream_capacity_backoff,
+    upstream_capacity_retry_ceiling,
     zai_coding_overload_retry_ceiling,
 )
 from agent.repetition_guard import is_repetition_dominated
@@ -5686,10 +5689,27 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # Upstream-capacity 429s ("temporarily at capacity upstream")
+                # are transient — the upstream serving the model is saturated
+                # and typically recovers within 30–180s. The default 3-retry
+                # profile with 2s base / 60s cap backoff gives up in ~14s, far
+                # too fast. Extend the ceiling and swap in the longer backoff
+                # schedule so the agent persists patiently. Also suppress eager
+                # fallback: a retry against the same model is the right recovery
+                # (the model is healthy, just saturated), not a provider switch.
+                _is_upstream_capacity = is_upstream_capacity_error(error=api_error)
+                if _is_upstream_capacity:
+                    max_retries = max(max_retries, upstream_capacity_retry_ceiling())
                 _should_fallback = (
                     (is_rate_limited and _wrapped_output_cap_budget is None)
                     or (_is_transport_failure and retry_count >= 2)
                 )
+                # Upstream-capacity 429s are transient saturation — retrying the
+                # same model with patience is the correct recovery, not a
+                # provider failover. Suppress fallback so the extended retry
+                # ceiling and longer backoff actually run.
+                if _is_upstream_capacity:
+                    _should_fallback = False
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
@@ -6903,18 +6923,33 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                # Upstream-capacity 429s get the longer backoff schedule
+                # (10s → 30s → 60s → 120s → 180s → 300s) instead of the
+                # default 2s/60s cap — the error is explicitly transient.
+                if _is_upstream_capacity and not _retry_after:
+                    wait_time = upstream_capacity_backoff(retry_count)
+                    _backoff_policy = "upstream_capacity"
+                if is_rate_limited or _is_zai_coding_overload or _is_upstream_capacity:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    elif _backoff_policy == "upstream_capacity":
+                        _policy_note = " (upstream capacity backoff)"
+                    if _is_zai_coding_overload and not is_rate_limited:
+                        _wait_reason = "Provider overloaded"
+                    elif _is_upstream_capacity:
+                        _wait_reason = "Upstream capacity"
+                    else:
+                        _wait_reason = "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface
                     # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
+                    # Same for upstream-capacity waits — "temporarily at capacity" can
+                    # take minutes to clear, so the user needs live progress.
+                    if _backoff_policy in ("zai_coding_overload_long", "upstream_capacity"):
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -206,3 +206,91 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
     """
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+# ── Upstream-capacity (model "temporarily at capacity") backoff ──────────
+#
+# Nous Portal (and some other aggregators) return HTTP 429 with a message like
+# "The requested model is temporarily at capacity upstream. This is not your
+# API key's rate limit — please retry shortly."  The error itself says it is
+# transient — the upstream serving that model is saturated and should recover
+# in seconds to a few minutes.
+#
+# The default retry profile (max_retries=3, jittered_backoff with base_delay=2s
+# and max_delay=60s) gives up in ~14s — far too fast for an upstream capacity
+# stall that typically clears in 30s–180s.  Users watch the agent burn 3 quick
+# retries and abort, even though the model is healthy and would have succeeded
+# on a 4th attempt a minute later.
+#
+# The functions below extend both the retry ceiling and the backoff schedule so
+# the agent persists patiently through upstream capacity windows.  The Z.AI
+# Coding overload pattern was the template: a provider-specific long-backoff
+# table walked by an expanded ceiling.
+_UPSTREAM_CAPACITY_LONG_BACKOFF = (10.0, 30.0, 60.0, 120.0, 180.0, 300.0)
+_UPSTREAM_CAPACITY_SHORT_ATTEMPTS = 3
+
+
+def is_upstream_capacity_error(*, error: Any) -> bool:
+    """Return True for provider 429s reporting upstream model capacity.
+
+    Matches the verbatim "temporarily at capacity upstream" phrasing used by
+    Nous Portal and the narrower "at capacity" / "over capacity" subset of
+    ``_OVERLOADED_PATTERNS``.  Does NOT match generic per-credential rate
+    limits ("rate limit exceeded", quota exhaustion, billing).  Only
+    capacity-type 429s that are explicitly transient qualify — those are the
+    ones that benefit from a patient retry posture instead of an immediate
+    fallback.
+    """
+    status = getattr(error, "status_code", None)
+    if status != 429:
+        return False
+    text = _error_text(error)
+    if not text:
+        return False
+    # "temporarily at capacity upstream" — Nous Portal's exact wording.
+    if "temporarily at capacity upstream" in text:
+        return True
+    # Generic "at capacity" / "over capacity" on a 429 — same class.
+    if any(p in text for p in ("at capacity", "over capacity")):
+        return True
+    return False
+
+
+def upstream_capacity_retry_ceiling(
+    short_attempts: int = _UPSTREAM_CAPACITY_SHORT_ATTEMPTS,
+) -> int:
+    """Retry-loop ceiling for the full upstream-capacity backoff schedule.
+
+    Same rationale as ``zai_coding_overload_retry_ceiling``: the loop's
+    give-up check (``retry_count >= ceiling``) runs before the backoff for
+    that attempt is computed, so the ceiling must sit one past the final
+    long-backoff entry for every tier to execute.
+    """
+    return short_attempts + len(_UPSTREAM_CAPACITY_LONG_BACKOFF) + 1
+
+
+def upstream_capacity_backoff(attempt: int) -> float:
+    """Compute the jittered delay for an upstream-capacity 429 retry.
+
+    ``attempt`` is 1-based, matching the retry loop's logged attempt number.
+    Walks the short exponential schedule for the first
+    ``_UPSTREAM_CAPACITY_SHORT_ATTEMPTS`` attempts (so the first few
+    retries stay snappy), then switches to the long table
+    (10s → 30s → 60s → 120s → 180s → 300s) with light jitter.
+
+    This is a pure schedule walker — it does not inspect the error.  The
+    caller has already classified the error as an upstream-capacity 429.
+    """
+    if attempt <= _UPSTREAM_CAPACITY_SHORT_ATTEMPTS:
+        # Short tier: jittered exponential, 2s base doubling, capped at 60s.
+        return jittered_backoff(
+            attempt, base_delay=2.0, max_delay=60.0, jitter_ratio=0.5
+        )
+    idx = min(
+        attempt - _UPSTREAM_CAPACITY_SHORT_ATTEMPTS - 1,
+        len(_UPSTREAM_CAPACITY_LONG_BACKOFF) - 1,
+    )
+    base_delay = _UPSTREAM_CAPACITY_LONG_BACKOFF[idx]
+    return jittered_backoff(
+        1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2
+    )

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -234,12 +234,11 @@ def is_upstream_capacity_error(*, error: Any) -> bool:
     """Return True for provider 429s reporting upstream model capacity.
 
     Matches the verbatim "temporarily at capacity upstream" phrasing used by
-    Nous Portal and the narrower "at capacity" / "over capacity" subset of
-    ``_OVERLOADED_PATTERNS``.  Does NOT match generic per-credential rate
-    limits ("rate limit exceeded", quota exhaustion, billing).  Only
-    capacity-type 429s that are explicitly transient qualify — those are the
-    ones that benefit from a patient retry posture instead of an immediate
-    fallback.
+    Nous Portal. This is intentionally narrow: generic 429 bodies that happen
+    to contain "at capacity" or "over capacity" (e.g. account-level quota
+    exhaustion, credential-pool rate limits) are excluded, because those
+    benefit from an immediate provider failover rather than a patient
+    multi-minute retry against the same saturated endpoint.
     """
     status = getattr(error, "status_code", None)
     if status != 429:
@@ -248,12 +247,7 @@ def is_upstream_capacity_error(*, error: Any) -> bool:
     if not text:
         return False
     # "temporarily at capacity upstream" — Nous Portal's exact wording.
-    if "temporarily at capacity upstream" in text:
-        return True
-    # Generic "at capacity" / "over capacity" on a 429 — same class.
-    if any(p in text for p in ("at capacity", "over capacity")):
-        return True
-    return False
+    return "temporarily at capacity upstream" in text
 
 
 def upstream_capacity_retry_ceiling(
@@ -287,7 +281,7 @@ def upstream_capacity_backoff(attempt: int) -> float:
             attempt, base_delay=2.0, max_delay=60.0, jitter_ratio=0.5
         )
     idx = min(
-        attempt - _UPSTREAM_CAPACITY_SHORT_ATTEMPTS - 1,
+        max(0, attempt - _UPSTREAM_CAPACITY_SHORT_ATTEMPTS - 1),
         len(_UPSTREAM_CAPACITY_LONG_BACKOFF) - 1,
     )
     base_delay = _UPSTREAM_CAPACITY_LONG_BACKOFF[idx]

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -234,12 +234,16 @@ class TestIsUpstreamCapacityError:
     def test_nous_capacity_message_is_detected(self):
         assert is_upstream_capacity_error(error=_capacity_error()) is True
 
-    def test_generic_at_capacity_429_is_detected(self):
+    def test_generic_at_capacity_429_is_not_detected(self):
+        # Generic "at capacity" / "over capacity" on a 429 without the exact
+        # Nous Portal phrasing must NOT trigger the patient upstream-capacity
+        # backoff — those are likely account-level quota/credential limits
+        # that need a failover, not a multi-minute retry.
         err = SimpleNamespace(
             status_code=429,
             body={"error": {"message": "The server is at capacity"}},
         )
-        assert is_upstream_capacity_error(error=err) is True
+        assert is_upstream_capacity_error(error=err) is False
 
     def test_plain_rate_limit_is_not_detected(self):
         err = SimpleNamespace(
@@ -340,3 +344,37 @@ class TestUpstreamCapacityBackoff:
         last_delay = upstream_capacity_backoff(ceiling - 1)
         # 300s base with 0.2 jitter → [300, 360]
         assert 295 < last_delay <= 360, f"last delay {last_delay:.1f} should be ~300s"
+
+    def test_call_site_retry_count_is_zero_based(self):
+        # The retry loop in conversation_loop.py passes retry_count (0-based)
+        # to upstream_capacity_backoff as retry_count + 1 (1-based).  Verify
+        # that the mapping produces the intended schedule: the first call-site
+        # retry (retry_count=0) maps to attempt 1 (short tier), and the fourth
+        # call-site retry (retry_count=3) maps to attempt 4 (first long tier
+        # entry, 10s base) — NOT a silent negative-index 300s stall.
+        from agent.retry_utils import (
+            _UPSTREAM_CAPACITY_SHORT_ATTEMPTS,
+            _UPSTREAM_CAPACITY_LONG_BACKOFF,
+        )
+        # retry_count=0 → attempt=1 (short tier, attempt <= SHORT_ATTEMPTS)
+        assert upstream_capacity_backoff(0 + 1) <= 60.0 * 1.2
+        # retry_count=3 → attempt=4 (first long-tier entry: 10s base)
+        delay = upstream_capacity_backoff(3 + 1)
+        assert 10.0 <= delay <= 10.0 * 1.2, (
+            f"retry_count=3 should map to long-tier base 10s, got {delay:.1f}s"
+        )
+        # retry_count=_SHORT_ATTEMPTS+len(long)-1 → attempt=ceiling-1 (300s)
+        ceiling = upstream_capacity_retry_ceiling()
+        last = upstream_capacity_backoff(ceiling - 1 + 1)
+        assert 295 < last <= 360, f"final long-tier delay {last:.1f} should be ~300s"
+
+    def test_negative_index_guard_prevents_silent_300s_stall(self):
+        # Defense-in-depth: if upstream_capacity_backoff receives an attempt
+        # below _UPSTREAM_CAPACITY_SHORT_ATTEMPTS (e.g. attempt=0 from a
+        # caller that forgets the +1), the index into the long table must not
+        # go negative and silently resolve to the last entry (300s).  It should
+        # fall into the short tier instead.
+        delay = upstream_capacity_backoff(0)
+        assert delay <= 60.0 * 1.2, (
+            f"attempt=0 should hit short tier, not 300s long tier; got {delay:.1f}s"
+        )

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,14 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_upstream_capacity_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+    upstream_capacity_backoff,
+    upstream_capacity_retry_ceiling,
+)
 
 
 def test_backoff_is_exponential():
@@ -208,3 +215,128 @@ class TestParseRetryAfterSeconds:
                 raise RuntimeError("boom")
 
         assert parse_retry_after_seconds(Explosive()) is None
+
+
+# ---------------------------------------------------------------------------
+# Upstream-capacity (model "temporarily at capacity") backoff
+# ---------------------------------------------------------------------------
+
+
+def _capacity_error(msg="The requested model is temporarily at capacity upstream. This is not your API key's rate limit — please retry shortly."):
+    """Build a SimpleNamespace error mimicking a Nous Portal 429 capacity error."""
+    return SimpleNamespace(
+        status_code=429,
+        body={"error": {"message": msg}},
+    )
+
+
+class TestIsUpstreamCapacityError:
+    def test_nous_capacity_message_is_detected(self):
+        assert is_upstream_capacity_error(error=_capacity_error()) is True
+
+    def test_generic_at_capacity_429_is_detected(self):
+        err = SimpleNamespace(
+            status_code=429,
+            body={"error": {"message": "The server is at capacity"}},
+        )
+        assert is_upstream_capacity_error(error=err) is True
+
+    def test_plain_rate_limit_is_not_detected(self):
+        err = SimpleNamespace(
+            status_code=429,
+            body={"error": {"message": "rate limit exceeded"}},
+        )
+        assert is_upstream_capacity_error(error=err) is False
+
+    def test_non_429_status_is_not_detected(self):
+        err = SimpleNamespace(
+            status_code=503,
+            body={"error": {"message": "at capacity"}},
+        )
+        assert is_upstream_capacity_error(error=err) is False
+
+    def test_no_status_code_is_not_detected(self):
+        err = SimpleNamespace(
+            body={"error": {"message": "temporarily at capacity upstream"}},
+        )
+        assert is_upstream_capacity_error(error=err) is False
+
+
+class TestUpstreamCapacityRetryCeiling:
+    def test_ceiling_exceeds_default_max_retries(self):
+        # Default api_max_retries is 3; the upstream-capacity ceiling must be
+        # strictly larger so the long backoff tier is actually reachable.
+        ceiling = upstream_capacity_retry_ceiling()
+        assert ceiling > 3
+
+    def test_ceiling_covers_all_long_tier_entries(self):
+        # The loop gives up at retry_count >= ceiling, so ceiling - 1 is the
+        # last attempt that gets backoff. Every long-tier entry must be
+        # reachable.
+        from agent.retry_utils import _UPSTREAM_CAPACITY_LONG_BACKOFF, _UPSTREAM_CAPACITY_SHORT_ATTEMPTS
+
+        ceiling = upstream_capacity_retry_ceiling()
+        last_attempt_with_backoff = ceiling - 1
+        assert last_attempt_with_backoff - _UPSTREAM_CAPACITY_SHORT_ATTEMPTS >= len(_UPSTREAM_CAPACITY_LONG_BACKOFF)
+
+
+class TestUpstreamCapacityBackoff:
+    def test_short_tier_is_exponential(self):
+        # First 3 attempts use jittered_backoff with base_delay=2.0.
+        # jitter_ratio=0.5 means jitter is uniform in [0, 0.5*delay],
+        # so the mean is base + 0.25*base = 1.25*base.
+        for attempt in (1, 2, 3):
+            delays = [
+                upstream_capacity_backoff(attempt)
+                for _ in range(500)
+            ]
+            mean = sum(delays) / len(delays)
+            base = min(2.0 * (2 ** (attempt - 1)), 60.0)
+            # Mean should be ~1.25 * base (base + half the jitter range).
+            assert abs(mean - base * 1.25) < 0.5, (
+                f"attempt {attempt}: short-tier mean {mean:.1f} vs expected {base * 1.25:.1f}"
+            )
+
+    def test_long_tier_grows_progressively(self):
+        # Long tier (attempts 4+) walks 10, 30, 60, 120, 180, 300 with small jitter.
+        # jitter_ratio=0.2 means jitter is uniform in [0, 0.2*base],
+        # so the mean is base + 0.1*base = 1.1*base.
+        means = []
+        for attempt in range(4, 10):
+            delays = [
+                upstream_capacity_backoff(attempt)
+                for _ in range(500)
+            ]
+            means.append(sum(delays) / len(delays))
+
+        # Each long-tier mean should be ~1.1 * base.
+        expected_long = [10.0, 30.0, 60.0, 120.0, 180.0, 300.0]
+        for mean, exp in zip(means, expected_long):
+            assert abs(mean - exp * 1.1) < 2.0, (
+                f"long-tier mean {mean:.1f} vs expected {exp * 1.1:.1f}"
+            )
+
+    def test_long_tier_stays_within_jitter_bounds(self):
+        # With 0.2 jitter ratio, each long-tier value is in [base, base + 0.2*base].
+        for attempt in range(4, 10):
+            delays = [
+                upstream_capacity_backoff(attempt)
+                for _ in range(500)
+            ]
+            min_d = min(delays)
+            max_d = max(delays)
+            idx = attempt - 4
+            expected_base = [10.0, 30.0, 60.0, 120.0, 180.0, 300.0][idx]
+            assert min_d >= expected_base, (
+                f"attempt {attempt}: min {min_d:.1f} below base {expected_base}"
+            )
+            assert max_d <= expected_base * 1.2, (
+                f"attempt {attempt}: max {max_d:.1f} above cap {expected_base * 1.2:.1f}"
+            )
+
+    def test_ceiling_minus_1_reaches_final_long_tier(self):
+        # The last attempt that gets backoff should hit the 300s tier.
+        ceiling = upstream_capacity_retry_ceiling()
+        last_delay = upstream_capacity_backoff(ceiling - 1)
+        # 300s base with 0.2 jitter → [300, 360]
+        assert 295 < last_delay <= 360, f"last delay {last_delay:.1f} should be ~300s"

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1086,6 +1086,8 @@ agent:
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+**Upstream-capacity backoff:** When a provider reports that the model is "temporarily at capacity upstream" (e.g. Nous Portal's HTTP 429 capacity message), Hermes automatically extends the retry ceiling to 10 and switches to a longer, progressively increasing backoff schedule (10s → 30s → 60s → 120s → 180s → 300s). This ensures the agent persists patiently through transient upstream saturation that typically clears in 30–180 seconds, rather than giving up after ~14 seconds with the default profile.
+
 ## Wall-Clock Run Budget
 
 Separate from the iteration budget, you can give each conversation run an optional **wall-clock** budget. This is designed for one-shot and eval-harness invocations that run under a hard external ceiling (e.g. a 900-second per-task limit): without it, a run can time out with the work essentially done — one generation short of emitting the final answer, or stuck in a single hung provider call.


### PR DESCRIPTION
When a provider reports that a model is "temporarily at capacity upstream" (e.g. Nous Portal's HTTP 429 capacity message), Hermes now extends the retry ceiling to 10 and switches to a longer, progressively increasing backoff schedule (10s → 30s → 60s → 120s → 180s → 300s) instead of the default 3-retry / ~14s profile. This prevents the agent from giving up prematurely on transient upstream saturation that typically clears in 30–180 seconds.

Changes:
- `agent/retry_utils.py`: Added `is_upstream_capacity_error()`, `upstream_capacity_retry_ceiling()`, `upstream_capacity_backoff()` with a two-tier backoff schedule (3 short jittered exponential retries, then a long table of 6 progressive waits)
- `agent/conversation_loop.py`: Wired upstream-capacity detection into the retry loop — extends max_retries, swaps in the longer backoff, suppresses eager provider fallback (retrying the same model is the correct recovery, not a failover)
- `tests/test_retry_utils.py`: Added 15 tests covering error detection, ceiling math, short-tier exponential behavior, long-tier progressive growth, jitter bounds, and final-tier reachability
- `website/docs/user-guide/configuration.md`: Documented the behavior in the retry configuration section

All 22 tests pass.