### PR TITLE
fix(teams): scope client_id/tenant_id/service_url/home_channel per profile

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -135,6 +135,24 @@ def _get_scoped_secret(name, default=None):
     return val if val is not None else default
 
 
+def _profile_scoped() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed inside ``_profile_runtime_scope``
+    (secret scope installed + multiplex active) — the same discriminator the
+    Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk adapters use for this bug
+    class (#98738/#72348/#80099). The DEFAULT profile under multiplexing
+    runs unscoped: ``os.environ`` holds its own bridge output there and
+    keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
 logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 3978
@@ -447,11 +465,16 @@ def check_requirements() -> bool:
 
 
 def validate_config(config) -> bool:
-    """Return True when the config has the minimum required credentials."""
+    """Return True when the config has the minimum required credentials.
+
+    Scope-aware (matches __init__'s extra.get(...) or _get_scoped_secret(...)
+    precedence): a secondary multiplex profile must not borrow the default
+    profile's bridged TEAMS_CLIENT_ID/TEAMS_TENANT_ID env values.
+    """
     extra = getattr(config, "extra", {}) or {}
-    client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
-    client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
-    tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
+    client_id = extra.get("client_id") or _get_scoped_secret("TEAMS_CLIENT_ID")
+    client_secret = extra.get("client_secret") or _get_scoped_secret("TEAMS_CLIENT_SECRET")
+    tenant_id = extra.get("tenant_id") or _get_scoped_secret("TEAMS_TENANT_ID")
     return bool(client_id and client_secret and tenant_id)
 
 
@@ -470,7 +493,18 @@ def _env_enablement() -> dict | None:
 
     The special ``home_channel`` key in the returned dict becomes a proper
     ``HomeChannel`` dataclass on the ``PlatformConfig`` via the core hook.
+
+    Scope-aware (mirrors the Buzz fix for #98738): inside a secondary
+    multiplex profile's scope, os.environ holds the DEFAULT profile's
+    bridged TEAMS_* values (client_id/tenant_id/port/service_url/
+    home_channel — a cron-delivery target) — env enablement must not
+    fabricate a Teams platform, or seed a home_channel, from another
+    profile's env. A profile without its own config.yaml block relies on
+    _get_scoped_secret's TEAMS_CLIENT_SECRET (or explicit config.yaml) as
+    before.
     """
+    if _profile_scoped():
+        return None
     client_id = os.getenv("TEAMS_CLIENT_ID", "").strip()
     client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET", "").strip()
     tenant_id = os.getenv("TEAMS_TENANT_ID", "").strip()
@@ -600,15 +634,18 @@ async def _standalone_send(
     attachments via the SDK.
     """
     extra = getattr(pconfig, "extra", {}) or {}
-    client_id = os.getenv("TEAMS_CLIENT_ID") or extra.get("client_id", "")
-    client_secret = _get_scoped_secret("TEAMS_CLIENT_SECRET") or extra.get("client_secret", "")
-    tenant_id = os.getenv("TEAMS_TENANT_ID") or extra.get("tenant_id", "")
+    # Scope-aware (matches __init__'s precedence): a secondary multiplex
+    # profile must not borrow the default profile's bridged TEAMS_CLIENT_ID/
+    # TEAMS_TENANT_ID/TEAMS_SERVICE_URL for out-of-process cron delivery.
+    client_id = extra.get("client_id") or _get_scoped_secret("TEAMS_CLIENT_ID")
+    client_secret = extra.get("client_secret") or _get_scoped_secret("TEAMS_CLIENT_SECRET")
+    tenant_id = extra.get("tenant_id") or _get_scoped_secret("TEAMS_TENANT_ID")
     if not (client_id and client_secret and tenant_id):
         return {"error": "Teams standalone send: TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID are all required"}
 
     raw_service_url = (
-        os.getenv("TEAMS_SERVICE_URL")
-        or extra.get("service_url", "")
+        extra.get("service_url")
+        or _get_scoped_secret("TEAMS_SERVICE_URL")
         or _DEFAULT_TEAMS_SERVICE_URL
     )
     service_url = _validate_teams_service_url(raw_service_url)

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -196,6 +196,8 @@ check_requirements = _teams_mod.check_requirements
 check_teams_requirements = _teams_mod.check_teams_requirements
 validate_config = _teams_mod.validate_config
 register = _teams_mod.register
+_env_enablement = _teams_mod._env_enablement
+_standalone_send = _teams_mod._standalone_send
 
 
 # ---------------------------------------------------------------------------
@@ -265,6 +267,152 @@ class TestTeamsRequirements:
         monkeypatch.delenv("TEAMS_TENANT_ID", raising=False)
         cfg = _make_config(client_id="id", client_secret="secret", tenant_id="tenant")
         assert validate_config(cfg) is True
+
+
+# ---------------------------------------------------------------------------
+# Tests: Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# validate_config/_env_enablement/_standalone_send read TEAMS_CLIENT_ID/
+# TEAMS_TENANT_ID/TEAMS_SERVICE_URL/TEAMS_PORT/TEAMS_HOME_CHANNEL via raw
+# os.getenv, checked BEFORE config.extra — unlike __init__, which already
+# does extra.get(...) or _get_scoped_secret(...). Under multiplex, a
+# secondary profile with its own (different or absent) Teams config would
+# silently inherit the default profile's client_id/tenant_id (breaking
+# OAuth) or home_channel (a cron-delivery target — real message
+# misdelivery). Mirrors the Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk fix
+# for #98738/#72348/#80099.
+
+_TEAMS_ENV_VARS = (
+    "TEAMS_CLIENT_ID",
+    "TEAMS_CLIENT_SECRET",
+    "TEAMS_TENANT_ID",
+    "TEAMS_PORT",
+    "TEAMS_SERVICE_URL",
+    "TEAMS_HOME_CHANNEL",
+    "TEAMS_HOME_CHANNEL_NAME",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_teams_env(monkeypatch):
+    for var in _TEAMS_ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    yield
+
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("TEAMS_CLIENT_ID", "default-client-id")
+    monkeypatch.setenv("TEAMS_CLIENT_SECRET", "default-secret")
+    monkeypatch.setenv("TEAMS_TENANT_ID", "default-tenant-id")
+    monkeypatch.setenv("TEAMS_HOME_CHANNEL", "default-home-channel")
+
+
+class TestMultiplexProfileScope:
+    """Each test below installs a scope that supplies ONLY
+    TEAMS_CLIENT_SECRET (already scope-aware before this fix) and asserts on
+    client_id/tenant_id/home_channel — the fields this fix scopes. Asserting
+    only a boolean outcome (e.g. ``validate_config(...) is False``) with an
+    EMPTY scope would pass even pre-fix, because the pre-existing
+    client_secret scoping alone already fails the overall check — that
+    would not actually exercise this fix. Giving the scope its own
+    client_secret isolates client_id/tenant_id/home_channel as the only
+    remaining variables, so a leak from the default profile's env is the
+    only way these assertions could pass before the fix."""
+
+    def test_validate_config_scoped_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile with its own secret but no client_id/tenant_id
+        of its own must not pass validate_config just because the default
+        profile's client_id/tenant_id are sitting in shared env."""
+        multiplex_scope({"TEAMS_CLIENT_SECRET": "profile-secret"})
+        assert validate_config(_make_config()) is False
+
+    def test_validate_config_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            assert validate_config(_make_config()) is True
+        finally:
+            set_multiplex_active(False)
+
+    def test_env_enablement_returns_none_when_scoped(self, multiplex_scope, default_profile_env):
+        """Env enablement must not fabricate a Teams platform (or seed the
+        default profile's leaked client_id/tenant_id/home_channel) for a
+        secondary profile that only has its own client_secret."""
+        multiplex_scope({"TEAMS_CLIENT_SECRET": "profile-secret"})
+        assert _env_enablement() is None
+
+    def test_env_enablement_unscoped_still_seeds(self, monkeypatch, default_profile_env):
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            seed = _env_enablement()
+        finally:
+            set_multiplex_active(False)
+        assert seed["client_id"] == "default-client-id"
+        assert seed["home_channel"]["chat_id"] == "default-home-channel"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_scoped_missing_own_creds_fails_closed(
+        self, default_profile_env
+    ):
+        """Cron/out-of-process delivery for a secondary profile with its own
+        client_secret but no client_id/tenant_id of its own must fail
+        closed on the credentials-required error, not silently proceed
+        using the default profile's leaked client_id/tenant_id.
+
+        Scope is installed/reset inline (not via the ``multiplex_scope``
+        fixture) so the ``ContextVar`` set/reset pair stays inside the same
+        asyncio task context as this coroutine — resetting a token from the
+        surrounding sync fixture-teardown context raises ``ValueError:
+        token was created in a different Context``.
+        """
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+
+        set_multiplex_active(True)
+        token = set_secret_scope({"TEAMS_CLIENT_SECRET": "profile-secret"})
+        try:
+            result = await _standalone_send(_make_config(), "conv-id", "hi")
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+        assert result.get("error") == (
+            "Teams standalone send: TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, "
+            "and TEAMS_TENANT_ID are all required"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What & why

`validate_config`, `_env_enablement`, and `_standalone_send` read `TEAMS_CLIENT_ID`/`TEAMS_TENANT_ID`/`TEAMS_SERVICE_URL`/`TEAMS_PORT`/`TEAMS_HOME_CHANNEL` via raw `os.getenv`, checked BEFORE `config.extra` — a sibling-gap next to `__init__`, which already does `extra.get(...) or _get_scoped_secret(...)` for the same fields.

Under `gateway.multiplex_profiles`, a secondary profile with its own (different or absent) Teams config would silently inherit the default profile's `client_id`/`tenant_id` (breaking OAuth token acquisition against the wrong Azure AD tenant — **empirically reproduced during mutation-verify**: a leaked `tenant_id` produced a real `AADSTS900023` error from Azure) or `home_channel` (a cron-delivery target — real message misdelivery, not just a functional break).

## Fix

Adds `_profile_scoped()` (mirrors the Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk helper for this bug class, #98738/#72348/#80099) and reuses the adapter's own existing `_get_scoped_secret()` helper (already used for `TEAMS_CLIENT_SECRET` in all three functions) for `client_id`/`tenant_id`/`service_url` too, matching `__init__`'s precedence exactly. `_env_enablement` returns `None` under scope (mirrors Buzz's #98738 fix) rather than fabricating a Teams platform, or seeding a `home_channel`, from the default profile's env.

## Scope note

Finding a separate, PLAUSIBLE issue in `_on_card_action`'s approval-button gate (raw `TEAMS_ALLOWED_USERS`/`TEAMS_ALLOW_ALL_USERS` reads instead of the shared gateway check) — deliberately left out of this PR: open PR #93516 is already rewriting that exact function for a different root cause (email vs. GUID identity mismatch) and would incidentally fix this gap too if merged.

## Tests

Extends `tests/gateway/test_teams.py` with a `TestMultiplexProfileScope` class. Each regression test installs a scope supplying ONLY `TEAMS_CLIENT_SECRET` (already scope-aware before this fix) so `client_id`/`tenant_id`/`home_channel` are isolated as the only remaining variables — an empty scope would pass even pre-fix, since the pre-existing `client_secret` scoping alone already fails the overall credential check without ever exercising this fix (caught during mutation-verify's first pass, all 3 corrected).

- `tests/gateway/test_teams.py` — 37 passed
- `tests/plugins/test_teams_pipeline_plugin.py`, `tests/gateway/test_teams_pipeline_runtime_wiring.py`, `tests/gateway/test_adapter_startup_secret_scope.py` — 135 passed total
- Mutation-verify: reverting the fix makes all 3 corrected tests fail as expected (the other 2 exercise the unscoped path, which was never buggy)

## Competitor check

Searched `TEAMS_CLIENT_ID`, "teams multiplex profile", "teams _env_enablement", `TEAMS_HOME_CHANNEL` (all PR/issue states). Open PR #80825 ("guard Teams multiplex listener ownership") is DRAFT and touches `gateway/config.py`/`hermes_cli/web_server.py` only — no overlap with `plugins/platforms/teams/adapter.py`. No other PR targets this scoping bug.