### PR TITLE
fix(telegram): stop duplicate final bubble after flood-capped finalize with reply_to_mode=first (#71047)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2415,6 +2415,7 @@ class GatewayStreamConsumer:
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=final_text,
+                    reply_to=self._initial_reply_to_id,
                     metadata=self._metadata_for_send(final=True),
                 )
             except Exception as exc:
@@ -2450,7 +2451,17 @@ class GatewayStreamConsumer:
                 if not stale_id or stale_id == new_message_id:
                     continue
                 try:
-                    await delete_fn(self.chat_id, stale_id)
+                    deleted = await delete_fn(self.chat_id, stale_id)
+                    if deleted is False:
+                        # Telegram's delete_message reports failure by
+                        # returning False, not raising. The same flood
+                        # window that broke the finalize edit can reject
+                        # this delete too, leaving the preview bubble next
+                        # to the fresh final (#71047 Problem B). One short
+                        # bounded retry clears the common transient case;
+                        # a second failure stays best-effort.
+                        await asyncio.sleep(1.0)
+                        await delete_fn(self.chat_id, stale_id)
                 except Exception as exc:
                     logger.debug(
                         "Empty fallback preview cleanup failed (%s): %s",

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2217,12 +2217,23 @@ class GatewayStreamConsumer:
                 self._already_sent = True
                 self._fallback_prefix = ""
                 self._fallback_preserve_partial_messages = False
-                if delivery == "ambiguous":
+                if delivery in {"ambiguous", "preview"}:
                     # A timeout may mean Telegram accepted the send but the
-                    # client never received the response. Preserve duplicate
-                    # suppression for that one uncertain outcome.
+                    # client never received the response. A flood rejection
+                    # leaves the complete, ACKed preview as the authoritative
+                    # delivery. Preserve duplicate suppression in both cases.
                     self._final_content_delivered = True
-                    self._delivery_ambiguous = True
+                    if delivery == "preview":
+                        # This branch is only reached when the ACKed preview
+                        # already shows the complete final text
+                        # (final_text == _visible_prefix()), so record it as
+                        # the turn-final payload: the gateway's reconciliation
+                        # then confirms delivery instead of re-sending a
+                        # second bubble next to the never-deleted preview
+                        # (#71047 Problem B).
+                        self._record_turn_final_payload(final_text)
+                    else:
+                        self._delivery_ambiguous = True
                 else:
                     # A confirmed failure leaves the gateway free to perform
                     # its normal final send.
@@ -2387,8 +2398,9 @@ class GatewayStreamConsumer:
         """Commit a completed answer after Telegram finalization fails.
 
         Returns ``delivered`` on confirmed success, ``failed`` when the
-        gateway can safely retry, and ``ambiguous`` when a timeout may have
-        reached the platform already.
+        gateway can safely retry, ``ambiguous`` when a timeout may have
+        reached the platform already, and ``preview`` when flood control
+        leaves the complete streamed preview as the authoritative delivery.
         """
         # Tool/segment boundaries intentionally preserve the run-wide preview
         # IDs for normal fresh-final cleanup.  This recovery replaces only the
@@ -2423,6 +2435,8 @@ class GatewayStreamConsumer:
                 )
                 await asyncio.sleep(retry_delay)
                 continue
