### PR TITLE
fix(compression): keep sessions usable when summary models stall

### DIFF
--- a/agent/compression_attempt_context.py
+++ b/agent/compression_attempt_context.py
@@ -1,0 +1,33 @@
+"""Attempt-local state shared by context-compression call paths."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+from collections.abc import Callable, Iterator
+from typing import Optional
+
+_COMPRESSION_CANCELLED_CHECK: contextvars.ContextVar[
+    Optional[Callable[[], bool]]
+] = contextvars.ContextVar("hermes_compression_cancelled_check", default=None)
+
+
+@contextlib.contextmanager
+def compression_cancelled_check(check: Callable[[], bool]) -> Iterator[None]:
+    """Install the cancellation check for one compression attempt context."""
+    token = _COMPRESSION_CANCELLED_CHECK.set(check)
+    try:
+        yield
+    finally:
+        _COMPRESSION_CANCELLED_CHECK.reset(token)
+
+
+def attempt_compression_cancelled() -> Optional[bool]:
+    """Return this attempt's cancellation state, or None outside an attempt."""
+    check = _COMPRESSION_CANCELLED_CHECK.get()
+    if check is None:
+        return None
+    try:
+        return bool(check())
+    except Exception:
+        return False

--- a/agent/compression_static_fallback.py
+++ b/agent/compression_static_fallback.py
@@ -42,25 +42,27 @@ def run_static_compression_fallback(
     reason: str,
     telemetry_agent: Any = None,
     new_fence: Optional[Callable[[], Any]] = None,
-) -> Optional[tuple[list, str]]:
+) -> tuple[bool, Optional[tuple[list, str]]]:
     """Commit the built-in deterministic handoff after a fenced summary stall.
 
     Imports are local to keep this bounded helper independent of the two
     compression orchestrator modules during module initialization.
     """
-    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
-    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
-        return None
-
     try:
         from agent.context_compressor import ContextCompressor
         from agent.conversation_compression import CompressionCommitFence
     except Exception:
-        return None
+        return False, None
 
     compressor = getattr(telemetry_agent, "context_compressor", None)
     if not isinstance(compressor, ContextCompressor):
-        return None
+        return False, None
+
+    # From this point the built-in path owns recovery. A hard stop or local
+    # failure must degrade without issuing a second provider request.
+    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
+    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
+        return True, None
 
     retry_fence = None
     if new_fence is not None:
@@ -87,9 +89,9 @@ def run_static_compression_fallback(
             "Local deterministic compression fallback failed",
             exc_info=True,
         )
-        return None
+        return True, None
     if result_msgs is messages:
-        return None
+        return True, None
 
     record = getattr(compressor, "record_timeout_failure", None)
     if callable(record):
@@ -113,4 +115,4 @@ def run_static_compression_fallback(
             )
         except Exception:
             logger.debug("failed to emit local fallback warning", exc_info=True)
-    return result_msgs, result_prompt
+    return True, (result_msgs, result_prompt)

--- a/agent/compression_static_fallback.py
+++ b/agent/compression_static_fallback.py
@@ -1,0 +1,116 @@
+"""Attempt-local deterministic fallback for timed-out context compression."""
+
+from __future__ import annotations
+
+import contextlib
+import contextvars
+import logging
+from collections.abc import Callable, Iterator
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+# The host can overlap a fenced remote worker with a network-free retry. Keep
+# fallback selection in the retry's copied context instead of shared compressor
+# attributes visible to both attempts.
+_STATIC_SUMMARY_FALLBACK_REASON: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar("hermes_static_summary_fallback_reason", default=None)
+)
+
+
+@contextlib.contextmanager
+def static_summary_fallback(reason: str) -> Iterator[None]:
+    """Force one built-in compaction to use its deterministic handoff."""
+    token = _STATIC_SUMMARY_FALLBACK_REASON.set(
+        str(reason or "summary unavailable")
+    )
+    try:
+        yield
+    finally:
+        _STATIC_SUMMARY_FALLBACK_REASON.reset(token)
+
+
+def static_summary_fallback_reason() -> Optional[str]:
+    """Return the attempt-local reason for bypassing the summary LLM."""
+    return _STATIC_SUMMARY_FALLBACK_REASON.get()
+
+
+def run_static_compression_fallback(
+    *,
+    worker: Callable[[Any], tuple[list, str]],
+    messages: list,
+    reason: str,
+    telemetry_agent: Any = None,
+    new_fence: Optional[Callable[[], Any]] = None,
+) -> Optional[tuple[list, str]]:
+    """Commit the built-in deterministic handoff after a fenced summary stall.
+
+    Imports are local to keep this bounded helper independent of the two
+    compression orchestrator modules during module initialization.
+    """
+    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
+    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
+        return None
+
+    try:
+        from agent.context_compressor import ContextCompressor
+        from agent.conversation_compression import CompressionCommitFence
+    except Exception:
+        return None
+
+    compressor = getattr(telemetry_agent, "context_compressor", None)
+    if not isinstance(compressor, ContextCompressor):
+        return None
+
+    retry_fence = None
+    if new_fence is not None:
+        try:
+            retry_fence = new_fence()
+        except Exception:
+            logger.warning(
+                "static compression fallback fence factory failed",
+                exc_info=True,
+            )
+    if not isinstance(retry_fence, CompressionCommitFence):
+        retry_fence = CompressionCommitFence()
+
+    logger.warning(
+        "Context compression summary %s — committing the local deterministic "
+        "handoff without another LLM request",
+        reason,
+    )
+    try:
+        with static_summary_fallback(reason):
+            result_msgs, result_prompt = worker(retry_fence)
+    except Exception:
+        logger.warning(
+            "Local deterministic compression fallback failed",
+            exc_info=True,
+        )
+        return None
+    if result_msgs is messages:
+        return None
+
+    record = getattr(compressor, "record_timeout_failure", None)
+    if callable(record):
+        try:
+            record(
+                f"local fallback after summary {reason}",
+                failure_kind=(
+                    "ceiling_exhausted" if "total ceiling" in reason else "stalled"
+                ),
+            )
+        except Exception:
+            logger.debug("failed to record local fallback cooldown", exc_info=True)
+
+    emit = getattr(telemetry_agent, "_emit_warning", None)
+    if callable(emit):
+        try:
+            emit(
+                "⚠ Context compression used a local fallback summary because "
+                f"the summary model {reason}. The session remains usable; "
+                "future remote summary attempts are temporarily paused."
+            )
+        except Exception:
+            logger.debug("failed to emit local fallback warning", exc_info=True)
+    return result_msgs, result_prompt

--- a/agent/compression_static_fallback.py
+++ b/agent/compression_static_fallback.py
@@ -93,6 +93,13 @@ def run_static_compression_fallback(
     if result_msgs is messages:
         return True, None
 
+    clear = getattr(compressor, "_clear_compression_failure_cooldown", None)
+    if callable(clear):
+        try:
+            clear()
+        except Exception:
+            logger.debug("failed to reset superseded timeout cooldown", exc_info=True)
+
     record = getattr(compressor, "record_timeout_failure", None)
     if callable(record):
         try:

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -83,6 +83,13 @@ _SUMMARY_ROUTE_PIN: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("hermes_summary_route_pin", default=None)
 )
 
+# A host timeout fences the remote worker before it can publish.  Its local
+# retry must bypass the LLM without mutating shared compressor attributes that
+# the detached worker can still see, so keep the decision attempt-local.
+_STATIC_SUMMARY_FALLBACK_REASON: contextvars.ContextVar[Optional[str]] = (
+    contextvars.ContextVar("hermes_static_summary_fallback_reason", default=None)
+)
+
 # call_llm kwargs a pinned route may set. ``timeout`` lets a fallback entry
 # keep its own deadline instead of inheriting one the primary already burned
 # (same per-entry semantics the aux client applies to chain candidates).
@@ -135,6 +142,23 @@ def _pinned_summary_call_kwargs() -> Dict[str, Any]:
         for field in _PINNED_ROUTE_FIELDS
         if route.get(field) not in (None, "")
     }
