### PR TITLE
fix(sessions): safer state.db recovery load path + opt-in singleton-writer guard

### DIFF
--- a/hermes_cli/session_lost_and_found.py
+++ b/hermes_cli/session_lost_and_found.py
@@ -115,6 +115,115 @@ def _cli_supports_recover(binary: str) -> bool:
         shutil.rmtree(scratch_dir, ignore_errors=True)
 
 
+# Statements whose target is sqlite_schema/sqlite_master directly (the
+# .recover output's own re-registration of a virtual-table's shadow-table
+# wrapper, e.g. `INSERT INTO sqlite_schema VALUES('table','messages_fts',...,
+# 'CREATE VIRTUAL TABLE messages_fts USING fts5(...)')`) require
+# `PRAGMA writable_schema=ON`; every other statement — including the shadow
+# TABLE CREATEs that follow — must run with it OFF or SQLite registers them
+# as ordinary tables instead of letting the virtual-table module claim them.
+# Found live during the 2026-09-01 wide-corruption recovery (see
+# hermes-fixer docs/handoff-next-agent.md and Obsidian ADR 0030).
+_SQLITE_SCHEMA_INSERT_RE = re.compile(
+    r"^\s*INSERT\s+INTO\s+(sqlite_schema|sqlite_master)\b", re.IGNORECASE
+)
+
+
+def _split_recover_statements(sql_text: str):
+    """Split ``.recover`` output into individual statements on ``;``.
+
+    Respects ``'...'`` string/blob (``X'...'``) literal boundaries — a
+    doubled ``''`` inside a literal is an escaped single quote, per the SQL
+    spec — so a semicolon embedded in recovered row content never splits a
+    statement early.
+    """
+    start = 0
+    in_string = False
+    i = 0
+    n = len(sql_text)
+    while i < n:
+        ch = sql_text[i]
+        if in_string:
+            if ch == "'":
+                if i + 1 < n and sql_text[i + 1] == "'":
+                    i += 2
+                    continue
+                in_string = False
+            i += 1
+            continue
+        if ch == "'":
+            in_string = True
+            i += 1
+            continue
+        if ch == ";":
+            stmt = sql_text[start:i].strip()
+            if stmt:
+                yield stmt
+            start = i + 1
+        i += 1
+    tail = sql_text[start:].strip()
+    if tail:
+        yield tail
+
+
+def load_recover_sql(sql_text: str, lf_path: Path) -> dict[str, Any]:
+    """Execute ``.recover``-emitted SQL against a fresh ``lf_path`` database.
+
+    Statement-at-a-time via Python's ``sqlite3`` driver rather than piping
+    the dump into a second ``sqlite3`` CLI process. The CLI's own SQL parser
+    has a hard ~1MB single-statement size limit and zero tolerance for
+    invalid-UTF-8 content inside a literal — both killed the load leg
+    outright during the 2026-09-01 wide-corruption incident, on statements
+    up to 192KB carrying recovered row content, well past what a healthy
+    recovery needs to tolerate. A single unexecutable statement (a torn
+    cell recovered as syntactically-valid-but-garbage content, the same
+    class as that incident's one genuinely lost row) is skipped and
+    counted, not fatal to the whole load — the old CLI-pipe path could
+    silently stop mid-stream on the first bad statement while still
+    reporting the scratch DB as "usable" (it only checks for the presence
+    of *some* table), which is a silent-data-loss shape worse than a loud
+    per-statement skip.
+
+    Uses ``journal_mode=DELETE``: with WAL, ``close()`` on a freshly-loaded
+    large file inside the ``BEGIN;...COMMIT;`` envelope ``.recover`` emits
+    has been observed to truncate the file to 0 bytes on this platform.
+    """
+    if lf_path.exists():
+        lf_path.unlink()
+    conn = sqlite3.connect(str(lf_path), isolation_level=None)
+    executed = 0
+    failed = 0
+    failures: list[str] = []
+    try:
+        conn.execute("PRAGMA journal_mode=DELETE")
+        for stmt in _split_recover_statements(sql_text):
+            schema_insert = _SQLITE_SCHEMA_INSERT_RE.match(stmt) is not None
+            try:
+                if schema_insert:
+                    conn.execute("PRAGMA writable_schema=ON")
+                conn.execute(stmt)
+                executed += 1
+            except (sqlite3.Error, UnicodeError) as exc:
+                # UnicodeError: a literal carrying invalid-UTF-8 bytes can
+                # decode via surrogateescape but then fail to re-encode when
+                # the driver hands it to SQLite's C API. Same accepted-loss
+                # class as a torn cell that decodes to nonsense — count and
+                # move on rather than aborting the whole load over it.
+                failed += 1
+                if len(failures) < 20:
+                    failures.append(f"{exc}: {stmt[:200]!r}")
+            finally:
+                if schema_insert:
+                    conn.execute("PRAGMA writable_schema=OFF")
+    finally:
+        conn.close()
+    return {
+        "executed": executed,
+        "failed": failed,
+        "failure_samples": failures,
+    }
+
+
 def run_cli_lost_and_found_recover(
     source: Path,
     lf_path: Path,
@@ -122,45 +231,36 @@ def run_cli_lost_and_found_recover(
     *,
     timeout: float = 3600.0,
 ) -> dict[str, Any]:
-    """Run ``sqlite3 <source> .recover`` streamed into a fresh scratch DB.
+    """Run ``sqlite3 <source> .recover`` and load the dump via Python.
 
     ``--ignore-freelist`` avoids resurrecting deleted rows; older shells
-    without that option fall back to a plain ``.recover``.
+    without that option fall back to a plain ``.recover``. Only the *dump*
+    leg shells out to the CLI (``.recover`` is a CLI-only feature, not part
+    of Python's ``sqlite3`` module) — the load leg is :func:`load_recover_sql`,
+    not a second CLI process. See that function's docstring for why.
     """
 
     attempts: list[dict[str, Any]] = []
     for command in (".recover --ignore-freelist", ".recover"):
-        if lf_path.exists():
-            lf_path.unlink()
-        dump = subprocess.Popen(
-            [sqlite3_bin, "-readonly", str(source), command],
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        load = subprocess.Popen(
-            [sqlite3_bin, str(lf_path)],
-            stdin=dump.stdout,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.PIPE,
-        )
-        assert dump.stdout is not None
-        dump.stdout.close()  # let dump receive SIGPIPE if load dies
         try:
-            _, load_err = load.communicate(timeout=timeout)
-            dump_err = dump.stderr.read() if dump.stderr is not None else b""
-            dump.wait(timeout=60)
-        except subprocess.TimeoutExpired:
-            dump.kill()
-            load.kill()
-            raise LostAndFoundError(
-                f"sqlite3 .recover timed out after {timeout:.0f}s"
+            dump = subprocess.run(
+                [sqlite3_bin, "-readonly", str(source), command],
+                capture_output=True,
+                timeout=timeout,
             )
+        except subprocess.TimeoutExpired:
+            raise LostAndFoundError(
+                f"sqlite3 {command} timed out after {timeout:.0f}s"
+            )
+        dump_sql = dump.stdout.decode("utf-8", "surrogateescape")
+        load_report = load_recover_sql(dump_sql, lf_path)
         attempt = {
             "command": command,
             "dump_returncode": dump.returncode,
-            "load_returncode": load.returncode,
-            "dump_stderr_tail": dump_err.decode("utf-8", "replace")[-2000:],
-            "load_stderr_tail": load_err.decode("utf-8", "replace")[-2000:],
+            "dump_stderr_tail": dump.stderr.decode("utf-8", "replace")[-2000:],
+            "load_executed": load_report["executed"],
+            "load_failed": load_report["failed"],
+            "load_failure_samples": load_report["failure_samples"],
         }
         attempts.append(attempt)
         if _lost_and_found_db_usable(lf_path):
@@ -172,8 +272,8 @@ def run_cli_lost_and_found_recover(
         "sqlite3 .recover did not produce a usable lost_and_found database: "
         + "; ".join(
             f"[{a['command']}] dump rc={a['dump_returncode']} "
-            f"load rc={a['load_returncode']} "
-            f"{a['dump_stderr_tail'] or a['load_stderr_tail']}".strip()
+            f"executed={a['load_executed']} failed={a['load_failed']} "
+            f"{a['dump_stderr_tail']}".strip()
             for a in attempts
         )
     )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4503,6 +4503,86 @@ def quarantine_cross_process_lock(path: Path, timeout: float = 5.0):
             handle.close()
 
 
+def _state_db_single_writer_enabled() -> bool:
+    """Opt-in switch for the singleton-writer flock (2026-09-01 wide-corruption
+    handoff, `hermes-fixer` docs/handoff-next-agent.md and Obsidian ADR 0030
+    "Layer 1"). Off by default: the incident that motivated it (33 profile
+    `state.db` files, some via multiplexed `serve` processes) never confirmed
+    concurrent app-level writers as root cause — the confirmed mechanism was a
+    macOS Time Machine local snapshot racing the live WAL file, which the
+    `tmutil addexclusion` on state.db*/profiles/*/state.db* addresses
+    directly. This flock is defense-in-depth against a *related but distinct*
+    latent risk (two writer processes on the same path), opt-in via env so it
+    can't itself introduce a new startup-hang failure mode for users who
+    never hit that risk.
+    """
+    return os.environ.get("STATE_DB_SINGLE_WRITER", "").strip().lower() in (
+        "1", "true", "yes",
+    )
+
+
+def acquire_state_db_singleton_writer_lock(path: Path):
+    """Best-effort exclusive flock so only one writer process holds *path* open.
+
+    No-op (returns None) unless ``STATE_DB_SINGLE_WRITER`` is truthy in the
+    environment. Kernel-level ``flock`` — same primitive as
+    :func:`quarantine_cross_process_lock` and ``_cross_process_repair_lock`` —
+    so a killed holder (``kill -9`` included) releases automatically instead
+    of wedging every future opener the way a pidfile would. Non-blocking: a
+    second writer fails fast with a clear ``sqlite3.OperationalError`` rather
+    than hanging, since a silent multi-minute stall is exactly the failure
+    shape (gateway housekeeping going dark for 35 minutes) that made the
+    2026-09-01 wide corruption hard to diagnose after the fact.
+
+    Caller owns the returned handle's lifetime — release via
+    :func:`release_state_db_singleton_writer_lock` in ``close()``.
+    """
+    if not _state_db_single_writer_enabled():
+        return None
+    lock_path = path.with_name(path.name + ".singleton.lock")
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    handle = lock_path.open("a+b")
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (BlockingIOError, OSError) as exc:
+        handle.close()
+        raise sqlite3.OperationalError(
+            f"state.db singleton-writer lock held by another process "
+            f"({lock_path}) — STATE_DB_SINGLE_WRITER=true forbids a second "
+            f"concurrent writer on {path}. Set STATE_DB_SINGLE_WRITER=false "
+            "to disable this guard."
+        ) from exc
+    return handle
+
+
+def release_state_db_singleton_writer_lock(handle) -> None:
+    """Release a handle from :func:`acquire_state_db_singleton_writer_lock`."""
+    if handle is None:
+        return
+    try:
+        if _IS_WINDOWS:
+            import msvcrt
+
+            handle.seek(0)
+            msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+    except (OSError, AttributeError):
+        pass
+    finally:
+        handle.close()
+
+
 def quarantine_zeroed_state_db(
     path: Path, *, already_locked: bool = False
 ) -> Optional[Path]:
@@ -5012,6 +5092,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         # live-DB test-isolation guard block near _default_db_path().
         _ensure_test_isolation(self.db_path)
         self.read_only = read_only
+        # Set unconditionally (not just on the write path below) so close()
+        # and the failure-path finally block can always reference it, even
+        # if construction fails before the write-path acquire runs.
+        self._singleton_writer_lock = None
 
         self._lock = threading.Lock()
         # Read-path split (WAL only): recall/browse queries borrow a
@@ -5168,6 +5252,15 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 return
 
             self.db_path.parent.mkdir(parents=True, exist_ok=True)
+
+            # Opt-in singleton-writer guard (STATE_DB_SINGLE_WRITER) — see
+            # acquire_state_db_singleton_writer_lock. Acquired before any
+            # write-mode preflight/connect so a second writer fails fast
+            # instead of racing this one. Released in close(). (read_only
+            # never reaches this line — it returns above.)
+            self._singleton_writer_lock = acquire_state_db_singleton_writer_lock(
+                self.db_path
+            )
 
             # Read-only file/sidecar preflight (port of kilocode#12508):
             # repair-or-refuse BEFORE the first connection so users get an
@@ -5343,6 +5436,8 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if not initialization_complete:
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
+                lock, self._singleton_writer_lock = self._singleton_writer_lock, None
+                release_state_db_singleton_writer_lock(lock)
 
     # ── Read-path split ──
 
@@ -6519,6 +6614,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                         )
                 conn, self._conn = self._conn, None
                 self._close_connection_quietly(conn)
+        lock, self._singleton_writer_lock = getattr(
+            self, "_singleton_writer_lock", None
+        ), None
+        release_state_db_singleton_writer_lock(lock)
 
     def __del__(self) -> None:
         """Safety net: close the connection if the caller forgot.

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -17,7 +17,9 @@ import pytest
 from hermes_state import SessionDB
 from hermes_cli import session_recovery
 from hermes_cli.session_lost_and_found import (
+    _split_recover_statements,
     classify_lost_and_found_row,
+    load_recover_sql,
     map_lost_and_found_rows,
     rebuild_fts_indexes,
     stub_missing_parent_sessions,
@@ -569,3 +571,126 @@ def test_fingerprint_error_enumerates_parent_cli_session(
     assert "CLI session" in message
     assert "fresh shell" in message
     assert "snapshot" in message
+
+
+# ── load_recover_sql: the 2026-09-01 wide-corruption regression ────────────
+#
+# run_cli_lost_and_found_recover used to pipe .recover's dump straight into
+# a second `sqlite3` CLI process to load it. That CLI's own SQL parser has
+# a hard ~1MB single-statement size limit and zero tolerance for invalid
+# UTF-8 inside a literal — both broke the load leg outright during the
+# 2026-09-01 wide state.db corruption (see hermes-fixer's
+# docs/handoff-next-agent.md and Obsidian ADR 0030). These tests exercise
+# load_recover_sql directly — no real `.recover`-capable sqlite3 CLI needed,
+# so they always run (unlike the CLI-gated tests above).
+
+
+def test_split_recover_statements_respects_quoted_semicolons() -> None:
+    sql = (
+        "CREATE TABLE t(x);"
+        "INSERT INTO t VALUES('a;b''c;d');"
+        "INSERT INTO t VALUES(X'0102030B3B');"  # blob literal containing 0x3B (';')
+    )
+    statements = list(_split_recover_statements(sql))
+    assert statements == [
+        "CREATE TABLE t(x)",
+        "INSERT INTO t VALUES('a;b''c;d')",
+        "INSERT INTO t VALUES(X'0102030B3B')",
+    ]
+
+
+def test_load_recover_sql_survives_oversized_statement(tmp_path: Path) -> None:
+    """A single statement well past the sqlite3 CLI's ~1MB parse limit.
+
+    The old CLI-pipe load leg failed the whole recovery on a statement this
+    size; the incident's real .recover dumps carried INSERT statements up
+    to 192KB. This one is well over 1MB to prove there is no size ceiling
+    on the Python-driver path.
+    """
+    big_value = "x" * (2 * 1024 * 1024)
+    sql = "CREATE TABLE t(x);" f"INSERT INTO t VALUES('{big_value}');"
+    lf_path = tmp_path / "lost_and_found.db"
+
+    report = load_recover_sql(sql, lf_path)
+
+    assert report["failed"] == 0
+    assert report["executed"] == 2
+    conn = sqlite3.connect(str(lf_path))
+    try:
+        (value,) = conn.execute("SELECT x FROM t").fetchone()
+        assert value == big_value
+    finally:
+        conn.close()
+
+
+def test_load_recover_sql_skips_bad_statements_without_aborting(
+    tmp_path: Path,
+) -> None:
+    """One unexecutable statement (garbage content, invalid syntax) must not
+    lose every statement after it — the old CLI-pipe path could die mid
+    stream on the first bad statement while _lost_and_found_db_usable still
+    reported the scratch DB as usable, silently dropping every row after
+    the failure point.
+    """
+    # A literal carrying a lone UTF-16 surrogate: decodes via
+    # surrogateescape on the dump side but cannot be handed back to
+    # SQLite's C API, so it must fail *this one statement*, not the load.
+    garbage = "\udcff\udcfe"
+    sql = (
+        "CREATE TABLE t(x);"
+        "INSERT INTO t VALUES('before');"
+        f"INSERT INTO t VALUES('{garbage}');"
+        "INSERT INTO nonexistent_table VALUES('also bad');"
+        "INSERT INTO t VALUES('after');"
+    )
+    lf_path = tmp_path / "lost_and_found.db"
+
+    report = load_recover_sql(sql, lf_path)
+
+    assert report["failed"] >= 1
+    conn = sqlite3.connect(str(lf_path))
+    try:
+        rows = {row[0] for row in conn.execute("SELECT x FROM t")}
+    finally:
+        conn.close()
+    assert "before" in rows
+    assert "after" in rows
+
+
+def test_load_recover_sql_toggles_writable_schema_for_schema_inserts(
+    tmp_path: Path,
+) -> None:
+    """A direct `INSERT INTO sqlite_schema` (.recover's re-registration of a
+    virtual-table shadow-table wrapper, e.g. messages_fts) fails outright
+    without `PRAGMA writable_schema=ON` — found live during the 2026-09-01
+    recovery. Confirms the toggle is applied around exactly that statement
+    and cleared immediately after (ordinary CREATE TABLEs that follow must
+    NOT run with it left on, or SQLite registers them as plain tables
+    instead of letting a virtual-table module claim them).
+    """
+    sql = (
+        "CREATE TABLE real_table(x);"
+        "INSERT INTO sqlite_schema VALUES("
+        "'table','ghost_shadow','ghost_shadow',0,"
+        "'CREATE TABLE ghost_shadow(a,b)');"
+        "CREATE TABLE after_schema_insert(y);"
+    )
+    lf_path = tmp_path / "lost_and_found.db"
+
+    report = load_recover_sql(sql, lf_path)
+
+    assert report["failed"] == 0, report["failure_samples"]
+    conn = sqlite3.connect(str(lf_path))
+    try:
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            )
+        }
+        # writable_schema must be OFF again by the time the next CREATE runs.
+        assert "after_schema_insert" in tables
+        assert "real_table" in tables
+        assert "ghost_shadow" in tables
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Two related fixes from diagnosing a wide state.db btree corruption:

- **`session_lost_and_found.py::load_recover_sql`**: `run_cli_lost_and_found_recover`'s last-resort lane used to pipe `sqlite3 <source> .recover` straight into a *second* `sqlite3` CLI process to load it. That CLI's own SQL parser has a hard ~1MB single-statement size limit and no tolerance for invalid-UTF-8 content inside a literal — both broke the load leg outright on a real corrupted database, on INSERT statements up to ~192KB carrying recovered row content. Worse, `_lost_and_found_db_usable` only checks that *some* table exists in the result, so a CLI parse failure partway through the stream could silently report the recovery as usable while dropping every row after the failure point.

  Replaced the load leg with a Python-driver loader that splits the dump into individual statements (respecting quoted/blob literal boundaries), executes them one at a time, and counts+continues past failures instead of aborting the whole load on the first bad one. It also handles the `PRAGMA writable_schema` toggle that `.recover`'s own re-registration of a virtual-table (FTS5) shadow table needs, and uses `journal_mode=DELETE` to avoid a WAL-mode `close()` truncating a freshly-loaded large file to 0 bytes.

- **`hermes_state.py::acquire_state_db_singleton_writer_lock`**: an opt-in (`STATE_DB_SINGLE_WRITER=true`) exclusive flock so two write-mode `SessionDB` processes can't hold the same `state.db` path open concurrently. Off by default — kernel-level flock, same primitive as the existing `quarantine_cross_process_lock` / `_cross_process_repair_lock`, so a killed holder (`kill -9` included) releases automatically. A second writer fails fast with a clear `sqlite3.OperationalError` instead of silently racing the first.

## Test plan

- [x] New regression tests in `tests/hermes_cli/test_session_recovery_lost_and_found.py`: an oversized (>1MB) statement, a statement carrying invalid-UTF-8 content that must be skipped-not-fatal, quoted-semicolon statement splitting, and the `writable_schema` toggle around a `sqlite_schema` re-registration.
- [x] `tests/hermes_cli/test_session_recovery.py`, `tests/hermes_cli/test_session_recovery_lost_and_found.py`, `tests/test_hermes_state.py`, `tests/test_hermes_state_readonly_preflight.py`, `tests/test_hermes_state_conn_lock_audit.py`, `tests/test_hermes_state_compression_busy_retry.py`, `tests/test_hermes_state_compression_locks.py` — 283 passed, 1 skipped (no `.recover`-capable sqlite3 CLI in this env), rebased on current `main`.