### PR TITLE
fix(desktop): merge primary chat across zones

### DIFF
--- a/apps/desktop/e2e/cross-zone-workspace-tab.spec.ts
+++ b/apps/desktop/e2e/cross-zone-workspace-tab.spec.ts
@@ -1,0 +1,101 @@
+import type { Locator } from '@playwright/test'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { MOCK_REPLY } from './mock-server'
+import { expect, type Page, test } from './test'
+
+let fixture: MockBackendFixture | null = null
+
+async function send(page: Page, text: string): Promise<void> {
+  const composer = page.locator('[data-slot="composer-rich-input"]:visible').last()
+  const surface = composer.locator('xpath=ancestor::*[@data-session-anchor][1]')
+
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.fill(text)
+  await page.keyboard.press('Enter')
+  await expect(surface).toContainText(text, { timeout: 30_000 })
+  await expect(surface).toContainText(MOCK_REPLY, { timeout: 60_000 })
+}
+
+async function drag(page: Page, source: Locator, targetX: number, targetY: number) {
+  const box = await source.boundingBox()
+  expect(box).not.toBeNull()
+
+  const startX = box!.x + box!.width / 2
+  const startY = box!.y + box!.height / 2
+
+  await page.mouse.move(startX, startY)
+  await page.mouse.down()
+
+  for (let step = 1; step <= 12; step++) {
+    await page.mouse.move(startX + (targetX - startX) * (step / 12), startY + (targetY - startY) * (step / 12))
+    await page.waitForTimeout(20)
+  }
+
+  await page.mouse.up()
+}
+
+async function groupIdFor(page: Page, paneId: string): Promise<string | null> {
+  return page.locator(`[data-tree-tab="${paneId}"]`).evaluate(tab => {
+    return tab.closest<HTMLElement>('[data-tree-group]')?.dataset.treeGroup ?? null
+  })
+}
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+
+  // Keep the primary workspace's tab visible after it becomes a lone pane in
+  // the lower split, matching the reporter's always-visible tab bars.
+  await fixture.page.evaluate(() => localStorage.setItem('hermes.desktop.tabStripDefault', 'always'))
+  await fixture.page.reload()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('a lower primary chat merges into an upper session strip', async () => {
+  const page = fixture!.page
+  const mainPrompt = 'E2E lower primary chat A'
+  const tilePrompt = 'E2E upper session tile B'
+
+  await send(page, mainPrompt)
+
+  // New-session intent opens a session TILE in the same strip, preserving the
+  // loaded primary workspace behind it. Give that tile a real session too.
+  await page.locator('[data-slot="sidebar"] button[aria-label="New session"]').first().click()
+  await send(page, tilePrompt)
+
+  const tileTab = page.locator('[data-tree-tab^="session-tile:"]').first()
+  const workspaceTab = page.locator('[data-tree-tab="workspace"]')
+  await expect(tileTab).toBeVisible({ timeout: 30_000 })
+  await expect(workspaceTab).toBeVisible({ timeout: 30_000 })
+
+  const tilePaneId = await tileTab.getAttribute('data-tree-tab')
+  expect(tilePaneId).not.toBeNull()
+
+  // Tear B into a top split, leaving the primary workspace chat A below it.
+  const sharedGroup = tileTab.locator('xpath=ancestor::*[@data-tree-group][1]')
+  const sharedBox = await sharedGroup.boundingBox()
+  expect(sharedBox).not.toBeNull()
+  await drag(page, tileTab, sharedBox!.x + sharedBox!.width / 2, sharedBox!.y + 54)
+
+  await expect
+    .poll(() => groupIdFor(page, 'workspace'), { timeout: 15_000 })
+    .not.toBe(await groupIdFor(page, tilePaneId!))
+  expect(await groupIdFor(page, 'workspace')).not.toBe(await groupIdFor(page, tilePaneId!))
+
+  // This is the user's failing gesture: drag the bottom primary chat onto the
+  // upper chat's tab strip. It must move `workspace` itself, not attempt to
+  // open the already-selected stored session as a duplicate tile.
+  const targetStrip = tileTab.locator('xpath=ancestor::*[@data-zone-tabstrip][1]')
+  const stripBox = await targetStrip.boundingBox()
+  expect(stripBox).not.toBeNull()
+  await drag(page, workspaceTab, stripBox!.x + stripBox!.width - 24, stripBox!.y + stripBox!.height / 2)
+
+  await expect.poll(() => groupIdFor(page, 'workspace'), { timeout: 15_000 }).toBe(await groupIdFor(page, tilePaneId!))
+})

