### PR TITLE
fix(doctor): stop disabled memory files from appearing active

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -409,12 +409,12 @@ def _doctor_memory_config(hermes_home: Path | None = None) -> dict:
     """Return the effective memory section used by doctor diagnostics."""
     home = hermes_home if hermes_home is not None else HERMES_HOME
     try:
-        from hermes_cli.config import read_user_config_raw
+        from hermes_cli.config import _expand_env_vars, read_user_config_raw
 
         config_path = home / "config.yaml"
         if not config_path.exists():
             return {}
-        config = read_user_config_raw(config_path)
+        config = _expand_env_vars(read_user_config_raw(config_path))
         try:
             from hermes_cli import managed_scope
 

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -405,6 +405,28 @@ def check_info(text: str):
     print(f"    {color('→', Colors.CYAN)} {text}")
 
 
+def _doctor_memory_config(hermes_home: Path | None = None) -> dict:
+    """Return the effective memory section used by doctor diagnostics."""
+    home = hermes_home if hermes_home is not None else HERMES_HOME
+    try:
+        from hermes_cli.config import read_user_config_raw
+
+        config_path = home / "config.yaml"
+        if not config_path.exists():
+            return {}
+        config = read_user_config_raw(config_path)
+        try:
+            from hermes_cli import managed_scope
+
+            config = managed_scope.apply_managed_overlay(config)
+        except Exception:
+            pass
+        section = config.get("memory") if isinstance(config, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception:
+        return {}
+
+
 # ── state.db health/stats thresholds (advisory only — module constants,
 # deliberately NOT config: doctor warnings are guidance, not policy) ──
 STATE_DB_SIZE_WARN_BYTES = 1 * 1024 * 1024 * 1024   # 1 GiB logical size
@@ -1980,8 +2002,19 @@ def run_doctor(args):
     else:
         check_warn(f"{_DHH} not found", "(will be created on first use)")
     
-    # Check expected subdirectories
-    expected_subdirs = ["cron", "sessions", "logs", "skills", "memories"]
+    from tools.memory_tool import get_builtin_memory_store_flags
+
+    _memory_config = _doctor_memory_config(hermes_home)
+    _memory_enabled, _user_profile_enabled = get_builtin_memory_store_flags(
+        {"memory": _memory_config}
+    )
+
+    # Check expected subdirectories. The built-in file store does not create or
+    # consume memories/ when both targets are disabled, so stale migration files
+    # are not an active diagnostic surface.
+    expected_subdirs = ["cron", "sessions", "logs", "skills"]
+    if _memory_enabled or _user_profile_enabled:
+        expected_subdirs.append("memories")
     for subdir_name in expected_subdirs:
         subdir_path = hermes_home / subdir_name
         if subdir_path.exists():
@@ -2016,22 +2049,28 @@ def run_doctor(args):
             check_ok(f"Created {_DHH}/SOUL.md with basic template")
             fixed_count += 1
     
-    # Check memory directory
+    # Check only enabled built-in stores. External providers are additive, but
+    # users can explicitly disable either legacy file target; stale files left
+    # by a migration must not be presented as active memory usage.
     memories_dir = hermes_home / "memories"
-    if memories_dir.exists():
+    if not (_memory_enabled or _user_profile_enabled):
+        check_info("Built-in memory files disabled by config")
+    elif memories_dir.exists():
         check_ok(f"{_DHH}/memories/ directory exists")
         memory_file = memories_dir / "MEMORY.md"
         user_file = memories_dir / "USER.md"
-        if memory_file.exists():
-            size = len(memory_file.read_text(encoding="utf-8").strip())
-            check_ok(f"MEMORY.md exists ({size} chars)")
-        else:
-            check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
-        if user_file.exists():
-            size = len(user_file.read_text(encoding="utf-8").strip())
-            check_ok(f"USER.md exists ({size} chars)")
-        else:
-            check_info("USER.md not created yet (will be created when the agent first writes a memory)")
+        if _memory_enabled:
+            if memory_file.exists():
+                size = len(memory_file.read_text(encoding="utf-8").strip())
+                check_ok(f"MEMORY.md exists ({size} chars)")
+            else:
+                check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
+        if _user_profile_enabled:
+            if user_file.exists():
+                size = len(user_file.read_text(encoding="utf-8").strip())
+                check_ok(f"USER.md exists ({size} chars)")
+            else:
+                check_info("USER.md not created yet (will be created when the agent first writes a memory)")
     else:
         check_warn(f"{_DHH}/memories/ not found", "(will be created on first use)")
         if should_fix:
@@ -3243,21 +3282,7 @@ def run_doctor(args):
         check_warn("No GITHUB_TOKEN", f"(60 req/hr rate limit — set in {_DHH}/.env for better rates)")
 
     _section("Memory Provider")
-    _active_memory_provider = ""
-    try:
-        from hermes_cli.config import read_user_config_raw as _read_raw_mem
-        _mem_cfg_path = HERMES_HOME / "config.yaml"
-        if _mem_cfg_path.exists():
-            # Raw-file diagnostic (+ managed overlay below, unchanged).
-            _raw_cfg = _read_raw_mem(_mem_cfg_path)
-            try:
-                from hermes_cli import managed_scope
-                _raw_cfg = managed_scope.apply_managed_overlay(_raw_cfg)
-            except Exception:
-                pass
-            _active_memory_provider = (_raw_cfg.get("memory") or {}).get("provider", "")
-    except Exception:
-        pass
+    _active_memory_provider = _doctor_memory_config().get("provider", "")
 
     if not _active_memory_provider:
         check_ok("Built-in memory active", "(no external provider configured — this is fine)")

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -285,18 +285,34 @@ def test_doctor_reports_vercel_backend_diagnostics(monkeypatch, tmp_path):
 class TestDoctorMemoryProviderSection:
     """The ◆ Memory Provider section should respect memory.provider config."""
 
-    def _make_hermes_home(self, tmp_path, provider=""):
+    def _make_hermes_home(self, tmp_path, provider="", memory_config=None):
         """Create a minimal HERMES_HOME with config.yaml."""
         home = tmp_path / ".hermes"
         home.mkdir(parents=True, exist_ok=True)
         import yaml
-        config = {"memory": {"provider": provider}} if provider else {"memory": {}}
+        config = dict(memory_config or {})
+        if provider:
+            config["provider"] = provider
+        config = {"memory": config}
         (home / "config.yaml").write_text(yaml.dump(config))
         return home
 
-    def _run_doctor_and_capture(self, monkeypatch, tmp_path, provider=""):
+    def _run_doctor_and_capture(
+        self,
+        monkeypatch,
+        tmp_path,
+        provider="",
+        *,
+        memory_config=None,
+        stale_builtin_files=False,
+    ):
         """Run doctor and capture stdout."""
-        home = self._make_hermes_home(tmp_path, provider)
+        home = self._make_hermes_home(tmp_path, provider, memory_config)
+        if stale_builtin_files:
+            memories = home / "memories"
+            memories.mkdir()
+            (memories / "MEMORY.md").write_text("stale memory", encoding="utf-8")
+            (memories / "USER.md").write_text("stale user", encoding="utf-8")
         monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
         monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
         monkeypatch.setattr(doctor_mod, "_DHH", str(home))
@@ -339,6 +355,29 @@ class TestDoctorMemoryProviderSection:
         out = self._run_doctor_and_capture(monkeypatch, tmp_path, provider="mem0")
         assert "Memory Provider" in out
         assert "Built-in memory active" not in out
+
+    @pytest.mark.parametrize(
+        ("memory_enabled", "user_profile_enabled"),
+        [(False, False), (False, True), (True, False)],
+    )
+    def test_disabled_builtin_stores_do_not_report_stale_files(
+        self, monkeypatch, tmp_path, memory_enabled, user_profile_enabled
+    ):
+        out = self._run_doctor_and_capture(
+            monkeypatch,
+            tmp_path,
+            provider="mnemosyne",
+            memory_config={
+                "memory_enabled": memory_enabled,
+                "user_profile_enabled": user_profile_enabled,
+            },
+            stale_builtin_files=True,
+        )
+
+        assert ("MEMORY.md exists" in out) is memory_enabled
+        assert ("USER.md exists" in out) is user_profile_enabled
+        if not memory_enabled and not user_profile_enabled:
+            assert "Built-in memory files disabled by config" in out
 
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -379,6 +379,25 @@ class TestDoctorMemoryProviderSection:
         if not memory_enabled and not user_profile_enabled:
             assert "Built-in memory files disabled by config" in out
 
+    def test_builtin_store_flags_expand_environment_references(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("MEMORY_ENABLED", "true")
+        out = self._run_doctor_and_capture(
+            monkeypatch,
+            tmp_path,
+            provider="mnemosyne",
+            memory_config={
+                "memory_enabled": "${MEMORY_ENABLED}",
+                "user_profile_enabled": False,
+            },
+            stale_builtin_files=True,
+        )
+
+        assert "MEMORY.md exists" in out
+        assert "USER.md exists" not in out
+        assert "Built-in memory files disabled by config" not in out
+
 
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` no longer reports stale `MEMORY.md` or `USER.md` files as active memory stores after users disable those built-in targets in favor of Mnemosyne or another external provider. The diagnostic now uses the same built-in store flags as agent startup while preserving the active provider health check.

### Symptom

The Directory Structure section printed character counts for stale built-in memory files even when `memory.memory_enabled` and `memory.user_profile_enabled` disabled those stores.

### Impact

Users migrating to an external provider could mistake leftover compatibility files and their legacy character budgets for the active provider's storage usage.

### Bug Cause

**Trigger:** `hermes_cli/doctor.py` / `run_doctor()` / Directory Structure memory checks

**Causal chain:**
1. A profile disables one or both built-in memory targets and retains stale files under `memories/` after migration.
2. Doctor checks only whether each file exists and ignores the configured built-in store flags.
3. Doctor prints the stale file's character count as though that store were active.

**Why it is wrong:** Agent startup already gates each built-in store with `memory_enabled` and `user_profile_enabled`, so the diagnostic disagreed with runtime behavior.

**Working sibling / contrast:** The Memory Provider section already reads the effective provider configuration and correctly reports the active external provider.

**Ruled out:** The external provider health check is not the source of the stale size output; the misleading lines come from the earlier Directory Structure file-existence branch.

### Fix

Centralize effective memory config resolution for doctor, reuse the built-in store flag resolver, and only inspect enabled file targets. When both built-in targets are disabled, doctor omits the legacy directory requirement and reports that the built-in files are disabled.

## Related Issue

Closes #100668

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/doctor.py` - align built-in memory file diagnostics with effective store flags and reuse effective memory config for provider health.
- `tests/hermes_cli/test_doctor.py` - cover fully and partially disabled stores with stale legacy files.

## How to Test

1. Configure an external memory provider and disable one or both built-in stores.
2. Leave stale `MEMORY.md` and `USER.md` files under the profile's `memories/` directory.
3. Run the focused doctor tests and confirm disabled targets are omitted while enabled targets remain visible.

```bash
scripts/run_tests.sh tests/hermes_cli/test_doctor.py -q
```

Result: 71 passed.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this fix.
- [x] I've run the repository test entry on the relevant doctor tests and all tests pass.
- [x] I've added tests for my changes.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update is N/A because behavior and configuration keys are unchanged.
- [x] `cli-config.yaml.example` update is N/A because no config keys changed.
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because architecture and workflows are unchanged.
- [x] I've considered cross-platform impact; the change uses platform-independent config and path APIs.
- [x] Tool description and schema updates are N/A because no model tool behavior changed.
