### PR TITLE
fix(cron): make Desktop a fallback scheduler owner

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7846,6 +7846,43 @@ def _maybe_run_worktree_maintenance() -> None:
     ).start()
 
 
+def desktop_scheduler_may_dispatch() -> bool:
+    """Return whether this profile's Desktop ticker may own a cron tick.
+
+    Desktop is a fallback scheduler, not a peer scheduler. A live gateway for
+    the same profile is authoritative. Service-owned profiles can also set
+    ``cron.desktop_fallback: false`` to make Desktop management-only even while
+    the gateway is temporarily unavailable.
+
+    The gateway-lock probe deliberately uses the context-scoped Hermes home so
+    multiplex Desktop tickers compare each profile with its own gateway lock.
+    Probe failures fail open only for the default Desktop-only behavior; an
+    explicit ``desktop_fallback: false`` remains fail-closed.
+    """
+    try:
+        cfg = load_config() or {}
+        cron_cfg = cfg.get("cron") if isinstance(cfg, dict) else None
+        if isinstance(cron_cfg, dict) and cron_cfg.get("desktop_fallback", True) is False:
+            logger.debug("Desktop cron dispatch disabled for this profile")
+            return False
+    except Exception as exc:
+        logger.debug("Could not read Desktop cron fallback policy: %s", exc)
+
+    try:
+        from gateway.status import is_gateway_runtime_lock_active
+
+        lock_path = get_hermes_home() / "gateway.lock"
+        if is_gateway_runtime_lock_active(lock_path):
+            logger.debug("Desktop cron deferred to the live gateway owner")
+            return False
+    except Exception as exc:
+        logger.debug(
+            "Could not inspect gateway cron ownership; preserving Desktop fallback: %s",
+            exc,
+        )
+    return True
+
+
 def tick(
     verbose: bool = True,
     adapters=None,
@@ -7853,6 +7890,7 @@ def tick(
     sync: bool = True,
     *,
     can_dispatch=None,
+    desktop_owner_guard: bool = False,
 ):
     """
     Check and run all due jobs.
@@ -7866,6 +7904,9 @@ def tick(
         loop: Optional asyncio event loop (from gateway) for live adapter sends
         can_dispatch: Optional synchronous gate; false leaves due jobs untouched
             for the next allowed tick
+        desktop_owner_guard: Apply Desktop fallback and gateway-ownership policy
+            before touching due jobs. Gateway and manual tick callers leave
+            this false.
 
     Returns:
         Number of jobs executed (0 if another tick is already running)
@@ -7933,6 +7974,9 @@ def tick(
         raise
 
     try:
+        if desktop_owner_guard and not desktop_scheduler_may_dispatch():
+            return 0
+
         # Global emergency stop (`hermes pause`): skip dispatch entirely while
         # the ESTOP sentinel exists. Never touches in-flight runs — due jobs
         # simply wait for the next tick after `hermes resume`. Logged once per

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -560,6 +560,7 @@ class InProcessCronScheduler(CronScheduler):
         profile_homes=None,
         profile_adapters=None,
         default_profile=None,
+        desktop_owner_guard=False,
     ):
         import logging
         from cron.scheduler import CronTickYielded
@@ -590,19 +591,27 @@ class InProcessCronScheduler(CronScheduler):
                 can_dispatch=can_dispatch,
                 profile_adapters=profile_adapters,
                 default_profile=default_profile,
+                desktop_owner_guard=desktop_owner_guard,
             )
             return
 
         # ── Single-profile (legacy) path ──────────────────────────────────
-        recovered = self.recover_interrupted()
-        if recovered:
-            logger.warning(
-                "Marked %d interrupted cron execution(s) unknown after restart",
-                recovered,
-            )
-        # Heartbeat once before the first sleep so `hermes cron status` sees a
-        # live ticker immediately after startup, not only after the first tick.
-        record_ticker_heartbeat()
+        def _may_dispatch() -> bool:
+            if not desktop_owner_guard:
+                return True
+            from cron.scheduler import desktop_scheduler_may_dispatch
+
+            return desktop_scheduler_may_dispatch()
+
+        if _may_dispatch():
+            recovered = self.recover_interrupted()
+            if recovered:
+                logger.warning(
+                    "Marked %d interrupted cron execution(s) unknown after restart",
+                    recovered,
+                )
+            # A deferred Desktop ticker must not impersonate gateway liveness.
+            record_ticker_heartbeat()
         # Exponential backoff for consecutive tick failures — most importantly
         # fd exhaustion (EMFILE/ENFILE, #87644).  While FDs stay exhausted the
         # ticker must NOT hammer the store every 60s; once they free (leak
@@ -610,6 +619,9 @@ class InProcessCronScheduler(CronScheduler):
         # resets, so the scheduler self-heals without a gateway restart.
         consecutive_failures = 0
         while not stop_event.is_set():
+            if not _may_dispatch():
+                stop_event.wait(interval)
+                continue
             ok = False
             try:
                 if can_dispatch is not None and not can_dispatch():
@@ -621,6 +633,7 @@ class InProcessCronScheduler(CronScheduler):
                         loop=loop,
                         sync=False,
                         can_dispatch=can_dispatch,
+                        desktop_owner_guard=desktop_owner_guard,
                     )
                 ok = True
             except BaseException as e:
@@ -670,6 +683,7 @@ class InProcessCronScheduler(CronScheduler):
         can_dispatch=None,
         profile_adapters=None,
         default_profile=None,
+        desktop_owner_guard=False,
     ):
         """Tick every served profile's cron store when multiplex_profiles is on.
 
@@ -697,15 +711,22 @@ class InProcessCronScheduler(CronScheduler):
             [p[0] if isinstance(p, tuple) else p for p in profile_homes],
         )
 
