### PR TITLE
fix(desktop): reconcile rehydrated failed tail turns

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -591,6 +591,32 @@ describe('active transcript refresh', () => {
 })
 
 describe('reconcileActiveTranscript', () => {
+  it('keeps one failed assistant bubble when refresh rebuilds the same tail turn under a new id', async () => {
+    const fixture = makeRefresh()
+    fixture.state.messages = [
+      {
+        id: 'optimistic-user',
+        parts: [{ text: 'question', type: 'text' }],
+        role: 'user'
+      },
+      {
+        error: 'connection lost after completion',
+        id: 'assistant-live-before-refresh',
+        parts: [{ text: 'answer', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+    vi.mocked(getLatestSessionMessages).mockResolvedValue(transcript('answer') as never)
+
+    await fixture.refresh()
+
+    const messages = fixture.states.get(ACTIVE_RUNTIME_ID)?.messages ?? []
+    const assistants = messages.filter(message => message.role === 'assistant')
+
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0]).toMatchObject({ error: 'connection lost after completion', pending: false })
+  })
+
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {
     setSessionOwnerHint(ACTIVE_STORED_ID, {
       connectionId: 'stale-messaging-owner',

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -601,6 +601,7 @@ describe('reconcileActiveTranscript', () => {
       },
       {
         error: 'connection lost after completion',
+        errorSurface: { code: 'transport_lost', layer: 'streaming', retryable: true },
         id: 'assistant-live-before-refresh',
         parts: [{ text: 'answer', type: 'text' }],
         role: 'assistant'
@@ -614,7 +615,11 @@ describe('reconcileActiveTranscript', () => {
     const assistants = messages.filter(message => message.role === 'assistant')
 
     expect(assistants).toHaveLength(1)
-    expect(assistants[0]).toMatchObject({ error: 'connection lost after completion', pending: false })
+    expect(assistants[0]).toMatchObject({
+      error: 'connection lost after completion',
+      errorSurface: { code: 'transport_lost', layer: 'streaming', retryable: true },
+      pending: false
+    })
   })
 
   it('resolves and hydrates a messaging session from the messaging sessions store', async () => {

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -707,6 +707,123 @@ describe('preserveLocalAssistantErrors', () => {
     expect(assistant?.error).toBe('OpenRouter 403')
     expect(assistant?.pending).toBe(false)
   })
+
+  it('merges a failed tail turn into its rehydrated assistant when renderer ids change', () => {
+    const hydrated = toChatMessages([
+      { role: 'user', content: 'read it', timestamp: 1 },
+      {
+        role: 'assistant',
+        content: '',
+        timestamp: 2,
+        tool_calls: [{ id: 'call-1', function: { name: 'read_file', arguments: '{"path":"README.md"}' } }]
+      },
+      { role: 'tool', tool_call_id: 'call-1', tool_name: 'read_file', content: 'contents', timestamp: 3 },
+      { role: 'assistant', content: 'Done.', timestamp: 4 }
+    ])
+
+    const hydratedAssistant = hydrated.find(message => message.role === 'assistant')!
+
+    const current: ChatMessage[] = [
+      {
+        id: 'optimistic-user',
+        parts: [{ text: 'read it', type: 'text' }],
+        role: 'user'
+      },
+      {
+        error: 'connection lost after completion',
+        id: 'assistant-live-before-hydration',
+        parts: hydratedAssistant.parts,
+        role: 'assistant',
+        timestamp: 2
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors(hydrated, current)
+    const assistants = merged.filter(message => message.role === 'assistant')
+
+    expect(assistants).toHaveLength(1)
+    expect(assistants[0]).toMatchObject({
+      error: 'connection lost after completion',
+      id: hydratedAssistant.id,
+      pending: false
+    })
+    expect(merged.filter(message => message.role === 'user')).toHaveLength(1)
+  })
+
+  it('does not match a later failed turn to identical assistant text from an older turn', () => {
+    const nextMessages: ChatMessage[] = [
+      { id: 'older-user', parts: [{ text: 'first', type: 'text' }], role: 'user' },
+      { id: 'older-assistant', parts: [{ text: 'Done.', type: 'text' }], role: 'assistant' },
+      { id: 'new-user', parts: [{ text: 'second', type: 'text' }], role: 'user' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages,
+      {
+        error: 'connection lost',
+        id: 'new-assistant-error',
+        parts: [{ text: 'Done.', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.filter(message => message.role === 'assistant').map(message => message.id)).toEqual([
+      'older-assistant',
+      'new-assistant-error'
+    ])
+  })
+
+  it('does not match a later failed turn to a reused tool-call id from an older turn', () => {
+    const nextMessages: ChatMessage[] = [
+      { id: 'older-user', parts: [{ text: 'first', type: 'text' }], role: 'user' },
+      { id: 'older-assistant', parts: [toolCallPart('call-reused')], role: 'assistant' },
+      { id: 'new-user', parts: [{ text: 'second', type: 'text' }], role: 'user' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages,
+      {
+        error: 'connection lost',
+        id: 'new-assistant-error',
+        parts: [toolCallPart('call-reused')],
+        role: 'assistant'
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.filter(message => message.role === 'assistant').map(message => message.id)).toEqual([
+      'older-assistant',
+      'new-assistant-error'
+    ])
+  })
+
+  it('does not match an unpersisted repeated prompt to an older identical turn', () => {
+    const nextMessages: ChatMessage[] = [
+      { id: 'stored-user', parts: [{ text: 'retry', type: 'text' }], role: 'user' },
+      { id: 'stored-assistant', parts: [{ text: 'Done.', type: 'text' }], role: 'assistant' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      ...nextMessages,
+      { id: 'optimistic-user', parts: [{ text: 'retry', type: 'text' }], role: 'user' },
+      {
+        error: 'connection lost',
+        id: 'new-assistant-error',
+        parts: [{ text: 'Done.', type: 'text' }],
+        role: 'assistant'
+      }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.filter(message => message.role === 'assistant').map(message => message.id)).toEqual([
+      'stored-assistant',
+      'new-assistant-error'
+    ])
+  })
 })
 
 describe('upsertToolPart', () => {

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -731,6 +731,7 @@ describe('preserveLocalAssistantErrors', () => {
       },
       {
         error: 'connection lost after completion',
+        errorSurface: { code: 'transport_lost', layer: 'streaming', retryable: true },
         id: 'assistant-live-before-hydration',
         parts: hydratedAssistant.parts,
         role: 'assistant',
@@ -744,6 +745,7 @@ describe('preserveLocalAssistantErrors', () => {
     expect(assistants).toHaveLength(1)
     expect(assistants[0]).toMatchObject({
       error: 'connection lost after completion',
+      errorSurface: { code: 'transport_lost', layer: 'streaming', retryable: true },
       id: hydratedAssistant.id,
       pending: false
     })
@@ -773,6 +775,31 @@ describe('preserveLocalAssistantErrors', () => {
       'older-assistant',
       'new-assistant-error'
     ])
+  })
+
+  it('does not transfer an older error to a later assistant produced by a hidden turn', () => {
+    // Hidden user directives are absent from the display projection, so their
+    // assistant can follow an earlier assistant under the same visible user.
+    const nextMessages: ChatMessage[] = [
+      { id: 'user-1', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      { id: 'widget-hydrated', parts: [{ text: 'Done.', type: 'text' }], role: 'assistant' }
+    ]
+
+    const currentMessages: ChatMessage[] = [
+      { id: 'user-1', parts: [{ text: 'question', type: 'text' }], role: 'user' },
+      {
+        error: 'old provider failure',
+        id: 'failed-before-widget',
+        parts: [{ text: 'Done.', type: 'text' }],
+        role: 'assistant'
+      },
+      { id: 'widget-live', parts: [{ text: 'Done.', type: 'text' }], role: 'assistant' }
+    ]
+
+    const merged = preserveLocalAssistantErrors(nextMessages, currentMessages)
+
+    expect(merged.find(message => message.id === 'widget-hydrated')?.error).toBeUndefined()
+    expect(merged.find(message => message.id === 'failed-before-widget')?.error).toBe('old provider failure')
   })
 
   it('does not match a later failed turn to a reused tool-call id from an older turn', () => {

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -40,6 +40,83 @@ const assistantTimelineMatch = (stored: ChatMessage, local: ChatMessage) => {
   return Boolean(storedText) && storedText === normalizedTimelineText(local)
 }
 
+const userTurnMatch = (stored: ChatMessage, local: ChatMessage) =>
+  stored.role === 'user' &&
+  local.role === 'user' &&
+  normalizedTimelineText(stored) === normalizedTimelineText(local) &&
+  (stored.attachmentRefs ?? []).join('\n') === (local.attachmentRefs ?? []).join('\n')
+
+/**
+ * Find the hydrated assistant representing a local failed tail turn.
+ *
+ * Text and provider tool-call ids are not globally unique, so the match is
+ * deliberately anchored to the last visible user turn on both timelines.
+ */
+const tailTurnAssistantMatchIndex = (
+  storedMessages: ChatMessage[],
+  localMessages: ChatMessage[],
+  localAssistantIndex: number
+) => {
+  if (
+    localMessages
+      .slice(localAssistantIndex + 1)
+      .some(message => message.role === 'user' && !message.hidden)
+  ) {
+    return -1
+  }
+
+  let localUserIndex = -1
+
+  for (let index = localAssistantIndex - 1; index >= 0; index -= 1) {
+    const message = localMessages[index]
+
+    if (message.role === 'user' && !message.hidden) {
+      localUserIndex = index
+
+      break
+    }
+  }
+
+  let storedUserIndex = -1
+
+  for (let index = storedMessages.length - 1; index >= 0; index -= 1) {
+    const message = storedMessages[index]
+
+    if (message.role === 'user' && !message.hidden) {
+      storedUserIndex = index
+
+      break
+    }
+  }
+
+  const localUserCount = localMessages
+    .slice(0, localAssistantIndex)
+    .filter(message => message.role === 'user' && !message.hidden).length
+
+  const storedUserCount = storedMessages.filter(message => message.role === 'user' && !message.hidden).length
+
+  if (
+    localUserIndex === -1 ||
+    storedUserIndex === -1 ||
+    localUserCount !== storedUserCount ||
+    !userTurnMatch(storedMessages[storedUserIndex], localMessages[localUserIndex])
+  ) {
+    return -1
+  }
+
+  const localAssistant = localMessages[localAssistantIndex]
+
+  for (let index = storedMessages.length - 1; index > storedUserIndex; index -= 1) {
+    const message = storedMessages[index]
+
+    if (message.role === 'assistant' && !message.hidden && assistantTimelineMatch(message, localAssistant)) {
+      return index
+    }
+  }
+
+  return -1
+}
+
 const timelinePartMatch = (stored: ChatMessagePart, local: ChatMessagePart) => {
   if (stored.type !== local.type) {
     return false
@@ -159,6 +236,18 @@ export function preserveLocalAssistantErrors(
     const message = currentMessages[index]
 
     if (message.role !== 'assistant' || !message.error || message.hidden || existingIds.has(message.id)) {
+      continue
+    }
+
+    const hydratedAssistantIndex = tailTurnAssistantMatchIndex(mergedNextMessages, currentMessages, index)
+
+    if (hydratedAssistantIndex !== -1) {
+      mergedNextMessages[hydratedAssistantIndex] = {
+        ...mergedNextMessages[hydratedAssistantIndex],
+        error: message.error,
+        pending: false
+      }
+
       continue
     }
 

--- a/apps/desktop/src/lib/chat-messages/reconciliation.ts
+++ b/apps/desktop/src/lib/chat-messages/reconciliation.ts
@@ -60,7 +60,7 @@ const tailTurnAssistantMatchIndex = (
   if (
     localMessages
       .slice(localAssistantIndex + 1)
-      .some(message => message.role === 'user' && !message.hidden)
+      .some(message => (message.role === 'user' || message.role === 'assistant') && !message.hidden)
   ) {
     return -1
   }
@@ -245,6 +245,7 @@ export function preserveLocalAssistantErrors(
       mergedNextMessages[hydratedAssistantIndex] = {
         ...mergedNextMessages[hydratedAssistantIndex],
         error: message.error,
+        ...(message.errorSurface ? { errorSurface: message.errorSurface } : {}),
         pending: false
       }
 


### PR DESCRIPTION
## Summary

- reconcile a renderer-only failed assistant with the equivalent hydrated assistant instead of appending a second visible bubble when their renderer ids differ;
- constrain semantic matching to the same visible tail user turn **and the final visible assistant in that turn**, so later assistant segments, repeated text, and provider-reused tool-call ids remain distinct;
- preserve the local structured error surface on the reconciled durable message;
- preserve the existing behavior when the failed user/assistant pair is genuinely absent from durable history.

## Why

`toChatMessages()` synthesizes renderer ids during hydration while retaining the database id separately as `rowId`. `preserveLocalAssistantErrors()` previously recognized an already-hydrated local error only by renderer `id`; an equivalent persisted turn with a rebuilt id therefore remained in the hydrated list while the local failed copy was appended after it.

This is the hydration/merge cause identified by @SnikzSoundProd in https://github.com/NousResearch/hermes-agent/issues/98524#issuecomment-5493843274. It is independent of #98864's streaming completion-boundary fix and #102034's proposed final-repository compaction deduplication.

The broad form of the suggested fix—matching the local error against any assistant in durable history—was not used. Assistant text and tool-call ids are not globally unique, and a single visible user turn can produce multiple assistant segments. This implementation consults semantic equivalence only after proving that the local error is the final visible assistant and both timelines have the same visible tail user turn and user-turn count.

## RED → GREEN

Evidence frame:

| Artifact | Revision |
|---|---|
| Historical RED base | `1e69c12b64dba4090eddffeae27f5a147068d34b` |
| Initial rebased candidate | `7ee2755fa4d66f9d892ffcc20cd5eef957b5ce89` |
| Reviewed product head | `7f0d7e96e47c3615f37b49f2d81ea8affcbc8bce` |
| Refreshed integration base | `966637323e6f90864e069dbc12755934c2c86387` |
| Current head | `fa8f5dbcc1a481b653f50787473ae58e49fd04c4` |

With the candidate tests present and the product file restored to current `main`, the real refresh-path and pure reconciliation witnesses are RED:

```text
2 failed, 109 skipped
expected assistant messages to have a length of 1 but got 2
```

Adversarial review found two additional regressions on the initial rebased candidate:

1. a later visible assistant produced through a hidden user directive could receive an older assistant's error when their text matched;
2. different-id reconciliation retained the error string but dropped `errorSurface`, degrading the structured recovery UI.

Both new controls fail on `7ee2755fa4d6` and pass on the reviewed head. On `7f0d7e96e47c`:

```text
Test Files  4 passed (4)
Tests       118 passed (118)
```

Focused coverage includes:

- durable transcript → `toChatMessages()` → `preserveLocalAssistantErrors()`;
- `reconcileActiveTranscript()` with a local failed tail and a freshly hydrated equivalent;
- a later assistant segment under the same visible user boundary;
- preservation of structured `errorSurface` metadata;
- identical assistant text in different turns;
- provider-reused tool-call ids in different turns;
- an unpersisted repeated prompt matching an older prompt;
- the existing omitted-failed-turn and same-id preservation contracts.

## Validation

```text
Historical focused suites on 7f0d7e96e47c: 118 passed
Current changed-path suites:              114 passed
Current adjacent state/render matrix:      63 passed
Current Desktop typecheck:                 passed
Current targeted ESLint:                   passed, 0 warnings
Current production build:                  passed
Current diff hygiene:                      passed
Hosted required CI on fa8f5dbcc1a4:        passed
```

The complete local UI run reported `7223 passed, 9 failed`. Eight failures passed when rerun in isolation and were timing/resource interference outside the changed paths. The remaining unrelated test invokes `sh`, which is unavailable in this Windows environment; the PR does not touch that test or its implementation.

## Related work and scope

- **Refs #98524**: this fixes one demonstrated hydration/merge cause. It does not claim to explain the reporter's exact incident without evidence that the local copy carried an error.
- #98864 fixes a separate streaming event-order cause and is intentionally unchanged.
- #102034 proposes a later renderer-repository deduplication path for post-compaction duplicates; it does not supersede this one-row failed-tail reconciliation case.
- #90667 and #87273 modify adjacent local-error reconciliation contracts but remain open. This PR should refresh composition if either lands first; it does not pre-adopt their independently scoped stale-error behavior.
- Attachment-representation normalization remains outside this demonstrated text-only witness; the matcher fails conservatively rather than collapsing an unproven pair.

