### PR TITLE
fix(update): surface leftover update autostashes older than 7 days (#63717)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5219,6 +5219,7 @@ _LAZY_COMMAND_EXPORTS = {
         "_sync_with_upstream_if_needed",
         "_update_node_dependencies",
         "_update_via_zip",
+        "_warn_orphaned_update_autostashes",
         "_upgrade_pip_before_lazy_refresh",
         "_validate_critical_files_syntax",
         "_validate_critical_modules_import",

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2541,7 +2541,7 @@ def _stash_local_changes_if_needed(git_cmd: list[str], cwd: Path) -> Optional[st
     from datetime import datetime, timezone
 
     stash_name = datetime.now(timezone.utc).strftime(
-        "hermes-update-autostash-%Y%m%d-%H%M%S"
+        f"{_AUTOSTASH_NAME_PREFIX}%Y%m%d-%H%M%S"
     )
     print("→ Local changes detected — stashing before update...")
     prev_stash = subprocess.run(
@@ -2627,6 +2627,83 @@ def _resolve_stash_selector(
         if commit.strip() == stash_ref:
             return selector.strip()
     return None
+
+#: Producer/consumer contract for update autostash names: the stash subject is
+#: this prefix + a UTC YYYYMMDD-HHMMSS stamp (see _stash_local_changes_if_needed
+#: and _warn_orphaned_update_autostashes).
+_AUTOSTASH_NAME_PREFIX = "hermes-update-autostash-"
+
+#: Age past which a leftover ``hermes-update-autostash-*`` entry is called out
+#: at update time. Entries younger than this are normal (a parked stash from
+#: the desktop updater's --keep-stash run minutes ago); older ones are almost
+#: always forgotten (#63717 problem 6: an orphan persisted 9+ days unnoticed).
+_AUTOSTASH_WARN_AGE_DAYS = 7
+
+
+def _warn_orphaned_update_autostashes(git_cmd: list[str], cwd: Path) -> int:
+    """Surface leftover update autostashes older than the warn threshold.
+
+    Autostash entries legitimately outlive an update run (``--keep-stash``
+    parks them; a conflicted or failed restore preserves them for safety), but
+    nothing ever re-surfaces them afterwards — they sit in ``git stash``
+    invisibly for weeks (#63717 problem 6). This prints a short notice naming
+    the stale entries with recovery/cleanup guidance. Deliberately NOT a GC:
+    a stash entry can be the only copy of the user's uncommitted work, so
+    Hermes never drops one automatically.
+
+    Best-effort — any git failure returns 0 and must not block the update.
+    Returns the number of stale entries warned about.
+    """
+    from datetime import timedelta, timezone
+
+    try:
+        stash_list = subprocess.run(
+            git_cmd + ["stash", "list", "--format=%gd %s"],
+            cwd=cwd,
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+        )
+        if stash_list.returncode != 0:
+            return 0
+        cutoff = datetime.now(timezone.utc) - timedelta(
+            days=_AUTOSTASH_WARN_AGE_DAYS
+        )
+        marker = _AUTOSTASH_NAME_PREFIX
+        stale: list[tuple[str, str]] = []
+        for line in stash_list.stdout.splitlines():
+            selector, _, subject = line.strip().partition(" ")
+            pos = subject.find(marker)
+            if pos < 0:
+                continue
+            stamp = subject[pos + len(marker):][:15]  # "YYYYMMDD-HHMMSS"
+            try:
+                stash_time = datetime.strptime(stamp, "%Y%m%d-%H%M%S").replace(
+                    tzinfo=timezone.utc
+                )
+            except ValueError:
+                # Unparseable name — age unknown; leave it alone rather than
+                # guess (same posture as _prune_orphan_rescue_refs).
+                continue
+            if stash_time < cutoff:
+                stale.append((selector, stamp))
+        if not stale:
+            return 0
+        print()
+        print(
+            f"⚠ {len(stale)} leftover update autostash entr"
+            f"{'y is' if len(stale) == 1 else 'ies are'} more than "
+            f"{_AUTOSTASH_WARN_AGE_DAYS} days old:"
+        )
+        for selector, stamp in stale:
+            print(f"    {selector}  ({_AUTOSTASH_NAME_PREFIX}{stamp})")
+        print("  These hold local changes stashed by earlier updates and never")
+        print("  restored. Review with: git stash show -p <entry>")
+        print("  Restore with: git stash apply <entry>   Discard with: git stash drop <entry>")
+        return len(stale)
+    except Exception as exc:
+        logger.debug("Autostash age check failed: %s", exc)
+        return 0
+
 
 def _print_stash_cleanup_guidance(
     stash_ref: str, stash_selector: Optional[str] = None
@@ -8461,6 +8538,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
         swept = clear_stale_tmp_packs(_m().PROJECT_ROOT)
         if swept:
             print("  (removed %d aborted-fetch pack temp file(s))" % len(swept))
+
+        # Surface autostash entries left behind by earlier updates (#63717
+        # problem 6) — parked --keep-stash runs and failed restores preserve
+        # the stash but nothing ever mentioned it again.
+        _m()._warn_orphaned_update_autostashes(git_cmd, _m().PROJECT_ROOT)
 
         print("→ Fetching updates...")
         fetch_result = subprocess.run(

--- a/tests/hermes_cli/test_update_autostash_orphan_warning.py
+++ b/tests/hermes_cli/test_update_autostash_orphan_warning.py
@@ -1,0 +1,104 @@
+"""Orphaned update-autostash surfacing (#63717 problem 6).
+
+``hermes update`` can legitimately leave an autostash behind (--keep-stash
+parks it; a conflicted restore preserves it), but nothing ever mentioned those
+entries again — they persisted invisibly for weeks. ``hermes update`` now
+warns about ``hermes-update-autostash-*`` entries older than the threshold.
+Behavioral tests use real git repos; no production mocking of the code under
+test.
+"""
+
+import subprocess
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _git(cwd, *args, check=True):
+    return subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True, check=check
+    )
+
+
+def _make_repo_with_autostash(tmp_path, age_days: float):
+    """Real repo with one hermes-update-autostash entry aged ``age_days``."""
+    import shutil
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "init")
+
+    (tmp_path / "tracked.txt").write_text("local change\n")
+    stamp = (
+        datetime.now(timezone.utc) - timedelta(days=age_days)
+    ).strftime("%Y%m%d-%H%M%S")
+    name = f"hermes-update-autostash-{stamp}"
+    _git(tmp_path, "stash", "push", "--include-untracked", "-m", name)
+    return name
+
+
+def test_old_autostash_is_surfaced(tmp_path, capsys):
+    name = _make_repo_with_autostash(tmp_path, age_days=9)
+    count = update_cmd._warn_orphaned_update_autostashes(["git"], tmp_path)
+    out = capsys.readouterr().out
+    assert count == 1
+    assert "leftover update autostash" in out
+    assert name in out
+    assert "git stash apply" in out
+    # Never a GC: the entry must still exist.
+    listed = _git(tmp_path, "stash", "list").stdout
+    assert name in listed
+
+
+def test_fresh_autostash_is_not_flagged(tmp_path, capsys):
+    _make_repo_with_autostash(tmp_path, age_days=1)
+    count = update_cmd._warn_orphaned_update_autostashes(["git"], tmp_path)
+    assert count == 0
+    assert "leftover update autostash" not in capsys.readouterr().out
+
+
+def test_non_hermes_stash_is_ignored(tmp_path, capsys):
+    import shutil
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "init")
+    (tmp_path / "tracked.txt").write_text("user's own WIP\n")
+    _git(tmp_path, "stash", "push", "-m", "my own stash from 20200101-000000")
+    count = update_cmd._warn_orphaned_update_autostashes(["git"], tmp_path)
+    assert count == 0
+    assert "leftover update autostash" not in capsys.readouterr().out
+
+
+def test_unparseable_autostash_timestamp_left_alone(tmp_path, capsys):
+    import shutil
+
+    if shutil.which("git") is None:
+        pytest.skip("git not available")
+    _git(tmp_path, "init", "-q", "-b", "main")
+    _git(tmp_path, "config", "user.email", "t@example.com")
+    _git(tmp_path, "config", "user.name", "t")
+    (tmp_path / "tracked.txt").write_text("v1\n")
+    _git(tmp_path, "add", "-A")
+    _git(tmp_path, "commit", "-qm", "init")
+    (tmp_path / "tracked.txt").write_text("change\n")
+    _git(tmp_path, "stash", "push", "-m", "hermes-update-autostash-notadate")
+    count = update_cmd._warn_orphaned_update_autostashes(["git"], tmp_path)
+    assert count == 0
+
+
+def test_git_failure_is_nonfatal(tmp_path):
+    # Not a git repo at all — must return 0, not raise.
+    assert update_cmd._warn_orphaned_update_autostashes(["git"], tmp_path) == 0


### PR DESCRIPTION
## Summary
`hermes update` now warns when `hermes-update-autostash-*` stash entries older than 7 days are sitting in the repo — closing the last still-live root cause (problem 6) of #63717's seven-cause Windows update diagnostic.

**Who hits this / when / why it matters:** any user whose update ran with `--keep-stash` (the desktop updater's mode) or whose stash restore hit conflicts. Both paths correctly preserve the stash — but nothing ever mentioned it again, so local changes sat invisible in `git stash` for weeks (the #63717 reporter found one 9+ days old, alongside 3,040 stale working-tree files). The user has no idea their uncommitted work is parked there.

## Changes
- `hermes_cli/update_cmd.py`: new `_warn_orphaned_update_autostashes()` — lists `git stash` entries, parses the `YYYYMMDD-HHMMSS` stamp embedded in `hermes-update-autostash-*` subjects (same parse posture as `_prune_orphan_rescue_refs`: unparseable names are left alone), prints the stale entries with review/restore/drop guidance. Called once at the start of the git update path, before the fetch. Best-effort: any git failure is a debug log, never an update blocker.
- `hermes_cli/main.py`: name registered in `_LAZY_COMMAND_EXPORTS` (the `_m()` indirection surface).
- `tests/hermes_cli/test_update_autostash_orphan_warning.py`: 5 behavioral tests with real git repos — old entry surfaced + NOT dropped, fresh entry silent, non-hermes stash ignored, unparseable timestamp left alone, non-repo dir non-fatal.

**Deliberately warn-only, never a GC.** A stash entry can be the only copy of a user's uncommitted work; the issue proposed auto-drop in `--yes` mode, but Hermes never deletes a stash automatically. (`updates.non_interactive_local_changes: discard` already exists for users who want that.)

## Validation
| | Before | After |
|---|---|---|
| `hermes update` with a 9-day-old parked autostash | silent — entry invisible unless the user runs `git stash list` themselves | `⚠ 1 leftover update autostash entry is more than 7 days old:` + selector + restore/drop guidance |
| stash contents | untouched | untouched (warn-only) |

Tests: 5/5 new tests pass; ruff clean; sibling autostash suites' pre-existing local failures unchanged (verified via stash-baseline run on clean origin/main).

## Provenance
Residual facet of #63717 (problem 6, one of two the reporter flagged as previously-unreported). The other six root causes were verified already fixed on main during the 2026-09-01 P1 sweep — full facet table posted on the issue.

Closes #63717.
