### PR TITLE
fix(mattermost): scope url/reply_mode/require_mention/free_response_channels/allowed_channels to the active profile under multiplexing

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -100,7 +100,7 @@ def validate_mattermost_config(config: PlatformConfig) -> bool:
     """Return True when Mattermost has enough config to connect."""
     extra = getattr(config, "extra", {}) or {}
     token = (getattr(config, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
-    url = (extra.get("url", "") or os.getenv("MATTERMOST_URL", "")).strip()
+    url = (extra.get("url", "") or _get_scoped_secret("MATTERMOST_URL", "")).strip()
     if not token:
         logger.debug("Mattermost: MATTERMOST_TOKEN not set")
         return False
@@ -120,7 +120,7 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._base_url: str = (
             config.extra.get("url", "")
-            or os.getenv("MATTERMOST_URL", "")
+            or _get_scoped_secret("MATTERMOST_URL", "")
         ).rstrip("/")
         self._token: str = config.token or _get_scoped_secret("MATTERMOST_TOKEN", "")
 
@@ -137,7 +137,7 @@ class MattermostAdapter(BasePlatformAdapter):
         # Reply mode: "thread" to nest replies, "off" for flat messages.
         self._reply_mode: str = (
             config.extra.get("reply_mode", "")
-            or os.getenv("MATTERMOST_REPLY_MODE", "off")
+            or _get_scoped_secret("MATTERMOST_REPLY_MODE", "off")
         ).lower()
 
         self._last_post_status: Optional[int] = None
@@ -870,7 +870,7 @@ class MattermostAdapter(BasePlatformAdapter):
             # ignored, even if @mentioned.  DMs are already excluded above.
             allowed_raw = self.config.extra.get("allowed_channels") if self.config.extra else None
             if allowed_raw is None:
-                allowed_raw = os.getenv("MATTERMOST_ALLOWED_CHANNELS", "")
+                allowed_raw = _get_scoped_secret("MATTERMOST_ALLOWED_CHANNELS", "")
             if isinstance(allowed_raw, list):
                 allowed_channels = {str(c).strip() for c in allowed_raw if str(c).strip()}
             else:
@@ -884,12 +884,18 @@ class MattermostAdapter(BasePlatformAdapter):
                 )
                 return
 
-            require_mention = os.getenv(
-                "MATTERMOST_REQUIRE_MENTION", "true"
-            ).lower() not in {"false", "0", "no"}
+            require_mention_raw = self.config.extra.get("require_mention") if self.config.extra else None
+            if require_mention_raw is None:
+                require_mention_raw = _get_scoped_secret("MATTERMOST_REQUIRE_MENTION", "true")
+            require_mention = str(require_mention_raw).lower() not in {"false", "0", "no"}
 
-            free_channels_raw = os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
-            free_channels = {ch.strip() for ch in free_channels_raw.split(",") if ch.strip()}
+            free_channels_raw = self.config.extra.get("free_response_channels") if self.config.extra else None
+            if free_channels_raw is None:
+                free_channels_raw = _get_scoped_secret("MATTERMOST_FREE_RESPONSE_CHANNELS", "")
+            if isinstance(free_channels_raw, list):
+                free_channels = {str(ch).strip() for ch in free_channels_raw if str(ch).strip()}
+            else:
+                free_channels = {ch.strip() for ch in str(free_channels_raw).split(",") if ch.strip()}
             is_free_channel = channel_id in free_channels
 
             mention_patterns = [
@@ -1057,7 +1063,7 @@ async def _standalone_send(
 
     base_url = (
         (getattr(pconfig, "extra", {}) or {}).get("url")
-        or os.getenv("MATTERMOST_URL", "")
+        or _get_scoped_secret("MATTERMOST_URL", "")
     ).rstrip("/")
     token = (getattr(pconfig, "token", None) or _get_scoped_secret("MATTERMOST_TOKEN", "")).strip()
     if not base_url or not token:
@@ -1232,40 +1238,62 @@ def interactive_setup() -> None:
 # ---------------------------------------------------------------------------
 
 
+def _profile_scoped_config_load() -> bool:
+    """True when running inside a multiplexed secondary profile's scope.
+
+    Secondary-profile adapters are constructed and connected inside
+    ``_profile_runtime_scope`` (secret scope installed + multiplex active) --
+    the same discriminator the Buzz/Discord/Telegram/WhatsApp/LINE/DingTalk
+    adapters use for this bug class (#98738 / #72348 / #80099). The DEFAULT
+    profile under multiplexing runs unscoped: ``os.environ`` holds its own
+    bridge output there and keeps its legacy precedence.
+    """
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
 def _apply_yaml_config(yaml_cfg: dict, mattermost_cfg: dict) -> dict | None:
-    """Translate ``config.yaml`` ``mattermost:`` keys into env vars.
+    """Translate ``config.yaml`` ``mattermost:`` keys into env vars and
+    ``PlatformConfig.extra`` entries.
 
     Implements the ``apply_yaml_config_fn`` contract (#24836 / #25443).
     Mirrors the legacy ``mattermost_cfg`` block that used to live in
     ``gateway/config.py::load_gateway_config()`` before this migration.
 
-    The MattermostAdapter reads its runtime configuration via
-    ``os.getenv()`` for ``MATTERMOST_REQUIRE_MENTION``,
-    ``MATTERMOST_FREE_RESPONSE_CHANNELS``, and
-    ``MATTERMOST_ALLOWED_CHANNELS``.  Rather than rewrite those call sites
-    to read from ``PlatformConfig.extra``, this hook keeps the env-driven
-    model and merely owns the YAML→env translation here, next to the
-    adapter that consumes it.
-
-    Env vars take precedence over YAML — every assignment is guarded
-    by ``not os.getenv(...)`` so an explicit env var survives a config.yaml
-    update.  Returns ``None`` because no extras are seeded into
-    ``PlatformConfig.extra`` directly (everything flows through env).
+    Env vars take precedence over YAML for single-profile deployments --
+    each env write is guarded by ``not os.getenv(...)`` so an explicit env
+    var survives a config.yaml update. Under a multiplexed secondary
+    profile's scope, the env write is skipped entirely (it would otherwise
+    leak into the process-global ``os.environ`` and be inherited by every
+    other profile); instead the values are returned so the caller merges
+    them into this profile's own ``PlatformConfig.extra``, which the
+    require_mention/free_response_channels/allowed_channels read sites now
+    check first.
     """
-    if "require_mention" in mattermost_cfg and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
-        os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
+    _skip_env_bridge = _profile_scoped_config_load()
+    seeded: dict = {}
+    if "require_mention" in mattermost_cfg:
+        seeded["require_mention"] = mattermost_cfg["require_mention"]
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_REQUIRE_MENTION"):
+            os.environ["MATTERMOST_REQUIRE_MENTION"] = str(mattermost_cfg["require_mention"]).lower()
     frc = mattermost_cfg.get("free_response_channels")
-    if frc is not None and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["MATTERMOST_FREE_RESPONSE_CHANNELS"] = str(frc)
+    if frc is not None:
+        seeded["free_response_channels"] = frc
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_FREE_RESPONSE_CHANNELS"):
+            _frc = ",".join(str(v) for v in frc) if isinstance(frc, list) else str(frc)
+            os.environ["MATTERMOST_FREE_RESPONSE_CHANNELS"] = _frc
     # allowed_channels: if set, bot ONLY responds in these channels (whitelist)
     ac = mattermost_cfg.get("allowed_channels")
-    if ac is not None and not os.getenv("MATTERMOST_ALLOWED_CHANNELS"):
-        if isinstance(ac, list):
-            ac = ",".join(str(v) for v in ac)
-        os.environ["MATTERMOST_ALLOWED_CHANNELS"] = str(ac)
-    return None  # all settings flow through env; nothing to merge into extras
+    if ac is not None:
+        seeded["allowed_channels"] = ac
+        if not _skip_env_bridge and not os.getenv("MATTERMOST_ALLOWED_CHANNELS"):
+            _ac = ",".join(str(v) for v in ac) if isinstance(ac, list) else str(ac)
+            os.environ["MATTERMOST_ALLOWED_CHANNELS"] = _ac
+    return seeded or None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -594,3 +594,182 @@ async def test_mattermost_top_level_channel_post_is_thread_root():
     assert msg_event.message_id == "top_post_123"
 
 
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope
+# ---------------------------------------------------------------------------
+#
+# __init__'s url/reply_mode, validate_mattermost_config's url,
+# _standalone_send's url, and _handle_ws_event's require_mention/
+# free_response_channels/allowed_channels, all previously read raw
+# os.getenv unconditionally (only MATTERMOST_TOKEN was already scoped).
+# _apply_yaml_config also wrote MATTERMOST_REQUIRE_MENTION/
+# MATTERMOST_FREE_RESPONSE_CHANNELS/MATTERMOST_ALLOWED_CHANNELS into the
+# process-global os.environ unconditionally. Under multiplex, os.environ
+# holds the DEFAULT profile's YAML-to-env bridge output -- a secondary
+# profile with its own (different or absent) Mattermost config would
+# silently connect to the default profile's server, or have its
+# mention-gating/channel-allowlist decisions driven by the default
+# profile's settings. Mirrors the LINE/DingTalk/IRC fix for #98738.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("MATTERMOST_URL", "https://default.example.com")
+    monkeypatch.setenv("MATTERMOST_REPLY_MODE", "thread")
+    monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("MATTERMOST_FREE_RESPONSE_CHANNELS", "chan_default")
+    monkeypatch.setenv("MATTERMOST_ALLOWED_CHANNELS", "chan_default")
+
+
+class TestMultiplexProfileScope:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_env
+    ):
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            token="profile-token",
+            extra={"url": "https://profile.example.com", "reply_mode": "off"},
+        )
+        adapter = MattermostAdapter(cfg)
+        assert adapter._base_url == "https://profile.example.com"
+        assert adapter._reply_mode == "off"
+
+    def test_secondary_missing_keys_fail_closed(
+        self, multiplex_scope, default_profile_env
+    ):
+        """Keys absent from the profile's own scope must NOT borrow the
+        default profile's bridged env values -- that would silently connect
+        the secondary profile's bot to the wrong Mattermost server."""
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        multiplex_scope()
+        adapter = MattermostAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter._base_url == ""
+        assert adapter._reply_mode == "off"  # hardcoded default, not "thread"
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        set_multiplex_active(True)
+        try:
+            adapter = MattermostAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter._base_url == "https://default.example.com"
+        assert adapter._reply_mode == "thread"
+
+    def test_validate_config_scoped_miss_ignores_default_url(
+        self, multiplex_scope, default_profile_env
+    ):
+        from plugins.platforms.mattermost.adapter import validate_mattermost_config
+
+        multiplex_scope({"MATTERMOST_TOKEN": "profile-token"})
+        cfg = PlatformConfig(enabled=True, token="profile-token", extra={})
+        assert validate_mattermost_config(cfg) is False
+
+    @pytest.mark.asyncio
+    async def test_ws_event_gating_uses_scoped_settings_not_default(
+        self, monkeypatch
+    ):
+        """A secondary profile's own require_mention/free_response_channels/
+        allowed_channels (installed via the scope) must gate its messages --
+        not the default profile's bridged settings."""
+        from agent.secret_scope import (
+            reset_secret_scope,
+            set_multiplex_active,
+            set_secret_scope,
+        )
+        from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+        monkeypatch.setenv("MATTERMOST_REQUIRE_MENTION", "true")
+        monkeypatch.delenv("MATTERMOST_FREE_RESPONSE_CHANNELS", raising=False)
+
+        adapter = _make_adapter()
+        adapter._bot_user_id = "bot_user_id"
+        adapter._bot_username = "hermes-bot"
+        adapter.handle_message = AsyncMock()
+
+        post_data = {
+            "id": "post_scoped",
+            "user_id": "user_123",
+            "channel_id": "chan_456",
+            "message": "hello with no mention",
+        }
+        event = {
+            "event": "posted",
+            "data": {
+                "post": json.dumps(post_data),
+                "channel_type": "O",
+                "sender_name": "@alice",
+            },
+        }
+
+        set_multiplex_active(True)
+        token = set_secret_scope({"MATTERMOST_REQUIRE_MENTION": "false"})
+        try:
+            await adapter._handle_ws_event(event)
+        finally:
+            reset_secret_scope(token)
+            set_multiplex_active(False)
+
+        # The profile's own scope disables require_mention -- the message
+        # must be dispatched even without an @mention, despite the default
+        # profile's env bridge saying require_mention=true.
+        assert adapter.handle_message.called
+
+    def test_apply_yaml_config_scoped_skips_env_write_and_seeds_extra(
+        self, multiplex_scope
+    ):
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        multiplex_scope()
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("MATTERMOST_REQUIRE_MENTION", None)
+            seeded = _apply_yaml_config({}, {"require_mention": False, "allowed_channels": ["c1"]})
+            assert seeded == {"require_mention": False, "allowed_channels": ["c1"]}
+            # Under a secondary profile's scope the env bridge must be
+            # skipped -- writing here would leak into every other profile's
+            # os.environ.
+            assert "MATTERMOST_REQUIRE_MENTION" not in os.environ
+
+    def test_apply_yaml_config_unscoped_still_bridges_env(self, monkeypatch):
+        """Single-profile / default-profile deployments keep the legacy
+        env-bridge behavior."""
+        from plugins.platforms.mattermost.adapter import _apply_yaml_config
+
+        monkeypatch.delenv("MATTERMOST_REQUIRE_MENTION", raising=False)
+        seeded = _apply_yaml_config({}, {"require_mention": True})
+        assert seeded == {"require_mention": True}
+        assert os.environ["MATTERMOST_REQUIRE_MENTION"] == "true"
+
+


### PR DESCRIPTION
## Summary

- `MattermostAdapter.__init__`, `validate_mattermost_config`, `_standalone_send`, and `_handle_ws_event`'s mention-gating block all read `MATTERMOST_URL`/`MATTERMOST_REPLY_MODE`/`MATTERMOST_REQUIRE_MENTION`/`MATTERMOST_FREE_RESPONSE_CHANNELS`/`MATTERMOST_ALLOWED_CHANNELS` via raw `os.getenv()` — only `MATTERMOST_TOKEN` was already scoped via `_get_scoped_secret()`.
- `_apply_yaml_config` additionally wrote `MATTERMOST_REQUIRE_MENTION`/`MATTERMOST_FREE_RESPONSE_CHANNELS`/`MATTERMOST_ALLOWED_CHANNELS` into the process-global `os.environ` unconditionally (guarded only by `not os.getenv(...)`, first-writer-wins) — the same `apply_yaml_config_fn` bug class already fixed for the Discord/Telegram/WhatsApp/DingTalk adapters in this series.
- Under `gateway.multiplex_profiles`, `os.environ` holds the DEFAULT profile's env-bridge output. A secondary profile with its own (or no) Mattermost config could silently connect to the default profile's server, thread its replies per the default profile's `reply_mode`, or — since `_handle_ws_event`'s mention-gating block runs on every **live inbound message**, not just at construction — have its `require_mention`/`free_response_channels`/`allowed_channels` decisions driven by the default profile's settings for the adapter's entire runtime lifetime.

## Fix

Mirrors the WhatsApp/DingTalk `apply_yaml_config_fn` pattern:
- Add `_profile_scoped_config_load()` (same helper as DingTalk).
- Rewrite `_apply_yaml_config` to skip the env-bridge write under a multiplexed secondary profile's scope, and instead return the YAML values as a dict merged into this profile's own `PlatformConfig.extra`.
- Make `require_mention`/`free_response_channels` read `extra` first (matching the existing `allowed_channels` precedent), falling back to `_get_scoped_secret()` instead of raw `os.getenv` when `extra` is absent — **fixing a residual gap the DingTalk fix (#100615, item 6 of this series) left in its own analogous extra-first-with-raw-fallback read sites** (`_dingtalk_require_mention` et al. still fall back to bare `os.getenv` on an extra miss — flagging this as a follow-up worth a look, not fixed here since it's a different file/PR).
- Switch `__init__`'s `url`/`reply_mode`, `validate_mattermost_config`'s `url`, and `_standalone_send`'s `url` to `_get_scoped_secret()`.
- Leave `check_mattermost_requirements()` (no longer reads any `MATTERMOST_*` var on current `main` — just an aiohttp-importability probe) and `_is_connected()` (already scope-aware via `hermes_cli.gateway.get_env_value`, which itself routes through `agent.secret_scope.get_secret`) untouched.

## Tests

Added `TestMultiplexProfileScope` (7 tests) to `tests/gateway/test_mattermost.py`, mirroring the fixture/assertion style established in `tests/gateway/test_line_plugin.py`'s class of the same name, plus 2 tests exercising `_apply_yaml_config`'s new seeded-dict return directly.

Mutation-verified: stashed the production fix and confirmed 5 of 7 new tests fail against pre-fix code (the other 2 are non-differentiating regression guards — extra-wins-over-env and unscoped-default-profile-precedence — which correctly pass either way). Restored the fix; all 30 tests in the file, the plugin-setup test, and the full 75-test `tests/gateway/test_adapter_startup_secret_scope.py` suite pass.

## Competitor check

This file is a hotspot with several open PRs; searched `MATTERMOST_URL`, `mattermost multiplex`, `mattermost scope`, `mattermost require_mention`. None address the multiplex-scoping concern fixed here — all are different concerns with two real (but reconcilable) line-level overlaps and two adjacency-only overlaps:
- **#67810** ("honor reply_mode from config.yaml") adds a new `reply_mode` bridge *into* `_apply_yaml_config` — the same function this PR restructures. A rebase needs to port their new `reply_mode` branch into the `_skip_env_bridge`/`seeded`-dict shape this PR introduces (straightforward: same pattern as the other three fields).
- **#72374** ("warn instead of silently ignoring an unknown reply_mode") changes the *same* `self._reply_mode = (...)` expression in `__init__`, wrapping it in a validation helper and changing the default constant — different concern (validation) from this PR's `os.getenv` → `_get_scoped_secret` swap. Trivially combinable on rebase.
- **#89972** ("per-channel and DM user allowlists") inserts a new allowlist check immediately before this PR's edited `require_mention`/`free_response_channels`/`allowed_channels` block and moves an unrelated code block — textual adjacency, no line-level overlap.
- **#51243** ("honor documented mention_patterns wake words") renames a local variable and extends the `has_mention` check further down in the same function, using the old single-line `free_channels = ...` form as diff context (this PR restructures that line) — needs a rebase to reconcile the anchor, but no semantic clash.
- **#91811** and **#49465** touch unrelated regions of the file (new slash-command state fields; a stale, already-superseded `check_mattermost_requirements()` body) — no overlap.

No open or merged PR touches the actual scope-leak fixed here.

## Checklist

- [x] Read current adapter code directly (not from a stale scan summary)
- [x] Minimal, precedent-matching fix (reuses the established WhatsApp/DingTalk `apply_yaml_config_fn` pattern)
- [x] New regression tests, mutation-verified against the pre-fix code
- [x] Full existing Mattermost test suite passes
- [x] Fresh competitor PR search immediately before opening this PR