### PR TITLE
fix(dingtalk): scope require_mention/allowlists per profile

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -1835,29 +1835,66 @@ def _manual_credential_entry(prompt, save_env_value, print_success) -> None:
     print_success("DingTalk credentials saved")
 
 
+def _profile_scoped_config_load() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed and connected inside
+    ``_profile_runtime_scope`` (secret scope installed + multiplex active) —
+    the same discriminator the Buzz/Discord/Telegram/WhatsApp/LINE adapters
+    use for this bug class (#98738 / #72348 / #80099). The DEFAULT profile
+    under multiplexing runs unscoped: ``os.environ`` holds its own bridge
+    output there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
 def _apply_yaml_config(yaml_cfg: dict, dingtalk_cfg: dict) -> dict | None:
-    """Translate config.yaml dingtalk: keys into DINGTALK_* env vars.
+    """Translate config.yaml dingtalk: keys into DINGTALK_* env vars and
+    PlatformConfig.extra entries.
 
     Implements the apply_yaml_config_fn contract (#24849). Mirrors the legacy
     dingtalk_cfg block from gateway/config.py::load_gateway_config(). Env vars
-    take precedence over YAML (each assignment guarded by not os.getenv(...)).
-    Returns None — everything flows through env.
+    take precedence over YAML (each assignment guarded by not os.getenv(...))
+    for single-profile deployments.
+
+    Returns the bridged values as a dict, merged into this profile's
+    PlatformConfig.extra by the caller — every one of these fields is
+    already read extra-first (_dingtalk_require_mention/
+    _dingtalk_free_response_chats/_dingtalk_allowed_chats/
+    _compile_mention_patterns/_load_allowed_users), so seeding extra is both
+    how a scoped secondary profile's own YAML value reaches its adapter AND
+    how the process-global env write below is made skippable under
+    multiplex without losing single-profile behavior.
     """
     import json as _json
-    if "require_mention" in dingtalk_cfg and not os.getenv("DINGTALK_REQUIRE_MENTION"):
-        os.environ["DINGTALK_REQUIRE_MENTION"] = str(dingtalk_cfg["require_mention"]).lower()
-    if "mention_patterns" in dingtalk_cfg and not os.getenv("DINGTALK_MENTION_PATTERNS"):
-        os.environ["DINGTALK_MENTION_PATTERNS"] = _json.dumps(dingtalk_cfg["mention_patterns"])
+
+    _skip_env_bridge = _profile_scoped_config_load()
+    seeded: dict = {}
+    if "require_mention" in dingtalk_cfg:
+        seeded["require_mention"] = dingtalk_cfg["require_mention"]
+        if not _skip_env_bridge and not os.getenv("DINGTALK_REQUIRE_MENTION"):
+            os.environ["DINGTALK_REQUIRE_MENTION"] = str(dingtalk_cfg["require_mention"]).lower()
+    if "mention_patterns" in dingtalk_cfg:
+        seeded["mention_patterns"] = dingtalk_cfg["mention_patterns"]
+        if not _skip_env_bridge and not os.getenv("DINGTALK_MENTION_PATTERNS"):
+            os.environ["DINGTALK_MENTION_PATTERNS"] = _json.dumps(dingtalk_cfg["mention_patterns"])
     frc = dingtalk_cfg.get("free_response_chats")
-    if frc is not None and not os.getenv("DINGTALK_FREE_RESPONSE_CHATS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["DINGTALK_FREE_RESPONSE_CHATS"] = str(frc)
+    if frc is not None:
+        seeded["free_response_chats"] = frc
+        if not _skip_env_bridge and not os.getenv("DINGTALK_FREE_RESPONSE_CHATS"):
+            _frc = ",".join(str(v) for v in frc) if isinstance(frc, list) else str(frc)
+            os.environ["DINGTALK_FREE_RESPONSE_CHATS"] = _frc
     ac = dingtalk_cfg.get("allowed_chats")
-    if ac is not None and not os.getenv("DINGTALK_ALLOWED_CHATS"):
-        if isinstance(ac, list):
-            ac = ",".join(str(v) for v in ac)
-        os.environ["DINGTALK_ALLOWED_CHATS"] = str(ac)
+    if ac is not None:
+        seeded["allowed_chats"] = ac
+        if not _skip_env_bridge and not os.getenv("DINGTALK_ALLOWED_CHATS"):
+            _ac = ",".join(str(v) for v in ac) if isinstance(ac, list) else str(ac)
+            os.environ["DINGTALK_ALLOWED_CHATS"] = _ac
     allowed = dingtalk_cfg.get("allowed_users")
     if allowed is None:
         # Fall back to the documented nested paths (#44928). The docs
@@ -1884,11 +1921,12 @@ def _apply_yaml_config(yaml_cfg: dict, dingtalk_cfg: dict) -> dict | None:
                 if isinstance(_dt_extra, dict) and _dt_extra.get("allowed_users") is not None:
                     allowed = _dt_extra.get("allowed_users")
                     break
-    if allowed is not None and not os.getenv("DINGTALK_ALLOWED_USERS"):
-        if isinstance(allowed, list):
-            allowed = ",".join(str(v) for v in allowed)
-        os.environ["DINGTALK_ALLOWED_USERS"] = str(allowed)
-    return None
+    if allowed is not None:
+        seeded["allowed_users"] = allowed
+        if not _skip_env_bridge and not os.getenv("DINGTALK_ALLOWED_USERS"):
+            _allowed = ",".join(str(v) for v in allowed) if isinstance(allowed, list) else str(allowed)
+            os.environ["DINGTALK_ALLOWED_USERS"] = _allowed
+    return seeded or None
 
 
 def _is_connected(config) -> bool:

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -1,5 +1,6 @@
 """Tests for DingTalk platform adapter."""
 import asyncio
+import os
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -765,3 +766,91 @@ class TestDingTalkAdapterAICards:
         mock_card_sdk.deliver_card_with_options_async.assert_called_once()
         mock_card_sdk.streaming_update_with_options_async.assert_called_once()
         assert result.success is True
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# _apply_yaml_config's env writes for require_mention/mention_patterns/
+# free_response_chats/allowed_chats/allowed_users were unconditional
+# (first-writer-wins into process-global os.environ, never seeded into
+# PlatformConfig.extra) even though every one of these fields is already
+# read extra-first by the adapter (_dingtalk_require_mention/
+# _dingtalk_free_response_chats/_dingtalk_allowed_chats/
+# _compile_mention_patterns/_load_allowed_users). Under multiplex, a
+# secondary profile's own config.yaml values leaked into shared env for
+# every other DingTalk adapter to inherit. Mirrors the Buzz/Discord/
+# Telegram/WhatsApp/LINE fix for #98738/#72348/#80099.
+
+_DINGTALK_ENV_VARS = (
+    "DINGTALK_REQUIRE_MENTION",
+    "DINGTALK_MENTION_PATTERNS",
+    "DINGTALK_FREE_RESPONSE_CHATS",
+    "DINGTALK_ALLOWED_CHATS",
+    "DINGTALK_ALLOWED_USERS",
+)
+
+
+class TestMultiplexProfileScope:
+
+    def test_scoped_load_seeds_extra_without_env_leak(self, monkeypatch):
+        from agent import secret_scope as ss
+        from plugins.platforms.dingtalk.adapter import _apply_yaml_config
+
+        for var in _DINGTALK_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        ss.set_multiplex_active(True)
+        tok = ss.set_secret_scope({})
+        try:
+            seeded = _apply_yaml_config(
+                {},
+                {
+                    "require_mention": True,
+                    "mention_patterns": ["^hermes"],
+                    "free_response_chats": ["cid-free"],
+                    "allowed_chats": ["cid-allowed"],
+                    "allowed_users": ["staff-1"],
+                },
+            )
+        finally:
+            ss.reset_secret_scope(tok)
+
+        assert seeded == {
+            "require_mention": True,
+            "mention_patterns": ["^hermes"],
+            "free_response_chats": ["cid-free"],
+            "allowed_chats": ["cid-allowed"],
+            "allowed_users": ["staff-1"],
+        }
+        for var in _DINGTALK_ENV_VARS:
+            assert os.getenv(var) is None, f"{var} leaked into process env under scope"
+
+    def test_unscoped_single_profile_still_bridges_env(self, monkeypatch):
+        """Unscoped (single-profile) behavior is unchanged."""
+        from agent import secret_scope as ss
+        from plugins.platforms.dingtalk.adapter import _apply_yaml_config
+
+        for var in _DINGTALK_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        ss.set_multiplex_active(False)
+        _apply_yaml_config(
+            {}, {"require_mention": True, "allowed_users": ["staff-1"]},
+        )
+        assert os.environ["DINGTALK_REQUIRE_MENTION"] == "true"
+        assert os.environ["DINGTALK_ALLOWED_USERS"] == "staff-1"
+
+    def test_scoped_profiles_own_extra_reaches_adapter(self, monkeypatch):
+        """The extra _apply_yaml_config now seeds must actually reach the
+        adapter's own extra-first read accessors — not just avoid the leak."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        for var in _DINGTALK_ENV_VARS:
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setenv("DINGTALK_ALLOWED_USERS", "default-profile-staff")
+
+        adapter = DingTalkAdapter(
+            PlatformConfig(enabled=True, extra={"allowed_users": ["profile-staff"]})
+        )
+        assert adapter._is_user_allowed("profile-staff", "") is True
+        assert adapter._is_user_allowed("default-profile-staff", "") is False


### PR DESCRIPTION
## What & why

`_apply_yaml_config()` wrote `require_mention`, `mention_patterns`, `free_response_chats`, `allowed_chats`, and `allowed_users` to process-global `os.environ` unconditionally and never seeded `PlatformConfig.extra` (its own docstring: "Returns None — everything flows through env"). Under `gateway.multiplex_profiles`, a secondary profile's own `config.yaml` values for these 5 fields leaked into shared env for every other DingTalk adapter to inherit — and had no way to reach the profile's own adapter either, since every one of these fields is already read extra-first (`_dingtalk_require_mention`/`_dingtalk_free_response_chats`/`_dingtalk_allowed_chats`/`_compile_mention_patterns`/`_load_allowed_users`) — `_apply_yaml_config` simply never populated the `extra` dict those reads already prefer.

## Fix

Adds `_profile_scoped_config_load()` (mirrors the Buzz/Discord/Telegram/WhatsApp/LINE helper for this bug class, #98738/#72348/#80099) to gate the env writes, and returns the bridged values as a dict so `gateway/config.py` merges them into this profile's `extra` — fixing both directions: the leak, and the scoped profile's own YAML value actually taking effect at the adapter level.

## Scope note

`DINGTALK_ALLOWED_USERS` is also consulted directly by the gateway-level `_is_user_authorized` (via the already-scope-aware `_auth_env`/`_platform_gate_env` in `gateway/authz_mixin.py`, which reads only the profile's secret-scope-derived `.env` — never `PlatformConfig.extra`). A secondary profile that configures its allowlist purely via the top-level `config.yaml` block (not its own `.env`) already would not have that value reach gateway-level authorization correctly, independent of this fix — that's a pre-existing architectural gap in the shared `_platform_gate_env` mechanism (it never consults `extra`, for any platform using this pattern), not something this fix introduces or regresses. This fix only stops the leak direction; the adapter's own `_load_allowed_users()` correctly resolves the profile's own value via `extra` either way.

## Tests

Extends `tests/gateway/test_dingtalk.py` with a `TestMultiplexProfileScope` class covering `_apply_yaml_config`'s scoped-vs-single-profile write behavior, plus a system-level check that a scoped profile's own extra-seeded allowlist is honored while the default profile's leaked env value is not.

- `tests/gateway/test_dingtalk.py` — 37 passed
- `tests/tools/test_send_message_missing_platforms.py`, `tests/gateway/test_adapter_startup_secret_scope.py`, `tests/gateway/test_media_metadata_contract.py`, `tests/gateway/test_stream_consumer.py`, `tests/gateway/test_allowed_channels_widening.py` (all files referencing this module) — 195 passed total
- Mutation-verify: reverting the fix makes the write-side test fail as expected (the other two exercise paths — unscoped single-profile, and the pre-existing extra-first read — that were never buggy)

## Competitor check

Searched `DINGTALK_ALLOWED_USERS`, "dingtalk multiplex profile", "dingtalk _apply_yaml_config", `DINGTALK_REQUIRE_MENTION` (all PR/issue states). Open PR #44934 ("merge config and env allowed_users as documented") targets `gateway/platforms/dingtalk.py`, a file that no longer exists — this repo migrated DingTalk to the bundled-plugin architecture (`plugins/platforms/dingtalk/adapter.py`) in merged PR #49408, after #44934 was opened; confirmed stale, not a live competitor. Merged PR #67998 is the prior-art precedent already referenced in this fix's comments (the nested-`extra.allowed_users` fallback), not a competitor.