### PR TITLE
fix(desktop): stop completed todo flash on thread open

### DIFF
--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -135,6 +135,15 @@ describe('revisioned snapshots', () => {
     expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
 
+  it('does not replay a completed snapshot when an idle session is opened', () => {
+    const snapshot = { revision: 7, todos: [todo('finished', 'completed')] }
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, false)
+
+    expect($todosBySession.get().s1).toBeUndefined()
+    expect($todoRevisionsBySession.get().s1).toBe(7)
+  })
+
   it('applies an unversioned update after a revisioned snapshot (tool.start merge)', () => {
     setSessionTodos('s1', [todo('a', 'pending'), todo('b', 'pending')], 5)
     setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'pending')])

--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -144,6 +144,16 @@ describe('revisioned snapshots', () => {
     expect($todoRevisionsBySession.get().s1).toBe(7)
   })
 
+  it('preserves existing todos when an idle snapshot is stale', () => {
+    setSessionTodos('s1', [todo('current', 'in_progress')], 7)
+    const current = $todosBySession.get().s1
+
+    restoreSessionTodosFromSnapshot('s1', { revision: 6, todos: [todo('stale', 'completed')] }, false)
+
+    expect($todosBySession.get().s1).toBe(current)
+    expect($todoRevisionsBySession.get().s1).toBe(7)
+  })
+
   it('applies an unversioned update after a revisioned snapshot (tool.start merge)', () => {
     setSessionTodos('s1', [todo('a', 'pending'), todo('b', 'pending')], 5)
     setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'pending')])

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -9,12 +9,12 @@ import { $sessionStates } from './session-states'
 
 /**
  * Live todo list per runtime session, rendered by the composer status stack
- * (the inline transcript panel is gone). Fed from two places:
+ * (the inline transcript panel is gone). Fed from three places:
  *
  * - live `todo` tool events (use-message-stream)
- * - stored-session hydration (desktop-controller) — but only when the list is
- *   still in flight, so reopening an old chat doesn't pin its finished plan
- *   above the composer forever.
+ * - resume/activate snapshots while the backend says the turn is running
+ * - post-turn stored-session hydration — but only for a list that just
+ *   finished, so the final checkmarks can complete their live linger.
  */
 export const $todosBySession = atom<Record<string, TodoItem[]>>({})
 export const $todoRevisionsBySession = atom<Record<string, number>>({})
@@ -147,9 +147,9 @@ export function clearActiveSessionTodos(sid: string) {
   dropSessionTodos(sid, false)
 }
 
-/** Apply a session.resume/activate or todo.updated full snapshot. Idle
- * sessions keep the existing stale-active guard; running sessions restore the
- * active plan because the backend has proved that turn is still live. */
+/** Apply a session.resume/activate or todo.updated full snapshot. Resume and
+ * activate only restore while the backend proves the turn is still running;
+ * an idle snapshot is historical state and must not restart the live linger. */
 export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, running: boolean) {
   const todos = parseTodos(snapshot)
 
@@ -166,10 +166,8 @@ export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, 
     return
   }
 
-  const visible = running ? todos : todosForHydration(todos)
-
-  if (visible !== null) {
-    setSessionTodos(sid, visible, revision)
+  if (running) {
+    setSessionTodos(sid, todos, revision)
   } else if (acceptRevision(sid, revision)) {
     dropSessionTodos(sid, false)
   }


### PR DESCRIPTION
## What does this PR do?

Stops Hermes Desktop from replaying a historical completed task list when an idle conversation is opened.

`session.resume` and `session.activate` carry the latest persisted todo snapshot. The Desktop used to feed completed snapshots into the same four-second linger used for a completion observed live, so opening a thread made old work appear above the composer and then disappear. Idle activation snapshots are now treated as historical presentation state and cleared. Snapshots still restore when the backend reports that the turn is running, and post-turn hydration still owns the live final-checkmark linger.

## Related Issue

Fixes #100652

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Update `apps/desktop/src/store/todos.ts` so idle resume/activate snapshots advance the revision watermark and clear presentation state instead of restarting the completion linger.
- Preserve active snapshot restoration for genuinely running turns and the existing post-turn completion linger.
- Add a regression test that fails on the previous behavior and verifies completed idle snapshots remain hidden.
- Correct the todo-store ownership comments to distinguish live events, active resume snapshots, and post-turn hydration.

## How to Test

1. Complete a Desktop conversation that uses and finishes a task list.
2. Open another conversation, then return to the completed conversation.
3. Confirm the historical completed task list does not appear above the composer; reconnect to a running conversation and confirm its active task list still restores.

Automated regression proof:

- Before the production change, the new test failed because `$todosBySession.s1` contained the completed item.
- After the production change, the same test passes and the accepted revision remains recorded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A: this is a Desktop-only TypeScript change; no Python files changed
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — inline ownership comments updated; standalone docs N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — platform-neutral renderer store logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

No screenshot is required; the regression is a deterministic state transition covered at the store boundary.

- `npm run test:ui`: **701 files, 6,935 tests passed**
- Targeted todo tests: **2 files, 18 tests passed**
- `npm run typecheck`: passed
- `npm run lint`: passed with 0 errors (existing warnings remain)
- `npm run build`: passed
- `npm run test:desktop:platforms`: **143 files passed, 2 skipped; 2,051 tests passed, 6 skipped; 1 unrelated managed SSH updater test failed with status 127**. The identical failure reproduces on an untouched `origin/main` worktree.