-        # Recovery + initial heartbeat for every profile.
-        # A profile may have been deleted since this snapshot was taken;
-        # never recreate a deleted home's cron workspace via the heartbeat
-        # below (#47368).
+        def _may_dispatch() -> bool:
+            if not desktop_owner_guard:
+                return True
+            from cron.scheduler import desktop_scheduler_may_dispatch
+
+            return desktop_scheduler_may_dispatch()
+
+        # Recover and heartbeat only live profiles Desktop may own. A deleted
+        # profile must never be recreated from a stale startup snapshot.
         for entry in _existing_profile_homes(profile_homes):
             home = entry[1] if isinstance(entry, tuple) else entry
             home_token = set_hermes_home_override(str(home))
             try:
                 with use_cron_store(home):
+                    if not _may_dispatch():
+                        continue
                     recovered = self.recover_interrupted()
                     if recovered:
                         logger.warning(
@@ -722,9 +743,15 @@ class InProcessCronScheduler(CronScheduler):
             ok = False
             _tick_error = None
             _profile_errors: dict[str, str] = {}
+            attempted_homes = []
             try:
                 if can_dispatch is not None and not can_dispatch():
                     logger.debug("Cron dispatch paused while gateway drains existing work")
+                    if not desktop_owner_guard:
+                        attempted_homes.extend(
+                            entry[1] if isinstance(entry, tuple) else entry
+                            for entry in _existing_profile_homes(profile_homes)
+                        )
                 else:
                     for entry in _existing_profile_homes(profile_homes):
                         _pname = entry[0] if isinstance(entry, tuple) else None
@@ -732,6 +759,9 @@ class InProcessCronScheduler(CronScheduler):
                         home_token = set_hermes_home_override(str(home))
                         try:
                             with use_cron_store(home):
+                                if not _may_dispatch():
+                                    continue
+                                attempted_homes.append(home)
                                 # Deliver each profile's cron via ITS OWN adapters.
                                 # The shared `adapters` set belongs to the default
                                 # profile only. A secondary profile uses its own map
@@ -751,6 +781,7 @@ class InProcessCronScheduler(CronScheduler):
                                     loop=loop,
                                     sync=False,
                                     can_dispatch=can_dispatch,
+                                    desktop_owner_guard=desktop_owner_guard,
                                 )
                         except CronTickYielded as e:
                             # This profile is served stale and a fresh
@@ -776,6 +807,8 @@ class InProcessCronScheduler(CronScheduler):
             # no profile completed and all beats are unsuccessful (#32612).
             for entry in _existing_profile_homes(profile_homes):
                 home = entry[1] if isinstance(entry, tuple) else entry
