### PR TITLE
fix(desktop): stop token reconnect looping on 401/4401

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -1,4 +1,9 @@
-import { isGatewayReauthRequired, JsonRpcGatewayError, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  isGatewayHandshakeAuthFailure,
+  isGatewayReauthRequired,
+  JsonRpcGatewayError,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { useEffect, useRef } from 'react'
 
 import { shouldApplyPostBootProgressError } from '@/components/boot-failure-reauth'
@@ -386,16 +391,22 @@ export function useGatewayBoot({
         await callbacksRef.current.refreshHermesConfig().catch(() => undefined)
         await callbacksRef.current.refreshSessions().catch(() => undefined)
       } catch (err) {
-        // OAuth session expired mid-reconnect: surface the actionable "sign in
-        // again" recovery overlay once instead of silently looping the backoff
-        // against a ticket that can never succeed. Transport failures fall
-        // through to the backoff in the finally block below — they must NOT
-        // take the full-screen "couldn't start" path (locks reading/drafting).
-        if (!cancelled && isGatewayReauthRequired(err) && !reauthNotified) {
+        // OAuth session expired, or a token gateway closed the upgrade with
+        // 4401/401: surface the recovery overlay once instead of looping
+        // "connecting" against a credential that can never succeed.
+        // Transport failures fall through to the backoff below.
+        if (!cancelled && !reauthNotified && (isGatewayReauthRequired(err) || isGatewayHandshakeAuthFailure(err))) {
           reauthNotified = true
           const message = err instanceof Error ? err.message : String(err)
           failDesktopBoot(message)
-          notifyError(err, translateNow('boot.errors.gatewaySignInRequired'))
+          notifyError(
+            err,
+            translateNow(
+              /paste a new session token|handshake failed: 4401|\b401\b|\b403\b/i.test(message)
+                ? 'boot.errors.gatewaySessionTokenRejected'
+                : 'boot.errors.gatewaySignInRequired'
+            )
+          )
         }
       } finally {
         reconnecting = false

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -99,6 +99,7 @@ export const ar = defineLocale({
       gatewayConnectionLostDetail:
         'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'تسجيل الدخول للبوابة مطلوب',
+      gatewaySessionTokenRejected: 'ألصق رمز جلسة جديد',
       ipcBridgeUnavailable: 'جسر IPC لسطح المكتب غير متاح.'
     },
     failure: {

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -84,6 +84,7 @@ export const en: Translations = {
       gatewayConnectionLostDetail:
         'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'Gateway sign-in required',
+      gatewaySessionTokenRejected: 'Paste a new session token',
       ipcBridgeUnavailable: 'Desktop IPC bridge is unavailable.'
     },
     failure: {

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -84,6 +84,7 @@ export const ja = defineLocale({
       gatewayConnectionLostDetail:
         'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: 'ゲートウェイへのサインインが必要です',
+      gatewaySessionTokenRejected: '新しいセッショントークンを貼り付けてください',
       ipcBridgeUnavailable: 'デスクトップ IPC ブリッジが利用できません。'
     },
     failure: {

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -101,6 +101,7 @@ export const ru = defineLocale({
       desktopBootFailed: 'Не удалось запустить приложение',
       gatewayConnectionLost: 'Соединение с шлюзом потеряно',
       gatewaySignInRequired: 'Требуется вход в шлюз',
+      gatewaySessionTokenRejected: 'Вставьте новый токен сессии',
       ipcBridgeUnavailable: 'IPC-мост приложения недоступен.'
     },
     failure: {

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -131,6 +131,7 @@ export interface Translations {
       gatewayConnectionLost: string
       gatewayConnectionLostDetail: string
       gatewaySignInRequired: string
+      gatewaySessionTokenRejected: string
       ipcBridgeUnavailable: string
     }
     failure: {

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -84,6 +84,7 @@ export const zhHant = defineLocale({
       gatewayConnectionLostDetail:
         'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: '需要閘道登入',
+      gatewaySessionTokenRejected: '貼上新的工作階段 Token',
       ipcBridgeUnavailable: '桌面 IPC 橋接器不可用。'
     },
     failure: {

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -84,6 +84,7 @@ export const zh: Translations = {
       gatewayConnectionLostDetail:
         'Still retrying in the background. You can keep reading and drafting — open Gateway settings if this persists.',
       gatewaySignInRequired: '需要登录网关',
+      gatewaySessionTokenRejected: '粘贴新的会话 token',
       ipcBridgeUnavailable: '桌面 IPC 桥不可用。'
     },
     failure: {

--- a/apps/desktop/src/lib/gateway-ws-url.test.ts
+++ b/apps/desktop/src/lib/gateway-ws-url.test.ts
@@ -1,4 +1,10 @@
-import { GatewayReauthRequiredError, isGatewayReauthRequired, resolveGatewayWsUrl } from '@hermes/shared'
+import {
+  GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE,
+  GatewayReauthRequiredError,
+  isGatewayHandshakeAuthFailure,
+  isGatewayReauthRequired,
+  resolveGatewayWsUrl
+} from '@hermes/shared'
 import { describe, expect, it, vi } from 'vitest'
 
 const oauthConn = { authMode: 'oauth' as const, wsUrl: 'ws://host/api/ws?ticket=stale' }
@@ -89,6 +95,28 @@ describe('resolveGatewayWsUrl', () => {
       await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, tokenConn)).resolves.toBe(tokenConn.wsUrl)
     })
 
+    it('does not reuse the stale token URL when mint reports 401', async () => {
+      const getGatewayWsUrl = vi.fn().mockResolvedValue({
+        error: '401: Unauthorized',
+        needsOauthLogin: true,
+        ok: false
+      })
+
+      const error = await resolveGatewayWsUrl({ getGatewayWsUrl }, tokenConn).catch(e => e)
+
+      expect(error).toBeInstanceOf(GatewayReauthRequiredError)
+      expect(error.message).toBe(GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE)
+      expect(isGatewayReauthRequired(error)).toBe(true)
+    })
+
+    it('does not reuse the stale token URL when mint throws 401', async () => {
+      const getGatewayWsUrl = vi.fn().mockRejectedValue(new Error('401: gateway session expired'))
+
+      await expect(resolveGatewayWsUrl({ getGatewayWsUrl }, tokenConn)).rejects.toBeInstanceOf(
+        GatewayReauthRequiredError
+      )
+    })
+
     it('falls back to the cached URL when the preload method is absent', async () => {
       await expect(resolveGatewayWsUrl({}, tokenConn)).resolves.toBe(tokenConn.wsUrl)
     })
@@ -96,6 +124,15 @@ describe('resolveGatewayWsUrl', () => {
     it('treats a missing authMode as non-oauth (falls back safely)', async () => {
       await expect(resolveGatewayWsUrl({}, { wsUrl: tokenConn.wsUrl })).resolves.toBe(tokenConn.wsUrl)
     })
+  })
+})
+
+describe('isGatewayHandshakeAuthFailure', () => {
+  it('matches 4401 handshake errors and structured 401s', () => {
+    expect(isGatewayHandshakeAuthFailure(new Error('WebSocket handshake failed: 4401'))).toBe(true)
+    expect(isGatewayHandshakeAuthFailure({ statusCode: 401 })).toBe(true)
+    expect(isGatewayHandshakeAuthFailure({ ok: false, error: '401: Unauthorized' })).toBe(true)
+    expect(isGatewayHandshakeAuthFailure(new Error('connection closed'))).toBe(false)
   })
 })
 

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -8,6 +8,7 @@ interface ListenerEntry {
 
 class FakeSocket {
   static readonly CLOSED = 3
+  static readonly CONNECTING = 0
   static readonly OPEN = 1
 
   readonly sent: string[] = []
@@ -127,5 +128,30 @@ describe('JsonRpcGatewayClient heartbeat recovery', () => {
     expect(client.connectionState).toBe('open')
     expect(socket.readyState).toBe(FakeSocket.OPEN)
     expect(socket.sent).toEqual([])
+  })
+})
+
+describe('JsonRpcGatewayClient handshake auth close', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('rejects a 4401 upgrade as a 401 handshake failure', async () => {
+    vi.stubGlobal('WebSocket', { CONNECTING: FakeSocket.CONNECTING, OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+    socket.readyState = FakeSocket.CONNECTING
+
+    const client = new JsonRpcGatewayClient({
+      connectErrorMessage: 'Could not connect to Hermes gateway',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const pending = client.connect('ws://gateway.test/api/ws?token=stale')
+    socket.emit('close', { code: 4401, reason: 'Unauthorized' })
+
+    await expect(pending).rejects.toMatchObject({
+      message: expect.stringMatching(/4401/),
+      statusCode: 401
+    })
   })
 })

--- a/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
+++ b/apps/desktop/src/lib/json-rpc-gateway-heartbeat.test.ts
@@ -154,4 +154,25 @@ describe('JsonRpcGatewayClient handshake auth close', () => {
       statusCode: 401
     })
   })
+
+  it('prefers a 4401 close over a preceding error event', async () => {
+    vi.stubGlobal('WebSocket', { CONNECTING: FakeSocket.CONNECTING, OPEN: FakeSocket.OPEN })
+    const socket = new FakeSocket()
+    socket.readyState = FakeSocket.CONNECTING
+
+    const client = new JsonRpcGatewayClient({
+      connectErrorMessage: 'Could not connect to Hermes gateway',
+      socketFactory: () => socket as unknown as WebSocket
+    })
+
+    const pending = client.connect('ws://gateway.test/api/ws?token=stale')
+    socket.emit('error', {})
+    await Promise.resolve()
+    socket.emit('close', { code: 4401, reason: 'Unauthorized' })
+
+    await expect(pending).rejects.toMatchObject({
+      message: expect.stringMatching(/4401/),
+      statusCode: 401
+    })
+  })
 })

--- a/apps/shared/src/index.ts
+++ b/apps/shared/src/index.ts
@@ -102,11 +102,13 @@ export {
 } from './translucency'
 export {
   buildHermesWebSocketUrl,
+  GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE,
   type GatewayAuthMode,
   GatewayReauthRequiredError,
   type GatewayWsConnection,
   type GatewayWsUrlResult,
   type HermesWebSocketUrlOptions,
+  isGatewayHandshakeAuthFailure,
   isGatewayReauthRequired,
   resolveGatewayWsUrl,
   type ResolveGatewayWsUrlDeps,

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -272,12 +272,11 @@ export class JsonRpcGatewayClient {
       }
 
       const onError = () => {
-        // Bad-token gate closes with 4401 slightly after the error event.
-        // Prefer that close code over the generic connect failure so the
-        // renderer can surface paste-token instead of retrying forever.
-        queueMicrotask(() => {
+        // Bad-token gate closes with 4401 in a later task than `error`.
+        // A microtask would settle the generic failure first and drop 4401.
+        setTimeout(() => {
           failConnect(new Error(this.options.connectErrorMessage))
-        })
+        }, 0)
       }
 
       socket.addEventListener('open', onOpen, { once: true })

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -100,6 +100,21 @@ const DEFAULT_HEARTBEAT_DEADLINE_MS = 45_000
 // handshake doesn't land in this window, fail to 'error' so callers can retry.
 const DEFAULT_CONNECT_TIMEOUT_MS = 15_000
 
+/** Hermes dashboard/gateway closes an unauthenticated /api/ws upgrade with 4401. */
+function handshakeConnectError(event: { code?: number; reason?: string }, fallback: string): Error {
+  const code = Number(event?.code)
+  const reason = String(event?.reason || '').trim()
+
+  if (code === 4401 || code === 401 || code === 403) {
+    const error = new Error(`WebSocket handshake failed: ${code}${reason ? ` ${reason}` : ''}`)
+    ;(error as Error & { statusCode: number }).statusCode = 401
+
+    return error
+  }
+
+  return new Error(fallback)
+}
+
 export class JsonRpcGatewayClient {
   private nextId = 0
   private pending = new Map<GatewayRequestId, PendingCall>()
@@ -223,6 +238,18 @@ export class JsonRpcGatewayClient {
 
         socket.removeEventListener('open', onOpen)
         socket.removeEventListener('error', onError)
+        socket.removeEventListener('close', onHandshakeClose)
+      }
+
+      const failConnect = (error: Error) => {
+        if (settled) {
+          return
+        }
+
+        settled = true
+        cleanup()
+        this.setState('error')
+        reject(error)
       }
 
       const onOpen = () => {
@@ -240,19 +267,22 @@ export class JsonRpcGatewayClient {
         void this.fetchReplay()
       }
 
-      const onError = () => {
-        if (settled || this.socket !== socket) {
-          return
-        }
+      const onHandshakeClose = (event: { code?: number; reason?: string }) => {
+        failConnect(handshakeConnectError(event, this.options.connectErrorMessage))
+      }
 
-        settled = true
-        cleanup()
-        this.setState('error')
-        reject(new Error(this.options.connectErrorMessage))
+      const onError = () => {
+        // Bad-token gate closes with 4401 slightly after the error event.
+        // Prefer that close code over the generic connect failure so the
+        // renderer can surface paste-token instead of retrying forever.
+        queueMicrotask(() => {
+          failConnect(new Error(this.options.connectErrorMessage))
+        })
       }
 
       socket.addEventListener('open', onOpen, { once: true })
       socket.addEventListener('error', onError, { once: true })
+      socket.addEventListener('close', onHandshakeClose, { once: true })
 
       if (this.options.connectTimeoutMs > 0) {
         timer = setTimeout(() => {

--- a/apps/shared/src/websocket-url.ts
+++ b/apps/shared/src/websocket-url.ts
@@ -20,6 +20,9 @@ export type GatewayWsUrlResult =
   | { ok: true; wsUrl: string }
   | { error: string; needsOauthLogin?: boolean; ok: false }
 
+export const GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE =
+  "This connection's session token was rejected. Open Settings -> Gateway and paste a new session token."
+
 export class GatewayReauthRequiredError extends Error {
   readonly needsOauthLogin = true
 
@@ -34,6 +37,37 @@ export function isGatewayReauthRequired(error: unknown): error is GatewayReauthR
     error instanceof GatewayReauthRequiredError ||
     (typeof error === 'object' && error !== null && (error as { needsOauthLogin?: unknown }).needsOauthLogin === true)
   )
+}
+
+/** Token/ticket handshake refused (HTTP 401/403 or gateway close 4401). */
+const GATEWAY_AUTH_FAILURE_RE =
+  /\b(401|403|4401)\b|unauthorized|session token was rejected|needs oauth login/i
+
+export function isGatewayHandshakeAuthFailure(error: unknown): boolean {
+  if (isGatewayReauthRequired(error)) {
+    return true
+  }
+
+  if (error && typeof error === 'object') {
+    const record = error as { error?: unknown; needsSessionToken?: unknown; statusCode?: unknown }
+    if (record.needsSessionToken === true) {
+      return true
+    }
+
+    const status = Number(record.statusCode)
+
+    if (status === 401 || status === 403 || status === 4401) {
+      return true
+    }
+
+    if (typeof record.error === 'string' && GATEWAY_AUTH_FAILURE_RE.test(record.error)) {
+      return true
+    }
+  }
+
+  const text = error instanceof Error ? error.message : String(error ?? '')
+
+  return GATEWAY_AUTH_FAILURE_RE.test(text)
 }
 
 export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: GatewayWsConnection): Promise<string> {
@@ -79,14 +113,32 @@ export async function resolveGatewayWsUrl(deps: ResolveGatewayWsUrlDeps, conn: G
   }
 
   if (mint) {
-    const fresh = await mint(profile).catch(() => null)
+    try {
+      const fresh = await mint(profile)
 
-    if (typeof fresh === 'string') {
-      return fresh
-    }
+      if (typeof fresh === 'string') {
+        return fresh
+      }
 
-    if (fresh?.ok) {
-      return fresh.wsUrl
+      if (fresh?.ok) {
+        return fresh.wsUrl
+      }
+
+      if (fresh && isGatewayHandshakeAuthFailure(fresh)) {
+        throw new GatewayReauthRequiredError(GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE, {
+          cause: new Error(fresh.error)
+        })
+      }
+    } catch (error) {
+      if (isGatewayReauthRequired(error)) {
+        throw error
+      }
+
+      if (isGatewayHandshakeAuthFailure(error)) {
+        throw new GatewayReauthRequiredError(GATEWAY_SESSION_TOKEN_REJECTED_MESSAGE, {
+          cause: error instanceof Error ? error : undefined
+        })
+      }
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

After a dashboard token rotation, Desktop retried the stale WS URL forever and never left the "connecting" spinner. Token mint swallowed 401 (`needsOauthLogin`) and fell back to the cached URL; `/api/ws` then closed with 4401 and `connect()` reported a generic failure.

Token mint now throws a paste-token reauth error on 401/403 instead of reusing the stale URL. A 4401 handshake close is classified as 401 so the reconnect loop surfaces recovery once.

## Related Issue

Fixes #100530

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/shared/src/websocket-url.ts`: honor token 401/403; `isGatewayHandshakeAuthFailure`
- `apps/shared/src/json-rpc-gateway.ts`: map close 4401 during connect
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: stop reconnect loop on handshake auth failure

## How to Test

```text
cd apps/desktop
npx vitest run src/lib/gateway-ws-url.test.ts src/lib/json-rpc-gateway-heartbeat.test.ts src/app/gateway/hooks/use-gateway-boot.test.tsx src/i18n/languages.test.ts
# 68 passed
```

Not runtime-tested against a live dashboard token rotation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
