### PR TITLE
fix(ntfy): scope server/topic/publish_topic reads to the active profile under multiplexing

### DIFF
--- a/plugins/platforms/ntfy/adapter.py
+++ b/plugins/platforms/ntfy/adapter.py
@@ -155,21 +155,21 @@ def check_requirements() -> bool:
     """
     if not HTTPX_AVAILABLE:
         return False
-    topic = os.getenv("NTFY_TOPIC", "").strip()
+    topic = _get_scoped_secret("NTFY_TOPIC", "").strip()
     return bool(topic)
 
 
 def validate_config(config) -> bool:
     """Validate that the configured ntfy platform has a topic set."""
     extra = getattr(config, "extra", {}) or {}
-    topic = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+    topic = extra.get("topic") or _get_scoped_secret("NTFY_TOPIC", "")
     return bool(topic)
 
 
 def is_connected(config) -> bool:
     """Check whether ntfy is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    topic = os.getenv("NTFY_TOPIC") or extra.get("topic", "")
+    topic = _get_scoped_secret("NTFY_TOPIC") or extra.get("topic", "")
     return bool(topic)
 
 
@@ -189,12 +189,12 @@ class NtfyAdapter(BasePlatformAdapter):
         extra = config.extra or {}
         self._server: str = (
             extra.get("server")
-            or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+            or _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER)
         ).rstrip("/")
-        self._topic: str = extra.get("topic") or os.getenv("NTFY_TOPIC", "")
+        self._topic: str = extra.get("topic") or _get_scoped_secret("NTFY_TOPIC", "")
         self._publish_topic: str = (
             extra.get("publish_topic")
-            or os.getenv("NTFY_PUBLISH_TOPIC", "")
+            or _get_scoped_secret("NTFY_PUBLISH_TOPIC", "")
             or self._topic
         )
         self._token: str = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
@@ -488,27 +488,27 @@ def _env_enablement() -> dict | None:
     core hook — it becomes a proper ``HomeChannel`` dataclass on the
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
-    topic = os.getenv("NTFY_TOPIC", "").strip()
+    topic = _get_scoped_secret("NTFY_TOPIC", "").strip()
     if not topic:
         return None
     seed: dict = {
         "topic": topic,
-        "server": os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER).rstrip("/"),
+        "server": _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER).rstrip("/"),
     }
-    publish_topic = os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+    publish_topic = _get_scoped_secret("NTFY_PUBLISH_TOPIC", "").strip()
     if publish_topic:
         seed["publish_topic"] = publish_topic
     token = _get_scoped_secret("NTFY_TOKEN", "").strip()
     if token:
         seed["token"] = token
-    markdown = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    markdown = _get_scoped_secret("NTFY_MARKDOWN", "").strip().lower()
     if markdown:
         seed["markdown"] = markdown in ("1", "true", "yes")
-    home = os.getenv("NTFY_HOME_CHANNEL", "").strip() or topic
+    home = _get_scoped_secret("NTFY_HOME_CHANNEL", "").strip() or topic
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("NTFY_HOME_CHANNEL_NAME", home),
+            "name": _get_scoped_secret("NTFY_HOME_CHANNEL_NAME", home),
         }
     return seed
 
