### PR TITLE
fix(agent): reasoning-effort validation 400s are format errors, not context overflow

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -502,6 +502,22 @@ _REQUEST_VALIDATION_PATTERNS = [
     "invalid_request_error",
     "unknown_parameter",
     "unsupported_parameter",
+    # Reasoning-effort validation: a structured 400 whose error code names a
+    # reasoning-effort vocabulary violation is a request-shape rejection —
+    # the effort LEVEL was invalid for this provider, not the context. Must
+    # be classified before context_overflow so it never enters compression:
+    # compression cannot fix a bad parameter, and the loop ends in a bogus
+    # "Context length exceeded (77 tokens). Cannot compress further." on a
+    # tiny session (#100536).
+    "invalid_reasoning_effort",
+    "unsupported reasoning effort",
+    "invalid reasoning effort",
+    "reasoning_effort_not_supported",
+    # Some providers blame the parameter with effort-naming instead of a
+    # structured code ("reasoning.effort is not supported", "effort is
+    # invalid for this model"). Match the explicit effort-param phrasing,
+    # not the bare word "effort" (too collision-prone).
+    "reasoning.effort",
 ]
 
 # Request parameters that Hermes sends on SOME routes only, paired with the

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1190,6 +1190,68 @@ class TestMultimodalToolContentUnsupported:
         e = MockAPIError("bad request: missing field 'model'", status_code=400)
         result = classify_api_error(e, provider="openrouter", model="anthropic/claude-sonnet-4")
 
+    # ── Reasoning-effort validation 400s must never enter compression (#100536) ──
+
+    def test_structured_invalid_reasoning_effort_400_is_format_error(self):
+        """A custom Responses provider rejecting an unsupported reasoning level
+        returns a structured 400 naming the error_code. That is a
+        request-validation error, NOT a context overflow — compressing a tiny
+        session over it ends in a bogus 'Context length exceeded (77 tokens).
+        Cannot compress further.' (#100536)."""
+        e = MockAPIError(
+            '{"error": {"param": "reasoning.effort", '
+            '"error_code": "invalid_reasoning_effort", "retryable": false}}',
+            status_code=400,
+            body={
+                "error": {
+                    "param": "reasoning.effort",
+                    "error_code": "invalid_reasoning_effort",
+                    "retryable": False,
+                }
+            },
+        )
+        result = classify_api_error(
+            e, provider="openai", model="gpt-5.6-sol",
+        )
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_effort_param_phrase_400_is_format_error_not_overflow(self):
+        """Providers that blame the parameter by name ('reasoning.effort is
+        not supported') must be caught by the effort-param phrasing, not
+        routed to compression."""
+        e = MockAPIError(
+            "reasoning.effort is not supported for this model",
+            status_code=400,
+            body={"error": {"message": "reasoning.effort is not supported"}},
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-5.6-sol")
+        assert result.reason == FailoverReason.format_error
+
+    def test_plain_effort_vocabulary_400_is_format_error(self):
+        """Plain-text vocabulary errors ('Invalid reasoning effort: max...') are
+        deterministic request rejections — fail fast, never compress."""
+        e = MockAPIError(
+            "Invalid reasoning effort: 'max'. Supported values are: "
+            "none, low, medium, high, xhigh",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-5.6-sol")
+        assert result.reason == FailoverReason.format_error
+        assert result.retryable is False
+
+    def test_genuine_context_overflow_400_still_compresses(self):
+        """Guard: the new effort patterns must not shadow a REAL context
+        overflow — 'context length exceeded' 400s keep their compression
+        route."""
+        e = MockAPIError(
+            "This model's maximum context length is 200000 tokens. "
+            "However, your messages resulted in 250000 tokens",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="openai", model="gpt-5.6-sol")
+        assert result.reason == FailoverReason.context_overflow
+
 
 class TestOpenRouterUpstreamRateLimit:
     """Distinguish upstream-provider 429 from account-level 429 on OpenRouter.


### PR DESCRIPTION
Fixes #100536

## Problem

A structured HTTP 400 from a custom OpenAI-compatible Responses provider rejecting an unsupported reasoning level —

```json
{"error": {"param": "reasoning.effort", "error_code": "invalid_reasoning_effort", "retryable": false}}
```

— fell through the request-validation branch (which keys off generic parameter phrasing: "unknown/unsupported parameter") into the **context_overflow** patterns, entering the compression loop and ending in a bogus:

```
Context length exceeded (77 tokens). Cannot compress further.
```

on a tiny session. Compression cannot fix a rejected parameter — the request is re-sent unchanged and rejected identically — so the loop is pure waste, and the surfaced error misdirects the user toward context-size remedies when the real problem is that their provider's effort vocabulary stops at `xhigh`.

Root context: the transport clamps effort against the *model name's* vocabulary (`gpt-5.6*` → includes `max`), which is correct for the OpenAI backend but over-generous for custom relays of the same model names — the clamp can emit a level the relay rejects. This PR fixes the classification; the vocabulary question for undeclared custom providers is a separate policy decision.

## Fix

Explicit reasoning-effort vocabulary signals added to `_REQUEST_VALIDATION_PATTERNS`:

- structured codes: `invalid_reasoning_effort`, `reasoning_effort_not_supported`
- effort-param phrasing: `reasoning.effort`, `invalid/unsupported reasoning effort`

These 400s now fail fast as **non-retryable `format_error` with fallback**, exactly like every other deterministic request-shape rejection in that branch. Deliberately NOT matching the bare word "effort" — too collision-prone.

## Verification

- Reproduced the reporter's exact shape end-to-end through `classify_api_error` **before** the fix (fell past validation) and confirmed the fix reroutes all three provider phrasings to `format_error`
- 4 new tests: the reporter's exact structured body, the `reasoning.effort` param phrasing, the plain-text vocabulary form, and — the guard — a **genuine** `context-overflow 400 that still reaches compression**
- `test_error_classifier.py`: **126/126 pass**; reasoning-effort module suites (37/37) untouched and green