+
+
+@contextlib.contextmanager
+def static_summary_fallback(reason: str):
+    """Force one built-in compaction to use its deterministic handoff."""
+    token = _STATIC_SUMMARY_FALLBACK_REASON.set(
+        str(reason or "summary unavailable")
+    )
+    try:
+        yield
+    finally:
+        _STATIC_SUMMARY_FALLBACK_REASON.reset(token)
+
+
+def static_summary_fallback_reason() -> Optional[str]:
+    """Return the attempt-local reason for bypassing the summary LLM."""
+    return _STATIC_SUMMARY_FALLBACK_REASON.get()
 
 
 _SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
@@ -8024,7 +8048,10 @@ This compaction should PRIORITISE preserving all information related to the focu
                         self.threshold_tokens, self._prellm_skip_count,
                     )
 
-        if feasibility_skip:
+        static_fallback_reason = static_summary_fallback_reason()
+        if static_fallback_reason:
+            summary = None
+        elif feasibility_skip:
             summary = None  # No LLM call; Phase 4 inserts the deterministic fallback
         else:
             # Deriving the auto focus topic scans recent user turns — only pay
@@ -8064,7 +8091,7 @@ This compaction should PRIORITISE preserving all information related to the focu
         # rotating into a child session with a placeholder summary degrades the
         # conversation for zero benefit. Preserve it unchanged until access or
         # provider health is restored (#29559, #25585, #94448).
-        if not summary and not feasibility_skip and (
+        if not summary and not feasibility_skip and not static_fallback_reason and (
             self.abort_on_summary_failure
             or self._last_summary_auth_failure
             or self._last_summary_network_failure
@@ -8188,7 +8215,11 @@ This compaction should PRIORITISE preserving all information related to the focu
                 turns_to_summarize,
                 # A stale error from an earlier real failure must not be
                 # embedded into a deliberate feasibility skip's fallback.
-                reason=None if feasibility_skip else self._last_summary_error,
+                reason=(
+                    static_fallback_reason
+                    if static_fallback_reason
+                    else (None if feasibility_skip else self._last_summary_error)
+                ),
             )
 
         tail_messages: List[Dict[str, Any]] = []

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,7 @@ from agent.auxiliary_client import (
     call_llm,
     extract_content_or_reasoning,
 )
+from agent.compression_attempt_context import attempt_compression_cancelled
 from agent.compression_static_fallback import (
     static_summary_fallback,
     static_summary_fallback_reason,
@@ -3108,6 +3109,9 @@ class ContextCompressor(ContextEngine):
 
     def _compression_cancelled(self) -> bool:
         """Read the host-owned cooperative cancellation signal, if installed."""
+        attempt_cancelled = attempt_compression_cancelled()
+        if attempt_cancelled is not None:
+            return attempt_cancelled
         cancelled_check = getattr(self, "_compression_cancelled_check", None)
         if not callable(cancelled_check):
             return False

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -35,6 +35,10 @@ from agent.auxiliary_client import (
     call_llm,
     extract_content_or_reasoning,
 )
+from agent.compression_static_fallback import (
+    static_summary_fallback,
+    static_summary_fallback_reason,
+)
 from agent.context_engine import ContextEngine, sanitize_memory_context
 from agent.error_classifier import FailoverReason, classify_api_error
 from agent.message_sanitization import tool_result_id_variants
@@ -81,13 +85,6 @@ def _safe_int(value: Any) -> int | None:
 # compaction attempt makes (#96603) — there are no sibling digest calls.
 _SUMMARY_ROUTE_PIN: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
     contextvars.ContextVar("hermes_summary_route_pin", default=None)
-)
-
-# A host timeout fences the remote worker before it can publish.  Its local
-# retry must bypass the LLM without mutating shared compressor attributes that
-# the detached worker can still see, so keep the decision attempt-local.
-_STATIC_SUMMARY_FALLBACK_REASON: contextvars.ContextVar[Optional[str]] = (
-    contextvars.ContextVar("hermes_static_summary_fallback_reason", default=None)
 )
 
 # call_llm kwargs a pinned route may set. ``timeout`` lets a fallback entry
@@ -142,23 +139,6 @@ def _pinned_summary_call_kwargs() -> Dict[str, Any]:
         for field in _PINNED_ROUTE_FIELDS
         if route.get(field) not in (None, "")
     }
