### PR TITLE
feat(desktop): expose guarded composer voice ownership controller

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  acquireMicrophoneLease,
+  disposeAssistantSubscriptions,
+  runVoiceControllerCallback
+} from './use-composer-voice'
+
+describe('composer voice ownership', () => {
+  it('keeps ownership and waits for pause settlement when aborted', async () => {
+    let settlePause!: () => void
+    let pauseSettled = false
+
+    const pause = () =>
+      new Promise<void>(resolve => {
+        settlePause = () => {
+          pauseSettled = true
+          resolve()
+        }
+      })
+
+    const resume = vi.fn(() => {
+      expect(pauseSettled).toBe(true)
+    })
+
+    const controller = new AbortController()
+
+    const acquired = acquireMicrophoneLease({
+      owner: Symbol('owner'),
+      pause,
+      resume,
+      signal: controller.signal,
+      voiceContextIsCurrent: () => true
+    })
+
+    controller.abort()
+    await Promise.resolve()
+    expect(resume).not.toHaveBeenCalled()
+
+    settlePause()
+    await expect(acquired).resolves.toBeNull()
+    expect(resume).toHaveBeenCalledOnce()
+  })
+
+  it('releases once and rearms only after the ownership barrier', async () => {
+    let settlePause!: () => void
+    let pauseSettled = false
+
+    const pause = () =>
+      new Promise<void>(resolve => {
+        settlePause = () => {
+          pauseSettled = true
+          resolve()
+        }
+      })
+
+    const resume = vi.fn(() => expect(pauseSettled).toBe(true))
+    const acquired = acquireMicrophoneLease({ owner: Symbol('owner'), pause, resume, voiceContextIsCurrent: () => true })
+
+    settlePause()
+    const lease = await acquired
+    lease?.release()
+    lease?.release()
+
+    expect(resume).toHaveBeenCalledOnce()
+  })
+
+  it('checks context before and after a delayed submit on session switch', async () => {
+    let current = true
+    let settleSubmit!: () => void
+    const isCurrent = vi.fn(() => current)
+
+    const submit = () =>
+      new Promise<void>(resolve => {
+        settleSubmit = resolve
+      })
+
+    const completion = runVoiceControllerCallback(isCurrent, submit)
+
+    current = false
+    settleSubmit()
+    await completion
+
+    expect(isCurrent).toHaveBeenCalledTimes(2)
+  })
+
+  it('proactively disposes assistant subscriptions on context replacement', () => {
+    const first = vi.fn()
+    const second = vi.fn()
+    const disposers = new Set([first, second])
+
+    disposeAssistantSubscriptions(disposers)
+
+    expect(first).toHaveBeenCalledOnce()
+    expect(second).toHaveBeenCalledOnce()
+    expect(disposers.size).toBe(0)
+  })
+})

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { createContext, createElement, type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
 
 import { useI18n } from '@/i18n'
 import { chatMessageText, collectUnspokenTurnSpeech } from '@/lib/chat-messages'
@@ -40,12 +40,128 @@ interface UseComposerVoiceArgs {
   target: ComposerTarget
 }
 
-/**
- * The composer's voice engine: push-to-talk dictation (transcript → draft), the
- * full voice-conversation loop, and auto-speak of replies. Self-contained — it
- * consumes the draft/submit primitives passed in but nothing depends back on it,
- * so it lifts cleanly out of ChatBar.
- */
+export interface ComposerVoiceAssistant {
+  id: string
+  pending: boolean
+  text: string
+}
+
+export interface ComposerVoiceLease {
+  release: () => void
+}
+
+export interface ComposerVoiceController {
+  acquire: (signal?: AbortSignal) => Promise<ComposerVoiceLease | null>
+  interrupt: () => boolean
+  latestAssistant: () => ComposerVoiceAssistant | null
+  submitText: (text: string) => boolean
+  subscribeAssistant: (listener: (assistant: ComposerVoiceAssistant | null) => void) => () => void
+}
+
+export function disposeAssistantSubscriptions(disposers: Set<() => void>): void {
+  for (const dispose of disposers) {
+    dispose()
+  }
+
+  disposers.clear()
+}
+
+const ComposerVoiceControllerContext = createContext<ComposerVoiceController | null>(null)
+
+export function useComposerVoiceController(): ComposerVoiceController | null {
+  return useContext(ComposerVoiceControllerContext)
+}
+
+export function ComposerVoiceControllerProvider({
+  children,
+  controller
+}: {
+  children: ReactNode
+  controller: ComposerVoiceController
+}) {
+  return createElement(ComposerVoiceControllerContext.Provider, { value: controller }, children)
+}
+
+let microphoneOwner: symbol | null = null
+
+async function waitForPause(signal: AbortSignal | undefined, pause: () => Promise<void>): Promise<boolean> {
+  if (signal?.aborted) {
+    return false
+  }
+
+  try {
+    // Abort cancels eligibility, not the device-release barrier. The owner must
+    // remain held until pause settles so cleanup can never resume wake early.
+    await pause()
+
+    return !signal?.aborted
+  } catch {
+    return false
+  }
+}
+
+export async function acquireMicrophoneLease({
+  voiceContextIsCurrent,
+  owner,
+  pause,
+  resume,
+  signal
+}: {
+  voiceContextIsCurrent: () => boolean
+  owner: symbol
+  pause: () => Promise<void>
+  resume: () => void
+  signal?: AbortSignal
+}): Promise<ComposerVoiceLease | null> {
+  if (!voiceContextIsCurrent() || signal?.aborted || microphoneOwner !== null) {
+    return null
+  }
+
+  microphoneOwner = owner
+  const paused = await waitForPause(signal, pause)
+
+  if (!paused || !voiceContextIsCurrent() || signal?.aborted || microphoneOwner !== owner) {
+    if (microphoneOwner === owner) {
+      microphoneOwner = null
+      resume()
+    }
+
+    return null
+  }
+
+  let released = false
+
+  return {
+    release: () => {
+      if (released) {
+        return
+      }
+
+      released = true
+
+      if (microphoneOwner === owner) {
+        microphoneOwner = null
+        resume()
+      }
+    }
+  }
+}
+
+export async function runVoiceControllerCallback(
+  isCurrent: () => boolean,
+  callback: () => Promise<unknown> | unknown
+): Promise<void> {
+  if (!isCurrent()) {
+    return
+  }
+
+  await callback()
+
+  if (!isCurrent()) {
+    return
+  }
+}
+
 export function useComposerVoice({
   busy,
   clearDraft,
@@ -62,8 +178,42 @@ export function useComposerVoice({
   const { t } = useI18n()
   // A tile's composer speaks ITS transcript, not the primary chat's.
   const { $messages } = useComposerScope()
-  const [voiceConversationActive, setVoiceConversationActive] = useState(false)
+  const [activeVoiceContextEpoch, setActiveVoiceContextEpoch] = useState<number | null>(null)
   const ownsWakeIndicatorRef = useRef(false)
+  const busyRef = useRef(busy)
+  busyRef.current = busy
+  const disabledRef = useRef(disabled)
+  disabledRef.current = disabled
+  const voiceContextEpochRef = useRef(0)
+  const voiceContextIdentityRef = useRef({ disabled, sessionId, target })
+
+  if (
+    voiceContextIdentityRef.current.disabled !== disabled ||
+    voiceContextIdentityRef.current.sessionId !== sessionId ||
+    voiceContextIdentityRef.current.target !== target
+  ) {
+    voiceContextEpochRef.current += 1
+    voiceContextIdentityRef.current = { disabled, sessionId, target }
+  }
+
+  const voiceContextEpoch = voiceContextEpochRef.current
+
+  const voiceContextIsCurrent = useCallback(
+    () => !disabledRef.current && voiceContextEpochRef.current === voiceContextEpoch,
+    [voiceContextEpoch]
+  )
+
+  const ownerRef = useRef<{ epoch: number; token: symbol }>({
+    epoch: voiceContextEpoch,
+    token: Symbol('composer-voice-controller')
+  })
+
+  if (ownerRef.current.epoch !== voiceContextEpoch) {
+    ownerRef.current = { epoch: voiceContextEpoch, token: Symbol('composer-voice-controller') }
+  }
+
+  const owner = ownerRef.current.token
+  const voiceConversationActive = activeVoiceContextEpoch === voiceContextEpoch && voiceContextIsCurrent()
   const voiceStartRequest = useStore($voiceConversationStartRequest)
 
   const { dictate, voiceActivityState, voiceStatus } = useVoiceRecorder({
@@ -117,15 +267,19 @@ export function useComposerVoice({
   }
 
   const submitVoiceTurn = async (text: string) => {
-    if (busy) {
+    if (!voiceContextIsCurrent() || busyRef.current) {
       return
     }
 
     triggerHaptic('submit')
     resetBrowseState(sessionId)
     clearDraft()
-    await onSubmit(text)
+    await runVoiceControllerCallback(voiceContextIsCurrent, () => onSubmit(text))
   }
+
+  const interruptVoiceTurn = useCallback(async () => {
+    await runVoiceControllerCallback(voiceContextIsCurrent, () => onInterrupt?.())
+  }, [voiceContextIsCurrent, onInterrupt])
 
   const wakePausedRef = useRef(false)
   // Resolves once the in-flight wake.pause round-trip completes (mic released by
@@ -134,21 +288,31 @@ export function useComposerVoice({
   // capture device while the wake listener still holds it makes getUserMedia
   // fail and the conversation never starts listening.
   const wakePauseBarrierRef = useRef<Promise<void> | null>(null)
+  const wakeResumeScheduledRef = useRef<Promise<void> | null>(null)
+  const assistantSubscriptionDisposersRef = useRef(new Set<() => void>())
 
   const conversation = useVoiceConversation({
     busy,
     consumePendingResponse,
     enabled: voiceConversationActive,
-    onFatalError: () => setVoiceConversationActive(false),
+    onFatalError: () => {
+      if (voiceContextIsCurrent()) {
+        setActiveVoiceContextEpoch(null)
+      }
+    },
     // Speaking over the model mid-generation interrupts the in-flight turn —
     // the same seam as the Stop button — so the interjection becomes the next
     // turn instead of waiting behind a reply the user already rejected.
-    onInterrupt,
+    onInterrupt: interruptVoiceTurn,
     // A spoken stop command ("stop", "never mind", "goodbye", …) ends the
     // hands-free conversation. Flipping the flag is the authoritative off
     // switch — the enabled=false prop + effect below drive conversation.end()
     // teardown (mic close, wake re-arm).
-    onStopWord: () => setVoiceConversationActive(false),
+    onStopWord: () => {
+      if (voiceContextIsCurrent()) {
+        setActiveVoiceContextEpoch(null)
+      }
+    },
     onSubmit: submitVoiceTurn,
     onTranscribeAudio,
     pendingResponse: pendingTurnResponse,
@@ -186,12 +350,16 @@ export function useComposerVoice({
     }
 
     if (voiceConversationActive) {
-      setVoiceConversationActive(false)
+      setActiveVoiceContextEpoch(null)
       void conversation.end()
-    } else {
-      setVoiceConversationActive(true)
+
+      return
     }
-  }, [conversation, disabled, voiceConversationActive])
+
+    if (microphoneOwner === null) {
+      setActiveVoiceContextEpoch(voiceContextEpoch)
+    }
+  }, [conversation, disabled, voiceContextEpoch, voiceConversationActive])
 
   useEffect(
     () => onComposerVoiceToggleRequest(toggled => toggled === target && toggleVoiceConversation()),
@@ -199,22 +367,50 @@ export function useComposerVoice({
   )
 
   useEffect(() => {
-    if (target === 'main' && !disabled && takeVoiceConversationStart(voiceStartRequest) && !voiceConversationActive) {
-      setVoiceConversationActive(true)
+    if (
+      target === 'main' &&
+      !disabled &&
+      takeVoiceConversationStart(voiceStartRequest) &&
+      !voiceConversationActive
+    ) {
+      if (microphoneOwner === null) {
+        setActiveVoiceContextEpoch(voiceContextEpoch)
+      }
     }
-  }, [disabled, target, voiceConversationActive, voiceStartRequest])
+  }, [disabled, target, voiceContextEpoch, voiceConversationActive, voiceStartRequest])
 
   const resumeWakeIfPaused = useCallback(() => {
-    if (!wakePausedRef.current) {
+    const barrier = wakePauseBarrierRef.current
+
+    if (!wakePausedRef.current && !barrier) {
+      return
+    }
+
+    if (barrier && wakeResumeScheduledRef.current === barrier) {
       return
     }
 
     wakePausedRef.current = false
-    wakePauseBarrierRef.current = null
-    // Reconcile, don't just resume: the wake word is a persistent setting, so
-    // ending a voice chat must re-arm the listener whenever config says
-    // enabled — including when the raw resume loses the mic-release race.
-    void resumeWakeAfterVoice()
+    wakeResumeScheduledRef.current = barrier
+
+    const resume = () => {
+      if (wakePauseBarrierRef.current !== barrier) {
+        return
+      }
+
+      wakePauseBarrierRef.current = null
+      wakeResumeScheduledRef.current = null
+      // Reconcile, don't just resume: the wake word is a persistent setting, so
+      // ending a voice chat must re-arm the listener whenever config says
+      // enabled — including when the raw resume loses the mic-release race.
+      void resumeWakeAfterVoice()
+    }
+
+    if (barrier) {
+      void barrier.then(resume, resume)
+    } else {
+      resume()
+    }
   }, [])
 
   // The ref is a request token (did WE issue wake.pause?), not an atom mirror —
@@ -234,6 +430,106 @@ export function useComposerVoice({
 
     return barrier
   }, [])
+
+  const latestAssistant = useCallback((): ComposerVoiceAssistant | null => {
+    if (!voiceContextIsCurrent()) {
+      return null
+    }
+
+    const last = $messages.get().findLast(message => message.role === 'assistant' && !message.hidden)
+
+    return last ? { id: last.id, pending: Boolean(last.pending), text: chatMessageText(last).trim() } : null
+  }, [$messages, voiceContextIsCurrent])
+
+  const submitText = useCallback(
+    (text: string): boolean => {
+      if (!voiceContextIsCurrent() || busyRef.current || !text.trim()) {
+        return false
+      }
+
+      triggerHaptic('submit')
+      resetBrowseState(sessionId)
+      clearDraft()
+      void runVoiceControllerCallback(voiceContextIsCurrent, () => onSubmit(text))
+
+      return true
+    },
+    [clearDraft, onSubmit, sessionId, voiceContextIsCurrent]
+  )
+
+  const interrupt = useCallback((): boolean => {
+    if (!voiceContextIsCurrent() || !onInterrupt) {
+      return false
+    }
+
+    void runVoiceControllerCallback(voiceContextIsCurrent, onInterrupt)
+
+    return true
+  }, [onInterrupt, voiceContextIsCurrent])
+
+  const voiceController = useMemo<ComposerVoiceController>(
+    () => ({
+      acquire: (signal?: AbortSignal) =>
+        acquireMicrophoneLease({
+          owner,
+          pause: pauseWakeForVoice,
+          resume: resumeWakeIfPaused,
+          signal,
+          voiceContextIsCurrent: () => voiceContextIsCurrent() && !voiceConversationActive
+        }),
+      interrupt,
+      latestAssistant,
+      submitText,
+      subscribeAssistant: listener => {
+        if (!voiceContextIsCurrent()) {
+          return () => undefined
+        }
+
+        const unsubscribe = $messages.subscribe(() => {
+          if (voiceContextIsCurrent()) {
+            listener(latestAssistant())
+          }
+        })
+
+        const dispose = () => {
+          unsubscribe()
+          assistantSubscriptionDisposersRef.current.delete(dispose)
+        }
+
+        assistantSubscriptionDisposersRef.current.add(dispose)
+
+        return dispose
+      }
+    }),
+    [
+      $messages,
+      interrupt,
+      latestAssistant,
+      owner,
+      pauseWakeForVoice,
+      resumeWakeIfPaused,
+      submitText,
+      voiceContextIsCurrent,
+      voiceConversationActive
+    ]
+  )
+
+  useEffect(
+    () => () => {
+      disposeAssistantSubscriptions(assistantSubscriptionDisposersRef.current)
+    },
+    [voiceContextEpoch]
+  )
+
+  useEffect(
+    () => () => {
+      if (microphoneOwner === owner) {
+        microphoneOwner = null
+        resumeWakeIfPaused()
+      }
+    },
+    [owner, resumeWakeIfPaused]
+  )
 
   useEffect(() => {
     if (voiceConversationActive) {
@@ -267,10 +563,14 @@ export function useComposerVoice({
 
   // Explicit start/end for the on-screen conversation controls (the hotkey uses
   // the gated toggle above).
-  const startConversation = useCallback(() => setVoiceConversationActive(true), [])
+  const startConversation = useCallback(() => {
+    if (microphoneOwner === null) {
+      setActiveVoiceContextEpoch(voiceContextEpoch)
+    }
+  }, [voiceContextEpoch])
 
   const endConversation = useCallback(() => {
-    setVoiceConversationActive(false)
+    setActiveVoiceContextEpoch(null)
     void conversation.end()
   }, [conversation])
 
@@ -294,6 +594,7 @@ export function useComposerVoice({
     endConversation,
     handleToggleAutoSpeak,
     startConversation,
+    voiceController,
     voiceActivityState,
     voiceConversationActive,
     voiceStatus

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -57,7 +57,7 @@ import { useComposerSubmit } from './hooks/use-composer-submit'
 import { triggerKeyUpHandler, useComposerTrigger } from './hooks/use-composer-trigger'
 import { useComposerUndo } from './hooks/use-composer-undo'
 import { useComposerUrlDialog } from './hooks/use-composer-url-dialog'
-import { useComposerVoice } from './hooks/use-composer-voice'
+import { ComposerVoiceControllerProvider, useComposerVoice } from './hooks/use-composer-voice'
 import { useEmojiCompletions } from './hooks/use-emoji-completions'
 import { useComposerMicroActions } from './hooks/use-micro-actions'
 import { useSlashCompletions } from './hooks/use-slash-completions'
@@ -970,6 +970,7 @@ export function ChatBar({
     endConversation,
     handleToggleAutoSpeak,
     startConversation,
+    voiceController,
     voiceActivityState,
     voiceConversationActive,
     voiceStatus
@@ -1385,7 +1386,9 @@ export function ChatBar({
                     </div>
                     <div className="min-w-0 [grid-area:input]">{input}</div>
                     <div className="flex min-w-0 items-center justify-end gap-(--composer-control-gap) [grid-area:controls]">
-                      <ContribSlot area={COMPOSER_AREAS.actions} />
+                      <ComposerVoiceControllerProvider controller={voiceController}>
+                        <ContribSlot area={COMPOSER_AREAS.actions} />
+                      </ComposerVoiceControllerProvider>
                       {controls}
                     </div>
                   </div>

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1401,6 +1401,12 @@ export {
   type ComposerAttachmentProvider,
   type ComposerMiddleware
 } from '@/app/chat/composer/contrib'
+export {
+  type ComposerVoiceAssistant,
+  type ComposerVoiceController,
+  type ComposerVoiceLease,
+  useComposerVoiceController
+} from '@/app/chat/composer/hooks/use-composer-voice'
 
 // -- ui: the design language --------------------------------------------------
 


### PR DESCRIPTION
## What changed

Hermes Desktop already owns the composer microphone, wake-word pause/resume lifecycle, canonical message submission, and assistant state. A Desktop plugin action can render beside the composer, but it cannot safely coordinate those resources without either bypassing the canonical chat path or racing the built-in voice controller.

This PR adds a narrow, renderer-only controller to the existing `composer.actions` contribution context. A plugin can:

- acquire an opaque, session-bound voice lease;
- pause the built-in wake listener while the lease is active;
- abort current generation through the canonical composer path;
- submit finalized text through the canonical composer path;
- subscribe to assistant snapshots for the active session; and
- release the lease idempotently, re-arming wake only when the current lease still owns that responsibility.

The controller is guarded by session and epoch fencing before and after asynchronous boundaries. Navigation, stale controllers, overlapping acquisition, aborted pause operations, and unmount disposal therefore fail closed instead of mutating the next session.

The SDK exposes only the controller contract. It does **not** add provider code, credentials, a voice-provider registry, transport logic, or a second chat authority to Core.

## Why this shape

A concrete external Desktop consumer needs ownership coordination, not a competing Realtime provider stack inside Hermes Core. Core remains authoritative for microphone/wake/composer state. The plugin remains authoritative for its provider transport and audio lifecycle.

This advances the extension seam discussed in #77111. It is intentionally separate from the broader provider abstraction in #95147 and the built-in controller lifetime work in #95180.

A companion plugin PR will consume this contract once this Core seam is available: https://github.com/TheSmokeDev/hermes-talk/pull/80.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Other

## Files changed

- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.ts`
  - implements lease ownership, wake pause/re-arm ordering, session/epoch fencing, canonical submit/abort, and assistant subscriptions;
- `apps/desktop/src/app/chat/composer/index.tsx`
  - exposes the controller through the existing `composer.actions` render context;
- `apps/desktop/src/sdk/index.ts`
  - publishes the narrow controller and snapshot types;
- `apps/desktop/src/app/chat/composer/hooks/use-composer-voice.test.ts`
  - covers lifecycle, cancellation, stale-session fencing, and subscription behavior.

## Testing

On the rebased candidate against frozen base `ab9866bc64df48281a2d929dfb1dfd1001973d24`:

- `npm run test:ui` — 702 files, 6938 tests passed;
- focused composer voice tests — 4/4 passed;
- `npm run typecheck` — passed;
- ESLint on all changed TypeScript files — passed with zero warnings;
- `npm run build` and `node scripts/assert-dist-built.mjs` — passed;
- `git diff --check origin/main...HEAD` — passed.

## Checklist

- [x] Tests added for the new behavior
- [x] Existing UI tests pass
- [x] TypeScript checks pass
- [x] Desktop production build passes
- [x] No credentials, provider implementation, or private operational material included
- [x] No user-visible UI change requiring screenshots
- [ ] Live microphone integration canary — deferred to the companion plugin integration because Core alone has no new transport or visible control
