### PR TITLE
fix(anthropic): serialize concurrent lazy SDK imports (#100461)

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -19,6 +19,7 @@ import re
 import secrets
 import stat
 import subprocess
+import threading
 from pathlib import Path
 from urllib.parse import urlparse
 
@@ -129,25 +130,28 @@ except Exception:
 # paths. Access via the `_get_anthropic_sdk()` accessor below, which caches
 # the module after the first call and returns None on ImportError.
 _anthropic_sdk: Any = ...  # sentinel — None means "tried and missing"
+_anthropic_sdk_lock = threading.Lock()
 
 
 def _get_anthropic_sdk():
     """Return the ``anthropic`` SDK module, importing lazily. None if not installed."""
     global _anthropic_sdk
     if _anthropic_sdk is ...:
-        try:
-            from tools.lazy_deps import ensure as _lazy_ensure
-            _lazy_ensure("provider.anthropic", prompt=False)
-        except ImportError:
-            pass
-        except Exception:
-            # FeatureUnavailable — fall through to ImportError handling below
-            pass
-        try:
-            import anthropic as _sdk
-            _anthropic_sdk = _sdk
-        except ImportError:
-            _anthropic_sdk = None
+        with _anthropic_sdk_lock:
+            if _anthropic_sdk is ...:
+                try:
+                    from tools.lazy_deps import ensure as _lazy_ensure
+                    _lazy_ensure("provider.anthropic", prompt=False)
+                except ImportError:
+                    pass
+                except Exception:
+                    # FeatureUnavailable — fall through to ImportError handling below
+                    pass
+                try:
+                    import anthropic as _sdk
+                    _anthropic_sdk = _sdk
+                except ImportError:
+                    _anthropic_sdk = None
     return _anthropic_sdk
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Summary
- serialize the first lazy Anthropic SDK initialization with a process-local double-checked lock
- keep lazy loading while making first-use publication deterministic

## Root cause
The Anthropic SDK was intentionally changed from an eager module import to `_get_anthropic_sdk()` by `b5128a751b` for startup optimization. The issue’s suspected split commit `7cbffdd125` only relocated that code. The accessor checked the uninitialized sentinel without synchronization, so concurrent first calls could enter the expensive `ensure()`/`import anthropic` path together. On CPython 3.12.13 this can expose the SDK’s typing-heavy initialization to the concurrent cold-start failure reported in #100461.

The fix preserves lazy loading while serializing the complete first-use initialization and publishing the cached result under a double-checked `threading.Lock`. The lock is process-local; separate daemon processes still cold-start independently.

## Validation
Tests were not run locally per the requested workflow. A direct CPython 3.12.13 import probe with `anthropic==0.87.0` succeeded on this Windows host, and a repeated concurrent import probe also succeeded. A Linux reproduction was not possible here because the Docker Desktop Linux engine was unavailable.

Related to open PR #100505, which takes the same synchronization direction. Maintainers can consolidate the implementations if preferred.
 Fixes  #100461