-
-
-@contextlib.contextmanager
-def static_summary_fallback(reason: str):
-    """Force one built-in compaction to use its deterministic handoff."""
-    token = _STATIC_SUMMARY_FALLBACK_REASON.set(
-        str(reason or "summary unavailable")
-    )
-    try:
-        yield
-    finally:
-        _STATIC_SUMMARY_FALLBACK_REASON.reset(token)
-
-
-def static_summary_fallback_reason() -> Optional[str]:
-    """Return the attempt-local reason for bypassing the summary LLM."""
-    return _STATIC_SUMMARY_FALLBACK_REASON.get()
 
 
 _SUMMARY_PERMANENT_QUOTA_MARKERS: tuple[str, ...] = (
@@ -5349,26 +5329,39 @@ This compaction should PRIORITISE preserving all information related to the focu
                 with aux_interrupt_protection():
                     response = call_llm(**call_kwargs)
             finally:
-                route_known = bool(_aux_route.get("provider") and _aux_route.get("model"))
-                _aux_provider = _aux_route.get("provider") or self.provider or ""
-                _aux_model = _aux_route.get("model") or self.summary_model or self.model or ""
-                _aux_context = (
-                    self.context_length
-                    if route_known and _aux_model == self.model
-                    else None
-                )
-                self._record_aux_compression_call(
-                    prompt_messages=call_kwargs["messages"],
-                    # Current main intentionally omits max_tokens from the aux
-                    # call (summary_budget is prompt-level guidance only) —
-                    # use .get() so the telemetry hook never breaks the call.
-                    max_tokens=call_kwargs.get("max_tokens"),
-                    duration_ms=int((time.monotonic() - _aux_call_start) * 1000),
-                    aux_provider=_aux_provider,
-                    aux_model=_aux_model,
-                    effective_aux_context=_aux_context,
-                    phase_timings=_latency_info,
-                )
+                # A host-fenced call may wake only after a newer local fallback
+                # owns this shared compressor. Do not let the stale worker write
+                # into the successor's active telemetry during its unwind.
+                if not self._compression_cancelled():
+                    route_known = bool(
+                        _aux_route.get("provider") and _aux_route.get("model")
+                    )
+                    _aux_provider = _aux_route.get("provider") or self.provider or ""
+                    _aux_model = (
+                        _aux_route.get("model")
+                        or self.summary_model
+                        or self.model
+                        or ""
+                    )
+                    _aux_context = (
+                        self.context_length
+                        if route_known and _aux_model == self.model
+                        else None
+                    )
+                    self._record_aux_compression_call(
+                        prompt_messages=call_kwargs["messages"],
+                        # Current main intentionally omits max_tokens from the aux
+                        # call (summary_budget is prompt-level guidance only) —
+                        # use .get() so the telemetry hook never breaks the call.
+                        max_tokens=call_kwargs.get("max_tokens"),
+                        duration_ms=int(
+                            (time.monotonic() - _aux_call_start) * 1000
+                        ),
+                        aux_provider=_aux_provider,
+                        aux_model=_aux_model,
+                        effective_aux_context=_aux_context,
+                        phase_timings=_latency_info,
+                    )
             if self._compression_cancelled():
                 raise AuxiliaryExplicitCancellation()
             # Dict/object/str messages + reasoning-field fallback (DeepSeek /
@@ -5441,6 +5434,12 @@ This compaction should PRIORITISE preserving all information related to the focu
             self._last_summary_truncated_failure = False
             return self._with_summary_prefix(summary)
         except Exception as e:
+            # A provider can raise only after the host has fenced this attempt
+            # and a deterministic fallback has committed on the same compressor.
+            # Exit before exception-path fallback, cooldown, iterative-summary,
+            # model-selection, or telemetry writes can clobber successor state.
+            if self._compression_cancelled():
+                raise AuxiliaryExplicitCancellation() from e
             # ``call_llm`` raises ``RuntimeError`` for two very different cases:
             #   1. No provider configured ("No LLM provider configured ...") —
             #      a permanent misconfiguration, long cooldown is correct.

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -3074,19 +3074,12 @@ class ContextCompressor(ContextEngine):
         # not undo that cooldown when its summary eventually succeeds. The
         # hook is installed by compress_context for the duration of the
         # fenced call; when it reports cancellation, keep the host's cooldown.
-        cancelled_check = getattr(self, "_compression_cancelled_check", None)
-        if callable(cancelled_check):
-            try:
-                if cancelled_check():
-                    logger.info(
-                        "Skipping compression cooldown clear: host already "
-                        "cancelled this compression attempt"
-                    )
-                    return
-            except Exception:
-                logger.debug(
-                    "compression cancellation check failed", exc_info=True
-                )
+        if self._compression_cancelled():
+            logger.info(
+                "Skipping compression cooldown clear: host already cancelled "
+                "this compression attempt"
+            )
+            return
         self._summary_failure_cooldown_until = 0.0
         self._last_summary_error = None
         self._consecutive_timeout_failures = 0
@@ -5427,6 +5420,11 @@ This compaction should PRIORITISE preserving all information related to the focu
             summary = self._ground_historical_task_snapshot(summary, turns_to_summarize)
             summary = self._augment_summary_lean(summary, turns_to_summarize)
             self._validate_summary_user_provenance(summary, has_user_turn)
+            # Response processing can itself outlive the host budget. Re-check
+            # at the shared-state publication boundary so a stale successful
+            # attempt cannot overwrite the deterministic fallback's state.
+            if self._compression_cancelled():
+                raise AuxiliaryExplicitCancellation()
             # Store for iterative updates on next compaction
             self._previous_summary = summary
             self._clear_compression_failure_cooldown()

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -3321,6 +3321,10 @@ def compress_context(
     checkpoint_required = (
         getattr(agent, "compression_checkpoint_required", False) is True
     )
+    if checkpoint_required and commit_fence is not None:
+        # Arm fail-closed semantics before feasibility, lock, or snapshot work:
+        # any of those phases can stall before the provider hook itself starts.
+        commit_fence.require_precompress_checkpoint()
     if getattr(agent, "api_mode", None) == "codex_app_server":
         if checkpoint_required:
             raise _checkpoint_blocked(
@@ -3973,8 +3977,6 @@ def compress_context(
         # providers inside MemoryManager.on_pre_compress().
         evidence_messages = _direct_messages_for_pre_compress_memory(messages)
         if checkpoint_required and not _static_fallback_attempt:
-            if commit_fence is not None:
-                commit_fence.require_precompress_checkpoint()
             supports_checkpoint = getattr(
                 memory_manager, "supports_pre_compress_checkpoint", None
             )

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4133,14 +4133,21 @@ def compress_context(
         ):
             messages[:] = copy.deepcopy(messages_before_compression)
         # Record after restore so rollback cannot wipe a stall backoff, and
-        # while the lease is still held so the next turn cannot race it.
-        _stall_backoff = _record_stall_interrupted_backoff(
-            agent,
-            commit_fence=commit_fence,
-            started_at=_attempt_started_at,
-            messages=messages,
-            approx_tokens=approx_tokens,
+        # while the lease is still held so the next turn cannot race it. A
+        # detached primary that has been superseded by the local fallback must
+        # not publish another cooldown onto the successor-owned compressor.
+        _attempt_still_current = _compressor_attempt_is_current(
+            agent.context_compressor, _attempt_generation
         )
+        _stall_backoff = False
+        if _attempt_still_current:
+            _stall_backoff = _record_stall_interrupted_backoff(
+                agent,
+                commit_fence=commit_fence,
+                started_at=_attempt_started_at,
+                messages=messages,
+                approx_tokens=approx_tokens,
+            )
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression cancelled")
             _activity_heartbeat = None

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -67,6 +67,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.compression_static_fallback import run_static_compression_fallback
 from agent.context_engine import (
     automatic_compaction_status_message,
     sanitize_memory_context,
@@ -1402,89 +1403,6 @@ def _retry_compression_on_fallback_chain(
     return result_msgs, result_prompt
 
 
-def _retry_compression_with_static_fallback(
-    *,
-    worker: Callable[[CompressionCommitFence], Tuple[list, str]],
-    messages: list,
-    reason: str,
-    telemetry_agent: Any = None,
-    new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
-) -> Optional[Tuple[list, str]]:
-    """Commit the built-in deterministic handoff after a summary stall.
-
-    The remote attempt has already lost commit admission.  This bounded,
-    network-free retry runs synchronously so it cannot queue behind provider
-    workers that are themselves wedged. Plugin engines keep their configured
-    route fallback because only the built-in compressor owns this handoff.
-    """
-    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
-    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
-        return None
-
-    try:
-        from agent.context_compressor import (
-            ContextCompressor,
-            static_summary_fallback,
-        )
-    except Exception:
-        return None
-    compressor = getattr(telemetry_agent, "context_compressor", None)
-    if not isinstance(compressor, ContextCompressor):
-        return None
-
-    retry_fence = None
-    if new_fence is not None:
-        try:
-            retry_fence = new_fence()
-        except Exception:
-            logger.warning(
-                "static compression fallback fence factory failed",
-                exc_info=True,
-            )
-    if not isinstance(retry_fence, CompressionCommitFence):
-        retry_fence = CompressionCommitFence()
-
-    logger.warning(
-        "Context compression summary %s — committing the local deterministic "
-        "handoff without another LLM request",
-        reason,
-    )
-    try:
-        with static_summary_fallback(reason):
-            result_msgs, result_prompt = worker(retry_fence)
-    except Exception:
-        logger.warning(
-            "Local deterministic compression fallback failed",
-            exc_info=True,
-        )
-        return None
-    if result_msgs is messages:
-        return None
-
-    record = getattr(compressor, "record_timeout_failure", None)
-    if callable(record):
-        try:
-            record(
-                f"local fallback after summary {reason}",
-                failure_kind=(
-                    "ceiling_exhausted" if "total ceiling" in reason else "stalled"
-                ),
-            )
-        except Exception:
-            logger.debug("failed to record local fallback cooldown", exc_info=True)
-    emit = getattr(telemetry_agent, "_emit_warning", None)
-    if callable(emit):
-        try:
-            emit(
-                "⚠ Context compression used a local fallback summary because "
-                f"the summary model {reason}. The session remains usable; "
-                "future remote summary attempts are temporarily paused."
-            )
-        except Exception:
-            logger.debug("failed to emit local fallback warning", exc_info=True)
-    return result_msgs, result_prompt
-
-
 def run_compress_context_with_progress_timeout(
     *,
     worker: Callable[[CompressionCommitFence], Tuple[list, str]],
@@ -1828,7 +1746,7 @@ def run_compress_context_with_progress_timeout(
                 if total_exhausted
                 else f"made no progress for {since_progress:.1f}s"
             )
-            recovered = _retry_compression_with_static_fallback(
+            recovered = run_static_compression_fallback(
                 worker=worker,
                 messages=messages,
                 reason=reason,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -711,6 +711,8 @@ class CompressionCommitFence:
         self._lock_release_guard = threading.Lock()
         self._cancelled_lock_release: Optional[Callable[[], None]] = None
         self._cancelled_lock_release_requested = False
+        self._precompress_checkpoint_required = False
+        self._precompress_checkpoint_complete = threading.Event()
         # Forward-progress telemetry: the compression worker touches this
         # whenever the streamed summary call produces a token (see
         # ContextCompressor._call_summary_llm). Waiters use it to distinguish
@@ -844,6 +846,22 @@ class CompressionCommitFence:
     def retain_compression_lock_until_worker_done(self) -> None:
         """Prevent a timed-out live worker from overlapping a retry."""
         self._retain_cancelled_lock_until_worker_done = True
+
+    def require_precompress_checkpoint(self) -> None:
+        """Mark this attempt as requiring a durable pre-compress checkpoint."""
+        self._precompress_checkpoint_required = True
+
+    def mark_precompress_checkpoint_complete(self) -> None:
+        """Publish successful completion of the required checkpoint."""
+        self._precompress_checkpoint_complete.set()
+
+    @property
+    def required_checkpoint_incomplete(self) -> bool:
+        """Whether fallback would bypass an unfinished required checkpoint."""
+        return (
+            self._precompress_checkpoint_required
+            and not self._precompress_checkpoint_complete.is_set()
+        )
 
     def allow_cancelled_lock_release(self) -> None:
         """Undo :meth:`retain_compression_lock_until_worker_done`.
@@ -1225,6 +1243,31 @@ def _record_stall_interrupted_backoff(
         error,
     )
     return True
+
+
+def _record_stall_backoff_if_attempt_current(
+    agent: Any,
+    *,
+    attempt_generation: int,
+    commit_fence: Optional[CompressionCommitFence],
+    started_at: float,
+    messages: Any,
+    approx_tokens: Optional[int],
+) -> bool:
+    """Atomically publish backoff only while this attempt owns the compressor."""
+    compressor = getattr(agent, "context_compressor", None)
+    with _COMPRESSOR_ATTEMPT_LOCK:
+        if attempt_generation and int(
+            getattr(compressor, "_compression_attempt_generation", 0) or 0
+        ) != attempt_generation:
+            return False
+        return _record_stall_interrupted_backoff(
+            agent,
+            commit_fence=commit_fence,
+            started_at=started_at,
+            messages=messages,
+            approx_tokens=approx_tokens,
+        )
 
 
 def resolve_compression_fallback_route() -> Optional[dict]:
@@ -1741,7 +1784,7 @@ def run_compress_context_with_progress_timeout(
         # acquire it immediately. Run it BEFORE on_timeout: that callback
         # records the summary-failure cooldown, which would make the retry's
         # own summary call a no-op.
-        if stall_fallback:
+        if stall_fallback and not fence.required_checkpoint_incomplete:
             reason = (
                 "exceeded its total ceiling"
                 if total_exhausted
@@ -3930,6 +3973,8 @@ def compress_context(
         # providers inside MemoryManager.on_pre_compress().
         evidence_messages = _direct_messages_for_pre_compress_memory(messages)
         if checkpoint_required and not _static_fallback_attempt:
+            if commit_fence is not None:
+                commit_fence.require_precompress_checkpoint()
             supports_checkpoint = getattr(
                 memory_manager, "supports_pre_compress_checkpoint", None
             )
@@ -3966,6 +4011,8 @@ def compress_context(
                 ) from exc
             if isinstance(_maybe_ctx, str):
                 memory_context = sanitize_memory_context(_maybe_ctx)
+            if commit_fence is not None:
+                commit_fence.mark_precompress_checkpoint_complete()
         elif memory_manager and not _static_fallback_attempt:
             try:
                 _maybe_ctx = memory_manager.on_pre_compress(
@@ -4136,18 +4183,14 @@ def compress_context(
         # while the lease is still held so the next turn cannot race it. A
         # detached primary that has been superseded by the local fallback must
         # not publish another cooldown onto the successor-owned compressor.
-        _attempt_still_current = _compressor_attempt_is_current(
-            agent.context_compressor, _attempt_generation
+        _stall_backoff = _record_stall_backoff_if_attempt_current(
+            agent,
+            attempt_generation=_attempt_generation,
+            commit_fence=commit_fence,
+            started_at=_attempt_started_at,
+            messages=messages,
+            approx_tokens=approx_tokens,
         )
-        _stall_backoff = False
-        if _attempt_still_current:
-            _stall_backoff = _record_stall_interrupted_backoff(
-                agent,
-                commit_fence=commit_fence,
-                started_at=_attempt_started_at,
-                messages=messages,
-                approx_tokens=approx_tokens,
-            )
         if _activity_heartbeat is not None:
             _activity_heartbeat.stop("context compression cancelled")
             _activity_heartbeat = None
@@ -4367,8 +4410,9 @@ def compress_context(
                     agent.session_id or "none",
                 )
                 agent._last_compaction_in_place = False
-                _stall_backoff = _record_stall_interrupted_backoff(
+                _stall_backoff = _record_stall_backoff_if_attempt_current(
                     agent,
+                    attempt_generation=_attempt_generation,
                     commit_fence=commit_fence,
                     started_at=_attempt_started_at,
                     messages=messages,

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1402,6 +1402,89 @@ def _retry_compression_on_fallback_chain(
     return result_msgs, result_prompt
 
 
+def _retry_compression_with_static_fallback(
+    *,
+    worker: Callable[[CompressionCommitFence], Tuple[list, str]],
+    messages: list,
+    reason: str,
+    telemetry_agent: Any = None,
+    new_fence: Optional[Callable[[], CompressionCommitFence]] = None,
+) -> Optional[Tuple[list, str]]:
+    """Commit the built-in deterministic handoff after a summary stall.
+
+    The remote attempt has already lost commit admission.  This bounded,
+    network-free retry runs synchronously so it cannot queue behind provider
+    workers that are themselves wedged. Plugin engines keep their configured
+    route fallback because only the built-in compressor owns this handoff.
+    """
+    hard_cancel = getattr(telemetry_agent, "_hard_interrupt_requested", None)
+    if callable(getattr(hard_cancel, "is_set", None)) and hard_cancel.is_set():
+        return None
+
+    try:
+        from agent.context_compressor import (
+            ContextCompressor,
+            static_summary_fallback,
+        )
+    except Exception:
+        return None
+    compressor = getattr(telemetry_agent, "context_compressor", None)
+    if not isinstance(compressor, ContextCompressor):
+        return None
+
+    retry_fence = None
+    if new_fence is not None:
+        try:
+            retry_fence = new_fence()
+        except Exception:
+            logger.warning(
+                "static compression fallback fence factory failed",
+                exc_info=True,
+            )
+    if not isinstance(retry_fence, CompressionCommitFence):
+        retry_fence = CompressionCommitFence()
+
+    logger.warning(
+        "Context compression summary %s — committing the local deterministic "
+        "handoff without another LLM request",
+        reason,
+    )
+    try:
+        with static_summary_fallback(reason):
+            result_msgs, result_prompt = worker(retry_fence)
+    except Exception:
+        logger.warning(
+            "Local deterministic compression fallback failed",
+            exc_info=True,
+        )
+        return None
+    if result_msgs is messages:
+        return None
+
+    record = getattr(compressor, "record_timeout_failure", None)
+    if callable(record):
+        try:
+            record(
+                f"local fallback after summary {reason}",
+                failure_kind=(
+                    "ceiling_exhausted" if "total ceiling" in reason else "stalled"
+                ),
+            )
+        except Exception:
+            logger.debug("failed to record local fallback cooldown", exc_info=True)
+    emit = getattr(telemetry_agent, "_emit_warning", None)
+    if callable(emit):
+        try:
+            emit(
+                "⚠ Context compression used a local fallback summary because "
+                f"the summary model {reason}. The session remains usable; "
+                "future remote summary attempts are temporarily paused."
+            )
+        except Exception:
+            logger.debug("failed to emit local fallback warning", exc_info=True)
+    return result_msgs, result_prompt
+
+
 def run_compress_context_with_progress_timeout(
     *,
     worker: Callable[[CompressionCommitFence], Tuple[list, str]],
@@ -1450,13 +1533,11 @@ def run_compress_context_with_progress_timeout(
     ``on_timeout`` runs, allowing hosts to report the timeout accurately while
     preserving the existing three-argument timeout callback contract.
 
-    ``stall_fallback`` (default on) makes an aborted stall attempt the
-    configured ``auxiliary.compression.fallback_chain`` once — pinned onto a
-    fresh fence — before degrading to "continue without compression". Nothing
-    raises out of a silent stall, so the auxiliary client's own fallback
-    handling (exception-path only) never sees it (#78981). ``on_timeout``
-    therefore fires only after that attempt has also failed, which keeps its
-    cooldown bookkeeping from suppressing the retry it precedes.
+    ``stall_fallback`` (default on) makes the built-in compressor commit its
+    deterministic local handoff on a fresh fence after a stall. Plugin engines
+    that do not own that handoff retain the configured
+    ``auxiliary.compression.fallback_chain`` retry. ``on_timeout`` therefore
+    fires only if the applicable fallback also fails.
 
     ``new_fence`` mints that retry's fence. Hosts that publish the active
     fence for hard-interrupt admission pass a factory that publishes the new
@@ -1718,6 +1799,22 @@ def run_compress_context_with_progress_timeout(
                     "overlaps it",
                     min(_CANCELLED_WORKER_TEARDOWN_GRACE_SECONDS, ceiling),
                 )
+        # The built-in local retry is safe to overlap with the detached
+        # provider worker: cancellation permanently revoked that worker's
+        # commit admission, and attempt generations discard late candidates.
+        # Waive total-ceiling retention so the holder-qualified lease can be
+        # released and the deterministic retry can commit.
+        if stall_fallback and telemetry_agent is not None:
+            try:
+                from agent.context_compressor import ContextCompressor
+
+                if isinstance(
+                    getattr(telemetry_agent, "context_compressor", None),
+                    ContextCompressor,
+                ):
+                    fence.allow_cancelled_lock_release()
+            except Exception:
+                pass
         fence.release_cancelled_compression_lock()
         waited = time.monotonic() - wait_started
         since_progress = fence.seconds_since_progress()
@@ -1726,17 +1823,30 @@ def run_compress_context_with_progress_timeout(
         # records the summary-failure cooldown, which would make the retry's
         # own summary call a no-op.
         if stall_fallback:
-            recovered = _retry_compression_on_fallback_chain(
+            reason = (
+                "exceeded its total ceiling"
+                if total_exhausted
+                else f"made no progress for {since_progress:.1f}s"
+            )
+            recovered = _retry_compression_with_static_fallback(
                 worker=worker,
                 messages=messages,
-                system_prompt_fallback=system_prompt_fallback,
-                idle_timeout_seconds=idle,
-                total_ceiling_seconds=ceiling,
-                on_commit_overrun=on_commit_overrun,
-                on_timeout_cause=on_timeout_cause,
+                reason=reason,
                 telemetry_agent=telemetry_agent,
                 new_fence=new_fence,
             )
+            if recovered is None:
+                recovered = _retry_compression_on_fallback_chain(
+                    worker=worker,
+                    messages=messages,
+                    system_prompt_fallback=system_prompt_fallback,
+                    idle_timeout_seconds=idle,
+                    total_ceiling_seconds=ceiling,
+                    on_commit_overrun=on_commit_overrun,
+                    on_timeout_cause=on_timeout_cause,
+                    telemetry_agent=telemetry_agent,
+                    new_fence=new_fence,
+                )
             if recovered is not None:
                 return recovered
         if on_timeout is not None:
@@ -3285,7 +3395,13 @@ def compress_context(
     # Every automatic entrypoint must honor compressor-owned cooldown and
     # breaker state. Gateway hygiene constructs a fresh AIAgent, so the
     # persisted fallback streak is loaded by bind_session_state() before this.
-    if not force:
+    try:
+        from agent.context_compressor import static_summary_fallback_reason
+
+        _static_fallback_attempt = bool(static_summary_fallback_reason())
+    except Exception:
+        _static_fallback_attempt = False
+    if not force and not _static_fallback_attempt:
         _refresh_persisted_compression_guards(agent.context_compressor)
         blocked = getattr(
             type(agent.context_compressor),

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -67,6 +67,7 @@ from pathlib import Path
 from typing import Any, Callable, Dict, List, Literal, Optional, Tuple
 
 from agent.auxiliary_client import AuxiliaryExplicitCancellation
+from agent.compression_attempt_context import compression_cancelled_check
 from agent.compression_static_fallback import run_static_compression_fallback
 from agent.context_engine import (
     automatic_compaction_status_message,
@@ -1746,14 +1747,14 @@ def run_compress_context_with_progress_timeout(
                 if total_exhausted
                 else f"made no progress for {since_progress:.1f}s"
             )
-            recovered = run_static_compression_fallback(
+            builtin_fallback, recovered = run_static_compression_fallback(
                 worker=worker,
                 messages=messages,
                 reason=reason,
                 telemetry_agent=telemetry_agent,
                 new_fence=new_fence,
             )
-            if recovered is None:
+            if not builtin_fallback:
                 recovered = _retry_compression_on_fallback_chain(
                     worker=worker,
                     messages=messages,
@@ -3928,7 +3929,7 @@ def compress_context(
         # normalized evidence list is handed only to API v2+ checkpoint
         # providers inside MemoryManager.on_pre_compress().
         evidence_messages = _direct_messages_for_pre_compress_memory(messages)
-        if checkpoint_required:
+        if checkpoint_required and not _static_fallback_attempt:
             supports_checkpoint = getattr(
                 memory_manager, "supports_pre_compress_checkpoint", None
             )
@@ -3965,7 +3966,7 @@ def compress_context(
                 ) from exc
             if isinstance(_maybe_ctx, str):
                 memory_context = sanitize_memory_context(_maybe_ctx)
-        elif memory_manager:
+        elif memory_manager and not _static_fallback_attempt:
             try:
                 _maybe_ctx = memory_manager.on_pre_compress(
                     messages, evidence_messages=evidence_messages
@@ -4076,8 +4077,12 @@ def compress_context(
                 )
                 compressed = messages
             else:
-                with aux_progress_hook(_progress_hook), aux_interrupt_protection(
-                    cancel_check=_compression_cancel_requested
+                with (
+                    compression_cancelled_check(_compression_cancel_requested),
+                    aux_progress_hook(_progress_hook),
+                    aux_interrupt_protection(
+                        cancel_check=_compression_cancel_requested
+                    ),
                 ):
                     compressed = compress_fn(messages, **compress_kwargs)
                     # Freeze a hard stop that arrived after the final provider

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -280,6 +280,42 @@ class TestRunCompressContextWithProgressTimeout:
             "telemetry": dict(compressor._last_compression_telemetry or {}),
         } == fallback_state
 
+    def test_required_checkpoint_timeout_never_compacts_without_checkpoint(
+        self, monkeypatch
+    ):
+        original = [{"role": "user", "content": "keep"}]
+        release = threading.Event()
+        started = threading.Event()
+        static_fallback = MagicMock()
+        provider_retry = MagicMock()
+
+        def worker(fence: CompressionCommitFence):
+            fence.require_precompress_checkpoint()
+            started.set()
+            assert release.wait(timeout=2)
+            return original, "late"
+
+        monkeypatch.setattr(cc, "run_static_compression_fallback", static_fallback)
+        monkeypatch.setattr(
+            cc, "_retry_compression_on_fallback_chain", provider_retry
+        )
+        try:
+            result = run_compress_context_with_progress_timeout(
+                worker=worker,
+                messages=original,
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=0.05,
+                total_ceiling_seconds=1.0,
+                telemetry_agent=SimpleNamespace(),
+            )
+        finally:
+            release.set()
+
+        assert started.wait(timeout=1)
+        assert result == (original, "fallback")
+        static_fallback.assert_not_called()
+        provider_retry.assert_not_called()
+
     def test_builtin_static_fallback_failure_does_not_retry_provider(
         self, monkeypatch
     ):

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import concurrent.futures
 import threading
 import time
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
 import pytest
@@ -148,6 +149,69 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
+    def test_total_ceiling_commits_builtin_static_fallback(self, monkeypatch):
+        """A wedged summary must still yield a committed local handoff."""
+        from agent.context_compressor import ContextCompressor
+
+        with monkeypatch.context() as scoped:
+            scoped.setattr(
+                "agent.context_compressor.get_model_context_length",
+                lambda *_a, **_kw: 100_000,
+            )
+            compressor = ContextCompressor(model="test/model", quiet_mode=True)
+
+        compressor.record_timeout_failure = MagicMock()
+        agent = SimpleNamespace(
+            context_compressor=compressor,
+            _hard_interrupt_requested=threading.Event(),
+            _emit_warning=MagicMock(),
+            _touch_activity=MagicMock(),
+        )
+        original = [{"role": "user", "content": "keep-me"}]
+        compressed = [{"role": "user", "content": "local handoff"}]
+        remote_started = threading.Event()
+        release_remote = threading.Event()
+        calls = []
+
+        def worker(fence: CompressionCommitFence):
+            from agent.context_compressor import static_summary_fallback_reason
+
+            reason = static_summary_fallback_reason()
+            calls.append(reason)
+            if reason:
+                assert fence.begin_commit()
+                try:
+                    return compressed, "fallback-prompt"
+                finally:
+                    fence.finish_commit()
+            remote_started.set()
+            release_remote.wait(timeout=5)
+            if not fence.begin_commit():
+                return original, "late"
+            try:
+                return original, "late"
+            finally:
+                fence.finish_commit()
+
+        try:
+            result = run_compress_context_with_progress_timeout(
+                worker=worker,
+                messages=original,
+                system_prompt_fallback="system",
+                idle_timeout_seconds=0.5,
+                total_ceiling_seconds=0.5,
+                telemetry_agent=agent,
+            )
+        finally:
+            release_remote.set()
+
+        assert remote_started.wait(timeout=1)
+        assert result == (compressed, "fallback-prompt")
+        assert "total ceiling" in calls[-1]
+        assert calls[0] is None
+        compressor.record_timeout_failure.assert_called_once()
+        assert "local fallback" in agent._emit_warning.call_args.args[0].lower()
+
     def test_deadline_before_worker_start_uses_timeout_fallback(self, monkeypatch):
         original = [{"role": "user", "content": "keep-me"}]
         worker = MagicMock()

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -154,6 +154,7 @@ class TestRunCompressContextWithProgressTimeout:
         self, monkeypatch, timeout_path
     ):
         """A stale provider exception cannot mutate fallback-owned state."""
+        from agent.compression_attempt_context import compression_cancelled_check
         from agent.compression_static_fallback import static_summary_fallback_reason
         from agent.context_compressor import ContextCompressor
 
@@ -212,11 +213,10 @@ class TestRunCompressContextWithProgressTimeout:
                     )
                     progress_thread.start()
                 try:
-                    if not is_fallback:
-                        compressor._compression_cancelled_check = lambda: fence.is_cancelled
-                    candidate = compressor.compress(
-                        list(original), current_tokens=999_999, force=True
-                    )
+                    with compression_cancelled_check(lambda: fence.is_cancelled):
+                        candidate = compressor.compress(
+                            list(original), current_tokens=999_999, force=True
+                        )
                     if not fence.begin_commit():
                         return original, "late"
                     try:
@@ -279,6 +279,78 @@ class TestRunCompressContextWithProgressTimeout:
             "fallback_used": compressor._last_summary_fallback_used,
             "telemetry": dict(compressor._last_compression_telemetry or {}),
         } == fallback_state
+
+    def test_builtin_static_fallback_failure_does_not_retry_provider(
+        self, monkeypatch
+    ):
+        original = [{"role": "user", "content": "keep"}]
+        release = threading.Event()
+        started = threading.Event()
+        provider_retry = MagicMock(
+            return_value=([{"role": "assistant", "content": "provider"}], "provider")
+        )
+
+        def worker(_fence):
+            started.set()
+            assert release.wait(timeout=2)
+            return original, "late"
+
+        monkeypatch.setattr(
+            cc,
+            "run_static_compression_fallback",
+            lambda **_kwargs: (True, None),
+        )
+        monkeypatch.setattr(
+            cc, "_retry_compression_on_fallback_chain", provider_retry
+        )
+        try:
+            result = run_compress_context_with_progress_timeout(
+                worker=worker,
+                messages=original,
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=0.05,
+                total_ceiling_seconds=1.0,
+                telemetry_agent=SimpleNamespace(),
+            )
+        finally:
+            release.set()
+
+        assert started.wait(timeout=1)
+        assert result == (original, "fallback")
+        provider_retry.assert_not_called()
+
+    def test_plugin_engine_keeps_configured_provider_fallback(self, monkeypatch):
+        original = [{"role": "user", "content": "keep"}]
+        release = threading.Event()
+        provider_result = ([{"role": "assistant", "content": "provider"}], "provider")
+        provider_retry = MagicMock(return_value=provider_result)
+
+        def worker(_fence):
+            assert release.wait(timeout=2)
+            return original, "late"
+
+        monkeypatch.setattr(
+            cc,
+            "run_static_compression_fallback",
+            lambda **_kwargs: (False, None),
+        )
+        monkeypatch.setattr(
+            cc, "_retry_compression_on_fallback_chain", provider_retry
+        )
+        try:
+            result = run_compress_context_with_progress_timeout(
+                worker=worker,
+                messages=original,
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=0.05,
+                total_ceiling_seconds=1.0,
+                telemetry_agent=SimpleNamespace(),
+            )
+        finally:
+            release.set()
+
+        assert result == provider_result
+        provider_retry.assert_called_once()
 
     def test_deadline_before_worker_start_uses_timeout_fallback(self, monkeypatch):
         original = [{"role": "user", "content": "keep-me"}]

--- a/tests/agent/test_compress_context_progress_timeout.py
+++ b/tests/agent/test_compress_context_progress_timeout.py
@@ -149,8 +149,12 @@ class TestResolveContextCompressionTimeouts:
 
 
 class TestRunCompressContextWithProgressTimeout:
-    def test_total_ceiling_commits_builtin_static_fallback(self, monkeypatch):
-        """A wedged summary must still yield a committed local handoff."""
+    @pytest.mark.parametrize("timeout_path", ["total_ceiling", "no_progress"])
+    def test_static_fallback_fences_late_real_compressor_writes(
+        self, monkeypatch, timeout_path
+    ):
+        """A stale provider exception cannot mutate fallback-owned state."""
+        from agent.compression_static_fallback import static_summary_fallback_reason
         from agent.context_compressor import ContextCompressor
 
         with monkeypatch.context() as scoped:
@@ -158,59 +162,123 @@ class TestRunCompressContextWithProgressTimeout:
                 "agent.context_compressor.get_model_context_length",
                 lambda *_a, **_kw: 100_000,
             )
-            compressor = ContextCompressor(model="test/model", quiet_mode=True)
+            compressor = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=1,
+            )
+            compressor.summary_model = "test/summary-model"
+            compressor._summary_model_fallen_back = False
+            original = [
+                {
+                    "role": "user" if i % 2 == 0 else "assistant",
+                    "content": f"message {i}: " + ("context " * 300),
+                }
+                for i in range(20)
+            ]
+            remote_started = threading.Event()
+            release_remote = threading.Event()
+            remote_worker_finished = threading.Event()
+            stop_progress = threading.Event()
+            llm_calls = []
+            committed_session = []
 
-        compressor.record_timeout_failure = MagicMock()
-        agent = SimpleNamespace(
-            context_compressor=compressor,
-            _hard_interrupt_requested=threading.Event(),
-            _emit_warning=MagicMock(),
-            _touch_activity=MagicMock(),
-        )
-        original = [{"role": "user", "content": "keep-me"}]
-        compressed = [{"role": "user", "content": "local handoff"}]
-        remote_started = threading.Event()
-        release_remote = threading.Event()
-        calls = []
+            def blocked_summary(**_kwargs):
+                llm_calls.append("summary")
+                remote_started.set()
+                assert release_remote.wait(timeout=15)
+                raise RuntimeError("late provider failure")
 
-        def worker(fence: CompressionCommitFence):
-            from agent.context_compressor import static_summary_fallback_reason
+            scoped.setattr("agent.context_compressor.call_llm", blocked_summary)
+            agent = SimpleNamespace(
+                context_compressor=compressor,
+                _hard_interrupt_requested=threading.Event(),
+                _emit_warning=MagicMock(),
+            )
 
-            reason = static_summary_fallback_reason()
-            calls.append(reason)
-            if reason:
-                assert fence.begin_commit()
+            def worker(fence: CompressionCommitFence):
+                is_fallback = bool(static_summary_fallback_reason())
+                progress_thread = None
+                if not is_fallback and timeout_path == "total_ceiling":
+                    def keep_progressing():
+                        while not stop_progress.wait(0.01):
+                            fence.touch_progress()
+
+                    progress_thread = threading.Thread(
+                        target=keep_progressing,
+                        name="compression-test-progress",
+                        daemon=True,
+                    )
+                    progress_thread.start()
                 try:
-                    return compressed, "fallback-prompt"
+                    if not is_fallback:
+                        compressor._compression_cancelled_check = lambda: fence.is_cancelled
+                    candidate = compressor.compress(
+                        list(original), current_tokens=999_999, force=True
+                    )
+                    if not fence.begin_commit():
+                        return original, "late"
+                    try:
+                        committed_session[:] = candidate
+                        return candidate, "fallback" if is_fallback else "remote"
+                    finally:
+                        fence.finish_commit()
                 finally:
-                    fence.finish_commit()
-            remote_started.set()
-            release_remote.wait(timeout=5)
-            if not fence.begin_commit():
-                return original, "late"
-            try:
-                return original, "late"
-            finally:
-                fence.finish_commit()
+                    if not is_fallback:
+                        stop_progress.set()
+                        if progress_thread is not None:
+                            progress_thread.join(timeout=1)
+                        remote_worker_finished.set()
 
-        try:
+            idle = 1.0
+            ceiling = 3.0 if timeout_path == "total_ceiling" else 4.0
             result = run_compress_context_with_progress_timeout(
                 worker=worker,
                 messages=original,
                 system_prompt_fallback="system",
-                idle_timeout_seconds=0.5,
-                total_ceiling_seconds=0.5,
+                idle_timeout_seconds=idle,
+                total_ceiling_seconds=ceiling,
                 telemetry_agent=agent,
             )
-        finally:
-            release_remote.set()
 
-        assert remote_started.wait(timeout=1)
-        assert result == (compressed, "fallback-prompt")
-        assert "total ceiling" in calls[-1]
-        assert calls[0] is None
-        compressor.record_timeout_failure.assert_called_once()
-        assert "local fallback" in agent._emit_warning.call_args.args[0].lower()
+            try:
+                assert remote_started.is_set()
+                assert not remote_worker_finished.is_set()
+                assert result[0] == committed_session
+                assert result[0] != original
+                assert compressor._last_summary_fallback_used is True
+                fallback_state = {
+                    "committed": list(committed_session),
+                    "previous_summary": compressor._previous_summary,
+                    "summary_model": compressor.summary_model,
+                    "model_fallen_back": compressor._summary_model_fallen_back,
+                    "aux_error": compressor._last_aux_model_failure_error,
+                    "aux_model": compressor._last_aux_model_failure_model,
+                    "last_error": compressor._last_summary_error,
+                    "cooldown": compressor._summary_failure_cooldown_until,
+                    "fallback_used": compressor._last_summary_fallback_used,
+                    "telemetry": dict(compressor._last_compression_telemetry or {}),
+                }
+            finally:
+                release_remote.set()
+                assert remote_worker_finished.wait(timeout=2)
+
+        assert llm_calls == ["summary"], "stale attempt launched a provider fallback"
+        assert compressor.summary_model == "test/summary-model"
+        assert compressor._summary_model_fallen_back is False
+        assert {
+            "committed": list(committed_session),
+            "previous_summary": compressor._previous_summary,
+            "summary_model": compressor.summary_model,
+            "model_fallen_back": compressor._summary_model_fallen_back,
+            "aux_error": compressor._last_aux_model_failure_error,
+            "aux_model": compressor._last_aux_model_failure_model,
+            "last_error": compressor._last_summary_error,
+            "cooldown": compressor._summary_failure_cooldown_until,
+            "fallback_used": compressor._last_summary_fallback_used,
+            "telemetry": dict(compressor._last_compression_telemetry or {}),
+        } == fallback_state
 
     def test_deadline_before_worker_start_uses_timeout_fallback(self, monkeypatch):
         original = [{"role": "user", "content": "keep-me"}]

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -68,6 +68,86 @@ def _messages():
 
 
 class TestWorkerTeardownOnCeiling:
+    def test_late_production_worker_cannot_republish_stall_backoff(
+        self, tmp_path: Path
+    ):
+        _db, agent = _build_agent(tmp_path, "STATIC_PRODUCTION_OVERLAP")
+        # Exercise the production compress_context ownership/cancellation path
+        # without the durable lease obscuring the shared-compressor race.
+        agent._session_db = None
+        compressor = agent.context_compressor
+        compressor.summary_model = "test/summary-model"
+        compressor._summary_model_fallen_back = False
+        original = [
+            {
+                "role": "user" if i % 2 == 0 else "assistant",
+                "content": f"message {i}: " + ("context " * 300),
+            }
+            for i in range(20)
+        ]
+        remote_started = threading.Event()
+        release_remote = threading.Event()
+        remote_finished = threading.Event()
+        successor_claimed = threading.Event()
+        llm_calls: list[str] = []
+
+        def blocked_summary(**_kwargs):
+            llm_calls.append("summary")
+            remote_started.set()
+            assert release_remote.wait(timeout=10)
+            raise RuntimeError("late provider failure")
+
+        def release_after_successor_claims_compressor():
+            assert remote_started.wait(timeout=5)
+            deadline = time.monotonic() + 5
+            while time.monotonic() < deadline:
+                if getattr(compressor, "_compression_attempt_generation", 0) >= 2:
+                    successor_claimed.set()
+                    release_remote.set()
+                    return
+                time.sleep(0.01)
+            release_remote.set()
+
+        releaser = threading.Thread(
+            target=release_after_successor_claims_compressor,
+            name="release-stale-compressor",
+            daemon=True,
+        )
+        releaser.start()
+
+        def worker(fence: CompressionCommitFence):
+            try:
+                return compress_context(
+                    agent,
+                    copy.deepcopy(original),
+                    "sys",
+                    approx_tokens=500_000,
+                    commit_fence=fence,
+                )
+            finally:
+                remote_finished.set()
+
+        with patch("agent.context_compressor.call_llm", side_effect=blocked_summary):
+            result, _prompt = run_compress_context_with_progress_timeout(
+                worker=worker,
+                messages=original,
+                system_prompt_fallback="fallback",
+                idle_timeout_seconds=1.0,
+                total_ceiling_seconds=4.0,
+                telemetry_agent=agent,
+            )
+            assert remote_started.is_set()
+            assert successor_claimed.wait(timeout=1)
+            assert remote_finished.wait(timeout=2)
+
+        releaser.join(timeout=1)
+        assert not releaser.is_alive()
+        assert result != original
+        assert llm_calls == ["summary"]
+        assert compressor._consecutive_timeout_failures == 1
+        assert "local fallback after summary" in (compressor._last_summary_error or "")
+        assert compressor._summary_failure_cooldown_until > time.monotonic()
+
     def test_cooperative_worker_joined_within_grace(self):
         """A worker that exits promptly after cancel is joined on the
         total-ceiling path; the lease is released normally (no retention) —

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -24,7 +24,7 @@ import os
 import threading
 import time
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -68,6 +68,63 @@ def _messages():
 
 
 class TestWorkerTeardownOnCeiling:
+    def test_checkpoint_required_arms_before_feasibility_can_stall(
+        self, tmp_path: Path
+    ):
+        _db, agent = _build_agent(tmp_path, "CHECKPOINT_EARLY_ARM")
+        agent._session_db = None
+        agent.compression_checkpoint_required = True
+        agent._compression_feasibility_checked = False
+        entered = threading.Event()
+        release = threading.Event()
+        static_fallback = MagicMock()
+        provider_fallback = MagicMock()
+        original = _messages()
+
+        def blocked_feasibility(_agent):
+            entered.set()
+            assert release.wait(timeout=5)
+
+        def worker(fence: CompressionCommitFence):
+            return compress_context(
+                agent,
+                copy.deepcopy(original),
+                "sys",
+                approx_tokens=500_000,
+                commit_fence=fence,
+            )
+
+        with (
+            patch(
+                "agent.conversation_compression.check_compression_model_feasibility",
+                side_effect=blocked_feasibility,
+            ),
+            patch(
+                "agent.conversation_compression.run_static_compression_fallback",
+                static_fallback,
+            ),
+            patch(
+                "agent.conversation_compression._retry_compression_on_fallback_chain",
+                provider_fallback,
+            ),
+        ):
+            try:
+                result = run_compress_context_with_progress_timeout(
+                    worker=worker,
+                    messages=original,
+                    system_prompt_fallback="fallback",
+                    idle_timeout_seconds=0.2,
+                    total_ceiling_seconds=2.0,
+                    telemetry_agent=agent,
+                )
+            finally:
+                release.set()
+
+        assert entered.is_set()
+        assert result == (original, "fallback")
+        static_fallback.assert_not_called()
+        provider_fallback.assert_not_called()
+
     def test_late_production_worker_cannot_republish_stall_backoff(
         self, tmp_path: Path
     ):

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -373,6 +373,32 @@ class TestCompress:
     def _make_messages(self, n):
         return [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"} for i in range(n)]
 
+    def test_forced_static_fallback_skips_remote_summary(self):
+        from agent.context_compressor import static_summary_fallback
+
+        with patch("agent.context_compressor.get_model_context_length", return_value=100000):
+            c = ContextCompressor(
+                model="test/model",
+                quiet_mode=True,
+                protect_first_n=1,
+                protect_last_n=1,
+            )
+        msgs = self._make_messages(12)
+
+        with patch("agent.context_compressor.call_llm") as mock_llm, \
+             static_summary_fallback("host total ceiling exhausted"):
+            result = c.compress(msgs, current_tokens=999999, force=True)
+
+        mock_llm.assert_not_called()
+        assert result != msgs
+        assert c._last_summary_fallback_used is True
+        fallback = next(
+            message["content"]
+            for message in result
+            if "Summary generation was unavailable" in message.get("content", "")
+        )
+        assert "host total ceiling exhausted" in fallback
+
 
 
 

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -373,6 +373,72 @@ class TestCompress:
     def _make_messages(self, n):
         return [{"role": "user" if i % 2 == 0 else "assistant", "content": f"msg {i}"} for i in range(n)]
 
+    def test_late_success_rechecks_before_shared_state_publication(self):
+        from agent.auxiliary_client import AuxiliaryExplicitCancellation
+        from agent.compression_attempt_context import compression_cancelled_check
+
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=100000
+        ):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+        c._previous_summary = "successor-owned summary"
+        c._summary_failure_cooldown_until = 123.0
+        c._last_summary_error = "successor-owned error"
+        checks = 0
+
+        def cancelled_after_response_processing():
+            nonlocal checks
+            checks += 1
+            # Start, telemetry-finally, and immediate post-call checks pass.
+            # Cancellation wins only at the final shared-state boundary.
+            return checks >= 4
+
+        response = {
+            "choices": [
+                {
+                    "message": {
+                        "content": (
+                            "## Active Task\nUser asked: 'keep context'\n\n"
+                            "## Goal\nContinue the session."
+                        )
+                    }
+                }
+            ]
+        }
+        with (
+            patch("agent.context_compressor.call_llm", return_value=response),
+            compression_cancelled_check(cancelled_after_response_processing),
+            pytest.raises(AuxiliaryExplicitCancellation),
+        ):
+            c._generate_summary(
+                [{"role": "user", "content": "keep context"}]
+            )
+
+        assert c._previous_summary == "successor-owned summary"
+        assert c._summary_failure_cooldown_until == 123.0
+        assert c._last_summary_error == "successor-owned error"
+
+    def test_cooldown_clear_uses_attempt_local_cancellation(self):
+        from agent.compression_attempt_context import compression_cancelled_check
+
+        with patch(
+            "agent.context_compressor.get_model_context_length", return_value=100000
+        ):
+            c = ContextCompressor(model="test/model", quiet_mode=True)
+        c._summary_failure_cooldown_until = 123.0
+        c._last_summary_error = "successor-owned error"
+        c._consecutive_timeout_failures = 2
+        # Simulate the shared attribute having already been replaced by the
+        # uncancelled successor attempt.
+        c._compression_cancelled_check = lambda: False
+
+        with compression_cancelled_check(lambda: True):
+            c._clear_compression_failure_cooldown()
+
+        assert c._summary_failure_cooldown_until == 123.0
+        assert c._last_summary_error == "successor-owned error"
+        assert c._consecutive_timeout_failures == 2
+
     def test_forced_static_fallback_skips_remote_summary(self):
         from agent.context_compressor import static_summary_fallback
 


### PR DESCRIPTION
## What does this PR do?

Sessions now complete context compaction with the built-in deterministic handoff when the remote summary worker stalls or exceeds the host ceiling. The fallback commits on a fresh fence without another LLM request, surfaces a visible warning, and temporarily backs off remote summary attempts instead of ending the turn with an unchanged oversized transcript.

### Symptom

A long session can remain at "Summarizing session..." or "Compacting context..." until the host timeout, after which the turn ends without compaction and the oversized session remains unusable.

### Impact

Users on slow, quota-limited, or unresponsive summary routes can lose the active turn and repeatedly hit the same compaction wall. The affected population is not measured.

### Bug Cause

**Trigger:** `agent/conversation_compression.py` / `run_compress_context_with_progress_timeout()` when the summary worker loses its progress or total-ceiling budget before the commit boundary.

**Causal chain:**
1. A context-heavy session starts remote summary generation under a host-owned commit fence.
2. The provider worker outlives the host budget, so the host revokes its commit admission; the compressor's normal deterministic failure branch cannot publish on that poisoned fence.
3. The timeout wrapper retries another remote route when configured or returns the original transcript, and preflight terminates the turn because the oversized request is still unchanged.

**Why it is wrong:** The host timeout path bypassed the built-in deterministic handoff even though that handoff is specifically designed to preserve continuity without a provider response.

**Working sibling / contrast:** Ordinary summary exceptions reach `ContextCompressor.compress()` Phase 4 and already build the deterministic handoff. Only host-fenced stalls escaped before that branch could commit.

**Ruled out:** SessionDB commit contention is not the trigger. Once `begin_commit()` wins, the existing path waits for the commit and reports overruns; this bug occurs before commit admission.

### Fix

- Add an attempt-local static-fallback context so the built-in compressor can assemble its existing deterministic handoff without issuing another LLM request.
- After a host summary timeout, permanently fence the remote worker, release only its holder-qualified lease, and synchronously commit the local handoff on a fresh published fence.
- Preserve plugin context engines' configured remote fallback behavior, record timeout backoff after local recovery, and emit a visible fallback warning.

## Related Issue

Fixes #100602

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/context_compressor.py` - add attempt-local deterministic fallback selection and reuse the existing bounded handoff builder.
- `agent/conversation_compression.py` - commit the local handoff after host timeout while fencing late remote publication.
- `tests/agent/test_compress_context_progress_timeout.py` - cover a remote worker that outlives the total ceiling and a successful fresh-fence fallback.
- `tests/agent/test_context_compressor.py` - verify forced local fallback makes no remote LLM call and preserves the timeout reason.

## How to Test

1. Run the focused compressor and timeout suites.
2. Run the worker-isolation, lifecycle, terminal-timeout, session-sync, attempt-ownership, concurrent-fork, and orphan-recovery suites.
3. Confirm all 251 relevant tests pass and Ruff reports no errors.

```bash
scripts/run_tests.sh tests/agent/test_compress_context_progress_timeout.py tests/agent/test_context_compressor.py
scripts/run_tests.sh tests/agent/test_compression_worker_isolation_76354.py tests/agent/test_compression_attempt_lifecycle.py tests/run_agent/test_compression_timeout_terminal.py tests/gateway/test_compression_failure_session_sync.py
scripts/run_tests.sh tests/agent/test_compression_attempt_ownership.py tests/agent/test_compression_concurrent_fork.py tests/agent/test_compression_orphan_recovery.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the repository test entry on all relevant suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation and docstrings are updated
- [x] `cli-config.yaml.example` changes are not applicable
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are not applicable
- [x] I've considered cross-platform impact; the implementation uses Python synchronization primitives and has no platform-specific branch
- [x] Tool description and schema changes are not applicable

## Screenshots / Logs

Not applicable. The regression is covered by deterministic timeout and session-state tests.
