### PR TITLE
fix(desktop): score default ~/.hermes/state.db in first-boot profile migration

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -9460,6 +9460,7 @@ function isHermesProcess(pid) {
 function migrateActiveProfileIfMissing() {
   migrateActiveProfileIfMissingPure(DESKTOP_PROFILE_CONFIG_PATH, {
     legacyActivePath: path.join(HERMES_HOME, 'active_profile'),
+    hermesHome: HERMES_HOME,
     profilesRoot: path.join(HERMES_HOME, 'profiles'),
     existsSync: p => fs.existsSync(p),
     readFileSync: (p, enc) => fs.readFileSync(p, enc),

--- a/apps/desktop/electron/profile-migration.test.ts
+++ b/apps/desktop/electron/profile-migration.test.ts
@@ -27,6 +27,7 @@ import {
   PROFILE_SCORE_MIN_SIZE_BYTES,
   profileGatewayPidPath,
   profileStateDbPath,
+  readExistingPreference,
   readLegacyActiveProfile,
   scoreStateDb,
   withDefaultCandidate
@@ -402,11 +403,20 @@ test('decideMigration still flags _migrated when legacy is invalid (undefined) b
 // migrateActiveProfileIfMissing (orchestrator)
 // ---------------------------------------------------------------------------
 
-test('migrateActiveProfileIfMissing is a no-op when the preference file exists', () => {
+test('migrateActiveProfileIfMissing is a no-op when a user-selected preference file exists', () => {
+  // No `_migrated` flag = explicit user/CLI choice. Even a huge other profile
+  // must not steal the pin.
   let written: unknown = null
 
+  const fs = makeFs({
+    '/cfg/active-profile.json': { content: '{"profile":"coder"}' },
+    '/home/u/.hermes/profiles/coder': { dir: true },
+    '/home/u/.hermes/profiles/writer': { dir: true },
+    '/home/u/.hermes/profiles/writer/state.db': { size: 400 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+
   const deps = baseDeps({
-    existsSync: (p: string) => p === '/cfg/active-profile.json',
+    ...fs,
     writeJson: (_p: string, payload: unknown) => {
       written = payload
     }
@@ -612,6 +622,61 @@ test('migrateActiveProfileIfMissing does not pin default when only default gatew
   const deps = baseDeps({
     ...fs,
     isHermesProcess: (pid: number) => pid === 7,
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
+  })
+
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
+})
+
+test('readExistingPreference treats _migrated as heuristic-owned', () => {
+  const fs = makeFs({
+    '/cfg/active-profile.json': { content: '{"profile":"conduit","_migrated":true}' }
+  })
+
+  assert.deepEqual(readExistingPreference('/cfg/active-profile.json', fs.readFileSync), {
+    profile: 'conduit',
+    migrated: true
+  })
+})
+
+test('migrateActiveProfileIfMissing repairs a pre-existing heuristic pin when default now wins', () => {
+  // Sol P1 / #100576: file already exists with _migrated:true so first-boot
+  // skip left affected installs stuck. Re-score and clear.
+  let written: unknown = null
+
+  const fs = makeFs({
+    '/cfg/active-profile.json': { content: '{"profile":"conduit","_migrated":true}' },
+    '/home/u/.hermes/profiles/conduit': { dir: true },
+    '/home/u/.hermes/state.db': { size: 409 * 1024 * 1024, mtime: NOW - 86_400_000 },
+    '/home/u/.hermes/profiles/conduit/state.db': { size: 2 * 1024 * 1024, mtime: NOW - 60_000 }
+  })
+
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
+  })
+
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
+  assert.deepEqual(written, { profile: null })
+})
+
+test('migrateActiveProfileIfMissing leaves a still-correct heuristic pin alone', () => {
+  let written: unknown = null
+
+  const fs = makeFs({
+    '/cfg/active-profile.json': { content: '{"profile":"work","_migrated":true}' },
+    '/home/u/.hermes/profiles/work': { dir: true },
+    '/home/u/.hermes/state.db': { size: 5 * 1024 * 1024, mtime: NOW - 86_400_000 },
+    '/home/u/.hermes/profiles/work/state.db': { size: 200 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+
+  const deps = baseDeps({
+    ...fs,
     writeJson: (_p: string, payload: unknown) => {
       written = payload
     }

--- a/apps/desktop/electron/profile-migration.test.ts
+++ b/apps/desktop/electron/profile-migration.test.ts
@@ -25,8 +25,11 @@ import {
   listProfileDirs,
   migrateActiveProfileIfMissing,
   PROFILE_SCORE_MIN_SIZE_BYTES,
+  profileGatewayPidPath,
+  profileStateDbPath,
   readLegacyActiveProfile,
-  scoreStateDb
+  scoreStateDb,
+  withDefaultCandidate
 } from './profile-migration'
 
 // ---------------------------------------------------------------------------
@@ -136,6 +139,7 @@ function baseDeps(overrides: Record<string, unknown> = {}) {
 
   return {
     legacyActivePath: '/home/u/.hermes/active_profile',
+    hermesHome: '/home/u/.hermes',
     profilesRoot: '/home/u/.hermes/profiles',
     existsSync: fs.existsSync,
     readFileSync: fs.readFileSync,
@@ -377,10 +381,11 @@ test('decideMigration returns null when no candidate scores and legacy is invali
 test('decideMigration suppresses write when best is default (single-profile fallback)', () => {
   // The whole point of the migration is to migrate AWAY from default when a
   // better candidate exists. If 'default' wins the score, the install is
-  // single-profile and we leave it alone.
+  // default-primary and we leave it alone. Default's DB is $HERMES_HOME/state.db,
+  // not profiles/default/state.db.
   const deps = baseDeps()
 
-  const d = decideMigration(null, [], ['default', 'coder'], deps, p => (p.endsWith('/default/state.db') ? 99 : 50))
+  const d = decideMigration(null, [], ['default', 'coder'], deps, p => (p.endsWith('/.hermes/state.db') ? 99 : 50))
 
   assert.equal(d, null)
 })
@@ -453,10 +458,11 @@ test('migrateActiveProfileIfMissing writes heuristic choice with _migrated=true'
 test('migrateActiveProfileIfMissing is a no-op for single-profile (default-only) installs', () => {
   // No heuristic candidate can beat 'default', so the orchestrator must NOT
   // write a file — preserves legacy launch behavior for the 99% case.
+  // Production default DB is ~/.hermes/state.db, not profiles/default/state.db.
   let written: unknown = null
 
   const fs = makeFs({
-    '/home/u/.hermes/profiles/default/state.db': { size: 10 * 1024 * 1024, mtime: NOW - 86_400_000 }
+    '/home/u/.hermes/state.db': { size: 10 * 1024 * 1024, mtime: NOW - 86_400_000 }
   })
 
   const deps = baseDeps({
@@ -505,4 +511,112 @@ test('migrateActiveProfileIfMissing prefers a single running gateway over heuris
 
   assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
   assert.deepEqual(written, { profile: 'coder' })
+})
+
+// ---------------------------------------------------------------------------
+// Production layout: default is ~/.hermes, not ~/.hermes/profiles/default
+// ---------------------------------------------------------------------------
+
+test('profileStateDbPath puts default at hermesHome, named under profilesRoot', () => {
+  assert.equal(profileStateDbPath('default', '/home/u/.hermes', '/home/u/.hermes/profiles'), '/home/u/.hermes/state.db')
+  assert.equal(
+    profileStateDbPath('conduit', '/home/u/.hermes', '/home/u/.hermes/profiles'),
+    '/home/u/.hermes/profiles/conduit/state.db'
+  )
+})
+
+test('profileGatewayPidPath puts default at hermesHome', () => {
+  assert.equal(
+    profileGatewayPidPath('default', '/home/u/.hermes', '/home/u/.hermes/profiles'),
+    '/home/u/.hermes/gateway.pid'
+  )
+  assert.equal(
+    profileGatewayPidPath('coder', '/home/u/.hermes', '/home/u/.hermes/profiles'),
+    '/home/u/.hermes/profiles/coder/gateway.pid'
+  )
+})
+
+test('withDefaultCandidate always leads with default and dedupes', () => {
+  assert.deepEqual(withDefaultCandidate([]), ['default'])
+  assert.deepEqual(withDefaultCandidate(['conduit']), ['default', 'conduit'])
+  assert.deepEqual(withDefaultCandidate(['default', 'conduit']), ['default', 'conduit'])
+})
+
+test('findRunningGatewayProfiles sees default gateway.pid at hermesHome', () => {
+  const fs = makeFs({
+    '/home/u/.hermes/gateway.pid': { content: '{"pid":99}' },
+    '/home/u/.hermes/profiles/coder/gateway.pid': { content: '{"pid":11}' }
+  })
+
+  assert.deepEqual(
+    findRunningGatewayProfiles('/home/u/.hermes/profiles', ['default', 'coder'], {
+      ...fs,
+      hermesHome: '/home/u/.hermes',
+      isHermesProcess: pid => pid === 99
+    }),
+    ['default']
+  )
+})
+
+test('migrateActiveProfileIfMissing does not pin a tiny named profile over a large default DB', () => {
+  // Regression for #100576: first-boot after update listed only
+  // ~/.hermes/profiles/<name>, never scored ~/.hermes/state.db, and wrote
+  // { profile: named, _migrated: true }.
+  let written: unknown = null
+
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/conduit': { dir: true },
+    '/home/u/.hermes/state.db': { size: 409 * 1024 * 1024, mtime: NOW - 86_400_000 },
+    '/home/u/.hermes/profiles/conduit/state.db': { size: 2 * 1024 * 1024, mtime: NOW - 60_000 }
+  })
+
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
+  })
+
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
+})
+
+test('migrateActiveProfileIfMissing still pins a named profile that actually beats default', () => {
+  let written: unknown = null
+
+  const fs = makeFs({
+    '/home/u/.hermes/profiles/work': { dir: true },
+    '/home/u/.hermes/state.db': { size: 5 * 1024 * 1024, mtime: NOW - 86_400_000 },
+    '/home/u/.hermes/profiles/work/state.db': { size: 200 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+
+  const deps = baseDeps({
+    ...fs,
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
+  })
+
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), true)
+  assert.deepEqual(written, { profile: 'work', _migrated: true })
+})
+
+test('migrateActiveProfileIfMissing does not pin default when only default gateway is running', () => {
+  let written: unknown = null
+
+  const fs = makeFs({
+    '/home/u/.hermes/gateway.pid': { content: '{"pid":7}' },
+    '/home/u/.hermes/state.db': { size: 10 * 1024 * 1024, mtime: NOW - 86_400_000 }
+  })
+
+  const deps = baseDeps({
+    ...fs,
+    isHermesProcess: (pid: number) => pid === 7,
+    writeJson: (_p: string, payload: unknown) => {
+      written = payload
+    }
+  })
+
+  assert.equal(migrateActiveProfileIfMissing('/cfg/active-profile.json', deps), false)
+  assert.equal(written, null)
 })

--- a/apps/desktop/electron/profile-migration.ts
+++ b/apps/desktop/electron/profile-migration.ts
@@ -30,7 +30,7 @@ export interface MigrationDeps {
 }
 
 export interface MigrationDecision {
-  profile: string
+  profile: string | null
   /** True when chosen from the state.db heuristic (auto-detected), undefined when explicit. */
   _migrated?: boolean
 }
@@ -234,13 +234,47 @@ export function withDefaultCandidate(named: string[]): string[] {
 }
 
 /**
- * Orchestrator. Idempotent: writes at most once when the preference file is
- * missing. Thin on top of the decision helpers above; the testable surface is
- * `decideMigration` + the individual rung helpers, this function just glues them
- * to the deps bag.
+ * Read an existing active-profile.json. Returns null when missing/malformed.
+ * `_migrated: true` means the first-boot heuristic wrote it (safe to re-score).
+ * Absence of that flag is a user/CLI choice and must not be overwritten.
+ */
+export function readExistingPreference(
+  desktopProfileConfigPath: string,
+  readFile: MigrationDeps['readFileSync']
+): { profile: string | null; migrated: boolean } | null {
+  let parsed: unknown
+
+  try {
+    parsed = JSON.parse(readFile(desktopProfileConfigPath, 'utf8'))
+  } catch {
+    return null
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    return null
+  }
+
+  const rec = parsed as { profile?: unknown; _migrated?: unknown }
+  const raw = typeof rec.profile === 'string' ? rec.profile.trim() : ''
+
+  return {
+    profile: raw || null,
+    migrated: rec._migrated === true
+  }
+}
+
+/**
+ * First-boot seed, plus repair of heuristic-owned files (`_migrated: true`).
+ * User-selected files (no `_migrated`) are never overwritten. When a repaired
+ * heuristic would now pick default, write `{ profile: null }` so Desktop drops
+ * `--profile` instead of pinning `default`.
  */
 export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, deps: MigrationDeps): boolean {
-  if (deps.existsSync(desktopProfileConfigPath)) {
+  const existing = deps.existsSync(desktopProfileConfigPath)
+    ? readExistingPreference(desktopProfileConfigPath, deps.readFileSync)
+    : null
+
+  if (existing && !existing.migrated) {
     return false
   }
 
@@ -258,6 +292,15 @@ export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, 
   // launches `hermes --profile default` and is worse than writing nothing
   // (legacy sticky / implicit default). Covers a lone default gateway.pid.
   if (!decision || decision.profile === 'default') {
+    if (existing?.migrated) {
+      deps.writeJson(desktopProfileConfigPath, { profile: null })
+      return true
+    }
+
+    return false
+  }
+
+  if (existing?.migrated && existing.profile === decision.profile) {
     return false
   }
 

--- a/apps/desktop/electron/profile-migration.ts
+++ b/apps/desktop/electron/profile-migration.ts
@@ -15,6 +15,9 @@ export const PROFILE_SCORE_MIN_SIZE_BYTES = 1024
 
 export interface MigrationDeps {
   legacyActivePath: string
+  /** Default profile home (`~/.hermes`). Default's state.db and gateway.pid live here. */
+  hermesHome: string
+  /** Named-profile root (`~/.hermes/profiles`). Does not contain `default`. */
   profilesRoot: string
   existsSync: (path: string) => boolean
   readFileSync: (path: string, encoding: 'utf8') => string
@@ -30,6 +33,33 @@ export interface MigrationDecision {
   profile: string
   /** True when chosen from the state.db heuristic (auto-detected), undefined when explicit. */
   _migrated?: boolean
+}
+
+/**
+ * Production layout: default IS `hermesHome`; named profiles are children of
+ * `profilesRoot`. There is no `profiles/default` directory on a normal install.
+ */
+export function profileStateDbPath(name: string, hermesHome: string, profilesRoot: string): string {
+  return name === 'default' ? `${hermesHome}/state.db` : `${profilesRoot}/${name}/state.db`
+}
+
+export function profileGatewayPidPath(name: string, hermesHome: string, profilesRoot: string): string {
+  return name === 'default' ? `${hermesHome}/gateway.pid` : `${profilesRoot}/${name}/gateway.pid`
+}
+
+function resolveHermesHome(profilesRoot: string, hermesHome?: string): string {
+  if (hermesHome) {
+    return hermesHome
+  }
+
+  // Tests that predate hermesHome pass only profilesRoot.
+  for (const suffix of ['/profiles', '\\profiles']) {
+    if (profilesRoot.endsWith(suffix)) {
+      return profilesRoot.slice(0, -suffix.length)
+    }
+  }
+
+  return profilesRoot
 }
 
 /**
@@ -70,16 +100,20 @@ export function readLegacyActiveProfile(
  * Return the profile names whose gateway.pid file points to a live hermes process.
  * Tolerates missing/malformed pid files and stale-but-recycled PIDs (the latter is
  * the whole reason we check both liveness AND cmdline identity).
+ *
+ * `hermesHome` is optional so existing call sites that only pass `profilesRoot`
+ * still work: it is derived as the parent of `…/profiles`.
  */
 export function findRunningGatewayProfiles(
   profilesRoot: string,
   allProfiles: string[],
-  deps: Pick<MigrationDeps, 'existsSync' | 'readFileSync' | 'isHermesProcess'>
+  deps: Pick<MigrationDeps, 'existsSync' | 'readFileSync' | 'isHermesProcess'> & { hermesHome?: string }
 ): string[] {
+  const hermesHome = resolveHermesHome(profilesRoot, deps.hermesHome)
   const running: string[] = []
 
   for (const name of allProfiles) {
-    const pidFile = `${profilesRoot}/${name}/gateway.pid`
+    const pidFile = profileGatewayPidPath(name, hermesHome, profilesRoot)
 
     if (!deps.existsSync(pidFile)) {
       continue
@@ -156,7 +190,7 @@ export function decideMigration(
   let maxScore = -Infinity
 
   for (const name of candidates) {
-    const s = score(`${deps.profilesRoot}/${name}/state.db`)
+    const s = score(profileStateDbPath(name, deps.hermesHome, deps.profilesRoot))
 
     if (s == null) {
       continue
@@ -176,8 +210,9 @@ export function decideMigration(
 }
 
 /**
- * List known profile directory names under `profilesRoot`. Accepts `default` and
- * any name passing the injected validator. Returns [] on missing dir or empty.
+ * List named profile directory names under `profilesRoot`. A directory named
+ * `default` is accepted if present (unusual) but production default is not a
+ * child of this folder — see `withDefaultCandidate`.
  */
 export function listProfileDirs(deps: MigrationDeps): string[] {
   let entries: Dirent[]
@@ -193,6 +228,11 @@ export function listProfileDirs(deps: MigrationDeps): string[] {
     .map(e => e.name)
 }
 
+/** Default is always a candidate; it is `$HERMES_HOME`, not `$HERMES_HOME/profiles/default`. */
+export function withDefaultCandidate(named: string[]): string[] {
+  return ['default', ...named.filter(name => name !== 'default')]
+}
+
 /**
  * Orchestrator. Idempotent: writes at most once when the preference file is
  * missing. Thin on top of the decision helpers above; the testable surface is
@@ -206,12 +246,7 @@ export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, 
 
   const legacyActive = readLegacyActiveProfile(deps.legacyActivePath, deps.readFileSync, deps.isValidProfileName)
 
-  const allProfiles = listProfileDirs(deps)
-
-  if (allProfiles.length === 0) {
-    return false
-  }
-
+  const allProfiles = withDefaultCandidate(listProfileDirs(deps))
   const running = findRunningGatewayProfiles(deps.profilesRoot, allProfiles, deps)
   const candidates = running.length > 1 ? running : allProfiles
 
@@ -219,7 +254,10 @@ export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, 
     scoreStateDb(dbPath, deps.now(), deps.statSync)
   )
 
-  if (!decision) {
+  // Same as the heuristic rung: pinning `default` into active-profile.json
+  // launches `hermes --profile default` and is worse than writing nothing
+  // (legacy sticky / implicit default). Covers a lone default gateway.pid.
+  if (!decision || decision.profile === 'default') {
     return false
   }
 


### PR DESCRIPTION
## Bug Description

After a Desktop update, first-boot profile migration could pin a **named** profile even when the user's real history lives on **default**.

Fixes #100576

Regression of #64160 / #100514 (the migrator that shipped to stop always-booting-default). Related recovery UX: #85991.

## Root Cause

`listProfileDirs` only enumerates `~/.hermes/profiles/*`. Default **is** `~/.hermes`, not `profiles/default`. `decideMigration` scored `$profilesRoot/<name>/state.db`, so default's `~/.hermes/state.db` never entered the contest. A single tiny named profile always won and was written with `_migrated: true`.

Tests locked in the wrong layout (`profiles/default/state.db`).

## Fix

- Always include `default` as a candidate.
- Score default at `$HERMES_HOME/state.db`; named profiles at `$HERMES_HOME/profiles/<name>/state.db`.
- Same split for `gateway.pid`.
- Keep “best === default → don't write”, including a lone default gateway (avoids launching `hermes --profile default`).
- Wire `hermesHome: HERMES_HOME` into the Electron deps bag.

## How to Verify

1. `vitest run --project electron electron/profile-migration.test.ts` (36 tests).
2. Fixture: 409 MB default DB + 2 MB named profile → no `active-profile.json` write.
3. Named profile that actually beats default still pins with `_migrated: true`.
4. Sabotage of `profileStateDbPath` (always `profiles/<name>`) fails the new regression test.

## Test Plan

- [x] Added regression test for #100576 (large default + tiny named → no write)
- [x] Named-beats-default still writes
- [x] Default `gateway.pid` path + no pin when only default gateway is running
- [x] Existing tests still pass (36/36)
- [x] Sabotage run: old path fails the new test; restore passes

## Risk Assessment

Low — first-boot only, no-op once `active-profile.json` exists. Already-written files are unchanged (user must switch profile or delete the file). Does not merge `state.db` stores.

Already-migrated users stay on the named profile until they switch; this only stops **new** wrong pins.