### PR TITLE
feat(skills): Add optional cryptographic execution signing to skill_ledger via GEF-SPEC

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -242,11 +242,7 @@ honcho = ["honcho-ai==2.2.0"]
 # can't break fresh installs.
 supermemory = ["supermemory==3.50.0"]
 mem0 = ["mem0ai==2.0.10"]
-# Image resize recovery for the vision tools. Pillow is now a CORE dependency
-# (see the main `dependencies` list above) since the byte/pixel shrink paths are on
-# the default vision-embed path and the mid-session lazy install deadlocked the
-# CLI under prompt_toolkit (#40490). This extra is kept as a no-op back-compat
-# alias so existing requests for the `vision` extra resolve.
+audit = ["guardclaw==0.8.2"]
 vision = []
 # Kept as a no-op back-compat alias — `ptyprocess` and `pywinpty` are now
 # in the main `dependencies` list (with the same platform markers), so

--- a/tests/test_skill_ledger_signing.py
+++ b/tests/test_skill_ledger_signing.py
@@ -1,0 +1,31 @@
+"""
+tests/test_skill_ledger_signing.py
+
+Tests optional cryptographic execution signing for Hermes skill ledger mutations.
+"""
+
+import os
+import tempfile
+from pathlib import Path
+from tools.skill_ledger import append_entry, verify_skill_ledger_integrity
+
+
+def test_skill_ledger_cryptographic_signing_when_enabled(monkeypatch):
+    with tempfile.TemporaryDirectory() as td:
+        home = Path(td)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setenv("HERMES_AUDIT_SIGNING", "1")
+
+        # Record a curator mutation
+        entry_id = append_entry(
+            action="create",
+            skill="test-skill",
+            actor="curator",
+            evidence={"reason": "Self-improving evolution"},
+        )
+        assert entry_id is not None
+
+        # Verify ledger cryptographic integrity
+        summary = verify_skill_ledger_integrity()
+        if summary.get("chain_valid") is not None:
+            assert summary["chain_valid"] is True

--- a/tests/test_skill_ledger_signing.py
+++ b/tests/test_skill_ledger_signing.py
@@ -1,31 +1,82 @@
 """
 tests/test_skill_ledger_signing.py
 
-Tests optional cryptographic execution signing for Hermes skill ledger mutations.
+Rigorous tests for optional cryptographic execution signing for Hermes skill ledger mutations.
+Verifies persistent key management, multi-mutation chain verification, and tamper detection.
 """
 
 import os
 import tempfile
 from pathlib import Path
+import pytest
 from tools.skill_ledger import append_entry, verify_skill_ledger_integrity
 
 
-def test_skill_ledger_cryptographic_signing_when_enabled(monkeypatch):
+def test_unsigned_ledger_reports_none_chain_valid(monkeypatch):
+    """When signing is not active, verification reports chain_valid as None (not False)."""
+    with tempfile.TemporaryDirectory() as td:
+        home = Path(td)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.delenv("HERMES_AUDIT_SIGNING", raising=False)
+
+        # Append standard unsigned entry
+        entry_id = append_entry(action="create", skill="normal-skill", actor="user")
+        assert entry_id is not None
+
+        # Verify reports unsigned_ledger_active without falsely failing
+        summary = verify_skill_ledger_integrity()
+        assert summary.get("chain_valid") is None
+        assert summary.get("status") == "unsigned_ledger_active"
+
+
+def test_signed_ledger_persistent_key_and_tamper_detection(monkeypatch):
+    """When signing is active, verifies persistent key reuse across mutations and catches tampering."""
+    import importlib.util
+    if importlib.util.find_spec("guardclaw") is None:
+        pytest.skip("guardclaw not installed")
+
     with tempfile.TemporaryDirectory() as td:
         home = Path(td)
         monkeypatch.setenv("HERMES_HOME", str(home))
         monkeypatch.setenv("HERMES_AUDIT_SIGNING", "1")
 
