### PR TITLE
fix(irc): scope server/port/nickname/channel/use_tls reads to the active profile under multiplexing

### DIFF
--- a/plugins/platforms/irc/adapter.py
+++ b/plugins/platforms/irc/adapter.py
@@ -130,16 +130,17 @@ class IRCAdapter(BasePlatformAdapter):
         extra = getattr(config, "extra", {}) or {}
 
         # Connection settings (env vars override config.yaml)
-        self.server = os.getenv("IRC_SERVER") or extra.get("server", "")
+        self.server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
         try:
-            self.port = int(os.getenv("IRC_PORT") or extra.get("port", 6697))
+            self.port = int(_get_scoped_secret("IRC_PORT") or extra.get("port", 6697))
         except (ValueError, TypeError):
             self.port = 6697
-        self.nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
-        self.channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+        self.nickname = _get_scoped_secret("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
+        self.channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
+        _use_tls_raw = _get_scoped_secret("IRC_USE_TLS")
         self.use_tls = (
-            os.getenv("IRC_USE_TLS", "").lower() in {"1", "true", "yes"}
-            if os.getenv("IRC_USE_TLS")
+            _use_tls_raw.lower() in {"1", "true", "yes"}
+            if _use_tls_raw
             else extra.get("use_tls", True)
         )
         self.server_password = _get_scoped_secret("IRC_SERVER_PASSWORD") or extra.get("server_password", "")
@@ -545,8 +546,8 @@ def check_requirements() -> bool:
 
     Only requires the server and channel — no external pip packages needed.
     """
-    server = os.getenv("IRC_SERVER", "")
-    channel = os.getenv("IRC_CHANNEL", "")
+    server = _get_scoped_secret("IRC_SERVER", "")
+    channel = _get_scoped_secret("IRC_CHANNEL", "")
     # Also accept config.yaml-only configuration (no env vars).
     # The gateway passes PlatformConfig; we just check env for the
     # hermes setup / requirements check path.
@@ -556,8 +557,8 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     return bool(server and channel)
 
 
@@ -671,8 +672,8 @@ def interactive_setup() -> None:
 def is_connected(config) -> bool:
     """Check whether IRC is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     return bool(server and channel)
 
 
@@ -689,24 +690,24 @@ def _env_enablement() -> dict | None:
     the core hook — it becomes a proper ``HomeChannel`` dataclass on the
     ``PlatformConfig`` rather than being merged into ``extra``.
     """
-    server = os.getenv("IRC_SERVER", "").strip()
-    channel = os.getenv("IRC_CHANNEL", "").strip()
+    server = _get_scoped_secret("IRC_SERVER", "").strip()
+    channel = _get_scoped_secret("IRC_CHANNEL", "").strip()
     if not (server and channel):
         return None
     seed: dict = {
         "server": server,
         "channel": channel,
     }
-    port = os.getenv("IRC_PORT", "").strip()
+    port = _get_scoped_secret("IRC_PORT", "").strip()
     if port:
         try:
             seed["port"] = int(port)
         except ValueError:
             pass
-    nickname = os.getenv("IRC_NICKNAME", "").strip()
+    nickname = _get_scoped_secret("IRC_NICKNAME", "").strip()
     if nickname:
         seed["nickname"] = nickname
-    use_tls = os.getenv("IRC_USE_TLS", "").strip().lower()
+    use_tls = _get_scoped_secret("IRC_USE_TLS", "").strip().lower()
     if use_tls:
         seed["use_tls"] = use_tls in {"1", "true", "yes"}
     # Passwords live in PlatformConfig.extra as well for back-compat with
@@ -718,11 +719,11 @@ def _env_enablement() -> dict | None:
     # Optional home-channel (usually the same as IRC_CHANNEL, but can be a
     # dedicated reports channel).  Defaults to IRC_CHANNEL so cron jobs
     # with ``deliver=irc`` have a sensible target without extra config.
-    home = os.getenv("IRC_HOME_CHANNEL") or channel
+    home = _get_scoped_secret("IRC_HOME_CHANNEL") or channel
     if home:
         seed["home_channel"] = {
             "chat_id": home,
-            "name": os.getenv("IRC_HOME_CHANNEL_NAME", home),
+            "name": _get_scoped_secret("IRC_HOME_CHANNEL_NAME", home),
         }
     return seed
 
@@ -770,19 +771,19 @@ async def _standalone_send(
     primitive.
     """
     extra = getattr(pconfig, "extra", {}) or {}
-    server = os.getenv("IRC_SERVER") or extra.get("server", "")
-    channel = os.getenv("IRC_CHANNEL") or extra.get("channel", "")
+    server = _get_scoped_secret("IRC_SERVER") or extra.get("server", "")
+    channel = _get_scoped_secret("IRC_CHANNEL") or extra.get("channel", "")
     if not server or not channel:
         return {"error": "IRC standalone send: IRC_SERVER and IRC_CHANNEL must be configured"}
 
-    port_value = os.getenv("IRC_PORT") or extra.get("port", 6697)
+    port_value = _get_scoped_secret("IRC_PORT") or extra.get("port", 6697)
     try:
         port = int(port_value)
     except (TypeError, ValueError):
         return {"error": f"IRC standalone send: invalid port {port_value!r}"}
 
-    nickname = os.getenv("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
-    use_tls_env = os.getenv("IRC_USE_TLS")
+    nickname = _get_scoped_secret("IRC_NICKNAME") or extra.get("nickname", "hermes-bot")
+    use_tls_env = _get_scoped_secret("IRC_USE_TLS")
     if use_tls_env is not None:
         use_tls = use_tls_env.lower() in {"1", "true", "yes"}
     else:

--- a/tests/gateway/test_irc_adapter.py
+++ b/tests/gateway/test_irc_adapter.py
@@ -18,6 +18,8 @@ check_requirements = _irc_mod.check_requirements
 validate_config = _irc_mod.validate_config
 register = _irc_mod.register
 _standalone_send = _irc_mod._standalone_send
+is_connected = _irc_mod.is_connected
+_env_enablement = _irc_mod._env_enablement
 
 
 class TestIRCProtocolHelpers:
@@ -404,5 +406,144 @@ class TestIRCStandaloneSend:
 
         assert "error" in result
         assert "registration" in result["error"].lower() or "timeout" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s server/port/nickname/channel/use_tls, check_requirements/
+# validate_config/is_connected's server/channel, and _env_enablement's
+# server/channel/port/nickname/use_tls/home_channel, all previously read raw
+# os.getenv unconditionally (only IRC_SERVER_PASSWORD/IRC_NICKSERV_PASSWORD
+# were already scoped). Under multiplex, os.environ holds the DEFAULT
+# profile's YAML-to-env bridge output -- a secondary profile with its own
+# (different or absent) IRC config would silently connect to the default
+# profile's server/channel, or (for _env_enablement) get auto-enabled using
+# the default's channel as its cron home_channel -- a real message-
+# misdelivery risk, not just cosmetic. Mirrors the LINE/Buzz/SimpleX fix for
+# #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("IRC_SERVER", "default.example.net")
+    monkeypatch.setenv("IRC_CHANNEL", "#default")
+    monkeypatch.setenv("IRC_PORT", "6667")
+    monkeypatch.setenv("IRC_NICKNAME", "default-bot")
+    monkeypatch.setenv("IRC_USE_TLS", "false")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        """The secondary profile's own config.yaml extra is authoritative,
+        not the default profile's bridged server/channel/port/nick/tls."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "server": "profile.example.net",
+                "channel": "#profile",
+                "port": 6697,
+                "nickname": "profile-bot",
+                "use_tls": True,
+            },
+        )
+        adapter = IRCAdapter(cfg)
+        assert adapter.server == "profile.example.net"
+        assert adapter.channel == "#profile"
+        assert adapter.port == 6697
+        assert adapter.nickname == "profile-bot"
+        assert adapter.use_tls is True
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's own scope must NOT borrow the
+        default profile's bridged env values -- that would silently connect
+        the secondary profile's bot to the wrong IRC server/channel."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = IRCAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.server == ""
+        assert adapter.channel == ""
+        assert adapter.port == 6697  # falls through to the hardcoded default
+        assert adapter.nickname == "hermes-bot"
+        assert adapter.use_tls is True  # extra.get("use_tls", True) default
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = IRCAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter.server == "default.example.net"
+        assert adapter.channel == "#default"
+        assert adapter.port == 6667
+        assert adapter.nickname == "default-bot"
+        assert adapter.use_tls is False
+
+    def test_env_enablement_scoped_reads_own_channel_not_default(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A secondary profile's own .env (via the scope) seeds its own
+        server/channel; the default profile's bridged values must not leak
+        in."""
+        multiplex_scope({"IRC_SERVER": "profile.example.net", "IRC_CHANNEL": "#profile"})
+        seeded = _env_enablement()
+        assert seeded["server"] == "profile.example.net"
+        assert seeded["channel"] == "#profile"
+        assert seeded["home_channel"]["chat_id"] == "#profile"
+
+    def test_env_enablement_scoped_without_own_config_returns_none(
+        self, multiplex_scope, default_profile_env
+    ):
+        """A scope with no IRC_SERVER/IRC_CHANNEL of its own must not
+        auto-enable IRC using the default profile's server/channel."""
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        assert _env_enablement() is None
+
+    def test_check_requirements_and_is_connected_scoped_miss_ignore_default(
+        self, multiplex_scope, default_profile_env
+    ):
+        from gateway.config import PlatformConfig
+
+        multiplex_scope({"SOMETHING_ELSE": "x"})
+        assert check_requirements() is False
+        assert is_connected(PlatformConfig(enabled=True, extra={})) is False
 
 


### PR DESCRIPTION
## Summary

- `IRCAdapter.__init__`, `check_requirements`, `validate_config`, `is_connected`, `_env_enablement`, and `_standalone_send` all read `IRC_SERVER`/`IRC_PORT`/`IRC_NICKNAME`/`IRC_CHANNEL`/`IRC_USE_TLS` via raw `os.getenv()` — only `IRC_SERVER_PASSWORD`/`IRC_NICKSERV_PASSWORD` were already routed through the module's `_get_scoped_secret()` helper.
- Under `gateway.multiplex_profiles`, `env_enablement_fn`/`check_fn`/`is_connected` all run inside the same registry-enablement loop in `load_gateway_config()` (`gateway/config.py`, ~lines 2704-2820) which runs inside `_profile_runtime_scope` for secondary profiles, and adapter construction runs scoped the same way — so `os.environ` there still holds the DEFAULT profile's env-bridge output.
- **Notably a stronger variant than the sibling fixes in this series**: `__init__`'s original `os.getenv("IRC_SERVER") or extra.get(...)` ordering let a raw env read override even an *explicitly configured* `config.yaml` extra. A secondary profile that set its own `server`/`channel` via `extra` would still silently connect to the default profile's IRC server/channel/nick, because the default profile's config is always bridged to `os.environ` under multiplex and env was checked *first*. (The LINE/DingTalk/Teams/SMS/WeCom/ntfy fixes in this series didn't have this extra layer of severity — those used `extra.get(...) or os.getenv(...)`, so `extra` already won.)

## Fix

Switch every raw `IRC_*` read (except the two secret-material fields already scoped) to the module's existing `_get_scoped_secret()` helper — same fallback semantics as the rest of the series (scoped miss returns the default, never cross-profile-borrows `os.environ`; the DEFAULT profile's own unscoped construction still falls back to `os.environ`). Also collapses a double `os.getenv("IRC_USE_TLS")` call in `__init__` into a single `_get_scoped_secret()` lookup (identical behavior, one scope read instead of two).

