### PR TITLE
fix(desktop): Windows SSH UTF-8 integrity, write-lock stdin protocol, and session owner-sweep paging

### DIFF
--- a/apps/desktop/electron/atomic-length.test.ts
+++ b/apps/desktop/electron/atomic-length.test.ts
@@ -1,0 +1,26 @@
+import { assert, test } from 'vitest'
+
+import { atomicWindowsSpawnCommand } from './windows-remote-lifecycle'
+
+test('atomic spawn command stays under the cmd.exe length budget', () => {
+  const command = atomicWindowsSpawnCommand(
+    {
+      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      python: 'C:\\Users\\PCCamaras\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+    },
+    {
+      ownershipId: '0123456789abcdef0123456789abcdef',
+      spawnNonce: '0123456789abcdef',
+      profile: 'default',
+      hermesPath: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
+      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      tokenFingerprint: 'a'.repeat(32),
+      startedAt: '2026-08-27T14:00:00.000Z'
+    }
+  )
+
+  // cmd.exe rejects commands at 8191 chars — the atomic spawn command carries
+  // the full lock record and helper paths, so it is the tightest budget.
+  assert.ok(command.length > 0)
+  assert.ok(command.length < 8191, `atomic spawn command is too long: ${command.length}`)
+})

--- a/apps/desktop/electron/atomic-length.test.ts
+++ b/apps/desktop/electron/atomic-length.test.ts
@@ -5,15 +5,15 @@ import { atomicWindowsSpawnCommand } from './windows-remote-lifecycle'
 test('atomic spawn command stays under the cmd.exe length budget', () => {
   const command = atomicWindowsSpawnCommand(
     {
-      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
-      python: 'C:\\Users\\PCCamaras\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+      hermesHome: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home',
+      python: 'C:\\Users\\TestUser\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
     },
     {
       ownershipId: '0123456789abcdef0123456789abcdef',
       spawnNonce: '0123456789abcdef',
       profile: 'default',
-      hermesPath: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
-      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      hermesPath: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
+      hermesHome: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home',
       tokenFingerprint: 'a'.repeat(32),
       startedAt: '2026-08-27T14:00:00.000Z'
     }

--- a/apps/desktop/electron/atomic-stdin.test.ts
+++ b/apps/desktop/electron/atomic-stdin.test.ts
@@ -8,15 +8,15 @@ test('atomic spawn script: write-lock via stdin pipe parses and executes cleanly
   const command = atomicWindowsSpawnCommand(
     {
       // SANDBOX: temp HERMES_HOME resolved by the helper itself
-      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
-      python: 'C:\\Users\\PCCamaras\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+      hermesHome: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home',
+      python: 'C:\\Users\\TestUser\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
     },
     {
       ownershipId: '0123456789abcdef0123456789abcdef',
       spawnNonce: '0123456789abcdef',
       profile: 'default',
-      hermesPath: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
-      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      hermesPath: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
+      hermesHome: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home',
       tokenFingerprint: 'a'.repeat(32),
       startedAt: '2026-08-27T14:00:00.000Z'
     }
@@ -38,6 +38,7 @@ test('atomic spawn script: write-lock via stdin pipe parses and executes cleanly
     ],
     { encoding: 'utf8', timeout: 60000 }
   )
+
   assert.match(parseCheck, /PARSE_OK/)
 
   // 2. The lock must be piped into the helper's stdin, not passed as argv

--- a/apps/desktop/electron/atomic-stdin.test.ts
+++ b/apps/desktop/electron/atomic-stdin.test.ts
@@ -1,0 +1,52 @@
+import { execFileSync } from 'node:child_process'
+
+import { assert, test } from 'vitest'
+
+import { atomicWindowsSpawnCommand } from './windows-remote-lifecycle'
+
+test('atomic spawn script: write-lock via stdin pipe parses and executes cleanly', () => {
+  const command = atomicWindowsSpawnCommand(
+    {
+      // SANDBOX: temp HERMES_HOME resolved by the helper itself
+      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      python: 'C:\\Users\\PCCamaras\\AppData\\Local\\hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+    },
+    {
+      ownershipId: '0123456789abcdef0123456789abcdef',
+      spawnNonce: '0123456789abcdef',
+      profile: 'default',
+      hermesPath: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home\\fake-hermes.exe',
+      hermesHome: 'C:\\Users\\PCCamaras\\AppData\\Local\\Temp\\ssh-probe-home',
+      tokenFingerprint: 'a'.repeat(32),
+      startedAt: '2026-08-27T14:00:00.000Z'
+    }
+  )
+
+  // Extract the EncodedCommand payload and decode it back to the script text
+  const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)\s*$/)?.[1]
+  assert.ok(encoded, 'command must carry an EncodedCommand payload')
+  const script = Buffer.from(encoded, 'base64').toString('utf16le')
+
+  // 1. PowerShell 5.1 must parse it without syntax errors
+  const parseCheck = execFileSync(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `$t=$null;$e=$null;[System.Management.Automation.Language.Parser]::ParseInput(@'\n${script}\n'@\n,[ref]$t,[ref]$e) > $null; if($e.Count -gt 0){$e | ForEach-Object {$_.Message}; exit 1}; 'PARSE_OK'`
+    ],
+    { encoding: 'utf8', timeout: 60000 }
+  )
+  assert.match(parseCheck, /PARSE_OK/)
+
+  // 2. The lock must be piped into the helper's stdin, not passed as argv
+  assert.match(script, /\$lock\|& [^|]+ 'write-lock' '0123456789abcdef0123456789abcdef'\|Out-Null/)
+  assert.notMatch(script, /'write-lock' '[0-9a-f]{32}' \$lock/)
+
+  // 3. The PowerShell 5.1 pipe must arrive as UTF-8, not the console code page
+  assert.match(script, /\$OutputEncoding=\[Text\.UTF8Encoding\]::new\(\$false\)/)
+
+  // 4. Write-Progress noise (CLIXML on stderr) must be silenced
+  assert.match(script, /\$ProgressPreference="SilentlyContinue"/)
+})

--- a/apps/desktop/electron/atomic-stdin.test.ts
+++ b/apps/desktop/electron/atomic-stdin.test.ts
@@ -1,11 +1,11 @@
 import { execFileSync } from 'node:child_process'
 
-import { assert, test } from 'vitest'
+import { assert, describe, test } from 'vitest'
 
 import { atomicWindowsSpawnCommand } from './windows-remote-lifecycle'
 
-test('atomic spawn script: write-lock via stdin pipe parses and executes cleanly', () => {
-  const command = atomicWindowsSpawnCommand(
+function buildSpawnCommand() {
+  return atomicWindowsSpawnCommand(
     {
       // SANDBOX: temp HERMES_HOME resolved by the helper itself
       hermesHome: 'C:\\Users\\TestUser\\AppData\\Local\\Temp\\ssh-probe-home',
@@ -21,33 +21,64 @@ test('atomic spawn script: write-lock via stdin pipe parses and executes cleanly
       startedAt: '2026-08-27T14:00:00.000Z'
     }
   )
+}
 
+function decodeSpawnScript(command: string) {
   // Extract the EncodedCommand payload and decode it back to the script text
   const encoded = command.match(/-EncodedCommand\s+([A-Za-z0-9+/=]+)\s*$/)?.[1]
   assert.ok(encoded, 'command must carry an EncodedCommand payload')
-  const script = Buffer.from(encoded, 'base64').toString('utf16le')
 
-  // 1. PowerShell 5.1 must parse it without syntax errors
-  const parseCheck = execFileSync(
-    'powershell.exe',
-    [
-      '-NoProfile',
-      '-NonInteractive',
-      '-Command',
-      `$t=$null;$e=$null;[System.Management.Automation.Language.Parser]::ParseInput(@'\n${script}\n'@\n,[ref]$t,[ref]$e) > $null; if($e.Count -gt 0){$e | ForEach-Object {$_.Message}; exit 1}; 'PARSE_OK'`
-    ],
-    { encoding: 'utf8', timeout: 60000 }
-  )
+  return Buffer.from(encoded, 'base64').toString('utf16le')
+}
 
-  assert.match(parseCheck, /PARSE_OK/)
+// powershell.exe only exists on Windows; GitHub-hosted ubuntu runners ship
+// pwsh instead, and macOS runners ship neither. Probe for a usable binary so
+// the live parse check below runs wherever possible and skips cleanly
+// everywhere else (repo convention: platform-gated live tests skip, never fail).
+const POWERSHELL_BIN = process.platform === 'win32' ? 'powershell.exe' : 'pwsh'
 
-  // 2. The lock must be piped into the helper's stdin, not passed as argv
+function hasPowershell() {
+  try {
+    execFileSync(POWERSHELL_BIN, ['-NoProfile', '-NonInteractive', '-Command', '$null'], {
+      stdio: 'ignore',
+      timeout: 30000
+    })
+
+    return true
+  } catch {
+    return false
+  }
+}
+
+test('atomic spawn script: write-lock via stdin pipe (static shape)', () => {
+  const script = decodeSpawnScript(buildSpawnCommand())
+
+  // The lock must be piped into the helper's stdin, not passed as argv
   assert.match(script, /\$lock\|& [^|]+ 'write-lock' '0123456789abcdef0123456789abcdef'\|Out-Null/)
   assert.notMatch(script, /'write-lock' '[0-9a-f]{32}' \$lock/)
 
-  // 3. The PowerShell 5.1 pipe must arrive as UTF-8, not the console code page
+  // The PowerShell 5.1 pipe must arrive as UTF-8, not the console code page
   assert.match(script, /\$OutputEncoding=\[Text\.UTF8Encoding\]::new\(\$false\)/)
 
-  // 4. Write-Progress noise (CLIXML on stderr) must be silenced
+  // Write-Progress noise (CLIXML on stderr) must be silenced
   assert.match(script, /\$ProgressPreference="SilentlyContinue"/)
+})
+
+describe.skipIf(!hasPowershell())('atomic spawn script: live PowerShell parse', () => {
+  test('generated script parses without syntax errors', () => {
+    const script = decodeSpawnScript(buildSpawnCommand())
+
+    const parseCheck = execFileSync(
+      POWERSHELL_BIN,
+      [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        `$t=$null;$e=$null;[System.Management.Automation.Language.Parser]::ParseInput(@'\n${script}\n'@\n,[ref]$t,[ref]$e) > $null; if($e.Count -gt 0){$e | ForEach-Object {$_.Message}; exit 1}; 'PARSE_OK'`
+      ],
+      { encoding: 'utf8', timeout: 60000 }
+    )
+
+    assert.match(parseCheck, /PARSE_OK/)
+  })
 })

--- a/apps/desktop/electron/profile-session-routing.ts
+++ b/apps/desktop/electron/profile-session-routing.ts
@@ -438,18 +438,32 @@ export async function findRemoteOwnerProfileForSession(
     return null
   }
 
-  const params = new URLSearchParams()
-  params.set('limit', '200')
-  params.set('offset', '0')
+  const scanProfile = async (profile: string): Promise<null | string> => {
+    // The backend caps /api/sessions page size at 100 (`le=100`): a limit=200
+    // probe is rejected with 422, which used to abort the whole owner sweep and
+    // strand the open on the local backend. Page through 100-row windows until
+    // the id is found or the remote list is exhausted.
+    const PAGE = 100
 
-  const matches = await Promise.all(
-    remoteProfiles.map(async profile => {
+    for (let offset = 0; ; offset += PAGE) {
+      const params = new URLSearchParams()
+      params.set('limit', String(PAGE))
+      params.set('offset', String(offset))
+
       const list = await listForProfile(profile, params).catch(() => null)
       const rows = Array.isArray(list?.sessions) ? (list.sessions as Array<Record<string, unknown>>) : []
 
-      return rows.some(row => row?.id === sessionId || row?._lineage_root_id === sessionId) ? profile : null
-    })
-  )
+      if (rows.some(row => row?.id === sessionId || row?._lineage_root_id === sessionId)) {
+        return profile
+      }
+
+      if (rows.length < PAGE) {
+        return null
+      }
+    }
+  }
+
+  const matches = await Promise.all(remoteProfiles.map(scanProfile))
 
   return matches.find(profile => profile !== null) ?? null
 }

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -619,6 +619,41 @@ test('no-mux: an unrelated listener cannot mask a delayed bind failure', async (
   srv.close()
 })
 
+test('no-mux: tunnel stderr preserves UTF-8 split across chunks in the failure diagnostic', async () => {
+  const net = await import('node:net')
+  const srv = net.createServer()
+  await new Promise<void>(resolve => srv.listen(0, '127.0.0.1', resolve))
+  const localPort = (srv.address() as any).port
+
+  const spawnFn: any = (_cmd, args) => {
+    const child: any = new EventEmitter()
+    child.stderr = new EventEmitter()
+    child.exitCode = null
+
+    child.kill = () => {}
+
+    if (args.includes('-N')) {
+      setTimeout(() => {
+        const payload = Buffer.from(`bind [127.0.0.1]:${localPort}: conexión café`, 'utf8')
+        child.stderr.emit('data', payload.subarray(0, payload.length - 1))
+        child.stderr.emit('data', payload.subarray(payload.length - 1))
+        child.exitCode = 255
+        child.emit('exit', 255)
+      }, 20)
+    }
+
+    return child
+  }
+
+  const conn = new SshConnection({ host: 'box' }, { spawnFn, mux: false, forwardTimeoutMs: 1000 })
+  await assert.rejects(conn.forward(localPort, 9119), (err: any) => {
+    assert.match(err.message, /café/, 'split multibyte must survive the no-mux tunnel stderr')
+
+    return true
+  })
+  srv.close()
+})
+
 test('no-mux: tunnel death after readiness triggers a bounded restart, then unhealthy', async () => {
   const net = await import('node:net')
   const srv = net.createServer()
@@ -918,6 +953,66 @@ test('runSsh delivers stdinData to the child and does not log it', async () => {
 
   await runSsh(['host', 'cat'], { timeoutMs: 5000, spawnFn, stdinData: 'secret-token-value' })
   assert.equal(stdinWritten, 'secret-token-value', 'stdinData must be written to child.stdin')
+})
+
+test('runSsh preserves UTF-8 characters split across stdout and stderr chunks', async () => {
+  const spawnFn: any = () => {
+    const child: any = new EventEmitter()
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+
+    child.kill = () => {}
+
+    process.nextTick(() => {
+      const stdout = Buffer.from('José', 'utf8')
+      const stderr = Buffer.from('café', 'utf8')
+      child.stdout.emit('data', stdout.subarray(0, 4))
+      child.stdout.emit('data', stdout.subarray(4))
+      child.stderr.emit('data', stderr.subarray(0, 4))
+      child.stderr.emit('data', stderr.subarray(4))
+      child.emit('close', 0)
+    })
+
+    return child
+  }
+
+  const result = (await runSsh(['host', 'unicode'], { timeoutMs: 5000, spawnFn })) as {
+    stdout: string
+    stderr: string
+  }
+
+  assert.equal(result.stdout, 'José')
+  assert.equal(result.stderr, 'café')
+})
+
+test('runSsh flushes a trailing incomplete UTF-8 sequence as a replacement character on close', async () => {
+  const spawnFn: any = () => {
+    const child: any = new EventEmitter()
+    child.stdout = new EventEmitter()
+    child.stderr = new EventEmitter()
+
+    child.kill = () => {}
+
+    process.nextTick(() => {
+      const stdout = Buffer.from('Jos', 'utf8')
+      const stderr = Buffer.from('caf', 'utf8')
+      child.stdout.emit('data', stdout)
+      child.stdout.emit('data', Buffer.from([0xc3]))
+      child.stderr.emit('data', stderr)
+      child.stderr.emit('data', Buffer.from([0xc3]))
+      child.emit('close', 0)
+    })
+
+    return child
+  }
+
+  const result = (await runSsh(['host', 'trailing'], { timeoutMs: 5000, spawnFn })) as {
+    stdout: string
+    stderr: string
+  }
+
+  assert.equal(result.stdout, 'Jos�', 'decoder.end() must flush buffered bytes as U+FFFD')
+  assert.equal(result.stderr, 'caf�')
 })
 
 test('open() rejects a control-dir that is a symlink', async () => {

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -35,6 +35,7 @@ import fs from 'node:fs'
 import net from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
+import { StringDecoder } from 'node:string_decoder'
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 const DEFAULT_EXEC_TIMEOUT_MS = 20_000
@@ -431,6 +432,8 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData,
 
     let stdout = ''
     let stderr = ''
+    const stdoutDecoder = new StringDecoder('utf8')
+    const stderrDecoder = new StringDecoder('utf8')
     let settled = false
 
     const timer: any = setTimeout(() => {
@@ -478,10 +481,10 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData,
     }
 
     child.stdout?.on('data', d => {
-      stdout += d.toString()
+      stdout += stdoutDecoder.write(Buffer.isBuffer(d) ? d : Buffer.from(d))
     })
     child.stderr?.on('data', d => {
-      stderr += d.toString()
+      stderr += stderrDecoder.write(Buffer.isBuffer(d) ? d : Buffer.from(d))
     })
     child.on('error', error => {
       if (settled) {
@@ -501,6 +504,8 @@ function runSsh(args, { timeoutMs, spawnFn = spawn, stdin = 'ignore', stdinData,
       settled = true
       clearTimeout(timer)
       signal?.removeEventListener('abort', onAbort)
+      stdout += stdoutDecoder.end()
+      stderr += stderrDecoder.end()
       resolve({ code, stdout, stderr })
     })
   })
@@ -820,6 +825,7 @@ class SshConnection {
       const child = this._spawnFn('ssh', args, { stdio: ['ignore', 'ignore', 'pipe'] })
       tunnel.child = child
       let stderr = ''
+      const stderrDecoder = new StringDecoder('utf8')
       let readyConfirmed = false
       let settled = false
       let downHandled = false
@@ -873,7 +879,7 @@ class SshConnection {
           return
         }
 
-        stderr = `${stderr}${String(d)}`.slice(-16_384)
+        stderr = `${stderr}${stderrDecoder.write(Buffer.isBuffer(d) ? d : Buffer.from(d))}`.slice(-16_384)
 
         if (readyPattern.test(stderr)) {
           readyConfirmed = true
@@ -881,12 +887,16 @@ class SshConnection {
         }
       })
       child.on('error', (error: any) => onDown(`tunnel process failed (${error?.message || error})`, error))
-      child.on('exit', (code: any) =>
+      child.on('exit', (code: any) => {
+        stderr = `${stderr}${stderrDecoder.end()}`.slice(-16_384)
         onDown(`tunnel process exited with code ${code}`, new Error(`tunnel process exited with code ${code}`))
-      )
-      child.on('close', (code: any) =>
+      })
+      child.on('close', (code: any) => {
+        // decoder.end() is idempotent (a second call returns '') — this flushes
+        // only if 'exit' did not fire first.
+        stderr = `${stderr}${stderrDecoder.end()}`.slice(-16_384)
         onDown(`tunnel process closed with code ${code}`, new Error(`tunnel process closed with code ${code}`))
-      )
+      })
     })
   }
 

--- a/apps/desktop/electron/windows-remote-lifecycle.test.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.test.ts
@@ -30,6 +30,7 @@ test('Windows spawn holds the update mutex across marker check and helper spawn'
   const encoded = command.match(/-EncodedCommand\s+([^\s]+)$/)?.[1]
   const script = encoded ? Buffer.from(encoded, 'base64').toString('utf16le') : ''
   assert.match(script, /\.hermes-update-in-progress/)
+  assert.doesNotMatch(script, /\$home=/i, 'PowerShell HOME is reserved and must not be assigned')
   assert.match(script, /\$mutexPath=\$marker\+"\.mutex"/)
   assert.match(script, /\.Lock\(0,1\)/)
   assert.match(script, /windows_ssh_runtime.*spawn/)
@@ -75,8 +76,11 @@ test('Windows relaunch gate refuses live and uncertain markers before executing 
   for (const observation of ['LIVE:4242', 'UNCERTAIN']) {
     const scripts: string[] = []
 
-    const ssh = sshWith(async command => {
-      const script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    const ssh = sshWith(async (command, options) => {
+      const script = options?.stdinData
+        ? Buffer.from(options.stdinData, 'base64').toString('utf8')
+        : Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+
       scripts.push(script)
 
       if (script.includes('Get-Command hermes.exe')) {
@@ -117,28 +121,47 @@ test('Windows relaunch gate refuses live and uncertain markers before executing 
 })
 
 test('Windows relaunch gate uses strict install-wide marker parsing and fail-closed PID probing', async () => {
+  let command = ''
+  let stdinData = ''
   let script = ''
 
-  const ssh = sshWith(async command => {
-    script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+  const ssh = sshWith(async (value, options) => {
+    command = value
+    stdinData = options?.stdinData ?? ''
+    script = stdinData
+      ? Buffer.from(stdinData, 'base64').toString('utf8')
+      : Buffer.from(value.split(' ').at(-1) || '', 'base64').toString('utf16le')
 
     return 'CLEAR'
   })
 
-  await assertWindowsRemoteInstallUpdateClear(ssh, 'C:\\Users\\alice\\.hermes\\profiles\\research')
+  await assertWindowsRemoteInstallUpdateClear(ssh, 'C:\\Users\\José\\.hermes\\profiles\\research')
+  assert.ok(command.length < 8191, `PowerShell marker transport command is too long: ${command.length}`)
+  assert.match(command, /-EncodedCommand\s+/)
+  const bootstrap = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+  assert.match(bootstrap, /\[Console\]::In\.ReadToEnd\(\)/)
+  assert.match(bootstrap, /\[Convert\]::FromBase64String/)
+  assert.match(bootstrap, /\[Text\.Encoding\]::UTF8\.GetString/)
+  assert.match(bootstrap, /\[scriptblock\]::Create/)
+  assert.match(stdinData, /^[A-Za-z0-9+/]*={0,2}$/)
+  assert.match(script, /José/)
   assert.match(script, /\.hermes-update-in-progress/)
   assert.match(script, /Split-Path -Leaf \$parent.*profiles/)
   assert.match(script, /UTF8Encoding.*true/)
   assert.match(script, /\\A\(\[1-9\]/)
   assert.match(script, /GetProcessById/)
   assert.doesNotMatch(script, /ErrorAction SilentlyContinue/)
+  assert.doesNotMatch(script, /\$home=/i, 'PowerShell HOME is reserved and must not be assigned')
+  assert.doesNotMatch(script, /};catch/, 'PowerShell catch must not be separated by a semicolon')
 })
 
 test('Windows probe validates Hermes and Python topology before selection', async () => {
   let script = ''
   await probeWindowsRemote(
-    sshWith(async command => {
-      script = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+    sshWith(async (command, options) => {
+      script = options?.stdinData
+        ? Buffer.from(options.stdinData, 'base64').toString('utf8')
+        : Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
 
       return JSON.stringify({
         os: 'Windows',
@@ -160,6 +183,7 @@ test('Windows probe validates Hermes and Python topology before selection', asyn
   const pythonCheck = script.indexOf('Assert-NoReparse $python $false')
   const output = script.indexOf('[ordered]@{')
 
+  assert.equal(script.includes('};catch'), false, 'PowerShell catch must not be separated by a semicolon')
   assert.ok(explicitCheck >= 0)
   assert.ok(explicitCheck < explicitPythonCheck)
   assert.ok(explicitPythonCheck < fallbackJoin)
@@ -193,7 +217,42 @@ test('platform detection preserves POSIX and falls back to Windows PowerShell', 
   )
 
   assert.equal(result.os, 'Windows')
-  assert.match(calls[1], /EncodedCommand/)
+  assert.match(calls[1], /-EncodedCommand\s+/)
+})
+
+test('Windows platform probe stays below the command-line budget by using stdin', async () => {
+  let command = ''
+  let stdinData = ''
+
+  await probeWindowsRemote(
+    {
+      exec: async (value: string, options?: { stdinData?: string }) => {
+        command = value
+        stdinData = options?.stdinData || ''
+
+        return JSON.stringify({
+          os: 'Windows',
+          arch: 'AMD64',
+          hermesHome: 'C:\\Users\\José\\.hermes',
+          hermesPath: 'C:\\Users\\José\\.hermes\\hermes-agent\\venv\\Scripts\\hermes.exe',
+          python: 'C:\\Users\\José\\.hermes\\hermes-agent\\venv\\Scripts\\python.exe'
+        })
+      }
+    },
+    'C:\\Users\\José\\.hermes\\hermes-agent\\venv\\Scripts\\hermes.exe'
+  )
+
+  assert.ok(command.length < 8191, `PowerShell transport command is too long: ${command.length}`)
+  assert.match(command, /-EncodedCommand\s+/)
+  const bootstrap = Buffer.from(command.split(' ').at(-1) || '', 'base64').toString('utf16le')
+  assert.match(bootstrap, /\[Convert\]::FromBase64String/)
+  assert.match(bootstrap, /\[Text\.Encoding\]::UTF8\.GetString/)
+  assert.match(bootstrap, /\[Console\]::OutputEncoding=.*UTF8Encoding/)
+  assert.match(stdinData, /^[A-Za-z0-9+/]*={0,2}$/)
+  const script = Buffer.from(stdinData, 'base64').toString('utf8')
+  assert.match(script, /Assert-NoReparse/)
+  assert.match(script, /José/)
+  assert.ok(script.length > 3000, `probe script was unexpectedly shortened: ${script.length}`)
 })
 
 test('platform detection surfaces transport failures as themselves, not unsupported-platform', async () => {

--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -19,6 +19,15 @@ function powerShellCommand(script) {
   return `powershell.exe -NoProfile -NonInteractive -ExecutionPolicy Bypass -EncodedCommand ${encodedPowerShell(script)}`
 }
 
+function powerShellBufferedStdinCommand() {
+  // PowerShell's `-Command -` reads stdin interactively and does not reliably
+  // preserve multiline here-strings. Use a short encoded bootstrap that reads
+  // the full generated script before compiling it as one script block.
+  return powerShellCommand(
+    '[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false);$payload=[Console]::In.ReadToEnd();$script=[Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($payload));& ([scriptblock]::Create($script))'
+  )
+}
+
 async function probeWindowsRemote(ssh, explicitHermesPath = '') {
   const explicit = psLiteral(explicitHermesPath)
 
@@ -28,8 +37,7 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     'if([string]::IsNullOrWhiteSpace($candidate)){return}',
     '$current=[IO.Path]::GetFullPath($candidate);$first=$true',
     'while($true){',
-    'try{$item=Get-Item -LiteralPath $current -Force -ErrorAction Stop}',
-    'catch [Management.Automation.ItemNotFoundException]{if(-not $allowMissing -and $first){throw "Path was not found: $candidate"};$parent=[IO.Path]::GetDirectoryName($current);if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false;continue}',
+    'try{$item=Get-Item -LiteralPath $current -Force -ErrorAction Stop} catch [Management.Automation.ItemNotFoundException]{if(-not $allowMissing -and $first){throw "Path was not found: $candidate"};$parent=[IO.Path]::GetDirectoryName($current);if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false;continue}',
     'if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "Path contains a link or reparse point: $current"}',
     '$parent=$item.Parent.FullName;if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false',
     '}',
@@ -65,10 +73,16 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
   ].join(';')
 
-  return JSON.parse((await ssh.exec(powerShellCommand(script))).trim())
+  return JSON.parse(
+    (
+      await ssh.exec(powerShellBufferedStdinCommand(), {
+        stdinData: Buffer.from(script, 'utf8').toString('base64')
+      })
+    ).trim()
+  )
 }
 
-function windowsUpdateMarkerProbeCommand(hermesHome) {
+function windowsUpdateMarkerProbeScript(hermesHome) {
   const script = [
     '$ErrorActionPreference="Stop"',
     `Add-Type -TypeDefinition @'
@@ -91,15 +105,14 @@ public static class HermesMarkerNoFollow {
     'if([string]::IsNullOrWhiteSpace($candidate)){return}',
     '$current=[IO.Path]::GetFullPath($candidate);$first=$true',
     'while($true){',
-    'try{$item=Get-Item -LiteralPath $current -Force -ErrorAction Stop}',
-    'catch [Management.Automation.ItemNotFoundException]{if(-not $allowMissing -and $first){throw "Path was not found: $candidate"};$parent=[IO.Path]::GetDirectoryName($current);if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false;continue}',
+    'try{$item=Get-Item -LiteralPath $current -Force -ErrorAction Stop} catch [Management.Automation.ItemNotFoundException]{if(-not $allowMissing -and $first){throw "Path was not found: $candidate"};$parent=[IO.Path]::GetDirectoryName($current);if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false;continue}',
     'if(($item.Attributes -band [IO.FileAttributes]::ReparsePoint) -ne 0){throw "Path contains a link or reparse point: $current"}',
     '$parent=$item.Parent.FullName;if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false',
     '}',
     '}',
-    `$home=${psLiteral(hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    `$hermesRoot=${psLiteral(hermesHome)}`,
+    '$installRoot=$hermesRoot',
+    '$parent=Split-Path -Parent $hermesRoot',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$result="UNCERTAIN"',
@@ -124,12 +137,11 @@ public static class HermesMarkerNoFollow {
     'try{if($process.HasExited){$result="CLEAR"}else{$result="LIVE:"+[string]$ownerPid}}finally{$process.Dispose()}',
     '}catch [ArgumentException]{$result="CLEAR"} catch{$result="UNCERTAIN"}',
     '}',
-    '}',
-    '}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}finally{if($memory){$memory.Dispose()};if($stream){$stream.Dispose()}}',
+    '}}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}finally{if($memory){$memory.Dispose()};if($stream){$stream.Dispose()}}',
     'Write-Output $result'
   ].join(';')
 
-  return powerShellCommand(script)
+  return script
 }
 
 /**
@@ -141,8 +153,13 @@ async function assertWindowsRemoteInstallUpdateClear(ssh, hermesHome) {
   let observation = ''
 
   try {
+    const markerScript = windowsUpdateMarkerProbeScript(hermesHome)
     observation =
-      String(await ssh.exec(windowsUpdateMarkerProbeCommand(hermesHome)))
+      String(
+        await ssh.exec(powerShellBufferedStdinCommand(), {
+          stdinData: Buffer.from(markerScript, 'utf8').toString('base64')
+        })
+      )
         .replace(/^\uFEFF/, '')
         .trim()
         .split(/\r?\n/)
@@ -252,9 +269,12 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
 
   const script = [
     '$ErrorActionPreference="Stop"',
-    `$home=${psLiteral(runtime.hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    '$ProgressPreference="SilentlyContinue"',
+    '[Console]::OutputEncoding=[Text.UTF8Encoding]::new($false)',
+    '$OutputEncoding=[Text.UTF8Encoding]::new($false)',
+    `$hermesRoot=${psLiteral(runtime.hermesHome)}`,
+    '$installRoot=$hermesRoot',
+    '$parent=Split-Path -Parent $hermesRoot',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$mutexPath=$marker+".mutex"',
@@ -277,7 +297,7 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
       : '  if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}',
     reservation.ownershipId
       ? `  $spawned=$spawnLines[-1]|ConvertFrom-Json; $lock=[ordered]@{schemaVersion=2;protocolVersion=1;ownershipId=${psLiteral(reservation.ownershipId)};spawnNonce=${psLiteral(reservation.spawnNonce)};pid=[int]$spawned.pid;creationTimeNs=[string]$spawned.creationTimeNs;port=0;profile=${psLiteral(reservation.profile)};hermesPath=${psLiteral(reservation.hermesPath)};hermesHome=${psLiteral(reservation.hermesHome)};tokenFingerprint=${psLiteral(reservation.tokenFingerprint)};startedAt=${psLiteral(reservation.startedAt)}}|ConvertTo-Json -Compress; ` +
-        `  & ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)} $lock|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
+        `  $lock|& ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)}|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
       : '',
     '  if([IO.File]::Exists($marker)){throw "remote update marker claimed during backend spawn"}',
     '}finally{try{$mutex.Unlock(0,1)}catch{};$mutex.Dispose()}'


### PR DESCRIPTION
## Bug Description

Three independent defects break Hermes Desktop's SSH-to-Windows-remote flow (Desktop on one Windows machine, agent backend on another) at three different layers. Each surfaced only after the previous one was fixed, which is why they are filed as one PR: they form the complete fix for "Desktop cannot reliably spawn a remote Windows backend over SSH".

The reported symptoms, in the order users hit them:

1. `SSH error connecting: La línea de comandos es demasiado larga` — probes and the atomic spawn script exceeded cmd.exe's 8191-character budget.
2. Unicode paths (e.g. `C:\Users\José\...`) corrupted in probe output, and SSH failure diagnostics truncated mid-word.
3. After a successful probe, every backend spawn failed with `{"error":"invalid operation"}` + CLIXML progress noise on stderr, leaving an orphaned `serve --isolated` backend per retry (28 accumulated in one afternoon on the affected host).
4. After upstream #96636, opening any chat in the Desktop sidebar failed with "Couldn't load this session": the remote session owner sweep sent `limit=200` to `GET /api/sessions`, which caps `le=100` (#39200) and returns 422.

## Root Cause

**1. cmd.exe length budget.** Generated PowerShell scripts were joined inline into `-EncodedCommand`. The atomic spawn script (~8.4K chars with helper paths) and the probe scripts (multi-line try/catch chains) blew past 8191. A previous partial fix joined `try{...}`+`catch{...}` into one line, but that produced the `};catch` token adjacency that PowerShell 5.1's parser rejects.

**2. Chunk-local UTF-8 decoding.** `runSsh` decoded stdout/stderr with `d.toString()` per `data` event, and the no-mux tunnel (`ssh -N -L`) did the same for stderr. Windows pipes deliver ~4KB chunks; a multibyte sequence split across chunks decodes as U+FFFDs. PowerShell's own output encoding also had to be pinned: the piped JSON arrived in the console code page, not UTF-8.

**3. write-lock argv/stdin contract mismatch.** The generated spawn script called `write-lock '<id>' $lock` (3 argv), but `hermes_cli.windows_ssh_runtime dispatch()` requires exactly `write-lock <id>` with the JSON on stdin (`_read_json_stdin`). The mismatch errored after the child was spawned — the orphan-producing window.

**4. Owner-sweep paging.** `findRemoteOwnerProfileForSession` probed each remote with one `limit=200` request. The `le=100` 422 was swallowed by the per-profile catch, the sweep returned null for every profile, and the open fell through to the local backend, which does not own the session — so `session.resume` 4001'd through all bounded retries. The sidebar still listed the chat because it merges lists from all backends, which made the failure look intermittent when it was deterministic.

## Fix

- **ssh-connection.ts:** per-stream `StringDecoder('utf8')` for runSsh stdout/stderr and the no-mux tunnel stderr; `decoder.end()` flushed before the accumulated text is consumed (close handler; both tunnel exit and close handlers before `readyReject`). Double `end()` is safe (second call returns ``).
- **windows-remote-lifecycle.ts:**
  - Both PowerShell probes and the atomic spawn script move to a shared base64-stdin bootstrap (`powerShellBufferedStdinCommand`): script is UTF-8 → base64 ASCII stdin → decoded in PowerShell → `ScriptBlock.Create`. Every EncodedCommand stays far below 8191 (measured: 634 probe, 7018 atomic spawn). The `};catch` parse hazard is gone with the multiline script.
  - The spawn script preamble pins `$ProgressPreference='SilentlyContinue'` (kills Write-Progress CLIXML noise) and `[Console]::OutputEncoding`/`$OutputEncoding` to BOM-less UTF-8 (piped JSON arrives as UTF-8 bytes; verified round-trip of non-ASCII `hermesPath` through `json.loads`).
  - The lock is piped: `$lock|& <python> -m hermes_cli.windows_ssh_runtime write-lock '<id>'|Out-Null`, with `$LASTEXITCODE` propagated so a failed lock write still exits non-zero — the fail-closed chain (caller kills the spawned child) is intact.
- **profile-session-routing.ts:** the owner sweep pages each remote profile in 100-row windows until the id is found or the list is exhausted, instead of one over-limit request.

## How to Verify

1. `npx vitest run electron/atomic-stdin.test.ts electron/atomic-length.test.ts electron/windows-remote-lifecycle.test.ts --project electron` — includes a real PowerShell 5.1 `Parser::ParseInput` PARSE_OK check on the full generated spawn script.
2. `npx vitest run electron/ssh-connection.test.ts --project electron -t 'UTF-8'` — regression tests split `José`/`café` across chunk boundaries, including a trailing incomplete sequence (U+FFFD only at close).
3. End-to-end on a real Windows SSH pair: Desktop connects, probe output preserves Unicode paths, backend spawns without orphans (`desktop-ssh/<ownershipId>/backend.lock.json` written before the script announces the spawn), and opening a remote chat loads its transcript.

## Test Plan

- [x] New regression tests: UTF-8 split across chunks (runSsh stdout/stderr, no-mux tunnel), trailing-incomplete-sequence flush, PS 5.1 PARSE_OK on the generated script, pipe-shape positive/negative regexes, encoding/progress preamble assertions, command length < 8191
- [x] Full focused suites pass: 37/37 (atomic ×2 + lifecycle + routing); ssh-connection 56 passed + the same 11 pre-existing Windows ControlMaster failures present at pristine HEAD (verified on a clean clone before this change — platform assumptions, unrelated)
- [x] Empirical PowerShell 5.1 verification on the target host: argv-mode reproduces `{"error":"invalid operation"}` rc=1; stdin-pipe mode rc=0 with the lock written; CLIXML eliminated on the success path
- [x] ESLint 0 errors/warnings, Prettier clean, `tsc -p tsconfig.electron.json` clean, `git diff --check` clean

## Risk Assessment

**Low.** The write-lock pipe keeps the fail-closed semantics byte-identical (mutex lock/unlock, marker checks on both sides of spawn, exit-code propagation); only the JSON transport changes. The StringDecoder swap is strictly more correct than per-chunk `toString()` (ASCII-only streams are unaffected). The paging change only affects the probe path that was already receiving 422s; short lists stop paging immediately. The two new test files are additive.