### PR TITLE
fix(sessions): batch large cleanup queries

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -58,7 +58,7 @@ from hermes_startup_watchdog import report_startup_progress
 from hermes_cli.sqlite_runtime import (
     is_sqlite_wal_reset_vulnerable as _is_sqlite_wal_reset_vulnerable,
 )
-from typing import Any, Callable, Dict, Iterator, List, Optional, Set, Tuple, TypeVar, cast
+from typing import Any, Callable, Dict, Iterable, Iterator, List, Optional, Set, Tuple, TypeVar, cast
 
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
@@ -10076,19 +10076,18 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                   )
             """, (cutoff,)).fetchall()
             ids = [r[0] if isinstance(r, (tuple, list)) else r["id"] for r in rows]
-            if ids:
-                placeholders = ",".join("?" * len(ids))
+            for batch in self._session_id_batches(ids):
+                placeholders = ",".join("?" * len(batch))
                 conn.execute(
-                    f"DELETE FROM sessions WHERE id IN ({placeholders})", ids
+                    f"DELETE FROM sessions WHERE id IN ({placeholders})", batch
                 )
+            if ids:
                 self._delete_unreferenced_system_prompts(conn)
             return ids
 
         removed_ids = self._execute_write(_do) or []
         # Clean up any on-disk session files (belt-and-suspenders)
-        if sessions_dir and removed_ids:
-            for sid in removed_ids:
-                self._remove_session_files(sessions_dir, sid)
+        self._remove_session_files_bulk(sessions_dir, removed_ids)
         return len(removed_ids)
 
     def finalize_orphaned_compression_sessions(self) -> int:
@@ -14475,6 +14474,53 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         except OSError:
             pass
 
+    @staticmethod
+    def _remove_session_files_bulk(
+        sessions_dir: Optional[Path], session_ids: Iterable[str]
+    ) -> None:
+        """Remove transcript files for many sessions in one directory pass."""
+        if sessions_dir is None:
+            return
+        ids = set(session_ids)
+        if not ids:
+            return
+
+        prefix = "request_dump_"
+        try:
+            for p in sessions_dir.iterdir():
+                name = p.name
+                remove = False
+                if name.endswith(".jsonl"):
+                    remove = name[:-len(".jsonl")] in ids
+                elif name.endswith(".json"):
+                    stem = name[:-len(".json")]
+                    if stem in ids:
+                        remove = True
+                    elif stem.startswith(prefix):
+                        payload = stem[len(prefix):]
+                        candidates = set()
+                        timestamp_parts = payload.rsplit("_", 3)
+                        if len(timestamp_parts) == 4:
+                            candidates.add(timestamp_parts[0])
+                        legacy_parts = payload.rsplit("_", 1)
+                        if len(legacy_parts) == 2:
+                            candidates.add(legacy_parts[0])
+                        remove = bool(ids.intersection(candidates))
+                if remove:
+                    try:
+                        p.unlink(missing_ok=True)
+                    except OSError:
+                        pass
+        except OSError:
+            pass
+
+    @staticmethod
+    def _session_id_batches(session_ids: Iterable[str]) -> Iterator[List[str]]:
+        """Yield ID batches below SQLite's legacy 999-variable ceiling."""
+        ids = list(session_ids)
+        for start in range(0, len(ids), 900):
+            yield ids[start : start + 900]
+
     def get_session_delete_targets(self, session_id: str) -> List[str]:
         """Return every session row that :meth:`delete_session` would remove.
 
@@ -14762,35 +14808,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cursor = conn.execute(
                 f"SELECT id FROM sessions WHERE {self._EMPTY_SESSION_WHERE}"
             )
-            session_ids = {row["id"] for row in cursor.fetchall()}
+            session_ids = [row["id"] for row in cursor.fetchall()]
 
             if not session_ids:
                 return 0
 
-            placeholders = ",".join("?" * len(session_ids))
-            conn.execute(
-                f"UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({placeholders})",
-                list(session_ids),
-            )
-
-            for sid in session_ids:
+            for batch in self._session_id_batches(session_ids):
+                placeholders = ",".join("?" * len(batch))
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL "
+                    f"WHERE parent_session_id IN ({placeholders})",
+                    batch,
+                )
                 # DELETE FROM messages is paranoia — the selector's
                 # ``NOT EXISTS`` probe already proved these sessions own no
                 # message rows — but a row inserted between the SELECT and
                 # this statement would otherwise be left dangling, so we
                 # still leave a clean FK state.
                 conn.execute(
-                    "DELETE FROM messages WHERE session_id = ?", (sid,)
+                    f"DELETE FROM messages WHERE session_id IN ({placeholders})",
+                    batch,
                 )
-                conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-                removed_ids.append(sid)
+                conn.execute(
+                    f"DELETE FROM sessions WHERE id IN ({placeholders})",
+                    batch,
+                )
+                removed_ids.extend(batch)
             self._delete_unreferenced_system_prompts(conn)
             return len(session_ids)
 
         count = self._execute_write(_do)
-        for sid in removed_ids:
-            self._remove_session_files(sessions_dir, sid)
+        self._remove_session_files_bulk(sessions_dir, removed_ids)
         return count
 
     @staticmethod
@@ -15157,30 +15205,35 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             cursor = conn.execute(
                 f"SELECT s.id FROM sessions s WHERE {where}", where_params
             )
-            session_ids = {row["id"] for row in cursor.fetchall()}
+            session_ids = [row["id"] for row in cursor.fetchall()]
 
             if not session_ids:
                 return 0
 
-            # Orphan any sessions whose parent is about to be deleted
-            placeholders = ",".join("?" * len(session_ids))
-            conn.execute(
-                f"UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({placeholders})",
-                list(session_ids),
-            )
-
-            for sid in session_ids:
-                conn.execute("DELETE FROM messages WHERE session_id = ?", (sid,))
-                conn.execute("DELETE FROM sessions WHERE id = ?", (sid,))
-                removed_ids.append(sid)
+            # Stay below SQLite's host-parameter limit when large cron/session
+            # histories are pruned in one operation.
+            for batch in self._session_id_batches(session_ids):
+                placeholders = ",".join("?" * len(batch))
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL "
+                    f"WHERE parent_session_id IN ({placeholders})",
+                    batch,
+                )
+                conn.execute(
+                    f"DELETE FROM messages WHERE session_id IN ({placeholders})",
+                    batch,
+                )
+                conn.execute(
+                    f"DELETE FROM sessions WHERE id IN ({placeholders})",
+                    batch,
+                )
+                removed_ids.extend(batch)
             self._delete_unreferenced_system_prompts(conn)
             return len(session_ids)
 
         count = self._execute_write(_do)
-        # Clean up on-disk files outside the DB transaction
-        for sid in removed_ids:
-            self._remove_session_files(sessions_dir, sid)
+        # Clean up on-disk files outside the DB transaction in one pass.
+        self._remove_session_files_bulk(sessions_dir, removed_ids)
         return count
 
     def purge_stale_tool_call_markers(

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1135,6 +1135,89 @@ class TestPruneSessions:
         assert db.get_session("active") is not None
         assert db.count_open_prune_matches(older_than_days=90) == 1
 
+    def test_prune_large_batch_stays_below_sqlite_variable_limit(self, db, tmp_path):
+        # Modern SQLite builds often allow tens of thousands of bind variables,
+        # so pin the historical/default ceiling this regression protects.
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        old_ts = time.time() - 200 * 86400
+        rows = [
+            (f"old_cron_{i}", "cron", old_ts, old_ts + 1)
+            for i in range(1200)
+        ]
+        db._conn.executemany(
+            "INSERT INTO sessions (id, source, started_at, ended_at) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        db.create_session(
+            session_id="recent_child",
+            source="cli",
+            parent_session_id="old_cron_0",
+        )
+        db._conn.commit()
+        removed_dump = tmp_path / "request_dump_old_cron_1199_20260710_120000_123456.json"
+        removed_dump.write_text("{}", encoding="utf-8")
+        survivor_dump = tmp_path / "request_dump_recent_child_20260710_120000_123456.json"
+        survivor_dump.write_text("{}", encoding="utf-8")
+
+        pruned = db.prune_sessions(
+            older_than_days=90,
+            source="cron",
+            sessions_dir=tmp_path,
+        )
+
+        assert pruned == 1200
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE source = 'cron'"
+        ).fetchone()[0] == 0
+        child = db.get_session("recent_child")
+        assert child is not None
+        assert child["parent_session_id"] is None
+        assert not removed_dump.exists()
+        assert survivor_dump.exists()
+
+    def test_delete_empty_large_batch_stays_below_sqlite_variable_limit(self, db):
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        old_ts = time.time() - 200 * 86400
+        rows = [
+            (f"empty_{i}", "cli", old_ts, old_ts + 1)
+            for i in range(1200)
+        ]
+        db._conn.executemany(
+            "INSERT INTO sessions (id, source, started_at, ended_at) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        db._conn.commit()
+
+        deleted = db.delete_empty_sessions()
+
+        assert deleted == 1200
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id LIKE 'empty_%'"
+        ).fetchone()[0] == 0
+
+    def test_prune_empty_ghost_large_batch_stays_below_sqlite_variable_limit(self, db):
+        db._conn.setlimit(sqlite3.SQLITE_LIMIT_VARIABLE_NUMBER, 999)
+        old_ts = time.time() - 2 * 86400
+        rows = [
+            (f"ghost_{i}", "tui", old_ts, old_ts + 1)
+            for i in range(1200)
+        ]
+        db._conn.executemany(
+            "INSERT INTO sessions (id, source, started_at, ended_at) "
+            "VALUES (?, ?, ?, ?)",
+            rows,
+        )
+        db._conn.commit()
+
+        deleted = db.prune_empty_ghost_sessions()
+
+        assert deleted == 1200
+        assert db._conn.execute(
+            "SELECT COUNT(*) FROM sessions WHERE id LIKE 'ghost_%'"
+        ).fetchone()[0] == 0
+
     def test_open_prune_match_count_applies_other_filters(self, db):
         db.create_session(session_id="matching-open", source="cron")
         db.create_session(session_id="other-source", source="cli")


### PR DESCRIPTION
## What does this PR do?

Prevents large session cleanup operations from exceeding SQLite's host-parameter limit.

`prune_sessions()`, `delete_empty_sessions()`, and `prune_empty_ghost_sessions()` previously built one `IN (?, ..., ?)` clause containing every selected session ID. On SQLite builds with the traditional 999-variable ceiling, cleaning more than 999 sessions failed atomically with:

```text
sqlite3.OperationalError: too many SQL variables
```

The cleanup now processes IDs in batches of 900 while preserving the existing single `_execute_write()` transaction. Transcript and request-dump cleanup is also performed in one directory pass instead of one glob scan per deleted session.

## Related Issue

No exact issue or existing PR was found after searching open and closed issues/PRs for `too many SQL variables`, session prune, and SQLite variable-limit variants.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `hermes_state.py`
  - add a shared 900-ID SQLite batching helper;
  - batch the unbounded ID lists used by regular prune, empty-session cleanup, and TUI ghost cleanup;
  - delete messages/session rows set-wise per batch while retaining one outer transaction;
  - remove transcript/request-dump files in one directory pass for large cleanup sets.
- `tests/test_hermes_state.py`
  - add regressions with 1,200 sessions;
  - explicitly lower the connection's variable limit to 999 so the tests are deterministic on modern SQLite builds with higher compile-time limits;
  - verify child orphaning and selective request-dump cleanup remain intact.

The dashboard bulk-delete path was intentionally not changed: its API already caps requests at 500 IDs.

## How to Test

1. Regression proof against current `main` with only the new tests applied:

   ```bash
   HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
     tests/test_hermes_state.py \
     -k large_batch_stays_below_sqlite_variable_limit -q
   ```

   Result: **3 failed**, each with `sqlite3.OperationalError: too many SQL variables`.

2. Run the same command on this branch.

   Result: **3 passed**.

3. Run the affected suite:

   ```bash
   scripts/run_tests.sh \
     tests/test_hermes_state.py \
     tests/hermes_state/test_empty_sweep_archived_transcript_95868.py \
     tests/test_session_system_prompt_dedup.py \
     -q
   ```

   Result: **260 passed, 2 skipped, 0 failed**.

4. Lint and whitespace checks:

   ```bash
   uvx --from 'ruff==0.15.10' ruff check hermes_state.py tests/test_hermes_state.py
   git diff --check
   ```

   Result: both passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues to make sure this isn't a duplicate
- [x] My PR contains only changes related to this bug class
- [ ] I've run the full `pytest tests/ -q` suite — not run; the affected 260-test suite above passed
- [x] I've added tests for my changes
- [x] I've tested on Linux with Python 3.11 and SQLite 3.50.4

### Documentation & Housekeeping

- [x] Documentation update: N/A — no user-facing API/config change
- [x] `cli-config.yaml.example`: N/A — no config change
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A — no workflow/architecture change
- [x] Cross-platform impact considered: batching uses portable SQLite/Python APIs; production behavior is OS-independent
- [x] Tool descriptions/schemas: N/A — no tool schema change

## Risk

Low. Selection semantics and transaction boundaries are unchanged. The main behavioral difference is that unbounded ID lists are split into 900-ID SQL statements inside the same transaction. Existing child-orphaning and file-cleanup contracts remain covered by tests.
