### PR TITLE
fix(agent): stop the between-turns tool refresh from forking the cached prefix (#100336 defect b)

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -635,13 +635,18 @@ def build_turn_context(
     # Between-turns MCP refresh: an MCP server that finished connecting since
     # the previous turn (slow HTTP/OAuth servers routinely take 2-6s on a cold
     # connect, missing the bounded startup wait) lands in THIS turn's tool
-    # snapshot.  This is cache-safe by construction: it runs in the per-turn
+    # snapshot.  Timing is cache-safe by construction: it runs in the per-turn
     # prologue, before this turn's first API call assembles ``tools=``, so it
-    # only ever extends a fresh request prefix — it never mutates the cached
-    # prefix of an in-flight turn.  No-op when no MCP servers are registered
-    # (the common case, gated by the cheap ``has_registered_mcp_tools`` check)
-    # or when the tool set is unchanged (``refresh_agent_mcp_tools`` diffs by
-    # name and leaves the snapshot untouched on no-change).
+    # never mutates the prefix of an in-flight turn.  ``preserve_prefix`` makes
+    # the *content* cache-safe too (#100336): a plain rebuild re-derives the
+    # array from live availability, so a flapping ``check_fn`` silently drops a
+    # tool and a late arrival splices into sorted position — either one forks
+    # the tool block and re-prefills the whole history behind it, every turn it
+    # happens.  With the flag the live order is authoritative and the array
+    # only ever grows.  No-op when no MCP servers are registered (the common
+    # case, gated by the cheap ``has_registered_mcp_tools`` check) or when the
+    # tool set is unchanged (``refresh_agent_mcp_tools`` diffs by name and
+    # leaves the snapshot untouched on no-change).
     try:
         if not getattr(agent, "_skip_mcp_refresh", False):
             # Import-cost gate: ``tools.mcp_tool`` pulls in the whole ``mcp``
@@ -656,7 +661,9 @@ def build_turn_context(
             if "tools.mcp_tool" in _sys.modules:
                 from tools.mcp_tool import has_registered_mcp_tools, refresh_agent_mcp_tools
                 if has_registered_mcp_tools():
-                    refresh_agent_mcp_tools(agent, quiet_mode=True)
+                    refresh_agent_mcp_tools(
+                        agent, quiet_mode=True, preserve_prefix=True,
+                    )
     except Exception:
         logger.debug("between-turns MCP tool refresh skipped", exc_info=True)
 

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -224,3 +224,116 @@ def test_wait_returns_instantly_when_no_discovery_thread(monkeypatch):
     t0 = time.time()
     mcp_startup.wait_for_mcp_discovery()
     assert time.time() - t0 < 0.2  # never blocks on the bound when nothing's pending
+
+
+# ---------------------------------------------------------------------------
+# preserve_prefix: the tool array is a cached request prefix (#100336)
+# ---------------------------------------------------------------------------
+
+
+def _registered(monkeypatch, names):
+    """Make the registry report exactly *names* as still registered."""
+    from tools import registry as registry_mod
+
+    entries = [types.SimpleNamespace(name=n) for n in names]
+    monkeypatch.setattr(
+        registry_mod.registry, "get_all_entries", lambda: entries, raising=False
+    )
+
+
+def _serve(monkeypatch, defs):
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", lambda **kw: list(defs))
+
+
+def test_preserve_prefix_carries_a_flapping_tool_forward(monkeypatch):
+    """A check_fn flip must not shrink a live session's tool prefix.
+
+    ``browser_navigate``'s availability probe fails this turn (headless box,
+    expired credential, docker blip) so ``get_tool_definitions`` omits it. The
+    tool is still *registered* — only its probe flapped — so the snapshot must
+    keep it, byte-for-byte, instead of forking the cached prefix.
+    """
+    agent = _agent(["read_file", "browser_navigate", "terminal"])
+    before = list(agent.tools)
+
+    _serve(monkeypatch, [_tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["read_file", "browser_navigate", "terminal"])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+
+    assert added == set()
+    assert agent.tools == before
+    assert "browser_navigate" in agent.valid_tool_names
+
+
+def test_preserve_prefix_still_drops_a_deregistered_tool(monkeypatch):
+    """A server that genuinely went away still loses its schemas.
+
+    Carrying an unregistered name forward would advertise a tool whose handler
+    no longer exists — dispatch would answer "Unknown tool".
+    """
+    agent = _agent(["read_file", "mcp_granola_list", "terminal"])
+
+    _serve(monkeypatch, [_tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["read_file", "terminal"])
+
+    mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+
+    assert [t["function"]["name"] for t in agent.tools] == ["read_file", "terminal"]
+    assert "mcp_granola_list" not in agent.valid_tool_names
+
+
+def test_preserve_prefix_appends_late_arrivals_at_the_tail(monkeypatch):
+    """``get_definitions`` sorts by name, so a late tool can splice in at 0.
+
+    Under ``preserve_prefix`` the live order is authoritative and the new tool
+    extends the array, leaving every earlier byte where the provider cached it.
+    """
+    agent = _agent(["read_file", "terminal"])
+
+    # Sorted order would put the new tool first.
+    _serve(monkeypatch, [_tool("aaa_mcp_late"), _tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["aaa_mcp_late", "read_file", "terminal"])
+
+    added = mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+
+    assert added == {"aaa_mcp_late"}
+    assert [t["function"]["name"] for t in agent.tools] == [
+        "read_file", "terminal", "aaa_mcp_late",
+    ]
+
+
+def test_preserve_prefix_takes_the_fresh_schema_for_an_existing_slot(monkeypatch):
+    """Dynamic schema overrides still land — only the *position* is pinned.
+
+    Content changes reach the snapshot through the ``content_aware`` diff (the
+    compaction boundary); ``preserve_prefix`` must not turn that into a reorder.
+    """
+    agent = _agent(["read_file", "delegate_task"])
+
+    fresh = _tool("delegate_task")
+    fresh["function"]["description"] = "max_concurrent_children=4"
+    # Sorted order would move delegate_task ahead of read_file.
+    _serve(monkeypatch, [fresh, _tool("read_file")])
+    _registered(monkeypatch, ["read_file", "delegate_task"])
+
+    mcp_tool.refresh_agent_mcp_tools(
+        agent, preserve_prefix=True, content_aware=True,
+    )
+
+    assert [t["function"]["name"] for t in agent.tools] == ["read_file", "delegate_task"]
+    assert agent.tools[1]["function"]["description"] == "max_concurrent_children=4"
+
+
+def test_refresh_without_preserve_prefix_keeps_rebuilding(monkeypatch):
+    """Default (explicit /reload-mcp, compaction) behaviour is unchanged."""
+    agent = _agent(["read_file", "browser_navigate", "terminal"])
+
+    _serve(monkeypatch, [_tool("read_file"), _tool("terminal")])
+    _registered(monkeypatch, ["read_file", "browser_navigate", "terminal"])
+
+    mcp_tool.refresh_agent_mcp_tools(agent)
+
+    assert [t["function"]["name"] for t in agent.tools] == ["read_file", "terminal"]

--- a/tests/tools/test_refresh_agent_mcp_tools.py
+++ b/tests/tools/test_refresh_agent_mcp_tools.py
@@ -337,3 +337,43 @@ def test_refresh_without_preserve_prefix_keeps_rebuilding(monkeypatch):
     mcp_tool.refresh_agent_mcp_tools(agent)
 
     assert [t["function"]["name"] for t in agent.tools] == ["read_file", "terminal"]
+
+
+def test_preserve_prefix_holds_the_prefix_under_concurrent_flapping(monkeypatch):
+    """The merge runs under ``_agent_tools_lock`` — prove it holds up.
+
+    Six threads refresh while one tool's availability probe flips randomly.
+    The invariant is positional, not just set-based: the tools ahead of the
+    flapping one must never move, or the provider re-prefills behind them.
+    """
+    import random
+
+    base = ["a_read", "b_term", "c_web", "d_mem"]
+    flap = {"up": True}
+
+    def _serve_flapping(**_kw):
+        return [_tool(n) for n in base if n != "c_web" or flap["up"]]
+
+    import model_tools
+
+    monkeypatch.setattr(model_tools, "get_tool_definitions", _serve_flapping)
+    _registered(monkeypatch, base)
+
+    agent = _agent(base)
+    violations = []
+
+    def worker():
+        for _ in range(200):
+            flap["up"] = random.random() > 0.5
+            mcp_tool.refresh_agent_mcp_tools(agent, preserve_prefix=True)
+            names = [t["function"]["name"] for t in agent.tools]
+            if names != base:
+                violations.append(names)
+
+    threads = [threading.Thread(target=worker) for _ in range(6)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert violations == []

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -8305,6 +8305,7 @@ def refresh_agent_mcp_tools(
     disabled_override=None,
     quiet_mode: bool = True,
     content_aware: bool = False,
+    preserve_prefix: bool = False,
 ) -> set:
     """Re-derive an already-built agent's tool snapshot from the live registry.
 
@@ -8332,6 +8333,22 @@ def refresh_agent_mcp_tools(
     surface.  The new ``(tools, valid_tool_names)`` pair is published together
     under ``_agent_tools_lock`` so a concurrent reader never sees a
     cross-attribute half-swap.
+
+    ``preserve_prefix`` is for the callers that rebuild inside a live
+    conversation (the between-turns prologue).  There the tool array is a
+    cached request prefix: every provider that renders ``tools`` ahead of the
+    messages re-prefills the entire history behind any byte that moves.  A
+    plain rebuild moves two kinds of bytes — it drops a tool whose ``check_fn``
+    merely flapped (a headless browser probe, an expired credential, a docker
+    blip), and it splices a late-landing tool into sorted position, which can
+    be index 0.  With ``preserve_prefix`` the live order is authoritative:
+    existing tools keep their slot (schemas still refresh), a tool that is
+    still *registered* but momentarily unavailable is carried forward, a tool
+    that genuinely left the registry is still dropped, and new tools are
+    appended at the tail so the prefix only ever grows.  Carrying an
+    unavailable tool forward changes nothing about dispatch — ``check_fn``
+    gates exposure at snapshot time, never invocation, and every handler
+    already owns its own unavailability error.
 
     Returns the set of newly-added tool names (empty when nothing changed), so
     callers can decide whether to notify the user / re-emit session info.  The
@@ -8388,6 +8405,18 @@ def refresh_agent_mcp_tools(
     # this rebuild actually appended (matching agent_init's dedup-aware add).
     staged_engine_names = _reinject_post_build_tools(agent, new_defs, new_names)
 
+    # Snapshot registry membership OUTSIDE ``_agent_tools_lock`` — it is the
+    # only input ``preserve_prefix`` needs beyond the two tool lists, and
+    # taking ``registry._lock`` under the tools lock would be the first place
+    # in the process to nest those two.
+    registered_names: set = set()
+    if preserve_prefix:
+        try:
+            registered_names = {entry.name for entry in registry.get_all_entries()}
+        except Exception:  # noqa: BLE001
+            # Fail open to the plain rebuild rather than pinning a stale list.
+            preserve_prefix = False
+
     # Single atomic read-diff-publish so the returned ``added`` is consistent
     # with what was actually published, even under concurrent callers, and a
     # stale (older-generation) rebuild can't overwrite a newer published one.
@@ -8401,10 +8430,12 @@ def refresh_agent_mcp_tools(
         if snapshot_generation < published_gen:
             # A newer snapshot already won; our set is stale — drop it.
             return set()
-        current = {
-            t["function"]["name"]
-            for t in (getattr(agent, "tools", None) or [])
-        }
+        current_defs = list(getattr(agent, "tools", None) or [])
+        current = {t["function"]["name"] for t in current_defs}
+        if preserve_prefix:
+            new_defs, new_names = _merge_preserving_prefix(
+                current_defs, new_defs, registered_names,
+            )
         if new_names == current:
             # Same NAME set. For MCP-reload callers that is "no change" —
             # leave the live snapshot untouched (no churn). Content-aware
@@ -8440,6 +8471,40 @@ def refresh_agent_mcp_tools(
             engine_names.update(staged_engine_names)
         agent._tool_snapshot_generation = max(published_gen, snapshot_generation)
         return new_names - current
+
+
+def _merge_preserving_prefix(
+    current_defs: list, new_defs: list, registered_names: set,
+) -> tuple[list, set]:
+    """Fold a fresh tool snapshot into a live one without moving existing bytes.
+
+    The live tool array is a cached request prefix, so the merge is ordered by
+    ``current_defs``, not by the fresh list:
+
+    * a name in both keeps its slot and takes the fresh schema (dynamic
+      overrides — delegate_task limits, execute_code stubs — still land);
+    * a name only in the live list is carried forward when it is still
+      registered (its ``check_fn`` flapped) and dropped when it is not (the
+      MCP server or plugin genuinely went away);
+    * a name only in the fresh list is appended at the tail, so a late-landing
+      MCP tool extends the prefix instead of splicing into sorted position.
+    """
+    fresh = {}
+    for entry in new_defs:
+        name = (entry.get("function") or {}).get("name", "")
+        if name:
+            fresh[name] = entry
+
+    merged = []
+    for entry in current_defs:
+        name = (entry.get("function") or {}).get("name", "")
+        replacement = fresh.pop(name, None)
+        if replacement is not None:
+            merged.append(replacement)
+        elif name and name in registered_names:
+            merged.append(entry)
+    merged.extend(fresh.values())
+    return merged, {(t.get("function") or {}).get("name", "") for t in merged}
 
 
 def _reinject_post_build_tools(agent, tools_list: list, name_set: set) -> set:


### PR DESCRIPTION
## Summary

fixes https://github.com/NousResearch/hermes-agent/issues/100336

This PR takes **defect (b)** of #100336 — *"the tool listing embeds environment-dependent state"*. [#100358](https://github.com/NousResearch/hermes-agent/pull/100358) owns defect (a) (the nulled `system_prompt_hash` on a `/model` switch) and explicitly scopes (b) out; the two are complementary and touch disjoint code.

The reporter's second symptom is the one that fires **without** a model switch:

> one call's input *shrank* 4,555 tokens versus the previous call despite 950 tokens of new history being appended — the assembly itself changed shape

The shrink is real, it is reproducible, and it has a precise source: the per-turn MCP refresh republishes `agent.tools` from **live availability**, so an availability probe that flips silently removes a tool from a request prefix the provider has already cached.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Turn N+1 Prologue] --> B[refresh_agent_mcp_tools]
    B --> C[get_tool_definitions]
    C --> D{check_fn probe<br/>TTL 30s / grace 60s}
    D -->|True| E[Tool in schema list]
    D -->|False| F[Tool omitted]
    F --> G[agent.tools = new_defs<br/>SHRUNKEN ARRAY]
    E --> H[Late MCP tool<br/>sorted into index 0]
    H --> G
    G --> I[Cached prefix forked]
    I --> J[Full re-prefill<br/>~136k tokens]

    A --> K[preserve_prefix=True]
    K --> L[Live order authoritative]
    L --> M[Flapped tool carried forward]
    L --> N[Deregistered tool dropped]
    L --> O[New tool appended at tail]
    M --> P[Prefix byte-identical<br/>cache holds]
    N --> P
    O --> P
```

---

## Cause — line by line

`agent/turn_context.py:645-659` runs a tool-snapshot rebuild in **every** turn prologue whenever any MCP server is registered. Its comment states the contract it believes it has:

> `# This is cache-safe by construction: it runs in the per-turn prologue,`
> `# before this turn's first API call assembles tools=, so it`
> `# only ever extends a fresh request prefix`

The *timing* half of that is true. The *content* half is not, and nothing enforced it.

`tools/mcp_tool.py:8226-8297` — `refresh_agent_mcp_tools`:

1. `new_defs = get_tool_definitions(...)` (line 8226) recomputes the array from scratch.
2. `model_tools.get_tool_definitions` memoizes on `(scope, toolsets, registry._generation, config mtime, …)` — **`check_fn` results are not part of the key**. Any registry generation bump (an MCP server reconnecting, a plugin load, a lazy-server adoption) invalidates the memo and forces a full recompute.
3. That recompute reaches `registry.get_definitions` (`tools/registry.py:1061-1071`), which drops every tool whose `check_fn` currently returns `False`. `_check_fn_cached` has a 30 s TTL and a 60 s success-grace (`tools/registry.py:269-417`), so a probe that stays down past the grace is honoured — the exact `check_fn ... returned False` lines the reporter sees 13 of.
4. `agent.tools = new_defs` (line 8289) publishes the shrunken array **wholesale**.
5. The function returns `new_names - current` (line 8297) — **additions only**. Removals are invisible to the caller, which is why the prologue's "only ever extends" comment survived.

There is a second, independent prefix fork on the same line. `registry.get_definitions` iterates `sorted(tool_names)` (line 1061), so a genuinely new tool does not extend the array — it **splices into sorted position**, which for `aaa_*`-prefixed MCP tools is index 0. Even the *intended* additive case moved every byte of the tool block.

### Reproduction (no network, no provider)

Three registry tools, one with a flipping `check_fn`, driven through the real refresh helper:

```
turn 1 tools : ['alpha', 'bravo', 'charlie']
turn 2 tools : ['alpha', 'charlie']            added= set()
prefix forked on flip-down: True
turn 3 tools : ['alpha', 'bravo', 'charlie']   added= {'bravo'}
prefix forked on flip-up  : True
turn 4 tools : ['aaa_late', 'alpha', 'bravo', 'charlie']
late add landed at index  : 0
```

Two forks per availability flap, a third for the late arrival, and `added` reports nothing on the way down.

---

## Consequence

* **Cache.** Every provider that renders `tools` ahead of the messages (vLLM and every OpenAI-compatible chat template; Anthropic's tool block sits before the messages too) re-prefills the *entire* conversation behind the moved byte. On the reporter's ~139k-token session that is ~136k tokens per incident — the measured 99% → 2% collapse, with no model switch involved.
* **Frequency.** Unlike a `/model` switch this needs no user action. Any probe that flaps — a headless box's browser/CDP checks, a docker daemon blip, an OAuth credential whose refresh fails, `x_search`'s xAI resolver — forks the prefix, then forks it again on recovery.
* **Silent capability loss.** The model loses a tool mid-conversation with no signal to the caller or the user, because the helper only reports additions.
* **Cost.** Latency and spend, both proportional to session length, and worst exactly where prompt caching matters most.

---

## Solution

`refresh_agent_mcp_tools(..., preserve_prefix=True)` — a new keyword used by the one caller that rebuilds *inside a live conversation*, the between-turns prologue. Under it the **live array is authoritative** rather than the freshly sorted one, and `_merge_preserving_prefix` folds the new snapshot into it:

| Tool is… | Before | After |
|---|---|---|
| in both lists | rebuilt into sorted position | keeps its slot, takes the fresh schema |
| live only, **still registered** (probe flapped) | **dropped → prefix forks** | **carried forward → prefix intact** |
| live only, **deregistered** (server/plugin gone) | dropped | dropped |
| new only (late MCP connect) | spliced into sorted position | **appended at the tail** |

The distinction that makes this safe is *why* a tool vanished. A `check_fn` returning `False` means the tool is **still registered** and only its availability probe flipped; a server shutting down means the entry left the registry and its handler is gone. The merge reads registry membership — snapshotted outside `_agent_tools_lock`, so `registry._lock` is never nested under it — and keeps only the first class.

Carrying an unavailable tool forward changes nothing about dispatch: `check_fn` gates *exposure at snapshot time*, never invocation (`registry.dispatch` does not consult it), every handler already owns its own unavailability error, and `_check_fn_cached`'s 60 s success-grace already deliberately keeps flapping tools visible. This extends that same policy to the lifetime of a live session.

Explicit `/reload-mcp` (TUI, ACP, CLI, gateway) and the compaction boundary keep the plain rebuild — a user who just disabled a toolset expects it gone, and compaction resets the prefix anyway.

### Post-fix

```
turn 2 tools : ['alpha', 'bravo', 'charlie']   prefix forked on flip-down: False
turn 3 tools : ['alpha', 'bravo', 'charlie']   prefix forked on flip-up  : False
turn 4 tools : ['alpha', 'bravo', 'charlie', 'aaa_late']   late add landed at index: 3
```

---

## Files

| File | Change |
|---|---|
| `tools/mcp_tool.py` | `preserve_prefix` keyword + `_merge_preserving_prefix` helper |
| `agent/turn_context.py` | between-turns prologue passes `preserve_prefix=True`; the "only ever extends" comment now describes what the code does |
| `tests/tools/test_refresh_agent_mcp_tools.py` | 5 regression tests |

## Test plan

- [x] `python -m pytest tests/tools/test_refresh_agent_mcp_tools.py -q` — 13 passed (5 new)
- [x] `python -m pytest tests/tools/test_mcp_tool.py tests/test_compaction_tool_refresh.py -q` — 103 passed, 1 failed; the failure (`test_windows_location_vars_passed_without_secrets`, missing `ProgramFiles` in this Windows shell env) reproduces on unmodified `main` and is unrelated
- [x] `python -m pytest tests/agent/test_turn_context.py tests/agent/test_turn_context_overflow_warning.py tests/test_get_tool_definitions_cache_isolation.py -q` — 34 passed
- [ ] Long gateway session with MCP servers on a box where a browser/CDP probe fails: the tool block stays byte-identical across turns, and a slow MCP server's tools appear at the end of the array

Refs #100336. Complements #100358 (defect a) — no overlapping files.
