### PR TITLE
fix(matrix): accept is_voice kwarg in send_voice to match base class contract

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1500,7 +1500,8 @@ class MatrixAdapter(BasePlatformAdapter):
 
     async def send_voice(
         self, chat_id: str, audio_path: str, caption: Optional[str] = None, reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None) -> SendResult:
+        metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False) -> SendResult:
         """Upload audio as an MSC3245 voice message. Voice bubbles need Ogg/Opus but callers pass any
         format (e.g. TTS output), so transcode here — best-effort: without ffmpeg the original is sent."""
         converted_path: Optional[str] = None


### PR DESCRIPTION
## Summary

The base class delivery loop passes `is_voice=` to `adapter.send_voice()`, but the Matrix adapter's `send_voice()` did not accept that keyword argument. This caused a `TypeError` that silently dropped all audio/TTS attachments on Matrix.

## Root Cause

Gateway logs showed:
```
[Matrix] Delivering 1 non-image MEDIA attachment(s)
[Matrix] Error sending media: MatrixAdapter.send_voice() got an unexpected keyword argument 'is_voice'
```

The base class at `gateway/run.py:24328` calls:
```python
await adapter.send_voice(
    chat_id=event.source.chat_id,
    audio_path=media_path,
    metadata=_thread_meta,
    is_voice=is_voice,
)
```

But the Matrix adapter's `send_voice()` signature lacked the `is_voice` parameter.

## Fix

Added `is_voice: bool = False` to the Matrix adapter's `send_voice()` signature. The parameter is unused internally since the Matrix adapter handles voice transcoding (to Ogg/Opus for MSC3245) independently — it just needs to accept the kwarg without crashing.

## Test Plan

- Verified TTS voice notes now deliver correctly on Matrix after the fix
- Voice notes render as voice bubbles (MSC3245) in Element
- Gateway restart required to pick up the plugin change