### PR TITLE
fix(desktop): let Stop and update drain leftover serve backends

### DIFF
--- a/apps/desktop/electron/venv-blocker-scan.test.ts
+++ b/apps/desktop/electron/venv-blocker-scan.test.ts
@@ -206,6 +206,65 @@ describe('parseVenvBlockerScanOutput', () => {
     assert.equal(o.result.processes[0]?.safeToStop, false)
   })
 
+  it('classifies scanner-identified leftover serve processes as stoppable pool backends', () => {
+    const o = parseVenvBlockerScanOutput(
+      ok({
+        blocked: true,
+        processes: [
+          {
+            pid: 4242,
+            name: 'python.exe',
+            cmdline: 'python.exe -m hermes_cli.main --profile writer serve',
+            kind: 'pool-backend',
+            safeToStop: true,
+            label: 'serve',
+            createTime: 1722798000.25
+          }
+        ]
+      })
+    )
+
+    assert.equal(o.kind, 'blocked')
+
+    if (o.kind !== 'blocked') {
+      return
+    }
+
+    assert.deepEqual(o.result.processes[0], {
+      pid: 4242,
+      name: 'python.exe',
+      cmdline: 'python.exe -m hermes_cli.main --profile writer serve',
+      kind: 'pool-backend',
+      safeToStop: true,
+      label: 'serve',
+      createTime: 1722798000.25
+    })
+  })
+
+  it('does not trust a serve command line without scanner identity metadata', () => {
+    const o = parseVenvBlockerScanOutput(
+      ok({
+        blocked: true,
+        processes: [
+          {
+            pid: 4242,
+            name: 'python.exe',
+            cmdline: 'python.exe -m hermes_cli.main serve'
+          }
+        ]
+      })
+    )
+
+    assert.equal(o.kind, 'blocked')
+
+    if (o.kind !== 'blocked') {
+      return
+    }
+
+    assert.equal(o.result.processes[0]?.kind, 'other')
+    assert.equal(o.result.processes[0]?.safeToStop, false)
+  })
+
   it('never marks an arbitrary Python process safe to stop', () => {
     const o = parseVenvBlockerScanOutput(
       ok({
@@ -403,5 +462,43 @@ describe('stopSafeVenvBlockers', () => {
       }
     ])
     assert.deepEqual(outcome, { stopped: [47484], failed: [] })
+  })
+
+  it('stops leftover pool backends the scanner marked safe', async () => {
+    const calls: Array<{ command: string; args: string[] }> = []
+
+    const exec = (async (command: string, args: string[]) => {
+      calls.push({ command, args })
+
+      return { stdout: '', stderr: '' }
+    }) as any
+
+    const outcome = await stopSafeVenvBlockers(
+      '/update/root',
+      {
+        blocked: true,
+        processes: [
+          {
+            pid: 4242,
+            name: 'python.exe',
+            cmdline: 'python.exe -m hermes_cli.main serve',
+            kind: 'pool-backend',
+            safeToStop: true,
+            label: 'serve',
+            createTime: 1722798000.25
+          }
+        ]
+      },
+      exec,
+      () => 'C:\\Hermes\\venv\\Scripts\\python.exe'
+    )
+
+    assert.deepEqual(calls, [
+      {
+        command: 'C:\\Hermes\\venv\\Scripts\\python.exe',
+        args: ['-m', 'hermes_cli._scan_venv_blockers', '--terminate-safe', '4242', '1722798000.25']
+      }
+    ])
+    assert.deepEqual(outcome, { stopped: [4242], failed: [] })
   })
 })

--- a/apps/desktop/electron/venv-blocker-scan.ts
+++ b/apps/desktop/electron/venv-blocker-scan.ts
@@ -18,7 +18,7 @@ const execFileAsync = promisify(execFile)
 // Types
 // ---------------------------------------------------------------------------
 
