### PR TITLE
fix(agent): stop container hosts detecting themselves as containers

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1640,12 +1640,27 @@ def is_container() -> bool:
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
     # runtime still shows up in the mount table (overlay rootfs, runtime mount
     # paths), so scan mountinfo as a last resort.
+    #
+    # Only the line describing this process's ROOT mount ("/") may vote. A host
+    # that *runs* containerd/Docker carries the runtime's overlay mounts in the
+    # same table (e.g. /var/lib/docker/overlay2/<hash> with
+    # lowerdir=/var/lib/containerd/...), so matching anywhere in mountinfo makes
+    # every container HOST report itself as a container. Inside a real container
+    # "/" is itself the runtime's overlay, so the marker lands on that line.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                # mountinfo: <id> <parent> <maj:min> <root> <mountpoint> <opts>
+                #            [optional...] - <fstype> <source> <superopts>
+                head, sep, _tail = line.partition(" - ")
+                if not sep:
+                    continue
+                fields = head.split()
+                if len(fields) < 5 or fields[4] != "/":
+                    continue
+                if any(marker in line for marker in ("kubepods", "containerd", "crio")):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -371,6 +371,69 @@ class TestIsContainer:
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         assert is_container() is True
 
+    def _probe_with_mountinfo(self, monkeypatch, mountinfo: str) -> bool:
+        """Run is_container() against a synthetic /proc/self/mountinfo.
+
+        Neutralizes every earlier signal (no /.dockerenv, no k8s env var,
+        clean cgroup) so only the mountinfo fallback decides.
+        """
+        import builtins
+        import io
+
+        self._reset_cache(monkeypatch)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/self/mountinfo":
+                return io.StringIO(mountinfo)
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/init.scope\n")
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        return is_container()
+
+    def test_container_host_is_not_a_container(self, monkeypatch):
+        """A HOST running containerd must not detect itself as containerized.
+
+        Regression: the cgroup-v2 fallback used to substring-match the whole
+        mount table, so the runtime's own overlay mounts (present on any
+        machine that *runs* containers) made every Docker host report True.
+        Here "/" is a plain ext4 device — the machine is not a container.
+        """
+        mountinfo = (
+            "29 1 8:18 / / rw,noatime shared:1 - ext4 /dev/sdb2 rw\n"
+            "118 163 0:50 / /var/lib/docker/overlay2/2917fb0b rw,relatime shared:70 "
+            "- overlay overlay rw,lowerdir=/var/lib/containerd/snapshots/1/fs\n"
+        )
+        assert self._probe_with_mountinfo(monkeypatch, mountinfo) is False
+
+    def test_detects_containerd_overlay_root(self, monkeypatch):
+        """Inside a real container "/" IS the runtime overlay → True."""
+        mountinfo = (
+            "640 639 0:65 / / rw,relatime - overlay overlay "
+            "rw,lowerdir=/var/lib/containerd/snapshots/9/fs\n"
+        )
+        assert self._probe_with_mountinfo(monkeypatch, mountinfo) is True
+
+    def test_detects_kubepods_root(self, monkeypatch):
+        """A k8s pod's root mount carries the runtime marker → True."""
+        mountinfo = (
+            "1234 1233 0:58 / / rw,relatime - overlay overlay "
+            "rw,lowerdir=/var/lib/containerd/snapshots/842/fs\n"
+            "1235 1234 0:59 /kubepods/besteffort/podabc /etc/hosts rw,relatime "
+            "- ext4 /dev/sda1 rw\n"
+        )
+        assert self._probe_with_mountinfo(monkeypatch, mountinfo) is True
+
+    def test_plain_host_without_runtime(self, monkeypatch):
+        """No runtime anywhere in the mount table → False."""
+        mountinfo = "29 1 8:18 / / rw,noatime shared:1 - ext4 /dev/sdb2 rw\n"
+        assert self._probe_with_mountinfo(monkeypatch, mountinfo) is False
+
 
 class TestParseReasoningEffort:
     """Tests for parse_reasoning_effort() — string → reasoning config dict."""


### PR DESCRIPTION
## What

`is_container()` read the whole of `/proc/self/mountinfo` and substring-matched
`kubepods` / `containerd` / `crio` **anywhere in the table**. Any machine that
*runs* containers carries the runtime's own overlay mounts there, so every
Docker/containerd **host** reported itself as containerized.

## Why it matters

Observed on a bare-metal Debian box running dockerd: **29 matching mount lines**,
while every other signal said "host":

| Signal | Value |
|---|---|
| `/proc/1/cgroup` | `0::/init.scope` (clean) |
| PID 1 | `systemd` |
| `/.dockerenv` | absent |
| `KUBERNETES_SERVICE_HOST` | unset |
| `systemd-detect-virt --container` | `none` |

The matching lines were all of this shape — the host's own image store, never `/`:

```
118 163 0:50 / /var/lib/docker/overlay2/<hash> rw,relatime shared:70 \
  - overlay overlay rw,lowerdir=/var/lib/containerd/.../snapshots/1/fs
```

`is_container()` gates ~15 call sites (`gateway.py` ×5, `config.py`,
`web_server.py`, `voice_mode.py`, `skill_utils.py`, `doctor.py`). The
user-visible symptom was `gateway install --system` refusing with
*"Containers use restart policies"* on a machine that has no such thing.
The result is cached in `_container_detected` for the process lifetime, so a
single false positive persists for the whole run.

## The fix

Iterate `mountinfo` line by line, split on `" - "`, and let **only the line whose
mountpoint (field 5) is `/`** vote.

Inside a real container `/` **is** the runtime's overlay, so the marker lands on
that line and genuine cgroup-v2 containerd / CRI-O / k8s detection is preserved.
On a host the markers sit on `/var/lib/...` mountpoints and are correctly ignored.

Earlier signals (`/.dockerenv`, `/run/.containerenv`, `KUBERNETES_SERVICE_HOST`,
`/proc/1/cgroup` markers) are untouched — this only tightens the last-resort
cgroup-v2 fallback introduced for #47111.

## How to test

Four regression tests drive `is_container()` with synthetic `mountinfo`:

| Case | Expected |
|---|---|
| Host running containerd (markers on `/var/lib/...`) | `False` |
| Container with containerd overlay as `/` | `True` |
| k8s pod (`kubepods` + overlay root) | `True` |
| Plain host, no runtime | `False` |

```
pytest tests/test_hermes_constants.py -k TestIsContainer
```

`test_container_host_is_not_a_container` fails on `main` and passes with this
change — verified by stashing the source fix and re-running, so it is a real
regression test rather than a snapshot of current behaviour.

## Platforms tested

Linux (Debian 13, kernel 6.12, cgroup v2, bare metal running dockerd).
The changed code is Linux-only by construction: it reads `/proc`, and the
surrounding `try/except OSError` already covers platforms without it.

Related: #47111 (the PR that added the mountinfo fallback).

---

*Disclosure: this patch was written by Hermes itself — the agent instance running
on the affected host, which is also where the false positive was found,
reproduced and tested. Submitted by @nicolasestrem, who reviewed and approved it.*