--- a/apps/desktop/e2e/cross-zone-workspace-tab.spec.ts
+++ b/apps/desktop/e2e/cross-zone-workspace-tab.spec.ts
@@ -98,4 +98,6 @@ test('a lower primary chat merges into an upper session strip', async () => {
   await drag(page, workspaceTab, stripBox!.x + stripBox!.width - 24, stripBox!.y + stripBox!.height / 2)
 
   await expect.poll(() => groupIdFor(page, 'workspace'), { timeout: 15_000 }).toBe(await groupIdFor(page, tilePaneId!))
+  await expect(page.locator('[data-tree-tab="workspace"]')).toHaveAttribute('aria-selected', 'true')
+  await expect(page.locator('[data-session-anchor="workspace"]:visible')).toContainText(mainPrompt)
 })

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -179,6 +179,61 @@ describe('session drop targeting across stacked tabs', () => {
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 
+  it('reveals a minimized destination after moving the primary workspace into it', () => {
+    document.body.innerHTML = `
+      <div data-tree-group="top">
+        <div data-zone-tabstrip="top">
+          <button data-tree-tab="session-tile:top"></button>
+        </div>
+      </div>
+      <div data-tree-group="bottom">
+        <button id="workspace-tab" data-tree-tab="workspace"></button>
+      </div>
+    `
+
+    const top = document.querySelector<HTMLElement>('[data-tree-group="top"]')!
+    const bottom = document.querySelector<HTMLElement>('[data-tree-group="bottom"]')!
+    const strip = document.querySelector<HTMLElement>('[data-zone-tabstrip="top"]')!
+    const targetTab = document.querySelector<HTMLElement>('[data-tree-tab="session-tile:top"]')!
+    const workspaceTab = document.getElementById('workspace-tab')!
+
+    stubRect(top, { left: 0, top: 0, right: 1000, bottom: 390 })
+    stubRect(strip, { left: 0, top: 0, right: 1000, bottom: 32 })
+    stubRect(targetTab, { left: 0, top: 0, right: 300, bottom: 32 })
+    stubRect(bottom, { left: 0, top: 410, right: 1000, bottom: 800 })
+    stubRect(workspaceTab, { left: 0, top: 410, right: 300, bottom: 442 })
+
+    $layoutTree.set(
+      split('column', [
+        group(['session-tile:top'], { active: 'session-tile:top', id: 'top', minimized: true }),
+        group(['workspace'], { active: 'workspace', id: 'bottom' })
+      ])
+    )
+
+    startSessionDrag(
+      { id: 'main-session', profile: 'default', title: 'Main chat' },
+      {
+        button: 0,
+        clientX: 100,
+        clientY: 425,
+        currentTarget: workspaceTab,
+        pointerId: 1
+      } as unknown as ReactPointerEvent<HTMLElement>,
+      { sourcePaneId: 'workspace' }
+    )
+
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 800, clientY: 16 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 800, clientY: 16 }))
+
+    expect(findGroupOfPane($layoutTree.get()!, 'workspace')).toMatchObject({
+      active: 'workspace',
+      id: 'top',
+      minimized: false,
+      panes: ['session-tile:top', 'workspace']
+    })
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
   it('excludes the primary workspace pane from its own same-strip insertion slots', () => {
     document.body.innerHTML = `
       <div data-tree-group="shared">

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -1,7 +1,7 @@
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { group } from '@/components/pane-shell/tree/model'
+import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { openSessionTile } from '@/store/session-states'
 
@@ -123,6 +123,105 @@ describe('session drop targeting across stacked tabs', () => {
     dragTo(document.getElementById('row')!, 120, 400)
 
     expect(requestComposerInsertRefs).not.toHaveBeenCalled()
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('moves the primary workspace pane when its loaded chat is stacked into another chat strip', () => {
+    document.body.innerHTML = `
+      <div data-tree-group="top">
+        <div data-zone-tabstrip="top">
+          <button data-tree-tab="session-tile:top"></button>
+        </div>
+      </div>
+      <div data-tree-group="bottom">
+        <button id="workspace-tab" data-tree-tab="workspace"></button>
+      </div>
+    `
+
+    const top = document.querySelector<HTMLElement>('[data-tree-group="top"]')!
+    const bottom = document.querySelector<HTMLElement>('[data-tree-group="bottom"]')!
+    const strip = document.querySelector<HTMLElement>('[data-zone-tabstrip="top"]')!
+    const targetTab = document.querySelector<HTMLElement>('[data-tree-tab="session-tile:top"]')!
+    const workspaceTab = document.getElementById('workspace-tab')!
+
+    stubRect(top, { left: 0, top: 0, right: 1000, bottom: 390 })
+    stubRect(strip, { left: 0, top: 0, right: 1000, bottom: 32 })
+    stubRect(targetTab, { left: 0, top: 0, right: 300, bottom: 32 })
+    stubRect(bottom, { left: 0, top: 410, right: 1000, bottom: 800 })
+    stubRect(workspaceTab, { left: 0, top: 410, right: 300, bottom: 442 })
+
+    $layoutTree.set(
+      split('column', [
+        group(['session-tile:top'], { active: 'session-tile:top', id: 'top' }),
+        group(['workspace'], { active: 'workspace', id: 'bottom' })
+      ])
+    )
+
+    startSessionDrag(
+      { id: 'main-session', profile: 'default', title: 'Main chat' },
+      {
+        button: 0,
+        clientX: 100,
+        clientY: 425,
+        currentTarget: workspaceTab,
+        pointerId: 1
+      } as unknown as ReactPointerEvent<HTMLElement>,
+      { sourcePaneId: 'workspace' }
+    )
+
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 800, clientY: 16 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 800, clientY: 16 }))
+
+    expect(findGroupOfPane($layoutTree.get()!, 'workspace')).toMatchObject({
+      id: 'top',
+      panes: ['session-tile:top', 'workspace']
+    })
+    expect(openSessionTile).not.toHaveBeenCalled()
+  })
+
+  it('excludes the primary workspace pane from its own same-strip insertion slots', () => {
+    document.body.innerHTML = `
+      <div data-tree-group="shared">
+        <div data-zone-tabstrip="shared">
+          <button id="workspace-tab" data-tree-tab="workspace"></button>
+          <button data-tree-tab="session-tile:other"></button>
+        </div>
+      </div>
+    `
+
+    const groupEl = document.querySelector<HTMLElement>('[data-tree-group="shared"]')!
+    const strip = document.querySelector<HTMLElement>('[data-zone-tabstrip="shared"]')!
+    const workspaceTab = document.getElementById('workspace-tab')!
+    const otherTab = document.querySelector<HTMLElement>('[data-tree-tab="session-tile:other"]')!
+
+    stubRect(groupEl, { left: 0, top: 0, right: 1000, bottom: 800 })
+    stubRect(strip, { left: 0, top: 0, right: 1000, bottom: 32 })
+    stubRect(workspaceTab, { left: 0, top: 0, right: 300, bottom: 32 })
+    stubRect(otherTab, { left: 300, top: 0, right: 600, bottom: 32 })
+
+    const tree = group(['workspace', 'session-tile:other'], { active: 'workspace', id: 'shared' })
+    $layoutTree.set(tree)
+
+    startSessionDrag(
+      { id: 'main-session', profile: 'default', title: 'Main chat' },
+      {
+        button: 0,
+        clientX: 150,
+        clientY: 16,
+        currentTarget: workspaceTab,
+        pointerId: 1
+      } as unknown as ReactPointerEvent<HTMLElement>,
+      { sourcePaneId: 'workspace' }
+    )
+
+    // A small leftward drag over the workspace's own slot is a no-op. Before
+    // the fix, the slot named `workspace`; removal erased that anchor and the
+    // insert fell back to append, unexpectedly moving workspace to the end.
+    window.dispatchEvent(new MouseEvent('pointermove', { bubbles: true, clientX: 10, clientY: 16 }))
+    window.dispatchEvent(new MouseEvent('pointerup', { bubbles: true, clientX: 10, clientY: 16 }))
+
+    expect($layoutTree.get()).toBe(tree)
+    expect(findGroupOfPane($layoutTree.get()!, 'workspace')?.panes).toEqual(['workspace', 'session-tile:other'])
     expect(openSessionTile).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/app/chat/session-drag.test.ts
+++ b/apps/desktop/src/app/chat/session-drag.test.ts
@@ -1,7 +1,7 @@
 import type { PointerEvent as ReactPointerEvent } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
+import { findGroup, findGroupOfPane, group, split } from '@/components/pane-shell/tree/model'
 import { $layoutTree } from '@/components/pane-shell/tree/store'
 import { openSessionTile } from '@/store/session-states'
 
@@ -233,6 +233,81 @@ describe('session drop targeting across stacked tabs', () => {
     })
     expect(openSessionTile).not.toHaveBeenCalled()
   })
+
+  // The reviewed PR path is not strip-only: `subZonePosition` resolves an edge
+  // band to a split pos, and `moveTreePane` must carry the workspace through
+  // `movePane` for EVERY TileDock value, not just `center`. Parameterized over
+  // all four edges — each asserts the pane landed in a NEW split group on that
+  // edge of the destination zone AND the emptied lower zone dissolved (the
+  // reviewer's dangling-empty-group question, answered per edge).
+  it.each(['bottom', 'left', 'right', 'top'] as const)(
+    'moves the primary workspace on an edge-split drop (%s) and dissolves the source zone',
+    pos => {
+      document.body.innerHTML = `
+        <div data-tree-group="top">
+          <div data-tree-tab="session-tile:top"></div>
+        </div>
+        <div data-tree-group="bottom">
+          <button id="workspace-tab" data-tree-tab="workspace"></button>
+        </div>
+      `
+
+      const top = document.querySelector<HTMLElement>('[data-tree-group="top"]')!
+      const bottom = document.querySelector<HTMLElement>('[data-tree-group="bottom"]')!
+      const workspaceTab = document.getElementById('workspace-tab')!
+
+      stubRect(top, { left: 0, top: 0, right: 1000, bottom: 390 })
+      stubRect(bottom, { left: 0, top: 410, right: 1000, bottom: 800 })
+      stubRect(workspaceTab, { left: 0, top: 410, right: 300, bottom: 442 })
+
+      $layoutTree.set(
+        split('column', [
+          group(['session-tile:top'], { active: 'session-tile:top', id: 'top' }),
+          group(['workspace'], { active: 'workspace', id: 'bottom' })
+        ])
+      )
+
+      startSessionDrag(
+        { id: 'main-session', profile: 'default', title: 'Main chat' },
+        {
+          button: 0,
+          clientX: 100,
+          clientY: 425,
+          currentTarget: workspaceTab,
+          pointerId: 1
+        } as unknown as ReactPointerEvent<HTMLElement>,
+        { sourcePaneId: 'workspace' }
+      )
+
+      // Off the strip, past the center ellipse (r = 0.62): the dominant-axis
+      // radial pick resolves each named edge, e.g. bottom-right → 'bottom'.
+      window.dispatchEvent(
+        new MouseEvent('pointermove', {
+          bubbles: true,
+          clientX: pos === 'left' ? 30 : 970,
+          clientY: pos === 'top' ? 30 : 360
+        })
+      )
+      window.dispatchEvent(
+        new MouseEvent('pointerup', {
+          bubbles: true,
+          clientX: pos === 'left' ? 30 : 970,
+          clientY: pos === 'top' ? 30 : 360
+        })
+      )
+
+      // The workspace moved to a fresh group docked on `pos` of the upper zone
+      // — not duplicated through openSessionTile.
+      expect(openSessionTile).not.toHaveBeenCalled()
+      const tree = $layoutTree.get()!
+      expect(findGroupOfPane(tree, 'workspace')).toMatchObject({ panes: ['workspace'] })
+
+      // The upper zone still stands; the emptied lower one is GONE (normalize
+      // prunes it) — the reviewer's dangling-empty-group question.
+      expect(findGroup(tree, 'top')).not.toBeNull()
+      expect(findGroup(tree, 'bottom')).toBeNull()
+    }
+  )
 
   it('excludes the primary workspace pane from its own same-strip insertion slots', () => {
     document.body.innerHTML = `

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -38,11 +38,8 @@ import {
   subZonePosition
 } from '@/components/pane-shell/tree/renderer/drag-session'
 import {
-  $layoutTree,
   $treeDragging,
   type DropHint,
-  isMainStripPane,
-  isSessionStripPane,
   moveTreePane,
   revealTreePane,
   SESSION_TILE_DRAG

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -199,6 +199,10 @@ export function startSessionDrag(
             groupId: split.groupId,
             pos: split.pos
           })
+          // A minimized target keeps that state through movePane. The workspace
+          // is uncloseable and must never disappear into a collapsed zone, so
+          // finish the move through the same reveal invariant used by tiles.
+          revealTreePane(opts.sourcePaneId)
         } else {
           openSessionTile(payload.id, split.pos, split.anchor, split.before)
           // A tile for this session may already exist (openSessionTile is

--- a/apps/desktop/src/app/chat/session-drag.ts
+++ b/apps/desktop/src/app/chat/session-drag.ts
@@ -37,7 +37,16 @@ import {
   type StripSnapshot,
   subZonePosition
 } from '@/components/pane-shell/tree/renderer/drag-session'
-import { $treeDragging, type DropHint, revealTreePane, SESSION_TILE_DRAG } from '@/components/pane-shell/tree/store'
+import {
+  $layoutTree,
+  $treeDragging,
+  type DropHint,
+  isMainStripPane,
+  isSessionStripPane,
+  moveTreePane,
+  revealTreePane,
+  SESSION_TILE_DRAG
+} from '@/components/pane-shell/tree/store'
 import type { EngineZone, ZoneRect } from '@/components/pane-shell/tree/zones-engine'
 import { openSessionTile, type TileDock } from '@/store/session-states'
 
@@ -77,17 +86,19 @@ function snapshotSurfaces(): SurfaceSnapshot[] {
  *  is byte-identical to what the zone overlay paints. */
 
 /**
- * Begin dragging a session — a sidebar row OR a tile's own tab (same drop
- * language either way: stack, split, or composer link). Sub-threshold releases
- * stay ordinary clicks, so `opts.onTap` (activate the tile) rides the tab's
- * gesture; Esc aborts instantly. A stack/split commits through
- * `openSessionTile`, which OPENS a new tile from a sidebar row and MOVES the
- * existing one when its tab is the drag source.
+ * Begin dragging a session — a sidebar row, a tile tab, or the primary
+ * workspace tab (same drop language either way: stack, split, or composer
+ * link). Sub-threshold releases stay ordinary clicks, so `opts.onTap`
+ * (activate the tile) rides the tab's gesture; Esc aborts instantly. A
+ * stack/split normally commits through `openSessionTile`, which OPENS a new
+ * tile from a sidebar row and MOVES an existing tile. The primary workspace is
+ * already a pane and cannot be duplicated as a tile, so `sourcePaneId` moves
+ * that pane itself instead.
  */
 export function startSessionDrag(
   payload: SessionDragPayload,
   e: ReactPointerEvent<HTMLElement>,
-  opts?: { onTap?: () => void }
+  opts?: { onTap?: () => void; sourcePaneId?: 'workspace' }
 ) {
   let zones: EngineZone[] = []
   let strips: StripSnapshot[] = []
@@ -97,7 +108,7 @@ export function startSessionDrag(
 
   // Commit intent, updated per resolved move (the machinery flushes the final
   // move before commit, so these always match the released-at position).
-  let split: { anchor: string; before?: null | string; pos: TileDock } | null = null
+  let split: { anchor: string; before?: null | string; groupId: string; pos: TileDock } | null = null
   let link: null | string = null
 
   // The drag SOURCE (sidebar row or tile tab). Captured synchronously — React
@@ -144,10 +155,12 @@ export function startSessionDrag(
       const strip = strips.find(s => s.groupId === zone.id && rectContains(s.rect, x, y))
 
       if (strip) {
-        // Exclude the tile's OWN tab from the slots so re-dropping it in its
-        // home strip reorders cleanly (a no-op for a sidebar-row drag).
-        const stack = slotBefore(strip.slots, x, `session-tile:${payload.id}`)
-        split = { anchor: host.pane, before: stack.before, pos: 'center' }
+        // Exclude the actual source pane from the slots so re-dropping a tab
+        // in its home strip reorders cleanly. Tile tabs use their mirrored pane
+        // id; the primary chat moves the `workspace` pane itself.
+        const sourcePaneId = opts?.sourcePaneId ?? `session-tile:${payload.id}`
+        const stack = slotBefore(strip.slots, x, sourcePaneId)
+        split = { anchor: host.pane, before: stack.before, groupId: zone.id, pos: 'center' }
         link = null
 
         return { kind: 'group', groupId: zone.id, groupIds: [zone.id], pos: 'center', stack }
@@ -164,10 +177,10 @@ export function startSessionDrag(
       } else if (pos === 'center') {
         // A preview/page zone has no composer to link to — its center stacks
         // the session as a tab, same as dropping on the strip's tail.
-        split = { anchor: host.pane, pos: 'center' }
+        split = { anchor: host.pane, groupId: zone.id, pos: 'center' }
         link = null
       } else {
-        split = { anchor: surface?.anchor ?? host.pane, pos }
+        split = { anchor: surface?.anchor ?? host.pane, groupId: zone.id, pos }
         link = null
       }
 
@@ -176,11 +189,23 @@ export function startSessionDrag(
 
     onCommit() {
       if (split) {
-        openSessionTile(payload.id, split.pos, split.anchor, split.before)
-        // A tile for this session may already exist (openSessionTile is
-        // idempotent — e.g. persisted from an earlier run): a drop must never
-        // feel dead, so front/unhide/un-dismiss it either way.
-        revealTreePane(`session-tile:${payload.id}`)
+        if (opts?.sourcePaneId) {
+          // The primary workspace cannot become a session tile: openSessionTile
+          // deliberately refuses the session already loaded there. Move the
+          // pane itself so its source zone dissolves and the chat joins the
+          // destination strip instead of making the drop look dead.
+          moveTreePane(opts.sourcePaneId, {
+            before: split.before,
+            groupId: split.groupId,
+            pos: split.pos
+          })
+        } else {
+          openSessionTile(payload.id, split.pos, split.anchor, split.before)
+          // A tile for this session may already exist (openSessionTile is
+          // idempotent — e.g. persisted from an earlier run): a drop must never
+          // feel dead, so front/unhide/un-dismiss it either way.
+          revealTreePane(`session-tile:${payload.id}`)
+        }
       } else if (link) {
         // The "link to chat" drop: an @session chip in that surface's composer.
         requestComposerInsertRefs([sessionInlineRef(payload)], { target: link })

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -150,7 +150,7 @@ const workspaceTabDrag = (event: ReactPointerEvent<HTMLElement>, onTap: () => vo
     return false
   }
 
-  startSessionDrag(payload, event, { onTap })
+  startSessionDrag(payload, event, { onTap, sourcePaneId: 'workspace' })
 
   return true
 }


### PR DESCRIPTION
## Bug Description

Dragging the primary chat tab from one layout zone onto another chat's tab strip appeared to accept the drop, but the zones stayed separate.

Related follow-up to #96852, where always-visible lone-workspace tabs made this layout path directly testable.

## Root Cause

The workspace tab reused the session drag resolver so it could still be dropped into a composer as an `@session` link. Stack and split drops always committed through `openSessionTile`, though. That function intentionally refuses the session already loaded in the primary workspace, so the primary tab's drop became a silent no-op.

## Fix

- Identify the primary workspace as an existing source pane when its tab starts a session drag.
- Preserve composer-link drops, but commit workspace stack/split drops through the layout tree's pane move instead of trying to duplicate the selected session as a tile.
- Keep sidebar-row and session-tile drags on their existing `openSessionTile` path.
- Reveal the destination after moving the primary workspace so a minimized target cannot swallow the uncloseable chat.
- Add pointer-session unit coverage for cross-zone merge, minimized destinations, and same-strip self-slots, plus a real Electron/Playwright regression that creates the reported upper/lower chat layout and requires the primary transcript to remain active and visible after the merge.

## How to Verify

1. Put a session tile in an upper split and the primary workspace chat in a lower split with tab bars visible.
2. Drag the lower workspace tab onto the upper chat's tab strip.
3. Confirm the lower zone dissolves and both chats share the upper tab strip; dropping the same tab into a composer still creates an `@session` link.

## Test Plan

- [x] Regression test fails before the fix and passes after it
- [x] Targeted drag/session/layout tests: 92 passed
- [x] Full desktop UI suite after rebase: 6,937 passed
- [x] TypeScript and targeted ESLint passed
- [x] Production desktop build passed
- [x] Electron/Playwright reproduction passed

## Risk Assessment

Low — the alternate commit path is opt-in only for the `workspace` pane. Sidebar sessions and session tiles keep the existing open/move logic, and composer-link resolution is unchanged.

