### PR TITLE
fix(desktop): bare new sessions start detached in remote mode too (salvage #57926)

### DIFF
--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -208,7 +208,9 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
 //
 // Priority (first hit wins):
 //   1. Explicit sidebar project scope (drilled into a project / Home bucket)
-//   2. Configured default project dir / remote remembered cwd (detached otherwise)
+//   2. Configured default project dir (detached otherwise — in BOTH local and
+//      remote mode; a bare new chat never inherits the sticky remembered cwd,
+//      #57911 / #84220)
 //
 // The "active project" is just an atom ($projectScope) — so inside a project a
 // new session (cmd-n, the trunk "+") starts at that project's root (its primary

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -877,11 +877,8 @@ describe('workspaceCwdForNewSession', () => {
     // new session must NOT inherit /tradingview — pre-fix this returned the
     // sticky remembered cwd and the gateway mapped it back to the wrong
     // project via project_tree.py.
-    window.localStorage.setItem(
-      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
-      '/tradingview',
-    )
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    setCurrentCwd('/tradingview')
     applyConfiguredDefaultProjectDir(null)
 
     expect(workspaceCwdForNewSession()).toBe('')
@@ -892,10 +889,7 @@ describe('workspaceCwdForNewSession', () => {
     // *did* set a configured default — the explicit default pre-attaches
     // identically across local and remote mode.
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
-    window.localStorage.setItem(
-      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
-      '/tradingview',
-    )
+    setCurrentCwd('/tradingview')
     applyConfiguredDefaultProjectDir('/home/user/configured')
 
     expect(workspaceCwdForNewSession()).toBe('/home/user/configured')

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -37,6 +37,7 @@ import {
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
+  getRememberedWorkspaceCwd,
   getSessionOwnerHint,
   getSessionOwnerHints,
   hydrateSessionOwnerHints,
@@ -814,16 +815,22 @@ describe('workspaceCwdForNewSession', () => {
     $currentCwd.set('/live/session/path')
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
 
+    // Bare new sessions are intentionally DETACHED across every mode
+    // (#57911): neither sticky local nor sticky remote cwd is an accept-
+    // able bare-default — only an explicit configured default pre-attaches.
+    // The per-backend memory itself stays isolated (asserted directly).
     expect(workspaceCwdForNewSession()).toBe('')
 
     setCurrentCwd('/backend/project-a')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-a')
-
-    $connection.set({ baseUrl: 'http://backend-b', mode: 'remote' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-a')
     expect(workspaceCwdForNewSession()).toBe('')
 
+    $connection.set({ baseUrl: 'http://backend-b', mode: 'remote' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('')
+
     setCurrentCwd('/backend/project-b')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-b')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-b')
+    expect(workspaceCwdForNewSession()).toBe('')
 
     // Back on local with no configured default: a bare new chat is detached and
     // never reads the remote keys (nor inherits the sticky local workspace).
@@ -832,20 +839,23 @@ describe('workspaceCwdForNewSession', () => {
   })
 
   it('remembers only the workspace the user picked, not the one they looked at', () => {
-    // The reported bug (#77496 / #80213): on a remote backend a new chat starts
-    // in the remembered workspace, and every session resume used to write that
-    // key — so opening a project chat silently made it the destination for the
-    // next "New session". Following a conversation must leave the memory alone.
+    // The reported bug (#77496 / #80213): every session resume used to write
+    // the remembered-workspace key — so opening a project chat silently moved
+    // the memory. Following a conversation must leave the memory alone.
+    // (Since #57911 a bare new session is detached in remote mode too, so the
+    // memory is asserted directly — its remaining consumer is resume seeding
+    // via ensureDefaultWorkspaceCwd.)
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
     setCurrentCwd('/backend/picked')
 
     setCurrentCwdTransient('/backend/some-other-project')
 
     expect($currentCwd.get()).toBe('/backend/some-other-project')
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
   })
 
-  it('settling a resumed session does not move where the next new chat starts', () => {
+  it('settling a resumed session does not move the remembered workspace', () => {
     // The reporter's exact sequence: work in a project, open a chat from it,
     // then ask for a new session. Resume settling publishes the conversation's
     // cwd through commitWorkspaceCwdForSelectedSession — which must not claim
@@ -856,7 +866,39 @@ describe('workspaceCwdForNewSession', () => {
     setSelectedStoredSessionId('sess-in-project')
     commitWorkspaceCwdForSelectedSession('/backend/last-project')
 
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('does not stick a previous remote workspace onto a bare new session (#57911)', () => {
+    // Repro: in remote mode the user attaches to project-A so the renderer
+    // persists /tradingview as the remembered cwd under the remote key. The
+    // user then presses Cmd+N *without* being scoped into any project. A bare
+    // new session must NOT inherit /tradingview — pre-fix this returned the
+    // sticky remembered cwd and the gateway mapped it back to the wrong
+    // project via project_tree.py.
+    window.localStorage.setItem(
+      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
+      '/tradingview',
+    )
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    applyConfiguredDefaultProjectDir(null)
+
+    expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('respects an explicit configured default in remote mode (#57911)', () => {
+    // Symmetric guard: removing the remote branch must NOT regress users who
+    // *did* set a configured default — the explicit default pre-attaches
+    // identically across local and remote mode.
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    window.localStorage.setItem(
+      'hermes.desktop.workspace-cwd.remote.http%3A%2F%2Fbackend-a.default',
+      '/tradingview',
+    )
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1349,16 +1349,19 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  if ($connection.get()?.mode === 'remote') {
-    return getRememberedWorkspaceCwd()
-  }
-
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding
   // rail (which keys off $currentCwd) shows no branch and the first message runs
   // in the gateway's default rather than silently in the last repo you touched.
   // Only an explicit default-project-dir setting pre-attaches. Entering a
   // project/worktree attaches its cwd directly (startSessionInWorkspace), so the
   // "remember where I was when I'm in a project" case is unaffected.
+  //
+  // This must behave identically in local and remote mode: the remembered CWD
+  // under the remote-keyed workspaceCwdKey() can be from a *different* project
+  // than the one the user is currently scoped into, and bare-new-session in
+  // the wrong workspace was the #57911 symptom. Resume/restore still reads
+  // the remembered cwd via ensureDefaultWorkspaceCwd (where it remains
+  // remote-keyed and intentionally sticky).
   return getConfiguredDefaultProjectDir()
 }
 


### PR DESCRIPTION
## Summary

A bare new chat in **remote mode** now starts detached instead of silently inheriting the last project's remembered cwd — the remaining live half of #84220 (Desktop Home / All Projects new chat binds to the previous project) and the whole of #57911.

Salvage of #57926 by @Ahmett101 (commit cherry-picked with authorship preserved; test conflicts resolved against two months of `session.test.ts` churn).

## What was broken (who/when)

Desktop users on a **remote backend** (macOS Desktop → remote Linux gateway, the topology in @unsupportedpastels' and @RdWing's repros on #84220): after working in any named project, pressing ⌘N / "New Session" from the All-Projects overview created a session whose files pane and agent cwd were the **previous** project's folder. Local mode was already fixed (f3e0cf098b); the remote branch of `workspaceCwdForNewSession()` still short-circuited to the sticky remembered cwd:

```ts
// before
export const workspaceCwdForNewSession = (): string => {
  if ($connection.get()?.mode === 'remote') {
    return getRememberedWorkspaceCwd()
  }
  ...
  return getConfiguredDefaultProjectDir()
}
```

```ts
// after — identical in local and remote mode
export const workspaceCwdForNewSession = (): string => {
  ...
  return getConfiguredDefaultProjectDir()
}
```

## Changes

- `apps/desktop/src/store/session.ts`: drop the remote-mode early return; both modes return the explicitly configured default project dir ('' = detached).
- `apps/desktop/src/store/session.test.ts`: two new regression tests (sticky remote cwd must NOT leak into a bare new session; explicit configured default still pre-attaches in remote mode); three existing tests updated — they asserted the old remote inheritance, now assert the per-backend memory invariant directly via `getRememberedWorkspaceCwd()`.
- `apps/desktop/src/store/projects.ts` (follow-up commit): `resolveNewSessionCwd()` priority comment no longer lists "remote remembered cwd" as a new-session default.

**Not changed (intentionally):** `ensureDefaultWorkspaceCwd()` (session.ts:318-324) keeps its own remote branch reading `getRememberedWorkspaceCwd()` — that is the legitimate resume/restore "remember where I was" seeding path, and `$currentCwd` atom init likewise. Consumer trace confirmed the only production caller of the changed function is `resolveNewSessionCwd()`'s ALL_PROJECTS fallthrough (Home returns '' earlier; a concrete project scope returns its root earlier).

## Validation

| Check | Result |
|---|---|
| `vitest run src/store/session.test.ts src/store/projects.test.ts` | 136/136 pass |
| Full desktop suite (`npx vitest run`) | 8975 passed / 3 failed — all 3 pre-existing on `origin/main` (2 env-dependent electron tests fail identically on detached origin/main; 1 locale-dependent thousands-separator test passes under `LANG=en_US.UTF-8`) |
| `tsc -p tsconfig.json --noEmit` | clean |
| `eslint` on touched files | clean |
| Consumer trace (all `workspaceCwdForNewSession` / `getRememberedWorkspaceCwd` call sites) | no regressions; resume/restore path untouched |

## Provenance

- Original PR: #57926 (@Ahmett101, fixing #57911) — stale by ~12.6k commits but file-level churn was resolvable; substantive commit cherry-picked, test-alignment commit superseded by the conflict resolution.
- Residual-bug confirmation: maintainer verification note on #84220 (2026-09-01) naming this exact remote branch as the still-live half.

Closes #57911.
Refs #84220 (fixes the remote-mode residual; local mode already fixed by f3e0cf098b).
Credit: @Ahmett101 (original fix + tests), @fluxkapacitor and @unsupportedpastels (remote-mode repros on #84220).
