### PR TITLE
feat(state): refresh automatic session titles

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -10543,6 +10543,64 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             session_id, title, source=self.TITLE_SOURCE_USER
         )
 
+    def refresh_auto_title(self, session_id: str, title: str, *, source: str) -> bool:
+        """Refresh an automatic title only when its provenance still matches.
+
+        This is deliberately narrower than :meth:`set_auto_title`: an LLM
+        refresh may replace an existing LLM title, but it must never promote a
+        derived title or replace a user/legacy title.  The provenance check and
+        title write share one transaction and an exact-value compare-and-swap,
+        so a concurrent user rename wins rather than being overwritten by a
+        late automatic refresh.
+        """
+        if source not in (self.TITLE_SOURCE_DERIVED, self.TITLE_SOURCE_LLM):
+            raise ValueError(f"invalid automatic title source: {source!r}")
+        title = self.sanitize_title(title)
+
+        def _do(conn):
+            current = conn.execute(
+                "SELECT title, title_source FROM sessions WHERE id = ?",
+                (session_id,),
+            ).fetchone()
+            if current is None or current["title_source"] != source:
+                return 0
+
+            if title:
+                conflict = conn.execute(
+                    "SELECT id FROM sessions WHERE title = ? AND id != ?",
+                    (title, session_id),
+                ).fetchone()
+                if conflict:
+                    conflict_id = conflict["id"]
+                    if self._is_compression_ancestor(
+                        conn, ancestor_id=conflict_id, descendant_id=session_id
+                    ):
+                        conn.execute(
+                            "UPDATE sessions SET title = NULL WHERE id = ?",
+                            (conflict_id,),
+                        )
+                    else:
+                        raise ValueError(
+                            f"Title '{title}' is already in use by session {conflict_id}"
+                        )
+
+            # ``IS`` is NULL-safe.  Keep the source in the predicate as well as
+            # the title so a user rename that races the refresh cannot be lost.
+            cursor = conn.execute(
+                "UPDATE sessions SET title = ?, title_source = ? "
+                "WHERE id = ? AND title IS ? AND title_source IS ?",
+                (
+                    title,
+                    source if title else None,
+                    session_id,
+                    current["title"],
+                    current["title_source"],
+                ),
+            )
+            return cursor.rowcount
+
+        return self._execute_write(_do) > 0
+
     def set_auto_title(self, session_id: str, title: str, *, source: str) -> bool:
         """Set an automatically generated title, honoring provenance precedence.
 

--- a/tests/hermes_state/test_refresh_auto_title.py
+++ b/tests/hermes_state/test_refresh_auto_title.py
@@ -1,0 +1,86 @@
+"""Focused contracts for source-restricted automatic title refreshes."""
+
+import pytest
+
+from hermes_state import SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _auto_title(db, session_id, title, source=SessionDB.TITLE_SOURCE_LLM):
+    db.create_session(session_id, source="cli")
+    assert db.set_auto_title(session_id, title, source=source)
+
+
+def test_refreshes_only_when_the_existing_automatic_source_matches(db):
+    _auto_title(db, "llm", "Initial LLM Title")
+    _auto_title(db, "derived", "Initial Derived Title", SessionDB.TITLE_SOURCE_DERIVED)
+
+    assert db.refresh_auto_title("llm", "  Refreshed\nLLM\tTitle  ", source="llm")
+    assert db.get_session_title("llm") == "Refreshed LLM Title"
+    assert db.get_session_title_source("llm") == "llm"
+
+    assert not db.refresh_auto_title("derived", "Must Not Promote", source="llm")
+    assert db.get_session_title("derived") == "Initial Derived Title"
+    assert db.get_session_title_source("derived") == "derived"
+
+
+def test_refresh_never_overwrites_user_or_legacy_provenance(db):
+    _auto_title(db, "user", "Automatic Before Rename")
+    assert db.set_session_title("user", "User Rename")
+
+    _auto_title(db, "legacy", "Legacy Title")
+    db._conn.execute("UPDATE sessions SET title_source = NULL WHERE id = 'legacy'")
+    db._conn.commit()
+
+    for session_id, expected in (("user", "User Rename"), ("legacy", "Legacy Title")):
+        assert not db.refresh_auto_title(session_id, "Late Automatic Title", source="llm")
+        assert db.get_session_title(session_id) == expected
+
+
+def test_refresh_rejects_non_automatic_sources_and_missing_sessions(db):
+    _auto_title(db, "known", "Known Title")
+
+    with pytest.raises(ValueError, match="invalid automatic title source"):
+        db.refresh_auto_title("known", "Nope", source="user")
+    assert not db.refresh_auto_title("missing", "No Session", source="llm")
+
+
+def test_refresh_rejects_non_lineage_collisions_without_losing_current_title(db):
+    _auto_title(db, "target", "Current Title")
+    _auto_title(db, "other", "Taken Title")
+
+    with pytest.raises(ValueError, match="already in use by session other"):
+        db.refresh_auto_title("target", "Taken Title", source="llm")
+    assert db.get_session_title("target") == "Current Title"
+    assert db.get_session_title("other") == "Taken Title"
+
+
+def test_refresh_transfers_a_collision_from_a_compression_ancestor(db):
+    _auto_title(db, "parent", "Conversation Title")
+    _auto_title(db, "child", "Child Provisional Title")
+    db._conn.execute(
+        "UPDATE sessions SET ended_at = 10, end_reason = 'compression' WHERE id = 'parent'"
+    )
+    db._conn.execute(
+        "UPDATE sessions SET parent_session_id = 'parent', started_at = 11 WHERE id = 'child'"
+    )
+    db._conn.commit()
+
+    assert db.refresh_auto_title("child", "Conversation Title", source="llm")
+    assert db.get_session_title("parent") is None
+    assert db.get_session_title("child") == "Conversation Title"
+    assert db.get_session_title_source("child") == "llm"
+
+
+def test_refresh_cas_does_not_clobber_a_user_rename(db):
+    """A late LLM result must lose once a user rename has changed provenance."""
+    _auto_title(db, "session", "Initial Automatic Title")
+    assert db.set_session_title("session", "Concurrent User Rename")
+
+    assert not db.refresh_auto_title("session", "Late LLM Result", source="llm")
+    assert db.get_session_title("session") == "Concurrent User Rename"
+    assert db.get_session_title_source("session") == "user"


### PR DESCRIPTION
Change-Id: Ic174dd16cb8f8cc1c8fe80b2c50c69255393d3c1

## What does this PR do?

Adds `SessionDB.refresh_auto_title()`, a provenance-safe API for refreshing an existing automatically generated session title.

The existing `set_auto_title()` path intentionally protects pre-existing titles. That is correct for initial automatic titling, but it leaves no safe core API for an LLM to refresh a title after more session context becomes available. This PR adds the narrow operation needed for that refresh without allowing late LLM output to overwrite a user rename, a legacy title with unknown provenance, or a title generated by a different automatic source.

The API is generic core state behavior, not plugin-specific: title-producing integrations can use it to refresh only titles that still belong to the same automatic provenance source.

## Related Issue

None. This is a focused state-layer capability required for provenance-safe automatic title refreshes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds `SessionDB.refresh_auto_title(session_id, title, *, source)` in `hermes_state.py`.
- Restricts refreshes to the existing matching automatic source (`llm` or `derived`); rejects cross-source promotion and missing sessions.
- Preserves user-renamed and legacy titles by requiring the stored provenance to match the requested automatic source.
- Performs the provenance check and title update in one transaction with a title-and-source compare-and-swap, so a concurrent user rename wins over a late LLM result.
- Retains the existing unique-title behavior and transfers a duplicate title from a compression ancestor only when the lineage relationship is valid.
- Adds six focused state tests in `tests/hermes_state/test_refresh_auto_title.py` covering matching provenance, user/legacy protection, invalid sources, ordinary collisions, compression-ancestor transfer, and concurrent user-rename protection.

## How to Test

1. From the PR branch workspace, run:
   ```bash
   .venv/bin/python -m pytest -q tests/hermes_state/test_refresh_auto_title.py
   ```
2. Expected result: `6 passed`.
3. Verify that an LLM title can refresh only another LLM title, while a user rename or legacy title remains unchanged.

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've run `pytest tests/ -q` and all tests pass

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) — N/A for user-facing documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Verification Evidence

```text
.venv/bin/python -m pytest -q tests/hermes_state/test_refresh_auto_title.py
6 passed in 0.35s
```
