### PR TITLE
fix(tools): resolve hermes CLI beside the interpreter in bot_mode_dm deliveries

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 import pytest
 
-from tools import bot_mode_dm, bot_mode_probe
+from tools import bot_mode_dm, bot_mode_probe, bot_relay
 
 
 @pytest.fixture(autouse=True)
@@ -234,6 +234,9 @@ def _runner_author(command):
 
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
+    # These assertions target the -p/turn-args shape; pin the entrypoint resolution
+    # so the test stays hermetic across venvs that do/don't expose a sibling script.
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     home = _managed_home(tmp_path, teammates=("researcher",))
     agent = _FakeAgent(home, title="Bot Chat")
 
@@ -295,6 +298,7 @@ def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
     tool-side roster (read from the machine-root config) validated the
     target."""
     calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     home = _managed_home(tmp_path, peers=("spark",))
     # A reviewer-profile gateway context: the agent's session db lives under
     # that profile's home, so _agent_home() resolves there while the
@@ -316,6 +320,7 @@ def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
 
 def test_peer_delivery_command(tmp_path, monkeypatch):
     calls = _capture_spawn(monkeypatch)
+    monkeypatch.setattr(bot_relay, "_hermes_cli", lambda: "hermes")
     monkeypatch.setattr("socket.gethostname", lambda: "eri-mac.local")
     home = _managed_home(tmp_path, peers=("spark",))
     agent = _FakeAgent(home, title="Bot Chat")
@@ -339,6 +344,40 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
     assert mode == "stdin"
     assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark"]
+
+
+def test_delivery_pins_the_hermes_entrypoint_beside_this_interpreter(tmp_path, monkeypatch):
+    """A background delivery must not rely on PATH: the runner's service context
+    lacks the gateway's venv bin dir, so a bare ``hermes`` resolves to a system
+    install whose shebang picks the wrong interpreter and dies on import (#108628).
+    Both transports must invoke the entrypoint beside this interpreter instead."""
+    venv_bin = tmp_path / "venv" / ("Scripts" if sys.platform == "win32" else "bin")
+    venv_bin.mkdir(parents=True)
+    hermes_entry = venv_bin / ("hermes.exe" if sys.platform == "win32" else "hermes")
+    hermes_entry.write_text("#!/bin/sh\n", encoding="utf-8")
+    monkeypatch.setattr(sys, "executable", str(venv_bin / "python3"))
+
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",), peers=("spark",))
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="ping", agent=agent)
+    )
+    assert result["status"] == "sent"
+    mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
+    assert mode == "query-file"
+    assert transport_argv[0] == str(hermes_entry)
+    assert transport_argv[1:] == ["-p", "researcher", "chat", "--in", "~", "-c", "Bot Chat",
+                                  "--create-if-missing", "-Q"]
+
+    result2 = json.loads(
+        bot_mode_dm.message_agent_tool(target="spark", message="ping", agent=agent)
+    )
+    assert result2["status"] == "sent"
+    mode, _dm_file, transport_argv = _runner_parts(calls[1]["command"])
+    assert mode == "stdin"
+    assert transport_argv == [str(hermes_entry), "-p", "default", "peer", "dm", "spark"]
 
 
 def test_peer_delivery_author_carries_the_sender_hostname_and_local_stays_bare(tmp_path, monkeypatch):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -182,7 +182,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
             BOT_CHAT_TITLE, _handle, _hermes_root, _peers, _profile_name as _self_profile_name, _roster,
             is_bot_mode_managed,
         )
-        from tools.bot_relay import BOT_CHAT_TURN_ARGS
+        from tools.bot_relay import BOT_CHAT_TURN_ARGS, _hermes_cli
 
         if _session_title(agent) != BOT_CHAT_TITLE:
             return _err("message_agent is only available in a Bot Mode 'Bot Chat' session. "
@@ -230,7 +230,12 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         # Pin the registry-owning profile: `hermes peer` resolves bot_peers via the profile-scoped
         # load_config(), while the roster above reads the machine-root config — the CLI must run
         # in that same profile or a secondary-profile bot sees an empty registry.
-        return _start_delivery(["hermes", "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
+        # The delivery runs in a background service context whose PATH lacks the gateway's
+        # venv bin dir, so a bare "hermes" resolves to a system install and dies on import
+        # under the wrong interpreter (#108628). _hermes_cli pins the entrypoint beside
+        # this interpreter; _delivery_lock/_local_delivery_home match argv[0] by basename,
+        # so the absolute path stays compatible.
+        return _start_delivery([_hermes_cli(), "-p", _self_profile_name(root), "peer", "dm", dm_target], content,
                                f"@{peer_profile or peer_name} on peer '{peer_name}'", stdin_file=True,
                                author=peer_author, **delivery)
 
@@ -251,7 +256,7 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
         return _roster_err(f"No teammate named '{raw_target}' on this install, on a connected "
                            "machine, or on a registered peer. Pick a name from the roster "
                            "(roles are listed in your system prompt).")
-    return _start_delivery(["hermes", "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
+    return _start_delivery([_hermes_cli(), "-p", resolved, *BOT_CHAT_TURN_ARGS], content, f"@{_handle(resolved)}",
                            stdin_file=False, profile_home=roster_homes[resolved], author=author, **delivery)
 
 


### PR DESCRIPTION
## What does this PR do?

Bot-to-bot `message_agent` delivery builds both transport argvs — the local-teammate `hermes -p <bot> chat …` turn and the peer `hermes -p <default> peer dm …` transport — with a bare `"hermes"` as argv[0]. Since #96631 the delivery runner spawns via `terminal_tool(..., _host_local=True)`, which uses an isolated host-local environment cache that does **not** inherit the gateway's PATH. On docker/service installs (venv at `/opt/hermes/.venv`, no `hermes` on the runner's minimal PATH) every delivery therefore acks `status: queued` and then the background runner exits 1 with `FileNotFoundError: [Errno 2] No such file or directory: 'hermes'` (#100662).

This PR resolves the CLI at both argv construction sites in `tools/bot_mode_dm.py` using `bot_relay._hermes_cli()` — the exact resolver the relay's deliver RPC adopted for the same class of failure in #93590 (venv sibling of this gateway's interpreter → `shutil.which` → bare-name fallback). The runner is spawned with the gateway's own `sys.executable`, so the sibling lookup is correct in the runner's context too. The turn-lock matcher in `_delivery_lock()` already matches argv[0] by basename (see its comment referencing #93590), so resolved absolute paths — and `hermes.exe` on Windows — take the per-profile lock exactly as before.

## Related Issue

Fixes #100662

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/bot_mode_dm.py`: resolve the delivery CLI via `bot_relay._hermes_cli()` in `message_agent_tool` and use it for both argv construction sites (peer dm and local teammate chat) instead of the bare `"hermes"`.
- `tests/tools/test_bot_mode_dm.py`: existing transport-argv assertions now expect `_hermes_cli()` as argv[0] — they previously pinned the bare name, i.e. they encoded the buggy behavior; added `test_delivery_resolves_venv_sibling_cli`, which fakes a docker-style venv (no PATH hit, sibling entrypoint beside `sys.executable`) and asserts both transports carry the absolute sibling path.

## How to Test

1. `python -m pytest tests/tools/test_bot_mode_dm.py tests/tools/test_bot_relay_windows_paths.py tests/tools/test_bot_turn_lock.py tests/tools/test_bot_retry_policy.py tests/tools/test_bot_dm_payload_cache.py tests/tools/test_bot_mode_probe.py tests/tools/test_bot_relay.py tests/hermes_cli/test_chat_query_file.py -q` → Observed result: **148 passed, 1 skipped** (includes the new regression test).
2. Simulated the reporter's docker shape without docker: monkeypatched `sys.executable` to a fake venv with a `hermes` sibling and no PATH resolution — both the local and peer transports now embed the absolute sibling path (new test), where before this PR they embedded bare `hermes` and died with ENOENT under the isolated runner env.
3. Fallback behavior is unchanged and covered by the existing `test_bot_relay_windows_paths.py` suite (sibling → `shutil.which` → bare name).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (Windows covered: resolver checks `hermes.exe`, lock matcher splits on both separators)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A