+            if self._is_flood_error(result):
+                return "preview"
             return (
                 "ambiguous"
                 if self._send_failure_may_have_delivered(result)

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -166,3 +166,91 @@ async def test_telegram_long_flood_result_keeps_retry_after():
     assert result.retry_after == 30.0
 
 
+
+
+@pytest.mark.asyncio
+async def test_empty_fallback_resend_preserves_reply_anchor():
+    """The fresh-commit resend must carry the turn's reply anchor (#71047).
+
+    With reply_to_mode='first' the streamed preview is delivered as a reply
+    to the user's message. When a failed finalize edit forces the fresh
+    resend, the replacement message must use the same anchor so the visible
+    behavior matches the preview (and the non-streaming path).
+    """
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(success=True, message_id="final-1")
+
+    consumer = GatewayStreamConsumer(
+        adapter, "chat-1", initial_reply_to_id="111",
+    )
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.send.assert_awaited_once()
+    kwargs = adapter.send.await_args.kwargs
+    assert kwargs.get("reply_to") == "111"
+    # Preview replaced: deleted after the fresh final succeeded.
+    adapter.delete_message.assert_awaited_once_with("chat-1", "preview-1")
+    assert consumer.final_response_sent is True
+    assert consumer.final_content_delivered is True
+
+
+@pytest.mark.asyncio
+async def test_empty_fallback_preview_delete_retries_once(monkeypatch):
+    """A False (flood-rejected) preview delete gets one bounded retry."""
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(success=True, message_id="final-1")
+    adapter.delete_message = AsyncMock(side_effect=[False, True])
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    assert adapter.delete_message.await_count == 2
+    sleep.assert_awaited_once_with(1.0)
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
+async def test_flood_capped_resend_keeps_single_bubble_reply_first(monkeypatch):
+    """#71047 Problem B end-to-end shape: preview as reply, finalize edit and
+    fresh resend both flood-capped — the gateway suppression decision must
+    keep the complete ACKed preview as the single visible bubble instead of
+    letting the normal final send create a second one.
+    """
+    adapter = _adapter()
+    # Fresh-commit resend flood-capped past the inline retry budget.
+    adapter.send.return_value = SendResult(
+        success=False,
+        error="flood_control:41.0",
+        retry_after=41.0,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(
+        adapter, "chat-1", initial_reply_to_id="111",
+    )
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    # Preview must NOT be deleted — it is the only copy of the answer.
+    adapter.delete_message.assert_not_awaited()
+    # Mirror the gateway/run.py suppression decision: content delivered and
+    # the recorded payload reconciles, so the normal final send is skipped.
+    assert consumer.final_content_delivered is True
+    assert consumer.delivered_final_matches("Final answer") is True

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -123,6 +123,33 @@ async def test_empty_tail_commit_honors_retry_after(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_complete_preview_survives_long_flood_fallback_failure(monkeypatch):
+    """A complete ACKed preview must not trigger a duplicate normal final."""
+    adapter = _adapter()
+    adapter.send.return_value = SendResult(
+        success=False,
+        error="flood_control:20.0",
+        retry_after=20.0,
+    )
+    sleep = AsyncMock()
+    monkeypatch.setattr("gateway.stream_consumer.asyncio.sleep", sleep)
+
+    consumer = GatewayStreamConsumer(adapter, "chat-1")
+    consumer._message_id = "preview-1"
+    consumer._last_sent_text = "Final answer"
+    consumer._already_sent = True
+    consumer._fallback_final_send = True
+
+    await consumer._send_fallback_final("Final answer")
+
+    adapter.send.assert_awaited_once()
+    sleep.assert_not_awaited()
+    assert consumer.final_response_sent is False
+    assert consumer.final_content_delivered is True
+    assert consumer.delivered_final_matches("Final answer") is True
+
+
+@pytest.mark.asyncio
 async def test_telegram_long_flood_result_keeps_retry_after():
     """The real adapter contract preserves the server delay for consumers."""
     class FloodError(Exception):


### PR DESCRIPTION
Fixes the **Problem B** half of #71047 (Telegram streaming + `reply_to_mode: first` → duplicate final message). Problem A (config-set duplicate key) is handled separately in #78111 and is untouched here.

## Symptom

With `platforms.telegram.streaming: true` and `reply_to_mode: first` (default), users see **two bubbles** for one answer:

1. the streamed preview, delivered as a reply-quote of the user's message (often still raw markdown, sometimes with the cursor `▌` stuck), and
2. a fresh plain final message.

Gateway accounting shows a single logical delivery (`delivery_obligations` = one row), so the duplication is invisible to the ledger. Corroborated in-thread by @Enashka on v0.20.1 (four simultaneous `Telegram flood control, waiting 41.0s` warnings during finalize edits, both bubbles visible, one recorded delivery).

## Root cause

Finalize path for `REQUIRES_EDIT_FINALIZE` adapters, `gateway/stream_consumer.py`:

1. Preview is sent as a reply (`reply_to=self._initial_reply_to_id`) and edited progressively.
2. The turn-final `edit_message(finalize=True)` hits Telegram flood control; the adapter fails closed for waits > 5s (`_flood_cap_result`, `flood_control:41.0`), and `FALLBACK_ON_FINAL_EDIT_FLOOD=True` promotes the consumer straight into fallback mode.
3. The visible preview already equals the final text, so `_send_fallback_final` takes the `RESEND_FINAL_ON_EMPTY_STREAM_FALLBACK` branch → `_send_empty_fallback_final` tries a fresh commit send. Two defects there:
   - **Flood-capped resend → gateway duplicate.** The fresh send is in the *same* flood window, so it also fails with `flood_control:*` past the 5s inline-retry budget. The method returned `"failed"`, which cleared `final_content_delivered`, so `gateway/run.py`'s normal final send fired a brand-new message — next to the never-deleted, fully-ACKed preview. **Two bubbles.**
   - **Successful resend → anchor mismatch.** When the fresh commit succeeded, it was sent **without** `reply_to`, so the replacement message dropped the reply-quote the preview had (and that the non-streaming path uses under `reply_to_mode=first`). And if the best-effort `deleteMessage` on the preview was itself flood-rejected (Telegram's `delete_message` returns `False`, it doesn't raise), the preview also lingered → two bubbles again.

## Fix

Three small pieces, one file:

- **`"preview"` verdict for flood-rejected fresh commits** (cherry-picked from @fangliquanflq's #96097, commit `d8e7b9f43a`, authorship preserved; rebased onto current main and reconciled with `fd998120c1`'s payload-reconciliation contract): when the empty-tail resend is flood-capped, the complete ACKed preview is the authoritative delivery. Set `final_content_delivered=True` **and** record the turn-final payload so `delivered_final_matches()` confirms it — the gateway suppresses its normal final send instead of duplicating. `_delivery_ambiguous` is now set only for real timeouts. This branch is only reachable when `final_text == _visible_prefix()`, so no content is ever hidden (the #25010 unsent-tail guarantee holds).
- **Reply anchor on the resend:** `_send_empty_fallback_final` now passes `reply_to=self._initial_reply_to_id`, so the replacement final quotes the user's message exactly like the preview did, matching non-streaming behavior under `reply_to_mode=first`.
- **Delete retry:** a preview `delete_message` returning `False` (flood-rejected delete) gets one bounded 1s retry. Still best-effort, and the preview is only ever deleted **after** the replacement send succeeded — the user is never left with zero messages.

## Repro (real adapter + real PTB Bot against a local stub Bot API)

Script drives the real `TelegramAdapter` (python-telegram-bot 22.8) + real `GatewayStreamConsumer` against a local aiohttp stub of `api.telegram.org` that 429s (`retry_after=41`) the finalize `editMessageText` and the fresh-commit `sendMessage`, then mirrors `gateway/run.py`'s suppression decision.

**Before:**
```
preview message_id=1001 reply_to={"message_id": 111}
final_response_sent=False final_content_delivered=False suppress_normal_final_send=False
gateway normal final send: success=True message_id=1002
VISIBLE BUBBLES = 2
  msg 1001: reply_to=111 text='...final answer...▌'   <- stale preview
  msg 1002: reply_to=111 text='...final answer...'    <- duplicate
DUPLICATE_VISIBLE=True
```

**After (flood-capped resend):**
```
final_response_sent=False final_content_delivered=True suppress_normal_final_send=True
VISIBLE BUBBLES = 1  (the ACKed preview)
DUPLICATE_VISIBLE=False
```

**After (resend succeeds):**
```
deleted=[1001]
VISIBLE BUBBLES = 1
  msg 1002: reply_to={"message_id": 111}   <- anchor preserved
DUPLICATE_VISIBLE=False
```

## Tests

New/updated in `tests/gateway/test_telegram_final_delivery.py`:
- `test_complete_preview_survives_long_flood_fallback_failure` (from #96097)
- `test_empty_fallback_resend_preserves_reply_anchor`
- `test_empty_fallback_preview_delete_retries_once`
- `test_flood_capped_resend_keeps_single_bubble_reply_first`

Targeted run: `scripts/run_tests.sh tests/gateway/test_telegram_final_delivery.py tests/gateway/test_stream_consumer.py tests/gateway/test_duplicate_reply_suppression.py tests/gateway/test_telegram_overflow_partial.py tests/gateway/test_stream_consumer_fresh_final.py` → **all green** (84+ tests). `ruff check` clean.

## Related

- Supersedes the Problem-B portion of #71076 (its test left `initial_reply_to_id` null so it never exercised the `reply_to_mode=first` path, and it bundles unrelated Codex/Matrix changes; per triage it remains open for the config half).
- Builds on and would supersede #96097 (cherry-picked with credit; its branch is ~1200 commits behind main and conflicts with `fd998120c1`).
- @chizhangucb's duplicate report in the same thread is a different trigger (`interim_assistant_messages` + Codex commentary channel) and is **not** addressed here; @dasgltd's Discord per-send re-quoting is likewise separate.

## Infographic

![flood-control-fix](https://v3b.fal.media/files/b/0aa8b630/Az8O1TunNccwhy9Kz-XOB_taq4KqFg.png)
