### PR TITLE
fix(desktop): guard the whole build-critical dep set before clean (salvage #87980)

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -27,7 +27,7 @@
     "profile:main": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron --inspect=9229 .",
     "profile:main:cpu": "tsc --build tsconfig.electron.json && wait-on http://127.0.0.1:5174 && node scripts/bundle-electron-main.mjs --dev && cross-env XCURSOR_SIZE=24 NODE_OPTIONS=--cpu-prof HERMES_DESKTOP_DEV_SERVER=http://127.0.0.1:5174 electron .",
     "start": "npm run build && electron .",
-    "prebuild": "npm run clean",
+    "prebuild": "node scripts/assert-root-install.mjs && npm run clean",
     "build": "node scripts/assert-root-install.mjs && node scripts/write-build-stamp.mjs && vite build && node scripts/bundle-electron-main.mjs && node scripts/stage-native-deps.mjs",
     "postbuild": "node scripts/assert-dist-built.mjs",
     "prebuilder": "node scripts/patch-electron-builder-mac-binary.mjs",

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -1,35 +1,118 @@
-import { accessSync, readFileSync } from "fs"
+// Build-time guard: refuse to start a build the installed tree cannot finish.
+//
+// The desktop workspace's dependencies are hoisted to the repo-root
+// `node_modules`, so a root install that only covers *part* of the workspace
+// graph leaves this app importable-looking but unbuildable. The guard exists to
+// turn that into one actionable line ("run npm ci from the repo root") instead
+// of a failure deep inside vite.
+//
+// It runs from `prebuild`, ahead of `npm run clean`, so a tree that cannot
+// build is rejected before the build starts deleting its own outputs. `build`
+// re-runs it for anyone invoking the build steps directly; the check is pure
+// filesystem lookups, so paying for it twice costs nothing.
+
+import { existsSync, readFileSync } from "fs"
 import { createRequire } from "module"
-import { resolve, join } from "path"
+import { resolve, join, dirname } from "path"
+import { isMain } from "./utils.mjs"
 
-const app = resolve(import.meta.dirname, "..")
-const root = resolve(app, "..", "..")
+// Packages the build *consumes*, as opposed to merely declares. Each one is
+// load-bearing for a distinct build step, and each one has been observed
+// missing from a partial root install:
+//
+//   vite            — bundles the renderer (`vite build`).
+//   katex           — `src/styles.css` imports `katex/dist/katex.min.css`, so
+//                     the CSS transform fails before a single chunk is emitted.
+//   electron        — the runtime electron-builder packages; without it `pack`
+//                     cannot produce an unpacked app at all.
+//   electron-builder — the packager `npm run builder` shells out to.
+//
+// Checking only `vite` (the original guard) passes a tree missing any of the
+// others, which is how an incomplete install reached `vite build` and died on
+// an unresolved `katex/dist/katex.min.css` with no hint that the install — not
+// the source — was at fault (#86443).
+const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
 
-try {
-  accessSync(join(root, "node_modules", "vite", "package.json"))
-} catch {
-  console.error(`Run from repo root: cd ${root} && npm ci`)
-  process.exit(1)
+// Resolve the way Node's own lookup does — walk `node_modules` upward — rather
+// than through `require.resolve`. A package whose `exports` map does not expose
+// `./package.json` is not resolvable by path even when correctly installed, and
+// that must not read as "missing".
+function packageIsInstalled(name, fromDir) {
+  let dir = fromDir
+  for (;;) {
+    if (existsSync(join(dir, "node_modules", name, "package.json"))) return true
+    const parent = dirname(dir)
+    if (parent === dir) return false
+    dir = parent
+  }
 }
 
-// `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
-// and React refuses to run when the two come from different installed copies
-// ("Minified React error #527" — it throws before the first paint, so the app
-// window stays blank). npm stays silent about the split because the hoisted
-// react still satisfies react-dom's caret peer range. Fail the build loudly
-// instead of shipping a white screen.
-const requireFromApp = createRequire(join(app, "package.json"))
-const installedVersion = (pkg) =>
-  JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
+// Pure check — returns { ok: true } or { ok: false, error: "..." }.
+// Kept side-effect-free so it can be unit tested without spawning a process.
+export function checkRootInstall(appDir, rootDir) {
+  const missing = BUILD_CRITICAL_PACKAGES.filter(pkg => !packageIsInstalled(pkg, appDir))
+  if (missing.length > 0) {
+    return {
+      ok: false,
+      error:
+        `the desktop build needs ${missing.join(", ")}, which the current install ` +
+        `does not provide. A partial root install leaves the workspace looking ` +
+        `present while the build cannot complete. Reinstall from the repo root: ` +
+        `cd ${rootDir} && npm ci`
+    }
+  }
 
-const react = installedVersion("react")
-const reactDom = installedVersion("react-dom")
+  // `vite.config.ts` aliases react/react-dom to whatever this workspace resolves,
+  // and React refuses to run when the two come from different installed copies
+  // ("Minified React error #527" — it throws before the first paint, so the app
+  // window stays blank). npm stays silent about the split because the hoisted
+  // react still satisfies react-dom's caret peer range. Fail the build loudly
+  // instead of shipping a white screen.
+  const requireFromApp = createRequire(join(appDir, "package.json"))
+  const installedVersion = pkg =>
+    JSON.parse(readFileSync(requireFromApp.resolve(`${pkg}/package.json`), "utf8")).version
 
-if (react !== reactDom) {
-  console.error(
-    `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
-      `with error #527 and render a blank window. Pin both to the same version ` +
-      `in ${join(app, "package.json")}, then reinstall: cd ${root} && npm ci`
-  )
-  process.exit(1)
+  let react
+  let reactDom
+  try {
+    react = installedVersion("react")
+    reactDom = installedVersion("react-dom")
+  } catch (err) {
+    // Both are in BUILD_CRITICAL_PACKAGES' spirit but not its list: they are
+    // checked by version, and an unreadable package.json is a broken install
+    // rather than an absent one. Report it as such instead of throwing.
+    return {
+      ok: false,
+      error: `could not read the installed react/react-dom versions (${err.message}). Reinstall from the repo root: cd ${rootDir} && npm ci`
+    }
+  }
+
+  if (react !== reactDom) {
+    return {
+      ok: false,
+      error:
+        `react@${react} / react-dom@${reactDom} version mismatch — React would fail ` +
+        `with error #527 and render a blank window. Pin both to the same version ` +
+        `in ${join(appDir, "package.json")}, then reinstall: cd ${rootDir} && npm ci`
+    }
+  }
+
+  return { ok: true }
 }
+
+function main() {
+  const app = resolve(import.meta.dirname, "..")
+  const root = resolve(app, "..", "..")
+  const result = checkRootInstall(app, root)
+
+  if (!result.ok) {
+    console.error(`✗ assert-root-install: ${result.error}`)
+    process.exit(1)
+  }
+}
+
+if (isMain(import.meta.url)) {
+  main()
+}
+
+export default { checkRootInstall }

--- a/apps/desktop/scripts/assert-root-install.mjs
+++ b/apps/desktop/scripts/assert-root-install.mjs
@@ -32,6 +32,7 @@ import { isMain } from "./utils.mjs"
 // an unresolved `katex/dist/katex.min.css` with no hint that the install — not
 // the source — was at fault (#86443).
 const BUILD_CRITICAL_PACKAGES = ["vite", "katex", "electron", "electron-builder"]
+export { BUILD_CRITICAL_PACKAGES }
 
 // Resolve the way Node's own lookup does — walk `node_modules` upward — rather
 // than through `require.resolve`. A package whose `exports` map does not expose
@@ -114,5 +115,3 @@ function main() {
 if (isMain(import.meta.url)) {
   main()
 }
-
-export default { checkRootInstall }

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -4,9 +4,7 @@ import os from 'node:os'
 import path from 'node:path'
 import { test } from 'vitest'
 
-import { checkRootInstall } from '../scripts/assert-root-install.mjs'
-
-const BUILD_CRITICAL = ['vite', 'katex', 'electron', 'electron-builder']
+import { BUILD_CRITICAL_PACKAGES as BUILD_CRITICAL, checkRootInstall } from '../scripts/assert-root-install.mjs'
 
 // Build a throwaway repo shaped like this one: an app workspace whose
 // dependencies are hoisted to the repo root, which is what the guard walks.

--- a/apps/desktop/scripts/assert-root-install.test.mjs
+++ b/apps/desktop/scripts/assert-root-install.test.mjs
@@ -1,0 +1,124 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test } from 'vitest'
+
+import { checkRootInstall } from '../scripts/assert-root-install.mjs'
+
+const BUILD_CRITICAL = ['vite', 'katex', 'electron', 'electron-builder']
+
+// Build a throwaway repo shaped like this one: an app workspace whose
+// dependencies are hoisted to the repo root, which is what the guard walks.
+function makeTree({ rootPackages = BUILD_CRITICAL, react = '19.2.7', reactDom = '19.2.7' } = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-assert-root-'))
+  const appDir = path.join(tempRoot, 'apps', 'desktop')
+  fs.mkdirSync(appDir, { recursive: true })
+  fs.writeFileSync(path.join(appDir, 'package.json'), JSON.stringify({ name: 'desktop' }), 'utf8')
+
+  const writePackage = (name, version) => {
+    const dir = path.join(tempRoot, 'node_modules', name)
+    fs.mkdirSync(dir, { recursive: true })
+    fs.writeFileSync(path.join(dir, 'package.json'), JSON.stringify({ name, version }), 'utf8')
+  }
+  for (const name of rootPackages) writePackage(name, '1.0.0')
+  if (react !== null) writePackage('react', react)
+  if (reactDom !== null) writePackage('react-dom', reactDom)
+
+  return { tempRoot, appDir }
+}
+
+test('checkRootInstall passes on a complete root install', () => {
+  const { tempRoot, appDir } = makeTree()
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The regression this guard was widened for: the updater's partial `npm install`
+// left katex out while vite was present, so the old vite-only check passed and
+// the build died on an unresolved `katex/dist/katex.min.css` (#86443).
+test('checkRootInstall fails when katex is missing but vite is present', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /katex/)
+    assert.match(result.error, /npm ci/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails when electron is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'electron')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /electron/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall reports every missing package at once', () => {
+  const { tempRoot, appDir } = makeTree({ rootPackages: ['vite'] })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    for (const name of ['katex', 'electron', 'electron-builder']) {
+      assert.match(result.error, new RegExp(name))
+    }
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// The original guard's only check — kept, so widening coverage cannot silently
+// drop the case it already handled.
+test('checkRootInstall still fails when vite is missing', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'vite')
+  })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /vite/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+test('checkRootInstall fails on a react/react-dom version split', () => {
+  const { tempRoot, appDir } = makeTree({ react: '19.2.7', reactDom: '19.1.0' })
+  try {
+    const result = checkRootInstall(appDir, tempRoot)
+    assert.equal(result.ok, false)
+    assert.match(result.error, /#527/)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})
+
+// A package installed into the app's own node_modules rather than hoisted to the
+// root is still installed. The guard walks upward like Node does, so it must not
+// insist on the hoisted location.
+test('checkRootInstall accepts a package nested in the app workspace', () => {
+  const { tempRoot, appDir } = makeTree({
+    rootPackages: BUILD_CRITICAL.filter(name => name !== 'katex')
+  })
+  const nested = path.join(appDir, 'node_modules', 'katex')
+  fs.mkdirSync(nested, { recursive: true })
+  fs.writeFileSync(path.join(nested, 'package.json'), JSON.stringify({ name: 'katex' }), 'utf8')
+  try {
+    assert.deepEqual(checkRootInstall(appDir, tempRoot), { ok: true })
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

`hermes update` on Windows could delete the packaged Desktop app and report success: the rebuild's own `clean` step removed `Hermes.exe`, the rebuild then failed on dependencies a partial root install never provided, and nothing surfaced the failure (#86443). This PR rejects an unbuildable tree BEFORE the build starts deleting its own outputs.

Salvage of #87980 by @jackulau (cherry-picked, authorship preserved) — rebased onto current main, plus one follow-up commit (export the package list for the test, drop a dead default export).

## Changes

- `apps/desktop/scripts/assert-root-install.mjs`: widen the guard from vite-only to the 4 build-critical packages (`vite`, `katex`, `electron`, `electron-builder`), report every missing package at once, extract a pure `checkRootInstall(appDir, rootDir)` for testing. Resolution walks `node_modules` upward like Node does (a package whose `exports` map omits `./package.json` must not read as "missing" — verified `createRequire.resolve` fails on such packages while the walk succeeds).
- `apps/desktop/package.json`: run the guard from `prebuild`, ahead of `npm run clean` — a tree that cannot build is refused before the existing app is deleted. `build` re-runs it for direct invocations; the check is pure filesystem lookups.
- `apps/desktop/scripts/assert-root-install.test.mjs`: 7 scenarios (complete install, each package missing, all-missing aggregate report, react/react-dom split, nested workspace install accepted).

## Validation

| | Before | After |
|---|---|---|
| partial install (katex missing, vite present) | guard passes → clean deletes app → vite build dies on unresolved katex CSS | guard refuses before clean, names katex, exit 1 |
| complete install | build proceeds | build proceeds (verified `{ ok: true }` on a complete tree) |

- All 7 test scenarios pass (direct node harness; repo vitest for `scripts/*.test.mjs` is broken pre-existing — root `node_modules` missing `@rolldown/plugin-babel`, affects every script test, not this PR).
- Standalone run on this very clone correctly flags genuinely-absent `electron` and exits 1.
- npm lifecycle verified: `pre<script>` runs automatically before `<script>`; `npm run clean` standalone is unaffected; `dev:renderer` already invoked the guard.

## Provenance

- #87980 (@jackulau) — this salvage; original was 3715 commits behind but file-level churn was zero, clean cherry-pick.
- Exit-code half of #86443 already landed via #89838 (supersedes #87984); native-dep recovery tracked in #91079. Our open #87879 (restore a wiped build) is complementary recovery — this PR is prevention.

Closes #87980