@@ -540,20 +540,20 @@ async def _standalone_send(
     extra = getattr(pconfig, "extra", {}) or {}
     server = (
         extra.get("server")
-        or os.getenv("NTFY_SERVER_URL", DEFAULT_SERVER)
+        or _get_scoped_secret("NTFY_SERVER_URL", DEFAULT_SERVER)
     ).rstrip("/")
     publish_topic = (
         chat_id
         or extra.get("publish_topic")
-        or os.getenv("NTFY_PUBLISH_TOPIC", "").strip()
+        or _get_scoped_secret("NTFY_PUBLISH_TOPIC", "").strip()
         or extra.get("topic")
-        or os.getenv("NTFY_TOPIC", "").strip()
+        or _get_scoped_secret("NTFY_TOPIC", "").strip()
     )
     if not publish_topic:
         return {"error": "ntfy standalone send: NTFY_TOPIC not configured"}
 
     token = extra.get("token") or _get_scoped_secret("NTFY_TOKEN", "")
-    markdown_env = os.getenv("NTFY_MARKDOWN", "").strip().lower()
+    markdown_env = _get_scoped_secret("NTFY_MARKDOWN", "").strip().lower()
     markdown_enabled = bool(extra.get("markdown")) or markdown_env in ("1", "true", "yes")
 
     headers = {"Content-Type": "text/plain; charset=utf-8", "X-Tags": _ECHO_TAG, **_build_auth_header(token)}

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -491,3 +491,125 @@ class TestTruncateHelper:
         assert _ntfy._truncate_body("hi", context="test") == b"hi"
 
 
+# ---------------------------------------------------------------------------
+# 13. Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s server/topic/publish_topic, _env_enablement's topic/server/
+# publish_topic/markdown/home_channel, and check_requirements/validate_config/
+# is_connected's topic reads, all previously read raw os.getenv
+# unconditionally (only NTFY_TOKEN was already scoped). Under multiplex,
+# os.environ holds the DEFAULT profile's YAML-to-env bridge output -- a
+# secondary profile with its own (different or absent) ntfy config would
+# silently subscribe to / publish on the default profile's topic, or get
+# auto-enabled using the default profile's topic entirely. Mirrors the
+# LINE/Buzz/SimpleX fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("NTFY_TOPIC", "default-topic")
+    monkeypatch.setenv("NTFY_SERVER_URL", "https://default.example.com")
+    monkeypatch.setenv("NTFY_PUBLISH_TOPIC", "default-out")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config.yaml extra is authoritative,
+        not the default profile's bridged topic/server/publish_topic."""
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "topic": "profile-topic",
+                "server": "https://profile.example.com",
+                "publish_topic": "profile-out",
+            },
+        )
+        adapter = NtfyAdapter(cfg)
+        assert adapter._topic == "profile-topic"
+        assert adapter._server == "https://profile.example.com"
+        assert adapter._publish_topic == "profile-out"
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's own scope must NOT borrow the
+        default profile's bridged env values -- that would silently
+        subscribe/publish on the wrong topic."""
+        multiplex_scope()
+        adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._topic == ""
+        assert adapter._server == DEFAULT_SERVER
+        assert adapter._publish_topic == ""
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+
+        set_multiplex_active(True)
+        try:
+            adapter = NtfyAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter._topic == "default-topic"
+        assert adapter._server == "https://default.example.com"
+        assert adapter._publish_topic == "default-out"
+
+    def test_env_enablement_scoped_reads_own_topic_not_default(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile's own .env (via the scope) seeds its own
+        topic; the default profile's bridged topic must not leak in."""
+        multiplex_scope({"NTFY_TOPIC": "profile-topic"})
+        seeded = _env_enablement()
+        assert seeded["topic"] == "profile-topic"
+
+    def test_env_enablement_scoped_without_own_topic_returns_none(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A scope with no NTFY_TOPIC of its own must not auto-enable ntfy
+        using the default profile's topic."""
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        assert _env_enablement() is None
+
+    def test_check_requirements_scoped_miss_ignores_default_topic(
+        self, multiplex_scope, default_profile_env
+    ):
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        assert check_requirements() is False
+
+    def test_is_connected_scoped_miss_does_not_borrow_default_topic(
+        self, multiplex_scope, default_profile_env
+    ):
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        assert is_connected(PlatformConfig(enabled=True, extra={})) is False
+
+


### PR DESCRIPTION
## Summary

- `NtfyAdapter.__init__`, `_env_enablement`, `check_requirements`, `validate_config`, `is_connected`, and `_standalone_send` all read `NTFY_SERVER_URL`/`NTFY_TOPIC`/`NTFY_PUBLISH_TOPIC`/`NTFY_MARKDOWN`/`NTFY_HOME_CHANNEL(_NAME)` via raw `os.getenv()` — only `NTFY_TOKEN` was already routed through the module's `_get_scoped_secret()` helper.
- Under `gateway.multiplex_profiles`, `env_enablement_fn`/`check_fn`/`is_connected` all run inside the same registry-enablement loop in `load_gateway_config()` (`gateway/config.py`, ~lines 2704-2820), which runs inside `_profile_runtime_scope` for secondary profiles — confirmed by the loop's own comment listing ntfy among the plugins whose `is_connected` reads env vars directly. Adapter construction runs scoped the same way.
- Consequence: a secondary profile with its own (or no) ntfy topic configured could silently get auto-enabled via `_env_enablement()`/`is_connected()` using the default profile's topic even though it never configured ntfy, have its adapter subscribe to / publish on the default profile's topic and server, or deliver cron/`send_message_tool` messages via `_standalone_send` to the wrong topic entirely.

## Fix

Switch every raw `NTFY_*` read (except `NTFY_TOKEN`, already scoped) to the module's existing `_get_scoped_secret()` helper — same helper, same fallback semantics (scoped miss returns the default, never borrows `os.environ` cross-profile; the DEFAULT profile's own unscoped construction still falls back to `os.environ`). This mirrors the pattern already applied to the sibling LINE/DingTalk/Teams/SMS/WeCom adapters in this series.

