### PR TITLE
fix(wecom): scope WECOM_BOT_ID reads to the active profile under multiplexing

### DIFF
--- a/plugins/platforms/wecom/adapter.py
+++ b/plugins/platforms/wecom/adapter.py
@@ -317,7 +317,7 @@ class WeComAdapter(BasePlatformAdapter):
         super().__init__(config, Platform.WECOM)
 
         extra = config.extra or {}
-        self._bot_id = str(extra.get("bot_id") or os.getenv("WECOM_BOT_ID", "")).strip()
+        self._bot_id = str(extra.get("bot_id") or _get_scoped_secret("WECOM_BOT_ID", "")).strip()
         self._secret = str(extra.get("secret") or _get_scoped_secret("WECOM_SECRET", "")).strip()
         self._ws_url = str(
             extra.get("websocket_url")

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -76,6 +76,38 @@ class TestWeComAdapterAuthzScope:
         assert adapter._dm_policy == "pairing"
         assert adapter._allow_from == []
 
+    def test_scoped_construction_reads_bot_id_from_scope_not_environ(self, multiplex_on, monkeypatch):
+        """bot_id must honor the same scope as its neighboring _secret read
+        (both are read on adjacent lines in __init__) -- a secondary profile's
+        own bot_id must never fall back to the default profile's os.environ
+        value."""
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_BOT_ID", "default-profile-bot-id")
+        monkeypatch.setenv("WECOM_SECRET", "default-profile-secret")
+        token = secret_scope.set_secret_scope(
+            {"WECOM_BOT_ID": "scoped-bot-id", "WECOM_SECRET": "scoped-secret"}
+        )
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._bot_id == "scoped-bot-id"
+        assert adapter._secret == "scoped-secret"
+
+    def test_scoped_miss_does_not_leak_default_profiles_bot_id(self, multiplex_on, monkeypatch):
+        from agent import secret_scope
+        from plugins.platforms.wecom.adapter import WeComAdapter
+
+        monkeypatch.setenv("WECOM_BOT_ID", "default-profile-bot-id")
+        token = secret_scope.set_secret_scope({"SOMETHING_ELSE": "x"})
+        try:
+            adapter = WeComAdapter(PlatformConfig(enabled=True))
+        finally:
+            secret_scope.reset_secret_scope(token)
+        assert adapter._bot_id == ""
+
 
 class TestWeComConnect:
 


### PR DESCRIPTION
## Summary

- `WeComAdapter.__init__` read `WECOM_BOT_ID` via a raw `os.getenv()` call, while the immediately adjacent line reading `WECOM_SECRET` already used the module's `_get_scoped_secret()` helper (`agent.secret_scope`-aware).
- Under `gateway.multiplex_profiles`, a secondary profile's adapter is constructed inside a scoped context where `os.environ` still holds the DEFAULT profile's env-bridge output. A secondary profile with its own `WECOM_BOT_ID` configured could silently connect using the default profile's bot_id while (correctly) using its own secret — or, on a scope miss, leak the default profile's bot_id in entirely.
- This is the same profile-scoping bug class fixed for the adjacent `_secret`/`_dm_policy`/`_group_policy`/`_allow_from` reads in this same `__init__` by #76664 / #93545 (issue #93522) — `bot_id` was the one sibling line left behind.

## Fix

Switch the `bot_id` read from `os.getenv("WECOM_BOT_ID", "")` to `_get_scoped_secret("WECOM_BOT_ID", "")`, matching the established helper already used one line below for `_secret`.

`_standalone_send`'s out-of-process (cron) fallback branch constructs a fresh `WeComAdapter(pconfig)` when no live gateway adapter is available, so it inherits this fix automatically through `__init__` — no separate change needed there.

## Tests

Added two tests to the existing `TestWeComAdapterAuthzScope` class in `tests/gateway/test_wecom.py` (which already covers `dm_policy`/`allow_from` scoping per #93522), mirroring its established fixture/assertion style:
- `test_scoped_construction_reads_bot_id_from_scope_not_environ` — a secondary profile's own `WECOM_BOT_ID` wins over the default profile's `os.environ` value.
- `test_scoped_miss_does_not_leak_default_profiles_bot_id` — a scope miss returns empty, never borrowing the default profile's `os.environ` value.

Mutation-verified: stashed the one-line production fix, confirmed both new tests fail against pre-fix code (asserting the leak), restored the fix, confirmed all tests in `tests/gateway/test_wecom.py` pass (63 passed, 3 skipped) plus the full `_get_scoped_secret` parametrized suite in `tests/gateway/test_adapter_startup_secret_scope.py`.

## Competitor check

Searched open/closed PRs for `WECOM_BOT_ID`, `wecom scope`, `WeCom multiplex`. The two closest prior-art PRs (#93545, closed/superseded by merged #76664; #88559, open) both touch `plugins/platforms/wecom/adapter.py` for the *sibling* fields (`dm_policy`/`allow_from`/`group_policy`/`GATEWAY_ALLOW_ALL_USERS`/`WECOM_ALLOW_ALL_USERS`) but neither touches the `bot_id` line — confirmed by diffing both PRs directly. No open competitor for this specific fix.

## Checklist

- [x] Read current adapter code directly (not from a stale scan summary)
- [x] Minimal, precedent-matching fix (reuses existing `_get_scoped_secret` helper)
- [x] New regression tests, mutation-verified against the pre-fix code
- [x] Full existing WeCom test suite passes
- [x] Fresh competitor PR search immediately before opening this PR