### PR TITLE
fix(update): post-update state.db guard covers every profile (salvage #99954)

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2100,6 +2100,11 @@ def _verify_and_restore_one_state_db(home: Path, *, label: str) -> None:
             return
         ok = verify_sqlite_integrity(state_path, check_header=True, run_pragma=True)
         if ok.get("valid"):
+            logger.debug(
+                "Post-update state.db integrity OK (%s): %s",
+                label,
+                ok.get("message"),
+            )
             return
         print()
         print(
@@ -2151,11 +2156,12 @@ def _verify_and_restore_state_dbs_post_update() -> None:
     the update was never detected and never auto-restored, leaving that
     profile's sessions silently gone while the root DB passed.
     """
-    _verify_and_restore_one_state_db(get_hermes_home(), label="default home")
+    home = get_hermes_home()
+    _verify_and_restore_one_state_db(home, label="default home")
     try:
         from hermes_cli.backup import _sibling_profile_homes
 
-        for name, profile_home in _sibling_profile_homes(get_hermes_home()):
+        for name, profile_home in _sibling_profile_homes(home):
             _verify_and_restore_one_state_db(profile_home, label=f"profile {name}")
     except Exception as exc:
         logger.debug("Sibling-profile state.db guard sweep failed: %s", exc)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2083,6 +2083,84 @@ def _restore_state_db_from_snapshot(state_path: Path, snap_state: Path) -> bool:
     return bool(restored.get("valid"))
 
 
+def _verify_and_restore_one_state_db(home: Path, *, label: str) -> None:
+    """Post-update integrity check + auto-restore for ONE home's state.db.
+
+    Shared by the root-DB and sibling-profile guards (ZIP update path and
+    git-pull path both route here). A corrupt live DB is restored from the
+    most recent valid snapshot under that home's own state-snapshots dir.
+    Never raises: a guard that crashes the update tail would be worse than
+    the corruption it detects.
+    """
+    try:
+        from hermes_cli.backup import _quick_snapshot_root, verify_sqlite_integrity
+
+        state_path = home / "state.db"
+        if not state_path.exists():
+            return
+        ok = verify_sqlite_integrity(state_path, check_header=True, run_pragma=True)
+        if ok.get("valid"):
+            return
+        print()
+        print(
+            f"⚠ state.db is corrupted after update ({label}): "
+            + ok.get("message", "unknown error")
+        )
+        snap_root = _quick_snapshot_root(home)
+        if not snap_root.exists():
+            print("  ⚠ No pre-update snapshot for this home")
+            return
+        for snap_dir in sorted(
+            (d for d in snap_root.iterdir() if d.is_dir()), reverse=True
+        ):
+            snap_state = snap_dir / "state.db"
+            if not snap_state.exists():
+                continue
+            snap_ok = verify_sqlite_integrity(
+                snap_state, check_header=True, run_pragma=True
+            )
+            if not snap_ok.get("valid"):
+                continue
+            try:
+                if _restore_state_db_from_snapshot(state_path, snap_state):
+                    print(
+                        f"  ✓ Auto-restored from snapshot {snap_dir.name} ({label})"
+                    )
+                else:
+                    print(
+                        "  ✗ Auto-restore FAILED — restored copy also failed "
+                        "integrity"
+                    )
+            except OSError as exc:
+                print(f"  ✗ Auto-restore file copy failed: {exc}")
+            return
+        print("  ⚠ No valid pre-update snapshot found for this home")
+    except Exception as exc:
+        logger.debug(
+            "Post-update state.db guard (%s) failed: %s", label, exc
+        )
+
+
+def _verify_and_restore_state_dbs_post_update() -> None:
+    """Post-update integrity guard for the ROOT state.db AND every sibling
+    profile's state.db (#97994).
+
+    The pre-update snapshot already covers every sibling profile
+    (#66140 create_pre_update_snapshots_all_profiles), but the post-update
+    guard only ever verified the root DB — a profile database corrupted by
+    the update was never detected and never auto-restored, leaving that
+    profile's sessions silently gone while the root DB passed.
+    """
+    _verify_and_restore_one_state_db(get_hermes_home(), label="default home")
+    try:
+        from hermes_cli.backup import _sibling_profile_homes
+
+        for name, profile_home in _sibling_profile_homes(get_hermes_home()):
+            _verify_and_restore_one_state_db(profile_home, label=f"profile {name}")
+    except Exception as exc:
+        logger.debug("Sibling-profile state.db guard sweep failed: %s", exc)
+
+
 def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> bool:
     """Update Hermes Agent by downloading a ZIP archive.
 
@@ -2433,55 +2511,12 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
     except Exception as e:
         logger.debug("Model catalog seed during zip update failed: %s", e)
 
-    # ── Post-update state.db integrity guard (#68474) ─────────────────
-    # Same as the git-pull path: verify state.db survived the ZIP update
-    # and auto-restore from the most recent pre-update snapshot if needed.
+    # ── Post-update state.db integrity guard (#68474, #97994) ────────────
+    # Verify state.db survived the ZIP update in the root home AND every
+    # sibling profile, auto-restoring each from its own most recent valid
+    # pre-update snapshot when needed.
     try:
-        from hermes_cli.backup import _quick_snapshot_root, verify_sqlite_integrity
-
-        _state_path = get_hermes_home() / "state.db"
-        if _state_path.exists():
-            _state_ok = verify_sqlite_integrity(
-                _state_path, check_header=True, run_pragma=True
-            )
-            if not _state_ok.get("valid"):
-                print()
-                print(
-                    "⚠ state.db is corrupted after update: "
-                    + _state_ok.get("message", "unknown error")
-                )
-                _snap_root = _quick_snapshot_root(get_hermes_home())
-                if _snap_root.exists():
-                    _snap_dirs = sorted(
-                        (d for d in _snap_root.iterdir() if d.is_dir()),
-                        reverse=True,
-                    )
-                    for _snap_dir in _snap_dirs:
-                        _snap_state = _snap_dir / "state.db"
-                        if _snap_state.exists():
-                            _snap_ok = verify_sqlite_integrity(
-                                _snap_state, check_header=True, run_pragma=True
-                            )
-                            if _snap_ok.get("valid"):
-                                try:
-                                    if _restore_state_db_from_snapshot(
-                                        _state_path, _snap_state
-                                    ):
-                                        print(
-                                            "  ✓ Auto-restored from snapshot "
-                                            f"{_snap_dir.name}"
-                                        )
-                                    else:
-                                        print(
-                                            "  ✗ Auto-restore FAILED — restored "
-                                            "copy also failed integrity"
-                                        )
-                                    break
-                                except OSError as _exc:
-                                    print(
-                                        f"  ✗ Auto-restore file copy failed: {_exc}"
-                                    )
-                                    break
+        _verify_and_restore_state_dbs_post_update()
     except Exception as exc:
         logger.debug(
             "Post-update state.db integrity check (zip path) failed: %s", exc
@@ -9439,72 +9474,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
         except Exception:
             logger.debug("macOS TCC anchor refresh skipped", exc_info=True)
 
-        # ── Post-update state.db integrity guard (#68474) ─────────────────
-        # Verify that state.db survived the update intact.  If the live file
-        # is now corrupted (zeroed, missing header, integrity failure),
-        # automatically restore from the pre-update snapshot rather than
-        # letting the user discover silently that their sessions are gone.
+        # ── Post-update state.db integrity guard (#68474, #97994) ─────────
+        # Verify that state.db survived the update intact in the root home
+        # AND every sibling profile. If a live file is now corrupted (zeroed,
+        # missing header, integrity failure), automatically restore from that
+        # home's own pre-update snapshot rather than letting the user discover
+        # silently that their sessions are gone.
         try:
-            from hermes_cli.backup import _quick_snapshot_root, verify_sqlite_integrity
-
-            _state_path = get_hermes_home() / "state.db"
-            if _state_path.exists():
-                _state_ok = verify_sqlite_integrity(
-                    _state_path,
-                    check_header=True,
-                    run_pragma=True,
-                )
-                if _state_ok.get("valid"):
-                    logger.debug(
-                        "Post-update state.db integrity check: %s",
-                        _state_ok.get("message"),
-                    )
-                else:
-                    print()
-                    print(
-                        "⚠ state.db is corrupted after update: "
-                        + _state_ok.get("message", "unknown error")
-                    )
-                    _pre_snap_id = pre_update_snapshot_id
-                    if _pre_snap_id:
-                        _snap_state = (
-                            _quick_snapshot_root(get_hermes_home())
-                            / _pre_snap_id
-                            / "state.db"
-                        )
-                        if _snap_state.exists():
-                            _snap_ok = verify_sqlite_integrity(
-                                _snap_state, check_header=True, run_pragma=True
-                            )
-                            if _snap_ok.get("valid"):
-                                try:
-                                    if _restore_state_db_from_snapshot(
-                                        _state_path, _snap_state
-                                    ):
-                                        print(
-                                            "  ✓ Auto-restored from pre-update "
-                                            f"snapshot ({_pre_snap_id})"
-                                        )
-                                    else:
-                                        print(
-                                            "  ✗ Auto-restore FAILED — restored "
-                                            "copy also failed integrity"
-                                        )
-                                except OSError as _exc:
-                                    print(
-                                        f"  ✗ Auto-restore file copy failed: {_exc}"
-                                    )
-                            else:
-                                print(
-                                    "  ✗ Pre-update snapshot also failed integrity"
-                                )
-                        else:
-                            print(
-                                "  ⚠ Pre-update snapshot does not contain state.db"
-                            )
-                    else:
-                        print("  ⚠ No pre-update snapshot was taken")
-                    print()
+            _verify_and_restore_state_dbs_post_update()
         except Exception as exc:
             logger.debug("Post-update state.db integrity check failed: %s", exc)
 

--- a/tests/hermes_cli/test_update_state_autorestore.py
+++ b/tests/hermes_cli/test_update_state_autorestore.py
@@ -216,23 +216,21 @@ def test_restore_helper_propagates_copy_errors(tmp_path):
 # ── Multi-profile coverage (#97994) ─────────────────────────────────────
 
 
-def _make_valid_db(path: Path, rows: int, tag: str) -> None:
+def _make_valid_db(path: Path, rows: int) -> None:
     conn = sqlite3.connect(path)
     conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT)")
     conn.executemany(
         "INSERT INTO sessions (name) VALUES (?)",
-        [(f"{tag}{i}",) for i in range(rows)],
+        [(str(i),) for i in range(rows)],
     )
     conn.commit()
     conn.close()
 
 
-def _make_valid_snapshot(home: Path, snap_id: str, rows: int, tag: str) -> Path:
+def _make_valid_snapshot(home: Path, snap_id: str, rows: int) -> None:
     snap_dir = home / "state-snapshots" / snap_id
     snap_dir.mkdir(parents=True)
-    snap_db = snap_dir / "state.db"
-    _make_valid_db(snap_db, rows, tag)
-    return snap_dir
+    _make_valid_db(snap_dir / "state.db", rows)
 
 
 def test_post_update_guard_covers_sibling_profiles(tmp_path, monkeypatch, capsys):
@@ -248,12 +246,12 @@ def test_post_update_guard_covers_sibling_profiles(tmp_path, monkeypatch, capsys
     sibling_home.mkdir(parents=True)
 
     # Root DB: valid, with its own snapshot — must be left untouched.
-    _make_valid_db(root_home / "state.db", 10, "root")
+    _make_valid_db(root_home / "state.db", 10)
     root_before = (root_home / "state.db").read_bytes()
 
     # Sibling: live DB corrupted post-update (the #68474 zeroed signature),
     # with its own VALID pre-update snapshot under its own snapshots dir.
-    _make_valid_snapshot(sibling_home, "20260901-pre-update", 25, "snap")
+    _make_valid_snapshot(sibling_home, "20260901-pre-update", 25)
     (sibling_home / "state.db").write_bytes(b"\x00" * 4096)
 
     monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)
@@ -283,8 +281,8 @@ def test_post_update_guard_leaves_valid_sibling_dbs_alone(tmp_path, monkeypatch,
     sibling_home = tmp_path / "profiles" / "work"
     sibling_home.mkdir(parents=True)
 
-    _make_valid_db(root_home / "state.db", 10, "root")
-    _make_valid_db(sibling_home / "state.db", 7, "sib")
+    _make_valid_db(root_home / "state.db", 10)
+    _make_valid_db(sibling_home / "state.db", 7)
     sibling_before = (sibling_home / "state.db").read_bytes()
 
     monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)
@@ -310,7 +308,7 @@ def test_post_update_guard_survives_missing_sibling_snapshot(tmp_path, monkeypat
     sibling_home = tmp_path / "profiles" / "work"
     sibling_home.mkdir(parents=True)
 
-    _make_valid_db(root_home / "state.db", 10, "root")
+    _make_valid_db(root_home / "state.db", 10)
     (sibling_home / "state.db").write_bytes(b"\x00" * 4096)
 
     monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)

--- a/tests/hermes_cli/test_update_state_autorestore.py
+++ b/tests/hermes_cli/test_update_state_autorestore.py
@@ -211,3 +211,118 @@ def test_restore_helper_propagates_copy_errors(tmp_path):
 
     with pytest.raises(OSError):
         _restore_state_db_from_snapshot(state_path, tmp_path / "does-not-exist.db")
+
+
+# ── Multi-profile coverage (#97994) ─────────────────────────────────────
+
+
+def _make_valid_db(path: Path, rows: int, tag: str) -> None:
+    conn = sqlite3.connect(path)
+    conn.execute("CREATE TABLE sessions (id INTEGER PRIMARY KEY, name TEXT)")
+    conn.executemany(
+        "INSERT INTO sessions (name) VALUES (?)",
+        [(f"{tag}{i}",) for i in range(rows)],
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_valid_snapshot(home: Path, snap_id: str, rows: int, tag: str) -> Path:
+    snap_dir = home / "state-snapshots" / snap_id
+    snap_dir.mkdir(parents=True)
+    snap_db = snap_dir / "state.db"
+    _make_valid_db(snap_db, rows, tag)
+    return snap_dir
+
+
+def test_post_update_guard_covers_sibling_profiles(tmp_path, monkeypatch, capsys):
+    """#97994: the guard must verify + auto-restore EVERY profile's state.db,
+    not just the root home's. Pre-update snapshots already cover siblings
+    (#66140); the guard was the missing half."""
+    from hermes_cli import update_cmd
+    from hermes_cli.backup import _sibling_profile_homes
+
+    root_home = tmp_path / "default-home"
+    root_home.mkdir()
+    sibling_home = tmp_path / "profiles" / "work"
+    sibling_home.mkdir(parents=True)
+
+    # Root DB: valid, with its own snapshot — must be left untouched.
+    _make_valid_db(root_home / "state.db", 10, "root")
+    root_before = (root_home / "state.db").read_bytes()
+
+    # Sibling: live DB corrupted post-update (the #68474 zeroed signature),
+    # with its own VALID pre-update snapshot under its own snapshots dir.
+    _make_valid_snapshot(sibling_home, "20260901-pre-update", 25, "snap")
+    (sibling_home / "state.db").write_bytes(b"\x00" * 4096)
+
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)
+    monkeypatch.setattr(
+        "hermes_cli.backup._sibling_profile_homes",
+        lambda invoking_home: [("work", sibling_home)],
+    )
+
+    update_cmd._verify_and_restore_state_dbs_post_update()
+
+    # Sibling restored from ITS snapshot (snap rows, not zeroed bytes).
+    assert _row_count(sibling_home / "state.db") == 25
+    # Root DB byte-identical — untouched.
+    assert (root_home / "state.db").read_bytes() == root_before
+    # Operator-visible restore message mentions the profile.
+    out = capsys.readouterr().out
+    assert "profile work" in out
+
+
+def test_post_update_guard_leaves_valid_sibling_dbs_alone(tmp_path, monkeypatch, capsys):
+    """A healthy sibling profile must not be touched — the guard only acts
+    on corruption."""
+    from hermes_cli import update_cmd
+
+    root_home = tmp_path / "default-home"
+    root_home.mkdir()
+    sibling_home = tmp_path / "profiles" / "work"
+    sibling_home.mkdir(parents=True)
+
+    _make_valid_db(root_home / "state.db", 10, "root")
+    _make_valid_db(sibling_home / "state.db", 7, "sib")
+    sibling_before = (sibling_home / "state.db").read_bytes()
+
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)
+    monkeypatch.setattr(
+        "hermes_cli.backup._sibling_profile_homes",
+        lambda invoking_home: [("work", sibling_home)],
+    )
+
+    update_cmd._verify_and_restore_state_dbs_post_update()
+
+    assert (sibling_home / "state.db").read_bytes() == sibling_before
+    out = capsys.readouterr().out
+    assert "corrupted" not in out
+
+
+def test_post_update_guard_survives_missing_sibling_snapshot(tmp_path, monkeypatch, capsys):
+    """Corrupt sibling with NO snapshot: guard must report and continue,
+    never raise into the update tail."""
+    from hermes_cli import update_cmd
+
+    root_home = tmp_path / "default-home"
+    root_home.mkdir()
+    sibling_home = tmp_path / "profiles" / "work"
+    sibling_home.mkdir(parents=True)
+
+    _make_valid_db(root_home / "state.db", 10, "root")
+    (sibling_home / "state.db").write_bytes(b"\x00" * 4096)
+
+    monkeypatch.setattr(update_cmd, "get_hermes_home", lambda: root_home)
+    monkeypatch.setattr(
+        "hermes_cli.backup._sibling_profile_homes",
+        lambda invoking_home: [("work", sibling_home)],
+    )
+
+    # Must not raise even though no snapshot exists to restore from.
+    update_cmd._verify_and_restore_state_dbs_post_update()
+
+    out = capsys.readouterr().out
+    assert "corrupted" in out
+    # Still corrupt (no snapshot) — but the guard completed cleanly.
+    assert (sibling_home / "state.db").read_bytes() == b"\x00" * 4096


### PR DESCRIPTION
## Summary

On a multi-profile install, the post-update `state.db` integrity guard (#68474) verified only the root home's database — every `profiles/*/state.db` went through updates with no corruption detection and no auto-restore. A profile database corrupted by an update was silently gone while the update reported success (#97994's reporter lost a large profile DB this way and recovered it only via a still-open file descriptor).

Salvage of #99954 by @Sahilvishnaliya (cherry-picked, authorship preserved) — rebased onto current main, plus one review-follow-up commit.

**Not the rejected #98121 mechanism:** that PR copied every profile DB pre-update (I/O multiplication on multi-GB DBs) and was declined. This PR copies nothing — pre-update snapshots of all profiles already exist on main (#66140 `create_pre_update_snapshots_all_profiles`). It only extends the POST-update integrity check + restore-on-corruption to sibling profiles, using each profile's own existing snapshots. Cost per update: one read-only integrity probe per profile DB (with the existing 2 GiB cheap-probe fallback for large files).

## Changes

- `hermes_cli/update_cmd.py`: the two near-identical inline guards (ZIP-update path and git-pull path) collapse into shared `_verify_and_restore_one_state_db()` / `_verify_and_restore_state_dbs_post_update()`; the sweep now covers the root home AND every sibling profile, restoring each corrupt DB from its own most recent valid snapshot under its own `state-snapshots/`. Never raises into the update tail.
- `tests/hermes_cli/test_update_state_autorestore.py`: 3 new real-SQLite tests (corrupt sibling + valid snapshot → restored, root untouched byte-for-byte; healthy sibling untouched; corrupt sibling with no snapshot → reported, no raise).
- Follow-up commit: restore the success-path debug log the old git-pull guard had, drop a dead test-helper param, hoist a repeated `get_hermes_home()` call.

## Validation

| | Before | After |
|---|---|---|
| profile DB corrupted by update | undetected, sessions silently gone | detected, auto-restored from that profile's snapshot, operator-visible per-profile output |
| root DB | protected (#68474) | unchanged behavior, now via the shared helper |

- 11/11 `test_update_state_autorestore.py` (real SQLite, no mocks of code under test)
- E2E with real imports + temp HERMES_HOME: root valid (untouched), profile `work` zeroed → restored to its 42-row snapshot, profile `play` byte-identical
- `tests/hermes_cli/test_cmd_update.py`: 8 failures are pre-existing on clean origin/main (reproduced on an untouched main worktree), 39 pass — unchanged by this PR
- Snapshot-scan note: the old git-pull path targeted `pre_update_snapshot_id` only; the helper scans snapshot dirs newest-first, which is strictly more robust (finds an older valid snapshot when the pre-update one failed or skipped large files; nothing writes snapshots mid-update, so newest = pre-update in practice)

## Provenance

- #99954 (@Sahilvishnaliya) — this salvage.
- #98121 (@smfworks) — earlier attempt on the same issue, declined for pre-update copy I/O; this PR deliberately avoids that mechanism.

Closes #99954
Fixes #97994