+                if home not in attempted_homes:
+                    continue
                 home_token = set_hermes_home_override(str(home))
                 try:
                     with use_cron_store(home):

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2745,6 +2745,12 @@ DEFAULT_CONFIG = {
     },
 
     "cron": {
+        # Desktop normally provides a fallback scheduler for installs that do
+        # not run a gateway. Set this false for service-owned profiles whose
+        # cron jobs must run only inside the canonical gateway process. The
+        # desktop remains a management surface but never dispatches that
+        # profile's cron store.
+        "desktop_fallback": True,
         # Allow cron-spawned agents to use the cronjob toolset (create/edit/
         # remove scheduled jobs from within a cron run — the "cron-librarian"
         # pattern). Off by default: the cronjob toolset is policy-denied in

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -286,10 +286,11 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
     providers keep the single-store behavior — their registries are not
     profile-scoped (see _notify_cron_provider_for_profile).
 
-    Cross-process safe: the built-in provider's ``cron.scheduler.tick`` takes
-    the per-store ``cron/.tick.lock`` file lock, so this never double-fires
-    alongside a real gateway or a live pool backend on the same profile home —
-    whichever process grabs the lock first wins the tick.
+    The Desktop ticker is a fallback owner. The built-in provider defers each
+    profile to a live gateway and honors ``cron.desktop_fallback: false`` for
+    service-owned profiles that must fail closed instead of executing from a
+    reduced Desktop environment. The per-store tick lock remains the final
+    at-most-once fence during owner handoff.
     """
     from cron.scheduler_provider import InProcessCronScheduler, resolve_cron_scheduler
 
@@ -297,6 +298,7 @@ def _start_desktop_cron_ticker(stop_event: "threading.Event", interval: int = 60
 
     start_kwargs: dict = {"interval": interval}
     if isinstance(provider, InProcessCronScheduler):
+        start_kwargs["desktop_owner_guard"] = True
         try:
             from hermes_cli.profiles import profiles_to_serve
 

--- a/tests/cron/test_scheduler_ownership.py
+++ b/tests/cron/test_scheduler_ownership.py
@@ -1,0 +1,119 @@
+"""Behavioral coverage for Desktop versus gateway cron ownership."""
+
+from pathlib import Path
+
+
+def test_service_owned_profile_disables_desktop_even_if_lock_probe_breaks(monkeypatch):
+    import cron.scheduler as scheduler
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(
+        scheduler,
+        "load_config",
+        lambda: {"cron": {"desktop_fallback": False}},
+    )
+
+    def _unexpected_probe(_path):
+        raise AssertionError("explicit fail-closed policy must short-circuit the probe")
+
+    monkeypatch.setattr(gateway_status, "is_gateway_runtime_lock_active", _unexpected_probe)
+
+    assert scheduler.desktop_scheduler_may_dispatch() is False
+
+
+def test_desktop_defers_to_same_profile_gateway_lock(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+    import gateway.status as gateway_status
+
+    seen = []
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {}})
+    monkeypatch.setattr(scheduler, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        gateway_status,
+        "is_gateway_runtime_lock_active",
+        lambda path: seen.append(path) or True,
+    )
+
+    assert scheduler.desktop_scheduler_may_dispatch() is False
+    assert seen == [tmp_path / "gateway.lock"]
+
+
+def test_desktop_fallback_runs_without_gateway(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {}})
+    monkeypatch.setattr(scheduler, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        gateway_status,
+        "is_gateway_runtime_lock_active",
+        lambda _path: False,
+    )
+
+    assert scheduler.desktop_scheduler_may_dispatch() is True
+
+
+def test_desktop_probe_failure_preserves_default_fallback(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+    import gateway.status as gateway_status
+
+    monkeypatch.setattr(scheduler, "load_config", lambda: {"cron": {}})
+    monkeypatch.setattr(scheduler, "get_hermes_home", lambda: tmp_path)
+
+    def _broken_probe(_path):
+        raise PermissionError("cannot inspect lock")
+
+    monkeypatch.setattr(gateway_status, "is_gateway_runtime_lock_active", _broken_probe)
+
+    assert scheduler.desktop_scheduler_may_dispatch() is True
+
+
+def test_tick_guard_leaves_due_jobs_untouched(monkeypatch, tmp_path):
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(
+        scheduler,
+        "_get_lock_paths",
+        lambda: (tmp_path / "cron", tmp_path / "cron" / ".tick.lock"),
+    )
+    monkeypatch.setattr(scheduler, "desktop_scheduler_may_dispatch", lambda: False)
+
+    def _unexpected_due_read():
+        raise AssertionError("deferred Desktop tick must not inspect due jobs")
+
+    monkeypatch.setattr(scheduler, "get_due_jobs", _unexpected_due_read)
+
+    assert scheduler.tick(verbose=False, desktop_owner_guard=True) == 0
+
+
+class _OneWaitStop:
+    def __init__(self):
+        self.waits = 0
+
+    def is_set(self):
+        return self.waits > 0
+
+    def wait(self, _interval):
+        self.waits += 1
+        return True
+
+
+def test_guarded_provider_does_not_recover_heartbeat_or_tick(monkeypatch):
+    import cron.jobs as jobs
+    import cron.scheduler as scheduler
+    from cron.scheduler_provider import InProcessCronScheduler
+
+    provider = InProcessCronScheduler()
+    stop = _OneWaitStop()
+    monkeypatch.setattr(scheduler, "desktop_scheduler_may_dispatch", lambda: False)
+
+    def _unexpected(*_args, **_kwargs):
+        raise AssertionError("deferred Desktop provider touched scheduler state")
+
+    monkeypatch.setattr(provider, "recover_interrupted", _unexpected)
+    monkeypatch.setattr(jobs, "record_ticker_heartbeat", _unexpected)
+    monkeypatch.setattr(scheduler, "tick", _unexpected)
+
+    provider.start(stop, interval=1, desktop_owner_guard=True)
+
+    assert stop.waits == 1

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -200,6 +200,13 @@ def test_default_config_cron_provider_is_empty():
     assert DEFAULT_CONFIG["cron"]["provider"] == ""
 
 
+def test_default_config_preserves_desktop_only_cron_fallback():
+    """Existing Desktop-only installs keep their scheduler by default."""
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    assert DEFAULT_CONFIG["cron"]["desktop_fallback"] is True
+
+
 def test_discover_cron_schedulers_returns_list():
     """Discovery returns bundled non-default providers.
 
@@ -638,7 +645,6 @@ def test_multiplex_ticker_ticks_each_profile_once(tmp_path, monkeypatch):
     # With 2 profiles and multiple iterations, we should have seen at least 2 calls.
     assert len(tick_count) >= len(profile_homes), \
         f"Expected >= {len(profile_homes)} tick calls, got {len(tick_count)}"
-
 
 def test_multiplex_ticker_skips_deleted_profile_from_startup_snapshot(tmp_path):
     """A stale profile_homes entry must not recreate a deleted profile."""

--- a/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
+++ b/tests/hermes_cli/test_desktop_cron_ticker_profiles.py
@@ -67,6 +67,7 @@ def test_multi_profile_homes_passed_to_builtin(monkeypatch, _providers, tmp_path
 
     assert builtin.start_kwargs is not None
     assert builtin.start_kwargs["interval"] == 7
+    assert builtin.start_kwargs["desktop_owner_guard"] is True
     assert builtin.start_kwargs["profile_homes"] == homes
 
 
@@ -82,7 +83,7 @@ def test_single_profile_keeps_legacy_path(monkeypatch, _providers, tmp_path):
 
     ws._start_desktop_cron_ticker(threading.Event(), interval=9)
 
-    assert builtin.start_kwargs == {"interval": 9}
+    assert builtin.start_kwargs == {"interval": 9, "desktop_owner_guard": True}
 
 
 def test_enumeration_failure_fails_open(monkeypatch, _providers):
@@ -97,7 +98,7 @@ def test_enumeration_failure_fails_open(monkeypatch, _providers):
 
     ws._start_desktop_cron_ticker(threading.Event(), interval=11)
 
-    assert builtin.start_kwargs == {"interval": 11}
+    assert builtin.start_kwargs == {"interval": 11, "desktop_owner_guard": True}
 
 
 def test_external_provider_never_gets_profile_homes(monkeypatch, tmp_path):


### PR DESCRIPTION
## What changed

- make the built-in Desktop cron ticker defer to a live same-profile gateway
- add `cron.desktop_fallback` (default `true`) so service-owned profiles can make Desktop management-only
- stop deferred Desktop tickers from writing recovery or heartbeat state into the gateway-owned cron store
- preserve Desktop-only behavior when no gateway is running and fail open on lock-probe errors unless fallback was explicitly disabled

## Why

The existing `.tick.lock` guarantees at-most-once dispatch but not correct process provenance. A Desktop SSH backend and a canonical gateway sharing a profile can race; whichever process wins executes the job with its own interpreter, environment, and adapters. This makes scheduled jobs intermittently run from a reduced Desktop environment.

## Verification

`scripts/run_tests.sh tests/cron/test_scheduler_ownership.py tests/cron/test_scheduler_provider.py tests/hermes_cli/test_desktop_cron_ticker_profiles.py tests/cron/test_scheduler.py -q`

150 tests passed.