## Tests

Added `TestMultiplexProfileScope` (6 tests) to `tests/gateway/test_irc_adapter.py`, mirroring the fixture/assertion style already established in `tests/gateway/test_line_plugin.py`'s class of the same name.

Mutation-verified: stashed the production fix and confirmed 5 of 6 new tests fail against pre-fix code — including the "extra wins" test, since IRC's original env-first ordering meant even an explicit `extra` config wasn't a safe boundary before the fix. The 1 passing test (`test_default_profile_unscoped_keeps_env_precedence`) is a non-differentiating regression guard that correctly passes either way. Restored the fix; all 23 tests in the file pass, plus the file's 5 parametrized `_get_scoped_secret` tests in `tests/gateway/test_adapter_startup_secret_scope.py`.

## Competitor check

Searched `IRC_SERVER`, `irc multiplex`, `irc scope`. Three open PRs touch `plugins/platforms/irc/adapter.py`:
- **#74978** ("scoped-lock guard dead code... tuple truthiness") — touches `connect()`'s lock-acquisition logic only, no overlap with the env-read lines here.
- **#35643** ("close 7 long-running-adapter gaps") — adds new fields/properties immediately after `__init__`'s existing body ends, no overlap with the env-read lines this PR changes.
- **#46130** ("IRCv3 capability negotiation...") — a large, visibly stale feature PR (its diff still shows the pre-#76664 unscoped `IRC_SERVER_PASSWORD`/`IRC_NICKSERV_PASSWORD` reads as unchanged context, so it needs a rebase against `main` regardless of this PR). It touches the *same 3-line* `use_tls` expression in both `__init__` and `_standalone_send`, but only the `extra.get("use_tls", True)` → `_coerce_bool(extra.get("use_tls"), True)` half — a different sub-concern (YAML string coercion) from the `os.getenv(...)` → `_get_scoped_secret(...)` half this PR changes. Pure textual adjacency, trivially reconcilable on rebase; flagging transparently rather than dropping the `use_tls` scoping from scope.

No open or merged PR touches the actual scope-leak fixed here.

## Checklist

- [x] Read current adapter code directly (not from a stale scan summary)
- [x] Minimal, precedent-matching fix (reuses existing `_get_scoped_secret` helper)
- [x] New regression tests, mutation-verified against the pre-fix code
- [x] Full existing IRC test suite passes
- [x] Fresh competitor PR search immediately before opening this PR