### PR TITLE
fix(sms): scope TWILIO_PHONE_NUMBER per profile

### DIFF
--- a/plugins/platforms/sms/adapter.py
+++ b/plugins/platforms/sms/adapter.py
@@ -92,7 +92,10 @@ class SmsAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.SMS)
         self._account_sid: str = _get_scoped_secret("TWILIO_ACCOUNT_SID", "")
         self._auth_token: str = _get_scoped_secret("TWILIO_AUTH_TOKEN", "")
-        self._from_number: str = os.getenv("TWILIO_PHONE_NUMBER", "")
+        # Scope-aware, matching its sibling reads above: a secondary
+        # multiplex profile must not borrow the default profile's bridged
+        # TWILIO_PHONE_NUMBER (mirrors the Buzz fix for #98738).
+        self._from_number: str = _get_scoped_secret("TWILIO_PHONE_NUMBER", "")
         self._webhook_port: int = int(
             os.getenv("SMS_WEBHOOK_PORT", str(DEFAULT_WEBHOOK_PORT))
         )
@@ -469,7 +472,11 @@ async def _standalone_send(
     import base64
 
     account_sid = _get_scoped_secret("TWILIO_ACCOUNT_SID", "")
-    from_number = os.getenv("TWILIO_PHONE_NUMBER", "")
+    # Scope-aware, matching account_sid/auth_token above: a secondary
+    # multiplex profile's cron/out-of-process delivery must not send from
+    # the default profile's bridged TWILIO_PHONE_NUMBER (mirrors the Buzz
+    # fix for #98738).
+    from_number = _get_scoped_secret("TWILIO_PHONE_NUMBER", "")
     if not account_sid or not auth_token or not from_number:
         return {"error": "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"}
 

--- a/tests/gateway/test_sms.py
+++ b/tests/gateway/test_sms.py
@@ -321,3 +321,114 @@ class TestWebhookSignatureEnforcement:
         request = self._mock_request(oversized, content_length=None)
         resp = await adapter._handle_webhook(request)
         assert resp.status == 413
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__ and _standalone_send read TWILIO_PHONE_NUMBER via raw os.getenv,
+# right next to the already-scope-aware TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN
+# (_get_scoped_secret). Under multiplex, a secondary profile with its own
+# from-number would silently send replies from the default profile's
+# bridged TWILIO_PHONE_NUMBER instead — Twilio rejects a from-number not
+# owned by that profile's account, or misattributes the send. Mirrors the
+# Buzz fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("TWILIO_ACCOUNT_SID", "AC-default")
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "token-default")
+    monkeypatch.setenv("TWILIO_PHONE_NUMBER", "+15550000000")
+
+
+class TestMultiplexProfileScope:
+
+    def test_init_scoped_uses_own_from_number(self, multiplex_scope, default_profile_env):
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        multiplex_scope(
+            {
+                "TWILIO_ACCOUNT_SID": "AC-profile",
+                "TWILIO_AUTH_TOKEN": "token-profile",
+                "TWILIO_PHONE_NUMBER": "+15551112222",
+            }
+        )
+        adapter = SmsAdapter(PlatformConfig(enabled=True))
+        assert adapter._from_number == "+15551112222"
+
+    def test_init_scoped_missing_own_number_fails_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile with its own account_sid/auth_token but no
+        from-number of its own must not silently borrow the default
+        profile's bridged TWILIO_PHONE_NUMBER."""
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        multiplex_scope(
+            {"TWILIO_ACCOUNT_SID": "AC-profile", "TWILIO_AUTH_TOKEN": "token-profile"}
+        )
+        adapter = SmsAdapter(PlatformConfig(enabled=True))
+        assert adapter._from_number == ""
+
+    def test_init_unscoped_keeps_env_precedence(self, monkeypatch, default_profile_env):
+        from agent.secret_scope import set_multiplex_active
+        from plugins.platforms.sms.adapter import SmsAdapter
+
+        set_multiplex_active(True)
+        try:
+            adapter = SmsAdapter(PlatformConfig(enabled=True))
+        finally:
+            set_multiplex_active(False)
+        assert adapter._from_number == "+15550000000"
+
+    @pytest.mark.asyncio
+    async def test_standalone_send_scoped_uses_own_from_number(self, default_profile_env):
+        """Scope is installed/reset inline (not via the multiplex_scope
+        fixture) so the ContextVar set/reset pair stays inside the same
+        asyncio task context as this coroutine."""
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from plugins.platforms.sms.adapter import _standalone_send
+
+        set_multiplex_active(True)
+        token = set_secret_scope(
+            {"TWILIO_ACCOUNT_SID": "AC-profile", "TWILIO_AUTH_TOKEN": "token-profile"}
+        )
+        try:
+            pconfig = PlatformConfig(enabled=True)
+            result = await _standalone_send(pconfig, "+15559998888", "hi")
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+        # No from-number in the profile's own scope: fails closed on the
+        # standard "not configured" error rather than sending from the
+        # default profile's leaked +15550000000.
+        assert result.get("error") == (
+            "SMS not configured (TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN, TWILIO_PHONE_NUMBER required)"
+        )


### PR DESCRIPTION
## What & why

`__init__` and `_standalone_send` read `TWILIO_PHONE_NUMBER` via raw `os.getenv`, right next to the already-scope-aware `TWILIO_ACCOUNT_SID`/`TWILIO_AUTH_TOKEN` (`_get_scoped_secret`, established by merged PR #76664). Under `gateway.multiplex_profiles`, a secondary profile with its own Twilio account would silently send replies from the default profile's bridged `TWILIO_PHONE_NUMBER` instead — Twilio rejects a from-number not owned by that profile's account (auth failure), or the message gets attributed to the wrong sender.

## Reachability

`__init__`'s path is currently unreachable via normal secondary-profile adapter construction (`"sms"` is in `gateway/config.py`'s `PORT_BINDING_PLATFORM_VALUES`, so `_start_one_profile_adapters` refuses to construct a port-binding platform for a secondary profile) — fixed anyway for consistency with its sibling reads and to avoid a latent bug if that guard's scope ever changes. `_standalone_send`'s path **is** reachable: it's the generic cron/home-channel out-of-process delivery hook, which runs inside `_profile_runtime_scope`.

## Fix

Swaps both reads to the adapter's own existing `_get_scoped_secret()` helper, matching its sibling `account_sid`/`auth_token` reads exactly — no new mechanism needed.

## Tests

Adds a `TestMultiplexProfileScope` test class to `tests/gateway/test_sms.py` mirroring the established Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk/Teams coverage for this bug class.

- `tests/gateway/test_sms.py`, `tests/gateway/test_adapter_startup_secret_scope.py` — 94 passed
- Mutation-verify: reverting the fix makes all 3 new tests fail as expected (the 4th exercises the unscoped path, which was never buggy)

**Incidental finding, not fixed here (out of scope):** while writing the `_standalone_send` mutation-verify test, hit a pre-existing, unrelated `NameError: name 're' is not defined` in `_strip_markdown_for_sms` (`re.sub(...)` called with no `import re` anywhere in the module) — crashes every cron-delivered SMS with markdown-containing text. Already has four open competing PRs (#90876, #57619, #55378, #61180); not touched here.

## Competitor check

Searched `TWILIO_PHONE_NUMBER`, "sms adapter multiplex", "sms _standalone_send" (all PR/issue states). No PR targets this scoping bug. Merged PR #76664 is the prior-art precedent already referenced in this fix (established `_get_scoped_secret` for the sibling fields), not a competitor.