### PR TITLE
fix(slack): cancel orphaned socket reconnect tasks

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1163,6 +1163,11 @@ class SlackAdapter(BasePlatformAdapter):
         # user messages without bot_id/subtype=bot_message markers.
         self._user_is_bot_cache: Dict[Tuple[str, str], bool] = {}
         self._socket_mode_task: Optional[asyncio.Task] = None
+        # Track every task entering slack_sdk's unbounded connect() retry loop.
+        # The SDK can overwrite its public task attributes while an older
+        # reconnect is still alive, so those attributes are not a complete
+        # teardown inventory.
+        self._socket_connect_tasks: set[asyncio.Task] = set()
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}  # team_id → WebClient
         self._team_bot_user_ids: Dict[str, str] = {}  # team_id → bot_user_id
@@ -1446,6 +1451,23 @@ class SlackAdapter(BasePlatformAdapter):
         )
         _apply_slack_proxy(self._handler.client, self._proxy_url)
 
+        client = self._handler.client
+        original_connect = client.connect
+        connect_tasks: set[asyncio.Task] = set()
+        self._socket_connect_tasks = connect_tasks
+
+        async def _tracked_connect(*args: Any, **kwargs: Any) -> Any:
+            current = asyncio.current_task()
+            if current is not None:
+                connect_tasks.add(current)
+            try:
+                return await original_connect(*args, **kwargs)
+            finally:
+                if current is not None:
+                    connect_tasks.discard(current)
+
+        client.connect = _tracked_connect
+
         task = asyncio.create_task(self._handler.start_async())
         self._socket_mode_task = task
         self._socket_handler_started_monotonic = time.monotonic()
@@ -1474,9 +1496,18 @@ class SlackAdapter(BasePlatformAdapter):
         self._socket_mode_task = None
 
         client = getattr(handler, "client", None)
+        if client is not None:
+            # Stop SDK monitors from starting fresh reconnects while teardown
+            # drains the complete tracked task set.
+            client.closed = True
+            client.auto_reconnect_enabled = False
+        connect_tasks = self._socket_connect_tasks
         await _cancel_socket_tasks(
-            [task] + [getattr(client, attr, None) for attr in _SOCKET_CLIENT_TASK_ATTRS]
+            [task]
+            + [getattr(client, attr, None) for attr in _SOCKET_CLIENT_TASK_ATTRS]
+            + list(connect_tasks)
         )
+        self._socket_connect_tasks = set()
 
         if handler is not None:
             try:

--- a/tests/gateway/test_slack_socket_reconnect_heal.py
+++ b/tests/gateway/test_slack_socket_reconnect_heal.py
@@ -271,6 +271,30 @@ class TestSocketModeTeardown:
         )
 
 
+    @pytest.mark.asyncio
+    async def test_unbound_connect_task_cannot_outlive_teardown(self, adapter):
+        """A connect task overwritten in SDK task attributes must still be stopped."""
+        handler = _FakeHandler()
+        client = handler.client
+        with patch.object(_slack_mod, "AsyncSocketModeHandler", return_value=handler):
+            adapter._start_socket_mode_handler()
+        await asyncio.sleep(0.01)
+
+        # Reproduce the production race: a reconnect coroutine survives after
+        # the SDK rebinds its public task attributes, so teardown cannot find
+        # it through current_session_monitor/message_receiver anymore.
+        orphan = asyncio.create_task(client.connect())
+        await asyncio.sleep(0.01)
+        assert not orphan.done()
+
+        await adapter._stop_socket_mode_handler()
+        await asyncio.sleep(0.03)
+
+        session = client.aiohttp_client_session
+        assert orphan.done(), "an overwritten connect task outlived teardown"
+        assert session.ws_connect_after_close == 0
+
+
 class TestSocketModeRestart:
 
 


### PR DESCRIPTION
## Summary
- track every Slack SDK Socket Mode connect task independently of rebinding-prone SDK task attributes
- cancel and await tracked connect tasks before closing the shared client session
- add a regression for an overwritten/unbound connect task surviving teardown

## Root cause
During reconnect, Slack SDK task attributes can be rebound while an older unbounded `connect()` coroutine remains alive. Teardown then closes the shared aiohttp session without reaching that orphan, causing an endless `Session is closed` / `Connector is closed` loop.

## Verification
- targeted teardown suite: 4/4 passed
- Slack test suite: 457/457 passed
- Ruff: passed
- git diff --check: passed
- independent complete-deliverable review: passed with no security or logic findings