### PR TITLE
fix(whatsapp): scope require_mention/dm_policy/allowlists per profile

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -761,6 +761,16 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 _v = _wenv(_key)
                 if _v:
                     bridge_env[_key] = _v
+            # A scoped secondary profile that configured require_mention/
+            # mention_patterns/free_response_chats/dm_policy/allow_from/
+            # group_policy/group_allow_from via the top-level config.yaml
+            # whatsapp: block (not its own .env) has that value in
+            # self.config.extra (_apply_yaml_config seeds it there), but
+            # _wenv above only reads the secret scope/env — it never
+            # consults extra. Fill any gap the .env-derived loop above left,
+            # so the Node bridge sees this profile's own YAML config instead
+            # of silently reverting to bridge.js's built-in defaults (#80099).
+            _seed_bridge_env_from_extra(bridge_env, getattr(self.config, "extra", None) or {})
             # Pass the profile-aware cache directories so the bridge writes
             # media where the Python side reads it.  Without these the bridge
             # hardcodes ~/.hermes/{image,audio,document}_cache, which diverges
@@ -1887,38 +1897,114 @@ def interactive_setup() -> None:
             print_info("Home channel cleared.")
 
 
+def _profile_scoped_config_load() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed and connected inside
+    ``_profile_runtime_scope`` (secret scope installed + multiplex active) —
+    the same discriminator the Buzz/Discord/Telegram adapters use for this
+    bug class (#98738 / #72348 / #80099). The DEFAULT profile under
+    multiplexing runs unscoped: ``os.environ`` holds its own bridge output
+    there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def _seed_bridge_env_from_extra(bridge_env: dict, extra: dict) -> None:
+    """Inject this profile's YAML-bridged whatsapp config into the Node
+    bridge subprocess environment, filling gaps the ``.env``-derived
+    ``_wenv`` loop above left. Values already present in ``bridge_env`` win.
+    """
+    if not isinstance(extra, dict):
+        return
+
+    def _seed(name: str, value, *, lower: bool = False) -> None:
+        if value is None or name in bridge_env:
+            return
+        if isinstance(value, list):
+            bridge_env[name] = ",".join(str(v) for v in value)
+        else:
+            text = str(value)
+            bridge_env[name] = text.lower() if lower else text
+
+    _seed("WHATSAPP_REQUIRE_MENTION", extra.get("require_mention"), lower=True)
+    mp = extra.get("mention_patterns")
+    if mp is not None and "WHATSAPP_MENTION_PATTERNS" not in bridge_env:
+        import json as _json
+
+        try:
+            bridge_env["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(mp)
+        except (TypeError, ValueError):
+            pass
+    _seed("WHATSAPP_FREE_RESPONSE_CHATS", extra.get("free_response_chats"))
+    _seed("WHATSAPP_DM_POLICY", extra.get("dm_policy"), lower=True)
+    _seed("WHATSAPP_ALLOWED_USERS", extra.get("allow_from"))
+    _seed("WHATSAPP_GROUP_POLICY", extra.get("group_policy"), lower=True)
+    _seed("WHATSAPP_GROUP_ALLOWED_USERS", extra.get("group_allow_from"))
+
+
 def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
-    """Translate config.yaml whatsapp: keys into WHATSAPP_* env vars.
+    """Translate config.yaml whatsapp: keys into WHATSAPP_* env vars and
+    PlatformConfig.extra entries.
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     whatsapp_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML. Returns None — everything flows through env.
+    take precedence over YAML for single-profile deployments.
+
+    Returns the bridged values as a dict, merged into this profile's
+    PlatformConfig.extra by the caller — every one of these fields already
+    has an extra-first read path (WhatsAppAdapter.__init__'s dm_policy/
+    allow_from/group_policy/group_allow_from, and
+    gateway/platforms/whatsapp_common.py's _whatsapp_require_mention/
+    _whatsapp_free_response_chats/_compile_mention_patterns), so seeding
+    extra is both how a scoped secondary profile's own YAML value reaches
+    its adapter AND how the process-global env write below is made skippable
+    under multiplex (#80099) without losing single-profile behavior.
     """
     import json as _json
-    if "require_mention" in whatsapp_cfg and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
-        os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
-    if "mention_patterns" in whatsapp_cfg and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
-        os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
+
+    _skip_env_bridge = _profile_scoped_config_load()
+    seeded: dict = {}
+    if "require_mention" in whatsapp_cfg:
+        seeded["require_mention"] = whatsapp_cfg["require_mention"]
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_REQUIRE_MENTION"):
+            os.environ["WHATSAPP_REQUIRE_MENTION"] = str(whatsapp_cfg["require_mention"]).lower()
+    if "mention_patterns" in whatsapp_cfg:
+        seeded["mention_patterns"] = whatsapp_cfg["mention_patterns"]
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_MENTION_PATTERNS"):
+            os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
     frc = whatsapp_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
-    if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
-        os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
+    if frc is not None:
+        seeded["free_response_chats"] = frc
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
+            _frc = ",".join(str(v) for v in frc) if isinstance(frc, list) else str(frc)
+            os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = _frc
+    if "dm_policy" in whatsapp_cfg:
+        seeded["dm_policy"] = whatsapp_cfg["dm_policy"]
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_DM_POLICY"):
+            os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
     af = whatsapp_cfg.get("allow_from")
-    if af is not None and not os.getenv("WHATSAPP_ALLOWED_USERS"):
-        if isinstance(af, list):
-            af = ",".join(str(v) for v in af)
-        os.environ["WHATSAPP_ALLOWED_USERS"] = str(af)
-    if "group_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_GROUP_POLICY"):
-        os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
+    if af is not None:
+        seeded["allow_from"] = af
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_ALLOWED_USERS"):
+            _af = ",".join(str(v) for v in af) if isinstance(af, list) else str(af)
+            os.environ["WHATSAPP_ALLOWED_USERS"] = _af
+    if "group_policy" in whatsapp_cfg:
+        seeded["group_policy"] = whatsapp_cfg["group_policy"]
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_GROUP_POLICY"):
+            os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
     gaf = whatsapp_cfg.get("group_allow_from")
-    if gaf is not None and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
-        if isinstance(gaf, list):
-            gaf = ",".join(str(v) for v in gaf)
-        os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
-    return None
+    if gaf is not None:
+        seeded["group_allow_from"] = gaf
+        if not _skip_env_bridge and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
+            _gaf = ",".join(str(v) for v in gaf) if isinstance(gaf, list) else str(gaf)
+            os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = _gaf
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
+++ b/tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py
@@ -9,6 +9,8 @@ inbound messages.
 The fix routes WHATSAPP_* reads through ``get_secret()`` (``agent.secret_scope``)
 which honours the active scope.
 """
+import os
+
 import pytest
 
 from agent import secret_scope as ss
@@ -156,3 +158,127 @@ class TestWhatsAppCloudAdapterUsesSecretScope:
             assert _get_wsecret("WHATSAPP_DM_POLICY", default="pairing") == "allowlist"
         finally:
             ss.reset_secret_scope(tok)
+
+
+class TestWhatsAppYamlBridgeScopeIsolation:
+    """#80099 — _apply_yaml_config's WHATSAPP_* env writes for
+    require_mention/mention_patterns/free_response_chats/dm_policy/
+    allow_from/group_policy/group_allow_from must not pollute shared
+    process env under multiplex; a scoped secondary profile's own YAML
+    values must still reach its adapter via PlatformConfig.extra."""
+
+    _ENV_VARS = (
+        "WHATSAPP_REQUIRE_MENTION",
+        "WHATSAPP_MENTION_PATTERNS",
+        "WHATSAPP_FREE_RESPONSE_CHATS",
+        "WHATSAPP_DM_POLICY",
+        "WHATSAPP_ALLOWED_USERS",
+        "WHATSAPP_GROUP_POLICY",
+        "WHATSAPP_GROUP_ALLOWED_USERS",
+    )
+
+    def test_scoped_load_seeds_extra_without_env_leak(self, monkeypatch):
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        for var in self._ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            seeded = _apply_yaml_config(
+                {},
+                {
+                    "require_mention": True,
+                    "mention_patterns": ["(?i)hey bot"],
+                    "free_response_chats": ["120363001@g.us"],
+                    "dm_policy": "allowlist",
+                    "allow_from": ["15551234567@c.us"],
+                    "group_policy": "allowlist",
+                    "group_allow_from": ["120363002@g.us"],
+                },
+            )
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert seeded == {
+            "require_mention": True,
+            "mention_patterns": ["(?i)hey bot"],
+            "free_response_chats": ["120363001@g.us"],
+            "dm_policy": "allowlist",
+            "allow_from": ["15551234567@c.us"],
+            "group_policy": "allowlist",
+            "group_allow_from": ["120363002@g.us"],
+        }
+        for var in self._ENV_VARS:
+            assert os.getenv(var) is None, f"{var} leaked into process env under scope"
+
+    def test_unscoped_single_profile_still_bridges_env(self, monkeypatch):
+        """Unscoped (single-profile) behavior is unchanged: the legacy env
+        bridge still fires, matching pre-fix behavior exactly."""
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        for var in self._ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        ss.set_multiplex_active(False)
+        _apply_yaml_config(
+            {}, {"require_mention": True, "dm_policy": "allowlist"},
+        )
+        assert os.environ["WHATSAPP_REQUIRE_MENTION"] == "true"
+        assert os.environ["WHATSAPP_DM_POLICY"] == "allowlist"
+
+    def test_default_profile_env_does_not_leak_into_second_profiles_extra(self, monkeypatch):
+        """First-writer env (the default profile's bridge output) must not
+        override a scoped secondary profile's own extra-seeded value — the
+        same construction-time precedence WhatsAppAdapter.__init__ already
+        uses for dm_policy (config.extra.get(...) or _wenv(...))."""
+        from plugins.platforms.whatsapp.adapter import _wenv
+
+        monkeypatch.setenv("WHATSAPP_DM_POLICY", "pairing")  # default profile's leaked value
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            extra = {"dm_policy": "allowlist"}
+            resolved = str(extra.get("dm_policy") or _wenv("WHATSAPP_DM_POLICY", "pairing")).strip().lower()
+        finally:
+            ss.reset_secret_scope(tok)
+        assert resolved == "allowlist"
+
+
+class TestSeedBridgeEnvFromExtra:
+    """_seed_bridge_env_from_extra fills the Node bridge subprocess env from
+    a scoped profile's PlatformConfig.extra, for fields _wenv (the .env/scope
+    -only loop in connect()) can never see."""
+
+    def test_fills_gaps_from_extra(self):
+        from plugins.platforms.whatsapp.adapter import _seed_bridge_env_from_extra
+
+        bridge_env = {}
+        _seed_bridge_env_from_extra(
+            bridge_env,
+            {
+                "require_mention": True,
+                "mention_patterns": ["(?i)hey bot"],
+                "dm_policy": "Allowlist",
+                "allow_from": ["15551234567@c.us", "15559876543@c.us"],
+            },
+        )
+        assert bridge_env["WHATSAPP_REQUIRE_MENTION"] == "true"
+        assert bridge_env["WHATSAPP_MENTION_PATTERNS"] == '["(?i)hey bot"]'
+        assert bridge_env["WHATSAPP_DM_POLICY"] == "allowlist"
+        assert bridge_env["WHATSAPP_ALLOWED_USERS"] == "15551234567@c.us,15559876543@c.us"
+
+    def test_does_not_override_existing_env_derived_values(self):
+        """Values already resolved from the profile's own .env (via the
+        _wenv loop) win over extra — extra only fills gaps."""
+        from plugins.platforms.whatsapp.adapter import _seed_bridge_env_from_extra
+
+        bridge_env = {"WHATSAPP_DM_POLICY": "pairing"}
+        _seed_bridge_env_from_extra(bridge_env, {"dm_policy": "allowlist"})
+        assert bridge_env["WHATSAPP_DM_POLICY"] == "pairing"
+
+    def test_ignores_none_and_missing_keys(self):
+        from plugins.platforms.whatsapp.adapter import _seed_bridge_env_from_extra
+
+        bridge_env = {}
+        _seed_bridge_env_from_extra(bridge_env, {})
+        assert bridge_env == {}


### PR DESCRIPTION
## What & why

`_apply_yaml_config()` wrote `require_mention`, `mention_patterns`, `free_response_chats`, `dm_policy`, `allow_from`, `group_policy`, and `group_allow_from` to process-global `os.environ` unconditionally and never seeded `PlatformConfig.extra` (its own docstring: "everything flows through env"). Under `gateway.multiplex_profiles`, a secondary profile's own `config.yaml` values for these 7 fields leaked into shared env for every other WhatsApp adapter/bridge to inherit (issue #80099) — and had no way to reach the profile's own adapter either, since every one of these fields is already read extra-first (`WhatsAppAdapter.__init__`'s `dm_policy`/`allow_from`/`group_policy`/`group_allow_from`, and `gateway/platforms/whatsapp_common.py`'s `_whatsapp_require_mention`/`_whatsapp_free_response_chats`/`_compile_mention_patterns`) — `_apply_yaml_config` simply never populated the `extra` dict those reads already prefer.

## Fix

Adds `_profile_scoped_config_load()` (mirrors the Buzz/Discord/Telegram helper for this bug class, #98738/#72348) to gate the env writes, and returns the bridged values as a dict so `gateway/config.py` merges them into this profile's `extra` — fixing both directions: the leak, and the scoped profile's own YAML value actually taking effect.

The Node.js bridge subprocess reads these same 7 vars directly from its own env (`connect()`'s existing `_wenv`-based loop, which only consults the profile's `.env`-derived secret scope or raw env — never `extra`). A profile that configured one of these fields via the top-level `config.yaml` block (not its own `.env`) would still see the bridge silently revert to `bridge.js`'s defaults. Adds `_seed_bridge_env_from_extra()`, called right after the existing loop in `connect()`, to fill that gap from `self.config.extra` without overriding any `.env`-derived value already resolved.

## Tests

Extends `tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py` (the established test file for this bug class) with tests for `_apply_yaml_config`'s scoped-vs-single-profile write behavior and `_seed_bridge_env_from_extra`'s gap-filling.

- `tests/gateway/test_75349_whatsapp_multiplex_secret_scope.py` — 12 passed
- `tests/ -k whatsapp` (23 files) — 223 passed, 20 skipped (pre-existing, unrelated)
- Mutation-verify: reverting the fix makes 4 of the 12 new tests fail as expected (the other 8 exercise unscoped/single-profile paths and pre-existing scope tests, which were never buggy)

## Competitor check

Issue #80099 documents exactly this bug. PR #81010 attempted a fix and passed tests, but was self-closed by its author for backlog-capacity reasons ("too many open PRs... happy to reopen if maintainers want it") — not rejected by a maintainer, so treated as legitimate prior art per this account's established practice, not a live competitor (currently CLOSED, confirmed via `gh pr view`). This PR was written independently rather than reusing that patch. Searched `80099`, "whatsapp apply_yaml_config", `WHATSAPP_REQUIRE_MENTION`, "whatsapp multiplex bridge_env" (all PR/issue states) — no other open PR targets this.