### PR TITLE
fix(line): scope allow_all/allowlists/webhook config/home_channel per profile

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -678,7 +678,14 @@ def _csv_set(value: str) -> Set[str]:
 
 
 def _truthy_env(name: str, default: bool = False) -> bool:
-    v = os.getenv(name)
+    """Scope-aware boolean env read (see ``_get_scoped_secret``'s docstring).
+
+    Used for ``LINE_ALLOW_ALL_USERS`` — a raw ``os.getenv`` here would let a
+    secondary multiplex profile borrow (or be overridden by) the default
+    profile's bridged value for what is an authorization gate, not just a
+    display setting.
+    """
+    v = _get_scoped_secret(name)
     if v is None:
         return default
     return v.strip().lower() in {"1", "true", "yes", "on"}
@@ -713,12 +720,15 @@ class LineAdapter(BasePlatformAdapter):
         # Webhook server. Host default is ``None`` → dual-stack bind (both
         # IPv4 and IPv6); see DEFAULT_HOST above. ``LINE_HOST``/extra.host pin
         # a specific address when needed; empty string collapses to None.
+        # Scope-aware (see _get_scoped_secret's docstring): a secondary
+        # multiplex profile must not borrow the default profile's bridged
+        # LINE_HOST/LINE_PORT/LINE_PUBLIC_URL/allowlist env values.
         self.webhook_host = (
-            os.getenv("LINE_HOST") or extra.get("host", DEFAULT_HOST) or DEFAULT_HOST
+            _get_scoped_secret("LINE_HOST") or extra.get("host", DEFAULT_HOST) or DEFAULT_HOST
         )
         try:
             self.webhook_port = int(
-                os.getenv("LINE_PORT") or extra.get("port", DEFAULT_WEBHOOK_PORT)
+                _get_scoped_secret("LINE_PORT") or extra.get("port", DEFAULT_WEBHOOK_PORT)
             )
         except (TypeError, ValueError):
             self.webhook_port = DEFAULT_WEBHOOK_PORT
@@ -727,7 +737,7 @@ class LineAdapter(BasePlatformAdapter):
         # Public base URL — required for media sending when bind isn't
         # publicly reachable.
         self.public_base_url = (
-            os.getenv("LINE_PUBLIC_URL")
+            _get_scoped_secret("LINE_PUBLIC_URL")
             or extra.get("public_url", "")
             or ""
         ).rstrip("/")
@@ -737,13 +747,13 @@ class LineAdapter(BasePlatformAdapter):
             "LINE_ALLOW_ALL_USERS", bool(extra.get("allow_all_users", False))
         )
         self.allowed_users = _csv_set(
-            os.getenv("LINE_ALLOWED_USERS", "")
+            _get_scoped_secret("LINE_ALLOWED_USERS", "")
         ) | set(extra.get("allowed_users", []))
         self.allowed_groups = _csv_set(
-            os.getenv("LINE_ALLOWED_GROUPS", "")
+            _get_scoped_secret("LINE_ALLOWED_GROUPS", "")
         ) | set(extra.get("allowed_groups", []))
         self.allowed_rooms = _csv_set(
-            os.getenv("LINE_ALLOWED_ROOMS", "")
+            _get_scoped_secret("LINE_ALLOWED_ROOMS", "")
         ) | set(extra.get("allowed_rooms", []))
 
         # Slow-LLM postback button threshold
