### PR TITLE
fix(delegate): defer timed-out child teardown and drain in-flight transports FD-safely (#94248 native half)

### DIFF
--- a/contributors/emails/ileocorp@gmail.com
+++ b/contributors/emails/ileocorp@gmail.com
@@ -1,0 +1,2 @@
+ComicBit
+# PR #90889 cherry-pick in #94248 salvage

--- a/run_agent.py
+++ b/run_agent.py
@@ -5599,6 +5599,75 @@ class AIAgent:
                 exc,
             )
 
+    def _drain_transports_after_abandonment(self, *, reason: str) -> int:
+        """FD-safe transport drain for an abandoned (timed-out) worker (#94248).
+
+        A delegation deadline abandons this agent's daemon worker while it may
+        still be blocked inside an in-flight OpenSSL ``read`` (Codex Responses
+        stream, httpx request). The timeout thread must never hard-close those
+        transports — ``client.close()`` releases raw FDs under a live SSL BIO,
+        the #29507 / #67142 / #70773 native-corruption family and the SIGSEGV
+        shape reported in #94248. This helper only ``shutdown()``s pooled
+        sockets (safe from any thread), settling blocked reads with EOF/EPIPE
+        so the worker can unwind and run the real close from its own thread.
+
+        Returns the number of sockets shut down across all transports.
+        """
+        drained = 0
+        # Shared primary client (codex-direct / MoA stream on it directly).
+        try:
+            client = getattr(self, "client", None)
+            if client is not None:
+                drained += self._force_close_tcp_sockets(client)
+        except Exception:
+            logger.debug("Abandoned-worker drain: shared client sweep failed",
+                         exc_info=True)
+        # Cached per-request wire clients: abort (shutdown + poison the reuse
+        # slot) so the unwinding worker discards them instead of re-caching.
+        try:
+            with self._openai_client_lock():
+                cache = getattr(self, "_request_client_cache", None)
+                cached = cache["client"] if cache else None
+            if cached is not None:
+                self._abort_request_openai_client(cached, reason=reason)
+        except Exception:
+            logger.debug("Abandoned-worker drain: request client abort failed",
+                         exc_info=True)
+        try:
+            with self._openai_client_lock():
+                cache = getattr(self, "_request_anthropic_client_cache", None)
+                cached = cache["client"] if cache else None
+            if cached is not None:
+                self._abort_request_anthropic_client(cached, reason=reason)
+        except Exception:
+            logger.debug("Abandoned-worker drain: anthropic client abort failed",
+                         exc_info=True)
+        # Codex app-server session watches a private interrupt event.
+        try:
+            codex_session = getattr(self, "_codex_session", None)
+            request_interrupt = getattr(codex_session, "request_interrupt", None)
+            if callable(request_interrupt):
+                request_interrupt()
+        except Exception:
+            logger.debug("Abandoned-worker drain: codex interrupt failed",
+                         exc_info=True)
+        # Inline (cron-style) request abort hook, when registered.
+        try:
+            abort_active = getattr(self, "_active_request_abort", None)
+            if callable(abort_active):
+                abort_active(reason)
+        except Exception:
+            logger.debug("Abandoned-worker drain: active request abort failed",
+                         exc_info=True)
+        logger.info(
+            "Abandoned-worker transports drained (%s, tcp_shutdown=%d, "
+            "fd_release=deferred_to_worker) %s",
+            reason,
+            drained,
+            self._client_log_context(),
+        )
+        return drained
+
     def _build_primary_client_for_active_provider(self, *, reason: str) -> Any:
         """Build the shared client shape required by the active provider.
 

--- a/tests/tools/test_94248_timeout_transport_drain.py
+++ b/tests/tools/test_94248_timeout_transport_drain.py
@@ -1,0 +1,197 @@
+"""#94248 (native half): delegation timeout must drain transports FD-safely.
+
+A timed-out child's daemon worker is typically parked inside an in-flight
+OpenSSL read. The timeout thread must (1) never hard-close the child while the
+worker future is running (deferred close, #90889), and (2) drain the child's
+transports with socket ``shutdown()`` only — never ``client.close()`` — so the
+blocked read settles with EOF/EPIPE and the worker can unwind (bounded drain).
+Cross-thread FD release under a live SSL BIO is the #29507/#67142/#70773
+native-corruption family.
+"""
+from __future__ import annotations
+
+import threading
+import time
+from types import SimpleNamespace
+
+from tools import delegate_tool
+
+
+class _SslBlockedChild:
+    """Worker blocks (modelling an in-flight SSL read) until drained."""
+
+    def __init__(self) -> None:
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_saved_tool_names = []
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = None
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.read_settled = threading.Event()   # drain "EOF" signal
+        self.unwound = threading.Event()
+        self.closed = threading.Event()
+        self.close_while_blocked = False
+        self.drain_calls: list[str] = []
+        self.drain_threads: list[str] = []
+
+    def run_conversation(self, **_kwargs):
+        # Models the worker blocked in ssl.read: only the FD-safe drain
+        # (socket shutdown -> EOF) settles it; interrupts alone do not.
+        assert self.read_settled.wait(timeout=10), "drain never settled the read"
+        time.sleep(0.05)  # post-read unwind work (turn-finally flush)
+        self.unwound.set()
+        return {
+            "final_response": "",
+            "completed": False,
+            "interrupted": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def hard_interrupt(self, *_a, **_k):
+        # Cooperative interrupt cannot unblock a thread inside OpenSSL read.
+        pass
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1}
+
+    def _drain_transports_after_abandonment(self, *, reason: str) -> int:
+        self.drain_calls.append(reason)
+        self.drain_threads.append(threading.current_thread().name)
+        self.read_settled.set()
+        return 1
+
+    def close(self):
+        if not self.unwound.is_set():
+            self.close_while_blocked = True
+        self.closed.set()
+
+
+def _run(child, monkeypatch, timeout=0.4):
+    parent = SimpleNamespace(
+        session_id="parent-94248-drain",
+        _current_task_id=None,
+        _active_children=[child],
+        _active_children_lock=threading.Lock(),
+    )
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: timeout)
+    if hasattr(delegate_tool, "_get_worktree_isolation"):
+        monkeypatch.setattr(delegate_tool, "_get_worktree_isolation", lambda: False)
+    return delegate_tool._run_single_child(
+        task_index=0,
+        goal="exercise timeout transport drain",
+        child=child,
+        parent_agent=parent,
+    )
+
+
+def test_timeout_drains_transports_so_blocked_worker_can_unwind(monkeypatch):
+    child = _SslBlockedChild()
+
+    result = _run(child, monkeypatch)
+
+    assert result["status"] == "timeout"
+    # The drain ran from the timeout path (immediate sweep) and settled the
+    # blocked read; without it the worker would still be parked in ssl.read.
+    assert any(r.startswith("delegate_timeout") for r in child.drain_calls), (
+        "timeout path never drained the abandoned child's transports"
+    )
+    assert child.unwound.wait(timeout=5), (
+        "worker never unwound — the drain did not settle its blocked read"
+    )
+    assert child.closed.wait(timeout=5)
+    assert not child.close_while_blocked, (
+        "child.close() ran while the worker was still inside its blocked read"
+    )
+
+
+def test_timeout_drain_failure_does_not_break_timeout_result(monkeypatch):
+    child = _SslBlockedChild()
+
+    def _raising_drain(*, reason: str) -> int:
+        child.drain_calls.append(reason)
+        raise RuntimeError("transport sweep exploded")
+
+    child._drain_transports_after_abandonment = _raising_drain
+
+    result = _run(child, monkeypatch)
+
+    assert result["status"] == "timeout"
+    assert child.drain_calls, "drain hook was never attempted"
+    # Unblock the worker manually so the deferred close can run.
+    child.read_settled.set()
+    assert child.unwound.wait(timeout=5)
+    assert child.closed.wait(timeout=5)
+
+
+def test_timeout_without_drain_hook_still_defers_close(monkeypatch):
+    """Children lacking the hook (test doubles, third-party agents) keep the
+    plain deferred-close behavior."""
+    child = _SslBlockedChild()
+    # Shadow the hook with a non-callable: the timeout path must skip it.
+    child.__dict__["_drain_transports_after_abandonment"] = None
+
+    result = _run(child, monkeypatch)
+
+    assert result["status"] == "timeout"
+    assert not child.closed.is_set(), (
+        "close must stay deferred while the worker future is running"
+    )
+    child.read_settled.set()
+    assert child.unwound.wait(timeout=5)
+    assert child.closed.wait(timeout=5)
+    assert not child.close_while_blocked
+
+
+class _FakeSocket:
+    def __init__(self):
+        self.shutdown_calls = 0
+        self.closed = False
+
+    def settimeout(self, _v):
+        pass
+
+    def shutdown(self, _how):
+        self.shutdown_calls += 1
+
+    def close(self):
+        self.closed = True
+
+
+def test_agent_drain_shuts_sockets_down_without_fd_release(monkeypatch):
+    """AIAgent._drain_transports_after_abandonment must shutdown(), not close()."""
+    import threading as _threading
+    from unittest.mock import patch
+
+    with patch("run_agent.AIAgent.__init__", return_value=None):
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+
+    sock = _FakeSocket()
+    close_calls = {"n": 0}
+
+    class _FakeClient:
+        def close(self):
+            close_calls["n"] += 1
+
+    agent.client = _FakeClient()
+    agent._client_lock = _threading.RLock()
+    agent._codex_session = None
+    agent._active_request_abort = None
+
+    import agent.agent_runtime_helpers as arh
+
+    monkeypatch.setattr(arh, "_iter_pool_sockets", lambda _c: iter([sock]))
+
+    drained = agent._drain_transports_after_abandonment(reason="delegate_timeout_test")
+
+    assert drained == 1
+    assert sock.shutdown_calls == 1
+    assert not sock.closed, "drain must never release socket FDs"
+    assert close_calls["n"] == 0, "drain must never call client.close()"

--- a/tests/tools/test_delegate_timeout_cleanup.py
+++ b/tests/tools/test_delegate_timeout_cleanup.py
@@ -1,0 +1,90 @@
+"""Regression coverage for timed-out delegation teardown."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from tools import delegate_tool
+
+
+class _SlowUnwindingChild:
+    def __init__(self) -> None:
+        self.tool_progress_callback = None
+        self._credential_pool = None
+        self._delegate_saved_tool_names = []
+        self._delegate_role = "leaf"
+        self._delegate_depth = 1
+        self._subagent_id = None
+        self.model = "test-model"
+        self.session_prompt_tokens = 0
+        self.session_completion_tokens = 0
+        self.session_estimated_cost_usd = 0.0
+        self.session_cost_status = "unknown"
+        self.started = threading.Event()
+        self.interrupted = threading.Event()
+        self.unwinding = threading.Event()
+        self.allow_finish = threading.Event()
+        self.finished = threading.Event()
+        self.closed = threading.Event()
+        self.close_while_running = False
+
+    def run_conversation(self, **_kwargs):
+        self.started.set()
+        assert self.interrupted.wait(timeout=1)
+        # Model the real child turn's finally path: it still performs session
+        # activity/SQLite cleanup after the parent requests interruption.
+        self.unwinding.set()
+        assert self.allow_finish.wait(timeout=2)
+        self.finished.set()
+        return {
+            "final_response": "",
+            "completed": False,
+            "interrupted": True,
+            "api_calls": 1,
+            "messages": [],
+        }
+
+    def hard_interrupt(self, _reason=None):
+        self.interrupted.set()
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1}
+
+    def close(self):
+        if not self.finished.is_set():
+            self.close_while_running = True
+        self.closed.set()
+
+
+def test_timeout_does_not_close_child_while_worker_is_unwinding(monkeypatch):
+    child = _SlowUnwindingChild()
+    parent = SimpleNamespace(
+        session_id="parent-timeout-test",
+        _current_task_id=None,
+        _active_children=[child],
+        _active_children_lock=threading.Lock(),
+    )
+    monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 0.5)
+    monkeypatch.setattr(delegate_tool, "_get_worktree_isolation", lambda: False)
+
+    result = delegate_tool._run_single_child(
+        task_index=0,
+        goal="exercise timeout teardown",
+        child=child,
+        parent_agent=parent,
+    )
+
+    assert result["status"] == "timeout"
+    assert child.unwinding.wait(timeout=1)
+    try:
+        assert not child.closed.is_set(), (
+            "timed-out child.close() ran before its conversation thread unwound"
+        )
+    finally:
+        child.allow_finish.set()
+    assert child.finished.wait(timeout=1)
+    assert child.closed.wait(timeout=1)
+    assert not child.close_while_running, (
+        "timed-out child.close() raced its still-running conversation thread"
+    )

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2603,6 +2603,12 @@ def _run_single_child(
     parent-visible truncation flag stays truthful for all of the above.
     """
     child_start = time.monotonic()
+    # A timed-out Future may still be unwinding on its daemon worker. Closing
+    # the child from this owner thread before that Future settles races every
+    # resource the conversation's finally path still touches (notably its
+    # owned SessionDB). The timeout branch flips this when close ownership is
+    # handed to a Future done-callback instead.
+    _child_close_deferred = False
 
     # Get the progress callback from the child agent
     child_progress_cb = getattr(child, "tool_progress_callback", None)
@@ -3080,6 +3086,28 @@ def _run_single_child(
                     f"{_late_pending_steer}]"
                 )
             _attach_worktree(_error_entry)
+            if is_timeout and not _child_future.done():
+                # request_hard_interrupt() is cooperative: the worker still
+                # executes run_conversation's finally path before its Future
+                # becomes done. child.close() tears down that same agent's
+                # clients, messages, and owned SQLite handle, so calling it in
+                # our outer finally while the worker is alive can close SQLite
+                # underneath its final activity write. Future callbacks run
+                # only after the worker has fully returned (or raised), which
+                # is the first safe close boundary.
+                def _close_after_timed_out_worker(_done_future) -> None:
+                    try:
+                        close = getattr(child, "close", None)
+                        if callable(close):
+                            close()
+                    except Exception:
+                        logger.debug(
+                            "Failed to close timed-out child after worker exit",
+                            exc_info=True,
+                        )
+
+                _child_future.add_done_callback(_close_after_timed_out_worker)
+                _child_close_deferred = True
             return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread
@@ -3554,11 +3582,13 @@ def _run_single_child(
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) so subagent subprocesses
         # don't outlive the delegation.
-        try:
-            if hasattr(child, "close"):
-                child.close()
-        except Exception:
-            logger.debug("Failed to close child agent after delegation")
+        if not _child_close_deferred:
+            try:
+                close = getattr(child, "close", None)
+                if callable(close):
+                    close()
+            except Exception:
+                logger.debug("Failed to close child agent after delegation")
 
         # The AIAgent turn boundary normally closes the child scope itself. This
         # fallback covers failures before that boundary starts, but must not pop

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3108,6 +3108,41 @@ def _run_single_child(
 
                 _child_future.add_done_callback(_close_after_timed_out_worker)
                 _child_close_deferred = True
+
+                # Bounded drain (#94248 native half): the deferred close above
+                # only fires once the abandoned worker unwinds, but that worker
+                # is typically parked inside an in-flight OpenSSL read (Codex /
+                # httpx). Never hard-close that transport from this thread —
+                # releasing FDs under a live SSL read is the #29507/#70773
+                # native-corruption family. Instead shutdown() the child's
+                # pooled sockets, which is FD-safe from any thread and settles
+                # the blocked read with EOF/EPIPE so the worker can unwind and
+                # trigger the deferred close. One immediate sweep plus one
+                # delayed re-sweep (covers a fresh connection opened between
+                # the interrupt and the first sweep); a worker that still
+                # doesn't settle keeps its resources until process exit rather
+                # than risking a cross-thread FD release.
+                _drain = getattr(child, "_drain_transports_after_abandonment", None)
+                if callable(_drain):
+                    def _drain_once(phase: str) -> None:
+                        try:
+                            _drain(reason=f"delegate_timeout_{phase}")
+                        except Exception:
+                            logger.debug(
+                                "Timed-out child transport drain (%s) failed",
+                                phase,
+                                exc_info=True,
+                            )
+
+                    _drain_once("immediate")
+
+                    def _drain_resweep() -> None:
+                        if not _child_future.done():
+                            _drain_once("resweep")
+
+                    _resweep_timer = threading.Timer(5.0, _drain_resweep)
+                    _resweep_timer.daemon = True
+                    _resweep_timer.start()
             return _error_entry
         finally:
             # Shut down executor without waiting — if the child thread


### PR DESCRIPTION
## What does this PR do?

Fixes the **native half of #94248** — gateway SIGSEGV 17–72 ms after `Subagent N timed out` while delegated Codex workers are blocked in OpenSSL reads. (The SessionDB-race half was fixed by #99502; this PR lands the remaining child-teardown-ordering half tracked via #93992 / #98348 / #94313 / #90889.)

## Root cause

Two stacked defects in `_run_single_child()`'s timeout path:

1. **Close-under-running-future:** the outer `finally` called `child.close()` even when the timed-out worker future was still running — closing the child's owned SessionDB, httpx clients, and Codex session on the timeout thread while the worker was still unwinding (the dual-thread faulthandler dumps in #94248 show exactly this pair).
2. **No transport settle for the abandoned read:** the cooperative interrupt can't reach a thread inside OpenSSL `read`, so an abandoned worker never unwinds on its own — meaning any deferred close never fires, resources pin until process exit, and any path that hard-closes the transport releases FDs under a live SSL BIO (the #29507/#67142/#70773 native-corruption family).

## Fix (two commits)

1. **Cherry-pick of @ComicBit's #90889** (authorship preserved): when the timed-out future is still running, transfer `child.close()` to a future done-callback; normal/settled paths keep synchronous close.
2. **Bounded drain (new):** `AIAgent._drain_transports_after_abandonment()` — a shutdown()-only sweep, safe from any thread:
   - `force_close_tcp_sockets()` on the shared client (FD release stays with the owning worker/GC),
   - abort + poison the cached per-request openai/anthropic wire clients,
   - `request_interrupt()` on the Codex app-server session,
   - the inline `_active_request_abort` hook.

   The delegate timeout path runs one immediate drain plus one 5 s re-sweep (covers a connection opened between the interrupt and the first sweep). The settled read (EOF/EPIPE) lets the worker unwind, which triggers the deferred close **on the worker's own thread** — the only safe FD-release boundary. A worker that still never settles retains its resources rather than risking a cross-thread close. Never `client.close()`, never `socket.close()` from the timeout thread.

## Live repro (Linux)

Real TLS server **subprocess** that accepts and never responds + real `httpx.Client` blocked in OpenSSL `read` at the deadline + real `SessionDB` (temp db), driven through the real `_run_single_child` with a 1.5 s child timeout:

- **Before (main):** `child.close()` ran on the timeout thread with `in_flight_ssl_read=True` — client FDs released under the live read (the #94248 use-after-teardown error path), and the worker's unwind flush hit the closed SessionDB (the #94736 self-heal WARNING fired: `connection ... was closed while a write was still in flight`).
- **After (this branch):** the immediate drain settles the blocked read in ~1 ms (`drain(delegate_timeout_immediate)_tcp_shutdown=1`), the worker unwinds cleanly, and close runs on the worker thread with `in_flight_ssl_read=False`. No FD release under the read, no closed-handle flush.

**macOS labeling (honest):** the reported SIGSEGV is macOS arm64 and we have no macOS runner — this fix is platform-neutral teardown ordering (never release transport FDs or the SessionDB under an in-flight native read) proven on Linux; it has NOT been live-tested on macOS.

## Tests

- `tests/tools/test_94248_timeout_transport_drain.py` (new, 4 tests): drain runs from the timeout path and settles the blocked worker; drain-failure keeps the timeout result and deferred close intact; children without the hook keep plain deferred close; `AIAgent` drain shuts sockets down without any FD release or `client.close()`.
- `tests/tools/test_delegate_timeout_cleanup.py` (from #90889): timed-out `child.close()` cannot race the unwinding worker.
- Sabotage runs: disabling the drain hook fails the drain test at the intended assertion; adding `socket.close()` to the drain fails the FD-release test.
- Family suite: 159 passed (delegate/timeout/zombie/control-actions/70773/94736), plus 68 passed across `tests/run_agent/` client/close/interrupt files. `ruff check` clean; Windows-footgun checker clean.

## Related

Closes #94248. Supersedes the teardown-ordering halves of #90889 (cherry-picked), #98348, #94313, #93992 (its SessionDB `_read_ctx` half landed via #99502's class fix).