-        # Record a curator mutation
-        entry_id = append_entry(
+        # 1. Record first mutation
+        e1 = append_entry(
             action="create",
-            skill="test-skill",
+            skill="skill-alpha",
             actor="curator",
-            evidence={"reason": "Self-improving evolution"},
+            evidence={"reason": "Autonomous evolution #1"},
         )
-        assert entry_id is not None
+        assert e1 is not None
 
-        # Verify ledger cryptographic integrity
+        # Check key persistence
+        vault_dir = home / "skills" / ".guardclaw_curator_vault"
+        key_file = vault_dir / "curator_signing_key.json"
+        assert key_file.exists()
+        key_data_1 = key_file.read_text(encoding="utf-8")
+
+        # 2. Record second mutation and verify key is persisted and reused
+        e2 = append_entry(
+            action="update",
+            skill="skill-alpha",
+            actor="curator",
+            evidence={"reason": "Autonomous evolution #2"},
+        )
+        assert e2 is not None
+        key_data_2 = key_file.read_text(encoding="utf-8")
+        assert key_data_1 == key_data_2, "Signing key must be persistent across mutations"
+
+        # 3. Positive verification proof
         summary = verify_skill_ledger_integrity()
-        if summary.get("chain_valid") is not None:
-            assert summary["chain_valid"] is True
+        assert summary["chain_valid"] is True
+        assert summary["verified_count"] == 3  # Genesis + Mutation 1 + Mutation 2
+
+        # 4. Negative tamper verification proof
+        ledger_file = vault_dir / "ledger.jsonl"
+        assert ledger_file.exists()
+        original_content = ledger_file.read_text(encoding="utf-8")
+        tampered_content = original_content.replace("Autonomous evolution #1", "Malicious forged reason")
+        ledger_file.write_text(tampered_content, encoding="utf-8")
+
+        tamper_summary = verify_skill_ledger_integrity()
+        assert tamper_summary["chain_valid"] is False, "Tampered ledger must fail cryptographic verification"

--- a/tools/skill_ledger.py
+++ b/tools/skill_ledger.py
@@ -411,10 +411,41 @@ def append_entry(
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a", encoding="utf-8") as fh:
             fh.write(json.dumps(entry, ensure_ascii=False) + "\n")
+
+        # Optional GuardClaw cryptographic verification hook (GEF-SPEC-1.0)
+        if os.environ.get("HERMES_AUDIT_SIGNING"):
+            try:
+                import importlib
+                gc = importlib.import_module("guardclaw")
+                gef_dir = path.parent / ".guardclaw_curator_vault"
+                key_mgr = gc.Ed25519KeyManager.generate()
+                gef_ledger = gc.GEFLedger(
+                    key_manager=key_mgr,
+                    agent_id=f"hermes-{entry['actor']}",
+                    ledger_path=str(gef_dir),
+                )
+                gef_ledger.emit(
+                    record_type=gc.RecordType.TOOL_RESULT,
+                    payload={"action": action, "skill": skill, "entry_id": entry["id"], "actor": entry["actor"]},
+                )
+            except Exception:
+                pass
+
         return entry["id"]
     except Exception as e:
         logger.warning("skill_ledger: failed to append entry (%s) — mutation unaffected", e)
         return None
+
+
+def verify_skill_ledger_integrity() -> Dict[str, Any]:
+    """Verify cryptographic integrity of the skill mutation ledger if signing is active."""
+    try:
+        import importlib
+        gc = importlib.import_module("guardclaw")
+        gef_dir = ledger_path().parent / ".guardclaw_curator_vault"
+        return gc.verify_ledger(str(gef_dir))
+    except Exception as exc:
+        return {"chain_valid": False, "error": str(exc)}
 
 
 def record_mutation(

--- a/tools/skill_ledger.py
+++ b/tools/skill_ledger.py
@@ -418,7 +418,15 @@ def append_entry(
                 import importlib
                 gc = importlib.import_module("guardclaw")
                 gef_dir = path.parent / ".guardclaw_curator_vault"
-                key_mgr = gc.Ed25519KeyManager.generate()
+                gef_dir.mkdir(parents=True, exist_ok=True)
+                key_path = gef_dir / "curator_signing_key.json"
+                if key_path.exists():
+                    loader = getattr(gc.Ed25519KeyManager, "load", gc.Ed25519KeyManager.from_file)
+                    key_mgr = loader(str(key_path))
+                else:
+                    key_mgr = gc.Ed25519KeyManager.generate()
+                    key_mgr.save(str(key_path))
+
                 gef_ledger = gc.GEFLedger(
                     key_manager=key_mgr,
                     agent_id=f"hermes-{entry['actor']}",
@@ -426,10 +434,16 @@ def append_entry(
                 )
                 gef_ledger.emit(
                     record_type=gc.RecordType.TOOL_RESULT,
-                    payload={"action": action, "skill": skill, "entry_id": entry["id"], "actor": entry["actor"]},
+                    payload={
+                        "action": action,
+                        "skill": skill,
+                        "entry_id": entry["id"],
+                        "actor": entry["actor"],
+                        "evidence": entry.get("evidence", {}),
+                    },
                 )
-            except Exception:
-                pass
+            except Exception as exc:
+                logger.warning("skill_ledger: cryptographic signing failed: %s", exc)
 
         return entry["id"]
     except Exception as e:
@@ -439,11 +453,28 @@ def append_entry(
 
 def verify_skill_ledger_integrity() -> Dict[str, Any]:
     """Verify cryptographic integrity of the skill mutation ledger if signing is active."""
+    gef_dir = ledger_path().parent / ".guardclaw_curator_vault"
+    if not os.environ.get("HERMES_AUDIT_SIGNING") and not gef_dir.exists():
+        return {"chain_valid": None, "status": "unsigned_ledger_active"}
+
     try:
         import importlib
         gc = importlib.import_module("guardclaw")
-        gef_dir = ledger_path().parent / ".guardclaw_curator_vault"
-        return gc.verify_ledger(str(gef_dir))
+        key_path = gef_dir / "curator_signing_key.json"
+        pinned_key = None
+        if key_path.exists():
+            loader = getattr(gc.Ed25519KeyManager, "load", gc.Ed25519KeyManager.from_file)
+            key_mgr = loader(str(key_path))
+            pinned_key = key_mgr.public_key_hex
+
+        summary = gc.verify_ledger(str(gef_dir))
+        if pinned_key and summary.get("chain_valid"):
+            if summary.get("signer_public_key") and summary.get("signer_public_key") != pinned_key:
+                summary["chain_valid"] = False
+                summary["failure_detail"] = "signer_key_mismatch"
+        return summary
+    except ImportError:
+        return {"chain_valid": None, "status": "guardclaw_not_installed"}
     except Exception as exc:
         return {"chain_valid": False, "error": str(exc)}
 


### PR DESCRIPTION
### Summary
This PR adds optional cryptographic execution signing to `tools/skill_ledger.py` via the `HERMES_AUDIT_SIGNING` environment variable, implementing the open [GEF-SPEC-1.0](https://github.com/viruswami5511/guardclaw) standard (RFC 8785 canonicalization + Ed25519 hash chaining).

### Why This is Useful
As Hermes autonomously evolves and curates skills in the background, having an offline-verifiable, tamper-evident cryptographic trail of skill mutations ensures provenance and auditability.

- **100% Optional & Zero Overhead**: If `HERMES_AUDIT_SIGNING` is not enabled or `guardclaw` is not installed, the ledger operates exactly as before with zero external dependency requirements.
- **Offline Verifiable**: Ledgers can be verified anytime with `verify_skill_ledger_integrity()`.

### Verification
- [x] All existing `skill_ledger` operations continue to function unchanged.
- [x] Added automated unit test in `tests/test_skill_ledger_signing.py` (passed).