### PR TITLE
fix(dashboard): lock-free /api/model/options scope — salvage #74275 (#58576 lock-contention leg)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -7501,7 +7501,11 @@ async def get_model_options(
             # Keep the profile override inside the worker thread so the full
             # sync picker build (config load, pricing, refresh probes) runs
             # off the event loop under the requested profile.
-            with _profile_scope(profile):
+            # Use _config_profile_scope (contextvar only, no skill-module
+            # lock) — the payload build can block for 15s on a models.dev
+            # cache miss, and _profile_scope's RLock held across that block
+            # starves concurrent /api/config and freezes the server (#58576).
+            with _config_profile_scope(profile):
                 return build_model_options_payload(
                     load_picker_context(),
                     explicit_only=bool(explicit_only),

--- a/tests/hermes_cli/test_web_server_profile_unification.py
+++ b/tests/hermes_cli/test_web_server_profile_unification.py
@@ -7,6 +7,7 @@ reads/writes land in the REQUESTED profile, the dashboard's own profile
 stays untouched, and the chat PTY env is scoped via HERMES_HOME.
 """
 import json
+from contextlib import contextmanager
 
 import pytest
 import yaml
@@ -352,6 +353,47 @@ class TestProfileScopedModel:
 
 
 
+
+    def test_model_options_uses_config_only_scope_for_selected_profile(
+        self, client, monkeypatch
+    ):
+        """Regression (#58576): _profile_scope holds _SKILLS_PROFILE_LOCK
+        across its body, and the payload build can block up to 15s on a
+        models.dev cache miss — a cold request would starve concurrent
+        /api/config on the same lock. The handler must scope the worker
+        through _config_profile_scope (contextvar only, no lock) for the
+        selected profile."""
+        import hermes_cli.web_server as web_server
+
+        scopes = []
+
+        @contextmanager
+        def _recording_config_scope(profile):
+            scopes.append(("config", profile))
+            yield object()
+
+        @contextmanager
+        def _recording_profile_scope(profile):
+            scopes.append(("full", profile))
+            yield object()
+
+        monkeypatch.setattr(
+            web_server, "_config_profile_scope", _recording_config_scope
+        )
+        monkeypatch.setattr(web_server, "_profile_scope", _recording_profile_scope)
+        monkeypatch.setattr(
+            "hermes_cli.inventory.load_picker_context", lambda: object()
+        )
+        monkeypatch.setattr(
+            "hermes_cli.inventory.build_model_options_payload",
+            lambda _ctx, **kwargs: {"providers": [], "model": "", "provider": ""},
+        )
+
+        resp = client.get("/api/model/options", params={"profile": "worker_beta"})
+        assert resp.status_code == 200
+        # Only the config-only scope may wrap the payload build; entering
+        # _profile_scope would hold _SKILLS_PROFILE_LOCK across it (#58576).
+        assert scopes == [("config", "worker_beta")]
 
     def test_model_info_unknown_profile_404(self, client, isolated_profiles):
         """Regression: the broad except used to convert the 404 into a 200


### PR DESCRIPTION
Salvage of #74275 by @DavidMetcalfe (commits cherry-picked onto current main with original authorship preserved) — the remaining lock-contention leg of #58576.

## Problem

`GET /api/model/options` wraps its picker-payload build in `_profile_scope`, which holds the process-wide `_SKILLS_PROFILE_LOCK` (`threading.RLock`) for the full build. The build can block for seconds on network I/O (custom-provider `/models` probe, models.dev cache miss, pricing fetch). While the worker thread holds the lock, any endpoint that *synchronously* enters `_profile_scope` — `/api/config`'s offloaded `_run`, `/api/model/info`, and ~30 other handlers — queues behind it. With enough queued requests the dashboard appears frozen; this is the freeze @zhangyhhz's py-spy dump in #58576 pinned (MainThread stuck in `_profile_scope` → `get_config`, every worker in `fetch_models_dev`).

## Fix

Use `_config_profile_scope` (contextvar-only HERMES_HOME override, no lock) around `build_model_options_payload`. The payload build only needs config reads + credential checks — it never touches the skill-module globals `_SKILLS_PROFILE_LOCK` protects. Plus the contributor's regression test pinning the handler to the config-only scope.

## Live repro (before/after)

Real `hermes serve` (temp `HERMES_HOME`, code under test via `PYTHONPATH`), a stub OpenAI-compatible provider whose `GET /v1/models` hangs 8s (models the reporter's slow models.dev/probe network call), then `GET /api/model/options` fired as the aggressor while victim endpoints are timed concurrently:

| endpoint | main (before) | this PR (after) |
|---|---|---|
| `/api/model/options` (aggressor) | 12.9s | 12.6s (unchanged, expected — the probe itself is slow) |
| `/api/config` (victim, needs lock) | **11.4s** | **0.04s** |
| `/api/model/info` (victim) | 24.4s | 13.1s (still enters `_profile_scope` itself, only waits on its own probe now, not the aggregate queue) |
| `/api/status` (control, no lock) | 0.01s | 0.05s |

Repro scripts: stub provider + concurrent-timing driver against the real serve process (`/tmp/w7-gil-repro/lock_driver.py` in the wave-7 session).

**Live repro:** real `hermes serve` + hung `/v1/models` custom-provider probe — before: concurrent `/api/config` blocked 11.4s behind `_SKILLS_PROFILE_LOCK` while `/api/model/options` probed; after: `/api/config` returns in 0.04s during the same in-flight probe.

## Tests

- `tests/hermes_cli/test_web_server_profile_unification.py` — 31 passed (includes the new regression test `test_model_options_uses_config_only_scope_for_selected_profile`)
- `tests/hermes_cli/test_web_server_config_offloop.py` — passed
- ruff clean

## Notes / remaining #58576 scope

This lands the lock-contention leg (@DavidMetcalfe's diagnosis). The separate default-path GIL-pressure leg (large tool outputs on low-core boxes, @basi2815-create's 63.4s stall) was NOT reproducible on current main in a heavy-turn live harness (60 × 52KB tool results to ~595k ctx, probe p95 < 115ms even pinned to 1 CPU) — status posted on the issue.

Closes #74275 (salvage). Part of #58576.

## Infographic

![infographic](https://v3b.fal.media/files/b/0aa8b614/PBTOcFPTveQnTSMwSDoRc_Phpjhloa.png)
