### PR TITLE
feat(desktop): flat Bots roster with gateway chips behind a "Group by gateway" toggle

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.test.tsx
@@ -58,8 +58,8 @@ vi.mock('./roster-actions', () => ({ openRosterBot }))
 
 const noop = () => undefined
 
-function renderRow(bot: RosterRow) {
-  render(<BotRow bot={bot} onDelete={noop} onEdit={noop} onGroup={noop} />)
+function renderRow(bot: RosterRow, props: { showGateway?: boolean } = {}) {
+  render(<BotRow bot={bot} onDelete={noop} onEdit={noop} onGroup={noop} {...props} />)
 
   return screen.getByRole('button')
 }
@@ -173,5 +173,58 @@ describe('context-menu mutations hydrate the alias first', () => {
 
     expect(route.profile).toBe('worker')
     expect(params).toMatchObject({ name: 'backend-worker', ui_meta: { 'hermes-bots': { pinned: false } } })
+  })
+})
+
+describe('the gateway chip only appears when the pane asks for it', () => {
+  it('names the gateway on the row when the roster is a flat multi-gateway list', () => {
+    const row = renderRow(
+      {
+        connectionId: 'work',
+        connectionKind: 'ssh',
+        connectionLabel: 'Work',
+        name: 'research',
+        remoteSource: true,
+        sourceScoped: true
+      } as RosterRow,
+      { showGateway: true }
+    )
+
+    const chip = row.querySelector('[data-slot="badge"]')
+
+    expect(chip?.textContent).toBe('Work')
+    expect(chip?.querySelector('[data-connection-kind="ssh"]')).not.toBeNull()
+  })
+
+  it('stays off a grouped or single-gateway roster, where the heading already says it', () => {
+    const row = renderRow({
+      connectionId: 'work',
+      connectionLabel: 'Work',
+      name: 'research',
+      remoteSource: true,
+      sourceScoped: true
+    } as RosterRow)
+
+    expect(row.querySelector('[data-slot="badge"]')).toBeNull()
+    expect(row.textContent).not.toContain('Work')
+  })
+
+  it('flags an unreachable gateway on the chip, in words as well as tone', () => {
+    const row = renderRow(
+      {
+        connectionId: 'work',
+        connectionLabel: 'Work',
+        name: 'research',
+        remoteSource: true,
+        sourceReachable: false,
+        sourceScoped: true
+      } as RosterRow,
+      { showGateway: true }
+    )
+
+    const chip = row.querySelector('[data-slot="badge"]')
+
+    expect(chip?.className).toContain('amber')
+    expect(chip?.textContent).toContain('Unavailable')
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -7,6 +7,7 @@
  */
 
 import {
+  Badge,
   cn,
   coarseElapsed,
   Codicon,
@@ -59,6 +60,7 @@ import { useBots } from './i18n'
 import { displayName, stripPreviewMarkdown } from './labels'
 import { duplicateBot } from './profile-ops'
 import { openRosterBot } from './roster-actions'
+import { GatewayKindGlyph } from './roster-sections'
 import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
 import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, previewKind, workerActiveAt } from './row-helpers'
 import type { GroupMember, RosterRow, SidebarRowLabels } from './types'
@@ -81,10 +83,14 @@ interface BotRowProps {
   onDelete: (bot: RosterRow) => void
   onEdit: (bot: RosterRow) => void
   onGroup: (bot: RosterRow) => void
+  /** Label the row with its gateway. The pane asks for it when the roster is
+   *  a flat multi-gateway list, where no section heading says which gateway
+   *  a bot belongs to. */
+  showGateway?: boolean
   showHandle?: boolean
 }
 
-export function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }: BotRowProps) {
+export function BotRow({ bot, onDelete, onEdit, onGroup, showGateway, showHandle }: BotRowProps) {
   const { t } = useI18n()
   const b = useBots()
   const activeProfile = useValue(host.state.profile)
@@ -174,7 +180,8 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }: BotRowPro
 
   const handle = botHandle(bot.name, bot)
   const gatewayLabel = bot.connectionLabel || (bot.connectionId === 'local' ? 'This device' : '')
-  const showDetailsRow = Boolean(showHandle || displayPreview || fromBot)
+  const gatewayChip = showGateway ? gatewayLabel || String(bot.connectionId || '') : ''
+  const showDetailsRow = Boolean(gatewayChip || showHandle || displayPreview || fromBot)
 
   const rowTooltip = [displayName(bot, meta), `@${handle}`, gatewayLabel, sourceStatus.label]
     .filter(Boolean)
@@ -267,6 +274,19 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, showHandle }: BotRowPro
         </div>
         {showDetailsRow ? (
           <div className="flex min-w-0 items-center gap-1.5 text-xs text-(--ui-text-tertiary)">
+            {gatewayChip ? (
+              // Amber when the gateway is unreachable, same as its section
+              // heading and picker entry; the status text stays for readers.
+              <Badge
+                className="max-w-[45%] shrink-0 gap-1 font-normal"
+                size="xs"
+                variant={sourceStatus.available ? 'muted' : 'warn'}
+              >
+                <GatewayKindGlyph className="size-2.5" kind={bot.connectionKind} />
+                <span className="min-w-0 truncate">{gatewayChip}</span>
+                {sourceStatus.available ? null : <span className="sr-only">{sourceStatus.label}</span>}
+              </Badge>
+            ) : null}
             {showHandle ? (
               <span className="shrink-0 font-mono text-[0.6875rem] text-(--ui-text-quaternary)">{`@${handle}`}</span>
             ) : null}

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -60,6 +60,9 @@ type BotsMessages = {
     botsAndGroups: string
     botsOnly: string
     groupsOnly: string
+    /** View toggle in the filter menu: one foldable section per gateway (on)
+     *  or one flat list with a gateway chip on each row (off). */
+    groupByGateway: string
     /** The activity filter's four options, in menu order. */
     anyActivity: string
     activeNow: string
@@ -269,6 +272,7 @@ const en: BotsMessages = {
     botsAndGroups: 'Bots and group chats',
     botsOnly: 'Bots only',
     groupsOnly: 'Group chats only',
+    groupByGateway: 'Group by gateway',
     anyActivity: 'Any activity',
     activeNow: 'Active now',
     recentlyActive: 'Recently active',
@@ -464,6 +468,7 @@ const ja: BotsMessages = {
     botsAndGroups: 'ボットとグループチャット',
     botsOnly: 'ボットのみ',
     groupsOnly: 'グループチャットのみ',
+    groupByGateway: 'ゲートウェイごとにグループ化',
     anyActivity: 'すべてのアクティビティ',
     activeNow: '現在アクティブ',
     recentlyActive: '最近アクティブ',
@@ -658,6 +663,7 @@ const zh: BotsMessages = {
     botsAndGroups: '机器人和群聊',
     botsOnly: '仅机器人',
     groupsOnly: '仅群聊',
+    groupByGateway: '按网关分组',
     anyActivity: '任何活动',
     activeNow: '正在活动',
     recentlyActive: '最近活跃',
@@ -851,6 +857,7 @@ const zhHant: BotsMessages = {
     botsAndGroups: '機器人和群組聊天',
     botsOnly: '僅機器人',
     groupsOnly: '僅群組聊天',
+    groupByGateway: '依閘道器分組',
     anyActivity: '任何活動',
     activeNow: '目前活躍',
     recentlyActive: '最近活躍',

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -59,7 +59,7 @@ import { annotateOrphanedGroupChatMembers } from './hygiene'
 import { BOTS_LOCALES } from './i18n'
 import { displayName } from './labels'
 import { startBotRelay, stopBotRelay } from './relay'
-import { $activityToasts } from './roster-actions'
+import { $activityToasts, $rosterGroupedByGateway } from './roster-actions'
 import {
   botChatOwnsWorkspace,
   BotsPane,
@@ -213,6 +213,20 @@ export default {
         .catch(() => undefined)
     } catch {
       /* no storage — default (silent) stays */
+    }
+
+    // Hydrate the group-by-gateway roster pref (default ON).
+    try {
+      // @ts-expect-error TODO(bot-mode-types): PluginStorage.get requires a fallback argument.
+      Promise.resolve(ctx.storage?.get?.('roster-group-by-gateway'))
+        .then(value => {
+          if (typeof value === 'boolean') {
+            $rosterGroupedByGateway.set(value)
+          }
+        })
+        .catch(() => undefined)
+    } catch {
+      /* no storage — default (grouped) stays */
     }
 
     // Hydrate persisted group-chat room logs (epoch/running are runtime-only

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.test.ts
@@ -211,3 +211,21 @@ describe('the toast preference', () => {
     expect($activityToasts.get()).toBe(false)
   })
 })
+
+describe('the group-by-gateway preference', () => {
+  it('defaults to grouped and persists through the plugin storage without throwing', async () => {
+    const { $rosterGroupedByGateway, setRosterGroupedByGateway } = await loadActions()
+
+    expect($rosterGroupedByGateway.get()).toBe(true)
+
+    setRosterGroupedByGateway(false)
+    expect($rosterGroupedByGateway.get()).toBe(false)
+    expect(storageMock.set).toHaveBeenCalledWith('roster-group-by-gateway', false)
+
+    storageMock.set.mockImplementation(() => {
+      throw new Error('storage unavailable')
+    })
+    expect(() => setRosterGroupedByGateway(true)).not.toThrow()
+    expect($rosterGroupedByGateway.get()).toBe(true)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -43,6 +43,24 @@ export function setActivityToasts(enabled: boolean) {
   }
 }
 
+/** User pref: bucket the roster under one foldable heading per gateway
+ *  (default ON — the shape a multi-gateway roster has always had). OFF lists
+ *  every bot in one flat, activity-sorted list and each row carries a
+ *  gateway chip instead. Presentation only: it never filters a row out.
+ *  Persisted via ctx.storage. */
+export const $rosterGroupedByGateway = atom(true)
+
+/** Flip the group-by-gateway pref and persist it. */
+export function setRosterGroupedByGateway(enabled: boolean) {
+  $rosterGroupedByGateway.set(enabled)
+
+  try {
+    Promise.resolve(getPluginCtx()?.storage?.set?.('roster-group-by-gateway', enabled)).catch(() => undefined)
+  } catch {
+    /* storage unavailable — pref holds for this window only */
+  }
+}
+
 /** Detect new inbound activity from a fresh roster: last_active moved past
  *  the watermark for a bot whose chat isn't on screen -> unread + toast.
  *  Watermarks follow botActivitySession (canonical Bot Chat included) —

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -63,7 +63,13 @@ import { $groupMainTabsRev, shouldRenderGroupChatInPane } from './group-panes'
 import { $showHiddenBots, isBotHidden, isBotPinned } from './hidden-bots'
 import { useBots } from './i18n'
 import { deleteBot, mergeServerMeta, pullServerAvatars } from './profile-ops'
-import { $activityToasts, setActivityToasts, trackInboundActivity } from './roster-actions'
+import {
+  $activityToasts,
+  $rosterGroupedByGateway,
+  setActivityToasts,
+  setRosterGroupedByGateway,
+  trackInboundActivity
+} from './roster-actions'
 import {
   botNeedsHandleLabel,
   filterBotsByGateway,
@@ -259,6 +265,7 @@ export function BotsPane() {
   const [collapsedRosterSections, setCollapsedRosterSections] = useState<Set<string>>(() => new Set())
   const hiddenSectionRef = useRef<null | HTMLDivElement>(null)
   const activityToasts = useValue($activityToasts)
+  const groupedByGateway = useValue($rosterGroupedByGateway)
   const groupChatName = useValue($groupChatWorkspace)
   // Main-tab ownership is a module Map; this rev subscription makes the
   // shouldRenderGroupChatInPane gate below reactive to tab open/close
@@ -405,8 +412,12 @@ export function BotsPane() {
 
   const rosterRows = sortRosterRows([...botRows, ...groupRows])
   const sortedGroupRows = sortRosterRows(groupRows)
-  const gatewaySections = rosterGatewaySections(botRows, gatewayOptions, gatewayFilter)
+  const gatewaySections = rosterGatewaySections(botRows, gatewayOptions, gatewayFilter, groupedByGateway)
   const showGatewaySections = gatewaySections.sectioned && botRows.length > 0
+  // Flat multi-gateway list: the heading no longer says which gateway a row
+  // belongs to, so each row carries a gateway chip instead. A filtered view
+  // already names the gateway in the picker; a single gateway needs no label.
+  const showGatewayChips = !groupedByGateway && gatewayFilter === 'all' && gatewayOptions.length > 1
 
   const activeFilterCount =
     (rowKindFilter === 'all' ? 0 : 1) + (activityFilter === 'all' ? 0 : 1) + (gatewayFilter === 'all' ? 0 : 1)
@@ -438,7 +449,8 @@ export function BotsPane() {
       bot
     })),
     gatewayOptions,
-    gatewayFilter
+    gatewayFilter,
+    groupedByGateway
   )
 
   const toggleRosterSection = (id: string): void => {
@@ -533,6 +545,7 @@ export function BotsPane() {
       onDelete={setDeleting}
       onEdit={setEditing}
       onGroup={setGrouping}
+      showGateway={showGatewayChips}
       showHandle={botNeedsHandleLabel(bot, roster, allMeta)}
     />
   )
@@ -737,6 +750,17 @@ export function BotsPane() {
                       )
                     })
                   : []}
+                {gatewayOptions.length > 1 ? <DropdownMenuSeparator /> : null}
+                {gatewayOptions.length > 1 ? (
+                  // A view preference, not a filter: it never hides a row, so it
+                  // neither counts toward the active-filter badge nor resets
+                  // with "Clear filters".
+                  <DropdownMenuItem onSelect={() => setRosterGroupedByGateway(!groupedByGateway)}>
+                    <Codicon className="mr-1.5" name="group-by-ref-type" />
+                    <span className="min-w-0 flex-1">{b.roster.groupByGateway}</span>
+                    {groupedByGateway ? <Codicon name="check" /> : null}
+                  </DropdownMenuItem>
+                ) : null}
                 {activeFilterCount ? <DropdownMenuSeparator /> : null}
                 {activeFilterCount ? (
                   <DropdownMenuItem

--- a/apps/desktop/src/plugins/hermes-bots/roster-sections.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-sections.test.ts
@@ -1,0 +1,48 @@
+/**
+ * When the roster buckets bots under gateway headings, and when it lists them
+ * flat.
+ *
+ * Sectioning is a presentation choice layered over the row list: it must never
+ * drop or reorder a row, and it must step aside whenever a heading could not
+ * tell rows apart (one gateway, a gateway filter) or the user asked for a flat
+ * list. Everything the pane renders hangs off `sectioned`, so these pin the
+ * contract rather than the markup.
+ */
+
+import { describe, expect, it } from 'vitest'
+
+import { rosterGatewaySections } from './roster-sections'
+import type { RosterRow } from './types'
+
+const row = (name: string, connectionId: string) => ({ kind: 'bot', bot: { connectionId, name } as RosterRow }) as const
+
+const local = { connectionId: 'local', kind: 'local', label: 'This device' }
+const work = { connectionId: 'work', kind: 'ssh', label: 'Work' }
+
+const rows = [row('alpha', 'work'), row('beta', 'local'), row('gamma', 'work')]
+
+describe('gateway sections', () => {
+  it('buckets rows per gateway when more than one gateway is known', () => {
+    const result = rosterGatewaySections(rows, [local, work])
+
+    expect(result.sectioned).toBe(true)
+    expect(result.sections.map(section => [section.id, section.rows.map(r => r.bot.name)])).toEqual([
+      ['local', ['beta']],
+      ['work', ['alpha', 'gamma']]
+    ])
+  })
+
+  it('stays flat for a single gateway or a gateway filter', () => {
+    expect(rosterGatewaySections(rows, [work]).sectioned).toBe(false)
+    expect(rosterGatewaySections(rows, [local, work], 'work').sectioned).toBe(false)
+  })
+
+  it('lists every row flat, in the order given, when grouping is switched off', () => {
+    const result = rosterGatewaySections(rows, [local, work], 'all', false)
+
+    expect(result.sectioned).toBe(false)
+    expect(result.sections).toHaveLength(1)
+    expect(result.sections[0].option).toBeNull()
+    expect(result.sections[0].rows).toBe(rows)
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-sections.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-sections.tsx
@@ -127,15 +127,21 @@ export function rosterGatewayOptions(sources: GatewaySource[], roster: RosterRow
   )
 }
 
+/** Bucket bot rows under one section per gateway. Sectioning only happens
+ *  when it can tell rows apart: the filter is "all gateways", more than one
+ *  gateway is known, and the user has not switched the roster to a flat list
+ *  (`grouped`). Otherwise every row comes back in a single unlabeled
+ *  section, in the order it was given. */
 export function rosterGatewaySections<TRow extends RosterGatewayRow>(
   botRows: TRow[],
   gatewayOptions: RosterGatewayOption[],
-  gatewayFilter = 'all'
+  gatewayFilter = 'all',
+  grouped = true
 ): { sectioned: boolean; sections: RosterGatewaySection<TRow>[] } {
   const rows = Array.isArray(botRows) ? botRows : []
   const options = Array.isArray(gatewayOptions) ? gatewayOptions : []
 
-  if (gatewayFilter !== 'all' || options.length <= 1) {
+  if (!grouped || gatewayFilter !== 'all' || options.length <= 1) {
     return {
       sectioned: false,
       sections: [


### PR DESCRIPTION
## What does this PR do?

Adds a **"Group by gateway"** view toggle to the Bots roster filter menu in Desktop's Bot Mode. It is ON by default, so a multi-gateway roster keeps the foldable per-gateway sections it has today. Switched OFF, every bot lists in one flat, activity-sorted list and each row carries a small **gateway chip** (kind glyph + label, amber when the gateway is unreachable) in place of the section heading.

Why this shape:

- The flat list is the render path the gateway filter already uses, so no new list code: `rosterGatewaySections` just gains a `grouped` flag.
- It is a view preference, not a filter. It never hides a row, does not count toward the active-filter badge, and is not reset by "Clear filters".
- Persisted through plugin storage (`roster-group-by-gateway`), hydrated at plugin load exactly like the activity-toasts pref.
- Chips render only for the flat, unfiltered, multi-gateway roster. A single gateway needs no label, and a filtered view already names the gateway in the picker.
- Menu item only appears when more than one gateway is known, same gate as the gateway picker.

One trade-off worth knowing: in flat mode two same-named bots on different gateways sit next to each other. `botNeedsHandleLabel` only disambiguates within one gateway, so the chip is what tells them apart there. I left that as is rather than add `@handle` to rows that don't need it.

## Related Issue

Fixes #100608

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

All under `apps/desktop/src/plugins/hermes-bots/`:

- `roster-sections.tsx`: `rosterGatewaySections(rows, options, filter, grouped = true)`; `grouped: false` returns the single flat section.
- `roster-actions.ts`: `$rosterGroupedByGateway` atom + `setRosterGroupedByGateway()` persisting via `ctx.storage`.
- `plugin.tsx`: hydrate the pref next to the activity-toasts block.
- `roster-pane.tsx`: menu item after the gateway picker; passes `grouped` to both section builders; `showGateway` to `BotRow` when the roster is flat, unfiltered and multi-gateway.
- `bot-row.tsx`: new `showGateway` prop renders a `Badge` (`muted`, or `warn` when unreachable, size `xs`) with `GatewayKindGlyph` + label at the start of the details row. Unreachable adds an `sr-only` status label.
- `i18n.ts`: `roster.groupByGateway` in en, ja, zh, zh-hant.
- Tests: new `roster-sections.test.ts` (sectioning contract), `bot-row.test.tsx` (chip present only with `showGateway`, warn tone + status text when unreachable), `roster-actions.test.ts` (pref default, persistence, no throw without storage).

No new `HERMES_*` env vars, no core changes, no new SDK surface.

## How to Test

1. Register at least two gateways (e.g. this device + one remote connection) with a bot on each, open the Bots rail.
2. Open the roster filter menu (funnel icon). Below the gateway picker there is a new "Group by gateway" item with a check mark.
3. Select it: the sections disappear, bots list flat in activity order, and each row shows a chip with the gateway glyph and label. A gateway that is offline shows an amber chip.
4. Filter to one gateway: chips disappear (the picker already names it). Back to "All gateways": chips return.
5. Select "Group by gateway" again: sections return. Restart the app: the choice is remembered.
6. With a single gateway the item is not shown and nothing changes.

Automated, from `apps/desktop`:

```
npx vitest run --project ui src/plugins/hermes-bots   # 60 files, 577 tests pass
npm run typecheck
npm run lint
python ../../scripts/check-windows-footguns.py src/plugins/hermes-bots/
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, desktop-only change; the desktop vitest suite for the plugin passes (577 tests)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (in-code docs only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer-only, `check-windows-footguns.py` clean
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before (grouped, default) vs after (flat + gateway chip), dark:

![roster dark](https://raw.githubusercontent.com/juanilealb/hermes-agent/pr-assets-flat-roster/roster-dark.png)

Light:

![roster light](https://raw.githubusercontent.com/juanilealb/hermes-agent/pr-assets-flat-roster/roster-light.png)

The filter menu with the new item, ON and OFF:

<img src="https://raw.githubusercontent.com/juanilealb/hermes-agent/pr-assets-flat-roster/menu-dark-on.png" width="380"> <img src="https://raw.githubusercontent.com/juanilealb/hermes-agent/pr-assets-flat-roster/menu-dark-off.png" width="380">

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VpiPh6NtaiKVYtL8mAUALL
