### PR TITLE
fix(kanban): archive_task terminates a running worker instead of orphaning it

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7510,7 +7510,27 @@ def decompose_triage_task(
     return child_ids
 
 
-def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
+def archive_task(conn: sqlite3.Connection, task_id: str, *, signal_fn=None) -> bool:
+    # Upstream bug NousResearch/hermes-agent#76196: archiving a running task
+    # used to just null worker_pid in the DB without ever signalling the
+    # actual OS process, so a live worker kept running past its own archive
+    # and could still push/complete work against a task nothing tracks
+    # anymore. Mirror reclaim_task's termination pattern: read the prior
+    # claim/pid *before* the update, and — only if the task was actually
+    # running — best-effort SIGTERM/SIGKILL it via the same host-local-only
+    # helper reclaim_task already uses, before clearing the claim fields.
+    row = conn.execute(
+        "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return False
+    was_running = row["status"] == "running"
+    termination = None
+    if was_running:
+        termination = _terminate_reclaimed_worker(
+            row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
+        )
     with write_txn(conn):
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
@@ -7527,8 +7547,9 @@ def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
             conn, task_id,
             outcome="reclaimed", status="reclaimed",
             summary="task archived with run still active",
+            metadata=termination,
         )
-        _append_event(conn, task_id, "archived", None, run_id=run_id)
+        _append_event(conn, task_id, "archived", termination, run_id=run_id)
     # ``archived`` parents no longer block children, same as ``done``.
     # Promote newly-unblocked dependents immediately instead of waiting
     # for a later dispatcher tick.

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -244,6 +244,59 @@ def test_stale_claim_reclaim_event_records_diagnostic_payload(
         assert payload["host_local"] is True
 
 
+def test_archive_running_task_terminates_worker(kanban_home, monkeypatch):
+    """``archive_task`` on a *running* task must actually signal its
+    host-local worker process, not just null ``worker_pid`` in the DB
+    (#76196: previously a worker kept running past its own archive and
+    could still push/complete work against a task nothing tracks anymore,
+    with no record of the termination attempt for operators to audit)."""
+    import json
+    import hermes_cli.kanban_db as _kb
+
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        host = _kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        kb._set_worker_pid(conn, t, 54321)
+
+        monkeypatch.setattr(_kb, "_pid_alive", lambda _pid: False)
+        signalled = []
+        assert kb.archive_task(
+            conn, t,
+            signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        ) is True
+
+        assert signalled and signalled[0][0] == 54321
+
+        row = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'archived'",
+            (t,),
+        ).fetchone()
+        payload = json.loads(row["payload"])
+        assert payload["prev_pid"] == 54321
+        assert payload["host_local"] is True
+        assert payload["termination_attempted"] is True
+        assert payload["terminated"] is True
+
+        task = kb.get_task(conn, t)
+        assert task.status == "archived"
+
+
+def test_archive_non_running_task_does_not_attempt_termination(kanban_home):
+    """A ``ready``/``blocked``/``done`` task has no live worker to signal -
+    ``archive_task`` must not call ``signal_fn`` at all for those, only for
+    tasks that were actually ``running``."""
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x", assignee="a")
+        signalled = []
+        assert kb.archive_task(
+            conn, t,
+            signal_fn=lambda pid, sig: signalled.append((pid, sig)),
+        ) is True
+        assert signalled == []
+
+
 
 
 


### PR DESCRIPTION
## Summary
`archive_task` only nulled `worker_pid`/`claim_lock` in the DB and never signalled the actual OS process — unlike `reclaim_task`, which already does this correctly via `_terminate_reclaimed_worker`. A worker whose task got archived while `running` kept executing (observed: 5+ minutes, until it finished its turn and pushed a git commit against a task nothing tracked anymore), and the loss was unauditable since no event recorded the termination attempt.

Fixes #76196.

## Fix
Mirrors `reclaim_task`'s existing pattern exactly: read `status`/`claim_lock`/`worker_pid` *before* the update, and — only for tasks that were actually `running` — best-effort SIGTERM/SIGKILL the host-local worker via the same `_terminate_reclaimed_worker` helper `reclaim_task` already uses, recording the termination outcome on the `archived` event and run metadata.

Non-running tasks (`ready`/`blocked`/`done`) are unaffected — no termination is attempted since there's no live worker to signal.

## Test plan
- [x] Two new unit tests in `tests/hermes_cli/test_kanban_db.py`, following the exact pattern of the existing `test_stale_claim_reclaim_event_records_diagnostic_payload` test:
  - `test_archive_running_task_terminates_worker` — claims a task, sets a worker_pid, archives it, asserts `signal_fn` was called with that pid and the `archived` event payload carries `termination_attempted`/`terminated`.
  - `test_archive_non_running_task_does_not_attempt_termination` — archives a never-claimed task, asserts `signal_fn` is never called (no regression to the simple case).
- [x] Verified live end-to-end against a real dispatched worker on my own gateway: created a task, let it start executing a long-running tool call, ran `hermes kanban archive` on it mid-flight, confirmed the process was gone within the process-check window (clean SIGTERM, no SIGKILL escalation needed) — versus 5+ minutes of continued execution (culminating in an unwanted git push) before this fix.
- [x] `archive_task`'s only call site (`hermes_cli/kanban.py`) still calls it with exactly `(conn, tid)` — the new `signal_fn` parameter is keyword-only with a default, no signature break.