@@ -1625,18 +1635,27 @@ def _env_enablement() -> Optional[Dict[str, Any]]:
     """
     if not (_get_scoped_secret("LINE_CHANNEL_ACCESS_TOKEN") and _get_scoped_secret("LINE_CHANNEL_SECRET")):
         return None
+    # Scope-aware (see _get_scoped_secret's docstring): this seeds
+    # PlatformConfig.extra directly, so a raw os.getenv here would auto-seed
+    # a secondary multiplex profile with the default profile's bridged
+    # port/host/public_url/home_channel — home_channel is a cron-delivery
+    # target, so this was a real message-misdelivery risk, not just cosmetic.
     seeded: Dict[str, Any] = {}
-    if os.getenv("LINE_PORT"):
+    _port = _get_scoped_secret("LINE_PORT")
+    if _port:
         try:
-            seeded["port"] = int(os.environ["LINE_PORT"])
+            seeded["port"] = int(_port)
         except ValueError:
             pass
-    if os.getenv("LINE_HOST"):
-        seeded["host"] = os.environ["LINE_HOST"]
-    if os.getenv("LINE_PUBLIC_URL"):
-        seeded["public_url"] = os.environ["LINE_PUBLIC_URL"]
-    if os.getenv("LINE_HOME_CHANNEL"):
-        seeded["home_channel"] = os.environ["LINE_HOME_CHANNEL"]
+    _host = _get_scoped_secret("LINE_HOST")
+    if _host:
+        seeded["host"] = _host
+    _public_url = _get_scoped_secret("LINE_PUBLIC_URL")
+    if _public_url:
+        seeded["public_url"] = _public_url
+    _home_channel = _get_scoped_secret("LINE_HOME_CHANNEL")
+    if _home_channel:
+        seeded["home_channel"] = _home_channel
     return seeded or {}
 
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -383,6 +383,144 @@ class TestAdapterInit:
 
 
 # ---------------------------------------------------------------------------
+# 10. Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s allow_all/allowed_users/allowed_groups/allowed_rooms/
+# webhook_host/webhook_port/public_base_url, and _env_enablement's
+# port/host/public_url/home_channel, all previously read raw os.getenv
+# unconditionally. Under multiplex, os.environ holds the DEFAULT profile's
+# YAML-to-env bridge output — a secondary profile with its own (different or
+# absent) LINE config would silently inherit the default profile's
+# allow-all flag, allowlists, or (for _env_enablement) get auto-seeded with
+# the default's home_channel — a cron-delivery target, so a real
+# message-misdelivery risk, not just cosmetic. Mirrors the Buzz/SimpleX fix
+# for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("LINE_ALLOW_ALL_USERS", "true")
+    monkeypatch.setenv("LINE_ALLOWED_USERS", "Udefault")
+    monkeypatch.setenv("LINE_HOST", "default.example.com")
+    monkeypatch.setenv("LINE_PORT", "9111")
+    monkeypatch.setenv("LINE_PUBLIC_URL", "https://default.example.com")
+    monkeypatch.setenv("LINE_HOME_CHANNEL", "Udefault-home")
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "default-token")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "default-secret")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config is authoritative, not the
+        default profile's bridged allow-all flag/allowlist/host/port."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "allow_all_users": False,
+                "allowed_users": ["Uprofile"],
+                "host": "profile.example.com",
+                "port": 8000,
+                "public_url": "https://profile.example.com",
+            },
+        )
+        adapter = LineAdapter(cfg)
+        assert adapter.allow_all is False
+        assert adapter.allowed_users == {"Uprofile"}
+        assert adapter.webhook_host == "profile.example.com"
+        assert adapter.webhook_port == 8000
+        assert adapter.public_base_url == "https://profile.example.com"
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's config must NOT borrow the default
+        profile's bridged env values — that would silently open the bot to
+        every LINE user via the leaked allow-all flag."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.allow_all is False
+        assert adapter.allowed_users == set()
+        assert adapter.webhook_host is None  # DEFAULT_HOST — dual-stack bind, not the leaked default.example.com
+        assert adapter.public_base_url == ""
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter.allow_all is True
+        assert adapter.allowed_users == {"Udefault"}
+        assert adapter.webhook_host == "default.example.com"
+        assert adapter.webhook_port == 9111
+
+    def test_env_enablement_scoped_reads_own_home_channel_not_defaults(
+        self, multiplex_scope
+    ):
+        """A secondary profile's own .env (via the scope) seeds its own
+        home_channel; the default profile's bridged value must not leak in
+        when the scope lacks it (cron misdelivery risk)."""
+        multiplex_scope(
+            {
+                "LINE_CHANNEL_ACCESS_TOKEN": "profile-token",
+                "LINE_CHANNEL_SECRET": "profile-secret",
+                "LINE_HOME_CHANNEL": "Uprofile-home",
+            }
+        )
+        seeded = _env_enablement()
+        assert seeded["home_channel"] == "Uprofile-home"
+
+    def test_env_enablement_scoped_without_own_home_channel_does_not_borrow_default(
+        self, multiplex_scope, default_profile_env
+    ):
+        multiplex_scope(
+            {
+                "LINE_CHANNEL_ACCESS_TOKEN": "profile-token",
+                "LINE_CHANNEL_SECRET": "profile-secret",
+            }
+        )
+        seeded = _env_enablement()
+        assert "home_channel" not in (seeded or {})
+
+
+# ---------------------------------------------------------------------------
 # 9. Inbound message-type classification
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What & why

`LineAdapter.__init__` read `LINE_ALLOW_ALL_USERS`/`LINE_ALLOWED_USERS`/`LINE_ALLOWED_GROUPS`/`LINE_ALLOWED_ROOMS`/`LINE_HOST`/`LINE_PORT`/`LINE_PUBLIC_URL` via raw `os.getenv`, checked BEFORE `config.extra` (or unioned with it for the three allowlists). Under `gateway.multiplex_profiles`, a secondary profile would silently inherit the default profile's bridged allow-all flag (genuine authorization bypass — `LINE_ALLOW_ALL_USERS` opens the bot to every LINE user) and allowlists, or have its own webhook host/port/public URL overridden.

`_env_enablement()` had the same shape for `port`/`host`/`public_url`/`home_channel` — `home_channel` is a cron-delivery target, so a secondary profile with no LINE config of its own could get auto-seeded with the default profile's home channel and misdeliver notices there.

## Fix

Reuses this adapter's own established `_get_scoped_secret()` helper (already used for `LINE_CHANNEL_ACCESS_TOKEN`/`LINE_CHANNEL_SECRET` a few lines above each of these) instead of adding a new mechanism — it already has the correct semantics: scoped secondary profiles read their own `.env`-derived scope only (no cross-profile borrow), the default profile's unscoped construction path keeps legacy `os.getenv` precedence, and single-profile deployments are unaffected.

Fixing the raw env reads to go through it also resolves the three-allowlist union concern as a side effect: once `LINE_ALLOWED_USERS`/`GROUPS`/`ROOMS` are scope-aware, unioning them with `config.extra`'s own list only ever combines values that legitimately belong to the same profile.

## Tests

Extends `tests/gateway/test_line_plugin.py` with a `TestMultiplexProfileScope` class mirroring the established Buzz/SimpleX/A2A/Raft/Discord/Telegram/WhatsApp coverage for this bug class, plus two `_env_enablement`-specific tests for the `home_channel` cron-misdelivery case.

- `tests/gateway/test_line_plugin.py` — 36 passed
- `tests/gateway/test_adapter_startup_secret_scope.py` (the other file importing this module) — 75 passed
- Mutation-verify: reverting the fix makes 4 of the 5 new tests fail as expected (the 5th exercises the unscoped/single-profile path, which was never buggy)

## Competitor check

Searched `LINE_ALLOW_ALL_USERS`, "line multiplex profile", `LINE_HOME_CHANNEL`, "line adapter allowlist" (all PR/issue states). Open PR #88559 ("read adapter allowlists through profile secret scope") does **not** touch LINE (confirmed via `gh pr view --json files`: matrix/wecom/feishu/email/qqbot/signal/weixin/yuanbao only). Open PR #52237 does touch this exact file + test file, but its diff is entirely in `_handle_message_event` (adds a `role_authorized` flag bridging LINE's group/room allowlist decision to the gateway's own re-authorization, mirroring Discord's `role_authorized` pattern) — a different function, different concern, zero line-level overlap with this fix.