### PR TITLE
feat(desktop): show project names in session rows

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -91,6 +91,7 @@ const ORDERINGS: Option<SidebarOrdering>[] = [
 const ROW_META: Option<SidebarRowMeta>[] = [
   { icon: 'clock', id: 'updated', label: 'Updated' },
   { icon: 'comment', id: 'preview', label: 'Preview' },
+  { icon: 'root-folder', id: 'project', label: 'Project' },
   { icon: 'symbol-numeric', id: 'tokens', label: 'Tokens' },
   { icon: 'credit-card', id: 'cost', label: 'Cost' },
   { icon: 'git-pull-request', id: 'pr', label: 'PR' },

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -47,6 +47,7 @@ import {
   $sidebarPrDataWanted,
   $sidebarPrFilter,
   $sidebarProfileFilter,
+  $sidebarProjectDataWanted,
   $sidebarProjectFilter,
   $sidebarProjectOrderIds,
   $sidebarRecentsOpen,
@@ -360,6 +361,7 @@ export function ChatSidebar({
   const profileFilter = useStore($sidebarProfileFilter)
   const prFilter = useStore($sidebarPrFilter)
   const prDataWanted = useStore($sidebarPrDataWanted)
+  const projectDataWanted = useStore($sidebarProjectDataWanted)
   const prBranchOverrides = useStore($prBranchBySession)
   const pullRequests = useStore($pullRequestsByBranch)
   const filtersActive = useStore($sidebarFiltersActive)
@@ -755,6 +757,19 @@ export function ChatSidebar({
       return
     }
 
+    // The project LIST, for a flat view that was asked to NAME its rows'
+    // projects. `projects.tree` below fills $projectTree; the Project row
+    // detail resolves off $projects, which only `projects.list` fills — so
+    // without this the chip would fall back to the recorded repo leaf until the
+    // user had visited the grouped view. Gated like PR data (a view that shows
+    // no project name pays for no round trip) and issued now rather than behind
+    // the warm timer: switching the detail on is a request, not a background
+    // prefetch. Stale/reordered answers are the store's own problem — it
+    // guards on generation + active profile.
+    if (projectDataWanted) {
+      void refreshProjects()
+    }
+
     // Flat view: warm the tree in the background anyway. Fetching it only on
     // the switch meant the first switch of every run paid for the whole round
     // trip behind a skeleton, and the menu's Project filter had nothing to
@@ -762,7 +777,7 @@ export function ChatSidebar({
     const warm = window.setTimeout(() => void refreshProjectTree(), PROJECT_TREE_WARM_MS)
 
     return () => window.clearTimeout(warm)
-  }, [activeConnectionId, worktreeGroupingActive, showAllProfiles, profileScope, gatewayReady])
+  }, [activeConnectionId, worktreeGroupingActive, showAllProfiles, profileScope, gatewayReady, projectDataWanted])
 
   // Sessions the branch join can't answer for get one look at their own
   // transcript — a `gh pr create` in there names the PR outright. Backfills

--- a/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.test.tsx
@@ -3,11 +3,13 @@ import { atom } from 'nanostores'
 import type * as React from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import type { SessionInfo } from '@/hermes'
+import type { ProjectInfo, SessionInfo } from '@/hermes'
 import { createClientSessionState } from '@/lib/chat-runtime'
 import type * as ChatRuntime from '@/lib/chat-runtime'
 import type * as Time from '@/lib/time'
 import type * as ComposerStatusStore from '@/store/composer-status'
+import { $sidebarRowMeta } from '@/store/layout'
+import { $projects } from '@/store/projects'
 import type * as SessionStore from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
 import type * as SessionStatesStore from '@/store/session-states'
@@ -408,6 +410,88 @@ describe('SidebarSessionRow', () => {
     const avatar = handoffAvatar(container)
     expect(avatar).toBeTruthy()
     expect(tipTrigger(avatar as HTMLElement)).toBeTruthy()
+  })
+})
+
+// The Show menu's optional Project detail. The label comes from the same
+// resolver the card header reads (`sessionProjectLabel`), so a row and a card
+// can never name the same session's workspace differently.
+describe('Show → Project row detail', () => {
+  const project = (overrides: Partial<ProjectInfo>): ProjectInfo =>
+    ({
+      archived: false,
+      folders: [],
+      id: 'p1',
+      name: 'Hermes Agent',
+      ...overrides
+    }) as unknown as ProjectInfo
+
+  const hermesAgent = project({
+    folders: [{ added_at: 0, is_primary: true, label: null, path: '/repos/hermes-agent' }]
+  })
+
+  afterEach(() => {
+    $projects.set([])
+    $sidebarRowMeta.set(['preview', 'updated'])
+  })
+
+  it('names the project on the row when the detail is switched on', () => {
+    $projects.set([hermesAgent])
+    $sidebarRowMeta.set(['project'])
+
+    renderRow(makeSession({ cwd: '/repos/hermes-agent/agent', title: 'Fix the sidebar' }))
+
+    expect(screen.getByText('Hermes Agent')).toBeTruthy()
+  })
+
+  // The shipped view: the option is off, so the row must look exactly as it did
+  // before it existed.
+  it('says nothing about the project while the detail is off', () => {
+    $projects.set([hermesAgent])
+
+    renderRow(makeSession({ cwd: '/repos/hermes-agent/agent', title: 'Fix the sidebar' }))
+
+    expect(screen.queryByText('Hermes Agent')).toBeNull()
+  })
+
+  // A chat with no workspace at all resolves to no label — an optional detail
+  // with nothing to say takes no room rather than painting an empty chip.
+  it('takes no room for a session no project claims', () => {
+    $projects.set([hermesAgent])
+    $sidebarRowMeta.set(['project'])
+
+    const { container } = renderRow(makeSession({ title: 'Scratch chat' }))
+
+    expect(screen.queryByText('Hermes Agent')).toBeNull()
+    expect(container.querySelector('[data-row-actions]')?.textContent).toBe('')
+  })
+
+  // Falls back to the repo the backend recorded when project PLACEMENT can't
+  // claim the row (a worktree beside its checkout) — naming the repo is the
+  // whole point of showing a project instead of a scratch directory.
+  it('names the recorded repo when no project claims the row', () => {
+    $projects.set([])
+    $sidebarRowMeta.set(['project'])
+
+    renderRow(
+      makeSession({
+        cwd: '/repos/hermes-agent-worktree',
+        git_repo_root: '/repos/hermes-agent',
+        title: 'Worktree chat'
+      })
+    )
+
+    expect(screen.getByText('hermes-agent')).toBeTruthy()
+  })
+
+  // The card names the project in its own header line; the chip would repeat it.
+  it('leaves the card alone — its header already names the project', () => {
+    $projects.set([hermesAgent])
+    $sidebarRowMeta.set(['project'])
+
+    renderRow(makeSession({ cwd: '/repos/hermes-agent/agent', title: 'Fix the sidebar' }), { card: true })
+
+    expect(screen.getAllByText('Hermes Agent')).toHaveLength(1)
   })
 })
 

--- a/apps/desktop/src/app/chat/sidebar/session-row.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-row.tsx
@@ -175,6 +175,19 @@ function SidebarSessionRowImpl({
   // those branches should repaint.
   const prKey = sessionPrKey(session)
   const pr = useStoreSelector($pullRequestsByBranch, prs => (rowMeta.includes('pr') && prKey ? prs[prKey] : undefined))
+
+  // The project this row belongs to, when the Show menu asked for it. Only the
+  // one-line row: the card already names the same thing in its header (below),
+  // so rendering it here too would say it twice. The SAME resolver the header
+  // and the session tint read, so a row can never name a workspace the card
+  // disagrees with — and a chat with no project resolves to null and simply
+  // takes no room, rather than paying for an empty chip. A selector, not
+  // useStore($projects): the atom republishes with fresh identity on every
+  // tree poll, and only a row whose own label changed should repaint.
+  const projectLabel = useStoreSelector($projects, projects =>
+    !card && rowMeta.includes('project') ? sessionProjectLabel(session, projects) : null
+  )
+
   // Open in a pane, but not the focused one. A selector rather than a prop:
   // it reaches all four row render paths at once, the set only changes when a
   // tile opens or closes, and the boolean bails every unaffected row out.
@@ -199,6 +212,21 @@ function SidebarSessionRowImpl({
   // thing. Chips used to render in the body instead, which left them stranded
   // to the left of the kebab's own column: never flush right, never swapping.
   const trailing: { key: string; node: React.ReactNode }[] = []
+
+  if (projectLabel) {
+    // Broadest context first, and capped so a long project name narrows itself
+    // instead of eating the title — the tip only opens once it actually has to.
+    trailing.push({
+      key: 'project',
+      node: (
+        <OverflowTip label={projectLabel}>
+          <span className="max-w-20 shrink-0 truncate text-[0.625rem] leading-none text-(--ui-text-tertiary)">
+            {projectLabel}
+          </span>
+        </OverflowTip>
+      )
+    })
+  }
 
   if ((showProfile || pinnedProfile) && hasProfileTag) {
     trailing.push({ key: 'profile', node: <ProfileTag profile={session.profile} /> })

--- a/apps/desktop/src/store/layout-sidebar-view.test.ts
+++ b/apps/desktop/src/store/layout-sidebar-view.test.ts
@@ -1,8 +1,11 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { readKey } from '@/lib/storage'
 
 import {
   $sidebarGrouping,
   $sidebarOrdering,
+  $sidebarProjectDataWanted,
   $sidebarRowMeta,
   $sidebarViewCustomized,
   resetSidebarView,
@@ -23,6 +26,47 @@ describe('the sidebar as it ships', () => {
     expect($sidebarGrouping.get()).toBe('date')
     expect($sidebarOrdering.get()).toBe('updated')
     expect($sidebarRowMeta.get()).toEqual(['preview', 'updated'])
+  })
+
+  // The persisted codec is an ALLOW-LIST: `listOf(ROW_META)` drops any id it
+  // does not recognize while DECODING the stored record. Toggling the atom and
+  // reading it back in this module never reaches that decode — the seed is read
+  // exactly once, when the store module is first imported. So write the record
+  // through the real toggle, then boot a fresh instance of the store the way a
+  // reload would and require the option to come back intact. Drop `project`
+  // from ROW_META and this is the assertion that goes red.
+  it('reads the Project detail back from storage after a reload', async () => {
+    toggleSidebarRowMeta('project')
+
+    const saved = $sidebarRowMeta.get()
+
+    expect(saved).toContain('project')
+    expect(readKey('hermes.desktop.sidebarRowMeta')).toContain('project')
+
+    vi.resetModules()
+
+    const reloaded = await import('./layout')
+
+    expect(reloaded.$sidebarRowMeta.get()).toEqual(saved)
+  })
+
+  // The Project detail NAMES a row off `$projects`, which only `projects.list`
+  // fills — and the sidebar only issues that fetch for a view that asked for
+  // project data. The flat, date-grouped list never does, so switching the
+  // detail on has to raise the same kind of "someone needs this" signal the PR
+  // badge raises, or the chip paints from whatever a past visit to the grouped
+  // view happened to leave in the atom. Off by default: nobody who hasn't
+  // asked pays for the round trip.
+  it('asks for project data only once the Project detail is switched on', () => {
+    expect($sidebarProjectDataWanted.get()).toBe(false)
+
+    toggleSidebarRowMeta('project')
+
+    expect($sidebarProjectDataWanted.get()).toBe(true)
+
+    toggleSidebarRowMeta('project')
+
+    expect($sidebarProjectDataWanted.get()).toBe(false)
   })
 
   it('offers no reset until something actually moves off the defaults', () => {

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -250,8 +250,10 @@ export type SidebarOrdering = 'cost' | 'created' | 'manual' | 'status' | 'tokens
 /** The sort keys the menu offers; `manual` is entered by dragging, not picked. */
 export type SidebarSortKey = Exclude<SidebarOrdering, 'manual'>
 /** Optional per-row metadata the user can switch on. `preview` is card-only:
- *  the one-line row has nowhere to put a second line. */
-export type SidebarRowMeta = 'cost' | 'pr' | 'preview' | 'profile' | 'tokens' | 'updated'
+ *  the one-line row has nowhere to put a second line. `project` is its mirror
+ *  image — the card already names the project in its header, so the option is
+ *  what brings that context to the one-line row. */
+export type SidebarRowMeta = 'cost' | 'pr' | 'preview' | 'profile' | 'project' | 'tokens' | 'updated'
 
 function oneOf<T extends string>(values: readonly T[], fallback: T): Codec<T> {
   return {
@@ -267,7 +269,7 @@ function listOf<T extends string>(values: readonly T[]): Codec<T[]> {
   }
 }
 
-const ROW_META: readonly SidebarRowMeta[] = ['cost', 'pr', 'preview', 'profile', 'tokens', 'updated']
+const ROW_META: readonly SidebarRowMeta[] = ['cost', 'pr', 'preview', 'profile', 'project', 'tokens', 'updated']
 const STATUS_FILTERS: readonly SessionStatusBucket[] = ['needs-input', 'working', 'unread', 'draft', 'idle']
 const PR_FILTERS: readonly PullRequestBucket[] = ['open', 'draft', 'merged', 'closed', 'none']
 export const SIDEBAR_SORT_KEYS: readonly SidebarSortKey[] = ['updated', 'created', 'status', 'tokens', 'cost']
@@ -700,6 +702,16 @@ export function resetSidebarView() {
 export const $sidebarPrDataWanted: ReadableAtom<boolean> = computed(
   [$sidebarRowMeta, $sidebarPrFilter],
   (rowMeta, prFilter) => rowMeta.includes('pr') || prFilter.length > 0
+)
+
+/** Whether anything on screen needs the project LIST — `projects.list`, the
+ *  only fetch that fills `$projects`. The grouped tree pulls it on its own
+ *  structural edges; the flat list only needs it when a row was asked to NAME
+ *  its project, so the row detail is what makes that view ask. The menu's
+ *  Project filter is deliberately not here: it lists off `$projectTree`, which
+ *  the flat view already warms. */
+export const $sidebarProjectDataWanted: ReadableAtom<boolean> = computed([$sidebarRowMeta], rowMeta =>
+  rowMeta.includes('project')
 )
 
 // Write an order list only when it actually changed, so an identical drag


### PR DESCRIPTION
## What does this PR do?

Adds an optional **Project** detail to the Desktop session sidebar's **Show** menu.

When enabled, one-line session rows display the same resolved project name already used by project cards and session tinting. The preference is off by default, persists through the existing sidebar-view storage, and requests project-list data only while the detail is enabled. Cards do not repeat the label because they already show project context in their header.

## Related Issue

Fixes #99620

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `project` to the persisted `SidebarRowMeta` allow-list and the sidebar **Show** menu.
- Render a bounded, truncating project label on one-line session rows only when enabled.
- Refresh project-list data in flat/date-grouped views when project row metadata is requested.
- Cover enabled, default-off, missing-project, repository-fallback, card deduplication, persisted reload, and project-data gating behavior.

## How to Test

1. Open the Desktop session sidebar, open its filter menu, then enable **Show → Project**.
2. Confirm one-line rows with a project display its name, rows without a project add no empty chip, and Inbox-style cards do not duplicate their existing project header.
3. Restart/reload the Desktop app and confirm the option remains enabled.

Automated verification on macOS 26.6.2:

- `npm --workspace apps/desktop exec vitest run -- --project ui src/store/layout-sidebar-view.test.ts src/app/chat/sidebar/session-row.test.tsx` — 25 passed.
- `npm --workspace apps/desktop exec vitest run -- --project ui` — 701 files / 6,941 tests passed.
- `npm --workspace apps/desktop run typecheck` — passed.
- ESLint on all six changed files — passed.
- Prettier check on all six changed files — passed.
- `npm --workspace apps/desktop run build` — passed.
- Regression sabotage: removing the production row rendering makes the focused project-name test fail as expected.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A: no Python code changed; the complete Desktop UI suite and Desktop typecheck were run instead
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A: this adds a self-contained option to an existing menu and no public configuration or architecture contract changes
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — renderer/store-only change with no platform-specific API
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot included. The behavior is covered by focused DOM tests, the complete Desktop UI suite, typecheck, lint, formatting, and a production Desktop build.