## Tests

Added `TestMultiplexProfileScope` (7 tests) to `tests/gateway/test_ntfy_plugin.py`, mirroring the fixture/assertion style already established in `tests/gateway/test_line_plugin.py`'s class of the same name:
- secondary profile's own `extra` config wins over the default profile's bridged env
- a scope miss does not leak the default profile's topic/server/publish_topic (`__init__`, `_env_enablement`, `check_requirements`, `is_connected`)
- the DEFAULT profile's own unscoped construction still honors its own `os.environ`

Mutation-verified: stashed the production fix and confirmed 5 of 7 new tests fail against pre-fix code (the other 2 are non-differentiating regression guards that correctly pass either way — extra-always-wins-over-env, and unscoped-default-profile-precedence, neither of which the fix changes). Restored the fix; all 37 tests in the file pass, plus the file's 5 parametrized `_get_scoped_secret` tests in `tests/gateway/test_adapter_startup_secret_scope.py`.

## Competitor check

Searched `NTFY_TOPIC`, `ntfy multiplex`, `ntfy scope`. Two open PRs touch `plugins/platforms/ntfy/adapter.py`:
- **#87674** ("honor config.yaml in pre-flight check...") changes `check_requirements()`'s signature (`config=None` param) and reads `extra.get("topic")` as an additional fallback on the *same* `topic = os.getenv("NTFY_TOPIC", "").strip()` line this PR touches — but for an unrelated concern (config.yaml-only setups passing pre-flight vs. multiplex scope-awareness here). Pure textual adjacency, not a semantic conflict; a trivial rebase combines `_get_scoped_secret("NTFY_TOPIC", "")` with their `config` fallback. Flagging transparently rather than dropping the `check_requirements` change from scope.
- **#87675** ("support YAML platform configuration") adds a *new* `_apply_yaml_config()` hook that bridges `config.yaml` extras into `NTFY_*` env vars, guarded only by `not os.getenv(env)` (no multiplex/`_skip_env_bridge` gating) — this is the same first-writer-wins env-bridge bug class already fixed for Discord/Telegram/WhatsApp/DingTalk in this series, but on code that doesn't exist on `main` yet. No line overlap with this PR's changes; noting it here so a future scoping pass on `_apply_yaml_config` (if #87675 merges) knows to gate it the same way.

No open or merged PR touches the actual scope-leak fixed here.

## Checklist

- [x] Read current adapter code directly (not from a stale scan summary)
- [x] Minimal, precedent-matching fix (reuses existing `_get_scoped_secret` helper)
- [x] New regression tests, mutation-verified against the pre-fix code
- [x] Full existing ntfy test suite passes
- [x] Fresh competitor PR search immediately before opening this PR