-export type VenvBlockerKind = 'local-preview' | 'other'
+export type VenvBlockerKind = 'local-preview' | 'other' | 'pool-backend'
 
 export interface VenvBlockerProcess {
   pid: number
@@ -63,12 +63,26 @@ function classifyVenvBlocker(
   const isPython = /^python(?:w)?(?:\.exe)?$/i.test(process.name)
   const hintedCreateTime = typeof hints?.createTime === 'number' ? hints.createTime : undefined
 
+  const trustedCreateTime =
+    hintedCreateTime !== undefined && Number.isFinite(hintedCreateTime) && hintedCreateTime > 0
+
+  const trustedPoolBackend =
+    hints?.kind === 'pool-backend' && hints.safeToStop === true && trustedCreateTime
+
+  if (trustedPoolBackend) {
+    const hintedLabel = typeof hints?.label === 'string' ? hints.label.trim() : ''
+
+    return {
+      ...process,
+      kind: 'pool-backend',
+      safeToStop: true,
+      ...(hintedLabel ? { label: hintedLabel } : {}),
+      createTime: hintedCreateTime
+    }
+  }
+
   const trustedScannerIdentity =
-    hints?.kind === 'local-preview' &&
-    hints.safeToStop === true &&
-    hintedCreateTime !== undefined &&
-    Number.isFinite(hintedCreateTime) &&
-    hintedCreateTime > 0
+    hints?.kind === 'local-preview' && hints.safeToStop === true && trustedCreateTime
 
   if (!isPython || !moduleMatch || !trustedScannerIdentity) {
     return { ...process, kind: 'other', safeToStop: false }
@@ -97,9 +111,14 @@ function classifyVenvBlocker(
   }
 }
 
+function isSafeStopKind(kind: VenvBlockerKind): boolean {
+  return kind === 'local-preview' || kind === 'pool-backend'
+}
+
 /**
- * Stop only blockers that the fresh scanner identified as Python static-file
- * preview servers. Unknown Python/Hermes processes are deliberately ignored.
+ * Stop blockers the fresh scanner identified as Python static-file preview
+ * servers or leftover Desktop ``hermes serve`` pool backends. Unknown
+ * Python/Hermes processes are deliberately ignored.
  */
 export async function stopSafeVenvBlockers(
   updateRoot: string,
@@ -116,11 +135,11 @@ export async function stopSafeVenvBlockers(
     if (
       !pythonPath ||
       !process.safeToStop ||
-      process.kind !== 'local-preview' ||
+      !isSafeStopKind(process.kind) ||
       !process.createTime ||
       !Number.isFinite(process.createTime)
     ) {
-      if (process.safeToStop && process.kind === 'local-preview') {
+      if (process.safeToStop && isSafeStopKind(process.kind)) {
         failed.push(process.pid)
       }
 

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -639,7 +639,7 @@ export interface DesktopUpdateBlocker {
   pid: number
   name: string
   cmdline: string
-  kind: 'local-preview' | 'other'
+  kind: 'local-preview' | 'other' | 'pool-backend'
   safeToStop: boolean
   label?: string
   port?: number
@@ -648,7 +648,7 @@ export interface DesktopUpdateBlocker {
 
 export interface DesktopUpdateApplyOptions {
   dirtyStrategy?: DesktopUpdateDirtyStrategy
-  /** User confirmed that Desktop may stop freshly re-scanned safe local preview servers. */
+  /** User confirmed that Desktop may stop freshly re-scanned safe local preview servers and leftover pool backends. */
   stopSafeBlockers?: boolean
 }
 

--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -149,6 +149,38 @@ def _classify_local_preview_args(args: object) -> dict[str, object]:
     return metadata
 
 
+def _classify_pool_backend_args(args: object) -> dict[str, object]:
+    """Return safe-stop metadata for a Desktop ``hermes serve`` / dashboard argv.
+
+    Token-based via ``_hermes_holder_subcommand`` — never substring matching.
+    Gateway holders stay on the pausable-gateway exemption, not this path.
+    """
+    if not isinstance(args, (list, tuple)) or not all(isinstance(arg, str) for arg in args):
+        return {}
+    try:
+        from hermes_cli.update_cmd import _hermes_holder_subcommand  # noqa: PLC0415
+
+        purpose = _hermes_holder_subcommand(" ".join(args))
+    except Exception:
+        return {}
+    if purpose not in ("serve", "dashboard"):
+        return {}
+    return {"kind": "pool-backend", "safeToStop": True, "label": purpose}
+
+
+def _pool_backend_metadata(pid: int, name: str) -> dict[str, object]:
+    try:
+        import psutil  # noqa: PLC0415
+
+        process = psutil.Process(pid)
+        metadata = _classify_pool_backend_args(process.cmdline())
+        if metadata:
+            metadata["createTime"] = process.create_time()
+        return metadata
+    except Exception:
+        return {}
+
+
 def _local_preview_metadata(pid: int, name: str) -> dict[str, object]:
     if name.lower() not in {"python.exe", "pythonw.exe", "python", "pythonw"}:
         return {}
@@ -183,7 +215,8 @@ def _terminate_safe_preview(
         process = psutil_module.Process(pid)  # type: ignore[attr-defined]
         if abs(process.create_time() - expected_create_time) > 0.001:
             return False, "process identity changed"
-        if not _classify_local_preview_args(process.cmdline()):
+        args = process.cmdline()
+        if not _classify_local_preview_args(args) and not _classify_pool_backend_args(args):
             return False, "process is no longer a local preview"
 
         children = process.children(recursive=True)
@@ -390,6 +423,8 @@ def main() -> None:
             "cmdline": _redact_sensitive_cmdline(cmdline)[:120],
         }
         process.update(_local_preview_metadata(pid, name))
+        if process.get("kind") != "local-preview":
+            process.update(_pool_backend_metadata(pid, name))
         processes.append(process)
 
     data = {

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -18,6 +18,7 @@ import pytest
 import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
     _classify_local_preview_args,
+    _classify_pool_backend_args,
     _is_pausable_gateway,
     _probe_fail_json,
     _redact_sensitive_cmdline,
@@ -123,6 +124,19 @@ def test_classify_local_preview_args_rejects_arbitrary_python_process() -> None:
     assert _classify_local_preview_args(["python.exe", "important-script.py"]) == {}
 
 
+def test_classify_pool_backend_args_accepts_profile_scoped_serve() -> None:
+    assert _classify_pool_backend_args(
+        [r"C:\Hermes\venv\Scripts\python.exe", "-m", "hermes_cli.main", "--profile", "writer", "serve"]
+    ) == {"kind": "pool-backend", "safeToStop": True, "label": "serve"}
+
+
+def test_classify_pool_backend_args_rejects_gateway_and_arbitrary_python() -> None:
+    assert _classify_pool_backend_args(
+        [r"C:\Hermes\venv\Scripts\python.exe", "-m", "hermes_cli.main", "gateway", "run"]
+    ) == {}
+    assert _classify_pool_backend_args(["python.exe", "important-script.py"]) == {}
+
+
 def test_classify_local_preview_args_rejects_module_flags_passed_to_a_script() -> None:
     assert _classify_local_preview_args(
         ["python.exe", "important-script.py", "-m", "http.server", "8765"]
@@ -169,6 +183,47 @@ def test_terminate_safe_preview_revalidates_identity_and_exact_argv() -> None:
     assert error is None
     assert parent.terminated is True
     assert child.terminated is True
+
+
+def test_terminate_safe_preview_accepts_leftover_serve_backend() -> None:
+    class FakeProcess:
+        def __init__(self, pid: int, *, created: float, args: list[str]) -> None:
+            self.pid = pid
+            self._created = created
+            self._args = args
+            self.terminated = False
+            self._children: list[FakeProcess] = []
+
+        def create_time(self) -> float:
+            return self._created
+
+        def cmdline(self) -> list[str]:
+            return self._args
+
+        def children(self, *, recursive: bool) -> list[FakeProcess]:
+            return self._children
+
+        def terminate(self) -> None:
+            self.terminated = True
+
+        def kill(self) -> None:
+            pass
+
+    parent = FakeProcess(
+        100,
+        created=1722798000.25,
+        args=["python.exe", "-m", "hermes_cli.main", "--profile", "writer", "serve"],
+    )
+    fake_psutil = types.SimpleNamespace(
+        Process=lambda pid: parent,
+        wait_procs=lambda processes, timeout: (processes, []),
+    )
+
+    stopped, error = _terminate_safe_preview(100, 1722798000.25, psutil_module=fake_psutil)
+
+    assert stopped is True
+    assert error is None
+    assert parent.terminated is True
 
 
 def test_terminate_safe_preview_refuses_reused_pid() -> None:


### PR DESCRIPTION
## What does this PR do?

Desktop already tree-kills pool backends before update, but leftover `hermes serve` / `dashboard` holders that are not in the pause/deferral path still lock the Windows venv and abort with "another process is holding the Hermes install open". Stop and update only terminated `local-preview` http.server processes.

Leftover serve/dashboard holders are now classified as `pool-backend` (token-based subcommand parse, same identity-guard as local-preview) so the existing Stop and update path can drain them. Gateway run stays on the pausable-gateway exemption. Arbitrary Python is still not safe to stop.

## Related Issue

Fixes #100331

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/_scan_venv_blockers.py`: classify leftover serve/dashboard; terminate-safe accepts them
- `apps/desktop/electron/venv-blocker-scan.ts`: `pool-backend` kind + Stop and update
- tests for classify / parse / stop

## How to Test

```text
uv run --extra dev python -m pytest tests/hermes_cli/test_scan_venv_blockers.py -q
# 41 passed

cd apps/desktop
npx vitest run electron/venv-blocker-scan.test.ts src/store/updates.test.ts
# 88 passed
```

Not runtime-tested on native Windows against a 10-profile fleet.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (unit)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
