### PR TITLE
feat(simplex): make delivery correlated and complete the messaging lifecycle

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -934,20 +934,10 @@ class GatewayAuthorizationMixin:
             if normalized_user_id:
                 check_ids.add(normalized_user_id)
 
-        # SimpleX: SIMPLEX_ALLOWED_USERS accepts either the numeric contactId
-        # or the contact's display name. The adapter sets user_id=contactId for
-        # stability across renames, but the SimpleX UI never surfaces the
-        # numeric id — operators only see display names, so that's what they
-        # naturally put in the env var. Match both so the allowlist works
-        # regardless of which form was chosen.
-        # Plugin platform: compare by value since Platform.SIMPLEX is not a
-        # hardcoded enum member (it's a dynamic plugin platform).
-        if (
-            source.platform is not None
-            and source.platform.value == "simplex"
-            and source.user_name
-        ):
-            check_ids.add(source.user_name)
+        # SimpleX authorization deliberately uses only ``user_id``, which the
+        # adapter sets to the daemon's immutable numeric contactId. Remote
+        # profile/display names are mutable and therefore cannot safely grant
+        # access when they collide with an allowlist entry.
 
         # Buzz (Nostr-based): BUZZ_ALLOWED_USERS accepts npub or hex, but
         # inbound event pubkeys are always 64-char hex. Decode npub entries

--- a/gateway/edit_supersede.py
+++ b/gateway/edit_supersede.py
@@ -1,0 +1,145 @@
+"""Gateway-owned correlation of inbound edits with queued and active turns."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from gateway.event_sidecars import replace_correlated_event_text
+
+
+logger = logging.getLogger(__name__)
+
+
+class GatewayEditSupersedeMixin:
+    """Bounded owner for queue replacement and in-flight edit redirection."""
+
+    def _replace_queued_message(
+        self,
+        session_key: str,
+        adapter: Any,
+        message_id: str,
+        new_text: str,
+    ) -> bool:
+        """Replace the first matching event in debounce, head, or overflow."""
+        replace_debounced = getattr(adapter, "replace_text_debounce_message", None)
+        if callable(replace_debounced) and replace_debounced(
+            session_key, message_id, new_text
+        ):
+            return True
+
+        pending_slot = (
+            getattr(adapter, "_pending_messages", None)
+            if adapter is not None
+            else None
+        )
+        if isinstance(pending_slot, dict):
+            pending_event = pending_slot.get(session_key)
+            if pending_event is not None and replace_correlated_event_text(
+                pending_event, message_id, new_text
+            ):
+                return True
+
+        state = self._peek_session_state(session_key)
+        overflow = state.conversation.queued_events if state else []
+        return any(
+            replace_correlated_event_text(event, message_id, new_text)
+            for event in overflow
+        )
+
+    def _handle_edit_supersede(
+        self,
+        event: Any,
+        session_key: str,
+        adapter: Any,
+    ) -> bool:
+        """Supersede a queued or active turn correlated to an inbound edit."""
+        is_edit = bool(
+            event.metadata.get("is_edit", False) if event.metadata else False
+        )
+        message_id = event.message_id
+        if not is_edit or not message_id:
+            return False
+
+        if self._replace_queued_message(
+            session_key,
+            adapter,
+            message_id,
+            event.text or "",
+        ):
+            logger.info(
+                "Edit supersede — replaced queued message_id=%s for session %s",
+                message_id,
+                session_key,
+            )
+            return True
+
+        state = self._peek_session_state(session_key)
+        if state and (
+            state.turn.active_message_id == message_id
+            or message_id in state.turn.active_message_ids
+        ):
+            running_agent = state.turn.agent
+            pending_sentinel = self._agent_pending_sentinel
+            if running_agent is pending_sentinel:
+                logger.info(
+                    "Edit supersede — active turn is still initializing for "
+                    "message_id=%s in session %s; dropping the edit rather "
+                    "than misrouting it as a new turn",
+                    message_id,
+                    session_key,
+                )
+                return True
+            if running_agent is not None:
+                framing = (
+                    "[User edited their earlier message. Corrected message: "
+                    f'"{event.text}"]'
+                )
+                handled = False
+                if (
+                    getattr(running_agent, "_supports_active_turn_redirect", False)
+                    is True
+                    and hasattr(running_agent, "redirect")
+                ):
+                    try:
+                        handled = bool(running_agent.redirect(framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — redirect failed for session %s: %s",
+                            session_key,
+                            exc,
+                        )
+                if not handled and hasattr(running_agent, "steer"):
+                    try:
+                        handled = bool(running_agent.steer(framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — steer failed for session %s: %s",
+                            session_key,
+                            exc,
+                        )
+                if handled:
+                    logger.info(
+                        "Edit supersede — redirected/steered in-flight turn "
+                        "message_id=%s for session %s",
+                        message_id,
+                        session_key,
+                    )
+                    return True
+
+                logger.warning(
+                    "Edit supersede — redirect/steer unavailable for session %s, "
+                    "queueing edit as normal pending event",
+                    session_key,
+                )
+                self._queue_or_replace_pending_event(session_key, event)
+                return True
+
+        logger.info(
+            "Edit supersede — uncorrelated edit dropped "
+            "(platform=%s, chat=%s, message_id=%s)",
+            getattr(getattr(event.source, "platform", None), "value", "?"),
+            getattr(event.source, "chat_id", "?"),
+            message_id,
+        )
+        return True

--- a/gateway/event_sidecars.py
+++ b/gateway/event_sidecars.py
@@ -1,0 +1,118 @@
+"""Generic lifecycle sidecars carried by gateway message events.
+
+Transport adapters sometimes need state that must survive event batching but
+must not alter the public ``MessageEvent`` schema: correlated component IDs
+for edit supersession and one-shot cleanup callbacks for ephemeral artifacts.
+This module owns that state so platform plugins do not grow special cases in
+the base adapter or gateway runner.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import logging
+from typing import Any, Callable
+
+
+CORRELATED_MESSAGE_ITEMS_KEY = "correlated_message_items"
+_POST_TURN_CLEANUP_ATTR = "_post_turn_cleanup_callbacks"
+
+
+def merge_correlated_message_items(existing: Any, incoming: Any) -> None:
+    """Append ``incoming`` correlation components to ``existing`` in order."""
+    existing_metadata = dict(getattr(existing, "metadata", None) or {})
+    incoming_metadata = dict(getattr(incoming, "metadata", None) or {})
+    incoming_items = incoming_metadata.get(CORRELATED_MESSAGE_ITEMS_KEY)
+    if not isinstance(incoming_items, list):
+        return
+
+    existing_items = existing_metadata.get(CORRELATED_MESSAGE_ITEMS_KEY)
+    if not isinstance(existing_items, list):
+        existing_items = []
+    existing_metadata[CORRELATED_MESSAGE_ITEMS_KEY] = [
+        *existing_items,
+        *incoming_items,
+    ]
+    existing.metadata = existing_metadata
+
+
+def add_post_turn_cleanup_callback(event: Any, callback: Callable[[], Any]) -> None:
+    """Attach one cleanup callback to run after the event's turn completes."""
+    callbacks = list(getattr(event, _POST_TURN_CLEANUP_ATTR, []) or [])
+    callbacks.append(callback)
+    setattr(event, _POST_TURN_CLEANUP_ATTR, callbacks)
+
+
+def merge_event_sidecars(existing: Any, incoming: Any) -> None:
+    """Merge correlation and cleanup sidecars when two events are combined."""
+    merge_correlated_message_items(existing, incoming)
+    for callback in list(getattr(incoming, _POST_TURN_CLEANUP_ATTR, []) or []):
+        if callable(callback):
+            add_post_turn_cleanup_callback(existing, callback)
+
+
+def replace_correlated_event_text(
+    event: Any,
+    message_id: str,
+    new_text: str,
+) -> bool:
+    """Replace one correlated component while preserving the aggregate event."""
+    metadata = getattr(event, "metadata", None) or {}
+    components = metadata.get(CORRELATED_MESSAGE_ITEMS_KEY, [])
+    if isinstance(components, list):
+        for component in components:
+            if not isinstance(component, dict):
+                continue
+            if str(component.get("message_id")) != str(message_id):
+                continue
+            component["text"] = new_text
+            event.text = "\n".join(
+                str(item.get("text", ""))
+                for item in components
+                if isinstance(item, dict)
+            )
+            return True
+
+    if str(getattr(event, "message_id", "")) == str(message_id):
+        event.text = new_text
+        return True
+    return False
+
+
+def correlated_event_message_ids(event: Any) -> set[str]:
+    """Return every stable message ID represented by an aggregate event."""
+    metadata = getattr(event, "metadata", None) or {}
+    components = metadata.get(CORRELATED_MESSAGE_ITEMS_KEY, [])
+    message_ids = {
+        str(component.get("message_id"))
+        for component in components
+        if isinstance(component, dict) and component.get("message_id") is not None
+    } if isinstance(components, list) else set()
+    message_id = getattr(event, "message_id", None)
+    if message_id is not None:
+        message_ids.add(str(message_id))
+    return message_ids
+
+
+async def run_post_turn_cleanup_callbacks(
+    event: Any,
+    *,
+    timeout: float,
+    logger: logging.Logger,
+    platform_name: str,
+) -> None:
+    """Run event cleanup callbacks with bounded, failure-isolated semantics."""
+    for callback in list(getattr(event, _POST_TURN_CLEANUP_ATTR, []) or []):
+        if not callable(callback):
+            continue
+        try:
+            result = callback()
+            if inspect.isawaitable(result):
+                await asyncio.wait_for(result, timeout=timeout)
+        except (asyncio.TimeoutError, Exception):
+            logger.debug(
+                "[%s] Post-turn artifact cleanup failed",
+                platform_name,
+                exc_info=True,
+            )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -5785,6 +5785,14 @@ class BasePlatformAdapter(ABC):
         if result.success:
             return result
 
+        # A transport that has already delivered part of a split response, or
+        # lost the acknowledgement after submitting a command, cannot safely
+        # retry or fall back with the full content: either path duplicates
+        # messages the user may already have received. Preserve the adapter's
+        # explicit outcome and let the caller/operator decide whether to resend.
+        if result.error_kind in {"partial_delivery", "delivery_unknown"}:
+            return result
+
         error_str = result.error or ""
         is_network = result.retryable or self._is_retryable_error(error_str)
 

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -24,6 +24,12 @@ from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
 from utils import normalize_proxy_url
+from gateway.event_sidecars import (
+    merge_correlated_message_items,
+    merge_event_sidecars,
+    replace_correlated_event_text,
+    run_post_turn_cleanup_callbacks,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -2871,34 +2877,6 @@ def merge_pending_message_event(
     """
     existing = pending_messages.get(session_key)
     if existing:
-        def _merge_event_sidecars() -> None:
-            """Preserve transport-owned correlation and cleanup state."""
-            existing_metadata = dict(getattr(existing, "metadata", None) or {})
-            incoming_metadata = dict(getattr(event, "metadata", None) or {})
-            existing_components = existing_metadata.get("simplex_batch_items")
-            incoming_components = incoming_metadata.get("simplex_batch_items")
-            if isinstance(incoming_components, list):
-                if not isinstance(existing_components, list):
-                    existing_components = []
-                existing_metadata["simplex_batch_items"] = [
-                    *existing_components,
-                    *incoming_components,
-                ]
-                existing.metadata = existing_metadata
-
-            incoming_cleanup = list(
-                getattr(event, "_post_turn_cleanup_callbacks", []) or []
-            )
-            if incoming_cleanup:
-                existing_cleanup = list(
-                    getattr(existing, "_post_turn_cleanup_callbacks", []) or []
-                )
-                setattr(
-                    existing,
-                    "_post_turn_cleanup_callbacks",
-                    [*existing_cleanup, *incoming_cleanup],
-                )
-
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)
@@ -2916,7 +2894,7 @@ def merge_pending_message_event(
             existing.media_text_inlined = existing_inline_flags
 
         if existing_is_photo and incoming_is_photo:
-            _merge_event_sidecars()
+            merge_event_sidecars(existing, event)
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             existing.media_text_inlined.extend(incoming_inline_flags)
@@ -2926,7 +2904,7 @@ def merge_pending_message_event(
             return
 
         if existing_has_media or incoming_has_media:
-            _merge_event_sidecars()
+            merge_event_sidecars(existing, event)
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
@@ -2951,7 +2929,7 @@ def merge_pending_message_event(
             and getattr(existing, "message_type", None) == MessageType.TEXT
             and event.message_type == MessageType.TEXT
         ):
-            _merge_event_sidecars()
+            merge_event_sidecars(existing, event)
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             return
@@ -5920,26 +5898,7 @@ class BasePlatformAdapter(ABC):
         state = self._text_debounce_store().get(session_key)
         if state is None:
             return False
-        event = state.event
-        metadata = getattr(event, "metadata", None) or {}
-        components = metadata.get("simplex_batch_items", [])
-        if isinstance(components, list):
-            for component in components:
-                if not isinstance(component, dict):
-                    continue
-                if str(component.get("message_id")) != str(message_id):
-                    continue
-                component["text"] = new_text
-                event.text = "\n".join(
-                    str(item.get("text", ""))
-                    for item in components
-                    if isinstance(item, dict)
-                )
-                return True
-        if str(getattr(event, "message_id", "")) == str(message_id):
-            event.text = new_text
-            return True
-        return False
+        return replace_correlated_event_text(state.event, message_id, new_text)
 
     def _is_queue_text_debounce_candidate(self, event: MessageEvent) -> bool:
         """Return True for normal text eligible for queue-mode debounce."""
@@ -6026,18 +5985,7 @@ class BasePlatformAdapter(ABC):
                     if state.event.text
                     else event.text
                 )
-            state_metadata = dict(getattr(state.event, "metadata", None) or {})
-            event_metadata = dict(getattr(event, "metadata", None) or {})
-            state_components = state_metadata.get("simplex_batch_items")
-            event_components = event_metadata.get("simplex_batch_items")
-            if isinstance(event_components, list):
-                if not isinstance(state_components, list):
-                    state_components = []
-                state_metadata["simplex_batch_items"] = [
-                    *state_components,
-                    *event_components,
-                ]
-                state.event.metadata = state_metadata
+            merge_correlated_message_items(state.event, event)
             latest_message_id = getattr(event, "message_id", None)
             latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
             if latest_message_id is not None:
@@ -7285,24 +7233,12 @@ class BasePlatformAdapter(ABC):
             # artifacts they created (for example a received-file target).
             # Run them only after the turn has consumed the event, and keep
             # failures isolated from session cleanup and the pending drain.
-            for _cleanup_cb in list(
-                getattr(event, "_post_turn_cleanup_callbacks", []) or []
-            ):
-                if not callable(_cleanup_cb):
-                    continue
-                try:
-                    _cleanup_result = _cleanup_cb()
-                    if inspect.isawaitable(_cleanup_result):
-                        await asyncio.wait_for(
-                            _cleanup_result,
-                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
-                        )
-                except (asyncio.TimeoutError, Exception):
-                    logger.debug(
-                        "[%s] Post-turn artifact cleanup failed",
-                        self.name,
-                        exc_info=True,
-                    )
+            await run_post_turn_cleanup_callbacks(
+                event,
+                timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                logger=logger,
+                platform_name=self.name,
+            )
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2871,6 +2871,34 @@ def merge_pending_message_event(
     """
     existing = pending_messages.get(session_key)
     if existing:
+        def _merge_event_sidecars() -> None:
+            """Preserve transport-owned correlation and cleanup state."""
+            existing_metadata = dict(getattr(existing, "metadata", None) or {})
+            incoming_metadata = dict(getattr(event, "metadata", None) or {})
+            existing_components = existing_metadata.get("simplex_batch_items")
+            incoming_components = incoming_metadata.get("simplex_batch_items")
+            if isinstance(incoming_components, list):
+                if not isinstance(existing_components, list):
+                    existing_components = []
+                existing_metadata["simplex_batch_items"] = [
+                    *existing_components,
+                    *incoming_components,
+                ]
+                existing.metadata = existing_metadata
+
+            incoming_cleanup = list(
+                getattr(event, "_post_turn_cleanup_callbacks", []) or []
+            )
+            if incoming_cleanup:
+                existing_cleanup = list(
+                    getattr(existing, "_post_turn_cleanup_callbacks", []) or []
+                )
+                setattr(
+                    existing,
+                    "_post_turn_cleanup_callbacks",
+                    [*existing_cleanup, *incoming_cleanup],
+                )
+
         existing_is_photo = getattr(existing, "message_type", None) == MessageType.PHOTO
         incoming_is_photo = event.message_type == MessageType.PHOTO
         existing_has_media = bool(existing.media_urls)
@@ -2888,6 +2916,7 @@ def merge_pending_message_event(
             existing.media_text_inlined = existing_inline_flags
 
         if existing_is_photo and incoming_is_photo:
+            _merge_event_sidecars()
             existing.media_urls.extend(event.media_urls)
             existing.media_types.extend(event.media_types)
             existing.media_text_inlined.extend(incoming_inline_flags)
@@ -2897,6 +2926,7 @@ def merge_pending_message_event(
             return
 
         if existing_has_media or incoming_has_media:
+            _merge_event_sidecars()
             if incoming_has_media:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
@@ -2921,6 +2951,7 @@ def merge_pending_message_event(
             and getattr(existing, "message_type", None) == MessageType.TEXT
             and event.message_type == MessageType.TEXT
         ):
+            _merge_event_sidecars()
             if event.text:
                 existing.text = f"{existing.text}\n{event.text}" if existing.text else event.text
             return
@@ -5879,6 +5910,37 @@ class BasePlatformAdapter(ABC):
             self._text_debounce = store
         return store
 
+    def replace_text_debounce_message(
+        self,
+        session_key: str,
+        message_id: str,
+        new_text: str,
+    ) -> bool:
+        """Replace one correlated component still in the busy-text buffer."""
+        state = self._text_debounce_store().get(session_key)
+        if state is None:
+            return False
+        event = state.event
+        metadata = getattr(event, "metadata", None) or {}
+        components = metadata.get("simplex_batch_items", [])
+        if isinstance(components, list):
+            for component in components:
+                if not isinstance(component, dict):
+                    continue
+                if str(component.get("message_id")) != str(message_id):
+                    continue
+                component["text"] = new_text
+                event.text = "\n".join(
+                    str(item.get("text", ""))
+                    for item in components
+                    if isinstance(item, dict)
+                )
+                return True
+        if str(getattr(event, "message_id", "")) == str(message_id):
+            event.text = new_text
+            return True
+        return False
+
     def _is_queue_text_debounce_candidate(self, event: MessageEvent) -> bool:
         """Return True for normal text eligible for queue-mode debounce."""
         result = (
@@ -5964,6 +6026,18 @@ class BasePlatformAdapter(ABC):
                     if state.event.text
                     else event.text
                 )
+            state_metadata = dict(getattr(state.event, "metadata", None) or {})
+            event_metadata = dict(getattr(event, "metadata", None) or {})
+            state_components = state_metadata.get("simplex_batch_items")
+            event_components = event_metadata.get("simplex_batch_items")
+            if isinstance(event_components, list):
+                if not isinstance(state_components, list):
+                    state_components = []
+                state_metadata["simplex_batch_items"] = [
+                    *state_components,
+                    *event_components,
+                ]
+                state.event.metadata = state_metadata
             latest_message_id = getattr(event, "message_id", None)
             latest_anchor = latest_message_id or getattr(event, "reply_to_message_id", None)
             if latest_message_id is not None:
@@ -7207,6 +7281,28 @@ class BasePlatformAdapter(ABC):
                         )
                 except (asyncio.TimeoutError, Exception):
                     pass
+            # Transport adapters may attach callbacks for ephemeral inbound
+            # artifacts they created (for example a received-file target).
+            # Run them only after the turn has consumed the event, and keep
+            # failures isolated from session cleanup and the pending drain.
+            for _cleanup_cb in list(
+                getattr(event, "_post_turn_cleanup_callbacks", []) or []
+            ):
+                if not callable(_cleanup_cb):
+                    continue
+                try:
+                    _cleanup_result = _cleanup_cb()
+                    if inspect.isawaitable(_cleanup_result):
+                        await asyncio.wait_for(
+                            _cleanup_result,
+                            timeout=_POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS,
+                        )
+                except (asyncio.TimeoutError, Exception):
+                    logger.debug(
+                        "[%s] Post-turn artifact cleanup failed",
+                        self.name,
+                        exc_info=True,
+                    )
             # Some adapters keep platform-level typing tasks.  If callback
             # work or a late refresh recreated one, make one final bounded stop
             # before releasing the session guard.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9907,6 +9907,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return True
             return False
 
+        # BasePlatformAdapter owns a short queue-mode debounce buffer in
+        # addition to the runner's pending slot and overflow FIFO.  Search it
+        # first so an edit cannot miss the exact message merely because its
+        # debounce timer has not fired yet.
+        replace_debounced = getattr(adapter, "replace_text_debounce_message", None)
+        if callable(replace_debounced) and replace_debounced(
+            session_key, message_id, new_text
+        ):
+            return True
+
         # Primary slot
         pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
         if isinstance(pending_slot, dict):
@@ -9966,6 +9976,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _q_state = self._peek_session_state(session_key)
         if _q_state and _q_state.turn.active_message_id == _msg_id:
             running_agent = _q_state.turn.agent
+            if running_agent is _AGENT_PENDING_SENTINEL:
+                logger.info(
+                    "Edit supersede — active turn is still initializing for "
+                    "message_id=%s in session %s; dropping the edit rather "
+                    "than misrouting it as a new turn",
+                    _msg_id,
+                    session_key,
+                )
+                return True
             if running_agent is not None and running_agent is not _AGENT_PENDING_SENTINEL:
                 _framing = f'[User edited their earlier message. Corrected message: "{event.text}"]'
                 _handled = False

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9869,6 +9869,137 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _q_state.conversation.queued_events = kept
         return removed
 
+    def _replace_queued_message(
+        self,
+        session_key: str,
+        adapter: Any,
+        message_id: str,
+        new_text: str,
+    ) -> bool:
+        """Replace the text of the first queued event matching ``message_id``.
+
+        Searches the primary pending slot first, then the overflow FIFO.
+        Mutates the matching event's ``.text`` in place and preserves all
+        other fields and FIFO order.  Returns True if a match was replaced,
+        False if no match was found in either queue level.
+
+        Modeled on ``_clear_goal_pending_continuations`` (same two-level
+        search pattern).
+        """
+        # Primary slot
+        pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
+        if isinstance(pending_slot, dict):
+            pending_event = pending_slot.get(session_key)
+            if pending_event is not None and getattr(pending_event, "message_id", None) == message_id:
+                pending_event.text = new_text
+                return True
+
+        # Overflow FIFO
+        _q_state = self._peek_session_state(session_key)
+        overflow = _q_state.conversation.queued_events if _q_state else []
+        for ev in overflow:
+            if getattr(ev, "message_id", None) == message_id:
+                ev.text = new_text
+                return True
+
+        return False
+
+    def _handle_edit_supersede(
+        self,
+        event: "MessageEvent",
+        session_key: str,
+        adapter: Any,
+    ) -> bool:
+        """Correlate an inbound edit with queued or in-flight messages.
+
+        Called from the synchronous edit-supersede block in
+        ``_handle_message`` (#35535).  Returns True if the event was handled
+        (queue-replaced, in-flight redirected/steered, or silently dropped);
+        the caller should return ``None`` to skip normal dispatch.  Returns
+        False for non-edit events that should continue through normal
+        processing.
+
+        Design intent (per issue #35535 design review):
+          * Queue match -> replace text in-place, silent (no ack).
+          * In-flight match (active_message_id) -> redirect/steer with
+            framing text.  Neither primitive cancels in-flight tools — this
+            is the best available approach without transcript mutation.
+          * No match (uncorrelated edit) -> silently dropped.  An isolated
+            out-of-context correction would confuse the model.
+
+        SYNCHRONOUS: no await between queued-replace, in-flight check, and
+        decision.  All operations are in-memory attribute writes.
+        """
+        _is_edit = bool(event.metadata.get("is_edit", False) if event.metadata else False)
+        _msg_id = event.message_id
+        if not _is_edit or not _msg_id:
+            return False  # not an edit — continue normal dispatch
+
+        # 1. Try queued supersede
+        if self._replace_queued_message(session_key, adapter, _msg_id, event.text or ""):
+            logger.info(
+                "Edit supersede — replaced queued message_id=%s for session %s",
+                _msg_id, session_key,
+            )
+            return True
+
+        # 2. Try in-flight redirect / steer
+        _q_state = self._peek_session_state(session_key)
+        if _q_state and _q_state.turn.active_message_id == _msg_id:
+            running_agent = _q_state.turn.agent
+            if running_agent is not None and running_agent is not _AGENT_PENDING_SENTINEL:
+                _framing = f'[User edited their earlier message. Corrected message: "{event.text}"]'
+                _handled = False
+                # Prefer redirect() over steer() — redirect delivers as
+                # user-side input next model iteration, steer appends to
+                # last tool result.  Neither cancels in-flight tools.
+                if (
+                    getattr(running_agent, "_supports_active_turn_redirect", False) is True
+                    and hasattr(running_agent, "redirect")
+                ):
+                    try:
+                        _handled = bool(running_agent.redirect(_framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — redirect failed for session %s: %s",
+                            session_key, exc,
+                        )
+                if not _handled and hasattr(running_agent, "steer"):
+                    try:
+                        _handled = bool(running_agent.steer(_framing))
+                    except Exception as exc:
+                        logger.warning(
+                            "Edit supersede — steer failed for session %s: %s",
+                            session_key, exc,
+                        )
+                if _handled:
+                    logger.info(
+                        "Edit supersede — redirected/steered in-flight turn "
+                        "message_id=%s for session %s",
+                        _msg_id, session_key,
+                    )
+                    return True
+                # Fallback: queue the edit as a normal pending event
+                logger.warning(
+                    "Edit supersede — redirect/steer unavailable for session %s, "
+                    "queueing edit as normal pending event",
+                    session_key,
+                )
+                self._queue_or_replace_pending_event(session_key, event)
+                return True
+
+        # 3. Uncoupled edit (#35535 deliberate policy): no queued match,
+        #    no in-flight match.  An isolated out-of-context correction
+        #    would confuse the model — drop it silently.
+        logger.info(
+            "Edit supersede — uncorrelated edit dropped "
+            "(platform=%s, chat=%s, message_id=%s)",
+            getattr(getattr(event.source, "platform", None), "value", "?"),
+            getattr(event.source, "chat_id", "?"),
+            _msg_id,
+        )
+        return True
+
     def _goal_still_active_for_session(self, session_id: str) -> bool:
         """Best-effort fresh DB check before running a queued continuation."""
         if not session_id:
@@ -18848,6 +18979,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception:
                 logger.debug("reaped-session staleness check failed", exc_info=True)
 
+        # ── Edit supersede (#35535) ────────────────────────────────────
+        # SYNCHRONOUS block: no await between queued-replace, in-flight
+        # check, and decision.  An inbound EDIT of a previously-sent message
+        # supersedes the queued original or the in-flight turn; an isolated
+        # out-of-context correction is silently dropped.
+        _edit_adapter = self._adapter_for_source(source)
+        if _edit_adapter is not None:
+            if self._handle_edit_supersede(event, _quick_key, _edit_adapter):
+                return None
+
         if self._is_session_running(_quick_key):
             # Resolve the command once; every command's mid-run behavior is
             # declared on its CommandDef (busy_policy / busy_handler in
@@ -19842,6 +19983,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _claim_state.turn.lease = _active_session_lease
         _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
         _claim_state.turn.started_ts = time.time()
+        _claim_state.turn.active_message_id = event.message_id or None
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3031,6 +3031,8 @@ from gateway.session_state import (
     legacy_lease_token_property,
 )
 from gateway.authz_mixin import GatewayAuthorizationMixin
+from gateway.edit_supersede import GatewayEditSupersedeMixin
+from gateway.event_sidecars import correlated_event_message_ids
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
 from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
@@ -7320,7 +7322,12 @@ class TurnRunner:
 _SESSION_DB_UNPINNED = object()
 
 
-class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, GatewaySlashCommandsMixin):
+class GatewayRunner(
+    GatewayAuthorizationMixin,
+    GatewayEditSupersedeMixin,
+    GatewayKanbanWatchersMixin,
+    GatewaySlashCommandsMixin,
+):
     """
     Main gateway controller.
 
@@ -7339,6 +7346,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         DEFAULT_GATEWAY_SIGNAL_INTERRUPT_GRACE_TIMEOUT
     )
     _exit_code: Optional[int] = None
+    _agent_pending_sentinel = _AGENT_PENDING_SENTINEL
     _draining: bool = False
     _external_drain_active: bool = False
     _restart_requested: bool = False
@@ -9868,178 +9876,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     kept.append(queued_event)
             _q_state.conversation.queued_events = kept
         return removed
-
-    def _replace_queued_message(
-        self,
-        session_key: str,
-        adapter: Any,
-        message_id: str,
-        new_text: str,
-    ) -> bool:
-        """Replace the text of the first queued event matching ``message_id``.
-
-        Searches the primary pending slot first, then the overflow FIFO.
-        Mutates the matching event's ``.text`` in place and preserves all
-        other fields and FIFO order.  Returns True if a match was replaced,
-        False if no match was found in either queue level.
-
-        Modeled on ``_clear_goal_pending_continuations`` (same two-level
-        search pattern).
-        """
-        def _replace_event(event: Any) -> bool:
-            metadata = getattr(event, "metadata", None) or {}
-            components = metadata.get("simplex_batch_items", [])
-            if isinstance(components, list):
-                for component in components:
-                    if not isinstance(component, dict):
-                        continue
-                    if str(component.get("message_id")) != str(message_id):
-                        continue
-                    component["text"] = new_text
-                    event.text = "\n".join(
-                        str(item.get("text", ""))
-                        for item in components
-                        if isinstance(item, dict)
-                    )
-                    return True
-            if getattr(event, "message_id", None) == message_id:
-                event.text = new_text
-                return True
-            return False
-
-        # BasePlatformAdapter owns a short queue-mode debounce buffer in
-        # addition to the runner's pending slot and overflow FIFO.  Search it
-        # first so an edit cannot miss the exact message merely because its
-        # debounce timer has not fired yet.
-        replace_debounced = getattr(adapter, "replace_text_debounce_message", None)
-        if callable(replace_debounced) and replace_debounced(
-            session_key, message_id, new_text
-        ):
-            return True
-
-        # Primary slot
-        pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
-        if isinstance(pending_slot, dict):
-            pending_event = pending_slot.get(session_key)
-            if pending_event is not None and _replace_event(pending_event):
-                return True
-
-        # Overflow FIFO
-        _q_state = self._peek_session_state(session_key)
-        overflow = _q_state.conversation.queued_events if _q_state else []
-        for ev in overflow:
-            if _replace_event(ev):
-                return True
-
-        return False
-
-    def _handle_edit_supersede(
-        self,
-        event: "MessageEvent",
-        session_key: str,
-        adapter: Any,
-    ) -> bool:
-        """Correlate an inbound edit with queued or in-flight messages.
-
-        Called from the synchronous edit-supersede block in
-        ``_handle_message`` (#35535).  Returns True if the event was handled
-        (queue-replaced, in-flight redirected/steered, or silently dropped);
-        the caller should return ``None`` to skip normal dispatch.  Returns
-        False for non-edit events that should continue through normal
-        processing.
-
-        Design intent (per issue #35535 design review):
-          * Queue match -> replace text in-place, silent (no ack).
-          * In-flight match (active_message_id) -> redirect/steer with
-            framing text.  Neither primitive cancels in-flight tools — this
-            is the best available approach without transcript mutation.
-          * No match (uncorrelated edit) -> silently dropped.  An isolated
-            out-of-context correction would confuse the model.
-
-        SYNCHRONOUS: no await between queued-replace, in-flight check, and
-        decision.  All operations are in-memory attribute writes.
-        """
-        _is_edit = bool(event.metadata.get("is_edit", False) if event.metadata else False)
-        _msg_id = event.message_id
-        if not _is_edit or not _msg_id:
-            return False  # not an edit — continue normal dispatch
-
-        # 1. Try queued supersede
-        if self._replace_queued_message(session_key, adapter, _msg_id, event.text or ""):
-            logger.info(
-                "Edit supersede — replaced queued message_id=%s for session %s",
-                _msg_id, session_key,
-            )
-            return True
-
-        # 2. Try in-flight redirect / steer
-        _q_state = self._peek_session_state(session_key)
-        if _q_state and (
-            _q_state.turn.active_message_id == _msg_id
-            or _msg_id in _q_state.turn.active_message_ids
-        ):
-            running_agent = _q_state.turn.agent
-            if running_agent is _AGENT_PENDING_SENTINEL:
-                logger.info(
-                    "Edit supersede — active turn is still initializing for "
-                    "message_id=%s in session %s; dropping the edit rather "
-                    "than misrouting it as a new turn",
-                    _msg_id,
-                    session_key,
-                )
-                return True
-            if running_agent is not None and running_agent is not _AGENT_PENDING_SENTINEL:
-                _framing = f'[User edited their earlier message. Corrected message: "{event.text}"]'
-                _handled = False
-                # Prefer redirect() over steer() — redirect delivers as
-                # user-side input next model iteration, steer appends to
-                # last tool result.  Neither cancels in-flight tools.
-                if (
-                    getattr(running_agent, "_supports_active_turn_redirect", False) is True
-                    and hasattr(running_agent, "redirect")
-                ):
-                    try:
-                        _handled = bool(running_agent.redirect(_framing))
-                    except Exception as exc:
-                        logger.warning(
-                            "Edit supersede — redirect failed for session %s: %s",
-                            session_key, exc,
-                        )
-                if not _handled and hasattr(running_agent, "steer"):
-                    try:
-                        _handled = bool(running_agent.steer(_framing))
-                    except Exception as exc:
-                        logger.warning(
-                            "Edit supersede — steer failed for session %s: %s",
-                            session_key, exc,
-                        )
-                if _handled:
-                    logger.info(
-                        "Edit supersede — redirected/steered in-flight turn "
-                        "message_id=%s for session %s",
-                        _msg_id, session_key,
-                    )
-                    return True
-                # Fallback: queue the edit as a normal pending event
-                logger.warning(
-                    "Edit supersede — redirect/steer unavailable for session %s, "
-                    "queueing edit as normal pending event",
-                    session_key,
-                )
-                self._queue_or_replace_pending_event(session_key, event)
-                return True
-
-        # 3. Uncoupled edit (#35535 deliberate policy): no queued match,
-        #    no in-flight match.  An isolated out-of-context correction
-        #    would confuse the model — drop it silently.
-        logger.info(
-            "Edit supersede — uncorrelated edit dropped "
-            "(platform=%s, chat=%s, message_id=%s)",
-            getattr(getattr(event.source, "platform", None), "value", "?"),
-            getattr(event.source, "chat_id", "?"),
-            _msg_id,
-        )
-        return True
 
     def _goal_still_active_for_session(self, session_id: str) -> bool:
         """Best-effort fresh DB check before running a queued continuation."""
@@ -20036,14 +19872,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
         _claim_state.turn.started_ts = time.time()
         _claim_state.turn.active_message_id = event.message_id or None
-        _component_ids = {
-            str(component.get("message_id"))
-            for component in (event.metadata or {}).get("simplex_batch_items", [])
-            if isinstance(component, dict) and component.get("message_id") is not None
-        }
-        if event.message_id is not None:
-            _component_ids.add(str(event.message_id))
-        _claim_state.turn.active_message_ids = _component_ids
+        _claim_state.turn.active_message_ids = correlated_event_message_ids(event)
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9974,7 +9974,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         # 2. Try in-flight redirect / steer
         _q_state = self._peek_session_state(session_key)
-        if _q_state and _q_state.turn.active_message_id == _msg_id:
+        if _q_state and (
+            _q_state.turn.active_message_id == _msg_id
+            or _msg_id in _q_state.turn.active_message_ids
+        ):
             running_agent = _q_state.turn.agent
             if running_agent is _AGENT_PENDING_SENTINEL:
                 logger.info(
@@ -20033,6 +20036,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _claim_state.turn.agent = _AGENT_PENDING_SENTINEL
         _claim_state.turn.started_ts = time.time()
         _claim_state.turn.active_message_id = event.message_id or None
+        _component_ids = {
+            str(component.get("message_id"))
+            for component in (event.metadata or {}).get("simplex_batch_items", [])
+            if isinstance(component, dict) and component.get("message_id") is not None
+        }
+        if event.message_id is not None:
+            _component_ids.add(str(event.message_id))
+        _claim_state.turn.active_message_ids = _component_ids
         self._persist_active_agents()
         _run_generation = self._begin_session_run_generation(_quick_key)
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9886,20 +9886,39 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         Modeled on ``_clear_goal_pending_continuations`` (same two-level
         search pattern).
         """
+        def _replace_event(event: Any) -> bool:
+            metadata = getattr(event, "metadata", None) or {}
+            components = metadata.get("simplex_batch_items", [])
+            if isinstance(components, list):
+                for component in components:
+                    if not isinstance(component, dict):
+                        continue
+                    if str(component.get("message_id")) != str(message_id):
+                        continue
+                    component["text"] = new_text
+                    event.text = "\n".join(
+                        str(item.get("text", ""))
+                        for item in components
+                        if isinstance(item, dict)
+                    )
+                    return True
+            if getattr(event, "message_id", None) == message_id:
+                event.text = new_text
+                return True
+            return False
+
         # Primary slot
         pending_slot = getattr(adapter, "_pending_messages", None) if adapter is not None else None
         if isinstance(pending_slot, dict):
             pending_event = pending_slot.get(session_key)
-            if pending_event is not None and getattr(pending_event, "message_id", None) == message_id:
-                pending_event.text = new_text
+            if pending_event is not None and _replace_event(pending_event):
                 return True
 
         # Overflow FIFO
         _q_state = self._peek_session_state(session_key)
         overflow = _q_state.conversation.queued_events if _q_state else []
         for ev in overflow:
-            if getattr(ev, "message_id", None) == message_id:
-                ev.text = new_text
+            if _replace_event(ev):
                 return True
 
         return False
@@ -11152,6 +11171,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key,
             )
             return True  # handled (silently dropped); do not fall through
+
+        # Edits must supersede the matching queued or in-flight message before
+        # ordinary busy-mode redirect/queue logic sees them. Base adapters call
+        # this busy handler instead of the cold ``_handle_message`` path, so
+        # leaving correlation only there makes the feature unreachable during
+        # the exact active-turn window it is designed for.
+        edit_adapter = self._adapter_for_source(event.source)
+        if edit_adapter is not None and self._handle_edit_supersede(
+            event, session_key, edit_adapter
+        ):
+            return True
 
         effective_mode = self._effective_busy_input_mode(event.source)
 

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -73,6 +73,9 @@ class TurnState:
     # preserves that: release/rebind only match when generation is current.
     lease_token: Any = None
     lease_generation: Optional[int] = None
+    # MessageEvent.message_id of the event that started this turn; used by
+    # edit-supersede (#35535) to correlate inbound edits with in-flight turns.
+    active_message_id: Optional[str] = None
 
     def clear(self) -> None:
         """Reset the per-turn slot (agent / start ts / lease / busy-ack).
@@ -85,6 +88,7 @@ class TurnState:
         self.started_ts = 0.0
         self.lease = None
         self.busy_ack_ts = 0.0
+        self.active_message_id = None
 
 
 @dataclass

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -78,7 +78,7 @@ class TurnState:
     active_message_id: Optional[str] = None
     # Every correlated component ID represented by the active event.  A
     # transport may batch several user messages into one turn while retaining
-    # their independent edit identities (SimpleX ``simplex_batch_items``).
+    # their independent edit identities through generic event sidecars.
     active_message_ids: set[str] = field(default_factory=set)
 
     def clear(self) -> None:

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -76,6 +76,10 @@ class TurnState:
     # MessageEvent.message_id of the event that started this turn; used by
     # edit-supersede (#35535) to correlate inbound edits with in-flight turns.
     active_message_id: Optional[str] = None
+    # Every correlated component ID represented by the active event.  A
+    # transport may batch several user messages into one turn while retaining
+    # their independent edit identities (SimpleX ``simplex_batch_items``).
+    active_message_ids: set[str] = field(default_factory=set)
 
     def clear(self) -> None:
         """Reset the per-turn slot (agent / start ts / lease / busy-ack).
@@ -89,6 +93,7 @@ class TurnState:
         self.lease = None
         self.busy_ack_ts = 0.0
         self.active_message_id = None
+        self.active_message_ids.clear()
 
 
 @dataclass

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -1020,12 +1020,12 @@ class SimplexAdapter(BasePlatformAdapter):
         try:
             if os.path.isfile(normalized) or os.path.islink(normalized):
                 os.remove(normalized)
-        except OSError:
+        except OSError as exc:
             self._diagnostics["media_cleanup_failures"] += 1
             logger.warning(
-                "SimpleX: failed to remove owned temporary media %s",
+                "SimpleX: failed to remove owned temporary media %s (%s)",
                 os.path.basename(normalized),
-                exc_info=True,
+                type(exc).__name__,
             )
 
     async def _expire_owned_media_path(self, path: str) -> None:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -788,8 +788,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         file_id,
                     )
                     return
-                pending = self._pending_file_transfers.pop(file_id, None) or chat_item
-                self._cancel_file_timeout(file_id)
+                pending = self._pending_file_transfers.get(file_id) or chat_item
                 if not self._file_sender_is_authorized(pending):
                     self._diagnostics["file_rejections"] += 1
                     return
@@ -800,6 +799,8 @@ class SimplexAdapter(BasePlatformAdapter):
                     else None
                 )
                 if file_path:
+                    self._pending_file_transfers.pop(file_id, None)
+                    self._cancel_file_timeout(file_id)
                     file_path = self._resolve_file_path(file_path)
                     pending_item_data = pending.get("chatItem", {}) or {}
                     pending_file = pending_item_data.setdefault("file", {})
@@ -812,8 +813,13 @@ class SimplexAdapter(BasePlatformAdapter):
                         logger.exception(
                             "SimpleX: error processing deferred file message"
                         )
-                elif file_id not in self._terminal_file_transfers:
-                    self._mark_file_terminal(file_id, "completed-without-path")
+                elif pending:
+                    # Some daemon orderings announce completion before the
+                    # AChatItem acquires fileSource.filePath.  Keep the
+                    # authorized wrapper pending until the file-bearing
+                    # newChatItems event arrives (or the bounded timeout emits
+                    # the caption fallback); never terminalize pathless data.
+                    self._track_pending_file(file_id, pending)
             return
 
         if resp_type in {"chatError", "chatErrors", "messageError"}:
@@ -1195,6 +1201,33 @@ class SimplexAdapter(BasePlatformAdapter):
         completed_file_id: Optional[int] = None
 
         if file_info and isinstance(file_info, dict):
+            raw_file_id = file_info.get("fileId")
+            try:
+                guarded_file_id = (
+                    int(raw_file_id) if raw_file_id is not None else None
+                )
+            except (TypeError, ValueError):
+                guarded_file_id = None
+            terminal = (
+                self._terminal_file_transfers.get(guarded_file_id)
+                if guarded_file_id is not None
+                else None
+            )
+            if terminal:
+                if is_edit and terminal.get("reason") == "completed":
+                    # A caption edit retains the chat-item correlation but is
+                    # text-only: the attachment was already consumed and its
+                    # cleanup ownership must not be armed a second time.
+                    file_info = None
+                else:
+                    self._diagnostics["late_file_completions"] += 1
+                    logger.info(
+                        "SimpleX: ignored duplicate completed chat item for fileId=%s",
+                        guarded_file_id,
+                    )
+                    return
+
+        if file_info and isinstance(file_info, dict):
             file_source = file_info.get("fileSource", {}) or {}
             file_path = (
                 file_source.get("filePath")
@@ -1211,16 +1244,6 @@ class SimplexAdapter(BasePlatformAdapter):
                 normalized_file_id = int(file_id) if file_id is not None else None
             except (TypeError, ValueError):
                 normalized_file_id = None
-            if (
-                normalized_file_id is not None
-                and normalized_file_id in self._terminal_file_transfers
-            ):
-                self._diagnostics["late_file_completions"] += 1
-                logger.info(
-                    "SimpleX: ignored duplicate completed chat item for fileId=%s",
-                    normalized_file_id,
-                )
-                return
             if file_path:
                 file_path = self._resolve_file_path(file_path)
 
@@ -1255,6 +1278,9 @@ class SimplexAdapter(BasePlatformAdapter):
                     return
 
             if file_info and file_path:
+                if normalized_file_id is not None:
+                    self._pending_file_transfers.pop(normalized_file_id, None)
+                    self._cancel_file_timeout(normalized_file_id)
                 completed_file_id = normalized_file_id
                 receive_target = (
                     self._terminal_file_target(normalized_file_id)
@@ -2610,12 +2636,26 @@ async def _standalone_send(
     if not ws_url:
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
-    async def _send_confirmed(ws, command: str, corr_id: str) -> dict:
+    async def _send_confirmed(
+        ws,
+        command: str,
+        corr_id: str,
+        *,
+        await_file_complete: bool = False,
+    ) -> dict:
         await ws.send(json.dumps({"corrId": corr_id, "cmd": command}))
+        deferred: List[dict] = []
         while True:
             raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
             event = json.loads(raw)
             if event.get("corrId") != corr_id:
+                resp = (
+                    event.get("resp")
+                    if isinstance(event.get("resp"), dict)
+                    else event
+                )
+                if isinstance(resp, dict):
+                    deferred.append(resp)
                 continue
             resp = event.get("resp") if isinstance(event.get("resp"), dict) else event
             error = _response_error(resp)
@@ -2625,12 +2665,58 @@ async def _standalone_send(
                 raise RuntimeError(
                     f"unexpected SimpleX response: {_response_type(resp) or '<missing>'}"
                 )
+            break
+
+        if not await_file_complete:
             return resp
 
-    owned_temp_paths: List[str] = []
+        ack_ids = set(_response_item_ids(resp))
+
+        def _matches_file_terminal(candidate: dict) -> Optional[bool]:
+            candidate_type = _response_type(candidate)
+            if candidate_type not in {
+                "sndFileComplete",
+                "sndFileCompleteXFTP",
+                "sndFileError",
+                "sndFileWarning",
+            }:
+                return None
+            wrapper = SimplexAdapter._normalize_chat_item_wrapper(
+                candidate.get("chatItem") or candidate.get("chatItem_") or {}
+            )
+            item_id = SimplexAdapter._item_id_from_wrapper(wrapper)
+            if ack_ids:
+                if item_id is None or item_id not in ack_ids:
+                    return None
+            return candidate_type in {"sndFileComplete", "sndFileCompleteXFTP"}
+
+        for candidate in deferred:
+            terminal = _matches_file_terminal(candidate)
+            if terminal is True:
+                return resp
+            if terminal is False:
+                raise RuntimeError("SimpleX standalone file transfer failed")
+
+        while True:
+            raw = await asyncio.wait_for(ws.recv(), timeout=300.0)
+            event = json.loads(raw)
+            candidate = (
+                event.get("resp")
+                if isinstance(event.get("resp"), dict)
+                else event
+            )
+            if not isinstance(candidate, dict):
+                continue
+            terminal = _matches_file_terminal(candidate)
+            if terminal is True:
+                return resp
+            if terminal is False:
+                raise RuntimeError("SimpleX standalone file transfer failed")
+
+    cleanup_temp_paths: set[str] = set()
     try:
         chat_ref = SimplexAdapter._chat_ref(chat_id)
-        commands: List[str] = []
+        commands: List[tuple[str, Optional[str]]] = []
         if message:
             for chunk in BasePlatformAdapter.truncate_message(
                 message, MAX_MESSAGE_LENGTH, len_fn=_simplex_payload_len
@@ -2640,8 +2726,11 @@ async def _standalone_send(
                     "mentions": {},
                 }]
                 commands.append(
-                    f"/_send {chat_ref} json "
-                    f"{json.dumps(composed, ensure_ascii=False)}"
+                    (
+                        f"/_send {chat_ref} json "
+                        f"{json.dumps(composed, ensure_ascii=False)}",
+                        None,
+                    )
                 )
 
         for media in media_files or []:
@@ -2659,8 +2748,6 @@ async def _standalone_send(
                 file_path = path
             elif not force_document and _is_image_ext(ext):
                 file_path, thumb = SimplexAdapter._prepare_image(path)
-                if os.path.abspath(file_path) != os.path.abspath(path):
-                    owned_temp_paths.append(file_path)
                 msg_content = {"type": "image", "image": thumb, "text": ""}
             else:
                 msg_content = {"type": "file", "text": ""}
@@ -2670,16 +2757,41 @@ async def _standalone_send(
                 "msgContent": msg_content,
                 "mentions": {},
             }]
+            owned_conversion = (
+                file_path
+                if os.path.abspath(file_path) != os.path.abspath(path)
+                else None
+            )
             commands.append(
-                f"/_send {chat_ref} json "
-                f"{json.dumps(composed, ensure_ascii=False)}"
+                (
+                    f"/_send {chat_ref} json "
+                    f"{json.dumps(composed, ensure_ascii=False)}",
+                    owned_conversion,
+                )
             )
 
         item_ids: List[str] = []
         async with _wsclient.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
-            for index, command in enumerate(commands):
+            for index, (command, owned_conversion) in enumerate(commands):
                 corr_id = f"{_CORR_PREFIX}snd-{uuid.uuid4().hex}-{index}"
-                resp = await _send_confirmed(ws, command, corr_id)
+                try:
+                    resp = await _send_confirmed(
+                        ws,
+                        command,
+                        corr_id,
+                        await_file_complete=owned_conversion is not None,
+                    )
+                except asyncio.TimeoutError:
+                    # The daemon may still be reading the file after its chat
+                    # acknowledgement. Preserve the only conversion on an
+                    # ambiguous timeout rather than corrupting delivery.
+                    raise
+                except RuntimeError:
+                    if owned_conversion:
+                        cleanup_temp_paths.add(owned_conversion)
+                    raise
+                if owned_conversion:
+                    cleanup_temp_paths.add(owned_conversion)
                 item_ids.extend(_response_item_ids(resp))
 
         return {
@@ -2691,7 +2803,7 @@ async def _standalone_send(
     except Exception as e:
         return {"error": f"SimpleX send failed: {e}"}
     finally:
-        for temp_path in owned_temp_paths:
+        for temp_path in cleanup_temp_paths:
             try:
                 if os.path.isfile(temp_path) or os.path.islink(temp_path):
                     os.remove(temp_path)

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -264,11 +264,15 @@ class SimplexAdapter(BasePlatformAdapter):
         files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "").strip() or str(
             extra.get("files_folder", "") or ""
         ).strip()
-        self.files_folder = (
-            os.path.abspath(os.path.expanduser(files_folder))
-            if files_folder
-            else ""
-        )
+        expanded_files_folder = os.path.expanduser(files_folder)
+        if expanded_files_folder and not os.path.isabs(expanded_files_folder):
+            logger.warning(
+                "SimpleX: ignoring relative SIMPLEX_FILES_FOLDER; configure the "
+                "exact absolute path passed to simplex-chat --files-folder"
+            )
+            self.files_folder = ""
+        else:
+            self.files_folder = expanded_files_folder
         self._file_transfer_timeout = max(
             1.0, float(extra.get("file_transfer_timeout", 300.0))
         )
@@ -316,6 +320,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # consumed when the file finishes downloading.
         self._pending_file_transfers: Dict[int, dict] = {}
         self._file_transfer_tasks: Dict[int, asyncio.Task] = {}
+        self._file_receive_started: set[int] = set()
         self._file_receive_targets: Dict[int, str] = {}
         self._terminal_file_transfers: Dict[int, dict] = {}
         self._owned_media_cleanup_tasks: Dict[str, asyncio.Task] = {}
@@ -340,6 +345,7 @@ class SimplexAdapter(BasePlatformAdapter):
             "file_failures": 0,
             "file_timeouts": 0,
             "late_file_completions": 0,
+            "media_cleanup_failures": 0,
         }
 
         # Direct-message reaction approvals. State is intentionally ephemeral:
@@ -472,6 +478,7 @@ class SimplexAdapter(BasePlatformAdapter):
             )
         self._file_transfer_tasks.clear()
         self._pending_file_transfers.clear()
+        self._file_receive_started.clear()
         self._file_receive_targets.clear()
         self._terminal_file_transfers.clear()
         for path in list(self._owned_media_cleanup_tasks):
@@ -659,6 +666,12 @@ class SimplexAdapter(BasePlatformAdapter):
                         file_id,
                     )
                     return
+                if file_id in self._file_receive_started:
+                    logger.debug(
+                        "SimpleX: ignoring duplicate descriptor for fileId=%s",
+                        file_id,
+                    )
+                    return
                 wrapper = self._normalize_chat_item_wrapper(resp.get("chatItem", {}))
                 if not wrapper:
                     wrapper = self._pending_file_transfers.get(file_id, {})
@@ -669,6 +682,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         file_id,
                     )
                     return
+                self._file_receive_started.add(file_id)
                 self._track_pending_file(file_id, wrapper)
                 inner = wrapper.get("chatItem", {}) if wrapper else {}
                 file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
@@ -977,6 +991,7 @@ class SimplexAdapter(BasePlatformAdapter):
 
     def _mark_file_terminal(self, file_id: int, reason: str) -> Optional[str]:
         """Remember a terminal transfer long enough to reject late duplicates."""
+        self._file_receive_started.discard(file_id)
         target = self._file_receive_targets.pop(file_id, None)
         prior = self._terminal_file_transfers.get(file_id, {})
         if target is None:
@@ -1006,7 +1021,8 @@ class SimplexAdapter(BasePlatformAdapter):
             if os.path.isfile(normalized) or os.path.islink(normalized):
                 os.remove(normalized)
         except OSError:
-            logger.debug(
+            self._diagnostics["media_cleanup_failures"] += 1
+            logger.warning(
                 "SimpleX: failed to remove owned temporary media %s",
                 os.path.basename(normalized),
                 exc_info=True,
@@ -1019,12 +1035,14 @@ class SimplexAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             return
 
-    def _schedule_owned_media_cleanup(self, path: str) -> None:
+    def _schedule_owned_media_cleanup(self, path: str, *, reset: bool = False) -> None:
         """Install a TTL backstop for an adapter-created media path."""
         normalized = os.path.abspath(path)
         existing = self._owned_media_cleanup_tasks.get(normalized)
         if existing and not existing.done():
-            return
+            if not reset:
+                return
+            existing.cancel()
         task = asyncio.create_task(self._expire_owned_media_path(normalized))
         self._owned_media_cleanup_tasks[normalized] = task
 
@@ -1275,10 +1293,29 @@ class SimplexAdapter(BasePlatformAdapter):
             if file_path:
                 file_path = self._resolve_file_path(file_path)
 
+            # A daemon-relative path is only meaningful relative to the exact
+            # --files-folder configured on simplex-chat. Never pass a path
+            # relative to Hermes' unrelated working directory to media tools.
+            if file_path and not os.path.isabs(file_path):
+                reason = (
+                    "SIMPLEX_FILES_FOLDER is required to resolve the daemon's "
+                    "relative attachment path"
+                )
+                if normalized_file_id is not None:
+                    self._pending_file_transfers.pop(normalized_file_id, None)
+                    self._cancel_file_timeout(normalized_file_id)
+                    self._mark_file_terminal(normalized_file_id, reason)
+                self._diagnostics["file_failures"] += 1
+                logger.warning("SimpleX: %s", reason)
+                file_info = None
+                file_path = None
+                if not text:
+                    text = f"[Attachment unavailable: {reason}]"
+
             # XFTP-backed files can arrive before the download completes.
             # Accept exactly once from rcvFileDescrReady; accepting here can
             # race the descriptor and leave the transfer parked indefinitely.
-            if file_id is not None and (
+            if file_info and file_id is not None and (
                 not file_path
                 or file_status_type not in (None, "rcvComplete")
             ):
@@ -1416,7 +1453,10 @@ class SimplexAdapter(BasePlatformAdapter):
             metadata={"is_edit": True} if is_edit else {},
         )
         if owned_media_path and not self.retain_received_files:
-            self._schedule_owned_media_cleanup(owned_media_path)
+            # Descriptor receipt arms a backstop while the transfer is in
+            # flight. Re-arm it at completion so a long-running transfer does
+            # not shorten the consuming turn's cleanup window.
+            self._schedule_owned_media_cleanup(owned_media_path, reset=True)
             setattr(
                 msg_event,
                 "_post_turn_cleanup_callbacks",

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -72,6 +72,11 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from gateway.event_sidecars import (
+    CORRELATED_MESSAGE_ITEMS_KEY,
+    add_post_turn_cleanup_callback,
+    replace_correlated_event_text,
+)
 from plugins.platforms.simplex.approvals import SimplexApprovalMixin
 from plugins.platforms.simplex.batching import prepend_cancelled_batch
 from plugins.platforms.simplex.config import (
@@ -1241,14 +1246,9 @@ class SimplexAdapter(
             # flight. Re-arm it at completion so a long-running transfer does
             # not shorten the consuming turn's cleanup window.
             self._schedule_owned_media_cleanup(owned_media_path, reset=True)
-            setattr(
+            add_post_turn_cleanup_callback(
                 msg_event,
-                "_post_turn_cleanup_callbacks",
-                [
-                    lambda path=owned_media_path: self._cleanup_owned_media_path(
-                        path
-                    )
-                ],
+                lambda path=owned_media_path: self._cleanup_owned_media_path(path),
             )
 
         logger.debug(
@@ -1298,7 +1298,7 @@ class SimplexAdapter(
         existing = self._pending_text_batches.get(key)
         event.metadata = dict(event.metadata or {})
         event.metadata.setdefault(
-            "simplex_batch_items",
+            CORRELATED_MESSAGE_ITEMS_KEY,
             [{"message_id": event.message_id, "text": event.text or ""}],
         )
         if existing is None:
@@ -1309,8 +1309,8 @@ class SimplexAdapter(
                     f"{existing.text}\n{event.text}" if existing.text else event.text
                 )
             existing.metadata = dict(existing.metadata or {})
-            existing.metadata.setdefault("simplex_batch_items", []).extend(
-                event.metadata["simplex_batch_items"]
+            existing.metadata.setdefault(CORRELATED_MESSAGE_ITEMS_KEY, []).extend(
+                event.metadata[CORRELATED_MESSAGE_ITEMS_KEY]
             )
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
@@ -1342,20 +1342,11 @@ class SimplexAdapter(
         pending = self._pending_text_batches.get(key)
         if pending is None or not event.message_id:
             return False
-        items = (pending.metadata or {}).get("simplex_batch_items", [])
-        if not isinstance(items, list):
-            return False
-        for item in items:
-            if not isinstance(item, dict):
-                continue
-            if str(item.get("message_id")) != str(event.message_id):
-                continue
-            item["text"] = event.text or ""
-            pending.text = "\n".join(
-                str(component.get("text", ""))
-                for component in items
-                if isinstance(component, dict)
-            )
+        if replace_correlated_event_text(
+            pending,
+            event.message_id,
+            event.text or "",
+        ):
             logger.info(
                 "SimpleX: superseded batched message item_id=%s",
                 event.message_id,

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -38,6 +38,10 @@ Optional environment variables:
                                into a single MessageEvent — same pattern as
                                Telegram's text batching.
 
+Optional ``config.yaml`` settings (``platforms.simplex.extra``):
+    files_folder               Absolute path of the daemon's --files-folder;
+                               resolves relative received-attachment paths.
+
 The ``websockets`` Python package is imported lazily — the plugin is
 discoverable and ``hermes setup`` can describe it even when websockets is
 not installed. ``check_requirements()`` returns False until the package
@@ -51,7 +55,9 @@ import logging
 import os
 import random
 import re
+import tempfile
 import time
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -72,7 +78,9 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
-MAX_MESSAGE_LENGTH = 8000  # SimpleX has no hard limit; chunk for sanity
+# The protocol's encoded JSON envelope must fit below roughly 15.6 KiB.
+# Keep a substantial envelope/escaping margin and split before serialization.
+MAX_MESSAGE_LENGTH = 8000
 WS_RETRY_DELAY_INITIAL = 2.0
 WS_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0
@@ -130,6 +138,51 @@ def _is_audio_ext(ext: str) -> bool:
     return ext.lower() in {".mp3", ".wav", ".ogg", ".m4a", ".aac", ".opus"}
 
 
+def _sanitize_filename(name: str) -> str:
+    """Return a safe local path fragment for a peer-supplied file name."""
+    basename = os.path.basename(str(name or "")).strip()
+    cleaned = re.sub(r"[^A-Za-z0-9._-]", "_", basename)
+    return cleaned[:120] or "file"
+
+
+def _response_type(resp: Optional[dict]) -> str:
+    return str((resp or {}).get("type") or "") if isinstance(resp, dict) else ""
+
+
+def _response_error(resp: Optional[dict]) -> Optional[str]:
+    """Return a bounded diagnostic string for a daemon error response."""
+    if not isinstance(resp, dict):
+        return "SimpleX daemon did not answer"
+    resp_type = _response_type(resp)
+    if resp_type not in {"chatCmdError", "chatError", "chatErrors"}:
+        return None
+    detail = resp.get("chatError") or resp.get("chatErrors") or resp
+    try:
+        rendered = json.dumps(detail, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        rendered = str(detail)
+    return f"{resp_type}: {rendered[:1000]}"
+
+
+def _response_item_ids(resp: Optional[dict]) -> List[str]:
+    """Extract stable daemon chat-item IDs from a command response."""
+    if not isinstance(resp, dict):
+        return []
+    wrappers: List[dict] = []
+    if isinstance(resp.get("chatItems"), list):
+        wrappers.extend(item for item in resp["chatItems"] if isinstance(item, dict))
+    if isinstance(resp.get("chatItem"), dict):
+        wrappers.append(resp["chatItem"])
+    ids: List[str] = []
+    for wrapper in wrappers:
+        inner = wrapper.get("chatItem", {}) if isinstance(wrapper, dict) else {}
+        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        if item_id is not None:
+            ids.append(str(item_id))
+    return ids
+
+
 # ---------------------------------------------------------------------------
 # SimpleX Adapter
 # ---------------------------------------------------------------------------
@@ -142,6 +195,11 @@ class SimplexAdapter(BasePlatformAdapter):
     """
 
     MAX_MESSAGE_LENGTH = MAX_MESSAGE_LENGTH
+    splits_long_messages = True
+    REQUIRES_EDIT_FINALIZE = True
+
+    _EA_HEADER = "⚠️ Dangerous command requires approval\n"
+    _EA_CMD_BUDGET = 2000
 
     def __init__(self, config: PlatformConfig, **kwargs):
         platform = Platform("simplex")
@@ -159,6 +217,11 @@ class SimplexAdapter(BasePlatformAdapter):
         else:
             self.auto_accept = bool(extra.get("auto_accept", True))
 
+        # The daemon reports received paths relative to --files-folder and
+        # exposes only a setter, not a query API. Mirror the non-secret path in
+        # config so downstream media consumers always receive openable paths.
+        self.files_folder = str(extra.get("files_folder", "") or "")
+
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
         # processes every member's traffic). Use ``*`` to accept any group.
@@ -173,6 +236,8 @@ class SimplexAdapter(BasePlatformAdapter):
         self._health_task: Optional[asyncio.Task] = None
         self._running = False
         self._last_ws_activity = 0.0
+        self._ws_ready = asyncio.Event()
+        self._connect_timeout = float(extra.get("connect_timeout", 10.0))
 
         # Track sent correlation IDs to filter echoes
         self._pending_corr_ids: set = set()
@@ -188,6 +253,23 @@ class SimplexAdapter(BasePlatformAdapter):
         # because we actually await responses to commands we send.
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._corr_counter = 0
+        self._command_tasks: set[asyncio.Task] = set()
+
+        # Bounded, non-secret runtime diagnostics. The details are also logged;
+        # these counters make health checks useful without scraping prose.
+        self._diagnostics: Dict[str, int] = {
+            "command_errors": 0,
+            "async_errors": 0,
+            "reconnects": 0,
+            "send_failures": 0,
+        }
+
+        # Direct-message reaction approvals. State is intentionally ephemeral:
+        # after restart old reactions are ignored and the typed /approve lane
+        # remains authoritative.
+        self._approval_prompts_by_item: Dict[str, dict] = {}
+        self._approval_prompt_by_session: Dict[str, str] = {}
+        self._approval_typed_only_until: Dict[str, float] = {}
 
         # Text message batching — concatenate rapid-fire messages into one
         # event before dispatching, mirroring Telegram's batching.
@@ -209,7 +291,7 @@ class SimplexAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     async def connect(self, *, is_reconnect: bool = False) -> bool:
-        """Connect to the simplex-chat daemon and start the WebSocket listener."""
+        """Start the listener and return only after its real socket is ready."""
         try:
             import websockets  # noqa: F401
         except ImportError:
@@ -223,20 +305,27 @@ class SimplexAdapter(BasePlatformAdapter):
             logger.error("SimpleX: SIMPLEX_WS_URL is required")
             return False
 
-        # Quick connectivity check — try to open and immediately close
-        try:
-            import websockets as _wsclient
-            async with _wsclient.connect(self.ws_url, open_timeout=10):
-                pass
-        except Exception as e:
-            logger.error("SimpleX: cannot reach daemon at %s: %s", self.ws_url, e)
-            return False
+        if self._running and self._ws is not None and self._ws_ready.is_set():
+            return True
 
         self._running = True
-        self._last_ws_activity = time.time()
+        self._ws_ready.clear()
         self._ws_task = asyncio.create_task(self._ws_listener())
-        self._health_task = asyncio.create_task(self._health_monitor())
 
+        try:
+            await asyncio.wait_for(
+                self._ws_ready.wait(), timeout=max(self._connect_timeout, 0.1)
+            )
+        except asyncio.TimeoutError:
+            logger.error("SimpleX: listener did not become ready before timeout")
+            await self.disconnect()
+            return False
+
+        if self._ws is None:
+            await self.disconnect()
+            return False
+
+        self._health_task = asyncio.create_task(self._health_monitor())
         if hasattr(self, "_mark_connected"):
             self._mark_connected()
         logger.info("SimpleX: connected to %s", self.ws_url)
@@ -279,8 +368,19 @@ class SimplexAdapter(BasePlatformAdapter):
         # Cancel pending command futures
         for fut in self._pending_responses.values():
             if not fut.done():
-                fut.cancel()
+                fut.set_exception(ConnectionError("SimpleX adapter disconnected"))
         self._pending_responses.clear()
+
+        for task in list(self._command_tasks):
+            if not task.done():
+                task.cancel()
+        if self._command_tasks:
+            await asyncio.gather(*self._command_tasks, return_exceptions=True)
+        self._command_tasks.clear()
+        self._ws_ready.clear()
+        self._approval_prompts_by_item.clear()
+        self._approval_prompt_by_session.clear()
+        self._approval_typed_only_until.clear()
 
         if hasattr(self, "_mark_disconnected"):
             self._mark_disconnected()
@@ -307,9 +407,15 @@ class SimplexAdapter(BasePlatformAdapter):
                     close_timeout=10,
                 ) as ws:
                     self._ws = ws
+                    self._ws_ready.set()
                     backoff = WS_RETRY_DELAY_INITIAL
                     self._last_ws_activity = time.time()
-                    logger.info("SimpleX WS: connected")
+                    if self._diagnostics["reconnects"]:
+                        logger.info("SimpleX WS: reconnected")
+                    else:
+                        logger.info("SimpleX WS: connected")
+                    if hasattr(self, "_mark_connected"):
+                        self._mark_connected()
 
                     async for raw in ws:
                         if not self._running:
@@ -338,9 +444,21 @@ class SimplexAdapter(BasePlatformAdapter):
                         e, backoff,
                     )
             finally:
-                self._ws = None
+                if self._ws is not None:
+                    self._ws = None
+                self._ws_ready.clear()
+                for corr_id, fut in list(self._pending_responses.items()):
+                    if not fut.done():
+                        fut.set_exception(
+                            ConnectionError("SimpleX WebSocket disconnected")
+                        )
+                    self._pending_responses.pop(corr_id, None)
+                    self._pending_corr_ids.discard(corr_id)
+                if hasattr(self, "_mark_disconnected"):
+                    self._mark_disconnected()
 
             if self._running:
+                self._diagnostics["reconnects"] += 1
                 jitter = backoff * 0.2 * random.random()
                 await asyncio.sleep(backoff + jitter)
                 backoff = min(backoff * 2, WS_RETRY_DELAY_MAX)
@@ -380,7 +498,8 @@ class SimplexAdapter(BasePlatformAdapter):
 
         # Handle correlated responses (replies to our own commands)
         if corr_id and corr_id in self._pending_responses:
-            fut = self._pending_responses.pop(corr_id)
+            fut = self._pending_responses[corr_id]
+            self._pending_corr_ids.discard(corr_id)
             if not fut.done():
                 fut.set_result(resp)
             return
@@ -389,12 +508,16 @@ class SimplexAdapter(BasePlatformAdapter):
         # into _pending_responses (e.g. fire-and-forget).
         if corr_id and isinstance(corr_id, str) and corr_id.startswith(_CORR_PREFIX):
             self._pending_corr_ids.discard(corr_id)
+            error = _response_error(resp)
+            if error:
+                self._diagnostics["command_errors"] += 1
+                logger.warning("SimpleX: unawaited command failed: %s", error)
             return
 
         resp_type = resp.get("type") or event.get("type", "")
 
         # Auto-accept contact requests
-        if resp_type == "contactRequest" and self.auto_accept:
+        if resp_type == "receivedContactRequest" and self.auto_accept:
             contact_req = resp.get("contactRequest", {}) or {}
             contact_req_id = contact_req.get("contactRequestId")
             if contact_req_id is not None:
@@ -402,7 +525,9 @@ class SimplexAdapter(BasePlatformAdapter):
                     "SimpleX: auto-accepting contact request %s",
                     _redact_id(str(contact_req_id)),
                 )
-                await self._send_command(f"/accept {contact_req_id}")
+                self._spawn_command_task(
+                    self._accept_contact_request(str(contact_req_id))
+                )
             return
 
         # Early file-descriptor ready: simplex fires this before newChatItems
@@ -413,11 +538,31 @@ class SimplexAdapter(BasePlatformAdapter):
             rcv_file = resp.get("rcvFileTransfer", {}) or {}
             file_id = rcv_file.get("fileId") if isinstance(rcv_file, dict) else None
             if file_id is not None:
+                wrapper = self._normalize_chat_item_wrapper(resp.get("chatItem", {}))
+                if wrapper:
+                    self._pending_file_transfers.setdefault(file_id, wrapper)
+                inner = wrapper.get("chatItem", {}) if wrapper else {}
+                file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
+                file_name = (
+                    file_info.get("fileName", "")
+                    if isinstance(file_info, dict)
+                    else ""
+                ) or rcv_file.get("fileName", "")
+                target_dir = self.files_folder or tempfile.gettempdir()
+                target = os.path.join(
+                    target_dir,
+                    f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
+                )
+                while os.path.exists(target):
+                    target = os.path.join(
+                        target_dir,
+                        f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
+                    )
                 logger.debug(
-                    "SimpleX: rcvFileDescrReady for fileId=%s — sending /freceive",
+                    "SimpleX: rcvFileDescrReady for fileId=%s — accepting transfer",
                     file_id,
                 )
-                await self._send_fire_and_forget(f"/freceive {file_id}")
+                self._spawn_command_task(self._receive_file(int(file_id), target))
             return
 
         # New messages — simplex-chat sends "newChatItems" with an array
@@ -444,6 +589,20 @@ class SimplexAdapter(BasePlatformAdapter):
                 logger.exception("SimpleX: error processing chat item")
             return
 
+        if resp_type == "chatItemUpdated":
+            try:
+                await self._handle_chat_item(resp.get("chatItem", {}), is_edit=True)
+            except Exception:
+                logger.exception("SimpleX: error processing chat item update")
+            return
+
+        if resp_type == "chatItemReaction":
+            try:
+                await self._handle_reaction_event(resp)
+            except Exception:
+                logger.exception("SimpleX: error processing reaction event")
+            return
+
         # File transfer completion — deliver any deferred chat item
         if resp_type == "rcvFileComplete":
             chat_item = resp.get("chatItem", {}) or {}
@@ -459,10 +618,11 @@ class SimplexAdapter(BasePlatformAdapter):
                     else None
                 )
                 if file_path:
+                    file_path = self._resolve_file_path(file_path)
                     pending_item_data = pending.get("chatItem", {}) or {}
-                    pending_item_data.setdefault("file", {})["fileSource"] = {
-                        "filePath": file_path
-                    }
+                    pending_file = pending_item_data.setdefault("file", {})
+                    pending_file["fileSource"] = {"filePath": file_path}
+                    pending_file["fileStatus"] = {"type": "rcvComplete"}
                     pending["chatItem"] = pending_item_data
                     try:
                         await self._handle_chat_item(pending)
@@ -470,6 +630,11 @@ class SimplexAdapter(BasePlatformAdapter):
                         logger.exception(
                             "SimpleX: error processing deferred file message"
                         )
+            return
+
+        if resp_type in {"chatError", "chatErrors", "messageError"}:
+            self._diagnostics["async_errors"] += 1
+            logger.warning("SimpleX: asynchronous daemon error: %s", _response_error(resp) or resp_type)
             return
 
         if resp_type:
@@ -514,8 +679,34 @@ class SimplexAdapter(BasePlatformAdapter):
 
         return payload
 
-    async def _handle_chat_item(self, chat_item: dict) -> None:
-        """Process a single chat item from a newChatItems event."""
+    async def _accept_contact_request(self, request_id: str) -> None:
+        resp = await self._send_command(f"/_accept {request_id}", timeout=30.0)
+        error = _response_error(resp)
+        if error:
+            self._diagnostics["command_errors"] += 1
+            logger.warning("SimpleX: contact request acceptance failed: %s", error)
+
+    async def _receive_file(self, file_id: int, target: str) -> None:
+        resp = await self._send_command(
+            f"/freceive {file_id} approved_relays=on {target}", timeout=30.0
+        )
+        error = _response_error(resp)
+        if error or _response_type(resp) == "rcvFileAcceptedSndCancelled":
+            self._pending_file_transfers.pop(file_id, None)
+            self._diagnostics["command_errors"] += 1
+            logger.warning(
+                "SimpleX: file %s receive failed: %s",
+                file_id,
+                error or "sender cancelled",
+            )
+
+    def _resolve_file_path(self, file_path: str) -> str:
+        if file_path and not os.path.isabs(file_path) and self.files_folder:
+            return os.path.join(self.files_folder, file_path)
+        return file_path
+
+    async def _handle_chat_item(self, chat_item: dict, is_edit: bool = False) -> None:
+        """Process one received item or correlated item update."""
         # Normalizing here as well keeps every caller (singular event, batch
         # array, deferred rcvFileComplete replay) safe — the helper is
         # idempotent on already-normalized wrappers.
@@ -617,30 +808,37 @@ class SimplexAdapter(BasePlatformAdapter):
             )
             file_name = file_info.get("fileName", "")
             file_id = file_info.get("fileId")
-
-            ext = ""
+            file_status = file_info.get("fileStatus", {}) or {}
+            file_status_type = (
+                file_status.get("type") if isinstance(file_status, dict) else None
+            )
             if file_path:
-                ext = Path(file_path).suffix.lower()
-            if not ext and file_name:
-                ext = Path(file_name).suffix.lower()
+                file_path = self._resolve_file_path(file_path)
 
-            # Voice notes typically arrive before the file finishes
-            # downloading. Defer the message until rcvFileComplete fires.
-            if not file_path and _is_audio_ext(ext) and file_id is not None:
+            # XFTP-backed files can arrive before the download completes.
+            # Accept exactly once from rcvFileDescrReady; accepting here can
+            # race the descriptor and leave the transfer parked indefinitely.
+            if file_id is not None and file_status_type != "rcvComplete":
                 logger.info(
-                    "SimpleX: voice file %d not yet received, accepting transfer",
+                    "SimpleX: file %d pending descriptor/completion",
                     file_id,
                 )
                 self._pending_file_transfers[file_id] = chat_item
-                # Fire-and-forget: simplex-chat does not return a corrId reply
-                # for /freceive, so awaiting one would block the event loop.
-                await self._send_fire_and_forget(f"/freceive {file_id}")
                 return
 
             if file_path:
-                ext = Path(file_path).suffix.lower() or (
-                    Path(file_name).suffix.lower() if file_name else ""
-                )
+                ext = Path(file_name).suffix.lower() or Path(file_path).suffix.lower()
+                if not _is_image_ext(ext) and not _is_audio_ext(ext):
+                    try:
+                        with open(file_path, "rb") as media_file:
+                            sniffed = _guess_extension(media_file.read(16))
+                        if sniffed != ".bin":
+                            ext = sniffed
+                    except OSError:
+                        logger.warning(
+                            "SimpleX: received file path is not readable: %s",
+                            os.path.basename(file_path),
+                        )
                 if _is_image_ext(ext):
                     media_urls.append(file_path)
                     media_types.append(f"image/{ext.lstrip('.')}")
@@ -659,12 +857,16 @@ class SimplexAdapter(BasePlatformAdapter):
                 "groupProfile", {}
             ).get("displayName", chat_id)
 
+        item_id = meta.get("itemId")
+        message_id = str(item_id) if item_id is not None else None
+
         source = self.build_source(
             chat_id=chat_id,
             chat_name=chat_name,
             chat_type="group" if is_group else "dm",
             user_id=sender_id,
             user_name=sender_name or sender_id,
+            message_id=message_id,
         )
 
         # Message type
@@ -690,6 +892,18 @@ class SimplexAdapter(BasePlatformAdapter):
         except (ValueError, AttributeError):
             timestamp = datetime.now(tz=timezone.utc)
 
+        quoted = chat_item_data.get("quotedItem", {}) or {}
+        quoted_content = quoted.get("content", {}) if isinstance(quoted, dict) else {}
+        quoted_text = (
+            quoted_content.get("text", "")
+            if isinstance(quoted_content, dict)
+            else ""
+        )
+        quoted_dir = quoted.get("chatDir", {}) if isinstance(quoted, dict) else {}
+        quoted_dir_type = (
+            quoted_dir.get("type", "") if isinstance(quoted_dir, dict) else ""
+        )
+
         msg_event = MessageEvent(
             source=source,
             text=text or "",
@@ -698,6 +912,15 @@ class SimplexAdapter(BasePlatformAdapter):
             media_types=media_types,
             timestamp=timestamp,
             raw_message=chat_item,
+            message_id=message_id,
+            reply_to_message_id=(
+                str(quoted.get("itemId"))
+                if isinstance(quoted, dict) and quoted.get("itemId") is not None
+                else None
+            ),
+            reply_to_text=quoted_text or None,
+            reply_to_is_own_message=quoted_dir_type in {"directSnd", "groupSnd"},
+            metadata={"is_edit": True} if is_edit else {},
         )
 
         logger.debug(
@@ -710,7 +933,9 @@ class SimplexAdapter(BasePlatformAdapter):
         # Batch consecutive text messages so the agent sees one combined
         # message instead of dropping earlier ones when the user pastes
         # several lines in quick succession.
-        if msg_type == MessageType.TEXT and text:
+        if is_edit:
+            await self.handle_message(msg_event)
+        elif msg_type == MessageType.TEXT and text:
             self._enqueue_text_event(msg_event)
         else:
             await self.handle_message(msg_event)
@@ -720,8 +945,15 @@ class SimplexAdapter(BasePlatformAdapter):
     # ------------------------------------------------------------------
 
     def _text_batch_key(self, event: MessageEvent) -> str:
-        """Session-scoped key for text message batching."""
-        return f"{event.source.platform.value}:{event.source.chat_id}"
+        """Session-and-sender scoped key for text batching.
+
+        Group members share a chat id, so omitting the sender would merge one
+        member's words into another member's authorized event.
+        """
+        return (
+            f"{event.source.platform.value}:{event.source.chat_id}:"
+            f"{event.source.user_id or ''}"
+        )
 
     def _enqueue_text_event(self, event: MessageEvent) -> None:
         """Buffer a text event and reset the flush timer."""
@@ -807,18 +1039,20 @@ class SimplexAdapter(BasePlatformAdapter):
             return False
 
     async def _send_command(
-        self, command: str, timeout: float = 30.0
+        self,
+        command: str,
+        timeout: float = 30.0,
     ) -> Optional[dict]:
         """Send a command and await the correlated response."""
         ws = self._ws
-        if not ws:
-            logger.warning("SimpleX: command sent but WebSocket not connected")
+        if not ws or not self._ws_ready.is_set():
+            logger.warning("SimpleX: command rejected while WebSocket is not ready")
             return None
 
         corr_id = self._make_corr_id()
         payload = json.dumps({"corrId": corr_id, "cmd": command})
 
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         fut: asyncio.Future = loop.create_future()
         self._pending_responses[corr_id] = fut
 
@@ -827,23 +1061,136 @@ class SimplexAdapter(BasePlatformAdapter):
             result = await asyncio.wait_for(fut, timeout=timeout)
             return result
         except asyncio.TimeoutError:
-            logger.warning("SimpleX: command timed out: %s", command[:50])
-            self._pending_responses.pop(corr_id, None)
+            logger.warning("SimpleX: command timed out: %s", command.split(" ", 1)[0])
             return None
         except Exception as e:
-            logger.warning("SimpleX: command failed: %s — %s", command[:50], e)
-            self._pending_responses.pop(corr_id, None)
+            logger.warning(
+                "SimpleX: command failed: %s — %s",
+                command.split(" ", 1)[0],
+                e,
+            )
             return None
+        finally:
+            self._pending_responses.pop(corr_id, None)
+            self._pending_corr_ids.discard(corr_id)
+
+    def _spawn_command_task(self, coroutine) -> asyncio.Task:
+        """Run a correlated command outside the WebSocket reader task."""
+        task = asyncio.create_task(coroutine)
+        self._command_tasks.add(task)
+
+        def _done(done: asyncio.Task) -> None:
+            self._command_tasks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception:
+                logger.exception("SimpleX: background command task failed")
+
+        task.add_done_callback(_done)
+        return task
 
     async def _send_fire_and_forget(self, command: str) -> None:
-        """Send a command without waiting for a correlated response.
-
-        Use this for commands the daemon never sends a corrId reply for,
-        such as ``/freceive``. Awaiting a corr-id reply on those would
-        stall the event loop for the full command timeout.
-        """
+        """Send without blocking the reader; explicit errors remain logged."""
         corr_id = self._make_corr_id()
-        await self._send_ws({"corrId": corr_id, "cmd": command})
+        ok = await self._send_ws({"corrId": corr_id, "cmd": command})
+        if not ok:
+            self._pending_corr_ids.discard(corr_id)
+            self._diagnostics["send_failures"] += 1
+
+    @staticmethod
+    def _chat_ref(chat_id: str) -> str:
+        """Return the structured daemon ChatRef for a stable Hermes chat id."""
+        raw = str(chat_id or "")
+        if raw.startswith("group:"):
+            return f"#{raw[6:].split('|', 1)[0]}"
+        return f"@{raw.split('|', 1)[0]}"
+
+    @staticmethod
+    def _error_kind(error: str) -> tuple[str, bool]:
+        lowered = (error or "").lower()
+        if "largemsg" in lowered or "large compressed message" in lowered:
+            return "too_long", False
+        if "notfound" in lowered or "not found" in lowered:
+            return "not_found", False
+        if "forbidden" in lowered or "permission" in lowered:
+            return "forbidden", False
+        if any(token in lowered for token in ("timeout", "closed", "network", "broker")):
+            return "transient", True
+        return "unknown", False
+
+    def _send_result_from_response(
+        self,
+        resp: Optional[dict],
+        *,
+        expected: set[str],
+    ) -> SendResult:
+        error = _response_error(resp)
+        if error:
+            self._diagnostics["command_errors"] += 1
+            kind, retryable = self._error_kind(error)
+            return SendResult(
+                success=False,
+                error=error,
+                error_kind=kind,
+                retryable=retryable,
+                raw_response=resp,
+            )
+        if resp is None:
+            self._diagnostics["send_failures"] += 1
+            return SendResult(
+                success=False,
+                error="SimpleX daemon did not confirm the command",
+                error_kind="transient",
+                retryable=True,
+            )
+        resp_type = _response_type(resp)
+        if resp_type not in expected:
+            self._diagnostics["send_failures"] += 1
+            return SendResult(
+                success=False,
+                error=f"Unexpected SimpleX response: {resp_type or '<missing>'}",
+                error_kind="unknown",
+                raw_response=resp,
+            )
+        item_ids = _response_item_ids(resp)
+        return SendResult(
+            success=True,
+            message_id=item_ids[-1] if item_ids else None,
+            continuation_message_ids=tuple(item_ids[:-1]),
+            raw_response=resp,
+        )
+
+    async def _send_composed(
+        self,
+        chat_id: str,
+        msg_content: dict,
+        *,
+        reply_to: Optional[str] = None,
+        file_source: Optional[str] = None,
+        live: bool = False,
+        timeout: float = 30.0,
+    ) -> SendResult:
+        composed: Dict[str, Any] = {
+            "msgContent": msg_content,
+            "mentions": {},
+        }
+        if reply_to is not None:
+            try:
+                composed["quotedItemId"] = int(reply_to)
+            except (TypeError, ValueError):
+                logger.debug("SimpleX: ignoring non-numeric reply item id")
+        if file_source:
+            composed["fileSource"] = {"filePath": file_source}
+
+        live_flag = " live=on" if live else ""
+        command = (
+            f"/_send {self._chat_ref(chat_id)}{live_flag} json "
+            f"{json.dumps([composed], ensure_ascii=False)}"
+        )
+        resp = await self._send_command(command, timeout=timeout)
+        return self._send_result_from_response(resp, expected={"newChatItems"})
 
     # ------------------------------------------------------------------
     # Outbound — text
@@ -856,49 +1203,44 @@ class SimplexAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send a text message.
-
-        If *content* contains ``MEDIA:<path>`` tags (embedded by TTS / audio
-        tools to signal file attachments), they are stripped from the text
-        body and sent as native voice notes or documents.
-
-        Groups use the structured ``/_send #<id> json [...]`` form
-        because the bracket chat-command syntax (``#[<id>] text``) is
-        parsed by the daemon as a display-name lookup, which silently
-        drops when the group's display name isn't the literal ID. DMs
-        use the simple ``@<id> text`` form which has always worked in
-        production.
-
-        The call is fire-and-forget at the WebSocket level: the daemon
-        doesn't always return a corrId reply for chat commands, and
-        waiting for one would serialise all outbound traffic behind a
-        30-second timeout.
-        """
+        """Deliver text and embedded media with daemon-confirmed results."""
         _voice_exts = {".ogg", ".mp3", ".wav", ".m4a", ".opus"}
         media_paths = re.findall(r"MEDIA:(\S+)", content)
         if media_paths:
             content = re.sub(r"MEDIA:\S+", "", content).strip()
 
+        delivered_ids: List[str] = []
         if content:
-            for chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": chunk}}]
+            queue = list(self.truncate_message(content, MAX_MESSAGE_LENGTH))
+            first = True
+            while queue:
+                chunk = queue.pop(0)
+                result = await self._send_composed(
+                    chat_id,
+                    {"type": "text", "text": chunk},
+                    reply_to=reply_to if first else None,
                 )
-                if chat_id.startswith("group:"):
-                    cmd_str = f"/_send #{chat_id[6:]} json {composed}"
-                else:
-                    cmd_str = f"/_send @{chat_id} json {composed}"
-
-                ok = await self._send_ws(
-                    {"corrId": self._make_corr_id(), "cmd": cmd_str}
-                )
-                if not ok:
-                    return SendResult(
-                        success=False,
-                        error="SimpleX WebSocket is unavailable or closed",
-                        retryable=True,
-                        error_kind="transient",
-                    )
+                first = False
+                if (
+                    not result.success
+                    and result.error_kind == "too_long"
+                    and len(chunk) > 512
+                ):
+                    queue = self.truncate_message(
+                        chunk, max(256, len(chunk) // 2)
+                    ) + queue
+                    continue
+                if not result.success:
+                    result.message_id = delivered_ids[-1] if delivered_ids else None
+                    if delivered_ids:
+                        result.raw_response = {
+                            "partial_delivery": True,
+                            "delivered_message_ids": tuple(delivered_ids),
+                            "daemon_response": result.raw_response,
+                        }
+                    return result
+                if result.message_id:
+                    delivered_ids.append(result.message_id)
 
         for path in media_paths:
             is_voice = os.path.splitext(path)[1].lower() in _voice_exts
@@ -908,7 +1250,11 @@ class SimplexAdapter(BasePlatformAdapter):
                 media_result = await self.send_document(chat_id, path)
             if not media_result.success:
                 return media_result
-        return SendResult(success=True)
+        return SendResult(
+            success=True,
+            message_id=delivered_ids[-1] if delivered_ids else None,
+            continuation_message_ids=tuple(delivered_ids[:-1]),
+        )
 
     # ------------------------------------------------------------------
     # Channel directory enumeration
@@ -923,9 +1269,9 @@ class SimplexAdapter(BasePlatformAdapter):
         the WebSocket is down so the directory falls back to session-history
         discovery instead of wiping previously known targets.
 
-        Entry ``id`` values match the send-target formats the adapter
-        accepts: bare contact display name for DMs (``simplex:<name>``) and
-        ``group:<groupId>`` for groups (``simplex:group:<id>``).
+        Entry ``id`` values use immutable numeric contact/group IDs. Display
+        names remain labels only and never become authorization or routing
+        identities.
         """
         if not self._ws:
             return None
@@ -933,7 +1279,7 @@ class SimplexAdapter(BasePlatformAdapter):
         channels: List[Dict[str, Any]] = []
 
         resp = await self._send_command("/contacts", timeout=10.0)
-        if resp is None:
+        if resp is None or _response_error(resp):
             # Daemon unresponsive — keep whatever the directory already has.
             return None
         for contact in resp.get("contacts") or []:
@@ -944,18 +1290,16 @@ class SimplexAdapter(BasePlatformAdapter):
                 contact.get("localDisplayName", "")
                 or (contact.get("profile", {}) or {}).get("displayName", "")
             )
-            if contact_id is None and not name:
+            if contact_id is None:
                 continue
             channels.append({
-                # Display name is what the DM send path (``@<name>``)
-                # actually addresses; fall back to the numeric contactId.
-                "id": str(name or contact_id),
+                "id": str(contact_id),
                 "name": str(name or contact_id),
                 "type": "dm",
             })
 
         resp = await self._send_command("/groups", timeout=10.0)
-        if resp is not None:
+        if resp is not None and not _response_error(resp):
             for group in resp.get("groups") or []:
                 # The daemon returns each group as either a groupInfo dict
                 # or a [groupInfo, groupSummary] pair depending on version.
@@ -1079,31 +1423,16 @@ class SimplexAdapter(BasePlatformAdapter):
 
         png_path, thumb_uri = self._prepare_image(file_path)
 
-        # /_send addresses by numeric ID; /f only accepts display names which
-        # breaks for group IDs.
-        composed = json.dumps(
-            [
-                {
-                    "filePath": png_path,
-                    "msgContent": {
-                        "type": "image",
-                        "image": thumb_uri,
-                        "text": caption or "",
-                    },
-                }
-            ]
+        return await self._send_composed(
+            chat_id,
+            {
+                "type": "image",
+                "image": thumb_uri,
+                "text": caption or "",
+            },
+            reply_to=kwargs.get("reply_to"),
+            file_source=png_path,
         )
-
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"/_send @{chat_id} json {composed}"
-
-        result = await self._send_command(command)
-        if result is not None:
-            return SendResult(success=True)
-        return SendResult(success=False, error="Failed to send image")
 
     async def send_image_file(
         self,
@@ -1115,7 +1444,11 @@ class SimplexAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send a local image file via SimpleX."""
         return await self.send_image(
-            chat_id, f"file://{image_path}", caption=caption, **kwargs
+            chat_id,
+            f"file://{image_path}",
+            caption=caption,
+            reply_to=reply_to,
+            **kwargs,
         )
 
     async def send_video(
@@ -1141,25 +1474,12 @@ class SimplexAdapter(BasePlatformAdapter):
         if not Path(file_path).exists():
             return SendResult(success=False, error="File not found")
 
-        composed = json.dumps(
-            [
-                {
-                    "filePath": file_path,
-                    "msgContent": {"type": "file", "text": caption or ""},
-                }
-            ]
+        return await self._send_composed(
+            chat_id,
+            {"type": "file", "text": caption or ""},
+            reply_to=kwargs.get("reply_to"),
+            file_source=file_path,
         )
-
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"/_send @{chat_id} json {composed}"
-
-        result = await self._send_command(command)
-        if result is not None:
-            return SendResult(success=True)
-        return SendResult(success=False, error="Failed to send document")
 
     async def send_voice(
         self,
@@ -1180,29 +1500,353 @@ class SimplexAdapter(BasePlatformAdapter):
         if not Path(audio_path).exists():
             return SendResult(success=False, error="Voice file not found")
 
-        composed = json.dumps(
-            [
-                {
-                    "msgContent": {
-                        "type": "voice",
-                        "text": caption or "",
-                        "duration": duration,
-                    },
-                    "fileSource": {"filePath": audio_path},
-                }
-            ]
+        return await self._send_composed(
+            chat_id,
+            {
+                "type": "voice",
+                "text": caption or "",
+                "duration": duration,
+            },
+            reply_to=reply_to,
+            file_source=audio_path,
         )
 
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            command = f"/_send #{group_id} json {composed}"
-        else:
-            command = f"/_send @{chat_id} json {composed}"
+    async def edit_message(
+        self,
+        chat_id: str,
+        message_id: str,
+        content: str,
+        *,
+        finalize: bool = False,
+    ) -> SendResult:
+        """Update a streaming preview and finalize it with complete text."""
+        chunks = self.truncate_message(content, MAX_MESSAGE_LENGTH)
+        first_chunk = chunks[0] if chunks else ""
+        updated = {
+            "msgContent": {"type": "text", "text": first_chunk},
+            "mentions": {},
+        }
+        live_flag = "" if finalize else " live=on"
+        command = (
+            f"/_update item {self._chat_ref(chat_id)} {message_id}{live_flag} json "
+            f"{json.dumps(updated, ensure_ascii=False)}"
+        )
+        resp = await self._send_command(command)
+        result = self._send_result_from_response(
+            resp, expected={"chatItemUpdated", "chatItemNotChanged"}
+        )
+        if not result.success:
+            return result
+        result.message_id = str(message_id)
 
-        result = await self._send_command(command)
-        if result is not None:
-            return SendResult(success=True)
-        return SendResult(success=False, error="Failed to send voice message")
+        # Mid-stream edits remain one stable preview bubble. Only the final
+        # update emits overflow continuations, preventing each growing token
+        # update from duplicating the response.
+        if not finalize or len(chunks) <= 1:
+            return result
+
+        continuation_ids: List[str] = []
+        for chunk in chunks[1:]:
+            continuation = await self._send_composed(
+                chat_id, {"type": "text", "text": chunk}
+            )
+            if not continuation.success:
+                continuation.message_id = (
+                    continuation_ids[-1] if continuation_ids else str(message_id)
+                )
+                continuation.continuation_message_ids = tuple(continuation_ids)
+                continuation.raw_response = {
+                    "partial_overflow": True,
+                    "delivered_chunks": 1 + len(continuation_ids),
+                    "total_chunks": len(chunks),
+                    "last_message_id": continuation.message_id,
+                    "continuation_message_ids": tuple(continuation_ids),
+                    "daemon_response": continuation.raw_response,
+                }
+                return continuation
+            if continuation.message_id:
+                continuation_ids.append(continuation.message_id)
+
+        return SendResult(
+            success=True,
+            message_id=continuation_ids[-1] if continuation_ids else str(message_id),
+            continuation_message_ids=tuple(continuation_ids),
+        )
+
+    async def delete_message(self, chat_id: str, message_id: str) -> bool:
+        resp = await self._send_command(
+            f"/_delete item {self._chat_ref(chat_id)} {message_id} broadcast"
+        )
+        return self._send_result_from_response(
+            resp, expected={"chatItemsDeleted"}
+        ).success
+
+    async def _set_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        *,
+        added: bool,
+    ) -> SendResult:
+        reaction = json.dumps(
+            {"type": "emoji", "emoji": emoji}, ensure_ascii=False
+        )
+        toggle = "on" if added else "off"
+        resp = await self._send_command(
+            f"/_reaction {self._chat_ref(chat_id)} {message_id} {toggle} {reaction}",
+            timeout=10.0,
+        )
+        return self._send_result_from_response(
+            resp, expected={"chatItemReaction"}
+        )
+
+    @staticmethod
+    def _approval_timeout() -> float:
+        try:
+            from tools.approval import _get_approval_timeout
+
+            return max(1.0, float(_get_approval_timeout()))
+        except Exception:
+            return 300.0
+
+    def _approval_text(
+        self,
+        command: str,
+        description: str,
+        *,
+        allow_session: bool,
+        allow_permanent: bool,
+        smart_denied: bool,
+        reactions: bool,
+    ) -> str:
+        prefix = self.typed_command_prefix
+        lines = [self._format_exec_approval(command, description, smart_denied)]
+        choices = [f"Reply `{prefix}approve` to run once"]
+        if not smart_denied and allow_session:
+            choices.append(f"`{prefix}approve session` for this session")
+        if not smart_denied and allow_permanent:
+            choices.append(f"`{prefix}approve always` to persist the pattern")
+        choices.append(f"`{prefix}deny` to cancel")
+        lines.append(", or ".join(choices) + ".")
+        if reactions:
+            taps = ["✅ = run once"]
+            if not smart_denied and allow_session:
+                taps.append("🚀 = allow for this session")
+            taps.append("👎 = deny")
+            lines.append("Tap a reaction: " + "; ".join(taps) + ".")
+        return "\n\n".join(lines)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[dict] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Offer unambiguous direct-message reaction approvals with typed fallback."""
+        now = time.monotonic()
+        self._sweep_approval_prompts(now)
+        is_dm = not str(chat_id).startswith("group:")
+        existing_id = self._approval_prompt_by_session.get(session_key)
+        typed_only = self._approval_typed_only_until.get(session_key, 0.0) > now
+
+        if existing_id:
+            self._retire_approval_prompt(existing_id)
+            self._approval_typed_only_until[session_key] = now + self._approval_timeout()
+            typed_only = True
+
+        reaction_lane = is_dm and not typed_only
+        text = self._approval_text(
+            command,
+            description,
+            allow_session=allow_session,
+            allow_permanent=allow_permanent,
+            smart_denied=smart_denied,
+            reactions=reaction_lane,
+        )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id or not reaction_lane:
+            if not result.success or not result.message_id:
+                self._approval_typed_only_until[session_key] = (
+                    now + self._approval_timeout()
+                )
+            return result
+
+        choices = {"✅": "once", "👎": "deny"}
+        seeds = ["👎", "✅"]
+        if not smart_denied and allow_session:
+            choices["🚀"] = "session"
+            seeds.insert(1, "🚀")
+        prompt = {
+            "session_key": session_key,
+            "chat_id": str(chat_id),
+            "item_id": str(result.message_id),
+            "choices": choices,
+            "seeded": [],
+            "expires_at": now + self._approval_timeout(),
+        }
+        self._approval_prompts_by_item[prompt["item_id"]] = prompt
+        self._approval_prompt_by_session[session_key] = prompt["item_id"]
+        self._spawn_command_task(self._seed_approval_reactions(prompt, seeds))
+        self._spawn_command_task(self._expire_approval_prompt(prompt["item_id"]))
+        return result
+
+    async def _seed_approval_reactions(self, prompt: dict, seeds: List[str]) -> None:
+        for emoji in seeds[:3]:
+            if self._approval_prompts_by_item.get(prompt["item_id"]) is not prompt:
+                return
+            result = await self._set_reaction(
+                prompt["chat_id"], prompt["item_id"], emoji, added=True
+            )
+            if not result.success:
+                logger.info(
+                    "SimpleX: reaction seed unavailable; typed approval remains active"
+                )
+                return
+            prompt["seeded"].append(emoji)
+
+    async def _expire_approval_prompt(self, item_id: str) -> None:
+        prompt = self._approval_prompts_by_item.get(item_id)
+        if not prompt:
+            return
+        await asyncio.sleep(max(0.0, prompt["expires_at"] - time.monotonic()))
+        if self._approval_prompts_by_item.get(item_id) is prompt:
+            self._retire_approval_prompt(item_id)
+
+    def _sweep_approval_prompts(self, now: Optional[float] = None) -> None:
+        current = time.monotonic() if now is None else now
+        for item_id, prompt in list(self._approval_prompts_by_item.items()):
+            if prompt["expires_at"] <= current:
+                self._retire_approval_prompt(item_id)
+        for session_key, expiry in list(self._approval_typed_only_until.items()):
+            if expiry <= current:
+                self._approval_typed_only_until.pop(session_key, None)
+
+    def _retire_approval_prompt(self, item_id: str) -> None:
+        prompt = self._approval_prompts_by_item.pop(str(item_id), None)
+        if not prompt:
+            return
+        if self._approval_prompt_by_session.get(prompt["session_key"]) == str(item_id):
+            self._approval_prompt_by_session.pop(prompt["session_key"], None)
+        if prompt["seeded"]:
+            self._spawn_command_task(self._clear_approval_reactions(prompt))
+
+    async def _clear_approval_reactions(self, prompt: dict) -> None:
+        for emoji in list(prompt["seeded"]):
+            await self._set_reaction(
+                prompt["chat_id"], prompt["item_id"], emoji, added=False
+            )
+
+    @staticmethod
+    def _reaction_context(resp: dict) -> Optional[dict]:
+        wrapper = resp.get("reaction", {}) or {}
+        if not isinstance(wrapper, dict):
+            return None
+        chat_info = wrapper.get("chatInfo", {}) or {}
+        reaction = wrapper.get("chatReaction", {}) or {}
+        if not isinstance(chat_info, dict) or not isinstance(reaction, dict):
+            return None
+        chat_item = reaction.get("chatItem", {}) or {}
+        meta = chat_item.get("meta", {}) if isinstance(chat_item, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        msg_reaction = reaction.get("reaction", {}) or {}
+        emoji = (
+            msg_reaction.get("emoji", "")
+            if isinstance(msg_reaction, dict)
+            else ""
+        ).replace("\ufe0f", "")
+        chat_type = chat_info.get("type", "")
+        chat_dir = reaction.get("chatDir", {}) or {}
+        if chat_type == "direct":
+            contact = chat_info.get("contact", {}) or {}
+            chat_id = str(contact.get("contactId", ""))
+            user_id = chat_id
+            user_name = contact.get("localDisplayName", "")
+        elif chat_type == "group":
+            group = chat_info.get("groupInfo", {}) or {}
+            chat_id = f"group:{group.get('groupId', '')}"
+            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
+            user_id = str(member.get("memberId", ""))
+            user_name = member.get("localDisplayName", "")
+        else:
+            return None
+        return {
+            "item_id": str(item_id) if item_id is not None else "",
+            "chat_id": chat_id,
+            "user_id": user_id,
+            "user_name": user_name,
+            "emoji": emoji,
+            "added": bool(resp.get("added", False)),
+            "raw": resp,
+        }
+
+    async def _handle_reaction_event(self, resp: dict) -> None:
+        ctx = self._reaction_context(resp)
+        if not ctx:
+            return
+        hook = getattr(self, "_reaction_handler", None)
+        if hook is not None:
+            await hook(
+                {
+                    "event_name": (
+                        "reaction:added" if ctx["added"] else "reaction:removed"
+                    ),
+                    "platform": "simplex",
+                    **ctx,
+                }
+            )
+
+        if not ctx["added"]:
+            return
+        prompt = self._approval_prompts_by_item.get(ctx["item_id"])
+        if not prompt or prompt["chat_id"] != ctx["chat_id"]:
+            return
+        if not prompt["chat_id"].startswith("group:") and ctx["user_id"] != prompt["chat_id"]:
+            logger.warning("SimpleX: ignored approval reaction from another contact")
+            return
+        if time.monotonic() >= prompt["expires_at"]:
+            self._retire_approval_prompt(prompt["item_id"])
+            return
+        choice = prompt["choices"].get(ctx["emoji"])
+        if not choice:
+            return
+
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = int(resolve_gateway_approval(prompt["session_key"], choice) or 0)
+        except Exception:
+            logger.exception("SimpleX: failed to resolve reaction approval")
+            return
+        self._retire_approval_prompt(prompt["item_id"])
+        acknowledgement = {
+            "once": "Approved — running this once.",
+            "session": "Approved for this session.",
+            "deny": "Denied — the command will not run.",
+        }[choice]
+        if count <= 0:
+            acknowledgement = "That approval is no longer pending. Nothing ran."
+        self._spawn_command_task(self.send(prompt["chat_id"], acknowledgement))
+
+    def get_runtime_diagnostics(self) -> Dict[str, Any]:
+        """Return bounded transport state for status/incident tooling."""
+        return {
+            **self._diagnostics,
+            "ready": self._ws is not None and self._ws_ready.is_set(),
+            "pending_commands": len(self._pending_responses),
+            "pending_files": len(self._pending_file_transfers),
+            "pending_approval_prompts": len(self._approval_prompts_by_item),
+            "last_activity_age_seconds": (
+                max(0.0, time.time() - self._last_ws_activity)
+                if self._last_ws_activity
+                else None
+            ),
+        }
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """SimpleX has no typing-indicator API — no-op."""
@@ -1288,7 +1932,7 @@ async def _standalone_send(
     message: str,
     *,
     thread_id: Optional[str] = None,
-    media_files: Optional[List[str]] = None,
+    media_files: Optional[List[Any]] = None,
     force_document: bool = False,
 ) -> Dict[str, Any]:
     """Open an ephemeral WebSocket to the daemon, send, and close.
@@ -1298,11 +1942,8 @@ async def _standalone_send(
     separate process from ``hermes gateway``). Without this hook,
     ``deliver=simplex`` cron jobs fail with "No live adapter for platform".
 
-    ``thread_id`` and ``force_document`` are accepted for signature parity
-    with other plugins but are not meaningful here. ``media_files`` is
-    accepted but only the text body is delivered — SimpleX file transfers
-    require the daemon's filesystem-backed flow, which an ephemeral
-    connection cannot drive safely.
+    ``thread_id`` is accepted for signature parity. Text and media are
+    reported successful only after a correlated daemon acknowledgement.
     """
     try:
         import websockets as _wsclient
@@ -1316,30 +1957,81 @@ async def _standalone_send(
     if not ws_url:
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 
-    try:
-        composed = json.dumps(
-            [{"msgContent": {"type": "text", "text": message}}]
-        )
-        chunks = BasePlatformAdapter.truncate_message(message, MAX_MESSAGE_LENGTH)
-
-        async with _wsclient.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
-            for i, chunk in enumerate(chunks):
-                composed = json.dumps(
-                    [{"msgContent": {"type": "text", "text": chunk}}]
+    async def _send_confirmed(ws, command: str, corr_id: str) -> dict:
+        await ws.send(json.dumps({"corrId": corr_id, "cmd": command}))
+        while True:
+            raw = await asyncio.wait_for(ws.recv(), timeout=30.0)
+            event = json.loads(raw)
+            if event.get("corrId") != corr_id:
+                continue
+            resp = event.get("resp") if isinstance(event.get("resp"), dict) else event
+            error = _response_error(resp)
+            if error:
+                raise RuntimeError(error)
+            if _response_type(resp) != "newChatItems":
+                raise RuntimeError(
+                    f"unexpected SimpleX response: {_response_type(resp) or '<missing>'}"
                 )
-                if chat_id.startswith("group:"):
-                    cmd_str = f"/_send #{chat_id[6:]} json {composed}"
-                else:
-                    cmd_str = f"/_send @{chat_id} json {composed}"
-                payload = {
-                    "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}-{i}",
-                    "cmd": cmd_str,
-                }
-                await ws.send(json.dumps(payload))
-            # Give the daemon a moment to process the command(s) before closing.
-            await asyncio.sleep(0.5)
+            return resp
 
-        return {"success": True, "platform": "simplex", "chat_id": chat_id}
+    try:
+        chat_ref = SimplexAdapter._chat_ref(chat_id)
+        commands: List[str] = []
+        if message:
+            for chunk in BasePlatformAdapter.truncate_message(
+                message, MAX_MESSAGE_LENGTH
+            ):
+                composed = [{
+                    "msgContent": {"type": "text", "text": chunk},
+                    "mentions": {},
+                }]
+                commands.append(
+                    f"/_send {chat_ref} json "
+                    f"{json.dumps(composed, ensure_ascii=False)}"
+                )
+
+        for media in media_files or []:
+            if isinstance(media, (tuple, list)):
+                path = str(media[0])
+                is_voice = bool(media[1]) if len(media) > 1 else False
+            else:
+                path = str(media)
+                is_voice = False
+            if not Path(path).is_file():
+                return {"error": f"SimpleX media file not found: {os.path.basename(path)}"}
+            ext = Path(path).suffix.lower()
+            if is_voice:
+                msg_content = {"type": "voice", "text": "", "duration": 0}
+                file_path = path
+            elif not force_document and _is_image_ext(ext):
+                file_path, thumb = SimplexAdapter._prepare_image(path)
+                msg_content = {"type": "image", "image": thumb, "text": ""}
+            else:
+                msg_content = {"type": "file", "text": ""}
+                file_path = path
+            composed = [{
+                "fileSource": {"filePath": file_path},
+                "msgContent": msg_content,
+                "mentions": {},
+            }]
+            commands.append(
+                f"/_send {chat_ref} json "
+                f"{json.dumps(composed, ensure_ascii=False)}"
+            )
+
+        item_ids: List[str] = []
+        async with _wsclient.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
+            for index, command in enumerate(commands):
+                corr_id = f"{_CORR_PREFIX}snd-{uuid.uuid4().hex}-{index}"
+                resp = await _send_confirmed(ws, command, corr_id)
+                item_ids.extend(_response_item_ids(resp))
+
+        return {
+            "success": True,
+            "platform": "simplex",
+            "chat_id": chat_id,
+            "message_id": item_ids[-1] if item_ids else None,
+        }
     except Exception as e:
         return {"error": f"SimpleX send failed: {e}"}
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -345,11 +345,15 @@ class SimplexAdapter(
 
         # Text message batching — concatenate rapid-fire messages into one
         # event before dispatching, mirroring Telegram's batching.
+        text_batch_delay = _scoped_platform_setting(
+            "HERMES_SIMPLEX_TEXT_BATCH_DELAY", extra, "text_batch_delay"
+        )
         self._text_batch_delay = float(
-            os.getenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "0.8")
+            "0.8" if text_batch_delay in (None, "") else text_batch_delay
         )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
+        self._text_batch_dispatching: set[str] = set()
 
         logger.info(
             "SimpleX adapter initialized: url=%s auto_accept=%s groups=%s",
@@ -377,8 +381,20 @@ class SimplexAdapter(
             logger.error("SimpleX: SIMPLEX_WS_URL is required")
             return False
 
-        if self._running and self._ws is not None and self._ws_ready.is_set():
-            return True
+        if self._running and self._ws_task and not self._ws_task.done():
+            if self._ws is not None and self._ws_ready.is_set():
+                return True
+            try:
+                await asyncio.wait_for(
+                    self._ws_ready.wait(), timeout=max(self._connect_timeout, 0.1)
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "SimpleX: existing listener is still reconnecting to %s",
+                    self.ws_url,
+                )
+                return False
+            return self._ws is not None
 
         try:
             if not self._acquire_platform_lock(
@@ -402,7 +418,16 @@ class SimplexAdapter(
             await self.disconnect()
             return False
         except asyncio.CancelledError:
-            await self.disconnect()
+            # A second cancellation must not interrupt teardown after the
+            # daemon-ownership lock has been acquired. Keep the cleanup in its
+            # own task and drain it before propagating the original cancel.
+            cleanup_task = asyncio.create_task(self.disconnect())
+            while not cleanup_task.done():
+                try:
+                    await asyncio.shield(cleanup_task)
+                except asyncio.CancelledError:
+                    continue
+            cleanup_task.result()
             raise
         except Exception:
             logger.exception("SimpleX: listener startup failed")
@@ -1309,7 +1334,7 @@ class SimplexAdapter(
         in-flight event has been restored ahead of it.
         """
         if prior_task is not None:
-            if not prior_task.done():
+            if not prior_task.done() and key not in self._text_batch_dispatching:
                 prior_task.cancel()
             await asyncio.gather(prior_task, return_exceptions=True)
         await self._flush_text_batch(key)
@@ -1344,10 +1369,11 @@ class SimplexAdapter(
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text."""
         current_task = asyncio.current_task()
+        recovered_after_cancel = False
         try:
             await asyncio.sleep(self._text_batch_delay)
             event = self._pending_text_batches.pop(key, None)
-            if not event:
+            if event is None:
                 return
             logger.info(
                 "[SimpleX] Flushing text batch %s (%d chars)",
@@ -1355,16 +1381,23 @@ class SimplexAdapter(
                 len(event.text or ""),
             )
             try:
+                self._text_batch_dispatching.add(key)
                 await self.handle_message(event)
             except asyncio.CancelledError:
                 newer = self._pending_text_batches.get(key)
                 self._pending_text_batches[key] = prepend_cancelled_batch(
                     event, newer
                 )
+                recovered_after_cancel = True
                 raise
         finally:
+            self._text_batch_dispatching.discard(key)
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
+                if recovered_after_cancel and self._running:
+                    self._pending_text_batch_tasks[key] = asyncio.create_task(
+                        self._flush_text_batch(key)
+                    )
 
     # ------------------------------------------------------------------
     # Command interface

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -427,15 +427,19 @@ class SimplexAdapter(BasePlatformAdapter):
                 chat_items = [chat_items]
             for item in chat_items:
                 try:
-                    await self._handle_chat_item(item)
+                    await self._handle_chat_item(self._normalize_chat_item_wrapper(item))
                 except Exception:
                     logger.exception("SimpleX: error processing chat item")
             return
 
-        # Singular variant — some daemon versions emit this
+        # Singular variant — some daemon versions emit this. The AChatItem is
+        # usually nested one level down ({"type": "newChatItem", "chatItem":
+        # {"chatInfo": ..., "chatItem": ...}}); _handle_chat_item reads
+        # chatInfo/chatItem at the top level, so unwrap before dispatching or
+        # the message is silently dropped.
         if resp_type == "newChatItem":
             try:
-                await self._handle_chat_item(resp)
+                await self._handle_chat_item(self._normalize_chat_item_wrapper(resp))
             except Exception:
                 logger.exception("SimpleX: error processing chat item")
             return
@@ -471,8 +475,51 @@ class SimplexAdapter(BasePlatformAdapter):
         if resp_type:
             logger.debug("SimpleX: unhandled event type: %s", resp_type)
 
+    @staticmethod
+    def _normalize_chat_item_wrapper(payload: dict) -> dict:
+        """Normalize SimpleX AChatItem payload variants to {chatInfo, chatItem}.
+
+        Depending on daemon version and event type, the chat item wrapper
+        arrives in one of several shapes:
+
+        * ``{"chatInfo": ..., "chatItem": ...}`` — already normalized
+          (the usual ``newChatItems`` array element).
+        * ``{"type": "newChatItem", "chatItem": {"chatInfo": ...,
+          "chatItem": ...}}`` — the singular event nests the AChatItem one
+          level down.
+        * ``{"chatInfo": ..., "item": ...}`` — some responses name the item
+          field ``item`` instead of ``chatItem``.
+
+        ``_handle_chat_item`` only reads ``chatInfo``/``chatItem`` at the top
+        level, so anything not normalized here would be silently dropped.
+        """
+        if not isinstance(payload, dict):
+            return {}
+
+        nested = payload.get("chatItem")
+        if isinstance(nested, dict):
+            # Nested AChatItem: {type: newChatItem, chatItem: {chatInfo, chatItem}}
+            if isinstance(nested.get("chatInfo"), dict) and isinstance(
+                nested.get("chatItem"), dict
+            ):
+                return nested
+            # Already normalized: {chatInfo: ..., chatItem: {content/meta/...}}
+            if isinstance(payload.get("chatInfo"), dict):
+                return payload
+
+        if isinstance(payload.get("chatInfo"), dict) and isinstance(
+            payload.get("item"), dict
+        ):
+            return {"chatInfo": payload["chatInfo"], "chatItem": payload["item"]}
+
+        return payload
+
     async def _handle_chat_item(self, chat_item: dict) -> None:
         """Process a single chat item from a newChatItems event."""
+        # Normalizing here as well keeps every caller (singular event, batch
+        # array, deferred rcvFileComplete replay) safe — the helper is
+        # idempotent on already-normalized wrappers.
+        chat_item = self._normalize_chat_item_wrapper(chat_item)
         chat_info = chat_item.get("chatInfo", {}) or {}
         chat_item_data = chat_item.get("chatItem", {}) or {}
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -154,7 +154,7 @@ def _response_error(resp: Optional[dict]) -> Optional[str]:
     if not isinstance(resp, dict):
         return "SimpleX daemon did not answer"
     resp_type = _response_type(resp)
-    if resp_type == "localCommandOutcomeUnknown":
+    if resp_type in {"localCommandOutcomeUnknown", "localCommandNotSubmitted"}:
         return str(resp.get("error") or "SimpleX command outcome is unknown")[:1000]
     if resp_type not in {"chatCmdError", "chatError", "chatErrors"}:
         return None
@@ -226,6 +226,10 @@ class SimplexAdapter(BasePlatformAdapter):
         self._file_transfer_timeout = max(
             1.0, float(extra.get("file_transfer_timeout", 300.0))
         )
+        self.retain_received_files = bool(extra.get("retain_received_files", False))
+        self._media_cleanup_timeout = max(
+            60.0, float(extra.get("media_cleanup_timeout", 3600.0))
+        )
 
         allow_entries = _parse_comma_list(os.getenv("SIMPLEX_ALLOWED_USERS", ""))
         ignored_allow_entries = [
@@ -233,8 +237,10 @@ class SimplexAdapter(BasePlatformAdapter):
         ]
         if ignored_allow_entries:
             logger.warning(
-                "SimpleX: %d non-numeric SIMPLEX_ALLOWED_USERS entries are "
-                "ignored; migrate to stable contactIds from /contacts",
+                "SimpleX: %d non-numeric SIMPLEX_ALLOWED_USERS entries do not "
+                "authorize DMs; display names are ignored. Keep an entry only "
+                "if it is an exact group memberId, otherwise migrate to a "
+                "stable contactId from /contacts",
                 len(ignored_allow_entries),
             )
 
@@ -264,6 +270,10 @@ class SimplexAdapter(BasePlatformAdapter):
         # consumed when the file finishes downloading.
         self._pending_file_transfers: Dict[int, dict] = {}
         self._file_transfer_tasks: Dict[int, asyncio.Task] = {}
+        self._file_receive_targets: Dict[int, str] = {}
+        self._terminal_file_transfers: Dict[int, dict] = {}
+        self._owned_media_cleanup_tasks: Dict[str, asyncio.Task] = {}
+        self._outbound_temp_by_item: Dict[str, str] = {}
 
         # Correlation tracking for ``_send_command``. Separate from
         # ``_pending_corr_ids`` (which is the upstream cosmetic echo filter)
@@ -283,6 +293,7 @@ class SimplexAdapter(BasePlatformAdapter):
             "file_rejections": 0,
             "file_failures": 0,
             "file_timeouts": 0,
+            "late_file_completions": 0,
         }
 
         # Direct-message reaction approvals. State is intentionally ephemeral:
@@ -415,6 +426,15 @@ class SimplexAdapter(BasePlatformAdapter):
             )
         self._file_transfer_tasks.clear()
         self._pending_file_transfers.clear()
+        self._file_receive_targets.clear()
+        self._terminal_file_transfers.clear()
+        for path in list(self._owned_media_cleanup_tasks):
+            self._cleanup_owned_media_path(path)
+        for task in list(self._owned_media_cleanup_tasks.values()):
+            if not task.done():
+                task.cancel()
+        self._owned_media_cleanup_tasks.clear()
+        self._outbound_temp_by_item.clear()
         self._ws_ready.clear()
         self._approval_prompts_by_item.clear()
         self._approval_prompt_by_session.clear()
@@ -492,8 +512,18 @@ class SimplexAdapter(BasePlatformAdapter):
                         )
                     self._pending_responses.pop(corr_id, None)
                     self._pending_corr_ids.discard(corr_id)
-                if hasattr(self, "_mark_disconnected"):
-                    self._mark_disconnected()
+                # Do not call ``_mark_disconnected`` here: the base helper
+                # sets ``_running = False`` and would terminate this listener's
+                # own reconnect loop after the first socket drop. Keep the
+                # adapter alive while publishing transient disconnected state;
+                # explicit ``disconnect()`` owns the terminal state change.
+                if self._running and hasattr(self, "_write_runtime_status_safe"):
+                    self._write_runtime_status_safe(
+                        "disconnected",
+                        platform_state="disconnected",
+                        error_code=None,
+                        error_message=None,
+                    )
 
             if self._running:
                 self._diagnostics["reconnects"] += 1
@@ -577,6 +607,12 @@ class SimplexAdapter(BasePlatformAdapter):
             file_id = rcv_file.get("fileId") if isinstance(rcv_file, dict) else None
             if file_id is not None:
                 file_id = int(file_id)
+                if file_id in self._terminal_file_transfers:
+                    logger.debug(
+                        "SimpleX: ignoring descriptor for terminal fileId=%s",
+                        file_id,
+                    )
+                    return
                 wrapper = self._normalize_chat_item_wrapper(resp.get("chatItem", {}))
                 if not wrapper:
                     wrapper = self._pending_file_transfers.get(file_id, {})
@@ -605,6 +641,8 @@ class SimplexAdapter(BasePlatformAdapter):
                         target_dir,
                         f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
                     )
+                self._file_receive_targets[file_id] = target
+                self._schedule_owned_media_cleanup(target)
                 logger.debug(
                     "SimpleX: rcvFileDescrReady for fileId=%s — accepting transfer",
                     file_id,
@@ -644,10 +682,23 @@ class SimplexAdapter(BasePlatformAdapter):
             return
 
         if resp_type == "chatItemReaction":
-            try:
-                await self._handle_reaction_event(resp)
-            except Exception:
-                logger.exception("SimpleX: error processing reaction event")
+            self._spawn_dispatch_task(self._handle_reaction_event(resp))
+            return
+
+        if resp_type in {
+            "sndFileComplete",
+            "sndFileCompleteXFTP",
+            "sndFileError",
+            "sndFileWarning",
+        }:
+            wrapper = self._normalize_chat_item_wrapper(
+                resp.get("chatItem") or resp.get("chatItem_") or {}
+            )
+            item_id = self._item_id_from_wrapper(wrapper)
+            if item_id is not None:
+                temp_path = self._outbound_temp_by_item.pop(str(item_id), None)
+                if temp_path:
+                    self._cleanup_owned_media_path(temp_path)
             return
 
         if resp_type in {"rcvFileSndCancelled", "rcvFileError"}:
@@ -679,6 +730,24 @@ class SimplexAdapter(BasePlatformAdapter):
             file_info = chat_item_data.get("file", {}) or {}
             file_id = self._file_id_from_wrapper(chat_item)
             if file_id is not None:
+                if file_id in self._terminal_file_transfers:
+                    self._diagnostics["late_file_completions"] += 1
+                    late_source = file_info.get("fileSource", {}) or {}
+                    late_path = (
+                        late_source.get("filePath")
+                        if isinstance(late_source, dict)
+                        else None
+                    )
+                    target = self._terminal_file_target(file_id)
+                    if late_path and target:
+                        resolved = self._resolve_file_path(late_path)
+                        if os.path.abspath(resolved) == os.path.abspath(target):
+                            self._cleanup_owned_media_path(target)
+                    logger.info(
+                        "SimpleX: ignored late/duplicate completion for fileId=%s",
+                        file_id,
+                    )
+                    return
                 pending = self._pending_file_transfers.pop(file_id, None) or chat_item
                 self._cancel_file_timeout(file_id)
                 if not self._file_sender_is_authorized(pending):
@@ -692,6 +761,7 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 if file_path:
                     file_path = self._resolve_file_path(file_path)
+                    self._mark_file_terminal(file_id, "completed")
                     pending_item_data = pending.get("chatItem", {}) or {}
                     pending_file = pending_item_data.setdefault("file", {})
                     pending_file["fileSource"] = {"filePath": file_path}
@@ -703,6 +773,8 @@ class SimplexAdapter(BasePlatformAdapter):
                         logger.exception(
                             "SimpleX: error processing deferred file message"
                         )
+                else:
+                    self._mark_file_terminal(file_id, "completed-without-path")
             return
 
         if resp_type in {"chatError", "chatErrors", "messageError"}:
@@ -763,6 +835,14 @@ class SimplexAdapter(BasePlatformAdapter):
         except (TypeError, ValueError):
             return None
 
+    @staticmethod
+    def _item_id_from_wrapper(wrapper: dict) -> Optional[str]:
+        normalized = SimplexAdapter._normalize_chat_item_wrapper(wrapper)
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        return str(item_id) if item_id is not None else None
+
     def _file_sender_context(
         self, wrapper: dict
     ) -> tuple[Optional[str], Optional[str], Optional[str]]:
@@ -781,8 +861,16 @@ class SimplexAdapter(BasePlatformAdapter):
             group = chat_info.get("groupInfo", {}) or {}
             group_id = group.get("groupId")
             member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
+            member_contact_id = (
+                member.get("memberContactId") if isinstance(member, dict) else None
+            )
             member_id = member.get("memberId") if isinstance(member, dict) else None
-            user_id = str(member_id) if member_id is not None else None
+            stable_member_id = (
+                member_contact_id if member_contact_id is not None else member_id
+            )
+            user_id = (
+                str(stable_member_id) if stable_member_id is not None else None
+            )
             chat_id = f"group:{group_id}" if group_id is not None else None
             if (
                 group_id is None
@@ -806,6 +894,78 @@ class SimplexAdapter(BasePlatformAdapter):
         task = self._file_transfer_tasks.pop(file_id, None)
         if task and not task.done() and task is not asyncio.current_task():
             task.cancel()
+
+    def _prune_terminal_files(self) -> None:
+        now = time.monotonic()
+        for file_id, terminal in list(self._terminal_file_transfers.items()):
+            if float(terminal.get("expires_at", 0.0)) <= now:
+                self._terminal_file_transfers.pop(file_id, None)
+        while len(self._terminal_file_transfers) > 4096:
+            self._terminal_file_transfers.pop(next(iter(self._terminal_file_transfers)))
+
+    def _mark_file_terminal(self, file_id: int, reason: str) -> Optional[str]:
+        """Remember a terminal transfer long enough to reject late duplicates."""
+        target = self._file_receive_targets.pop(file_id, None)
+        prior = self._terminal_file_transfers.get(file_id, {})
+        if target is None:
+            target = prior.get("target")
+        self._terminal_file_transfers[file_id] = {
+            "target": target,
+            "reason": reason,
+            "expires_at": time.monotonic() + 86400.0,
+        }
+        self._prune_terminal_files()
+        return target
+
+    def _terminal_file_target(self, file_id: int) -> Optional[str]:
+        self._prune_terminal_files()
+        terminal = self._terminal_file_transfers.get(file_id)
+        if terminal:
+            return terminal.get("target")
+        return self._file_receive_targets.get(file_id)
+
+    def _cleanup_owned_media_path(self, path: str) -> None:
+        """Remove only an exact temporary path minted by this adapter."""
+        normalized = os.path.abspath(path)
+        task = self._owned_media_cleanup_tasks.pop(normalized, None)
+        if task and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+        try:
+            if os.path.isfile(normalized) or os.path.islink(normalized):
+                os.remove(normalized)
+        except OSError:
+            logger.debug(
+                "SimpleX: failed to remove owned temporary media %s",
+                os.path.basename(normalized),
+                exc_info=True,
+            )
+
+    async def _expire_owned_media_path(self, path: str) -> None:
+        try:
+            await asyncio.sleep(self._media_cleanup_timeout)
+            self._cleanup_owned_media_path(path)
+        except asyncio.CancelledError:
+            return
+
+    def _schedule_owned_media_cleanup(self, path: str) -> None:
+        """Install a TTL backstop for an adapter-created media path."""
+        normalized = os.path.abspath(path)
+        existing = self._owned_media_cleanup_tasks.get(normalized)
+        if existing and not existing.done():
+            return
+        task = asyncio.create_task(self._expire_owned_media_path(normalized))
+        self._owned_media_cleanup_tasks[normalized] = task
+
+        def _done(done: asyncio.Task) -> None:
+            if self._owned_media_cleanup_tasks.get(normalized) is done:
+                self._owned_media_cleanup_tasks.pop(normalized, None)
+            if not done.cancelled():
+                try:
+                    done.result()
+                except Exception:
+                    logger.exception("SimpleX: temporary media cleanup failed")
+
+        task.add_done_callback(_done)
 
     def _track_pending_file(self, file_id: int, wrapper: dict) -> None:
         self._pending_file_transfers[file_id] = wrapper
@@ -837,7 +997,13 @@ class SimplexAdapter(BasePlatformAdapter):
         msg_content = content.get("msgContent", {}) if isinstance(content, dict) else {}
         text = msg_content.get("text", "") if isinstance(msg_content, dict) else ""
         if not text:
-            return
+            if not isinstance(content, dict):
+                content = {}
+                inner["content"] = content
+            content["msgContent"] = {
+                "type": "text",
+                "text": f"[Attachment unavailable: {reason}]",
+            }
         logger.info("SimpleX: delivering file caption without attachment (%s)", reason)
         await self._handle_chat_item(fallback)
 
@@ -846,12 +1012,18 @@ class SimplexAdapter(BasePlatformAdapter):
         wrapper = self._pending_file_transfers.pop(file_id, None)
         if not wrapper:
             return
+        target = self._mark_file_terminal(file_id, "transfer timed out")
+        if target:
+            self._cleanup_owned_media_path(target)
         self._diagnostics["file_timeouts"] += 1
         await self._dispatch_file_fallback(wrapper, "transfer timed out")
 
     async def _fail_file_transfer(self, file_id: int, reason: str) -> None:
         wrapper = self._pending_file_transfers.pop(file_id, None)
         self._cancel_file_timeout(file_id)
+        target = self._mark_file_terminal(file_id, reason)
+        if target:
+            self._cleanup_owned_media_path(target)
         self._diagnostics["file_failures"] += 1
         if wrapper:
             await self._dispatch_file_fallback(wrapper, reason)
@@ -943,7 +1115,10 @@ class SimplexAdapter(BasePlatformAdapter):
             is_group = True
 
             member = item_direction.get("groupMember", {}) or {}
-            sender_id = str(member.get("memberId", ""))
+            sender_identity = member.get("memberContactId")
+            if sender_identity is None:
+                sender_identity = member.get("memberId", "")
+            sender_id = str(sender_identity)
             sender_name = member.get("localDisplayName", "") or member.get(
                 "memberProfile", {}
             ).get("displayName", "")
@@ -977,6 +1152,7 @@ class SimplexAdapter(BasePlatformAdapter):
         media_urls: List[str] = []
         media_types: List[str] = []
         file_info = chat_item_data.get("file")
+        owned_media_path: Optional[str] = None
 
         if file_info and isinstance(file_info, dict):
             file_source = file_info.get("fileSource", {}) or {}
@@ -1025,6 +1201,20 @@ class SimplexAdapter(BasePlatformAdapter):
                     return
 
             if file_info and file_path:
+                try:
+                    normalized_file_id = int(file_id) if file_id is not None else None
+                except (TypeError, ValueError):
+                    normalized_file_id = None
+                receive_target = (
+                    self._terminal_file_target(normalized_file_id)
+                    if normalized_file_id is not None
+                    else None
+                )
+                if (
+                    receive_target
+                    and os.path.abspath(file_path) == os.path.abspath(receive_target)
+                ):
+                    owned_media_path = receive_target
                 ext = Path(file_name).suffix.lower() or Path(file_path).suffix.lower()
                 if not _is_image_ext(ext) and not _is_audio_ext(ext):
                     try:
@@ -1120,6 +1310,17 @@ class SimplexAdapter(BasePlatformAdapter):
             reply_to_is_own_message=quoted_dir_type in {"directSnd", "groupSnd"},
             metadata={"is_edit": True} if is_edit else {},
         )
+        if owned_media_path and not self.retain_received_files:
+            self._schedule_owned_media_cleanup(owned_media_path)
+            setattr(
+                msg_event,
+                "_post_turn_cleanup_callbacks",
+                [
+                    lambda path=owned_media_path: self._cleanup_owned_media_path(
+                        path
+                    )
+                ],
+            )
 
         logger.debug(
             "SimpleX: message from %s in %s: %s",
@@ -1294,6 +1495,18 @@ class SimplexAdapter(BasePlatformAdapter):
 
         try:
             await ws.send(payload)
+        except Exception as e:
+            logger.warning(
+                "SimpleX: command was not submitted: %s — %s",
+                command.split(" ", 1)[0],
+                e,
+            )
+            return {
+                "type": "localCommandNotSubmitted",
+                "error": "SimpleX command was not submitted to the daemon",
+            }
+
+        try:
             result = await asyncio.wait_for(fut, timeout=timeout)
             return result
         except asyncio.TimeoutError:
@@ -1396,6 +1609,14 @@ class SimplexAdapter(BasePlatformAdapter):
                     retryable=False,
                     raw_response=resp,
                 )
+            if _response_type(resp) == "localCommandNotSubmitted":
+                return SendResult(
+                    success=False,
+                    error=error,
+                    error_kind="transient",
+                    retryable=True,
+                    raw_response=resp,
+                )
             kind, retryable = self._error_kind(error)
             return SendResult(
                 success=False,
@@ -1459,6 +1680,40 @@ class SimplexAdapter(BasePlatformAdapter):
         resp = await self._send_command(command, timeout=timeout)
         return self._send_result_from_response(resp, expected={"newChatItems"})
 
+    @staticmethod
+    def _split_utf8_payload(text: str, byte_budget: int = 12000) -> List[str]:
+        """Split by serialized UTF-8 bytes, never through a code point.
+
+        ``simplex-chat`` limits the encoded command envelope rather than
+        Python character count.  A margin below the protocol ceiling leaves
+        room for the JSON wrapper, chat reference, and quoting expansion.
+        """
+        if not text:
+            return [""]
+        chunks: List[str] = []
+        start = 0
+        while start < len(text):
+            used = 0
+            end = start
+            last_break: Optional[int] = None
+            while end < len(text):
+                char_cost = len(
+                    json.dumps(text[end], ensure_ascii=False).encode("utf-8")
+                ) - 2
+                if used + char_cost > byte_budget and end > start:
+                    break
+                used += char_cost
+                end += 1
+                if text[end - 1].isspace():
+                    last_break = end
+            if end < len(text) and last_break and last_break > start:
+                end = last_break
+            if end == start:
+                end += 1
+            chunks.append(text[start:end])
+            start = end
+        return chunks
+
     # ------------------------------------------------------------------
     # Outbound — text
     # ------------------------------------------------------------------
@@ -1478,7 +1733,9 @@ class SimplexAdapter(BasePlatformAdapter):
 
         delivered_ids: List[str] = []
         if content:
-            initial_chunks = list(self.truncate_message(content, MAX_MESSAGE_LENGTH))
+            initial_chunks: List[str] = []
+            for logical_chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
+                initial_chunks.extend(self._split_utf8_payload(logical_chunk))
             queue = [
                 (chunk, index == 0)
                 for index, chunk in enumerate(initial_chunks)
@@ -1489,6 +1746,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     chat_id,
                     {"type": "text", "text": chunk},
                     reply_to=reply_to if carries_reply else None,
+                    live=bool((metadata or {}).get("expect_edits")),
                 )
                 if (
                     not result.success
@@ -1711,8 +1969,13 @@ class SimplexAdapter(BasePlatformAdapter):
             return SendResult(success=False, error="Image file not found")
 
         png_path, thumb_uri = self._prepare_image(file_path)
+        owned_temp = (
+            os.path.abspath(png_path) != os.path.abspath(file_path)
+        )
+        if owned_temp:
+            self._schedule_owned_media_cleanup(png_path)
 
-        return await self._send_composed(
+        result = await self._send_composed(
             chat_id,
             {
                 "type": "image",
@@ -1722,6 +1985,12 @@ class SimplexAdapter(BasePlatformAdapter):
             reply_to=kwargs.get("reply_to"),
             file_source=png_path,
         )
+        if owned_temp:
+            if result.success and result.message_id:
+                self._outbound_temp_by_item[str(result.message_id)] = png_path
+            elif result.error_kind != "delivery_unknown":
+                self._cleanup_owned_media_path(png_path)
+        return result
 
     async def send_image_file(
         self,
@@ -1816,7 +2085,9 @@ class SimplexAdapter(BasePlatformAdapter):
         finalize: bool = False,
     ) -> SendResult:
         """Update a streaming preview and finalize it with complete text."""
-        chunks = self.truncate_message(content, MAX_MESSAGE_LENGTH)
+        chunks: List[str] = []
+        for logical_chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
+            chunks.extend(self._split_utf8_payload(logical_chunk))
         first_chunk = chunks[0] if chunks else ""
         updated = {
             "msgContent": {"type": "text", "text": first_chunk},
@@ -2079,7 +2350,10 @@ class SimplexAdapter(BasePlatformAdapter):
             group = chat_info.get("groupInfo", {}) or {}
             chat_id = f"group:{group.get('groupId', '')}"
             member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
-            user_id = str(member.get("memberId", ""))
+            member_identity = member.get("memberContactId")
+            if member_identity is None:
+                member_identity = member.get("memberId", "")
+            user_id = str(member_identity)
             user_name = member.get("localDisplayName", "")
         else:
             return None

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -75,6 +75,21 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from plugins.platforms.simplex.approvals import SimplexApprovalMixin
+from plugins.platforms.simplex.batching import prepend_cancelled_batch
+from plugins.platforms.simplex.config import (
+    profile_scoped as _profile_scoped,
+    profile_simplex_extra as _profile_simplex_extra,
+    scoped_platform_setting as _scoped_platform_setting,
+)
+from plugins.platforms.simplex.media import SimplexMediaMixin
+from plugins.platforms.simplex.messaging import SimplexMessagingMixin
+from plugins.platforms.simplex.protocol import (
+    response_error as _response_error,
+    response_item_ids as _response_item_ids,
+    response_type as _response_type,
+    simplex_payload_len as _simplex_payload_len,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -149,11 +164,6 @@ def _sanitize_filename(name: str) -> str:
     return cleaned[:120] or "file"
 
 
-def _simplex_payload_len(text: str) -> int:
-    """Measure a string as it appears inside the ensure_ascii=False JSON body."""
-    return len(json.dumps(text, ensure_ascii=False).encode("utf-8")) - 2
-
-
 def _delivered_source_prefix(content: str, chunks: List[str]) -> str:
     """Map formatted overflow chunks back to a monotonic source prefix."""
     cursor = 0
@@ -179,51 +189,16 @@ def _delivered_source_prefix(content: str, chunks: List[str]) -> str:
     return content[:cursor]
 
 
-def _response_type(resp: Optional[dict]) -> str:
-    return str((resp or {}).get("type") or "") if isinstance(resp, dict) else ""
-
-
-def _response_error(resp: Optional[dict]) -> Optional[str]:
-    """Return a bounded diagnostic string for a daemon error response."""
-    if not isinstance(resp, dict):
-        return "SimpleX daemon did not answer"
-    resp_type = _response_type(resp)
-    if resp_type in {"localCommandOutcomeUnknown", "localCommandNotSubmitted"}:
-        return str(resp.get("error") or "SimpleX command outcome is unknown")[:1000]
-    if resp_type not in {"chatCmdError", "chatError", "chatErrors"}:
-        return None
-    detail = resp.get("chatError") or resp.get("chatErrors") or resp
-    try:
-        rendered = json.dumps(detail, ensure_ascii=False, sort_keys=True)
-    except (TypeError, ValueError):
-        rendered = str(detail)
-    return f"{resp_type}: {rendered[:1000]}"
-
-
-def _response_item_ids(resp: Optional[dict]) -> List[str]:
-    """Extract stable daemon chat-item IDs from a command response."""
-    if not isinstance(resp, dict):
-        return []
-    wrappers: List[dict] = []
-    if isinstance(resp.get("chatItems"), list):
-        wrappers.extend(item for item in resp["chatItems"] if isinstance(item, dict))
-    if isinstance(resp.get("chatItem"), dict):
-        wrappers.append(resp["chatItem"])
-    ids: List[str] = []
-    for wrapper in wrappers:
-        inner = wrapper.get("chatItem", {}) if isinstance(wrapper, dict) else {}
-        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
-        item_id = meta.get("itemId") if isinstance(meta, dict) else None
-        if item_id is not None:
-            ids.append(str(item_id))
-    return ids
-
-
 # ---------------------------------------------------------------------------
 # SimpleX Adapter
 # ---------------------------------------------------------------------------
 
-class SimplexAdapter(BasePlatformAdapter):
+class SimplexAdapter(
+    SimplexMessagingMixin,
+    SimplexMediaMixin,
+    SimplexApprovalMixin,
+    BasePlatformAdapter,
+):
     """SimpleX Chat adapter using the simplex-chat daemon WebSocket API.
 
     Instantiated by the ``adapter_factory`` passed to
@@ -252,17 +227,25 @@ class SimplexAdapter(BasePlatformAdapter):
         # Contact-request auto-accept (on by default — matches the way most
         # bot deployments expect to behave). Read from env first, then fall
         # back to the value seeded by ``_env_enablement``.
-        env_auto = os.getenv("SIMPLEX_AUTO_ACCEPT")
-        if env_auto is not None:
-            self.auto_accept = env_auto.strip().lower() not in {"0", "false", "no", ""}
-        else:
-            self.auto_accept = bool(extra.get("auto_accept", True))
+        env_auto = _scoped_platform_setting(
+            "SIMPLEX_AUTO_ACCEPT", extra, "auto_accept"
+        )
+        auto_value = extra.get("auto_accept", True) if env_auto is None else env_auto
+        self.auto_accept = str(auto_value).strip().lower() not in {
+            "0",
+            "false",
+            "no",
+            "",
+        }
 
         # The daemon reports received paths relative to --files-folder and
         # exposes only a setter, not a query API. Mirror the non-secret path in
         # config so downstream media consumers always receive openable paths.
-        files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "").strip() or str(
-            extra.get("files_folder", "") or ""
+        env_files_folder = _scoped_platform_setting(
+            "SIMPLEX_FILES_FOLDER", extra, "files_folder"
+        )
+        files_folder = str(
+            env_files_folder or extra.get("files_folder", "")
         ).strip()
         expanded_files_folder = os.path.expanduser(files_folder)
         if expanded_files_folder and not os.path.isabs(expanded_files_folder):
@@ -281,7 +264,10 @@ class SimplexAdapter(BasePlatformAdapter):
             60.0, float(extra.get("media_cleanup_timeout", 3600.0))
         )
 
-        allow_entries = _parse_comma_list(os.getenv("SIMPLEX_ALLOWED_USERS", ""))
+        env_allowed_users = _scoped_platform_setting(
+            "SIMPLEX_ALLOWED_USERS", extra, "allowed_users"
+        )
+        allow_entries = _parse_comma_list(str(env_allowed_users or ""))
         ignored_allow_entries = [
             entry for entry in allow_entries if entry != "*" and not entry.isdigit()
         ]
@@ -297,9 +283,10 @@ class SimplexAdapter(BasePlatformAdapter):
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
         # processes every member's traffic). Use ``*`` to accept any group.
-        group_allowed_str = os.getenv("SIMPLEX_GROUP_ALLOWED", "") or extra.get(
-            "group_allowed", ""
+        env_group_allowed = _scoped_platform_setting(
+            "SIMPLEX_GROUP_ALLOWED", extra, "group_allowed"
         )
+        group_allowed_str = env_group_allowed or extra.get("group_allowed", "")
         self.group_allow_from = set(_parse_comma_list(group_allowed_str))
 
         # Running state
@@ -310,6 +297,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._last_ws_activity = 0.0
         self._ws_ready = asyncio.Event()
         self._connect_timeout = float(extra.get("connect_timeout", 10.0))
+        self._listener_lock_acquired = False
 
         # Track sent correlation IDs to filter echoes
         self._pending_corr_ids: set = set()
@@ -392,16 +380,32 @@ class SimplexAdapter(BasePlatformAdapter):
         if self._running and self._ws is not None and self._ws_ready.is_set():
             return True
 
-        self._running = True
-        self._ws_ready.clear()
-        self._ws_task = asyncio.create_task(self._ws_listener())
+        try:
+            if not self._acquire_platform_lock(
+                "simplex-ws", self.ws_url, "SimpleX daemon URL"
+            ):
+                return False
+        except Exception as exc:
+            logger.error("SimpleX: could not acquire daemon URL lock: %s", exc)
+            return False
+        self._listener_lock_acquired = True
 
         try:
+            self._running = True
+            self._ws_ready.clear()
+            self._ws_task = asyncio.create_task(self._ws_listener())
             await asyncio.wait_for(
                 self._ws_ready.wait(), timeout=max(self._connect_timeout, 0.1)
             )
         except asyncio.TimeoutError:
             logger.error("SimpleX: listener did not become ready before timeout")
+            await self.disconnect()
+            return False
+        except asyncio.CancelledError:
+            await self.disconnect()
+            raise
+        except Exception:
+            logger.exception("SimpleX: listener startup failed")
             await self.disconnect()
             return False
 
@@ -442,10 +446,16 @@ class SimplexAdapter(BasePlatformAdapter):
                 pass
             self._ws = None
 
-        # Cancel pending text-batch flush timers
-        for task in list(self._pending_text_batch_tasks.values()):
+        # Cancel and drain pending text-batch flush timers before clearing the
+        # buffers. A flush cancelled after popping its event re-buffers it;
+        # draining first prevents that recovery path from creating ghost state
+        # after disconnect has already cleared the dictionaries.
+        text_batch_tasks = list(self._pending_text_batch_tasks.values())
+        for task in text_batch_tasks:
             if not task.done():
                 task.cancel()
+        if text_batch_tasks:
+            await asyncio.gather(*text_batch_tasks, return_exceptions=True)
         self._pending_text_batch_tasks.clear()
         self._pending_text_batches.clear()
 
@@ -492,6 +502,10 @@ class SimplexAdapter(BasePlatformAdapter):
         self._approval_prompts_by_item.clear()
         self._approval_prompt_by_session.clear()
         self._approval_typed_only_until.clear()
+
+        if self._listener_lock_acquired:
+            self._release_platform_lock()
+            self._listener_lock_acquired = False
 
         if hasattr(self, "_mark_disconnected"):
             self._mark_disconnected()
@@ -871,281 +885,24 @@ class SimplexAdapter(BasePlatformAdapter):
         if resp_type:
             logger.debug("SimpleX: unhandled event type: %s", resp_type)
 
-    @staticmethod
-    def _normalize_chat_item_wrapper(payload: dict) -> dict:
-        """Normalize SimpleX AChatItem payload variants to {chatInfo, chatItem}.
 
-        Depending on daemon version and event type, the chat item wrapper
-        arrives in one of several shapes:
 
-        * ``{"chatInfo": ..., "chatItem": ...}`` — already normalized
-          (the usual ``newChatItems`` array element).
-        * ``{"type": "newChatItem", "chatItem": {"chatInfo": ...,
-          "chatItem": ...}}`` — the singular event nests the AChatItem one
-          level down.
-        * ``{"chatInfo": ..., "item": ...}`` — some responses name the item
-          field ``item`` instead of ``chatItem``.
 
-        ``_handle_chat_item`` only reads ``chatInfo``/``chatItem`` at the top
-        level, so anything not normalized here would be silently dropped.
-        """
-        if not isinstance(payload, dict):
-            return {}
 
-        nested = payload.get("chatItem")
-        if isinstance(nested, dict):
-            # Nested AChatItem: {type: newChatItem, chatItem: {chatInfo, chatItem}}
-            if isinstance(nested.get("chatInfo"), dict) and isinstance(
-                nested.get("chatItem"), dict
-            ):
-                return nested
-            # Already normalized: {chatInfo: ..., chatItem: {content/meta/...}}
-            if isinstance(payload.get("chatInfo"), dict):
-                return payload
 
-        if isinstance(payload.get("chatInfo"), dict) and isinstance(
-            payload.get("item"), dict
-        ):
-            return {"chatInfo": payload["chatInfo"], "chatItem": payload["item"]}
 
-        return payload
 
-    @staticmethod
-    def _file_id_from_wrapper(wrapper: dict) -> Optional[int]:
-        normalized = SimplexAdapter._normalize_chat_item_wrapper(wrapper)
-        inner = normalized.get("chatItem", {}) if normalized else {}
-        file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
-        raw_id = file_info.get("fileId") if isinstance(file_info, dict) else None
-        try:
-            return int(raw_id) if raw_id is not None else None
-        except (TypeError, ValueError):
-            return None
 
-    @staticmethod
-    def _item_id_from_wrapper(wrapper: dict) -> Optional[str]:
-        normalized = SimplexAdapter._normalize_chat_item_wrapper(wrapper)
-        inner = normalized.get("chatItem", {}) if normalized else {}
-        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
-        item_id = meta.get("itemId") if isinstance(meta, dict) else None
-        return str(item_id) if item_id is not None else None
 
-    def _file_sender_context(
-        self, wrapper: dict
-    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
-        """Return ``(user_id, chat_type, chat_id)`` for an attachment event."""
-        normalized = self._normalize_chat_item_wrapper(wrapper)
-        chat_info = normalized.get("chatInfo", {}) if normalized else {}
-        inner = normalized.get("chatItem", {}) if normalized else {}
-        chat_dir = inner.get("chatDir", {}) if isinstance(inner, dict) else {}
-        chat_type = chat_info.get("type") if isinstance(chat_info, dict) else None
-        if chat_type == "direct":
-            contact = chat_info.get("contact", {}) or {}
-            contact_id = contact.get("contactId")
-            user_id = str(contact_id) if contact_id is not None else None
-            return user_id, "dm", user_id
-        if chat_type == "group":
-            group = chat_info.get("groupInfo", {}) or {}
-            group_id = group.get("groupId")
-            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
-            member_contact_id = (
-                member.get("memberContactId") if isinstance(member, dict) else None
-            )
-            member_id = member.get("memberId") if isinstance(member, dict) else None
-            stable_member_id = (
-                member_contact_id if member_contact_id is not None else member_id
-            )
-            user_id = (
-                str(stable_member_id) if stable_member_id is not None else None
-            )
-            chat_id = f"group:{group_id}" if group_id is not None else None
-            if (
-                group_id is None
-                or not self.group_allow_from
-                or (
-                    "*" not in self.group_allow_from
-                    and str(group_id) not in self.group_allow_from
-                )
-            ):
-                return user_id, "group", None
-            return user_id, "group", chat_id
-        return None, None, None
 
-    def _file_sender_is_authorized(self, wrapper: dict) -> bool:
-        user_id, chat_type, chat_id = self._file_sender_context(wrapper)
-        if not user_id or not chat_id:
-            return False
-        return self._is_sender_authorized(user_id, chat_type, chat_id) is True
 
-    def _cancel_file_timeout(self, file_id: int) -> None:
-        task = self._file_transfer_tasks.pop(file_id, None)
-        if task and not task.done() and task is not asyncio.current_task():
-            task.cancel()
 
-    def _prune_terminal_files(self) -> None:
-        now = time.monotonic()
-        for file_id, terminal in list(self._terminal_file_transfers.items()):
-            if float(terminal.get("expires_at", 0.0)) <= now:
-                self._terminal_file_transfers.pop(file_id, None)
-        while len(self._terminal_file_transfers) > 4096:
-            self._terminal_file_transfers.pop(next(iter(self._terminal_file_transfers)))
 
-    def _mark_file_terminal(self, file_id: int, reason: str) -> Optional[str]:
-        """Remember a terminal transfer long enough to reject late duplicates."""
-        self._file_receive_started.discard(file_id)
-        target = self._file_receive_targets.pop(file_id, None)
-        prior = self._terminal_file_transfers.get(file_id, {})
-        if target is None:
-            target = prior.get("target")
-        self._terminal_file_transfers[file_id] = {
-            "target": target,
-            "reason": reason,
-            "expires_at": time.monotonic() + 86400.0,
-        }
-        self._prune_terminal_files()
-        return target
 
-    def _terminal_file_target(self, file_id: int) -> Optional[str]:
-        self._prune_terminal_files()
-        terminal = self._terminal_file_transfers.get(file_id)
-        if terminal:
-            return terminal.get("target")
-        return self._file_receive_targets.get(file_id)
 
-    def _cleanup_owned_media_path(self, path: str) -> None:
-        """Remove only an exact temporary path minted by this adapter."""
-        normalized = os.path.abspath(path)
-        task = self._owned_media_cleanup_tasks.pop(normalized, None)
-        if task and task is not asyncio.current_task() and not task.done():
-            task.cancel()
-        try:
-            if os.path.isfile(normalized) or os.path.islink(normalized):
-                os.remove(normalized)
-        except OSError as exc:
-            self._diagnostics["media_cleanup_failures"] += 1
-            logger.warning(
-                "SimpleX: failed to remove owned temporary media %s (%s)",
-                os.path.basename(normalized),
-                type(exc).__name__,
-            )
 
-    async def _expire_owned_media_path(self, path: str) -> None:
-        try:
-            await asyncio.sleep(self._media_cleanup_timeout)
-            self._cleanup_owned_media_path(path)
-        except asyncio.CancelledError:
-            return
 
-    def _schedule_owned_media_cleanup(self, path: str, *, reset: bool = False) -> None:
-        """Install a TTL backstop for an adapter-created media path."""
-        normalized = os.path.abspath(path)
-        existing = self._owned_media_cleanup_tasks.get(normalized)
-        if existing and not existing.done():
-            if not reset:
-                return
-            existing.cancel()
-        task = asyncio.create_task(self._expire_owned_media_path(normalized))
-        self._owned_media_cleanup_tasks[normalized] = task
 
-        def _done(done: asyncio.Task) -> None:
-            if self._owned_media_cleanup_tasks.get(normalized) is done:
-                self._owned_media_cleanup_tasks.pop(normalized, None)
-            if not done.cancelled():
-                try:
-                    done.result()
-                except Exception:
-                    logger.exception("SimpleX: temporary media cleanup failed")
-
-        task.add_done_callback(_done)
-
-    def _track_pending_file(self, file_id: int, wrapper: dict) -> None:
-        self._pending_file_transfers[file_id] = wrapper
-        existing = self._file_transfer_tasks.get(file_id)
-        if existing and not existing.done():
-            return
-        task = asyncio.create_task(self._expire_file_transfer(file_id))
-        self._file_transfer_tasks[file_id] = task
-
-        def _done(done: asyncio.Task) -> None:
-            if self._file_transfer_tasks.get(file_id) is done:
-                self._file_transfer_tasks.pop(file_id, None)
-            if not done.cancelled():
-                try:
-                    done.result()
-                except Exception:
-                    logger.exception("SimpleX: file-transfer expiry task failed")
-
-        task.add_done_callback(_done)
-
-    async def _dispatch_file_fallback(self, wrapper: dict, reason: str) -> None:
-        """Deliver an authorized file caption without an unavailable attachment."""
-        fallback = copy.deepcopy(self._normalize_chat_item_wrapper(wrapper))
-        inner = fallback.get("chatItem", {}) if fallback else {}
-        if not isinstance(inner, dict):
-            return
-        inner.pop("file", None)
-        content = inner.get("content", {}) or {}
-        msg_content = content.get("msgContent", {}) if isinstance(content, dict) else {}
-        text = msg_content.get("text", "") if isinstance(msg_content, dict) else ""
-        if not text:
-            if not isinstance(content, dict):
-                content = {}
-                inner["content"] = content
-            content["msgContent"] = {
-                "type": "text",
-                "text": f"[Attachment unavailable: {reason}]",
-            }
-        logger.info("SimpleX: delivering file caption without attachment (%s)", reason)
-        await self._handle_chat_item(fallback)
-
-    async def _expire_file_transfer(self, file_id: int) -> None:
-        await asyncio.sleep(self._file_transfer_timeout)
-        wrapper = self._pending_file_transfers.pop(file_id, None)
-        if not wrapper:
-            return
-        target = self._mark_file_terminal(file_id, "transfer timed out")
-        if target:
-            self._cleanup_owned_media_path(target)
-        self._diagnostics["file_timeouts"] += 1
-        await self._dispatch_file_fallback(wrapper, "transfer timed out")
-
-    async def _fail_file_transfer(self, file_id: int, reason: str) -> None:
-        wrapper = self._pending_file_transfers.pop(file_id, None)
-        self._cancel_file_timeout(file_id)
-        target = self._mark_file_terminal(file_id, reason)
-        if target:
-            self._cleanup_owned_media_path(target)
-        self._diagnostics["file_failures"] += 1
-        if wrapper:
-            await self._dispatch_file_fallback(wrapper, reason)
-
-    async def _accept_contact_request(self, request_id: str) -> None:
-        resp = await self._send_command(f"/_accept {request_id}", timeout=30.0)
-        error = _response_error(resp)
-        if error:
-            self._diagnostics["command_errors"] += 1
-            logger.warning("SimpleX: contact request acceptance failed: %s", error)
-
-    async def _receive_file(self, file_id: int, target: Optional[str]) -> None:
-        command = f"/freceive {file_id} approved_relays=on"
-        if target:
-            command += f" {target}"
-        resp = await self._send_command(command, timeout=30.0)
-        error = _response_error(resp)
-        if error or _response_type(resp) == "rcvFileAcceptedSndCancelled":
-            self._diagnostics["command_errors"] += 1
-            logger.warning(
-                "SimpleX: file %s receive failed: %s",
-                file_id,
-                error or "sender cancelled",
-            )
-            await self._fail_file_transfer(
-                file_id, error or "sender cancelled during acceptance"
-            )
-
-    def _resolve_file_path(self, file_path: str) -> str:
-        if file_path and not os.path.isabs(file_path) and self.files_folder:
-            return os.path.join(self.files_folder, file_path)
-        return file_path
 
     async def _handle_chat_item(self, chat_item: dict, is_edit: bool = False) -> None:
         """Process one received item or correlated item update."""
@@ -1397,6 +1154,11 @@ class SimplexAdapter(BasePlatformAdapter):
             user_id=sender_id,
             user_name=sender_name or sender_id,
             message_id=message_id,
+            # Reaching this point for a group proves it passed the explicit
+            # SIMPLEX_GROUP_ALLOWED intake gate. Carry that decision across
+            # the generic gateway boundary; DM senders remain subject to the
+            # separate SIMPLEX_ALLOWED_USERS/pairing policy.
+            role_authorized=is_group,
         )
 
         # Message type
@@ -1533,11 +1295,24 @@ class SimplexAdapter(BasePlatformAdapter):
                 existing.media_types.extend(event.media_types)
 
         prior_task = self._pending_text_batch_tasks.get(key)
-        if prior_task and not prior_task.done():
-            prior_task.cancel()
         self._pending_text_batch_tasks[key] = asyncio.create_task(
-            self._flush_text_batch(key)
+            self._restart_text_batch_flush(key, prior_task)
         )
+
+    async def _restart_text_batch_flush(
+        self, key: str, prior_task: Optional[asyncio.Task]
+    ) -> None:
+        """Cancel and drain the prior timer before starting its replacement.
+
+        Draining serializes the old flush's cancellation recovery with the new
+        flush, so the replacement cannot pop the newer event before the old
+        in-flight event has been restored ahead of it.
+        """
+        if prior_task is not None:
+            if not prior_task.done():
+                prior_task.cancel()
+            await asyncio.gather(prior_task, return_exceptions=True)
+        await self._flush_text_batch(key)
 
     def _replace_pending_batch_edit(self, event: MessageEvent) -> bool:
         """Supersede a SimpleX text item still inside the quiet-period batch."""
@@ -1579,7 +1354,14 @@ class SimplexAdapter(BasePlatformAdapter):
                 key,
                 len(event.text or ""),
             )
-            await self.handle_message(event)
+            try:
+                await self.handle_message(event)
+            except asyncio.CancelledError:
+                newer = self._pending_text_batches.get(key)
+                self._pending_text_batches[key] = prepend_cancelled_batch(
+                    event, newer
+                )
+                raise
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
@@ -1588,651 +1370,36 @@ class SimplexAdapter(BasePlatformAdapter):
     # Command interface
     # ------------------------------------------------------------------
 
-    def _make_corr_id(self) -> str:
-        """Mint a new correlation ID and remember it for echo-filtering.
 
-        We add every minted id to ``_pending_corr_ids`` so the inbound
-        event loop can drop the daemon's echo of our own commands without
-        ever invoking ``_handle_chat_item``. The set is bounded — when
-        it grows past ``_max_pending_corr``, the oldest entries are
-        evicted in a single sweep.
-        """
-        self._corr_counter += 1
-        corr_id = f"{_CORR_PREFIX}{self._corr_counter}-{int(time.time() * 1000)}"
-        self._pending_corr_ids.add(corr_id)
-        if len(self._pending_corr_ids) > self._max_pending_corr:
-            overflow = len(self._pending_corr_ids) - self._max_pending_corr
-            for _ in range(overflow):
-                try:
-                    self._pending_corr_ids.pop()
-                except KeyError:
-                    break
-        return corr_id
 
-    async def _send_ws(self, payload: dict) -> bool:
-        """Send one JSON payload over the active WebSocket.
 
-        Returns True on success, False if the socket is unavailable or an
-        error occurs so callers can surface failures instead of silently
-        reporting success.
-        """
-        ws = self._ws
-        if not ws:
-            logger.debug("SimpleX: WS send rejected (not connected)")
-            return False
-        try:
-            await ws.send(json.dumps(payload))
-            return True
-        except Exception as e:
-            logger.warning("SimpleX: WS send error: %s", e)
-            return False
 
-    async def _send_command(
-        self,
-        command: str,
-        timeout: float = 30.0,
-    ) -> Optional[dict]:
-        """Send a command and await the correlated response."""
-        ws = self._ws
-        if not ws or not self._ws_ready.is_set():
-            logger.warning("SimpleX: command rejected while WebSocket is not ready")
-            return None
 
-        corr_id = self._make_corr_id()
-        payload = json.dumps({"corrId": corr_id, "cmd": command})
 
-        loop = asyncio.get_running_loop()
-        fut: asyncio.Future = loop.create_future()
-        self._pending_responses[corr_id] = fut
 
-        try:
-            await ws.send(payload)
-        except Exception as e:
-            logger.warning(
-                "SimpleX: command was not submitted: %s — %s",
-                command.split(" ", 1)[0],
-                e,
-            )
-            self._pending_responses.pop(corr_id, None)
-            self._pending_corr_ids.discard(corr_id)
-            if not fut.done():
-                fut.cancel()
-            return {
-                "type": "localCommandNotSubmitted",
-                "error": "SimpleX command was not submitted to the daemon",
-            }
 
-        try:
-            result = await asyncio.wait_for(fut, timeout=timeout)
-            return result
-        except asyncio.TimeoutError:
-            logger.warning("SimpleX: command timed out: %s", command.split(" ", 1)[0])
-            return {
-                "type": "localCommandOutcomeUnknown",
-                "error": "SimpleX daemon confirmation timed out; delivery may have occurred",
-            }
-        except Exception as e:
-            logger.warning(
-                "SimpleX: command failed: %s — %s",
-                command.split(" ", 1)[0],
-                e,
-            )
-            return {
-                "type": "localCommandOutcomeUnknown",
-                "error": "SimpleX connection failed after command submission; delivery outcome is unknown",
-            }
-        finally:
-            self._pending_responses.pop(corr_id, None)
-            self._pending_corr_ids.discard(corr_id)
 
-    def _spawn_command_task(self, coroutine) -> asyncio.Task:
-        """Run a correlated command outside the WebSocket reader task."""
-        task = asyncio.create_task(coroutine)
-        self._command_tasks.add(task)
 
-        def _done(done: asyncio.Task) -> None:
-            self._command_tasks.discard(done)
-            if done.cancelled():
-                return
-            try:
-                done.result()
-            except Exception:
-                logger.exception("SimpleX: background command task failed")
-
-        task.add_done_callback(_done)
-        return task
-
-    def _spawn_dispatch_task(self, coroutine) -> asyncio.Task:
-        """Dispatch inbound work without ever blocking the WebSocket reader."""
-        task = asyncio.create_task(coroutine)
-        self._dispatch_tasks.add(task)
-
-        def _done(done: asyncio.Task) -> None:
-            self._dispatch_tasks.discard(done)
-            if done.cancelled():
-                return
-            try:
-                done.result()
-            except Exception:
-                logger.exception("SimpleX: background message dispatch failed")
-
-        task.add_done_callback(_done)
-        return task
-
-    async def _send_fire_and_forget(self, command: str) -> None:
-        """Send without blocking the reader; explicit errors remain logged."""
-        corr_id = self._make_corr_id()
-        ok = await self._send_ws({"corrId": corr_id, "cmd": command})
-        if not ok:
-            self._pending_corr_ids.discard(corr_id)
-            self._diagnostics["send_failures"] += 1
-
-    @staticmethod
-    def _chat_ref(chat_id: str) -> str:
-        """Return the structured daemon ChatRef for a stable Hermes chat id."""
-        raw = str(chat_id or "")
-        if raw.startswith("group:"):
-            return f"#{raw[6:].split('|', 1)[0]}"
-        return f"@{raw.split('|', 1)[0]}"
-
-    @staticmethod
-    def _error_kind(error: str) -> tuple[str, bool]:
-        lowered = (error or "").lower()
-        if "largemsg" in lowered or "large compressed message" in lowered:
-            return "too_long", False
-        if "notfound" in lowered or "not found" in lowered:
-            return "not_found", False
-        if "forbidden" in lowered or "permission" in lowered:
-            return "forbidden", False
-        if any(token in lowered for token in ("timeout", "closed", "network", "broker")):
-            return "transient", True
-        return "unknown", False
-
-    def _send_result_from_response(
-        self,
-        resp: Optional[dict],
-        *,
-        expected: set[str],
-    ) -> SendResult:
-        error = _response_error(resp)
-        if error:
-            self._diagnostics["command_errors"] += 1
-            if _response_type(resp) == "localCommandOutcomeUnknown":
-                return SendResult(
-                    success=False,
-                    error=error,
-                    error_kind="delivery_unknown",
-                    retryable=False,
-                    raw_response=resp,
-                )
-            if _response_type(resp) == "localCommandNotSubmitted":
-                return SendResult(
-                    success=False,
-                    error=error,
-                    error_kind="transient",
-                    retryable=True,
-                    raw_response=resp,
-                )
-            kind, retryable = self._error_kind(error)
-            return SendResult(
-                success=False,
-                error=error,
-                error_kind=kind,
-                retryable=retryable,
-                raw_response=resp,
-            )
-        if resp is None:
-            self._diagnostics["send_failures"] += 1
-            return SendResult(
-                success=False,
-                error="SimpleX daemon did not confirm the command",
-                error_kind="transient",
-                retryable=True,
-            )
-        resp_type = _response_type(resp)
-        if resp_type not in expected:
-            self._diagnostics["send_failures"] += 1
-            return SendResult(
-                success=False,
-                error=f"Unexpected SimpleX response: {resp_type or '<missing>'}",
-                error_kind="unknown",
-                raw_response=resp,
-            )
-        item_ids = _response_item_ids(resp)
-        return SendResult(
-            success=True,
-            message_id=item_ids[-1] if item_ids else None,
-            continuation_message_ids=tuple(item_ids[:-1]),
-            raw_response=resp,
-        )
-
-    async def _send_composed(
-        self,
-        chat_id: str,
-        msg_content: dict,
-        *,
-        reply_to: Optional[str] = None,
-        file_source: Optional[str] = None,
-        live: bool = False,
-        timeout: float = 30.0,
-    ) -> SendResult:
-        composed: Dict[str, Any] = {
-            "msgContent": msg_content,
-            "mentions": {},
-        }
-        if reply_to is not None:
-            try:
-                composed["quotedItemId"] = int(reply_to)
-            except (TypeError, ValueError):
-                logger.debug("SimpleX: ignoring non-numeric reply item id")
-        if file_source:
-            composed["fileSource"] = {"filePath": file_source}
-
-        live_flag = " live=on" if live else ""
-        command = (
-            f"/_send {self._chat_ref(chat_id)}{live_flag} json "
-            f"{json.dumps([composed], ensure_ascii=False)}"
-        )
-        resp = await self._send_command(command, timeout=timeout)
-        return self._send_result_from_response(resp, expected={"newChatItems"})
-
-    @staticmethod
-    def _split_utf8_payload(
-        text: str, byte_budget: int = MAX_MESSAGE_LENGTH
-    ) -> List[str]:
-        """Split by serialized UTF-8 bytes, never through a code point.
-
-        ``simplex-chat`` limits the encoded command envelope rather than
-        Python character count.  A margin below the protocol ceiling leaves
-        room for the JSON wrapper, chat reference, and quoting expansion.
-        """
-        if not text:
-            return [""]
-        chunks: List[str] = []
-        start = 0
-        while start < len(text):
-            used = 0
-            end = start
-            last_break: Optional[int] = None
-            while end < len(text):
-                char_cost = _simplex_payload_len(text[end])
-                if used + char_cost > byte_budget and end > start:
-                    break
-                used += char_cost
-                end += 1
-                if text[end - 1].isspace():
-                    last_break = end
-            if end < len(text) and last_break and last_break > start:
-                end = last_break
-            if end == start:
-                end += 1
-            chunks.append(text[start:end])
-            start = end
-        return chunks
 
     # ------------------------------------------------------------------
     # Outbound — text
     # ------------------------------------------------------------------
 
-    async def send(
-        self,
-        chat_id: str,
-        content: str,
-        reply_to: Optional[str] = None,
-        metadata: Optional[Dict[str, Any]] = None,
-    ) -> SendResult:
-        """Deliver text and embedded media with daemon-confirmed results."""
-        _voice_exts = {".ogg", ".mp3", ".wav", ".m4a", ".opus"}
-        media_paths = re.findall(r"MEDIA:(\S+)", content)
-        if media_paths:
-            content = re.sub(r"MEDIA:\S+", "", content).strip()
-
-        delivered_ids: List[str] = []
-        if content:
-            initial_chunks: List[str] = []
-            for logical_chunk in self.truncate_message(
-                content, MAX_MESSAGE_LENGTH, len_fn=self.message_len_fn
-            ):
-                initial_chunks.extend(self._split_utf8_payload(logical_chunk))
-            queue = [
-                (chunk, index == 0)
-                for index, chunk in enumerate(initial_chunks)
-            ]
-            while queue:
-                chunk, carries_reply = queue.pop(0)
-                result = await self._send_composed(
-                    chat_id,
-                    {"type": "text", "text": chunk},
-                    reply_to=reply_to if carries_reply else None,
-                    live=bool((metadata or {}).get("expect_edits")),
-                )
-                if (
-                    not result.success
-                    and result.error_kind == "too_long"
-                    and len(chunk) > 512
-                ):
-                    retry_chunks = self.truncate_message(
-                        chunk, max(256, len(chunk) // 2)
-                    )
-                    queue = [
-                        (retry_chunk, carries_reply and index == 0)
-                        for index, retry_chunk in enumerate(retry_chunks)
-                    ] + queue
-                    continue
-                if not result.success:
-                    result.message_id = delivered_ids[-1] if delivered_ids else None
-                    if delivered_ids:
-                        result.error_kind = "partial_delivery"
-                        result.retryable = False
-                        result.raw_response = {
-                            "partial_delivery": True,
-                            "delivered_message_ids": tuple(delivered_ids),
-                            "daemon_response": result.raw_response,
-                        }
-                    return result
-                if result.message_id:
-                    delivered_ids.append(result.message_id)
-
-        for path in media_paths:
-            is_voice = os.path.splitext(path)[1].lower() in _voice_exts
-            if is_voice:
-                media_result = await self.send_voice(chat_id, path)
-            else:
-                media_result = await self.send_document(chat_id, path)
-            if not media_result.success:
-                if delivered_ids:
-                    media_result.message_id = delivered_ids[-1]
-                    media_result.error_kind = "partial_delivery"
-                    media_result.retryable = False
-                    media_result.raw_response = {
-                        "partial_delivery": True,
-                        "delivered_message_ids": tuple(delivered_ids),
-                        "daemon_response": media_result.raw_response,
-                    }
-                return media_result
-            if media_result.message_id:
-                delivered_ids.append(media_result.message_id)
-        return SendResult(
-            success=True,
-            message_id=delivered_ids[-1] if delivered_ids else None,
-            continuation_message_ids=tuple(delivered_ids[:-1]),
-        )
 
     # ------------------------------------------------------------------
     # Channel directory enumeration
     # ------------------------------------------------------------------
 
-    async def list_channels(self) -> Optional[List[Dict[str, Any]]]:
-        """Enumerate contacts and allowed groups for the channel directory.
-
-        Called by ``gateway.channel_directory.build_channel_directory()``
-        every refresh cycle. Uses the daemon's ``/contacts`` and ``/groups``
-        commands over the live WebSocket. Returns ``None`` (not ``[]``) when
-        the WebSocket is down so the directory falls back to session-history
-        discovery instead of wiping previously known targets.
-
-        Entry ``id`` values use immutable numeric contact/group IDs. Display
-        names remain labels only and never become authorization or routing
-        identities.
-        """
-        if not self._ws:
-            return None
-
-        channels: List[Dict[str, Any]] = []
-
-        resp = await self._send_command("/contacts", timeout=10.0)
-        if resp is None or _response_error(resp):
-            # Daemon unresponsive — keep whatever the directory already has.
-            return None
-        for contact in resp.get("contacts") or []:
-            if not isinstance(contact, dict):
-                continue
-            contact_id = contact.get("contactId")
-            name = (
-                contact.get("localDisplayName", "")
-                or (contact.get("profile", {}) or {}).get("displayName", "")
-            )
-            if contact_id is None:
-                continue
-            channels.append({
-                "id": str(contact_id),
-                "name": str(name or contact_id),
-                "type": "dm",
-            })
-
-        resp = await self._send_command("/groups", timeout=10.0)
-        if resp is not None and not _response_error(resp):
-            for group in resp.get("groups") or []:
-                # The daemon returns each group as either a groupInfo dict
-                # or a [groupInfo, groupSummary] pair depending on version.
-                if isinstance(group, list) and group:
-                    group = group[0]
-                if not isinstance(group, dict):
-                    continue
-                group_id = group.get("groupId")
-                if group_id is None:
-                    continue
-                name = (
-                    group.get("localDisplayName", "")
-                    or (group.get("groupProfile", {}) or {}).get("displayName", "")
-                    or str(group_id)
-                )
-                channels.append({
-                    "id": f"group:{group_id}",
-                    "name": str(name),
-                    "type": "group",
-                })
-
-        return channels
 
     # ------------------------------------------------------------------
     # Outbound — media
     # ------------------------------------------------------------------
 
-    @staticmethod
-    def _prepare_image(file_path: str) -> tuple[str, str]:
-        """Ensure *file_path* is a PNG and return ``(png_path, thumb_data_uri)``.
 
-        SimpleX clients can't display WebP and a few other formats inline.
-        This converts to PNG when needed and generates a small JPEG thumbnail
-        for the ``image`` field in the ``/_send`` payload so the chat shows
-        an inline preview. Uses Pillow when available, falls back to
-        ImageMagick ``convert``.
-        """
-        import subprocess
-        p = Path(file_path)
-        png_path = file_path
-        thumb_uri = ""
 
-        def _temp_path(suffix: str) -> str:
-            fd, path = tempfile.mkstemp(prefix="hermes-simplex-", suffix=suffix)
-            os.close(fd)
-            return path
 
-        try:
-            from PIL import Image
 
-            img = Image.open(file_path)
-            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = _temp_path(".png")
-                img.save(png_path, "PNG")
-            thumb = img.copy()
-            thumb.thumbnail((128, 128))
-            import io
 
-            buf = io.BytesIO()
-            thumb.save(buf, "JPEG", quality=70)
-            thumb_uri = (
-                "data:image/jpg;base64,"
-                + base64.b64encode(buf.getvalue()).decode()
-            )
-        except ImportError:
-            try:
-                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = _temp_path(".png")
-                    subprocess.run(
-                        ["convert", file_path, png_path],
-                        check=True,
-                        capture_output=True,
-                        timeout=30,
-                    )
-                with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
-                    tmp_path = tmp.name
-                subprocess.run(
-                    [
-                        "convert",
-                        file_path,
-                        "-resize",
-                        "128x128",
-                        "-quality",
-                        "70",
-                        tmp_path,
-                    ],
-                    check=True,
-                    capture_output=True,
-                    timeout=30,
-                )
-                with open(tmp_path, "rb") as f:
-                    thumb_uri = (
-                        "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
-                    )
-                os.remove(tmp_path)
-            except (FileNotFoundError, subprocess.SubprocessError) as exc:
-                logger.warning("SimpleX: image conversion unavailable: %s", exc)
-
-        return png_path, thumb_uri
-
-    async def send_image(
-        self,
-        chat_id: str,
-        image_url: str,
-        caption: Optional[str] = None,
-        **kwargs,
-    ) -> SendResult:
-        """Send an image. Supports ``file://`` URLs and ``http(s)://`` URLs."""
-        from urllib.parse import unquote
-
-        if image_url.startswith("file://"):
-            file_path = unquote(image_url[7:])
-        else:
-            try:
-                from gateway.platforms.base import cache_image_from_url
-
-                file_path = await cache_image_from_url(image_url)
-            except Exception as e:
-                logger.warning("SimpleX: failed to download image: %s", e)
-                return SendResult(success=False, error=str(e))
-
-        if not file_path or not Path(file_path).exists():
-            return SendResult(success=False, error="Image file not found")
-
-        png_path, thumb_uri = self._prepare_image(file_path)
-        owned_temp = (
-            os.path.abspath(png_path) != os.path.abspath(file_path)
-        )
-        if owned_temp:
-            self._schedule_owned_media_cleanup(png_path)
-
-        result = await self._send_composed(
-            chat_id,
-            {
-                "type": "image",
-                "image": thumb_uri,
-                "text": caption or "",
-            },
-            reply_to=kwargs.get("reply_to"),
-            file_source=png_path,
-        )
-        if owned_temp:
-            if result.success and result.message_id:
-                self._outbound_temp_by_item[str(result.message_id)] = png_path
-            elif result.error_kind != "delivery_unknown":
-                self._cleanup_owned_media_path(png_path)
-        return result
-
-    async def send_image_file(
-        self,
-        chat_id: str,
-        image_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        **kwargs,
-    ) -> SendResult:
-        """Send a local image file via SimpleX."""
-        return await self.send_image(
-            chat_id,
-            f"file://{image_path}",
-            caption=caption,
-            reply_to=reply_to,
-            **kwargs,
-        )
-
-    async def send_video(
-        self,
-        chat_id: str,
-        video_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        **kwargs,
-    ) -> SendResult:
-        """Send a video file via SimpleX (as a file attachment)."""
-        return await self.send_document(
-            chat_id,
-            video_path,
-            caption=caption,
-            reply_to=reply_to,
-            **kwargs,
-        )
-
-    async def send_document(
-        self,
-        chat_id: str,
-        file_path: str,
-        caption: Optional[str] = None,
-        filename: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        **kwargs,
-    ) -> SendResult:
-        """Send a document/file attachment."""
-        if not Path(file_path).exists():
-            return SendResult(success=False, error="File not found")
-
-        return await self._send_composed(
-            chat_id,
-            {"type": "file", "text": caption or ""},
-            reply_to=reply_to,
-            file_source=file_path,
-        )
-
-    async def send_voice(
-        self,
-        chat_id: str,
-        audio_path: str,
-        caption: Optional[str] = None,
-        reply_to: Optional[str] = None,
-        duration: int = 0,
-        **kwargs,
-    ) -> SendResult:
-        """Send an audio file as a SimpleX voice note (plays inline).
-
-        SimpleX distinguishes a generic file attachment (``type: "file"``)
-        from an inline voice note (``type: "voice"``). ``/f`` would deliver
-        a downloadable file; the structured ``/_send`` form with
-        ``msgContent.type == "voice"`` produces the voice-note player.
-        """
-        if not Path(audio_path).exists():
-            return SendResult(success=False, error="Voice file not found")
-
-        return await self._send_composed(
-            chat_id,
-            {
-                "type": "voice",
-                "text": caption or "",
-                "duration": duration,
-            },
-            reply_to=reply_to,
-            file_source=audio_path,
-        )
 
     async def edit_message(
         self,
@@ -2315,270 +1482,16 @@ class SimplexAdapter(BasePlatformAdapter):
             resp, expected={"chatItemsDeleted"}
         ).success
 
-    async def _set_reaction(
-        self,
-        chat_id: str,
-        message_id: str,
-        emoji: str,
-        *,
-        added: bool,
-    ) -> SendResult:
-        reaction = json.dumps(
-            {"type": "emoji", "emoji": emoji}, ensure_ascii=False
-        )
-        toggle = "on" if added else "off"
-        resp = await self._send_command(
-            f"/_reaction {self._chat_ref(chat_id)} {message_id} {toggle} {reaction}",
-            timeout=10.0,
-        )
-        return self._send_result_from_response(
-            resp, expected={"chatItemReaction"}
-        )
 
-    @staticmethod
-    def _approval_timeout() -> float:
-        try:
-            from tools.approval import _get_approval_timeout
 
-            return max(1.0, float(_get_approval_timeout()))
-        except Exception:
-            return 300.0
 
-    def _approval_text(
-        self,
-        command: str,
-        description: str,
-        *,
-        allow_session: bool,
-        allow_permanent: bool,
-        smart_denied: bool,
-        reactions: bool,
-    ) -> str:
-        prefix = self.typed_command_prefix
-        lines = [self._format_exec_approval(command, description, smart_denied)]
-        choices = [f"Reply `{prefix}approve` to run once"]
-        if not smart_denied and allow_session:
-            choices.append(f"`{prefix}approve session` for this session")
-        if not smart_denied and allow_permanent:
-            choices.append(f"`{prefix}approve always` to persist the pattern")
-        choices.append(f"`{prefix}deny` to cancel")
-        lines.append(", or ".join(choices) + ".")
-        if reactions:
-            taps = ["✅ = run once"]
-            if not smart_denied and allow_session:
-                taps.append("🚀 = allow for this session")
-            taps.append("👎 = deny")
-            lines.append("Tap a reaction: " + "; ".join(taps) + ".")
-        return "\n\n".join(lines)
 
-    async def send_exec_approval(
-        self,
-        chat_id: str,
-        command: str,
-        session_key: str,
-        description: str = "dangerous command",
-        metadata: Optional[dict] = None,
-        allow_permanent: bool = True,
-        allow_session: bool = True,
-        smart_denied: bool = False,
-    ) -> SendResult:
-        """Offer unambiguous direct-message reaction approvals with typed fallback."""
-        now = time.monotonic()
-        self._sweep_approval_prompts(now)
-        is_dm = not str(chat_id).startswith("group:")
-        existing_id = self._approval_prompt_by_session.get(session_key)
-        superseded_prior = bool(existing_id)
-        typed_only = self._approval_typed_only_until.get(session_key, 0.0) > now
 
-        if existing_id:
-            self._retire_approval_prompt(existing_id)
-            self._approval_typed_only_until[session_key] = now + self._approval_timeout()
-            typed_only = True
 
-        reaction_lane = is_dm and not typed_only
-        text = self._approval_text(
-            command,
-            description,
-            allow_session=allow_session,
-            allow_permanent=allow_permanent,
-            smart_denied=smart_denied,
-            reactions=reaction_lane,
-        )
-        if superseded_prior:
-            text = (
-                "The earlier approval prompt was superseded; its reactions no "
-                "longer apply. Use the typed choices below.\n\n" + text
-            )
-        result = await self.send(chat_id, text, metadata=metadata)
-        if not result.success or not result.message_id or not reaction_lane:
-            if not result.success or not result.message_id:
-                self._approval_typed_only_until[session_key] = (
-                    now + self._approval_timeout()
-                )
-            return result
 
-        choices = {"✅": "once", "👎": "deny"}
-        seeds = ["👎", "✅"]
-        if not smart_denied and allow_session:
-            choices["🚀"] = "session"
-            seeds.insert(1, "🚀")
-        prompt = {
-            "session_key": session_key,
-            "chat_id": str(chat_id),
-            "item_id": str(result.message_id),
-            "choices": choices,
-            "seeded": [],
-            "expires_at": now + self._approval_timeout(),
-        }
-        self._approval_prompts_by_item[prompt["item_id"]] = prompt
-        self._approval_prompt_by_session[session_key] = prompt["item_id"]
-        self._spawn_command_task(self._seed_approval_reactions(prompt, seeds))
-        self._spawn_command_task(self._expire_approval_prompt(prompt["item_id"]))
-        return result
 
-    async def _seed_approval_reactions(self, prompt: dict, seeds: List[str]) -> None:
-        for emoji in seeds[:3]:
-            if self._approval_prompts_by_item.get(prompt["item_id"]) is not prompt:
-                return
-            result = await self._set_reaction(
-                prompt["chat_id"], prompt["item_id"], emoji, added=True
-            )
-            if not result.success:
-                logger.info(
-                    "SimpleX: reaction seed unavailable; typed approval remains active"
-                )
-                return
-            prompt["seeded"].append(emoji)
 
-    async def _expire_approval_prompt(self, item_id: str) -> None:
-        prompt = self._approval_prompts_by_item.get(item_id)
-        if not prompt:
-            return
-        await asyncio.sleep(max(0.0, prompt["expires_at"] - time.monotonic()))
-        if self._approval_prompts_by_item.get(item_id) is prompt:
-            self._retire_approval_prompt(item_id)
 
-    def _sweep_approval_prompts(self, now: Optional[float] = None) -> None:
-        current = time.monotonic() if now is None else now
-        for item_id, prompt in list(self._approval_prompts_by_item.items()):
-            if prompt["expires_at"] <= current:
-                self._retire_approval_prompt(item_id)
-        for session_key, expiry in list(self._approval_typed_only_until.items()):
-            if expiry <= current:
-                self._approval_typed_only_until.pop(session_key, None)
-
-    def _retire_approval_prompt(self, item_id: str) -> None:
-        prompt = self._approval_prompts_by_item.pop(str(item_id), None)
-        if not prompt:
-            return
-        if self._approval_prompt_by_session.get(prompt["session_key"]) == str(item_id):
-            self._approval_prompt_by_session.pop(prompt["session_key"], None)
-        if prompt["seeded"]:
-            self._spawn_command_task(self._clear_approval_reactions(prompt))
-
-    async def _clear_approval_reactions(self, prompt: dict) -> None:
-        for emoji in list(prompt["seeded"]):
-            await self._set_reaction(
-                prompt["chat_id"], prompt["item_id"], emoji, added=False
-            )
-
-    @staticmethod
-    def _reaction_context(resp: dict) -> Optional[dict]:
-        wrapper = resp.get("reaction", {}) or {}
-        if not isinstance(wrapper, dict):
-            return None
-        chat_info = wrapper.get("chatInfo", {}) or {}
-        reaction = wrapper.get("chatReaction", {}) or {}
-        if not isinstance(chat_info, dict) or not isinstance(reaction, dict):
-            return None
-        chat_item = reaction.get("chatItem", {}) or {}
-        meta = chat_item.get("meta", {}) if isinstance(chat_item, dict) else {}
-        item_id = meta.get("itemId") if isinstance(meta, dict) else None
-        msg_reaction = reaction.get("reaction", {}) or {}
-        emoji = (
-            msg_reaction.get("emoji", "")
-            if isinstance(msg_reaction, dict)
-            else ""
-        ).replace("\ufe0f", "")
-        chat_type = chat_info.get("type", "")
-        chat_dir = reaction.get("chatDir", {}) or {}
-        if chat_type == "direct":
-            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "directRcv":
-                return None
-            contact = chat_info.get("contact", {}) or {}
-            chat_id = str(contact.get("contactId", ""))
-            user_id = chat_id
-            user_name = contact.get("localDisplayName", "")
-        elif chat_type == "group":
-            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "groupRcv":
-                return None
-            group = chat_info.get("groupInfo", {}) or {}
-            chat_id = f"group:{group.get('groupId', '')}"
-            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
-            member_identity = member.get("memberContactId")
-            if member_identity is None:
-                member_identity = member.get("memberId", "")
-            user_id = str(member_identity)
-            user_name = member.get("localDisplayName", "")
-        else:
-            return None
-        return {
-            "item_id": str(item_id) if item_id is not None else "",
-            "chat_id": chat_id,
-            "user_id": user_id,
-            "user_name": user_name,
-            "emoji": emoji,
-            "added": bool(resp.get("added", False)),
-            "raw": resp,
-        }
-
-    async def _handle_reaction_event(self, resp: dict) -> None:
-        ctx = self._reaction_context(resp)
-        if not ctx:
-            return
-        hook = getattr(self, "_reaction_handler", None)
-        if hook is not None:
-            await hook(
-                {
-                    "event_name": (
-                        "reaction:added" if ctx["added"] else "reaction:removed"
-                    ),
-                    "platform": "simplex",
-                    **ctx,
-                }
-            )
-
-        if not ctx["added"]:
-            return
-        prompt = self._approval_prompts_by_item.get(ctx["item_id"])
-        if not prompt or prompt["chat_id"] != ctx["chat_id"]:
-            return
-        if not prompt["chat_id"].startswith("group:") and ctx["user_id"] != prompt["chat_id"]:
-            logger.warning("SimpleX: ignored approval reaction from another contact")
-            return
-        if time.monotonic() >= prompt["expires_at"]:
-            self._retire_approval_prompt(prompt["item_id"])
-            return
-        choice = prompt["choices"].get(ctx["emoji"])
-        if not choice:
-            return
-
-        try:
-            from tools.approval import resolve_gateway_approval
-
-            count = int(resolve_gateway_approval(prompt["session_key"], choice) or 0)
-        except Exception:
-            logger.exception("SimpleX: failed to resolve reaction approval")
-            return
-        self._retire_approval_prompt(prompt["item_id"])
-        acknowledgement = {
-            "once": "Approved — running this once.",
-            "session": "Approved for this session.",
-            "deny": "Denied — the command will not run.",
-        }[choice]
-        if count <= 0:
-            acknowledgement = "That approval is no longer pending. Nothing ran."
-        self._spawn_command_task(self.send(prompt["chat_id"], acknowledgement))
 
     def get_runtime_diagnostics(self) -> Dict[str, Any]:
         """Return bounded transport state for status/incident tooling."""
@@ -2616,7 +1529,10 @@ def check_requirements() -> bool:
     so the gateway never instantiates the adapter when the dependency is
     missing or no daemon URL is configured.
     """
-    if not os.getenv("SIMPLEX_WS_URL"):
+    if _profile_scoped():
+        if not str(_profile_simplex_extra().get("ws_url", "")).strip():
+            return False
+    elif not os.getenv("SIMPLEX_WS_URL"):
         return False
     try:
         import websockets  # noqa: F401
@@ -2628,14 +1544,16 @@ def check_requirements() -> bool:
 def validate_config(config) -> bool:
     """Validate that the platform config has enough info to connect."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    env_ws_url = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = env_ws_url or extra.get("ws_url", "")
     return bool(ws_url)
 
 
 def is_connected(config) -> bool:
     """Check whether SimpleX is configured (env or config.yaml)."""
     extra = getattr(config, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get("ws_url", "")
+    env_ws_url = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = env_ws_url or extra.get("ws_url", "")
     return bool(ws_url)
 
 
@@ -2651,6 +1569,8 @@ def _env_enablement() -> Optional[dict]:
     becomes a proper ``HomeChannel`` dataclass on the ``PlatformConfig``
     rather than being merged into ``extra``.
     """
+    if _profile_scoped():
+        return None
     ws_url = os.getenv("SIMPLEX_WS_URL", "").strip()
     if not ws_url:
         return None
@@ -2702,9 +1622,8 @@ async def _standalone_send(
         return {"error": "websockets not installed. Run: pip install websockets"}
 
     extra = getattr(pconfig, "extra", {}) or {}
-    ws_url = os.getenv("SIMPLEX_WS_URL") or extra.get(
-        "ws_url", "ws://127.0.0.1:5225"
-    )
+    env_ws_url = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
+    ws_url = env_ws_url or extra.get("ws_url", "ws://127.0.0.1:5225")
     if not ws_url:
         return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -276,9 +276,9 @@ class SimplexAdapter(
         if ignored_allow_entries:
             logger.warning(
                 "SimpleX: %d non-numeric SIMPLEX_ALLOWED_USERS entries do not "
-                "authorize DMs; display names are ignored. Keep an entry only "
-                "if it is an exact group memberId, otherwise migrate to a "
-                "stable contactId from /contacts",
+                "authorize DMs; display names and group memberIds are ignored. "
+                "Use stable contactId values from /contacts. Group access is "
+                "controlled separately by SIMPLEX_GROUP_ALLOWED",
                 len(ignored_allow_entries),
             )
 
@@ -1644,9 +1644,15 @@ async def _standalone_send(
 
     extra = getattr(pconfig, "extra", {}) or {}
     env_ws_url = _scoped_platform_setting("SIMPLEX_WS_URL", extra, "ws_url")
-    ws_url = env_ws_url or extra.get("ws_url", "ws://127.0.0.1:5225")
-    if not ws_url:
-        return {"error": "SimpleX standalone send: SIMPLEX_WS_URL is required"}
+    configured_ws_url = str(env_ws_url or extra.get("ws_url", "")).strip()
+    if _profile_scoped() and not configured_ws_url:
+        return {
+            "error": (
+                "SimpleX standalone send: SIMPLEX_WS_URL is required for the "
+                "active profile"
+            )
+        }
+    ws_url = configured_ws_url or "ws://127.0.0.1:5225"
 
     async def _send_confirmed(
         ws,

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -27,6 +27,9 @@ Optional environment variables:
     SIMPLEX_ALLOW_ALL_USERS    Set 'true' to allow all contacts
     SIMPLEX_AUTO_ACCEPT        Set 'false' to disable contact-request auto-accept
                                (default: 'true')
+    SIMPLEX_FILES_FOLDER       Absolute path passed to simplex-chat via
+                               --files-folder. Required for reliable inbound
+                               attachment paths and same-filesystem XFTP moves.
     SIMPLEX_GROUP_ALLOWED      Comma-separated group IDs to monitor, or '*'
                                for any group. Omit to disable groups entirely.
     SIMPLEX_HOME_CHANNEL       Default contact/group ID for cron delivery
@@ -258,7 +261,14 @@ class SimplexAdapter(BasePlatformAdapter):
         # The daemon reports received paths relative to --files-folder and
         # exposes only a setter, not a query API. Mirror the non-secret path in
         # config so downstream media consumers always receive openable paths.
-        self.files_folder = str(extra.get("files_folder", "") or "")
+        files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "").strip() or str(
+            extra.get("files_folder", "") or ""
+        ).strip()
+        self.files_folder = (
+            os.path.abspath(os.path.expanduser(files_folder))
+            if files_folder
+            else ""
+        )
         self._file_transfer_timeout = max(
             1.0, float(extra.get("file_transfer_timeout", 300.0))
         )
@@ -667,19 +677,28 @@ class SimplexAdapter(BasePlatformAdapter):
                     if isinstance(file_info, dict)
                     else ""
                 ) or rcv_file.get("fileName", "")
-                target_dir = self.files_folder or tempfile.gettempdir()
-                target = os.path.join(
-                    target_dir,
-                    f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
-                )
-                while os.path.exists(target):
+                target: Optional[str] = None
+                if self.files_folder:
                     target = os.path.join(
-                        target_dir,
+                        self.files_folder,
                         f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
                     )
-                self._file_receive_targets[file_id] = target
-                if not self.retain_received_files:
-                    self._schedule_owned_media_cleanup(target)
+                while target and os.path.exists(target):
+                    target = os.path.join(
+                        self.files_folder,
+                        f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
+                    )
+                if target:
+                    self._file_receive_targets[file_id] = target
+                    if not self.retain_received_files:
+                        self._schedule_owned_media_cleanup(target)
+                else:
+                    logger.warning(
+                        "SimpleX: SIMPLEX_FILES_FOLDER is not configured; "
+                        "receiving file %s to the daemon-managed folder without "
+                        "claiming cleanup ownership",
+                        file_id,
+                    )
                 logger.debug(
                     "SimpleX: rcvFileDescrReady for fileId=%s — accepting transfer",
                     file_id,
@@ -802,6 +821,14 @@ class SimplexAdapter(BasePlatformAdapter):
                     self._pending_file_transfers.pop(file_id, None)
                     self._cancel_file_timeout(file_id)
                     file_path = self._resolve_file_path(file_path)
+                    if not os.path.isabs(file_path):
+                        self._pending_file_transfers[file_id] = pending
+                        await self._fail_file_transfer(
+                            file_id,
+                            "SIMPLEX_FILES_FOLDER is required to resolve the "
+                            "daemon's relative attachment path",
+                        )
+                        return
                     pending_item_data = pending.get("chatItem", {}) or {}
                     pending_file = pending_item_data.setdefault("file", {})
                     pending_file["fileSource"] = {"filePath": file_path}
@@ -1080,10 +1107,11 @@ class SimplexAdapter(BasePlatformAdapter):
             self._diagnostics["command_errors"] += 1
             logger.warning("SimpleX: contact request acceptance failed: %s", error)
 
-    async def _receive_file(self, file_id: int, target: str) -> None:
-        resp = await self._send_command(
-            f"/freceive {file_id} approved_relays=on {target}", timeout=30.0
-        )
+    async def _receive_file(self, file_id: int, target: Optional[str]) -> None:
+        command = f"/freceive {file_id} approved_relays=on"
+        if target:
+            command += f" {target}"
+        resp = await self._send_command(command, timeout=30.0)
         error = _response_error(resp)
         if error or _response_type(resp) == "rcvFileAcceptedSndCancelled":
             self._diagnostics["command_errors"] += 1
@@ -2595,6 +2623,10 @@ def _env_enablement() -> Optional[dict]:
     group_allowed = os.getenv("SIMPLEX_GROUP_ALLOWED", "").strip()
     if group_allowed:
         seed["group_allowed"] = group_allowed
+
+    files_folder = os.getenv("SIMPLEX_FILES_FOLDER", "").strip()
+    if files_folder:
+        seed["files_folder"] = files_folder
 
     home = os.getenv("SIMPLEX_HOME_CHANNEL", "").strip()
     if home:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -79,8 +79,9 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 # The protocol's encoded JSON envelope must fit below roughly 15.6 KiB.
-# Keep a substantial envelope/escaping margin and split before serialization.
-MAX_MESSAGE_LENGTH = 8000
+# This limit is measured by ``message_len_fn`` in serialized UTF-8 bytes, not
+# Python code points, and leaves room for the command/chat JSON wrapper.
+MAX_MESSAGE_LENGTH = 12000
 WS_RETRY_DELAY_INITIAL = 2.0
 WS_RETRY_DELAY_MAX = 60.0
 HEALTH_CHECK_INTERVAL = 30.0
@@ -145,6 +146,36 @@ def _sanitize_filename(name: str) -> str:
     return cleaned[:120] or "file"
 
 
+def _simplex_payload_len(text: str) -> int:
+    """Measure a string as it appears inside the ensure_ascii=False JSON body."""
+    return len(json.dumps(text, ensure_ascii=False).encode("utf-8")) - 2
+
+
+def _delivered_source_prefix(content: str, chunks: List[str]) -> str:
+    """Map formatted overflow chunks back to a monotonic source prefix."""
+    cursor = 0
+    for index, formatted in enumerate(chunks):
+        visible = re.sub(r" \(\d+/\d+\)$", "", formatted)
+        variants = {visible}
+        if visible.endswith("\n```"):
+            variants.add(visible[:-4])
+        if visible.startswith("```") and "\n" in visible:
+            without_open = visible.split("\n", 1)[1]
+            variants.add(without_open)
+            if without_open.endswith("\n```"):
+                variants.add(without_open[:-4])
+
+        if index:
+            while cursor < len(content) and content[cursor].isspace():
+                cursor += 1
+        remaining = content[cursor:]
+        matches = [candidate for candidate in variants if remaining.startswith(candidate)]
+        if not matches:
+            return ""
+        cursor += len(max(matches, key=len))
+    return content[:cursor]
+
+
 def _response_type(resp: Optional[dict]) -> str:
     return str((resp or {}).get("type") or "") if isinstance(resp, dict) else ""
 
@@ -202,6 +233,11 @@ class SimplexAdapter(BasePlatformAdapter):
 
     _EA_HEADER = "⚠️ Dangerous command requires approval\n"
     _EA_CMD_BUDGET = 2000
+
+    @property
+    def message_len_fn(self):
+        """SimpleX constrains encoded command bytes, not Unicode code points."""
+        return _simplex_payload_len
 
     def __init__(self, config: PlatformConfig, **kwargs):
         platform = Platform("simplex")
@@ -642,7 +678,8 @@ class SimplexAdapter(BasePlatformAdapter):
                         f"simplex-rcv-{uuid.uuid4().hex}-{_sanitize_filename(file_name)}",
                     )
                 self._file_receive_targets[file_id] = target
-                self._schedule_owned_media_cleanup(target)
+                if not self.retain_received_files:
+                    self._schedule_owned_media_cleanup(target)
                 logger.debug(
                     "SimpleX: rcvFileDescrReady for fileId=%s — accepting transfer",
                     file_id,
@@ -739,7 +776,10 @@ class SimplexAdapter(BasePlatformAdapter):
                         else None
                     )
                     target = self._terminal_file_target(file_id)
-                    if late_path and target:
+                    terminal_reason = self._terminal_file_transfers[file_id].get(
+                        "reason"
+                    )
+                    if late_path and target and terminal_reason != "completed":
                         resolved = self._resolve_file_path(late_path)
                         if os.path.abspath(resolved) == os.path.abspath(target):
                             self._cleanup_owned_media_path(target)
@@ -761,7 +801,6 @@ class SimplexAdapter(BasePlatformAdapter):
                 )
                 if file_path:
                     file_path = self._resolve_file_path(file_path)
-                    self._mark_file_terminal(file_id, "completed")
                     pending_item_data = pending.get("chatItem", {}) or {}
                     pending_file = pending_item_data.setdefault("file", {})
                     pending_file["fileSource"] = {"filePath": file_path}
@@ -773,7 +812,7 @@ class SimplexAdapter(BasePlatformAdapter):
                         logger.exception(
                             "SimpleX: error processing deferred file message"
                         )
-                else:
+                elif file_id not in self._terminal_file_transfers:
                     self._mark_file_terminal(file_id, "completed-without-path")
             return
 
@@ -1153,6 +1192,7 @@ class SimplexAdapter(BasePlatformAdapter):
         media_types: List[str] = []
         file_info = chat_item_data.get("file")
         owned_media_path: Optional[str] = None
+        completed_file_id: Optional[int] = None
 
         if file_info and isinstance(file_info, dict):
             file_source = file_info.get("fileSource", {}) or {}
@@ -1167,6 +1207,20 @@ class SimplexAdapter(BasePlatformAdapter):
             file_status_type = (
                 file_status.get("type") if isinstance(file_status, dict) else None
             )
+            try:
+                normalized_file_id = int(file_id) if file_id is not None else None
+            except (TypeError, ValueError):
+                normalized_file_id = None
+            if (
+                normalized_file_id is not None
+                and normalized_file_id in self._terminal_file_transfers
+            ):
+                self._diagnostics["late_file_completions"] += 1
+                logger.info(
+                    "SimpleX: ignored duplicate completed chat item for fileId=%s",
+                    normalized_file_id,
+                )
+                return
             if file_path:
                 file_path = self._resolve_file_path(file_path)
 
@@ -1201,10 +1255,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     return
 
             if file_info and file_path:
-                try:
-                    normalized_file_id = int(file_id) if file_id is not None else None
-                except (TypeError, ValueError):
-                    normalized_file_id = None
+                completed_file_id = normalized_file_id
                 receive_target = (
                     self._terminal_file_target(normalized_file_id)
                     if normalized_file_id is not None
@@ -1328,6 +1379,13 @@ class SimplexAdapter(BasePlatformAdapter):
             chat_id[:20],
             (text or "")[:50],
         )
+
+        # Mark only after constructing and dispatching the first completed
+        # item.  Subsequent rcvFileComplete/newChatItems duplicates with the
+        # same fileId are then ignored without deleting a file the active turn
+        # may still be consuming.
+        if completed_file_id is not None:
+            self._mark_file_terminal(completed_file_id, "completed")
 
         # Batch consecutive text messages so the agent sees one combined
         # message instead of dropping earlier ones when the user pastes
@@ -1501,6 +1559,10 @@ class SimplexAdapter(BasePlatformAdapter):
                 command.split(" ", 1)[0],
                 e,
             )
+            self._pending_responses.pop(corr_id, None)
+            self._pending_corr_ids.discard(corr_id)
+            if not fut.done():
+                fut.cancel()
             return {
                 "type": "localCommandNotSubmitted",
                 "error": "SimpleX command was not submitted to the daemon",
@@ -1681,7 +1743,9 @@ class SimplexAdapter(BasePlatformAdapter):
         return self._send_result_from_response(resp, expected={"newChatItems"})
 
     @staticmethod
-    def _split_utf8_payload(text: str, byte_budget: int = 12000) -> List[str]:
+    def _split_utf8_payload(
+        text: str, byte_budget: int = MAX_MESSAGE_LENGTH
+    ) -> List[str]:
         """Split by serialized UTF-8 bytes, never through a code point.
 
         ``simplex-chat`` limits the encoded command envelope rather than
@@ -1697,9 +1761,7 @@ class SimplexAdapter(BasePlatformAdapter):
             end = start
             last_break: Optional[int] = None
             while end < len(text):
-                char_cost = len(
-                    json.dumps(text[end], ensure_ascii=False).encode("utf-8")
-                ) - 2
+                char_cost = _simplex_payload_len(text[end])
                 if used + char_cost > byte_budget and end > start:
                     break
                 used += char_cost
@@ -1734,7 +1796,9 @@ class SimplexAdapter(BasePlatformAdapter):
         delivered_ids: List[str] = []
         if content:
             initial_chunks: List[str] = []
-            for logical_chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
+            for logical_chunk in self.truncate_message(
+                content, MAX_MESSAGE_LENGTH, len_fn=self.message_len_fn
+            ):
                 initial_chunks.extend(self._split_utf8_payload(logical_chunk))
             queue = [
                 (chunk, index == 0)
@@ -2086,7 +2150,9 @@ class SimplexAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Update a streaming preview and finalize it with complete text."""
         chunks: List[str] = []
-        for logical_chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
+        for logical_chunk in self.truncate_message(
+            content, MAX_MESSAGE_LENGTH, len_fn=self.message_len_fn
+        ):
             chunks.extend(self._split_utf8_payload(logical_chunk))
         first_chunk = chunks[0] if chunks else ""
         updated = {
@@ -2118,6 +2184,10 @@ class SimplexAdapter(BasePlatformAdapter):
                 chat_id, {"type": "text", "text": chunk}
             )
             if not continuation.success:
+                delivered_chunks = chunks[: 1 + len(continuation_ids)]
+                delivered_prefix = _delivered_source_prefix(
+                    content, delivered_chunks
+                )
                 continuation.message_id = (
                     continuation_ids[-1] if continuation_ids else str(message_id)
                 )
@@ -2129,6 +2199,7 @@ class SimplexAdapter(BasePlatformAdapter):
                     "delivered_chunks": 1 + len(continuation_ids),
                     "total_chunks": len(chunks),
                     "last_message_id": continuation.message_id,
+                    "delivered_prefix": delivered_prefix,
                     "continuation_message_ids": tuple(continuation_ids),
                     "daemon_response": continuation.raw_response,
                 }
@@ -2556,12 +2627,13 @@ async def _standalone_send(
                 )
             return resp
 
+    owned_temp_paths: List[str] = []
     try:
         chat_ref = SimplexAdapter._chat_ref(chat_id)
         commands: List[str] = []
         if message:
             for chunk in BasePlatformAdapter.truncate_message(
-                message, MAX_MESSAGE_LENGTH
+                message, MAX_MESSAGE_LENGTH, len_fn=_simplex_payload_len
             ):
                 composed = [{
                     "msgContent": {"type": "text", "text": chunk},
@@ -2587,6 +2659,8 @@ async def _standalone_send(
                 file_path = path
             elif not force_document and _is_image_ext(ext):
                 file_path, thumb = SimplexAdapter._prepare_image(path)
+                if os.path.abspath(file_path) != os.path.abspath(path):
+                    owned_temp_paths.append(file_path)
                 msg_content = {"type": "image", "image": thumb, "text": ""}
             else:
                 msg_content = {"type": "file", "text": ""}
@@ -2616,6 +2690,17 @@ async def _standalone_send(
         }
     except Exception as e:
         return {"error": f"SimpleX send failed: {e}"}
+    finally:
+        for temp_path in owned_temp_paths:
+            try:
+                if os.path.isfile(temp_path) or os.path.islink(temp_path):
+                    os.remove(temp_path)
+            except OSError:
+                logger.debug(
+                    "SimpleX: failed to remove standalone image conversion %s",
+                    os.path.basename(temp_path),
+                    exc_info=True,
+                )
 
 
 def interactive_setup() -> None:

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -2879,11 +2879,11 @@ async def _standalone_send(
             try:
                 if os.path.isfile(temp_path) or os.path.islink(temp_path):
                     os.remove(temp_path)
-            except OSError:
+            except OSError as exc:
                 logger.debug(
-                    "SimpleX: failed to remove standalone image conversion %s",
+                    "SimpleX: failed to remove standalone image conversion %s (%s)",
                     os.path.basename(temp_path),
-                    exc_info=True,
+                    type(exc).__name__,
                 )
 
 

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -880,27 +880,25 @@ class SimplexAdapter(BasePlatformAdapter):
             content = re.sub(r"MEDIA:\S+", "", content).strip()
 
         if content:
-            corr_id = self._make_corr_id()
-            # Structured form: addresses by ID, and json.dumps escapes
-            # newlines + special chars correctly.  The bare @id text
-            # syntax is unreliable for DMs — the daemon silently drops
-            # messages when it cannot resolve the display name.
-            composed = json.dumps(
-                [{"msgContent": {"type": "text", "text": content}}]
-            )
-            if chat_id.startswith("group:"):
-                cmd_str = f"/_send #{chat_id[6:]} json {composed}"
-            else:
-                cmd_str = f"/_send @{chat_id} json {composed}"
-
-            ok = await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
-            if not ok:
-                return SendResult(
-                    success=False,
-                    error="SimpleX WebSocket is unavailable or closed",
-                    retryable=True,
-                    error_kind="transient",
+            for chunk in self.truncate_message(content, MAX_MESSAGE_LENGTH):
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": chunk}}]
                 )
+                if chat_id.startswith("group:"):
+                    cmd_str = f"/_send #{chat_id[6:]} json {composed}"
+                else:
+                    cmd_str = f"/_send @{chat_id} json {composed}"
+
+                ok = await self._send_ws(
+                    {"corrId": self._make_corr_id(), "cmd": cmd_str}
+                )
+                if not ok:
+                    return SendResult(
+                        success=False,
+                        error="SimpleX WebSocket is unavailable or closed",
+                        retryable=True,
+                        error_kind="transient",
+                    )
 
         for path in media_paths:
             is_voice = os.path.splitext(path)[1].lower() in _voice_exts
@@ -910,7 +908,6 @@ class SimplexAdapter(BasePlatformAdapter):
                 media_result = await self.send_document(chat_id, path)
             if not media_result.success:
                 return media_result
-
         return SendResult(success=True)
 
     # ------------------------------------------------------------------
@@ -1323,22 +1320,23 @@ async def _standalone_send(
         composed = json.dumps(
             [{"msgContent": {"type": "text", "text": message}}]
         )
-        if chat_id.startswith("group:"):
-            group_id = chat_id[6:]
-            cmd_str = f"/_send #{group_id} json {composed}"
-        else:
-            cmd_str = f"/_send @{chat_id} json {composed}"
+        chunks = BasePlatformAdapter.truncate_message(message, MAX_MESSAGE_LENGTH)
 
-        payload = {
-            "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}",
-            "cmd": cmd_str,
-        }
-
-        async with _wsclient.connect(
-            ws_url, open_timeout=10, close_timeout=5
-        ) as ws:
-            await ws.send(json.dumps(payload))
-            # Give the daemon a moment to process the command before closing.
+        async with _wsclient.connect(ws_url, open_timeout=10, close_timeout=5) as ws:
+            for i, chunk in enumerate(chunks):
+                composed = json.dumps(
+                    [{"msgContent": {"type": "text", "text": chunk}}]
+                )
+                if chat_id.startswith("group:"):
+                    cmd_str = f"/_send #{chat_id[6:]} json {composed}"
+                else:
+                    cmd_str = f"/_send @{chat_id} json {composed}"
+                payload = {
+                    "corrId": f"{_CORR_PREFIX}snd-{int(time.time() * 1000)}-{i}",
+                    "cmd": cmd_str,
+                }
+                await ws.send(json.dumps(payload))
+            # Give the daemon a moment to process the command(s) before closing.
             await asyncio.sleep(0.5)
 
         return {"success": True, "platform": "simplex", "chat_id": chat_id}

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -788,21 +788,23 @@ class SimplexAdapter(BasePlatformAdapter):
                     break
         return corr_id
 
-    async def _send_ws(self, payload: dict) -> None:
-        """Fire-and-forget JSON payload write.
+    async def _send_ws(self, payload: dict) -> bool:
+        """Send one JSON payload over the active WebSocket.
 
-        Drops cleanly when the WebSocket is missing or already closed; the
-        caller never has to handle reconnection — the ``_ws_listener``
-        loop does that out of band.
+        Returns True on success, False if the socket is unavailable or an
+        error occurs so callers can surface failures instead of silently
+        reporting success.
         """
         ws = self._ws
         if not ws:
-            logger.debug("SimpleX: WS send dropped (not connected)")
-            return
+            logger.debug("SimpleX: WS send rejected (not connected)")
+            return False
         try:
             await ws.send(json.dumps(payload))
+            return True
         except Exception as e:
             logger.warning("SimpleX: WS send error: %s", e)
+            return False
 
     async def _send_command(
         self, command: str, timeout: float = 30.0
@@ -891,7 +893,14 @@ class SimplexAdapter(BasePlatformAdapter):
             else:
                 cmd_str = f"/_send @{chat_id} json {composed}"
 
-            await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
+            ok = await self._send_ws({"corrId": corr_id, "cmd": cmd_str})
+            if not ok:
+                return SendResult(
+                    success=False,
+                    error="SimpleX WebSocket is unavailable or closed",
+                    retryable=True,
+                    error_kind="transient",
+                )
 
         for path in media_paths:
             is_voice = os.path.splitext(path)[1].lower() in _voice_exts

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -20,11 +20,10 @@ Required environment variables:
                                (default: ws://127.0.0.1:5225)
 
 Optional environment variables:
-    SIMPLEX_ALLOWED_USERS      Comma-separated allowlist. Each entry may be
-                               either a numeric contactId (stable across
-                               renames; visible via `/contacts` in the CLI)
-                               or a contact display name (what the SimpleX
-                               UI shows). Both forms are accepted.
+    SIMPLEX_ALLOWED_USERS      Comma-separated numeric contactId allowlist
+                               (stable across renames; visible via
+                               `/contacts` in the CLI). Display names are
+                               deliberately not authorization identities.
     SIMPLEX_ALLOW_ALL_USERS    Set 'true' to allow all contacts
     SIMPLEX_AUTO_ACCEPT        Set 'false' to disable contact-request auto-accept
                                (default: 'true')
@@ -818,7 +817,10 @@ class SimplexAdapter(BasePlatformAdapter):
             # XFTP-backed files can arrive before the download completes.
             # Accept exactly once from rcvFileDescrReady; accepting here can
             # race the descriptor and leave the transfer parked indefinitely.
-            if file_id is not None and file_status_type != "rcvComplete":
+            if file_id is not None and (
+                not file_path
+                or file_status_type not in (None, "rcvComplete")
+            ):
                 logger.info(
                     "SimpleX: file %d pending descriptor/completion",
                     file_id,
@@ -1211,24 +1213,30 @@ class SimplexAdapter(BasePlatformAdapter):
 
         delivered_ids: List[str] = []
         if content:
-            queue = list(self.truncate_message(content, MAX_MESSAGE_LENGTH))
-            first = True
+            initial_chunks = list(self.truncate_message(content, MAX_MESSAGE_LENGTH))
+            queue = [
+                (chunk, index == 0)
+                for index, chunk in enumerate(initial_chunks)
+            ]
             while queue:
-                chunk = queue.pop(0)
+                chunk, carries_reply = queue.pop(0)
                 result = await self._send_composed(
                     chat_id,
                     {"type": "text", "text": chunk},
-                    reply_to=reply_to if first else None,
+                    reply_to=reply_to if carries_reply else None,
                 )
-                first = False
                 if (
                     not result.success
                     and result.error_kind == "too_long"
                     and len(chunk) > 512
                 ):
-                    queue = self.truncate_message(
+                    retry_chunks = self.truncate_message(
                         chunk, max(256, len(chunk) // 2)
-                    ) + queue
+                    )
+                    queue = [
+                        (retry_chunk, carries_reply and index == 0)
+                        for index, retry_chunk in enumerate(retry_chunks)
+                    ] + queue
                     continue
                 if not result.success:
                     result.message_id = delivered_ids[-1] if delivered_ids else None
@@ -1338,18 +1346,21 @@ class SimplexAdapter(BasePlatformAdapter):
         ImageMagick ``convert``.
         """
         import subprocess
-        import tempfile
-
         p = Path(file_path)
         png_path = file_path
         thumb_uri = ""
+
+        def _temp_path(suffix: str) -> str:
+            fd, path = tempfile.mkstemp(prefix="hermes-simplex-", suffix=suffix)
+            os.close(fd)
+            return path
 
         try:
             from PIL import Image
 
             img = Image.open(file_path)
             if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                png_path = str(p.with_suffix(".png"))
+                png_path = _temp_path(".png")
                 img.save(png_path, "PNG")
             thumb = img.copy()
             thumb.thumbnail((128, 128))
@@ -1364,7 +1375,7 @@ class SimplexAdapter(BasePlatformAdapter):
         except ImportError:
             try:
                 if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
-                    png_path = str(p.with_suffix(".png"))
+                    png_path = _temp_path(".png")
                     subprocess.run(
                         ["convert", file_path, png_path],
                         check=True,
@@ -1460,7 +1471,13 @@ class SimplexAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a video file via SimpleX (as a file attachment)."""
-        return await self.send_document(chat_id, video_path, caption=caption)
+        return await self.send_document(
+            chat_id,
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
+            **kwargs,
+        )
 
     async def send_document(
         self,
@@ -1468,6 +1485,7 @@ class SimplexAdapter(BasePlatformAdapter):
         file_path: str,
         caption: Optional[str] = None,
         filename: Optional[str] = None,
+        reply_to: Optional[str] = None,
         **kwargs,
     ) -> SendResult:
         """Send a document/file attachment."""
@@ -1477,7 +1495,7 @@ class SimplexAdapter(BasePlatformAdapter):
         return await self._send_composed(
             chat_id,
             {"type": "file", "text": caption or ""},
-            reply_to=kwargs.get("reply_to"),
+            reply_to=reply_to,
             file_source=file_path,
         )
 
@@ -2076,7 +2094,10 @@ def interactive_setup() -> None:
             save_env_value(var, value)
 
     _prompt("SIMPLEX_WS_URL", "Daemon WebSocket URL (default ws://127.0.0.1:5225)")
-    _prompt("SIMPLEX_ALLOWED_USERS", "Allowed contactIds or display names (comma-separated; blank=skip)")
+    _prompt(
+        "SIMPLEX_ALLOWED_USERS",
+        "Allowed numeric contactIds (comma-separated; blank=skip)",
+    )
     _prompt(
         "SIMPLEX_GROUP_ALLOWED",
         "Allowed group IDs (comma-separated, or '*' for any; blank=disable groups)",
@@ -2122,8 +2143,8 @@ def register(ctx) -> None:
             "You are chatting via SimpleX Chat, a private decentralised "
             "messenger. Contacts are identified by opaque internal IDs, "
             "not phone numbers or usernames. SimpleX supports standard "
-            "markdown formatting. There is no typing indicator and no "
-            "hard message length limit, but keep responses conversational. "
+            "markdown formatting. There is no typing indicator; long "
+            "messages are split safely by the adapter. "
             "You can attach native images, voice notes, and arbitrary "
             "files; the adapter handles MEDIA:<path> tags by sending them "
             "as inline voice notes (audio extensions) or documents."

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -51,14 +51,11 @@ is present, so the gateway will not attempt to instantiate the adapter.
 """
 
 import asyncio
-import base64
-import copy
 import json
 import logging
 import os
 import random
 import re
-import tempfile
 import time
 import uuid
 from datetime import datetime, timezone

--- a/plugins/platforms/simplex/adapter.py
+++ b/plugins/platforms/simplex/adapter.py
@@ -49,6 +49,7 @@ is present, so the gateway will not attempt to instantiate the adapter.
 
 import asyncio
 import base64
+import copy
 import json
 import logging
 import os
@@ -153,6 +154,8 @@ def _response_error(resp: Optional[dict]) -> Optional[str]:
     if not isinstance(resp, dict):
         return "SimpleX daemon did not answer"
     resp_type = _response_type(resp)
+    if resp_type == "localCommandOutcomeUnknown":
+        return str(resp.get("error") or "SimpleX command outcome is unknown")[:1000]
     if resp_type not in {"chatCmdError", "chatError", "chatErrors"}:
         return None
     detail = resp.get("chatError") or resp.get("chatErrors") or resp
@@ -220,6 +223,20 @@ class SimplexAdapter(BasePlatformAdapter):
         # exposes only a setter, not a query API. Mirror the non-secret path in
         # config so downstream media consumers always receive openable paths.
         self.files_folder = str(extra.get("files_folder", "") or "")
+        self._file_transfer_timeout = max(
+            1.0, float(extra.get("file_transfer_timeout", 300.0))
+        )
+
+        allow_entries = _parse_comma_list(os.getenv("SIMPLEX_ALLOWED_USERS", ""))
+        ignored_allow_entries = [
+            entry for entry in allow_entries if entry != "*" and not entry.isdigit()
+        ]
+        if ignored_allow_entries:
+            logger.warning(
+                "SimpleX: %d non-numeric SIMPLEX_ALLOWED_USERS entries are "
+                "ignored; migrate to stable contactIds from /contacts",
+                len(ignored_allow_entries),
+            )
 
         # Group allowlist. Without ``SIMPLEX_GROUP_ALLOWED``, group messages
         # are ignored entirely (safer default — a bot in a group otherwise
@@ -246,6 +263,7 @@ class SimplexAdapter(BasePlatformAdapter):
         # when a newChatItems event carries an unfinished rcvFileTransfer,
         # consumed when the file finishes downloading.
         self._pending_file_transfers: Dict[int, dict] = {}
+        self._file_transfer_tasks: Dict[int, asyncio.Task] = {}
 
         # Correlation tracking for ``_send_command``. Separate from
         # ``_pending_corr_ids`` (which is the upstream cosmetic echo filter)
@@ -253,6 +271,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._pending_responses: Dict[str, asyncio.Future] = {}
         self._corr_counter = 0
         self._command_tasks: set[asyncio.Task] = set()
+        self._dispatch_tasks: set[asyncio.Task] = set()
 
         # Bounded, non-secret runtime diagnostics. The details are also logged;
         # these counters make health checks useful without scraping prose.
@@ -261,6 +280,9 @@ class SimplexAdapter(BasePlatformAdapter):
             "async_errors": 0,
             "reconnects": 0,
             "send_failures": 0,
+            "file_rejections": 0,
+            "file_failures": 0,
+            "file_timeouts": 0,
         }
 
         # Direct-message reaction approvals. State is intentionally ephemeral:
@@ -376,6 +398,23 @@ class SimplexAdapter(BasePlatformAdapter):
         if self._command_tasks:
             await asyncio.gather(*self._command_tasks, return_exceptions=True)
         self._command_tasks.clear()
+
+        for task in list(self._dispatch_tasks):
+            if not task.done():
+                task.cancel()
+        if self._dispatch_tasks:
+            await asyncio.gather(*self._dispatch_tasks, return_exceptions=True)
+        self._dispatch_tasks.clear()
+
+        for task in list(self._file_transfer_tasks.values()):
+            if not task.done():
+                task.cancel()
+        if self._file_transfer_tasks:
+            await asyncio.gather(
+                *self._file_transfer_tasks.values(), return_exceptions=True
+            )
+        self._file_transfer_tasks.clear()
+        self._pending_file_transfers.clear()
         self._ws_ready.clear()
         self._approval_prompts_by_item.clear()
         self._approval_prompt_by_session.clear()
@@ -537,9 +576,18 @@ class SimplexAdapter(BasePlatformAdapter):
             rcv_file = resp.get("rcvFileTransfer", {}) or {}
             file_id = rcv_file.get("fileId") if isinstance(rcv_file, dict) else None
             if file_id is not None:
+                file_id = int(file_id)
                 wrapper = self._normalize_chat_item_wrapper(resp.get("chatItem", {}))
-                if wrapper:
-                    self._pending_file_transfers.setdefault(file_id, wrapper)
+                if not wrapper:
+                    wrapper = self._pending_file_transfers.get(file_id, {})
+                if not wrapper or not self._file_sender_is_authorized(wrapper):
+                    self._diagnostics["file_rejections"] += 1
+                    logger.warning(
+                        "SimpleX: refusing file %s before sender authorization",
+                        file_id,
+                    )
+                    return
+                self._track_pending_file(file_id, wrapper)
                 inner = wrapper.get("chatItem", {}) if wrapper else {}
                 file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
                 file_name = (
@@ -602,14 +650,40 @@ class SimplexAdapter(BasePlatformAdapter):
                 logger.exception("SimpleX: error processing reaction event")
             return
 
+        if resp_type in {"rcvFileSndCancelled", "rcvFileError"}:
+            wrapper = self._normalize_chat_item_wrapper(
+                resp.get("chatItem") or resp.get("chatItem_") or {}
+            )
+            rcv_file = resp.get("rcvFileTransfer", {}) or {}
+            raw_file_id = (
+                rcv_file.get("fileId") if isinstance(rcv_file, dict) else None
+            )
+            file_id = self._file_id_from_wrapper(wrapper)
+            if file_id is None and raw_file_id is not None:
+                try:
+                    file_id = int(raw_file_id)
+                except (TypeError, ValueError):
+                    file_id = None
+            if file_id is not None:
+                if wrapper and file_id not in self._pending_file_transfers:
+                    self._pending_file_transfers[file_id] = wrapper
+                await self._fail_file_transfer(file_id, resp_type)
+            return
+
         # File transfer completion — deliver any deferred chat item
         if resp_type == "rcvFileComplete":
-            chat_item = resp.get("chatItem", {}) or {}
+            chat_item = self._normalize_chat_item_wrapper(
+                resp.get("chatItem", {}) or {}
+            )
             chat_item_data = chat_item.get("chatItem", {}) or {}
             file_info = chat_item_data.get("file", {}) or {}
-            file_id = file_info.get("fileId") if isinstance(file_info, dict) else None
-            if file_id is not None and file_id in self._pending_file_transfers:
-                pending = self._pending_file_transfers.pop(file_id)
+            file_id = self._file_id_from_wrapper(chat_item)
+            if file_id is not None:
+                pending = self._pending_file_transfers.pop(file_id, None) or chat_item
+                self._cancel_file_timeout(file_id)
+                if not self._file_sender_is_authorized(pending):
+                    self._diagnostics["file_rejections"] += 1
+                    return
                 file_source = file_info.get("fileSource", {}) or {}
                 file_path = (
                     file_source.get("filePath")
@@ -678,6 +752,110 @@ class SimplexAdapter(BasePlatformAdapter):
 
         return payload
 
+    @staticmethod
+    def _file_id_from_wrapper(wrapper: dict) -> Optional[int]:
+        normalized = SimplexAdapter._normalize_chat_item_wrapper(wrapper)
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
+        raw_id = file_info.get("fileId") if isinstance(file_info, dict) else None
+        try:
+            return int(raw_id) if raw_id is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    def _file_sender_context(
+        self, wrapper: dict
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Return ``(user_id, chat_type, chat_id)`` for an attachment event."""
+        normalized = self._normalize_chat_item_wrapper(wrapper)
+        chat_info = normalized.get("chatInfo", {}) if normalized else {}
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        chat_dir = inner.get("chatDir", {}) if isinstance(inner, dict) else {}
+        chat_type = chat_info.get("type") if isinstance(chat_info, dict) else None
+        if chat_type == "direct":
+            contact = chat_info.get("contact", {}) or {}
+            contact_id = contact.get("contactId")
+            user_id = str(contact_id) if contact_id is not None else None
+            return user_id, "dm", user_id
+        if chat_type == "group":
+            group = chat_info.get("groupInfo", {}) or {}
+            group_id = group.get("groupId")
+            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
+            member_id = member.get("memberId") if isinstance(member, dict) else None
+            user_id = str(member_id) if member_id is not None else None
+            chat_id = f"group:{group_id}" if group_id is not None else None
+            if (
+                group_id is None
+                or not self.group_allow_from
+                or (
+                    "*" not in self.group_allow_from
+                    and str(group_id) not in self.group_allow_from
+                )
+            ):
+                return user_id, "group", None
+            return user_id, "group", chat_id
+        return None, None, None
+
+    def _file_sender_is_authorized(self, wrapper: dict) -> bool:
+        user_id, chat_type, chat_id = self._file_sender_context(wrapper)
+        if not user_id or not chat_id:
+            return False
+        return self._is_sender_authorized(user_id, chat_type, chat_id) is True
+
+    def _cancel_file_timeout(self, file_id: int) -> None:
+        task = self._file_transfer_tasks.pop(file_id, None)
+        if task and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    def _track_pending_file(self, file_id: int, wrapper: dict) -> None:
+        self._pending_file_transfers[file_id] = wrapper
+        existing = self._file_transfer_tasks.get(file_id)
+        if existing and not existing.done():
+            return
+        task = asyncio.create_task(self._expire_file_transfer(file_id))
+        self._file_transfer_tasks[file_id] = task
+
+        def _done(done: asyncio.Task) -> None:
+            if self._file_transfer_tasks.get(file_id) is done:
+                self._file_transfer_tasks.pop(file_id, None)
+            if not done.cancelled():
+                try:
+                    done.result()
+                except Exception:
+                    logger.exception("SimpleX: file-transfer expiry task failed")
+
+        task.add_done_callback(_done)
+
+    async def _dispatch_file_fallback(self, wrapper: dict, reason: str) -> None:
+        """Deliver an authorized file caption without an unavailable attachment."""
+        fallback = copy.deepcopy(self._normalize_chat_item_wrapper(wrapper))
+        inner = fallback.get("chatItem", {}) if fallback else {}
+        if not isinstance(inner, dict):
+            return
+        inner.pop("file", None)
+        content = inner.get("content", {}) or {}
+        msg_content = content.get("msgContent", {}) if isinstance(content, dict) else {}
+        text = msg_content.get("text", "") if isinstance(msg_content, dict) else ""
+        if not text:
+            return
+        logger.info("SimpleX: delivering file caption without attachment (%s)", reason)
+        await self._handle_chat_item(fallback)
+
+    async def _expire_file_transfer(self, file_id: int) -> None:
+        await asyncio.sleep(self._file_transfer_timeout)
+        wrapper = self._pending_file_transfers.pop(file_id, None)
+        if not wrapper:
+            return
+        self._diagnostics["file_timeouts"] += 1
+        await self._dispatch_file_fallback(wrapper, "transfer timed out")
+
+    async def _fail_file_transfer(self, file_id: int, reason: str) -> None:
+        wrapper = self._pending_file_transfers.pop(file_id, None)
+        self._cancel_file_timeout(file_id)
+        self._diagnostics["file_failures"] += 1
+        if wrapper:
+            await self._dispatch_file_fallback(wrapper, reason)
+
     async def _accept_contact_request(self, request_id: str) -> None:
         resp = await self._send_command(f"/_accept {request_id}", timeout=30.0)
         error = _response_error(resp)
@@ -691,12 +869,14 @@ class SimplexAdapter(BasePlatformAdapter):
         )
         error = _response_error(resp)
         if error or _response_type(resp) == "rcvFileAcceptedSndCancelled":
-            self._pending_file_transfers.pop(file_id, None)
             self._diagnostics["command_errors"] += 1
             logger.warning(
                 "SimpleX: file %s receive failed: %s",
                 file_id,
                 error or "sender cancelled",
+            )
+            await self._fail_file_transfer(
+                file_id, error or "sender cancelled during acceptance"
             )
 
     def _resolve_file_path(self, file_path: str) -> str:
@@ -821,14 +1001,30 @@ class SimplexAdapter(BasePlatformAdapter):
                 not file_path
                 or file_status_type not in (None, "rcvComplete")
             ):
-                logger.info(
-                    "SimpleX: file %d pending descriptor/completion",
-                    file_id,
-                )
-                self._pending_file_transfers[file_id] = chat_item
-                return
+                try:
+                    normalized_file_id = int(file_id)
+                except (TypeError, ValueError):
+                    normalized_file_id = None
+                if (
+                    normalized_file_id is None
+                    or not self._file_sender_is_authorized(chat_item)
+                ):
+                    self._diagnostics["file_rejections"] += 1
+                    logger.warning(
+                        "SimpleX: refusing pending file before sender authorization"
+                    )
+                    if not text:
+                        return
+                    file_info = None
+                else:
+                    logger.info(
+                        "SimpleX: file %d pending descriptor/completion",
+                        normalized_file_id,
+                    )
+                    self._track_pending_file(normalized_file_id, chat_item)
+                    return
 
-            if file_path:
+            if file_info and file_path:
                 ext = Path(file_name).suffix.lower() or Path(file_path).suffix.lower()
                 if not _is_image_ext(ext) and not _is_audio_ext(ext):
                     try:
@@ -935,12 +1131,14 @@ class SimplexAdapter(BasePlatformAdapter):
         # Batch consecutive text messages so the agent sees one combined
         # message instead of dropping earlier ones when the user pastes
         # several lines in quick succession.
+        if is_edit and self._replace_pending_batch_edit(msg_event):
+            return
         if is_edit:
-            await self.handle_message(msg_event)
+            self._spawn_dispatch_task(self.handle_message(msg_event))
         elif msg_type == MessageType.TEXT and text:
             self._enqueue_text_event(msg_event)
         else:
-            await self.handle_message(msg_event)
+            self._spawn_dispatch_task(self.handle_message(msg_event))
 
     # ------------------------------------------------------------------
     # Text message batching
@@ -961,6 +1159,11 @@ class SimplexAdapter(BasePlatformAdapter):
         """Buffer a text event and reset the flush timer."""
         key = self._text_batch_key(event)
         existing = self._pending_text_batches.get(key)
+        event.metadata = dict(event.metadata or {})
+        event.metadata.setdefault(
+            "simplex_batch_items",
+            [{"message_id": event.message_id, "text": event.text or ""}],
+        )
         if existing is None:
             self._pending_text_batches[key] = event
         else:
@@ -968,6 +1171,10 @@ class SimplexAdapter(BasePlatformAdapter):
                 existing.text = (
                     f"{existing.text}\n{event.text}" if existing.text else event.text
                 )
+            existing.metadata = dict(existing.metadata or {})
+            existing.metadata.setdefault("simplex_batch_items", []).extend(
+                event.metadata["simplex_batch_items"]
+            )
             if event.media_urls:
                 existing.media_urls.extend(event.media_urls)
                 existing.media_types.extend(event.media_types)
@@ -978,6 +1185,33 @@ class SimplexAdapter(BasePlatformAdapter):
         self._pending_text_batch_tasks[key] = asyncio.create_task(
             self._flush_text_batch(key)
         )
+
+    def _replace_pending_batch_edit(self, event: MessageEvent) -> bool:
+        """Supersede a SimpleX text item still inside the quiet-period batch."""
+        key = self._text_batch_key(event)
+        pending = self._pending_text_batches.get(key)
+        if pending is None or not event.message_id:
+            return False
+        items = (pending.metadata or {}).get("simplex_batch_items", [])
+        if not isinstance(items, list):
+            return False
+        for item in items:
+            if not isinstance(item, dict):
+                continue
+            if str(item.get("message_id")) != str(event.message_id):
+                continue
+            item["text"] = event.text or ""
+            pending.text = "\n".join(
+                str(component.get("text", ""))
+                for component in items
+                if isinstance(component, dict)
+            )
+            logger.info(
+                "SimpleX: superseded batched message item_id=%s",
+                event.message_id,
+            )
+            return True
+        return False
 
     async def _flush_text_batch(self, key: str) -> None:
         """Wait for the quiet period then dispatch the aggregated text."""
@@ -1064,14 +1298,20 @@ class SimplexAdapter(BasePlatformAdapter):
             return result
         except asyncio.TimeoutError:
             logger.warning("SimpleX: command timed out: %s", command.split(" ", 1)[0])
-            return None
+            return {
+                "type": "localCommandOutcomeUnknown",
+                "error": "SimpleX daemon confirmation timed out; delivery may have occurred",
+            }
         except Exception as e:
             logger.warning(
                 "SimpleX: command failed: %s — %s",
                 command.split(" ", 1)[0],
                 e,
             )
-            return None
+            return {
+                "type": "localCommandOutcomeUnknown",
+                "error": "SimpleX connection failed after command submission; delivery outcome is unknown",
+            }
         finally:
             self._pending_responses.pop(corr_id, None)
             self._pending_corr_ids.discard(corr_id)
@@ -1089,6 +1329,23 @@ class SimplexAdapter(BasePlatformAdapter):
                 done.result()
             except Exception:
                 logger.exception("SimpleX: background command task failed")
+
+        task.add_done_callback(_done)
+        return task
+
+    def _spawn_dispatch_task(self, coroutine) -> asyncio.Task:
+        """Dispatch inbound work without ever blocking the WebSocket reader."""
+        task = asyncio.create_task(coroutine)
+        self._dispatch_tasks.add(task)
+
+        def _done(done: asyncio.Task) -> None:
+            self._dispatch_tasks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception:
+                logger.exception("SimpleX: background message dispatch failed")
 
         task.add_done_callback(_done)
         return task
@@ -1131,6 +1388,14 @@ class SimplexAdapter(BasePlatformAdapter):
         error = _response_error(resp)
         if error:
             self._diagnostics["command_errors"] += 1
+            if _response_type(resp) == "localCommandOutcomeUnknown":
+                return SendResult(
+                    success=False,
+                    error=error,
+                    error_kind="delivery_unknown",
+                    retryable=False,
+                    raw_response=resp,
+                )
             kind, retryable = self._error_kind(error)
             return SendResult(
                 success=False,
@@ -1241,6 +1506,8 @@ class SimplexAdapter(BasePlatformAdapter):
                 if not result.success:
                     result.message_id = delivered_ids[-1] if delivered_ids else None
                     if delivered_ids:
+                        result.error_kind = "partial_delivery"
+                        result.retryable = False
                         result.raw_response = {
                             "partial_delivery": True,
                             "delivered_message_ids": tuple(delivered_ids),
@@ -1257,7 +1524,18 @@ class SimplexAdapter(BasePlatformAdapter):
             else:
                 media_result = await self.send_document(chat_id, path)
             if not media_result.success:
+                if delivered_ids:
+                    media_result.message_id = delivered_ids[-1]
+                    media_result.error_kind = "partial_delivery"
+                    media_result.retryable = False
+                    media_result.raw_response = {
+                        "partial_delivery": True,
+                        "delivered_message_ids": tuple(delivered_ids),
+                        "daemon_response": media_result.raw_response,
+                    }
                 return media_result
+            if media_result.message_id:
+                delivered_ids.append(media_result.message_id)
         return SendResult(
             success=True,
             message_id=delivered_ids[-1] if delivered_ids else None,
@@ -1573,6 +1851,8 @@ class SimplexAdapter(BasePlatformAdapter):
                     continuation_ids[-1] if continuation_ids else str(message_id)
                 )
                 continuation.continuation_message_ids = tuple(continuation_ids)
+                continuation.error_kind = "partial_delivery"
+                continuation.retryable = False
                 continuation.raw_response = {
                     "partial_overflow": True,
                     "delivered_chunks": 1 + len(continuation_ids),
@@ -1671,6 +1951,7 @@ class SimplexAdapter(BasePlatformAdapter):
         self._sweep_approval_prompts(now)
         is_dm = not str(chat_id).startswith("group:")
         existing_id = self._approval_prompt_by_session.get(session_key)
+        superseded_prior = bool(existing_id)
         typed_only = self._approval_typed_only_until.get(session_key, 0.0) > now
 
         if existing_id:
@@ -1687,6 +1968,11 @@ class SimplexAdapter(BasePlatformAdapter):
             smart_denied=smart_denied,
             reactions=reaction_lane,
         )
+        if superseded_prior:
+            text = (
+                "The earlier approval prompt was superseded; its reactions no "
+                "longer apply. Use the typed choices below.\n\n" + text
+            )
         result = await self.send(chat_id, text, metadata=metadata)
         if not result.success or not result.message_id or not reaction_lane:
             if not result.success or not result.message_id:
@@ -1781,11 +2067,15 @@ class SimplexAdapter(BasePlatformAdapter):
         chat_type = chat_info.get("type", "")
         chat_dir = reaction.get("chatDir", {}) or {}
         if chat_type == "direct":
+            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "directRcv":
+                return None
             contact = chat_info.get("contact", {}) or {}
             chat_id = str(contact.get("contactId", ""))
             user_id = chat_id
             user_name = contact.get("localDisplayName", "")
         elif chat_type == "group":
+            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "groupRcv":
+                return None
             group = chat_info.get("groupInfo", {}) or {}
             chat_id = f"group:{group.get('groupId', '')}"
             member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}

--- a/plugins/platforms/simplex/approvals.py
+++ b/plugins/platforms/simplex/approvals.py
@@ -1,0 +1,280 @@
+"""Reaction-backed dangerous-command approvals for SimpleX."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import List, Optional
+
+from gateway.platforms.base import SendResult
+
+logger = logging.getLogger(__name__)
+
+
+class SimplexApprovalMixin:
+    async def _set_reaction(
+        self,
+        chat_id: str,
+        message_id: str,
+        emoji: str,
+        *,
+        added: bool,
+    ) -> SendResult:
+        reaction = json.dumps(
+            {"type": "emoji", "emoji": emoji}, ensure_ascii=False
+        )
+        toggle = "on" if added else "off"
+        resp = await self._send_command(
+            f"/_reaction {self._chat_ref(chat_id)} {message_id} {toggle} {reaction}",
+            timeout=10.0,
+        )
+        return self._send_result_from_response(
+            resp, expected={"chatItemReaction"}
+        )
+
+    @staticmethod
+    def _approval_timeout() -> float:
+        try:
+            from tools.approval import _get_approval_timeout
+
+            return max(1.0, float(_get_approval_timeout()))
+        except Exception:
+            return 300.0
+
+    def _approval_text(
+        self,
+        command: str,
+        description: str,
+        *,
+        allow_session: bool,
+        allow_permanent: bool,
+        smart_denied: bool,
+        reactions: bool,
+    ) -> str:
+        prefix = self.typed_command_prefix
+        lines = [self._format_exec_approval(command, description, smart_denied)]
+        choices = [f"Reply `{prefix}approve` to run once"]
+        if not smart_denied and allow_session:
+            choices.append(f"`{prefix}approve session` for this session")
+        if not smart_denied and allow_permanent:
+            choices.append(f"`{prefix}approve always` to persist the pattern")
+        choices.append(f"`{prefix}deny` to cancel")
+        lines.append(", or ".join(choices) + ".")
+        if reactions:
+            taps = ["✅ = run once"]
+            if not smart_denied and allow_session:
+                taps.append("🚀 = allow for this session")
+            taps.append("👎 = deny")
+            lines.append("Tap a reaction: " + "; ".join(taps) + ".")
+        return "\n\n".join(lines)
+
+    async def send_exec_approval(
+        self,
+        chat_id: str,
+        command: str,
+        session_key: str,
+        description: str = "dangerous command",
+        metadata: Optional[dict] = None,
+        allow_permanent: bool = True,
+        allow_session: bool = True,
+        smart_denied: bool = False,
+    ) -> SendResult:
+        """Offer unambiguous direct-message reaction approvals with typed fallback."""
+        now = time.monotonic()
+        self._sweep_approval_prompts(now)
+        is_dm = not str(chat_id).startswith("group:")
+        existing_id = self._approval_prompt_by_session.get(session_key)
+        superseded_prior = bool(existing_id)
+        typed_only = self._approval_typed_only_until.get(session_key, 0.0) > now
+
+        if existing_id:
+            self._retire_approval_prompt(existing_id)
+            self._approval_typed_only_until[session_key] = now + self._approval_timeout()
+            typed_only = True
+
+        reaction_lane = is_dm and not typed_only
+        text = self._approval_text(
+            command,
+            description,
+            allow_session=allow_session,
+            allow_permanent=allow_permanent,
+            smart_denied=smart_denied,
+            reactions=reaction_lane,
+        )
+        if superseded_prior:
+            text = (
+                "The earlier approval prompt was superseded; its reactions no "
+                "longer apply. Use the typed choices below.\n\n" + text
+            )
+        result = await self.send(chat_id, text, metadata=metadata)
+        if not result.success or not result.message_id or not reaction_lane:
+            if not result.success or not result.message_id:
+                self._approval_typed_only_until[session_key] = (
+                    now + self._approval_timeout()
+                )
+            return result
+
+        choices = {"✅": "once", "👎": "deny"}
+        seeds = ["👎", "✅"]
+        if not smart_denied and allow_session:
+            choices["🚀"] = "session"
+            seeds.insert(1, "🚀")
+        prompt = {
+            "session_key": session_key,
+            "chat_id": str(chat_id),
+            "item_id": str(result.message_id),
+            "choices": choices,
+            "seeded": [],
+            "expires_at": now + self._approval_timeout(),
+        }
+        self._approval_prompts_by_item[prompt["item_id"]] = prompt
+        self._approval_prompt_by_session[session_key] = prompt["item_id"]
+        self._spawn_command_task(self._seed_approval_reactions(prompt, seeds))
+        self._spawn_command_task(self._expire_approval_prompt(prompt["item_id"]))
+        return result
+
+    async def _seed_approval_reactions(self, prompt: dict, seeds: List[str]) -> None:
+        for emoji in seeds[:3]:
+            if self._approval_prompts_by_item.get(prompt["item_id"]) is not prompt:
+                return
+            result = await self._set_reaction(
+                prompt["chat_id"], prompt["item_id"], emoji, added=True
+            )
+            if not result.success:
+                logger.info(
+                    "SimpleX: reaction seed unavailable; typed approval remains active"
+                )
+                return
+            prompt["seeded"].append(emoji)
+
+    async def _expire_approval_prompt(self, item_id: str) -> None:
+        prompt = self._approval_prompts_by_item.get(item_id)
+        if not prompt:
+            return
+        await asyncio.sleep(max(0.0, prompt["expires_at"] - time.monotonic()))
+        if self._approval_prompts_by_item.get(item_id) is prompt:
+            self._retire_approval_prompt(item_id)
+
+    def _sweep_approval_prompts(self, now: Optional[float] = None) -> None:
+        current = time.monotonic() if now is None else now
+        for item_id, prompt in list(self._approval_prompts_by_item.items()):
+            if prompt["expires_at"] <= current:
+                self._retire_approval_prompt(item_id)
+        for session_key, expiry in list(self._approval_typed_only_until.items()):
+            if expiry <= current:
+                self._approval_typed_only_until.pop(session_key, None)
+
+    def _retire_approval_prompt(self, item_id: str) -> None:
+        prompt = self._approval_prompts_by_item.pop(str(item_id), None)
+        if not prompt:
+            return
+        if self._approval_prompt_by_session.get(prompt["session_key"]) == str(item_id):
+            self._approval_prompt_by_session.pop(prompt["session_key"], None)
+        if prompt["seeded"]:
+            self._spawn_command_task(self._clear_approval_reactions(prompt))
+
+    async def _clear_approval_reactions(self, prompt: dict) -> None:
+        for emoji in list(prompt["seeded"]):
+            await self._set_reaction(
+                prompt["chat_id"], prompt["item_id"], emoji, added=False
+            )
+
+    @staticmethod
+    def _reaction_context(resp: dict) -> Optional[dict]:
+        wrapper = resp.get("reaction", {}) or {}
+        if not isinstance(wrapper, dict):
+            return None
+        chat_info = wrapper.get("chatInfo", {}) or {}
+        reaction = wrapper.get("chatReaction", {}) or {}
+        if not isinstance(chat_info, dict) or not isinstance(reaction, dict):
+            return None
+        chat_item = reaction.get("chatItem", {}) or {}
+        meta = chat_item.get("meta", {}) if isinstance(chat_item, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        msg_reaction = reaction.get("reaction", {}) or {}
+        emoji = (
+            msg_reaction.get("emoji", "")
+            if isinstance(msg_reaction, dict)
+            else ""
+        ).replace("\ufe0f", "")
+        chat_type = chat_info.get("type", "")
+        chat_dir = reaction.get("chatDir", {}) or {}
+        if chat_type == "direct":
+            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "directRcv":
+                return None
+            contact = chat_info.get("contact", {}) or {}
+            chat_id = str(contact.get("contactId", ""))
+            user_id = chat_id
+            user_name = contact.get("localDisplayName", "")
+        elif chat_type == "group":
+            if not isinstance(chat_dir, dict) or chat_dir.get("type") != "groupRcv":
+                return None
+            group = chat_info.get("groupInfo", {}) or {}
+            chat_id = f"group:{group.get('groupId', '')}"
+            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
+            member_identity = member.get("memberContactId")
+            if member_identity is None:
+                member_identity = member.get("memberId", "")
+            user_id = str(member_identity)
+            user_name = member.get("localDisplayName", "")
+        else:
+            return None
+        return {
+            "item_id": str(item_id) if item_id is not None else "",
+            "chat_id": chat_id,
+            "user_id": user_id,
+            "user_name": user_name,
+            "emoji": emoji,
+            "added": bool(resp.get("added", False)),
+            "raw": resp,
+        }
+
+    async def _handle_reaction_event(self, resp: dict) -> None:
+        ctx = self._reaction_context(resp)
+        if not ctx:
+            return
+        hook = getattr(self, "_reaction_handler", None)
+        if hook is not None:
+            await hook(
+                {
+                    "event_name": (
+                        "reaction:added" if ctx["added"] else "reaction:removed"
+                    ),
+                    "platform": "simplex",
+                    **ctx,
+                }
+            )
+
+        if not ctx["added"]:
+            return
+        prompt = self._approval_prompts_by_item.get(ctx["item_id"])
+        if not prompt or prompt["chat_id"] != ctx["chat_id"]:
+            return
+        if not prompt["chat_id"].startswith("group:") and ctx["user_id"] != prompt["chat_id"]:
+            logger.warning("SimpleX: ignored approval reaction from another contact")
+            return
+        if time.monotonic() >= prompt["expires_at"]:
+            self._retire_approval_prompt(prompt["item_id"])
+            return
+        choice = prompt["choices"].get(ctx["emoji"])
+        if not choice:
+            return
+
+        try:
+            from tools.approval import resolve_gateway_approval
+
+            count = int(resolve_gateway_approval(prompt["session_key"], choice) or 0)
+        except Exception:
+            logger.exception("SimpleX: failed to resolve reaction approval")
+            return
+        self._retire_approval_prompt(prompt["item_id"])
+        acknowledgement = {
+            "once": "Approved — running this once.",
+            "session": "Approved for this session.",
+            "deny": "Denied — the command will not run.",
+        }[choice]
+        if count <= 0:
+            acknowledgement = "That approval is no longer pending. Nothing ran."
+        self._spawn_command_task(self.send(prompt["chat_id"], acknowledgement))

--- a/plugins/platforms/simplex/batching.py
+++ b/plugins/platforms/simplex/batching.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import Any
 
+from gateway.event_sidecars import CORRELATED_MESSAGE_ITEMS_KEY
+
 
 def prepend_cancelled_batch(cancelled: Any, newer: Any | None) -> Any:
     """Restore a cancelled in-flight event ahead of any newly queued event.
@@ -28,8 +30,8 @@ def prepend_cancelled_batch(cancelled: Any, newer: Any | None) -> Any:
 
     cancelled.metadata = dict(cancelled.metadata or {})
     newer_metadata = dict(newer.metadata or {})
-    cancelled_items = cancelled.metadata.setdefault("simplex_batch_items", [])
-    newer_items = newer_metadata.get("simplex_batch_items", [])
+    cancelled_items = cancelled.metadata.setdefault(CORRELATED_MESSAGE_ITEMS_KEY, [])
+    newer_items = newer_metadata.get(CORRELATED_MESSAGE_ITEMS_KEY, [])
     if isinstance(cancelled_items, list) and isinstance(newer_items, list):
         cancelled_items.extend(newer_items)
     return cancelled

--- a/plugins/platforms/simplex/batching.py
+++ b/plugins/platforms/simplex/batching.py
@@ -1,0 +1,35 @@
+"""Lossless text-batch merge primitives for the SimpleX adapter."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def prepend_cancelled_batch(cancelled: Any, newer: Any | None) -> Any:
+    """Restore a cancelled in-flight event ahead of any newly queued event.
+
+    The cancelled event remains the aggregate holder so its source,
+    timestamp, and first message ID stay authoritative. Per-item metadata is
+    merged with the text/media payload; later edit events therefore retain a
+    stable map back to every SimpleX chat item in the batch.
+    """
+    if newer is None:
+        return cancelled
+
+    if newer.text:
+        cancelled.text = (
+            f"{cancelled.text}\n{newer.text}"
+            if cancelled.text
+            else newer.text
+        )
+    if newer.media_urls:
+        cancelled.media_urls.extend(newer.media_urls)
+        cancelled.media_types.extend(newer.media_types)
+
+    cancelled.metadata = dict(cancelled.metadata or {})
+    newer_metadata = dict(newer.metadata or {})
+    cancelled_items = cancelled.metadata.setdefault("simplex_batch_items", [])
+    newer_items = newer_metadata.get("simplex_batch_items", [])
+    if isinstance(cancelled_items, list) and isinstance(newer_items, list):
+        cancelled_items.extend(newer_items)
+    return cancelled

--- a/plugins/platforms/simplex/config.py
+++ b/plugins/platforms/simplex/config.py
@@ -14,7 +14,10 @@ def profile_scoped() -> bool:
 
         return bool(is_multiplex_active() and current_secret_scope() is not None)
     except Exception:
-        return False
+        # This helper is an isolation boundary. If the multiplex state cannot
+        # be established, treating the call as unscoped would fall through to
+        # the process environment and could expose another profile's values.
+        return True
 
 
 def scoped_platform_setting(

--- a/plugins/platforms/simplex/config.py
+++ b/plugins/platforms/simplex/config.py
@@ -1,0 +1,54 @@
+"""Profile-aware configuration helpers for the SimpleX platform plugin."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Mapping
+
+
+def profile_scoped() -> bool:
+    """Return whether a multiplexed secondary profile owns this call."""
+    try:
+        from agent.secret_scope import current_secret_scope, is_multiplex_active
+
+        return bool(is_multiplex_active() and current_secret_scope() is not None)
+    except Exception:
+        return False
+
+
+def scoped_platform_setting(
+    env_name: str,
+    extra: Mapping[str, Any] | None,
+    key: str,
+) -> Any:
+    """Read a setting without leaking the default profile's bridged env.
+
+    The process environment belongs to the default profile. A multiplexed
+    secondary profile must use its own ``PlatformConfig.extra`` mapping and
+    fail closed when a key is absent. Single-profile and default-profile
+    execution retain the established environment-over-config precedence.
+    """
+    if profile_scoped():
+        return (extra or {}).get(key)
+    return os.getenv(env_name)
+
+
+def profile_simplex_extra() -> dict[str, Any]:
+    """Load ``simplex.extra`` from the active secondary profile's config."""
+    if not profile_scoped():
+        return {}
+    try:
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import read_user_config_raw
+
+        config = read_user_config_raw(Path(get_hermes_home()) / "config.yaml")
+    except Exception:
+        return {}
+    if not isinstance(config, dict):
+        return {}
+    simplex = ((config.get("gateway") or {}).get("platforms") or {}).get("simplex")
+    if not isinstance(simplex, dict):
+        return {}
+    extra = simplex.get("extra", simplex)
+    return extra if isinstance(extra, dict) else {}

--- a/plugins/platforms/simplex/media.py
+++ b/plugins/platforms/simplex/media.py
@@ -1,0 +1,505 @@
+"""Inbound transfer state and outbound media egress for SimpleX."""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import copy
+import logging
+import os
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Optional
+
+from gateway.platforms.base import SendResult
+from plugins.platforms.simplex.protocol import (
+    response_error as _response_error,
+    response_type as _response_type,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SimplexMediaMixin:
+    @staticmethod
+    def _normalize_chat_item_wrapper(payload: dict) -> dict:
+        """Normalize SimpleX AChatItem payload variants to {chatInfo, chatItem}.
+
+        Depending on daemon version and event type, the chat item wrapper
+        arrives in one of several shapes:
+
+        * ``{"chatInfo": ..., "chatItem": ...}`` — already normalized
+          (the usual ``newChatItems`` array element).
+        * ``{"type": "newChatItem", "chatItem": {"chatInfo": ...,
+          "chatItem": ...}}`` — the singular event nests the AChatItem one
+          level down.
+        * ``{"chatInfo": ..., "item": ...}`` — some responses name the item
+          field ``item`` instead of ``chatItem``.
+
+        ``_handle_chat_item`` only reads ``chatInfo``/``chatItem`` at the top
+        level, so anything not normalized here would be silently dropped.
+        """
+        if not isinstance(payload, dict):
+            return {}
+
+        nested = payload.get("chatItem")
+        if isinstance(nested, dict):
+            # Nested AChatItem: {type: newChatItem, chatItem: {chatInfo, chatItem}}
+            if isinstance(nested.get("chatInfo"), dict) and isinstance(
+                nested.get("chatItem"), dict
+            ):
+                return nested
+            # Already normalized: {chatInfo: ..., chatItem: {content/meta/...}}
+            if isinstance(payload.get("chatInfo"), dict):
+                return payload
+
+        if isinstance(payload.get("chatInfo"), dict) and isinstance(
+            payload.get("item"), dict
+        ):
+            return {"chatInfo": payload["chatInfo"], "chatItem": payload["item"]}
+
+        return payload
+
+    @staticmethod
+    def _file_id_from_wrapper(wrapper: dict) -> Optional[int]:
+        normalized = SimplexMediaMixin._normalize_chat_item_wrapper(wrapper)
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        file_info = inner.get("file", {}) if isinstance(inner, dict) else {}
+        raw_id = file_info.get("fileId") if isinstance(file_info, dict) else None
+        try:
+            return int(raw_id) if raw_id is not None else None
+        except (TypeError, ValueError):
+            return None
+
+    @staticmethod
+    def _item_id_from_wrapper(wrapper: dict) -> Optional[str]:
+        normalized = SimplexMediaMixin._normalize_chat_item_wrapper(wrapper)
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        return str(item_id) if item_id is not None else None
+
+    def _file_sender_context(
+        self, wrapper: dict
+    ) -> tuple[Optional[str], Optional[str], Optional[str]]:
+        """Return ``(user_id, chat_type, chat_id)`` for an attachment event."""
+        normalized = self._normalize_chat_item_wrapper(wrapper)
+        chat_info = normalized.get("chatInfo", {}) if normalized else {}
+        inner = normalized.get("chatItem", {}) if normalized else {}
+        chat_dir = inner.get("chatDir", {}) if isinstance(inner, dict) else {}
+        chat_type = chat_info.get("type") if isinstance(chat_info, dict) else None
+        if chat_type == "direct":
+            contact = chat_info.get("contact", {}) or {}
+            contact_id = contact.get("contactId")
+            user_id = str(contact_id) if contact_id is not None else None
+            return user_id, "dm", user_id
+        if chat_type == "group":
+            group = chat_info.get("groupInfo", {}) or {}
+            group_id = group.get("groupId")
+            member = chat_dir.get("groupMember", {}) if isinstance(chat_dir, dict) else {}
+            member_contact_id = (
+                member.get("memberContactId") if isinstance(member, dict) else None
+            )
+            member_id = member.get("memberId") if isinstance(member, dict) else None
+            stable_member_id = (
+                member_contact_id if member_contact_id is not None else member_id
+            )
+            user_id = (
+                str(stable_member_id) if stable_member_id is not None else None
+            )
+            chat_id = f"group:{group_id}" if group_id is not None else None
+            if (
+                group_id is None
+                or not self.group_allow_from
+                or (
+                    "*" not in self.group_allow_from
+                    and str(group_id) not in self.group_allow_from
+                )
+            ):
+                return user_id, "group", None
+            return user_id, "group", chat_id
+        return None, None, None
+
+    def _file_sender_is_authorized(self, wrapper: dict) -> bool:
+        user_id, chat_type, chat_id = self._file_sender_context(wrapper)
+        if not user_id or not chat_id:
+            return False
+        return self._is_sender_authorized(user_id, chat_type, chat_id) is True
+
+    def _cancel_file_timeout(self, file_id: int) -> None:
+        task = self._file_transfer_tasks.pop(file_id, None)
+        if task and not task.done() and task is not asyncio.current_task():
+            task.cancel()
+
+    def _prune_terminal_files(self) -> None:
+        now = time.monotonic()
+        for file_id, terminal in list(self._terminal_file_transfers.items()):
+            if float(terminal.get("expires_at", 0.0)) <= now:
+                self._terminal_file_transfers.pop(file_id, None)
+        while len(self._terminal_file_transfers) > 4096:
+            self._terminal_file_transfers.pop(next(iter(self._terminal_file_transfers)))
+
+    def _mark_file_terminal(self, file_id: int, reason: str) -> Optional[str]:
+        """Remember a terminal transfer long enough to reject late duplicates."""
+        self._file_receive_started.discard(file_id)
+        target = self._file_receive_targets.pop(file_id, None)
+        prior = self._terminal_file_transfers.get(file_id, {})
+        if target is None:
+            target = prior.get("target")
+        self._terminal_file_transfers[file_id] = {
+            "target": target,
+            "reason": reason,
+            "expires_at": time.monotonic() + 86400.0,
+        }
+        self._prune_terminal_files()
+        return target
+
+    def _terminal_file_target(self, file_id: int) -> Optional[str]:
+        self._prune_terminal_files()
+        terminal = self._terminal_file_transfers.get(file_id)
+        if terminal:
+            return terminal.get("target")
+        return self._file_receive_targets.get(file_id)
+
+    def _cleanup_owned_media_path(self, path: str) -> None:
+        """Remove only an exact temporary path minted by this adapter."""
+        normalized = os.path.abspath(path)
+        task = self._owned_media_cleanup_tasks.pop(normalized, None)
+        if task and task is not asyncio.current_task() and not task.done():
+            task.cancel()
+        try:
+            if os.path.isfile(normalized) or os.path.islink(normalized):
+                os.remove(normalized)
+        except OSError as exc:
+            self._diagnostics["media_cleanup_failures"] += 1
+            logger.warning(
+                "SimpleX: failed to remove owned temporary media %s (%s)",
+                os.path.basename(normalized),
+                type(exc).__name__,
+            )
+
+    async def _expire_owned_media_path(self, path: str) -> None:
+        try:
+            await asyncio.sleep(self._media_cleanup_timeout)
+            self._cleanup_owned_media_path(path)
+        except asyncio.CancelledError:
+            return
+
+    def _schedule_owned_media_cleanup(self, path: str, *, reset: bool = False) -> None:
+        """Install a TTL backstop for an adapter-created media path."""
+        normalized = os.path.abspath(path)
+        existing = self._owned_media_cleanup_tasks.get(normalized)
+        if existing and not existing.done():
+            if not reset:
+                return
+            existing.cancel()
+        task = asyncio.create_task(self._expire_owned_media_path(normalized))
+        self._owned_media_cleanup_tasks[normalized] = task
+
+        def _done(done: asyncio.Task) -> None:
+            if self._owned_media_cleanup_tasks.get(normalized) is done:
+                self._owned_media_cleanup_tasks.pop(normalized, None)
+            if not done.cancelled():
+                try:
+                    done.result()
+                except Exception:
+                    logger.exception("SimpleX: temporary media cleanup failed")
+
+        task.add_done_callback(_done)
+
+    def _track_pending_file(self, file_id: int, wrapper: dict) -> None:
+        self._pending_file_transfers[file_id] = wrapper
+        existing = self._file_transfer_tasks.get(file_id)
+        if existing and not existing.done():
+            return
+        task = asyncio.create_task(self._expire_file_transfer(file_id))
+        self._file_transfer_tasks[file_id] = task
+
+        def _done(done: asyncio.Task) -> None:
+            if self._file_transfer_tasks.get(file_id) is done:
+                self._file_transfer_tasks.pop(file_id, None)
+            if not done.cancelled():
+                try:
+                    done.result()
+                except Exception:
+                    logger.exception("SimpleX: file-transfer expiry task failed")
+
+        task.add_done_callback(_done)
+
+    async def _dispatch_file_fallback(self, wrapper: dict, reason: str) -> None:
+        """Deliver an authorized file caption without an unavailable attachment."""
+        fallback = copy.deepcopy(self._normalize_chat_item_wrapper(wrapper))
+        inner = fallback.get("chatItem", {}) if fallback else {}
+        if not isinstance(inner, dict):
+            return
+        inner.pop("file", None)
+        content = inner.get("content", {}) or {}
+        msg_content = content.get("msgContent", {}) if isinstance(content, dict) else {}
+        text = msg_content.get("text", "") if isinstance(msg_content, dict) else ""
+        if not text:
+            if not isinstance(content, dict):
+                content = {}
+                inner["content"] = content
+            content["msgContent"] = {
+                "type": "text",
+                "text": f"[Attachment unavailable: {reason}]",
+            }
+        logger.info("SimpleX: delivering file caption without attachment (%s)", reason)
+        await self._handle_chat_item(fallback)
+
+    async def _expire_file_transfer(self, file_id: int) -> None:
+        await asyncio.sleep(self._file_transfer_timeout)
+        wrapper = self._pending_file_transfers.pop(file_id, None)
+        if not wrapper:
+            return
+        target = self._mark_file_terminal(file_id, "transfer timed out")
+        if target:
+            self._cleanup_owned_media_path(target)
+        self._diagnostics["file_timeouts"] += 1
+        await self._dispatch_file_fallback(wrapper, "transfer timed out")
+
+    async def _fail_file_transfer(self, file_id: int, reason: str) -> None:
+        wrapper = self._pending_file_transfers.pop(file_id, None)
+        self._cancel_file_timeout(file_id)
+        target = self._mark_file_terminal(file_id, reason)
+        if target:
+            self._cleanup_owned_media_path(target)
+        self._diagnostics["file_failures"] += 1
+        if wrapper:
+            await self._dispatch_file_fallback(wrapper, reason)
+
+    async def _accept_contact_request(self, request_id: str) -> None:
+        resp = await self._send_command(f"/_accept {request_id}", timeout=30.0)
+        error = _response_error(resp)
+        if error:
+            self._diagnostics["command_errors"] += 1
+            logger.warning("SimpleX: contact request acceptance failed: %s", error)
+
+    async def _receive_file(self, file_id: int, target: Optional[str]) -> None:
+        command = f"/freceive {file_id} approved_relays=on"
+        if target:
+            command += f" {target}"
+        resp = await self._send_command(command, timeout=30.0)
+        error = _response_error(resp)
+        if error or _response_type(resp) == "rcvFileAcceptedSndCancelled":
+            self._diagnostics["command_errors"] += 1
+            logger.warning(
+                "SimpleX: file %s receive failed: %s",
+                file_id,
+                error or "sender cancelled",
+            )
+            await self._fail_file_transfer(
+                file_id, error or "sender cancelled during acceptance"
+            )
+
+    def _resolve_file_path(self, file_path: str) -> str:
+        if file_path and not os.path.isabs(file_path) and self.files_folder:
+            return os.path.join(self.files_folder, file_path)
+        return file_path
+
+    @staticmethod
+    def _prepare_image(file_path: str) -> tuple[str, str]:
+        """Ensure *file_path* is a PNG and return ``(png_path, thumb_data_uri)``.
+
+        SimpleX clients can't display WebP and a few other formats inline.
+        This converts to PNG when needed and generates a small JPEG thumbnail
+        for the ``image`` field in the ``/_send`` payload so the chat shows
+        an inline preview. Uses Pillow when available, falls back to
+        ImageMagick ``convert``.
+        """
+        import subprocess
+        p = Path(file_path)
+        png_path = file_path
+        thumb_uri = ""
+
+        def _temp_path(suffix: str) -> str:
+            fd, path = tempfile.mkstemp(prefix="hermes-simplex-", suffix=suffix)
+            os.close(fd)
+            return path
+
+        try:
+            from PIL import Image
+
+            img = Image.open(file_path)
+            if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+                png_path = _temp_path(".png")
+                img.save(png_path, "PNG")
+            thumb = img.copy()
+            thumb.thumbnail((128, 128))
+            import io
+
+            buf = io.BytesIO()
+            thumb.save(buf, "JPEG", quality=70)
+            thumb_uri = (
+                "data:image/jpg;base64,"
+                + base64.b64encode(buf.getvalue()).decode()
+            )
+        except ImportError:
+            try:
+                if p.suffix.lower() not in (".png", ".jpg", ".jpeg"):
+                    png_path = _temp_path(".png")
+                    subprocess.run(
+                        ["convert", file_path, png_path],
+                        check=True,
+                        capture_output=True,
+                        timeout=30,
+                    )
+                with tempfile.NamedTemporaryFile(suffix=".jpg", delete=False) as tmp:
+                    tmp_path = tmp.name
+                subprocess.run(
+                    [
+                        "convert",
+                        file_path,
+                        "-resize",
+                        "128x128",
+                        "-quality",
+                        "70",
+                        tmp_path,
+                    ],
+                    check=True,
+                    capture_output=True,
+                    timeout=30,
+                )
+                with open(tmp_path, "rb") as f:
+                    thumb_uri = (
+                        "data:image/jpg;base64," + base64.b64encode(f.read()).decode()
+                    )
+                os.remove(tmp_path)
+            except (FileNotFoundError, subprocess.SubprocessError) as exc:
+                logger.warning("SimpleX: image conversion unavailable: %s", exc)
+
+        return png_path, thumb_uri
+
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send an image. Supports ``file://`` URLs and ``http(s)://`` URLs."""
+        from urllib.parse import unquote
+
+        if image_url.startswith("file://"):
+            file_path = unquote(image_url[7:])
+        else:
+            try:
+                from gateway.platforms.base import cache_image_from_url
+
+                file_path = await cache_image_from_url(image_url)
+            except Exception as e:
+                logger.warning("SimpleX: failed to download image: %s", e)
+                return SendResult(success=False, error=str(e))
+
+        if not file_path or not Path(file_path).exists():
+            return SendResult(success=False, error="Image file not found")
+
+        png_path, thumb_uri = self._prepare_image(file_path)
+        owned_temp = (
+            os.path.abspath(png_path) != os.path.abspath(file_path)
+        )
+        if owned_temp:
+            self._schedule_owned_media_cleanup(png_path)
+
+        result = await self._send_composed(
+            chat_id,
+            {
+                "type": "image",
+                "image": thumb_uri,
+                "text": caption or "",
+            },
+            reply_to=kwargs.get("reply_to"),
+            file_source=png_path,
+        )
+        if owned_temp:
+            if result.success and result.message_id:
+                self._outbound_temp_by_item[str(result.message_id)] = png_path
+            elif result.error_kind != "delivery_unknown":
+                self._cleanup_owned_media_path(png_path)
+        return result
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a local image file via SimpleX."""
+        return await self.send_image(
+            chat_id,
+            f"file://{image_path}",
+            caption=caption,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
+    async def send_video(
+        self,
+        chat_id: str,
+        video_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a video file via SimpleX (as a file attachment)."""
+        return await self.send_document(
+            chat_id,
+            video_path,
+            caption=caption,
+            reply_to=reply_to,
+            **kwargs,
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        filename: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """Send a document/file attachment."""
+        if not Path(file_path).exists():
+            return SendResult(success=False, error="File not found")
+
+        return await self._send_composed(
+            chat_id,
+            {"type": "file", "text": caption or ""},
+            reply_to=reply_to,
+            file_source=file_path,
+        )
+
+    async def send_voice(
+        self,
+        chat_id: str,
+        audio_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        duration: int = 0,
+        **kwargs,
+    ) -> SendResult:
+        """Send an audio file as a SimpleX voice note (plays inline).
+
+        SimpleX distinguishes a generic file attachment (``type: "file"``)
+        from an inline voice note (``type: "voice"``). ``/f`` would deliver
+        a downloadable file; the structured ``/_send`` form with
+        ``msgContent.type == "voice"`` produces the voice-note player.
+        """
+        if not Path(audio_path).exists():
+            return SendResult(success=False, error="Voice file not found")
+
+        return await self._send_composed(
+            chat_id,
+            {
+                "type": "voice",
+                "text": caption or "",
+                "duration": duration,
+            },
+            reply_to=reply_to,
+            file_source=audio_path,
+        )

--- a/plugins/platforms/simplex/media.py
+++ b/plugins/platforms/simplex/media.py
@@ -9,7 +9,6 @@ import logging
 import os
 import tempfile
 import time
-import uuid
 from pathlib import Path
 from typing import Optional
 
@@ -126,6 +125,14 @@ class SimplexMediaMixin:
         user_id, chat_type, chat_id = self._file_sender_context(wrapper)
         if not user_id or not chat_id:
             return False
+        if chat_type == "group":
+            # ``_file_sender_context`` returns a group chat_id only after the
+            # exact group has passed ``SIMPLEX_GROUP_ALLOWED``. Preserve that
+            # adapter-owned decision here just as ``_handle_chat_item`` does
+            # with ``role_authorized=True``; rebuilding a generic gateway
+            # source would otherwise discard it and reject allowed-group
+            # attachment transfers.
+            return True
         return self._is_sender_authorized(user_id, chat_type, chat_id) is True
 
     def _cancel_file_timeout(self, file_id: int) -> None:

--- a/plugins/platforms/simplex/messaging.py
+++ b/plugins/platforms/simplex/messaging.py
@@ -1,0 +1,454 @@
+"""Correlated command and text egress lifecycle for SimpleX."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import time
+from typing import Any, Dict, List, Optional
+
+from gateway.platforms.base import SendResult
+from plugins.platforms.simplex.protocol import (
+    response_error as _response_error,
+    response_item_ids as _response_item_ids,
+    response_type as _response_type,
+    simplex_payload_len as _simplex_payload_len,
+)
+
+logger = logging.getLogger(__name__)
+MAX_MESSAGE_LENGTH = 12000
+_CORR_PREFIX = "hermes-"
+
+
+class SimplexMessagingMixin:
+    def _make_corr_id(self) -> str:
+        """Mint a new correlation ID and remember it for echo-filtering.
+
+        We add every minted id to ``_pending_corr_ids`` so the inbound
+        event loop can drop the daemon's echo of our own commands without
+        ever invoking ``_handle_chat_item``. The set is bounded — when
+        it grows past ``_max_pending_corr``, the oldest entries are
+        evicted in a single sweep.
+        """
+        self._corr_counter += 1
+        corr_id = f"{_CORR_PREFIX}{self._corr_counter}-{int(time.time() * 1000)}"
+        self._pending_corr_ids.add(corr_id)
+        if len(self._pending_corr_ids) > self._max_pending_corr:
+            overflow = len(self._pending_corr_ids) - self._max_pending_corr
+            for _ in range(overflow):
+                try:
+                    self._pending_corr_ids.pop()
+                except KeyError:
+                    break
+        return corr_id
+
+    async def _send_ws(self, payload: dict) -> bool:
+        """Send one JSON payload over the active WebSocket.
+
+        Returns True on success, False if the socket is unavailable or an
+        error occurs so callers can surface failures instead of silently
+        reporting success.
+        """
+        ws = self._ws
+        if not ws:
+            logger.debug("SimpleX: WS send rejected (not connected)")
+            return False
+        try:
+            await ws.send(json.dumps(payload))
+            return True
+        except Exception as e:
+            logger.warning("SimpleX: WS send error: %s", e)
+            return False
+
+    async def _send_command(
+        self,
+        command: str,
+        timeout: float = 30.0,
+    ) -> Optional[dict]:
+        """Send a command and await the correlated response."""
+        ws = self._ws
+        if not ws or not self._ws_ready.is_set():
+            logger.warning("SimpleX: command rejected while WebSocket is not ready")
+            return None
+
+        corr_id = self._make_corr_id()
+        payload = json.dumps({"corrId": corr_id, "cmd": command})
+
+        loop = asyncio.get_running_loop()
+        fut: asyncio.Future = loop.create_future()
+        self._pending_responses[corr_id] = fut
+
+        try:
+            await ws.send(payload)
+        except Exception as e:
+            logger.warning(
+                "SimpleX: command was not submitted: %s — %s",
+                command.split(" ", 1)[0],
+                e,
+            )
+            self._pending_responses.pop(corr_id, None)
+            self._pending_corr_ids.discard(corr_id)
+            if not fut.done():
+                fut.cancel()
+            return {
+                "type": "localCommandNotSubmitted",
+                "error": "SimpleX command was not submitted to the daemon",
+            }
+
+        try:
+            result = await asyncio.wait_for(fut, timeout=timeout)
+            return result
+        except asyncio.TimeoutError:
+            logger.warning("SimpleX: command timed out: %s", command.split(" ", 1)[0])
+            return {
+                "type": "localCommandOutcomeUnknown",
+                "error": "SimpleX daemon confirmation timed out; delivery may have occurred",
+            }
+        except Exception as e:
+            logger.warning(
+                "SimpleX: command failed: %s — %s",
+                command.split(" ", 1)[0],
+                e,
+            )
+            return {
+                "type": "localCommandOutcomeUnknown",
+                "error": "SimpleX connection failed after command submission; delivery outcome is unknown",
+            }
+        finally:
+            self._pending_responses.pop(corr_id, None)
+            self._pending_corr_ids.discard(corr_id)
+
+    def _spawn_command_task(self, coroutine) -> asyncio.Task:
+        """Run a correlated command outside the WebSocket reader task."""
+        task = asyncio.create_task(coroutine)
+        self._command_tasks.add(task)
+
+        def _done(done: asyncio.Task) -> None:
+            self._command_tasks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception:
+                logger.exception("SimpleX: background command task failed")
+
+        task.add_done_callback(_done)
+        return task
+
+    def _spawn_dispatch_task(self, coroutine) -> asyncio.Task:
+        """Dispatch inbound work without ever blocking the WebSocket reader."""
+        task = asyncio.create_task(coroutine)
+        self._dispatch_tasks.add(task)
+
+        def _done(done: asyncio.Task) -> None:
+            self._dispatch_tasks.discard(done)
+            if done.cancelled():
+                return
+            try:
+                done.result()
+            except Exception:
+                logger.exception("SimpleX: background message dispatch failed")
+
+        task.add_done_callback(_done)
+        return task
+
+    async def _send_fire_and_forget(self, command: str) -> None:
+        """Send without blocking the reader; explicit errors remain logged."""
+        corr_id = self._make_corr_id()
+        ok = await self._send_ws({"corrId": corr_id, "cmd": command})
+        if not ok:
+            self._pending_corr_ids.discard(corr_id)
+            self._diagnostics["send_failures"] += 1
+
+    @staticmethod
+    def _chat_ref(chat_id: str) -> str:
+        """Return the structured daemon ChatRef for a stable Hermes chat id."""
+        raw = str(chat_id or "")
+        if raw.startswith("group:"):
+            return f"#{raw[6:].split('|', 1)[0]}"
+        return f"@{raw.split('|', 1)[0]}"
+
+    @staticmethod
+    def _error_kind(error: str) -> tuple[str, bool]:
+        lowered = (error or "").lower()
+        if "largemsg" in lowered or "large compressed message" in lowered:
+            return "too_long", False
+        if "notfound" in lowered or "not found" in lowered:
+            return "not_found", False
+        if "forbidden" in lowered or "permission" in lowered:
+            return "forbidden", False
+        if any(token in lowered for token in ("timeout", "closed", "network", "broker")):
+            return "transient", True
+        return "unknown", False
+
+    def _send_result_from_response(
+        self,
+        resp: Optional[dict],
+        *,
+        expected: set[str],
+    ) -> SendResult:
+        error = _response_error(resp)
+        if error:
+            self._diagnostics["command_errors"] += 1
+            if _response_type(resp) == "localCommandOutcomeUnknown":
+                return SendResult(
+                    success=False,
+                    error=error,
+                    error_kind="delivery_unknown",
+                    retryable=False,
+                    raw_response=resp,
+                )
+            if _response_type(resp) == "localCommandNotSubmitted":
+                return SendResult(
+                    success=False,
+                    error=error,
+                    error_kind="transient",
+                    retryable=True,
+                    raw_response=resp,
+                )
+            kind, retryable = self._error_kind(error)
+            return SendResult(
+                success=False,
+                error=error,
+                error_kind=kind,
+                retryable=retryable,
+                raw_response=resp,
+            )
+        if resp is None:
+            self._diagnostics["send_failures"] += 1
+            return SendResult(
+                success=False,
+                error="SimpleX daemon did not confirm the command",
+                error_kind="transient",
+                retryable=True,
+            )
+        resp_type = _response_type(resp)
+        if resp_type not in expected:
+            self._diagnostics["send_failures"] += 1
+            return SendResult(
+                success=False,
+                error=f"Unexpected SimpleX response: {resp_type or '<missing>'}",
+                error_kind="unknown",
+                raw_response=resp,
+            )
+        item_ids = _response_item_ids(resp)
+        return SendResult(
+            success=True,
+            message_id=item_ids[-1] if item_ids else None,
+            continuation_message_ids=tuple(item_ids[:-1]),
+            raw_response=resp,
+        )
+
+    async def _send_composed(
+        self,
+        chat_id: str,
+        msg_content: dict,
+        *,
+        reply_to: Optional[str] = None,
+        file_source: Optional[str] = None,
+        live: bool = False,
+        timeout: float = 30.0,
+    ) -> SendResult:
+        composed: Dict[str, Any] = {
+            "msgContent": msg_content,
+            "mentions": {},
+        }
+        if reply_to is not None:
+            try:
+                composed["quotedItemId"] = int(reply_to)
+            except (TypeError, ValueError):
+                logger.debug("SimpleX: ignoring non-numeric reply item id")
+        if file_source:
+            composed["fileSource"] = {"filePath": file_source}
+
+        live_flag = " live=on" if live else ""
+        command = (
+            f"/_send {self._chat_ref(chat_id)}{live_flag} json "
+            f"{json.dumps([composed], ensure_ascii=False)}"
+        )
+        resp = await self._send_command(command, timeout=timeout)
+        return self._send_result_from_response(resp, expected={"newChatItems"})
+
+    @staticmethod
+    def _split_utf8_payload(
+        text: str, byte_budget: int = MAX_MESSAGE_LENGTH
+    ) -> List[str]:
+        """Split by serialized UTF-8 bytes, never through a code point.
+
+        ``simplex-chat`` limits the encoded command envelope rather than
+        Python character count.  A margin below the protocol ceiling leaves
+        room for the JSON wrapper, chat reference, and quoting expansion.
+        """
+        if not text:
+            return [""]
+        chunks: List[str] = []
+        start = 0
+        while start < len(text):
+            used = 0
+            end = start
+            last_break: Optional[int] = None
+            while end < len(text):
+                char_cost = _simplex_payload_len(text[end])
+                if used + char_cost > byte_budget and end > start:
+                    break
+                used += char_cost
+                end += 1
+                if text[end - 1].isspace():
+                    last_break = end
+            if end < len(text) and last_break and last_break > start:
+                end = last_break
+            if end == start:
+                end += 1
+            chunks.append(text[start:end])
+            start = end
+        return chunks
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Deliver text and embedded media with daemon-confirmed results."""
+        _voice_exts = {".ogg", ".mp3", ".wav", ".m4a", ".opus"}
+        media_paths = re.findall(r"MEDIA:(\S+)", content)
+        if media_paths:
+            content = re.sub(r"MEDIA:\S+", "", content).strip()
+
+        delivered_ids: List[str] = []
+        if content:
+            initial_chunks: List[str] = []
+            for logical_chunk in self.truncate_message(
+                content, MAX_MESSAGE_LENGTH, len_fn=self.message_len_fn
+            ):
+                initial_chunks.extend(self._split_utf8_payload(logical_chunk))
+            queue = [
+                (chunk, index == 0)
+                for index, chunk in enumerate(initial_chunks)
+            ]
+            while queue:
+                chunk, carries_reply = queue.pop(0)
+                result = await self._send_composed(
+                    chat_id,
+                    {"type": "text", "text": chunk},
+                    reply_to=reply_to if carries_reply else None,
+                    live=bool((metadata or {}).get("expect_edits")),
+                )
+                if (
+                    not result.success
+                    and result.error_kind == "too_long"
+                    and len(chunk) > 512
+                ):
+                    retry_chunks = self.truncate_message(
+                        chunk, max(256, len(chunk) // 2)
+                    )
+                    queue = [
+                        (retry_chunk, carries_reply and index == 0)
+                        for index, retry_chunk in enumerate(retry_chunks)
+                    ] + queue
+                    continue
+                if not result.success:
+                    result.message_id = delivered_ids[-1] if delivered_ids else None
+                    if delivered_ids:
+                        result.error_kind = "partial_delivery"
+                        result.retryable = False
+                        result.raw_response = {
+                            "partial_delivery": True,
+                            "delivered_message_ids": tuple(delivered_ids),
+                            "daemon_response": result.raw_response,
+                        }
+                    return result
+                if result.message_id:
+                    delivered_ids.append(result.message_id)
+
+        for path in media_paths:
+            is_voice = os.path.splitext(path)[1].lower() in _voice_exts
+            if is_voice:
+                media_result = await self.send_voice(chat_id, path)
+            else:
+                media_result = await self.send_document(chat_id, path)
+            if not media_result.success:
+                if delivered_ids:
+                    media_result.message_id = delivered_ids[-1]
+                    media_result.error_kind = "partial_delivery"
+                    media_result.retryable = False
+                    media_result.raw_response = {
+                        "partial_delivery": True,
+                        "delivered_message_ids": tuple(delivered_ids),
+                        "daemon_response": media_result.raw_response,
+                    }
+                return media_result
+            if media_result.message_id:
+                delivered_ids.append(media_result.message_id)
+        return SendResult(
+            success=True,
+            message_id=delivered_ids[-1] if delivered_ids else None,
+            continuation_message_ids=tuple(delivered_ids[:-1]),
+        )
+
+    async def list_channels(self) -> Optional[List[Dict[str, Any]]]:
+        """Enumerate contacts and allowed groups for the channel directory.
+
+        Called by ``gateway.channel_directory.build_channel_directory()``
+        every refresh cycle. Uses the daemon's ``/contacts`` and ``/groups``
+        commands over the live WebSocket. Returns ``None`` (not ``[]``) when
+        the WebSocket is down so the directory falls back to session-history
+        discovery instead of wiping previously known targets.
+
+        Entry ``id`` values use immutable numeric contact/group IDs. Display
+        names remain labels only and never become authorization or routing
+        identities.
+        """
+        if not self._ws:
+            return None
+
+        channels: List[Dict[str, Any]] = []
+
+        resp = await self._send_command("/contacts", timeout=10.0)
+        if resp is None or _response_error(resp):
+            # Daemon unresponsive — keep whatever the directory already has.
+            return None
+        for contact in resp.get("contacts") or []:
+            if not isinstance(contact, dict):
+                continue
+            contact_id = contact.get("contactId")
+            name = (
+                contact.get("localDisplayName", "")
+                or (contact.get("profile", {}) or {}).get("displayName", "")
+            )
+            if contact_id is None:
+                continue
+            channels.append({
+                "id": str(contact_id),
+                "name": str(name or contact_id),
+                "type": "dm",
+            })
+
+        resp = await self._send_command("/groups", timeout=10.0)
+        if resp is not None and not _response_error(resp):
+            for group in resp.get("groups") or []:
+                # The daemon returns each group as either a groupInfo dict
+                # or a [groupInfo, groupSummary] pair depending on version.
+                if isinstance(group, list) and group:
+                    group = group[0]
+                if not isinstance(group, dict):
+                    continue
+                group_id = group.get("groupId")
+                if group_id is None:
+                    continue
+                name = (
+                    group.get("localDisplayName", "")
+                    or (group.get("groupProfile", {}) or {}).get("displayName", "")
+                    or str(group_id)
+                )
+                channels.append({
+                    "id": f"group:{group_id}",
+                    "name": str(name),
+                    "type": "group",
+                })
+
+        return channels

--- a/plugins/platforms/simplex/plugin.yaml
+++ b/plugins/platforms/simplex/plugin.yaml
@@ -31,6 +31,12 @@ optional_env:
     description: "Auto-accept incoming contact requests (default: true)"
     prompt: "Auto-accept contact requests? (true/false)"
     password: false
+  - name: SIMPLEX_FILES_FOLDER
+    description: >-
+      Absolute path passed to simplex-chat via --files-folder. Required for
+      reliable inbound attachment paths and same-filesystem XFTP moves.
+    prompt: "SimpleX daemon files folder (absolute path)"
+    password: false
   - name: SIMPLEX_GROUP_ALLOWED
     description: >-
       Comma-separated SimpleX group IDs the bot should participate in, or

--- a/plugins/platforms/simplex/protocol.py
+++ b/plugins/platforms/simplex/protocol.py
@@ -1,0 +1,59 @@
+"""Pure SimpleX daemon protocol helpers shared by adapter mixins."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+
+def simplex_payload_len(text: str) -> int:
+    """Measure text as serialized in an ``ensure_ascii=False`` JSON string."""
+    return len(json.dumps(text, ensure_ascii=False).encode("utf-8")) - 2
+
+
+def response_type(response: Optional[dict]) -> str:
+    return (
+        str((response or {}).get("type") or "")
+        if isinstance(response, dict)
+        else ""
+    )
+
+
+def response_error(response: Optional[dict]) -> Optional[str]:
+    """Return a bounded diagnostic for a daemon error response."""
+    if not isinstance(response, dict):
+        return "SimpleX daemon did not answer"
+    kind = response_type(response)
+    if kind in {"localCommandOutcomeUnknown", "localCommandNotSubmitted"}:
+        return str(response.get("error") or "SimpleX command outcome is unknown")[
+            :1000
+        ]
+    if kind not in {"chatCmdError", "chatError", "chatErrors"}:
+        return None
+    detail = response.get("chatError") or response.get("chatErrors") or response
+    try:
+        rendered = json.dumps(detail, ensure_ascii=False, sort_keys=True)
+    except (TypeError, ValueError):
+        rendered = str(detail)
+    return f"{kind}: {rendered[:1000]}"
+
+
+def response_item_ids(response: Optional[dict]) -> list[str]:
+    """Extract stable daemon chat-item IDs from a command response."""
+    if not isinstance(response, dict):
+        return []
+    wrappers: list[dict] = []
+    if isinstance(response.get("chatItems"), list):
+        wrappers.extend(
+            item for item in response["chatItems"] if isinstance(item, dict)
+        )
+    if isinstance(response.get("chatItem"), dict):
+        wrappers.append(response["chatItem"])
+    ids: list[str] = []
+    for wrapper in wrappers:
+        inner = wrapper.get("chatItem", {}) if isinstance(wrapper, dict) else {}
+        meta = inner.get("meta", {}) if isinstance(inner, dict) else {}
+        item_id = meta.get("itemId") if isinstance(meta, dict) else None
+        if item_id is not None:
+            ids.append(str(item_id))
+    return ids

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -375,6 +375,18 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "EMAIL_ALLOW_ALL_USERS",
     "SMS_ALLOW_ALL_USERS",
     "PHOTON_ALLOW_ALL_USERS",
+    # SimpleX transport/runtime settings alter adapter initialization and file
+    # path ownership. Tests opt into them explicitly instead of inheriting a
+    # developer's active gateway profile.
+    "SIMPLEX_WS_URL",
+    "SIMPLEX_FILES_FOLDER",
+    "SIMPLEX_ALLOWED_USERS",
+    "SIMPLEX_ALLOW_ALL_USERS",
+    "SIMPLEX_AUTO_ACCEPT",
+    "SIMPLEX_GROUP_ALLOWED",
+    "SIMPLEX_HOME_CHANNEL",
+    "SIMPLEX_HOME_CHANNEL_NAME",
+    "HERMES_SIMPLEX_TEXT_BATCH_DELAY",
     # Gateway home channels are set by /sethome in real profiles. Tests that
     # exercise dashboard notification toggles must opt in explicitly or they
     # can accidentally subscribe against a developer's real home channel.

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -1,0 +1,392 @@
+"""Tests for gateway-core edit supersede (#35535).
+
+An inbound EDIT of a message, correlated by message_id, supersedes the queued
+original or the in-flight turn.  Non-edit events are completely unaffected.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+import types
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+# Minimal telegram stubs so gateway imports cleanly.
+_tg = types.ModuleType("telegram")
+_tg.constants = types.ModuleType("telegram.constants")
+_ct = MagicMock()
+_ct.SUPERGROUP = "supergroup"
+_ct.GROUP = "group"
+_ct.PRIVATE = "private"
+_tg.constants.ChatType = _ct
+sys.modules.setdefault("telegram", _tg)
+sys.modules.setdefault("telegram.constants", _tg.constants)
+sys.modules.setdefault("telegram.ext", types.ModuleType("telegram.ext"))
+
+from gateway.platforms.base import (  # noqa: E402
+    MessageEvent,
+    MessageType,
+    SessionSource,
+    build_session_key,
+)
+from gateway.run import GatewayRunner, _AGENT_PENDING_SENTINEL  # noqa: E402
+from gateway.session_state import SessionState  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_source(platform_value="telegram", chat_id="c1", user_id="u1"):
+    return SessionSource(
+        platform=MagicMock(value=platform_value),
+        chat_id=chat_id,
+        chat_type="private",
+        user_id=user_id,
+    )
+
+
+def _make_event(
+    text: str = "hello",
+    message_id: str = "msg_1",
+    is_edit: bool = False,
+    message_type: MessageType = MessageType.TEXT,
+    source: SessionSource = None,
+) -> MessageEvent:
+    if source is None:
+        source = _make_source()
+    meta = {"is_edit": True} if is_edit else {}
+    return MessageEvent(
+        text=text,
+        message_type=message_type,
+        source=source,
+        message_id=message_id,
+        metadata=meta,
+    )
+
+
+def _make_adapter() -> MagicMock:
+    adapter = MagicMock()
+    adapter._pending_messages = {}
+    adapter._send_with_retry = AsyncMock()
+    adapter.config = MagicMock()
+    adapter.config.extra = {}
+    adapter.platform = MagicMock(value="telegram")
+    return adapter
+
+
+def _make_running_agent(supports_redirect: bool = True, supports_steer: bool = True) -> MagicMock:
+    agent = MagicMock()
+    agent._active_children = []
+    agent._active_children_lock = threading.Lock()
+    agent.get_activity_summary.return_value = {
+        "api_call_count": 4,
+        "max_iterations": 60,
+        "current_tool": "terminal",
+    }
+    agent._supports_active_turn_redirect = supports_redirect
+    if supports_redirect:
+        agent.redirect = MagicMock(return_value=True)
+    if supports_steer:
+        agent.steer = MagicMock(return_value=True)
+    return agent
+
+
+def _make_runner() -> GatewayRunner:
+    runner = object.__new__(GatewayRunner)
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._busy_ack_ts = {}
+    runner._sessions = {}
+    runner._draining = False
+    runner.adapters = {}
+    runner.config = MagicMock()
+    runner.session_store = None
+    runner.hooks = MagicMock()
+    runner.hooks.emit = AsyncMock()
+    runner.pairing_store = MagicMock()
+    runner.pairing_store.is_approved.return_value = True
+    runner._is_user_authorized = lambda _source: True
+    return runner
+
+
+def _session_state(runner: GatewayRunner, session_key: str) -> SessionState:
+    if session_key not in runner._sessions:
+        runner._sessions[session_key] = SessionState()
+    return runner._sessions[session_key]
+
+
+# ===================================================================
+# Tests: _replace_queued_message
+# ===================================================================
+
+class TestReplaceQueuedMessage:
+    """Verify _replace_queued_message searches both queue levels."""
+
+    def test_replace_primary_slot(self):
+        """Edit replaces text in the primary pending slot."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        original = _make_event(text="original text", message_id="msg_1")
+        adapter._pending_messages[sk] = original
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_1", "edited text")
+
+        assert replaced is True
+        assert adapter._pending_messages[sk].text == "edited text"
+        # Other fields preserved
+        assert adapter._pending_messages[sk].message_id == "msg_1"
+        assert adapter._pending_messages[sk].message_type == MessageType.TEXT
+
+    def test_replace_overflow_fifo(self):
+        """Edit replaces text in the overflow FIFO when primary slot does not match."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        primary = _make_event(text="primary", message_id="msg_other")
+        adapter._pending_messages[sk] = primary
+        overflow = _make_event(text="overflow target", message_id="msg_target")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="first", message_id="msg_a"),
+            overflow,
+            _make_event(text="last", message_id="msg_c"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_target", "edited overflow")
+
+        assert replaced is True
+        assert adapter._pending_messages[sk].text == "primary"  # unchanged
+        assert _session_state(runner, sk).conversation.queued_events[1].text == "edited overflow"
+        # FIFO order preserved
+        assert len(_session_state(runner, sk).conversation.queued_events) == 3
+
+    def test_no_match_returns_false(self):
+        """No matching message_id in either queue returns False."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        adapter._pending_messages[sk] = _make_event(text="primary", message_id="msg_a")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="second", message_id="msg_b"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "nonexistent", "edited")
+
+        assert replaced is False
+        assert adapter._pending_messages[sk].text == "primary"
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "second"
+
+    def test_no_primary_slot_searches_overflow(self):
+        """No primary slot for session_key — searches overflow FIFO."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        # primary slot empty for this key (no entry)
+        assert sk not in adapter._pending_messages
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="target", message_id="msg_x"),
+        ]
+
+        replaced = runner._replace_queued_message(sk, adapter, "msg_x", "edited text")
+
+        assert replaced is True
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "edited text"
+
+
+# ===================================================================
+# Tests: _handle_edit_supersede
+# ===================================================================
+
+class TestHandleEditSupersede:
+    """Verify edit-correlation logic in _handle_edit_supersede."""
+
+    def test_non_edit_events_untouched(self):
+        """Events without is_edit metadata pass through (return False)."""
+        runner = _make_runner()
+        sk = "test_session"
+        event = _make_event(text="not an edit", message_id="msg_1", is_edit=False)
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.active_message_id = None
+
+        result = runner._handle_edit_supersede(event, sk, adapter)
+
+        assert result is False  # not handled, continue processing
+
+    def test_edit_no_message_id_passes_through(self):
+        """Edit with empty/None message_id passes through."""
+        runner = _make_runner()
+        sk = "test_session"
+        event = _make_event(text="no id", message_id="", is_edit=True)
+        adapter = _make_adapter()
+
+        result = runner._handle_edit_supersede(event, sk, adapter)
+
+        assert result is False
+
+    def test_edit_replaces_queued_primary(self):
+        """Edit event replaces the queued original in the primary slot and returns True."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        original = _make_event(text="original", message_id="msg_1")
+        adapter._pending_messages[sk] = original
+        edit_event = _make_event(text="corrected", message_id="msg_1", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        assert adapter._pending_messages[sk].text == "corrected"
+
+    def test_edit_replaces_queued_overflow(self):
+        """Edit event replaces matching message in overflow FIFO."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        adapter._pending_messages[sk] = _make_event(text="primary", message_id="other_msg")
+        _session_state(runner, sk).conversation.queued_events = [
+            _make_event(text="edited msg", message_id="msg_target"),
+        ]
+        edit_event = _make_event(text="corrected", message_id="msg_target", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        assert _session_state(runner, sk).conversation.queued_events[0].text == "corrected"
+
+    def test_edit_redirects_in_flight_when_supported(self):
+        """Edit matching active_message_id calls redirect() on running agent."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_inflight"
+        edit_event = _make_event(text="mid-flight correction", message_id="msg_inflight", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        agent.redirect.assert_called_once()
+        call_args = agent.redirect.call_args[0][0]
+        assert 'User edited their earlier message.' in call_args
+        assert 'mid-flight correction' in call_args
+
+    def test_edit_steers_when_redirect_unsupported(self):
+        """Edit falls back to steer() when redirect is unavailable."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=False, supports_steer=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_steer"
+        edit_event = _make_event(text="steer this one", message_id="msg_steer", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        agent.steer.assert_called_once()
+        call_args = agent.steer.call_args[0][0]
+        assert 'User edited their earlier message.' in call_args
+
+    def test_edit_queues_when_both_primitives_unavailable(self):
+        """Edit falls back to queue when both redirect and steer are missing."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=False, supports_steer=False)
+        # Remove both methods
+        if hasattr(agent, 'redirect'):
+            del agent.redirect
+        if hasattr(agent, 'steer'):
+            del agent.steer
+
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_fallback"
+        edit_event = _make_event(text="fallback text", message_id="msg_fallback", is_edit=True)
+        # Register adapter so _queue_or_replace_pending_event can find it
+        runner.adapters[edit_event.source.platform] = adapter
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        # Should have been queued via _queue_or_replace_pending_event
+        assert sk in adapter._pending_messages
+        assert adapter._pending_messages[sk].text == "fallback text"
+
+    def test_stale_edit_dropped(self):
+        """Edit with no active_message_id (turn cleared) is dropped, not redirected."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent()
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = None  # turn already cleared
+        edit_event = _make_event(text="stale edit", message_id="msg_stale", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True  # handled (dropped)
+        agent.redirect.assert_not_called()
+        agent.steer.assert_not_called()
+        assert sk not in adapter._pending_messages  # not queued either
+
+    def test_uncorrelated_edit_dropped_no_new_turn(self):
+        """Edit matching no queued or in-flight message is dropped with no dispatch."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.agent = None  # idle session
+        state.turn.active_message_id = None
+        edit_event = _make_event(text="orphan edit", message_id="msg_orphan", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True  # handled (dropped)
+        assert sk not in adapter._pending_messages
+
+    def test_pending_sentinel_edit_passed_through_to_queue(self):
+        """When the agent is _AGENT_PENDING_SENTINEL, treat the edit as uncorrelated (drop)."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        state = _session_state(runner, sk)
+        state.turn.agent = _AGENT_PENDING_SENTINEL
+        state.turn.active_message_id = "msg_sentinel"
+        edit_event = _make_event(text="sentinel edit", message_id="msg_sentinel", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        # The active_message_id matches but agent is sentinel, so we should
+        # either drop (uncorrelated since no real agent) or queue.  The task says
+        # "if turn.agent is a real agent (not None, not _AGENT_PENDING_SENTINEL)"
+        # for the redirect/steer path, so this falls through to uncorrelated drop.
+        assert result is True  # dropped
+
+    def test_edit_to_queued_overflow_match_first(self):
+        """Edit matching in primary slot takes priority over overflow and in-flight."""
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent()
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_inflight"
+        # Both primary and in-flight have same message_id
+        adapter._pending_messages[sk] = _make_event(text="queued", message_id="msg_inflight")
+        edit_event = _make_event(text="edit that matches both", message_id="msg_inflight", is_edit=True)
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        # Should replace the queued one (primary slot match comes first)
+        assert result is True
+        assert adapter._pending_messages[sk].text == "edit that matches both"
+        agent.redirect.assert_not_called()

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -73,6 +73,7 @@ def _make_adapter() -> MagicMock:
     adapter.config = MagicMock()
     adapter.config.extra = {}
     adapter.platform = MagicMock(value="telegram")
+    adapter.replace_text_debounce_message.return_value = False
     return adapter
 
 
@@ -216,6 +217,38 @@ class TestReplaceQueuedMessage:
         assert replaced is True
         assert adapter._pending_messages[sk].text == "first\ncorrected second"
         assert adapter._pending_messages[sk].message_id == "msg_1"
+
+    def test_replace_busy_debounce_before_queue_slots(self):
+        """Edits also search BasePlatformAdapter's pre-flush debounce state."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        adapter.replace_text_debounce_message.return_value = True
+
+        replaced = runner._replace_queued_message(
+            "test_session", adapter, "msg_2", "latest"
+        )
+
+        assert replaced is True
+        adapter.replace_text_debounce_message.assert_called_once_with(
+            "test_session", "msg_2", "latest"
+        )
+
+    def test_rapid_batched_edits_are_latest_wins(self):
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        batched = _make_event(text="first\nsecond", message_id="msg_1")
+        batched.metadata = {
+            "simplex_batch_items": [
+                {"message_id": "msg_1", "text": "first"},
+                {"message_id": "msg_2", "text": "second"},
+            ]
+        }
+        adapter._pending_messages[sk] = batched
+
+        assert runner._replace_queued_message(sk, adapter, "msg_2", "third")
+        assert runner._replace_queued_message(sk, adapter, "msg_2", "final")
+        assert batched.text == "first\nfinal"
 
 
 # ===================================================================

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -203,7 +203,7 @@ class TestReplaceQueuedMessage:
         sk = "test_session"
         batched = _make_event(text="first\nsecond", message_id="msg_1")
         batched.metadata = {
-            "simplex_batch_items": [
+            "correlated_message_items": [
                 {"message_id": "msg_1", "text": "first"},
                 {"message_id": "msg_2", "text": "second"},
             ]
@@ -239,7 +239,7 @@ class TestReplaceQueuedMessage:
         sk = "test_session"
         batched = _make_event(text="first\nsecond", message_id="msg_1")
         batched.metadata = {
-            "simplex_batch_items": [
+            "correlated_message_items": [
                 {"message_id": "msg_1", "text": "first"},
                 {"message_id": "msg_2", "text": "second"},
             ]

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -195,6 +195,28 @@ class TestReplaceQueuedMessage:
         assert replaced is True
         assert _session_state(runner, sk).conversation.queued_events[0].text == "edited text"
 
+    def test_replace_one_component_of_batched_simplex_event(self):
+        """Editing the second item in a batch must not erase the first item."""
+        runner = _make_runner()
+        adapter = _make_adapter()
+        sk = "test_session"
+        batched = _make_event(text="first\nsecond", message_id="msg_1")
+        batched.metadata = {
+            "simplex_batch_items": [
+                {"message_id": "msg_1", "text": "first"},
+                {"message_id": "msg_2", "text": "second"},
+            ]
+        }
+        adapter._pending_messages[sk] = batched
+
+        replaced = runner._replace_queued_message(
+            sk, adapter, "msg_2", "corrected second"
+        )
+
+        assert replaced is True
+        assert adapter._pending_messages[sk].text == "first\ncorrected second"
+        assert adapter._pending_messages[sk].message_id == "msg_1"
+
 
 # ===================================================================
 # Tests: _handle_edit_supersede
@@ -390,3 +412,29 @@ class TestHandleEditSupersede:
         assert result is True
         assert adapter._pending_messages[sk].text == "edit that matches both"
         agent.redirect.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_busy_handler_correlates_edit_before_ordinary_busy_policy(self):
+        """Base adapter busy ingress must reach edit supersession directly."""
+        runner = _make_runner()
+        source = _make_source()
+        event = _make_event(
+            text="corrected while active",
+            message_id="msg_inflight",
+            is_edit=True,
+            source=source,
+        )
+        adapter = _make_adapter()
+        runner.adapters[source.platform] = adapter
+        sk = "test_session"
+        agent = _make_running_agent(supports_redirect=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_inflight"
+
+        handled = await runner._handle_active_session_busy_message(event, sk)
+
+        assert handled is True
+        agent.redirect.assert_called_once()
+        assert "corrected while active" in agent.redirect.call_args.args[0]
+        adapter._send_with_retry.assert_not_awaited()

--- a/tests/gateway/test_edit_supersede.py
+++ b/tests/gateway/test_edit_supersede.py
@@ -331,6 +331,27 @@ class TestHandleEditSupersede:
         assert 'User edited their earlier message.' in call_args
         assert 'mid-flight correction' in call_args
 
+    def test_edit_redirects_any_in_flight_batch_component(self):
+        runner = _make_runner()
+        sk = "test_session"
+        adapter = _make_adapter()
+        agent = _make_running_agent(supports_redirect=True)
+        state = _session_state(runner, sk)
+        state.turn.agent = agent
+        state.turn.active_message_id = "msg_1"
+        state.turn.active_message_ids = {"msg_1", "msg_2", "msg_3"}
+        edit_event = _make_event(
+            text="corrected second component",
+            message_id="msg_2",
+            is_edit=True,
+        )
+
+        result = runner._handle_edit_supersede(edit_event, sk, adapter)
+
+        assert result is True
+        agent.redirect.assert_called_once()
+        assert "corrected second component" in agent.redirect.call_args.args[0]
+
     def test_edit_steers_when_redirect_unsupported(self):
         """Edit falls back to steer() when redirect is unavailable."""
         runner = _make_runner()

--- a/tests/gateway/test_event_sidecars.py
+++ b/tests/gateway/test_event_sidecars.py
@@ -1,0 +1,68 @@
+"""Behavior contracts for generic gateway event lifecycle sidecars."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.event_sidecars import (
+    CORRELATED_MESSAGE_ITEMS_KEY,
+    add_post_turn_cleanup_callback,
+    correlated_event_message_ids,
+    merge_event_sidecars,
+    replace_correlated_event_text,
+    run_post_turn_cleanup_callbacks,
+)
+
+
+def _event(message_id: str, text: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        message_id=message_id,
+        text=text,
+        metadata={
+            CORRELATED_MESSAGE_ITEMS_KEY: [
+                {"message_id": message_id, "text": text}
+            ]
+        },
+    )
+
+
+def test_merge_replace_and_collect_preserve_component_order():
+    first = _event("1", "first")
+    second = _event("2", "second")
+    callbacks = []
+    add_post_turn_cleanup_callback(first, lambda: callbacks.append("first"))
+    add_post_turn_cleanup_callback(second, lambda: callbacks.append("second"))
+
+    merge_event_sidecars(first, second)
+
+    assert correlated_event_message_ids(first) == {"1", "2"}
+    assert replace_correlated_event_text(first, "2", "corrected") is True
+    assert first.text == "first\ncorrected"
+    assert len(first._post_turn_cleanup_callbacks) == 2
+
+
+@pytest.mark.asyncio
+async def test_cleanup_callbacks_are_bounded_and_failure_isolated():
+    event = _event("1", "first")
+    completed = []
+
+    async def too_slow():
+        await asyncio.sleep(1)
+
+    add_post_turn_cleanup_callback(event, too_slow)
+    add_post_turn_cleanup_callback(event, lambda: completed.append("after-timeout"))
+    add_post_turn_cleanup_callback(event, lambda: (_ for _ in ()).throw(RuntimeError("boom")))
+    add_post_turn_cleanup_callback(event, lambda: completed.append("after-error"))
+
+    await run_post_turn_cleanup_callbacks(
+        event,
+        timeout=0.01,
+        logger=logging.getLogger(__name__),
+        platform_name="test",
+    )
+
+    assert completed == ["after-timeout", "after-error"]

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -151,6 +151,46 @@ def test_merge_pending_message_event_merges_text_and_photo_followups():
     assert merged.media_types == ["image/png"]
 
 
+def test_merge_pending_message_event_preserves_transport_sidecars():
+    pending = {}
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    first = MessageEvent(
+        text="first",
+        message_type=MessageType.TEXT,
+        source=source,
+        metadata={
+            "simplex_batch_items": [{"message_id": "1", "text": "first"}]
+        },
+    )
+    second = MessageEvent(
+        text="second",
+        message_type=MessageType.TEXT,
+        source=source,
+        metadata={
+            "simplex_batch_items": [{"message_id": "2", "text": "second"}]
+        },
+    )
+    cleanup_one = lambda: None
+    cleanup_two = lambda: None
+    first._post_turn_cleanup_callbacks = [cleanup_one]
+    second._post_turn_cleanup_callbacks = [cleanup_two]
+
+    merge_pending_message_event(pending, "session", first, merge_text=True)
+    merge_pending_message_event(pending, "session", second, merge_text=True)
+
+    merged = pending["session"]
+    assert merged.metadata["simplex_batch_items"] == [
+        {"message_id": "1", "text": "first"},
+        {"message_id": "2", "text": "second"},
+    ]
+    assert merged._post_turn_cleanup_callbacks == [cleanup_one, cleanup_two]
+
+
 @pytest.mark.asyncio
 async def test_recent_telegram_followups_append_in_pending_queue():
     runner = _make_runner()

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -109,7 +109,7 @@ async def test_claim_records_every_batched_message_id_for_edit_correlation():
     event = _make_event()
     event.message_id = "msg_1"
     event.metadata = {
-        "simplex_batch_items": [
+        "correlated_message_items": [
             {"message_id": "msg_1", "text": "first"},
             {"message_id": "msg_2", "text": "second"},
         ]
@@ -187,7 +187,7 @@ def test_merge_pending_message_event_preserves_transport_sidecars():
         message_type=MessageType.TEXT,
         source=source,
         metadata={
-            "simplex_batch_items": [{"message_id": "1", "text": "first"}]
+            "correlated_message_items": [{"message_id": "1", "text": "first"}]
         },
     )
     second = MessageEvent(
@@ -195,7 +195,7 @@ def test_merge_pending_message_event_preserves_transport_sidecars():
         message_type=MessageType.TEXT,
         source=source,
         metadata={
-            "simplex_batch_items": [{"message_id": "2", "text": "second"}]
+            "correlated_message_items": [{"message_id": "2", "text": "second"}]
         },
     )
     cleanup_one = lambda: None
@@ -207,7 +207,7 @@ def test_merge_pending_message_event_preserves_transport_sidecars():
     merge_pending_message_event(pending, "session", second, merge_text=True)
 
     merged = pending["session"]
-    assert merged.metadata["simplex_batch_items"] == [
+    assert merged.metadata["correlated_message_items"] == [
         {"message_id": "1", "text": "first"},
         {"message_id": "2", "text": "second"},
     ]

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -103,6 +103,29 @@ async def test_sentinel_placed_before_agent_setup():
     )
 
 
+@pytest.mark.asyncio
+async def test_claim_records_every_batched_message_id_for_edit_correlation():
+    runner = _make_runner()
+    event = _make_event()
+    event.message_id = "msg_1"
+    event.metadata = {
+        "simplex_batch_items": [
+            {"message_id": "msg_1", "text": "first"},
+            {"message_id": "msg_2", "text": "second"},
+        ]
+    }
+    captured = set()
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        captured.update(runner._session_state(qk).turn.active_message_ids)
+        return "ok"
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        await runner._handle_message(event)
+
+    assert captured == {"msg_1", "msg_2"}
+
+
 # ------------------------------------------------------------------
 # Test 2: Sentinel is cleaned up after _handle_message_with_agent
 # ------------------------------------------------------------------

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -987,6 +987,54 @@ async def test_descriptor_without_files_folder_never_targets_system_tmp():
 
 
 @pytest.mark.asyncio
+async def test_duplicate_descriptor_is_accepted_once(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+        )
+    )
+    adapter._receive_file = AsyncMock()
+    adapter.set_authorization_check(lambda *_args: True)
+    wrapper = _make_file_chat_item("", "report.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    event = {
+        "resp": {
+            "type": "rcvFileDescrReady",
+            "rcvFileTransfer": {"fileId": 7, "fileName": "report.pdf"},
+            "chatItem": wrapper,
+        }
+    }
+
+    await adapter._handle_event(event)
+    await adapter._handle_event(event)
+    await asyncio.gather(*list(adapter._command_tasks))
+
+    adapter._receive_file.assert_awaited_once()
+    assert adapter._file_receive_started == {7}
+
+
+def test_relative_files_folder_configuration_fails_closed(caplog):
+    from gateway.config import PlatformConfig
+
+    with caplog.at_level("WARNING"):
+        adapter = SimplexAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={
+                    "ws_url": "ws://localhost:5225",
+                    "files_folder": "relative/files",
+                },
+            )
+        )
+
+    assert adapter.files_folder == ""
+    assert "ignoring relative SIMPLEX_FILES_FOLDER" in caplog.text
+
+
+@pytest.mark.asyncio
 async def test_relative_completion_without_files_folder_falls_back_to_caption():
     from gateway.config import PlatformConfig
 
@@ -1008,6 +1056,37 @@ async def test_relative_completion_without_files_folder_falls_back_to_caption():
 
     await adapter._handle_event(
         {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in captured] == ["here you go"]
+    assert captured[0].media_urls == []
+    assert adapter.get_runtime_diagnostics()["file_failures"] == 1
+
+
+@pytest.mark.asyncio
+async def test_relative_completed_chat_item_falls_back_without_media():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "newChatItems",
+                "chatItems": [_make_file_chat_item("report.pdf", "report.pdf")],
+            }
+        }
     )
     if adapter._pending_text_batch_tasks:
         await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
@@ -1723,6 +1802,70 @@ async def test_successful_owned_receive_attaches_post_turn_cleanup(tmp_path):
     assert len(callbacks) == 1
     callbacks[0]()
     assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_completed_receive_rearms_cleanup_ttl(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+        )
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._receive_file = AsyncMock()
+    pending = _make_file_chat_item("", "owned.pdf")
+    pending["chatItem"]["file"].pop("fileSource")
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "owned.pdf"},
+                "chatItem": pending,
+            }
+        }
+    )
+    await asyncio.gather(*list(adapter._command_tasks))
+    target = Path(adapter._receive_file.await_args.args[1])
+    target.write_bytes(b"%PDF")
+    descriptor_task = adapter._owned_media_cleanup_tasks[str(target)]
+
+    complete = _make_file_chat_item(str(target), "owned.pdf")
+    await adapter._handle_event(
+        {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    await _drain_dispatches(adapter)
+    completion_task = adapter._owned_media_cleanup_tasks[str(target)]
+
+    assert completion_task is not descriptor_task
+    assert descriptor_task.done()
+    assert target.exists()
+    await adapter.disconnect()
+
+
+def test_owned_media_cleanup_failure_is_diagnostic(tmp_path, monkeypatch, caplog):
+    import os
+
+    from gateway.config import PlatformConfig
+
+    target = tmp_path / "simplex-rcv-owned.pdf"
+    target.write_bytes(b"%PDF")
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+
+    def fail_remove(_path):
+        raise OSError("cleanup denied")
+
+    monkeypatch.setattr(os, "remove", fail_remove)
+    with caplog.at_level("WARNING"):
+        adapter._cleanup_owned_media_path(str(target))
+
+    assert adapter.get_runtime_diagnostics()["media_cleanup_failures"] == 1
+    assert "failed to remove owned temporary media" in caplog.text
+    assert str(tmp_path) not in caplog.text
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -458,6 +458,9 @@ async def test_standalone_send_removes_owned_image_conversion(monkeypatch, tmp_p
     sent_payloads = []
 
     class DummyWs:
+        def __init__(self):
+            self.receives = 0
+
         async def __aenter__(self):
             return self
 
@@ -468,8 +471,21 @@ async def test_standalone_send_removes_owned_image_conversion(monkeypatch, tmp_p
             sent_payloads.append(json.loads(payload))
 
         async def recv(self):
+            self.receives += 1
+            if self.receives == 1:
+                return json.dumps(
+                    {"corrId": sent_payloads[-1]["corrId"], "resp": _send_ack(91)}
+                )
             return json.dumps(
-                {"corrId": sent_payloads[-1]["corrId"], "resp": _send_ack(91)}
+                {
+                    "resp": {
+                        "type": "sndFileCompleteXFTP",
+                        "chatItem": {
+                            "chatInfo": {"type": "direct"},
+                            "chatItem": {"meta": {"itemId": 91}},
+                        },
+                    }
+                }
             )
 
     import websockets
@@ -1709,6 +1725,97 @@ async def test_duplicate_success_completion_does_not_delete_active_media(tmp_pat
     assert adapter.get_runtime_diagnostics()["late_file_completions"] == 1
 
     captured[0]._post_turn_cleanup_callbacks[0]()
+
+
+@pytest.mark.asyncio
+async def test_pathless_completion_waits_for_later_file_bearing_item(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+        )
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._receive_file = AsyncMock()
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    invitation = _make_file_chat_item("", "ordered.pdf")
+    invitation["chatItem"]["file"].pop("fileSource")
+    invitation["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "ordered.pdf"},
+                "chatItem": invitation,
+            }
+        }
+    )
+    await asyncio.sleep(0)
+    target = Path(adapter._receive_file.await_args.args[1])
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileComplete",
+                "chatItem": {"chatItem": {"file": {"fileId": 7}}},
+            }
+        }
+    )
+    assert 7 in adapter._pending_file_transfers
+    assert 7 not in adapter._terminal_file_transfers
+
+    target.write_bytes(b"%PDF")
+    completed = _make_file_chat_item(str(target), "ordered.pdf")
+    await adapter._handle_event(
+        {"resp": {"type": "newChatItems", "chatItems": [completed]}}
+    )
+    await _drain_dispatches(adapter)
+
+    assert len(captured) == 1
+    assert captured[0].media_urls == [str(target)]
+    assert 7 not in adapter._pending_file_transfers
+    captured[0]._post_turn_cleanup_callbacks[0]()
+
+
+@pytest.mark.asyncio
+async def test_completed_media_caption_edit_remains_correlated_text_only(tmp_path):
+    from gateway.config import PlatformConfig
+
+    media = tmp_path / "photo.jpg"
+    media.write_bytes(b"\xff\xd8")
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    original = _make_file_chat_item(str(media), "photo.jpg")
+    original["chatItem"]["meta"]["itemId"] = 700
+    await adapter._handle_chat_item(original)
+    await _drain_dispatches(adapter)
+
+    edited = json.loads(json.dumps(original))
+    edited["chatItem"]["content"]["msgContent"]["text"] = "corrected caption"
+    await adapter._handle_event(
+        {"resp": {"type": "chatItemUpdated", "chatItem": edited}}
+    )
+    await _drain_dispatches(adapter)
+
+    assert len(captured) == 2
+    assert captured[1].text == "corrected caption"
+    assert captured[1].media_urls == []
+    assert captured[1].metadata == {"is_edit": True}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -1846,6 +1846,7 @@ async def test_completed_receive_rearms_cleanup_ttl(tmp_path):
 
 
 def test_owned_media_cleanup_failure_is_diagnostic(tmp_path, monkeypatch, caplog):
+    import errno
     import os
 
     from gateway.config import PlatformConfig
@@ -1856,8 +1857,8 @@ def test_owned_media_cleanup_failure_is_diagnostic(tmp_path, monkeypatch, caplog
         PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     )
 
-    def fail_remove(_path):
-        raise OSError("cleanup denied")
+    def fail_remove(path):
+        raise OSError(errno.EACCES, "cleanup denied", path)
 
     monkeypatch.setattr(os, "remove", fail_remove)
     with caplog.at_level("WARNING"):
@@ -1866,6 +1867,7 @@ def test_owned_media_cleanup_failure_is_diagnostic(tmp_path, monkeypatch, caplog
     assert adapter.get_runtime_diagnostics()["media_cleanup_failures"] == 1
     assert "failed to remove owned temporary media" in caplog.text
     assert str(tmp_path) not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -388,3 +388,150 @@ def _make_file_chat_item(file_path: str, file_name: str) -> dict:
     }
 
 
+@pytest.mark.asyncio
+async def test_document_file_sets_document_type():
+    """A non-image/non-audio file must classify as DOCUMENT, not TEXT,
+    so run.py's document-context injection surfaces the path to the agent."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_file_chat_item("/tmp/report.pdf", "report.pdf"))
+
+    assert dispatched, "_handle_chat_item did not dispatch any event"
+    assert dispatched[0].message_type == MessageType.DOCUMENT
+    assert dispatched[0].media_urls == ["/tmp/report.pdf"]
+    assert dispatched[0].media_types == ["application/octet-stream"]
+
+
+@pytest.mark.asyncio
+async def test_image_file_still_sets_photo_type():
+    """Regression guard: image files keep classifying as PHOTO after the
+    document catch-all was added."""
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    dispatched = []
+
+    async def _capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = _capture
+    await adapter._handle_chat_item(_make_file_chat_item("/tmp/pic.jpg", "pic.jpg"))
+
+    assert dispatched, "_handle_chat_item did not dispatch any event"
+    assert dispatched[0].message_type == MessageType.PHOTO
+
+
+# ---------------------------------------------------------------------------
+# Nested AChatItem normalization (singular newChatItem events)
+# ---------------------------------------------------------------------------
+
+def _make_direct_text_wrapper(text: str = "hello") -> dict:
+    """Minimal normalized AChatItem wrapper for a received direct text."""
+    return {
+        "chatInfo": {
+            "type": "direct",
+            "contact": {"contactId": 42, "localDisplayName": "tester"},
+        },
+        "chatItem": {
+            "chatDir": {"type": "directRcv"},
+            "meta": {"itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": text},
+            },
+        },
+    }
+
+
+def test_normalize_unwraps_nested_achatitem():
+    """{type: newChatItem, chatItem: {chatInfo, chatItem}} → inner wrapper."""
+    inner = _make_direct_text_wrapper()
+    payload = {"type": "newChatItem", "chatItem": inner}
+    assert SimplexAdapter._normalize_chat_item_wrapper(payload) is inner
+
+
+def test_normalize_passes_through_normalized_wrapper():
+    """An already-normalized {chatInfo, chatItem} wrapper is returned as-is."""
+    wrapper = _make_direct_text_wrapper()
+    assert SimplexAdapter._normalize_chat_item_wrapper(wrapper) is wrapper
+
+
+def test_normalize_maps_item_key_variant():
+    """{chatInfo, item} responses normalize to {chatInfo, chatItem}."""
+    wrapper = _make_direct_text_wrapper()
+    payload = {"chatInfo": wrapper["chatInfo"], "item": wrapper["chatItem"]}
+    normalized = SimplexAdapter._normalize_chat_item_wrapper(payload)
+    assert normalized["chatInfo"] is wrapper["chatInfo"]
+    assert normalized["chatItem"] is wrapper["chatItem"]
+
+
+def test_normalize_tolerates_non_dict():
+    assert SimplexAdapter._normalize_chat_item_wrapper(None) == {}
+    assert SimplexAdapter._normalize_chat_item_wrapper("junk") == {}
+
+
+@pytest.mark.asyncio
+async def test_handle_event_singular_new_chat_item_nested():
+    """A wrapped singular newChatItem event with the AChatItem nested one
+    level down must reach message handling instead of being silently
+    dropped because chatInfo isn't at the top level."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    event = {
+        "corrId": "",
+        "resp": {"type": "newChatItem", "chatItem": _make_direct_text_wrapper("hi there")},
+    }
+    await adapter._handle_event(event)
+
+    # Text messages are buffered by the batching layer before dispatch —
+    # the pending batch proves the item survived normalization.
+    batches = list(adapter._pending_text_batches.values())
+    assert batches, "nested newChatItem was dropped before dispatch"
+    assert batches[0].text == "hi there"
+    assert batches[0].source.chat_id == "42"
+    # Cancel the flush timer so no task leaks out of the test.
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()
+
+
+@pytest.mark.asyncio
+async def test_handle_event_new_chat_items_nested_elements():
+    """newChatItems arrays whose elements nest the AChatItem one level down
+    are normalized element-by-element."""
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    event = {
+        "corrId": "",
+        "resp": {
+            "type": "newChatItems",
+            "chatItems": [
+                {"chatItem": _make_direct_text_wrapper("first")},
+                _make_direct_text_wrapper("second"),  # already-normalized mix
+            ],
+        },
+    }
+    await adapter._handle_event(event)
+
+    batches = list(adapter._pending_text_batches.values())
+    assert batches, "nested newChatItems elements were dropped"
+    # Same chat → batched into one pending event, in arrival order.
+    assert batches[0].text == "first\nsecond"
+    for task in adapter._pending_text_batch_tasks.values():
+        task.cancel()

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -256,6 +256,17 @@ async def test_list_channels_returns_none_on_contacts_timeout():
     assert await adapter.list_channels() is None
 
 
+@pytest.mark.asyncio
+async def test_send_when_ws_not_connected_reports_failure():
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+    # No _ws assigned — _send_ws should drop quietly
+    result = await adapter.send("contact-42", "hi")
+    assert result.success is False
+    assert result.error is not None
+
+
 # ---------------------------------------------------------------------------
 # 8. Inbound: filter own-echo by corrId prefix
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -993,6 +993,8 @@ async def test_reaction_hook_and_direct_approval_resolution(monkeypatch):
         },
     }
     await adapter._handle_event({"resp": reaction})
+    if adapter._dispatch_tasks:
+        await asyncio.gather(*list(adapter._dispatch_tasks))
 
     assert resolved == [("session-1", "once")]
     assert hook_events[0]["event_name"] == "reaction:added"
@@ -1249,3 +1251,310 @@ async def test_partial_delivery_is_never_retried_or_fallback_duplicated():
     assert result.error_kind == "partial_delivery"
     assert result.retryable is False
     assert adapter._send_command.await_count == 2
+
+
+@pytest.mark.asyncio
+async def test_listener_reconnects_after_clean_socket_end(monkeypatch):
+    """A dropped socket must not clear the adapter's reconnect run flag."""
+    from gateway.config import PlatformConfig
+    import websockets
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._running = True
+    adapter._write_runtime_status_safe = MagicMock()
+    second_connected = asyncio.Event()
+    attempts = 0
+
+    class FakeSocket:
+        def __init__(self, *, hold: bool):
+            self.hold = hold
+
+        async def __aenter__(self):
+            if self.hold:
+                second_connected.set()
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def __aiter__(self):
+            async def messages():
+                if self.hold:
+                    while adapter._running:
+                        await asyncio.sleep(0.01)
+                if False:
+                    yield ""
+
+            return messages()
+
+    def fake_connect(*_args, **_kwargs):
+        nonlocal attempts
+        attempts += 1
+        return FakeSocket(hold=attempts > 1)
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+    monkeypatch.setattr(_simplex, "WS_RETRY_DELAY_INITIAL", 0.0)
+    task = asyncio.create_task(adapter._ws_listener())
+    await asyncio.wait_for(second_connected.wait(), timeout=1)
+
+    assert attempts >= 2
+    assert adapter._running is True
+    assert adapter.get_runtime_diagnostics()["reconnects"] >= 1
+
+    adapter._running = False
+    task.cancel()
+    await asyncio.gather(task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_pre_submit_failure_is_retryable_but_unknown_outcome_is_not():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._ws_ready.set()
+
+    class FlakySocket:
+        def __init__(self):
+            self.calls = 0
+
+        async def send(self, payload):
+            self.calls += 1
+            if self.calls == 1:
+                raise ConnectionError("not submitted")
+            corr_id = json.loads(payload)["corrId"]
+            asyncio.create_task(
+                adapter._handle_event({"corrId": corr_id, "resp": _send_ack(44)})
+            )
+
+    socket = FlakySocket()
+    adapter._ws = socket
+    delivered = await adapter._send_with_retry(
+        "42", "retry once", max_retries=1, base_delay=0
+    )
+    assert delivered.success is True
+    assert socket.calls == 2
+
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "localCommandOutcomeUnknown",
+            "error": "submitted but confirmation was lost",
+        }
+    )
+    unknown = await adapter._send_with_retry("42", "do not duplicate", max_retries=3)
+    assert unknown.error_kind == "delivery_unknown"
+    assert adapter._send_command.await_count == 1
+
+
+def test_utf8_payload_split_respects_serialized_byte_budget():
+    text = "🙂" * 4000
+    chunks = SimplexAdapter._split_utf8_payload(text)
+
+    assert len(chunks) > 1
+    assert "".join(chunks) == text
+    assert all(
+        len(json.dumps(chunk, ensure_ascii=False).encode("utf-8")) - 2 <= 12000
+        for chunk in chunks
+    )
+
+
+@pytest.mark.asyncio
+async def test_initial_stream_preview_uses_simplex_live_item():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value=_send_ack(77))
+
+    await adapter.send("42", "draft", metadata={"expect_edits": True})
+    assert " live=on json " in adapter._send_command.await_args.args[0]
+
+    await adapter.send("42", "final", metadata={"notify": True})
+    assert " live=on json " not in adapter._send_command.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_group_sender_prefers_member_contact_id():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "group_allowed": "*"},
+        )
+    )
+    adapter.group_allow_from = {"*"}
+    adapter.set_authorization_check(lambda *_args: True)
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("/tmp/report.pdf", "report.pdf")
+    wrapper["chatInfo"] = {
+        "type": "group",
+        "groupInfo": {"groupId": 9, "localDisplayName": "review"},
+    }
+    wrapper["chatItem"]["chatDir"] = {
+        "type": "groupRcv",
+        "groupMember": {
+            "memberId": "opaque-member",
+            "memberContactId": 42,
+            "localDisplayName": "operator",
+        },
+    }
+
+    await adapter._handle_chat_item(wrapper)
+    await _drain_dispatches(adapter)
+
+    assert captured[0].source.user_id == "42"
+    assert adapter._file_sender_context(wrapper)[0] == "42"
+
+
+@pytest.mark.asyncio
+async def test_late_file_completion_is_ignored_and_owned_target_removed(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://localhost:5225",
+                "files_folder": str(tmp_path),
+                "file_transfer_timeout": 0.01,
+            },
+        )
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._file_transfer_timeout = 0.01
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("", "late.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    wrapper["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+    target = tmp_path / "simplex-rcv-owned-late.pdf"
+    target.write_bytes(b"%PDF")
+    adapter._file_receive_targets[7] = str(target)
+
+    await adapter._handle_chat_item(wrapper)
+    await asyncio.sleep(0.03)
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+    before = len(captured)
+
+    complete = _make_file_chat_item(str(target), "late.pdf")
+    await adapter._handle_event(
+        {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    await _drain_dispatches(adapter)
+
+    assert len(captured) == before
+    assert not target.exists()
+    assert adapter.get_runtime_diagnostics()["late_file_completions"] == 1
+
+
+@pytest.mark.asyncio
+async def test_outbound_converted_image_removed_after_send_completion(tmp_path):
+    from gateway.config import PlatformConfig
+
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"RIFFxxxxWEBP")
+    converted = tmp_path / "converted.png"
+    converted.write_bytes(b"\x89PNG")
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._prepare_image = MagicMock(return_value=(str(converted), "data:image/jpg;base64,"))
+    adapter._send_composed = AsyncMock(
+        return_value=_simplex.SendResult(success=True, message_id="88")
+    )
+
+    result = await adapter.send_image("42", f"file://{source}")
+    assert result.success is True
+    assert converted.exists()
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "sndFileCompleteXFTP",
+                "chatItem": {
+                    "chatInfo": {"type": "direct"},
+                    "chatItem": {"meta": {"itemId": 88}},
+                },
+            }
+        }
+    )
+    assert not converted.exists()
+
+
+@pytest.mark.asyncio
+async def test_successful_owned_receive_attaches_post_turn_cleanup(tmp_path):
+    from gateway.config import PlatformConfig
+
+    target = tmp_path / "simplex-rcv-owned.pdf"
+    target.write_bytes(b"%PDF")
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+        )
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._file_receive_targets[7] = str(target)
+    pending = _make_file_chat_item("", "owned.pdf")
+    pending["chatItem"]["file"].pop("fileSource")
+    adapter._pending_file_transfers[7] = pending
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    complete = _make_file_chat_item(str(target), "owned.pdf")
+    await adapter._handle_event(
+        {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    await _drain_dispatches(adapter)
+
+    assert target.exists()
+    callbacks = captured[0]._post_turn_cleanup_callbacks
+    assert len(callbacks) == 1
+    callbacks[0]()
+    assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_captionless_failed_attachment_is_not_silent():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("", "missing.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    wrapper["chatItem"]["content"]["msgContent"]["text"] = ""
+    adapter._pending_file_transfers[7] = wrapper
+
+    await adapter._fail_file_transfer(7, "sender cancelled")
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert captured[0].text == "[Attachment unavailable: sender cancelled]"

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import re
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -254,6 +255,67 @@ async def test_list_channels_returns_none_on_contacts_timeout():
 
     adapter._send_command = fake_send_command
     assert await adapter.list_channels() is None
+
+
+@pytest.mark.asyncio
+async def test_send_short_content_single_send():
+    """Content within the limit is delivered as exactly one WS send."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    result = await adapter.send("contact-42", "short message")
+    mock_ws.send.assert_called_once()
+    assert result.success is True
+
+
+@pytest.mark.asyncio
+async def test_send_long_content_chunks_into_ordered_sends():
+    """Content longer than the max is split into multiple ordered sends,
+    each chunk staying within the advertised limit."""
+    from gateway.config import PlatformConfig
+    cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    adapter = SimplexAdapter(cfg)
+
+    mock_ws = AsyncMock()
+    adapter._ws = mock_ws
+
+    max_len = _simplex.MAX_MESSAGE_LENGTH
+    # Plain text (no code fences) longer than the limit -> several chunks.
+    long_text = "word " * (max_len // 2)
+    assert len(long_text) > max_len
+
+    result = await adapter.send("contact-42", long_text)
+    assert result.success is True
+    assert mock_ws.send.call_count > 1
+
+    total = mock_ws.send.call_count
+    bodies = []
+    for i, call in enumerate(mock_ws.send.call_args_list):
+        payload = json.loads(call[0][0])
+        # Every chunk is addressed to the same contact, in order.
+        assert payload["cmd"].startswith("/_send @contact-42 json ")
+        chunk = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+            "msgContent"
+        ]["text"]
+        # Each chunk body must respect the per-message limit.
+        assert len(chunk) <= max_len
+        # Multi-part indicator appended by the base helper (whatever its exact
+        # spacing): a trailing "(n/N)" marker must be present, in send order.
+        assert re.search(r"\(\d+/\d+\)\s*$", chunk)
+        assert re.search(rf"\({i + 1}/{total}\)\s*$", chunk)
+        # Drop the trailing part-indicator to recover the original body text.
+        bodies.append(re.sub(r"\s*\(\d+/\d+\)\s*$", "", chunk))
+
+    # Content coverage: reassembling the indicator-stripped chunk bodies must
+    # account for every word of the original message. truncate_message splits
+    # on word boundaries and lstrips inter-chunk whitespace, so word-for-word
+    # reassembly is reliable even if exact byte concatenation is not.
+    reassembled = " ".join(bodies).split()
+    assert reassembled == long_text.split()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -48,6 +48,13 @@ def _send_ack(item_id: int = 101) -> dict:
     }
 
 
+async def _drain_dispatches(adapter) -> None:
+    await asyncio.sleep(0)
+    tasks = list(adapter._dispatch_tasks)
+    if tasks:
+        await asyncio.gather(*tasks)
+
+
 # ---------------------------------------------------------------------------
 # 1. Platform enum (plugin-discovered, not bundled)
 # ---------------------------------------------------------------------------
@@ -506,6 +513,7 @@ async def test_document_file_sets_document_type():
 
     adapter.handle_message = _capture
     await adapter._handle_chat_item(_make_file_chat_item("/tmp/report.pdf", "report.pdf"))
+    await _drain_dispatches(adapter)
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.DOCUMENT
@@ -529,6 +537,7 @@ async def test_image_file_still_sets_photo_type():
 
     adapter.handle_message = _capture
     await adapter._handle_chat_item(_make_file_chat_item("/tmp/pic.jpg", "pic.jpg"))
+    await _drain_dispatches(adapter)
 
     assert dispatched, "_handle_chat_item did not dispatch any event"
     assert dispatched[0].message_type == MessageType.PHOTO
@@ -748,6 +757,7 @@ async def test_inbound_edit_keeps_item_id_and_bypasses_text_batch():
     await adapter._handle_event(
         {"resp": {"type": "chatItemUpdated", "chatItem": wrapper}}
     )
+    await _drain_dispatches(adapter)
 
     assert len(captured) == 1
     assert captured[0].message_id == "505"
@@ -791,6 +801,7 @@ async def test_file_descriptor_acceptance_and_completion_dispatch(tmp_path):
         )
     )
     adapter._receive_file = AsyncMock()
+    adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
     captured = []
 
     async def capture(event):
@@ -810,6 +821,7 @@ async def test_file_descriptor_acceptance_and_completion_dispatch(tmp_path):
             }
         }
     )
+    await _drain_dispatches(adapter)
     await asyncio.gather(*adapter._command_tasks)
     target = Path(adapter._receive_file.await_args.args[1])
     assert adapter._receive_file.await_args.args[0] == 7
@@ -833,6 +845,7 @@ async def test_file_descriptor_acceptance_and_completion_dispatch(tmp_path):
             }
         }
     )
+    await _drain_dispatches(adapter)
 
     assert len(captured) == 1
     assert captured[0].message_type == MessageType.DOCUMENT
@@ -1034,3 +1047,205 @@ def test_prepare_image_uses_temp_output_without_overwriting_peer_file(tmp_path):
         assert thumbnail.startswith("data:image/jpg;base64,")
     finally:
         Path(converted).unlink(missing_ok=True)
+
+
+@pytest.mark.asyncio
+async def test_reader_remains_available_when_media_handler_sends_reply():
+    """A media callback may send a busy ack; its corrId must reach the reader."""
+    from gateway.config import PlatformConfig
+
+    class RecordingWs:
+        def __init__(self):
+            self.payloads = []
+
+        async def send(self, payload):
+            self.payloads.append(json.loads(payload))
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    ws = RecordingWs()
+    adapter._ws = ws
+    adapter._ws_ready.set()
+    replies = []
+
+    async def callback(_event):
+        replies.append(await adapter.send("42", "busy acknowledgement"))
+
+    adapter.handle_message = callback
+    await adapter._handle_event(
+        {"resp": {"type": "newChatItems", "chatItems": [_make_file_chat_item("/tmp/pic.jpg", "pic.jpg")]}}
+    )
+    for _ in range(20):
+        if ws.payloads:
+            break
+        await asyncio.sleep(0)
+    assert ws.payloads, "message callback never submitted its reply command"
+
+    corr_id = ws.payloads[0]["corrId"]
+    await adapter._handle_event({"corrId": corr_id, "resp": _send_ack(901)})
+    await _drain_dispatches(adapter)
+
+    assert replies[0].success is True
+    assert replies[0].message_id == "901"
+
+
+@pytest.mark.asyncio
+async def test_file_download_requires_explicit_authorization(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "files_folder": str(tmp_path)},
+        )
+    )
+    adapter._receive_file = AsyncMock()
+    wrapper = _make_file_chat_item("", "untrusted.bin")
+    wrapper["chatItem"]["file"].pop("fileSource")
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "untrusted.bin"},
+                "chatItem": wrapper,
+            }
+        }
+    )
+
+    adapter._receive_file.assert_not_awaited()
+    assert adapter.get_runtime_diagnostics()["file_rejections"] == 1
+    assert adapter._pending_file_transfers == {}
+
+
+@pytest.mark.asyncio
+async def test_stalled_file_expires_and_preserves_caption():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://localhost:5225",
+                "file_transfer_timeout": 0.01,
+            },
+        )
+    )
+    adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+    adapter._file_transfer_timeout = 0.01
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("", "report.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    wrapper["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+    await adapter._handle_chat_item(wrapper)
+    await asyncio.sleep(0.03)
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in captured] == ["here you go"]
+    assert captured[0].media_urls == []
+    assert adapter.get_runtime_diagnostics()["file_timeouts"] == 1
+    assert adapter._pending_file_transfers == {}
+
+
+@pytest.mark.asyncio
+async def test_cancelled_file_releases_state_and_preserves_caption():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://localhost:5225",
+                "file_transfer_timeout": 10,
+            },
+        )
+    )
+    adapter.set_authorization_check(lambda user_id, chat_type, chat_id: True)
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("", "report.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    wrapper["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+    await adapter._handle_chat_item(wrapper)
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileSndCancelled",
+                "chatItem": wrapper,
+                "rcvFileTransfer": {"fileId": 7},
+            }
+        }
+    )
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in captured] == ["here you go"]
+    assert adapter.get_runtime_diagnostics()["file_failures"] == 1
+    assert adapter._file_transfer_tasks == {}
+
+
+def test_non_numeric_allowlist_entry_emits_migration_warning(monkeypatch, caplog):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4,mutable-name")
+    with caplog.at_level("WARNING"):
+        SimplexAdapter(
+            PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+        )
+
+    assert "non-numeric SIMPLEX_ALLOWED_USERS" in caplog.text
+    assert "mutable-name" not in caplog.text
+
+
+def test_outgoing_reaction_event_is_not_an_approval_input():
+    response = {
+        "type": "chatItemReaction",
+        "added": True,
+        "reaction": {
+            "chatInfo": {"type": "direct", "contact": {"contactId": 42}},
+            "chatReaction": {
+                "chatDir": {"type": "directSnd"},
+                "chatItem": {"meta": {"itemId": 800}},
+                "reaction": {"type": "emoji", "emoji": "✅"},
+            },
+        },
+    }
+    assert SimplexAdapter._reaction_context(response) is None
+
+
+@pytest.mark.asyncio
+async def test_partial_delivery_is_never_retried_or_fallback_duplicated():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    responses = [
+        _send_ack(1),
+        {
+            "type": "localCommandOutcomeUnknown",
+            "error": "confirmation timed out; delivery may have occurred",
+        },
+    ]
+    adapter._send_command = AsyncMock(side_effect=responses)
+    content = "z" * (_simplex.MAX_MESSAGE_LENGTH + 100)
+
+    result = await adapter._send_with_retry("42", content, max_retries=3)
+
+    assert result.success is False
+    assert result.error_kind == "partial_delivery"
+    assert result.retryable is False
+    assert adapter._send_command.await_count == 2

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -444,6 +444,52 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_standalone_send_removes_owned_image_conversion(monkeypatch, tmp_path):
+    source = tmp_path / "source.webp"
+    source.write_bytes(b"RIFFxxxxWEBP")
+    converted = tmp_path / "converted.png"
+    converted.write_bytes(b"\x89PNG")
+    monkeypatch.setattr(
+        SimplexAdapter,
+        "_prepare_image",
+        staticmethod(lambda _path: (str(converted), "data:image/jpg;base64,")),
+    )
+
+    sent_payloads = []
+
+    class DummyWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send(self, payload):
+            sent_payloads.append(json.loads(payload))
+
+        async def recv(self):
+            return json.dumps(
+                {"corrId": sent_payloads[-1]["corrId"], "resp": _send_ack(91)}
+            )
+
+    import websockets
+
+    monkeypatch.setattr(websockets, "connect", lambda *_args, **_kwargs: DummyWs())
+    pconfig = MagicMock()
+    pconfig.extra = {"ws_url": "ws://localhost:5225"}
+
+    result = await _standalone_send(
+        pconfig,
+        "42",
+        "",
+        media_files=[str(source)],
+    )
+
+    assert result["success"] is True
+    assert not converted.exists()
+
+
+@pytest.mark.asyncio
 async def test_health_monitor_does_not_reconnect_quiet_healthy_ws(monkeypatch):
     from gateway.config import PlatformConfig
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
@@ -924,6 +970,37 @@ async def test_streaming_edit_and_final_overflow_lifecycle():
 
 
 @pytest.mark.asyncio
+async def test_partial_stream_overflow_reports_exact_delivered_source_prefix():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value={"type": "chatItemUpdated"})
+    adapter._send_composed = AsyncMock(
+        side_effect=[
+            _simplex.SendResult(success=True, message_id="701"),
+            _simplex.SendResult(
+                success=False,
+                error="not submitted",
+                error_kind="transient",
+                retryable=True,
+            ),
+        ]
+    )
+    content = "word " * (_simplex.MAX_MESSAGE_LENGTH // 2)
+
+    result = await adapter.edit_message("42", "700", content, finalize=True)
+
+    assert result.success is False
+    assert result.raw_response["partial_overflow"] is True
+    delivered_prefix = result.raw_response["delivered_prefix"]
+    assert delivered_prefix
+    assert content.startswith(delivered_prefix)
+    assert len(delivered_prefix) < len(content)
+
+
+@pytest.mark.asyncio
 async def test_delete_and_error_diagnostics_are_truthful():
     from gateway.config import PlatformConfig
 
@@ -1337,6 +1414,7 @@ async def test_pre_submit_failure_is_retryable_but_unknown_outcome_is_not():
     )
     assert delivered.success is True
     assert socket.calls == 2
+    assert adapter._pending_responses == {}
 
     adapter._send_command = AsyncMock(
         return_value={
@@ -1350,8 +1428,13 @@ async def test_pre_submit_failure_is_retryable_but_unknown_outcome_is_not():
 
 
 def test_utf8_payload_split_respects_serialized_byte_budget():
+    from gateway.config import PlatformConfig
+
     text = "🙂" * 4000
     chunks = SimplexAdapter._split_utf8_payload(text)
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
 
     assert len(chunks) > 1
     assert "".join(chunks) == text
@@ -1359,6 +1442,14 @@ def test_utf8_payload_split_respects_serialized_byte_budget():
         len(json.dumps(chunk, ensure_ascii=False).encode("utf-8")) - 2 <= 12000
         for chunk in chunks
     )
+    assert adapter.message_len_fn(text) > adapter.MAX_MESSAGE_LENGTH
+    assert len(
+        adapter.truncate_message(
+            text,
+            adapter.MAX_MESSAGE_LENGTH,
+            len_fn=adapter.message_len_fn,
+        )
+    ) > 1
 
 
 @pytest.mark.asyncio
@@ -1531,6 +1622,93 @@ async def test_successful_owned_receive_attaches_post_turn_cleanup(tmp_path):
     assert len(callbacks) == 1
     callbacks[0]()
     assert not target.exists()
+
+
+@pytest.mark.asyncio
+async def test_retained_receive_survives_ttl_and_disconnect(tmp_path):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://localhost:5225",
+                "files_folder": str(tmp_path),
+                "retain_received_files": True,
+            },
+        )
+    )
+    adapter._media_cleanup_timeout = 0.01
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._receive_file = AsyncMock()
+    pending = _make_file_chat_item("", "retained.pdf")
+    pending["chatItem"]["file"].pop("fileSource")
+    pending["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "retained.pdf"},
+                "chatItem": pending,
+            }
+        }
+    )
+    await asyncio.gather(*list(adapter._command_tasks))
+    target = Path(adapter._receive_file.await_args.args[1])
+    target.write_bytes(b"%PDF")
+    complete = _make_file_chat_item(str(target), "retained.pdf")
+    await adapter._handle_event(
+        {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    await _drain_dispatches(adapter)
+    await asyncio.sleep(0.03)
+
+    assert not hasattr(captured[0], "_post_turn_cleanup_callbacks")
+    assert adapter._owned_media_cleanup_tasks == {}
+    assert target.exists()
+
+    await adapter.disconnect()
+    assert target.exists()
+
+
+@pytest.mark.asyncio
+async def test_duplicate_success_completion_does_not_delete_active_media(tmp_path):
+    from gateway.config import PlatformConfig
+
+    target = tmp_path / "simplex-rcv-active.pdf"
+    target.write_bytes(b"%PDF")
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._file_receive_targets[7] = str(target)
+    pending = _make_file_chat_item("", "active.pdf")
+    pending["chatItem"]["file"].pop("fileSource")
+    adapter._pending_file_transfers[7] = pending
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    complete = _make_file_chat_item(str(target), "active.pdf")
+    event = {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    await adapter._handle_event(event)
+    await _drain_dispatches(adapter)
+    await adapter._handle_event(event)
+    await _drain_dispatches(adapter)
+
+    assert len(captured) == 1
+    assert target.exists()
+    assert adapter.get_runtime_diagnostics()["late_file_completions"] == 1
+
+    captured[0]._post_turn_cleanup_callbacks[0]()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -116,6 +116,15 @@ def test_env_enablement_seeds_home_channel(monkeypatch):
     assert seed["home_channel"] == {"chat_id": "42", "name": "Personal"}
 
 
+def test_env_enablement_seeds_files_folder(monkeypatch, tmp_path):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://127.0.0.1:5225")
+    monkeypatch.setenv("SIMPLEX_FILES_FOLDER", str(tmp_path))
+
+    seed = _env_enablement()
+
+    assert seed["files_folder"] == str(tmp_path)
+
+
 # ---------------------------------------------------------------------------
 # 4. Adapter init
 # ---------------------------------------------------------------------------
@@ -930,6 +939,82 @@ async def test_receive_file_enables_approved_relays():
         "/freceive 9 approved_relays=on /tmp/safe-name.pdf",
         timeout=30.0,
     )
+
+
+@pytest.mark.asyncio
+async def test_receive_file_without_folder_uses_daemon_managed_path():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value={"type": "rcvFileAccepted"})
+
+    await adapter._receive_file(9, None)
+
+    adapter._send_command.assert_awaited_once_with(
+        "/freceive 9 approved_relays=on",
+        timeout=30.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_descriptor_without_files_folder_never_targets_system_tmp():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._receive_file = AsyncMock()
+    adapter.set_authorization_check(lambda *_args: True)
+    wrapper = _make_file_chat_item("", "report.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "report.pdf"},
+                "chatItem": wrapper,
+            }
+        }
+    )
+    await asyncio.gather(*list(adapter._command_tasks))
+
+    adapter._receive_file.assert_awaited_once_with(7, None)
+    assert adapter._file_receive_targets == {}
+    assert adapter._owned_media_cleanup_tasks == {}
+
+
+@pytest.mark.asyncio
+async def test_relative_completion_without_files_folder_falls_back_to_caption():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.set_authorization_check(lambda *_args: True)
+    adapter._text_batch_delay = 0
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    pending = _make_file_chat_item("", "report.pdf")
+    pending["chatItem"]["file"].pop("fileSource")
+    adapter._pending_file_transfers[7] = pending
+    complete = _make_file_chat_item("report.pdf", "report.pdf")
+
+    await adapter._handle_event(
+        {"resp": {"type": "rcvFileComplete", "chatItem": complete}}
+    )
+    if adapter._pending_text_batch_tasks:
+        await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in captured] == ["here you go"]
+    assert captured[0].media_urls == []
+    assert adapter.get_runtime_diagnostics()["file_failures"] == 1
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_simplex_plugin.py
+++ b/tests/gateway/test_simplex_plugin.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import asyncio
 import json
 import re
+import time
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -29,6 +31,21 @@ _guess_extension = _simplex._guess_extension
 _is_image_ext = _simplex._is_image_ext
 _is_audio_ext = _simplex._is_audio_ext
 _CORR_PREFIX = _simplex._CORR_PREFIX
+
+
+def _send_ack(item_id: int = 101) -> dict:
+    return {
+        "type": "newChatItems",
+        "chatItems": [
+            {
+                "chatInfo": {"type": "direct"},
+                "chatItem": {
+                    "meta": {"itemId": item_id},
+                    "chatDir": {"type": "directSnd"},
+                },
+            }
+        ],
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -148,19 +165,18 @@ async def test_send_dm():
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
 
-    mock_ws = AsyncMock()
-    adapter._ws = mock_ws
+    adapter._send_command = AsyncMock(return_value=_send_ack())
 
     result = await adapter.send("contact-42", "Hello, SimpleX!")
-    mock_ws.send.assert_called_once()
-    payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"].startswith("/_send @contact-42 json ")
-    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+    adapter._send_command.assert_awaited_once()
+    command = adapter._send_command.await_args.args[0]
+    assert command.startswith("/_send @contact-42 json ")
+    msg_content = json.loads(command.split(" json ", 1)[1])[0][
         "msgContent"
     ]
     assert msg_content == {"type": "text", "text": "Hello, SimpleX!"}
-    assert payload["corrId"].startswith(_CORR_PREFIX)
     assert result.success is True
+    assert result.message_id == "101"
 
 
 
@@ -178,13 +194,12 @@ async def test_send_group():
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
 
-    mock_ws = AsyncMock()
-    adapter._ws = mock_ws
+    adapter._send_command = AsyncMock(return_value=_send_ack())
 
     result = await adapter.send("group:grp-99", "Hello, group!")
-    payload = json.loads(mock_ws.send.call_args[0][0])
-    assert payload["cmd"].startswith("/_send #grp-99 json ")
-    msg_content = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+    command = adapter._send_command.await_args.args[0]
+    assert command.startswith("/_send #grp-99 json ")
+    msg_content = json.loads(command.split(" json ", 1)[1])[0][
         "msgContent"
     ]
     assert msg_content == {"type": "text", "text": "Hello, group!"}
@@ -230,8 +245,8 @@ async def test_list_channels_contacts_and_groups():
     adapter._send_command = fake_send_command
     channels = await adapter.list_channels()
 
-    assert {"id": "alice", "name": "alice", "type": "dm"} in channels
-    assert {"id": "bob", "name": "bob", "type": "dm"} in channels
+    assert {"id": "1", "name": "alice", "type": "dm"} in channels
+    assert {"id": "2", "name": "bob", "type": "dm"} in channels
     assert {"id": "group:7", "name": "friends", "type": "group"} in channels
     assert {"id": "group:9", "name": "work", "type": "group"} in channels
 
@@ -264,11 +279,10 @@ async def test_send_short_content_single_send():
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
 
-    mock_ws = AsyncMock()
-    adapter._ws = mock_ws
+    adapter._send_command = AsyncMock(return_value=_send_ack())
 
     result = await adapter.send("contact-42", "short message")
-    mock_ws.send.assert_called_once()
+    adapter._send_command.assert_awaited_once()
     assert result.success is True
 
 
@@ -280,8 +294,14 @@ async def test_send_long_content_chunks_into_ordered_sends():
     cfg = PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
     adapter = SimplexAdapter(cfg)
 
-    mock_ws = AsyncMock()
-    adapter._ws = mock_ws
+    counter = 0
+
+    async def send_command(_command, timeout=30.0):
+        nonlocal counter
+        counter += 1
+        return _send_ack(counter)
+
+    adapter._send_command = AsyncMock(side_effect=send_command)
 
     max_len = _simplex.MAX_MESSAGE_LENGTH
     # Plain text (no code fences) longer than the limit -> several chunks.
@@ -290,15 +310,15 @@ async def test_send_long_content_chunks_into_ordered_sends():
 
     result = await adapter.send("contact-42", long_text)
     assert result.success is True
-    assert mock_ws.send.call_count > 1
+    assert adapter._send_command.await_count > 1
 
-    total = mock_ws.send.call_count
+    total = adapter._send_command.await_count
     bodies = []
-    for i, call in enumerate(mock_ws.send.call_args_list):
-        payload = json.loads(call[0][0])
+    for i, call in enumerate(adapter._send_command.await_args_list):
+        command = call.args[0]
         # Every chunk is addressed to the same contact, in order.
-        assert payload["cmd"].startswith("/_send @contact-42 json ")
-        chunk = json.loads(payload["cmd"].split(" json ", 1)[1])[0][
+        assert command.startswith("/_send @contact-42 json ")
+        chunk = json.loads(command.split(" json ", 1)[1])[0][
             "msgContent"
         ]["text"]
         # Each chunk body must respect the per-message limit.
@@ -389,6 +409,10 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
         async def send(self, payload):
             sent_payloads.append(json.loads(payload))
 
+        async def recv(self):
+            corr_id = sent_payloads[-1]["corrId"]
+            return json.dumps({"corrId": corr_id, "resp": _send_ack()})
+
     def fake_connect(url, **kwargs):
         assert url == "ws://127.0.0.1:5225"
         assert kwargs["open_timeout"] == 10
@@ -399,7 +423,12 @@ async def test_standalone_send_defaults_to_local_daemon(monkeypatch):
     monkeypatch.setattr(websockets, "connect", fake_connect)
 
     result = await _standalone_send(pconfig, "contact-42", "hi")
-    assert result == {"success": True, "platform": "simplex", "chat_id": "contact-42"}
+    assert result == {
+        "success": True,
+        "platform": "simplex",
+        "chat_id": "contact-42",
+        "message_id": "101",
+    }
     assert sent_payloads[0]["cmd"].startswith("/_send @contact-42 json ")
     msg_content = json.loads(
         sent_payloads[0]["cmd"].split(" json ", 1)[1]
@@ -608,3 +637,400 @@ async def test_handle_event_new_chat_items_nested_elements():
     assert batches[0].text == "first\nsecond"
     for task in adapter._pending_text_batch_tasks.values():
         task.cancel()
+
+
+# ---------------------------------------------------------------------------
+# Correlated commands, lifecycle, transfers, edits, and reactions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_command_correlates_response_and_cleans_state():
+    from gateway.config import PlatformConfig
+
+    class RecordingWs:
+        def __init__(self):
+            self.payloads = []
+
+        async def send(self, payload):
+            self.payloads.append(json.loads(payload))
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    ws = RecordingWs()
+    adapter._ws = ws
+    adapter._ws_ready.set()
+
+    pending = asyncio.create_task(adapter._send_command("/contacts", timeout=1))
+    await asyncio.sleep(0)
+    corr_id = ws.payloads[0]["corrId"]
+    response = {"type": "contacts", "contacts": []}
+    await adapter._handle_event({"corrId": corr_id, "resp": response})
+
+    assert await pending == response
+    assert corr_id not in adapter._pending_responses
+    assert corr_id not in adapter._pending_corr_ids
+
+
+@pytest.mark.asyncio
+async def test_large_message_retry_preserves_reply_on_first_retry_only():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    calls = []
+
+    async def reply(command, timeout=30.0):
+        calls.append(command)
+        if len(calls) == 1:
+            return {
+                "type": "chatCmdError",
+                "chatError": {"type": "error", "errorType": "largeMsg"},
+            }
+        return _send_ack(100 + len(calls))
+
+    adapter._send_command = AsyncMock(side_effect=reply)
+    text = "x" * 1200
+    result = await adapter.send("42", text, reply_to="77")
+
+    assert result.success is True
+    assert len(calls) >= 3
+    retry_payloads = [json.loads(command.split(" json ", 1)[1])[0] for command in calls]
+    assert retry_payloads[0]["quotedItemId"] == 77
+    assert retry_payloads[1]["quotedItemId"] == 77
+    assert all("quotedItemId" not in item for item in retry_payloads[2:])
+    retried_text = "".join(
+        re.sub(r" \(\d+/\d+\)$", "", item["msgContent"]["text"])
+        for item in retry_payloads[1:]
+    )
+    assert retried_text == text
+
+
+@pytest.mark.asyncio
+async def test_contact_request_acceptance_uses_protocol_command():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value={"type": "contactRequestAccepted"})
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "receivedContactRequest",
+                "contactRequest": {"contactRequestId": 19},
+            }
+        }
+    )
+    await asyncio.gather(*adapter._command_tasks)
+
+    adapter._send_command.assert_awaited_once_with("/_accept 19", timeout=30.0)
+
+
+@pytest.mark.asyncio
+async def test_inbound_edit_keeps_item_id_and_bypasses_text_batch():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_direct_text_wrapper("corrected")
+    wrapper["chatItem"]["meta"]["itemId"] = 505
+    await adapter._handle_event(
+        {"resp": {"type": "chatItemUpdated", "chatItem": wrapper}}
+    )
+
+    assert len(captured) == 1
+    assert captured[0].message_id == "505"
+    assert captured[0].source.message_id == "505"
+    assert captured[0].metadata == {"is_edit": True}
+    assert adapter._pending_text_batches == {}
+
+
+def test_group_text_batches_are_scoped_by_sender():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    first = MagicMock()
+    first.source.platform.value = "simplex"
+    first.source.chat_id = "group:7"
+    first.source.user_id = "member-1"
+    second = MagicMock()
+    second.source.platform.value = "simplex"
+    second.source.chat_id = "group:7"
+    second.source.user_id = "member-2"
+
+    assert adapter._text_batch_key(first) != adapter._text_batch_key(second)
+
+
+@pytest.mark.asyncio
+async def test_file_descriptor_acceptance_and_completion_dispatch(tmp_path):
+    from gateway.config import PlatformConfig
+    from gateway.platforms.base import MessageType
+
+    receive_dir = tmp_path / "incoming"
+    receive_dir.mkdir()
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={
+                "ws_url": "ws://localhost:5225",
+                "files_folder": str(receive_dir),
+            },
+        )
+    )
+    adapter._receive_file = AsyncMock()
+    captured = []
+
+    async def capture(event):
+        captured.append(event)
+
+    adapter.handle_message = capture
+    wrapper = _make_file_chat_item("", "../../report.pdf")
+    wrapper["chatItem"]["file"].pop("fileSource")
+    wrapper["chatItem"]["file"]["fileStatus"] = {"type": "rcvInvitation"}
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "../../report.pdf"},
+                "chatItem": wrapper,
+            }
+        }
+    )
+    await asyncio.gather(*adapter._command_tasks)
+    target = Path(adapter._receive_file.await_args.args[1])
+    assert adapter._receive_file.await_args.args[0] == 7
+    assert target.parent == receive_dir
+    assert ".." not in target.name
+
+    completed = receive_dir / "report.pdf"
+    completed.write_bytes(b"%PDF-1.7\n")
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileComplete",
+                "chatItem": {
+                    "chatItem": {
+                        "file": {
+                            "fileId": 7,
+                            "fileSource": {"filePath": "report.pdf"},
+                        }
+                    }
+                },
+            }
+        }
+    )
+
+    assert len(captured) == 1
+    assert captured[0].message_type == MessageType.DOCUMENT
+    assert captured[0].media_urls == [str(completed)]
+    assert adapter._pending_file_transfers == {}
+
+
+@pytest.mark.asyncio
+async def test_receive_file_enables_approved_relays():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value={"type": "rcvFileAccepted"})
+
+    await adapter._receive_file(9, "/tmp/safe-name.pdf")
+
+    adapter._send_command.assert_awaited_once_with(
+        "/freceive 9 approved_relays=on /tmp/safe-name.pdf",
+        timeout=30.0,
+    )
+
+
+@pytest.mark.asyncio
+async def test_media_send_uses_structured_file_source_and_reply(tmp_path):
+    from gateway.config import PlatformConfig
+
+    document = tmp_path / "evidence.txt"
+    document.write_text("proof")
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value=_send_ack(601))
+
+    result = await adapter.send_document(
+        "42", str(document), caption="attached", reply_to="55"
+    )
+    command = adapter._send_command.await_args.args[0]
+    composed = json.loads(command.split(" json ", 1)[1])[0]
+
+    assert result.success is True
+    assert result.message_id == "601"
+    assert composed["fileSource"] == {"filePath": str(document)}
+    assert composed["quotedItemId"] == 55
+    assert composed["msgContent"] == {"type": "file", "text": "attached"}
+
+
+@pytest.mark.asyncio
+async def test_streaming_edit_and_final_overflow_lifecycle():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(return_value={"type": "chatItemUpdated"})
+
+    interim = await adapter.edit_message("42", "700", "working", finalize=False)
+    assert interim.success is True
+    assert " 700 live=on json " in adapter._send_command.await_args.args[0]
+
+    adapter._send_composed = AsyncMock(
+        side_effect=[
+            _simplex.SendResult(success=True, message_id="701"),
+            _simplex.SendResult(success=True, message_id="702"),
+        ]
+    )
+    final_text = "a" * (_simplex.MAX_MESSAGE_LENGTH * 2 + 100)
+    final = await adapter.edit_message("42", "700", final_text, finalize=True)
+
+    final_command = adapter._send_command.await_args.args[0]
+    assert " live=on" not in final_command
+    assert adapter._send_composed.await_count == 2
+    assert final.message_id == "702"
+    assert final.continuation_message_ids == ("701", "702")
+
+
+@pytest.mark.asyncio
+async def test_delete_and_error_diagnostics_are_truthful():
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter._send_command = AsyncMock(
+        return_value={
+            "type": "chatCmdError",
+            "chatError": {"type": "error", "errorType": "notFound"},
+        }
+    )
+
+    assert await adapter.delete_message("42", "99") is False
+    diagnostics = adapter.get_runtime_diagnostics()
+    assert diagnostics["command_errors"] == 1
+    assert diagnostics["ready"] is False
+
+
+@pytest.mark.asyncio
+async def test_reaction_hook_and_direct_approval_resolution(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(enabled=True, extra={"ws_url": "ws://localhost:5225"})
+    )
+    adapter.send = AsyncMock(
+        return_value=_simplex.SendResult(success=True, message_id="800")
+    )
+    spawned = []
+
+    def close_background(coroutine):
+        spawned.append(coroutine)
+        coroutine.close()
+        return MagicMock()
+
+    adapter._spawn_command_task = close_background
+    hook_events = []
+
+    async def reaction_hook(event):
+        hook_events.append(event)
+
+    adapter._reaction_handler = reaction_hook
+    import tools.approval as approval
+
+    resolved = []
+    monkeypatch.setattr(
+        approval,
+        "resolve_gateway_approval",
+        lambda session_key, choice: resolved.append((session_key, choice)) or 1,
+    )
+
+    await adapter.send_exec_approval("42", "rm harmless", "session-1")
+    reaction = {
+        "type": "chatItemReaction",
+        "added": True,
+        "reaction": {
+            "chatInfo": {
+                "type": "direct",
+                "contact": {"contactId": 42, "localDisplayName": "operator"},
+            },
+            "chatReaction": {
+                "chatDir": {"type": "directRcv"},
+                "chatItem": {"meta": {"itemId": 800}},
+                "reaction": {"type": "emoji", "emoji": "✅"},
+            },
+        },
+    }
+    await adapter._handle_event({"resp": reaction})
+
+    assert resolved == [("session-1", "once")]
+    assert hook_events[0]["event_name"] == "reaction:added"
+    assert hook_events[0]["item_id"] == "800"
+    assert adapter._approval_prompts_by_item == {}
+
+
+@pytest.mark.asyncio
+async def test_connect_waits_for_real_socket_and_disconnect_clears_state(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    adapter = SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"ws_url": "ws://localhost:5225", "connect_timeout": 0.5},
+        )
+    )
+    listener_stop = asyncio.Event()
+
+    async def fake_listener():
+        adapter._ws = AsyncMock()
+        adapter._ws_ready.set()
+        await listener_stop.wait()
+
+    monkeypatch.setattr(adapter, "_ws_listener", fake_listener)
+    assert await adapter.connect() is True
+    assert adapter.get_runtime_diagnostics()["ready"] is True
+
+    pending = asyncio.get_running_loop().create_future()
+    adapter._pending_responses["corr"] = pending
+    adapter._approval_prompts_by_item["1"] = {"session_key": "s"}
+    await adapter.disconnect()
+
+    assert isinstance(pending.exception(), ConnectionError)
+    assert adapter.get_runtime_diagnostics()["ready"] is False
+    assert adapter._approval_prompts_by_item == {}
+
+
+def test_prepare_image_uses_temp_output_without_overwriting_peer_file(tmp_path):
+    from PIL import Image
+
+    source = tmp_path / "picture.webp"
+    existing = tmp_path / "picture.png"
+    Image.new("RGB", (4, 4), color="red").save(source, "WEBP")
+    existing.write_bytes(b"preserve-me")
+
+    converted, thumbnail = SimplexAdapter._prepare_image(str(source))
+    try:
+        assert Path(converted) != existing
+        assert Path(converted).is_file()
+        assert existing.read_bytes() == b"preserve-me"
+        assert thumbnail.startswith("data:image/jpg;base64,")
+    finally:
+        Path(converted).unlink(missing_ok=True)

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -383,6 +383,36 @@ async def test_unlisted_group_is_dropped_without_authorization(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_group_is_dropped_when_group_allowlist_is_unset(monkeypatch):
+    monkeypatch.delenv("SIMPLEX_GROUP_ALLOWED", raising=False)
+    adapter = _adapter()
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_chat_item(_group_item(12, 7, "no group policy"))
+
+    assert adapter.group_allow_from == set()
+    assert adapter._pending_text_batch_tasks == {}
+    adapter.handle_message.assert_not_awaited()
+
+
+def test_group_authorization_grant_is_not_persisted():
+    from gateway.session import SessionSource
+
+    source = _adapter().build_source(
+        chat_id="group:12",
+        chat_type="group",
+        user_id="99",
+        role_authorized=True,
+    )
+
+    serialized = source.to_dict()
+    restored = SessionSource.from_dict(serialized)
+
+    assert "role_authorized" not in serialized
+    assert restored.role_authorized is False
+
+
+@pytest.mark.asyncio
 async def test_allowed_group_file_keeps_intake_authorization(monkeypatch):
     monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "12")
     adapter = _adapter()

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -228,6 +228,32 @@ async def test_secondary_standalone_send_uses_profile_daemon(
 
 
 @pytest.mark.asyncio
+async def test_secondary_standalone_send_without_profile_daemon_fails_closed(
+    monkeypatch, secondary_profile_scope
+):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
+
+    import websockets
+
+    connect = MagicMock()
+    monkeypatch.setattr(websockets, "connect", connect)
+
+    result = await _simplex._standalone_send(
+        SimpleNamespace(extra={}),
+        "42",
+        "hello",
+    )
+
+    assert result == {
+        "error": (
+            "SimpleX standalone send: SIMPLEX_WS_URL is required for the "
+            "active profile"
+        )
+    }
+    connect.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_connect_holds_scoped_listener_lock_until_disconnect(monkeypatch):
     adapter = _adapter()
     acquire = MagicMock(return_value=True)

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -54,18 +54,19 @@ def _text_event(adapter: SimplexAdapter, message_id: str, text: str):
 
 
 @pytest.mark.asyncio
-async def test_cancelled_flush_rebuffers_complete_batch_before_newer_text():
-    """Cancellation after pop must not lose text or edit-correlation metadata."""
+async def test_new_text_does_not_cancel_an_inflight_dispatch():
+    """A downstream side effect must not be duplicated by batch cancellation."""
     adapter = _adapter()
     adapter._text_batch_delay = 0
     first_dispatch_started = asyncio.Event()
+    allow_first_dispatch_to_finish = asyncio.Event()
     dispatched = []
 
     async def blocked_then_capture(event):
+        dispatched.append(event)
         if event.text == "first":
             first_dispatch_started.set()
-            await asyncio.Event().wait()
-        dispatched.append(event)
+            await allow_first_dispatch_to_finish.wait()
 
     adapter.handle_message = blocked_then_capture
     adapter._enqueue_text_event(_text_event(adapter, "1", "first"))
@@ -73,12 +74,47 @@ async def test_cancelled_flush_rebuffers_complete_batch_before_newer_text():
 
     # This resets the timer while the prior flush is already dispatching.
     adapter._enqueue_text_event(_text_event(adapter, "2", "second"))
+    allow_first_dispatch_to_finish.set()
     await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
 
-    assert [event.text for event in dispatched] == ["first\nsecond"]
+    assert [event.text for event in dispatched] == ["first", "second"]
     assert dispatched[0].metadata["simplex_batch_items"] == [
         {"message_id": "1", "text": "first"},
+    ]
+    assert dispatched[1].metadata["simplex_batch_items"] == [
         {"message_id": "2", "text": "second"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_inflight_dispatch_retries_when_adapter_is_running():
+    adapter = _adapter()
+    adapter._running = True
+    adapter._text_batch_delay = 0
+    first_dispatch_started = asyncio.Event()
+    dispatched = []
+    attempts = 0
+
+    async def cancelled_then_capture(event):
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            first_dispatch_started.set()
+            await asyncio.Event().wait()
+        dispatched.append(event)
+
+    adapter.handle_message = cancelled_then_capture
+    adapter._enqueue_text_event(_text_event(adapter, "1", "first"))
+    await asyncio.wait_for(first_dispatch_started.wait(), timeout=1)
+    adapter._pending_text_batch_tasks[
+        adapter._text_batch_key(_text_event(adapter, "1", "first"))
+    ].cancel()
+    await asyncio.sleep(0)
+    await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in dispatched] == ["first"]
+    assert dispatched[0].metadata["simplex_batch_items"] == [
+        {"message_id": "1", "text": "first"},
     ]
 
 
@@ -105,6 +141,7 @@ def test_secondary_profile_does_not_inherit_default_simplex_env(
     monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
     monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "false")
     monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "*")
+    monkeypatch.setenv("HERMES_SIMPLEX_TEXT_BATCH_DELAY", "30")
 
     configured = _adapter(
         extra={
@@ -118,11 +155,29 @@ def test_secondary_profile_does_not_inherit_default_simplex_env(
     assert configured.ws_url == "ws://secondary-daemon:5225"
     assert configured.auto_accept is True
     assert configured.group_allow_from == {"secondary-only"}
+    assert configured._text_batch_delay == 0.8
     assert unconfigured.auto_accept is True
     assert unconfigured.group_allow_from == set()
     assert _simplex.validate_config(unconfigured.config) is False
     assert _simplex.is_connected(unconfigured.config) is False
     assert _simplex._env_enablement() is None
+
+
+def test_profile_scope_detection_failure_does_not_fall_through_to_env(
+    monkeypatch,
+):
+    import sys
+
+    from plugins.platforms.simplex import config as simplex_config
+
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
+    monkeypatch.setitem(sys.modules, "agent.secret_scope", None)
+
+    assert simplex_config.profile_scoped() is True
+    assert (
+        simplex_config.scoped_platform_setting("SIMPLEX_WS_URL", {}, "ws_url")
+        is None
+    )
 
 
 @pytest.mark.asyncio
@@ -209,6 +264,57 @@ async def test_connect_fails_before_listener_when_lock_is_held(monkeypatch):
     assert await adapter.connect() is False
     listener.assert_not_awaited()
     adapter._release_platform_lock.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_connect_during_reconnect_does_not_start_second_listener(monkeypatch):
+    adapter = _adapter()
+    adapter._connect_timeout = 0.01
+    adapter._running = True
+    adapter._ws = None
+    adapter._ws_ready.clear()
+    adapter._ws_task = asyncio.create_task(asyncio.Event().wait())
+    adapter._acquire_platform_lock = MagicMock(return_value=True)
+
+    try:
+        assert await adapter.connect() is False
+        adapter._acquire_platform_lock.assert_not_called()
+        assert not adapter._ws_task.done()
+    finally:
+        adapter._ws_task.cancel()
+        await asyncio.gather(adapter._ws_task, return_exceptions=True)
+
+
+@pytest.mark.asyncio
+async def test_connect_double_cancel_still_releases_listener_lock(monkeypatch):
+    adapter = _adapter()
+    adapter._acquire_platform_lock = MagicMock(return_value=True)
+    adapter._release_platform_lock = MagicMock()
+    listener_started = asyncio.Event()
+    listener_cancelled = asyncio.Event()
+    allow_listener_exit = asyncio.Event()
+
+    async def slow_listener_cleanup():
+        listener_started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            listener_cancelled.set()
+            await allow_listener_exit.wait()
+            raise
+
+    monkeypatch.setattr(adapter, "_ws_listener", slow_listener_cleanup)
+    connect_task = asyncio.create_task(adapter.connect())
+    await asyncio.wait_for(listener_started.wait(), timeout=1)
+
+    connect_task.cancel()
+    await asyncio.wait_for(listener_cancelled.wait(), timeout=1)
+    connect_task.cancel()
+    allow_listener_exit.set()
+
+    with pytest.raises(asyncio.CancelledError):
+        await connect_task
+    adapter._release_platform_lock.assert_called_once()
 
 
 def _group_item(group_id: int, member_id: int, text: str) -> dict:

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -380,3 +380,56 @@ async def test_unlisted_group_is_dropped_without_authorization(monkeypatch):
     await adapter._handle_chat_item(_group_item(99, 7, "not authorized"))
     assert adapter._pending_text_batch_tasks == {}
     adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_allowed_group_file_keeps_intake_authorization(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "12")
+    adapter = _adapter()
+    adapter._receive_file = AsyncMock()
+    adapter.set_authorization_check(lambda *_args: False)
+    wrapper = _group_item(12, 99, "authorized attachment")
+    wrapper["chatItem"]["file"] = {
+        "fileId": 7,
+        "fileName": "report.pdf",
+        "fileStatus": {"type": "rcvInvitation"},
+    }
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 7, "fileName": "report.pdf"},
+                "chatItem": wrapper,
+            }
+        }
+    )
+    await asyncio.gather(*list(adapter._command_tasks))
+
+    adapter._receive_file.assert_awaited_once_with(7, None)
+
+
+@pytest.mark.asyncio
+async def test_unlisted_group_file_is_rejected_before_receive(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "12")
+    adapter = _adapter()
+    adapter._receive_file = AsyncMock()
+    adapter.set_authorization_check(lambda *_args: True)
+    wrapper = _group_item(99, 7, "unapproved attachment")
+    wrapper["chatItem"]["file"] = {
+        "fileId": 8,
+        "fileName": "report.pdf",
+        "fileStatus": {"type": "rcvInvitation"},
+    }
+
+    await adapter._handle_event(
+        {
+            "resp": {
+                "type": "rcvFileDescrReady",
+                "rcvFileTransfer": {"fileId": 8, "fileName": "report.pdf"},
+                "chatItem": wrapper,
+            }
+        }
+    )
+
+    adapter._receive_file.assert_not_awaited()

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -1,0 +1,276 @@
+"""Regression coverage for SimpleX upstream-review findings.
+
+Kept separate from ``test_simplex_plugin.py`` so the adapter's corrective
+contracts remain reviewable without extending the already-large core suite.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_simplex = load_plugin_adapter("simplex")
+
+SimplexAdapter = _simplex.SimplexAdapter
+
+
+def _adapter(*, extra: dict | None = None) -> SimplexAdapter:
+    from gateway.config import PlatformConfig
+
+    return SimplexAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra=(
+                extra
+                if extra is not None
+                else {"ws_url": "ws://localhost:5225"}
+            ),
+        )
+    )
+
+
+def _text_event(adapter: SimplexAdapter, message_id: str, text: str):
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    return MessageEvent(
+        source=adapter.build_source(
+            chat_id="42",
+            chat_name="contact-42",
+            chat_type="dm",
+            user_id="42",
+            user_name="contact-42",
+            message_id=message_id,
+        ),
+        text=text,
+        message_type=MessageType.TEXT,
+        message_id=message_id,
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_flush_rebuffers_complete_batch_before_newer_text():
+    """Cancellation after pop must not lose text or edit-correlation metadata."""
+    adapter = _adapter()
+    adapter._text_batch_delay = 0
+    first_dispatch_started = asyncio.Event()
+    dispatched = []
+
+    async def blocked_then_capture(event):
+        if event.text == "first":
+            first_dispatch_started.set()
+            await asyncio.Event().wait()
+        dispatched.append(event)
+
+    adapter.handle_message = blocked_then_capture
+    adapter._enqueue_text_event(_text_event(adapter, "1", "first"))
+    await asyncio.wait_for(first_dispatch_started.wait(), timeout=1)
+
+    # This resets the timer while the prior flush is already dispatching.
+    adapter._enqueue_text_event(_text_event(adapter, "2", "second"))
+    await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert [event.text for event in dispatched] == ["first\nsecond"]
+    assert dispatched[0].metadata["simplex_batch_items"] == [
+        {"message_id": "1", "text": "first"},
+        {"message_id": "2", "text": "second"},
+    ]
+
+
+@pytest.fixture
+def secondary_profile_scope():
+    from agent.secret_scope import (
+        reset_secret_scope,
+        set_multiplex_active,
+        set_secret_scope,
+    )
+
+    set_multiplex_active(True)
+    token = set_secret_scope({})
+    try:
+        yield
+    finally:
+        reset_secret_scope(token)
+        set_multiplex_active(False)
+
+
+def test_secondary_profile_does_not_inherit_default_simplex_env(
+    monkeypatch, secondary_profile_scope
+):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
+    monkeypatch.setenv("SIMPLEX_AUTO_ACCEPT", "false")
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "*")
+
+    configured = _adapter(
+        extra={
+            "ws_url": "ws://secondary-daemon:5225",
+            "auto_accept": True,
+            "group_allowed": "secondary-only",
+        }
+    )
+    unconfigured = _adapter(extra={})
+
+    assert configured.ws_url == "ws://secondary-daemon:5225"
+    assert configured.auto_accept is True
+    assert configured.group_allow_from == {"secondary-only"}
+    assert unconfigured.auto_accept is True
+    assert unconfigured.group_allow_from == set()
+    assert _simplex.validate_config(unconfigured.config) is False
+    assert _simplex.is_connected(unconfigured.config) is False
+    assert _simplex._env_enablement() is None
+
+
+@pytest.mark.asyncio
+async def test_secondary_standalone_send_uses_profile_daemon(
+    monkeypatch, secondary_profile_scope
+):
+    monkeypatch.setenv("SIMPLEX_WS_URL", "ws://default-daemon:5225")
+    connected_urls = []
+
+    class DummyWs:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def send(self, payload):
+            self.corr_id = json.loads(payload)["corrId"]
+
+        async def recv(self):
+            return json.dumps(
+                {
+                    "corrId": self.corr_id,
+                    "resp": {
+                        "type": "newChatItems",
+                        "chatItems": [
+                            {"chatItem": {"meta": {"itemId": 7}}}
+                        ],
+                    },
+                }
+            )
+
+    def fake_connect(url, **_kwargs):
+        connected_urls.append(url)
+        return DummyWs()
+
+    import websockets
+
+    monkeypatch.setattr(websockets, "connect", fake_connect)
+    result = await _simplex._standalone_send(
+        SimpleNamespace(extra={"ws_url": "ws://secondary-daemon:5225"}),
+        "42",
+        "hello",
+    )
+
+    assert result["success"] is True
+    assert connected_urls == ["ws://secondary-daemon:5225"]
+
+
+@pytest.mark.asyncio
+async def test_connect_holds_scoped_listener_lock_until_disconnect(monkeypatch):
+    adapter = _adapter()
+    acquire = MagicMock(return_value=True)
+    release = MagicMock()
+    adapter._acquire_platform_lock = acquire
+    adapter._release_platform_lock = release
+
+    async def ready_listener():
+        adapter._ws = AsyncMock()
+        adapter._ws_ready.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(adapter, "_ws_listener", ready_listener)
+    monkeypatch.setattr(adapter, "_health_monitor", AsyncMock())
+
+    assert await adapter.connect() is True
+    acquire.assert_called_once_with(
+        "simplex-ws", "ws://localhost:5225", "SimpleX daemon URL"
+    )
+    release.assert_not_called()
+
+    await adapter.disconnect()
+    release.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_connect_fails_before_listener_when_lock_is_held(monkeypatch):
+    adapter = _adapter()
+    adapter._acquire_platform_lock = MagicMock(return_value=False)
+    adapter._release_platform_lock = MagicMock()
+    listener = AsyncMock()
+    monkeypatch.setattr(adapter, "_ws_listener", listener)
+
+    assert await adapter.connect() is False
+    listener.assert_not_awaited()
+    adapter._release_platform_lock.assert_not_called()
+
+
+def _group_item(group_id: int, member_id: int, text: str) -> dict:
+    return {
+        "chatInfo": {
+            "type": "group",
+            "groupInfo": {
+                "groupId": group_id,
+                "localDisplayName": f"group-{group_id}",
+            },
+        },
+        "chatItem": {
+            "chatDir": {
+                "type": "groupRcv",
+                "groupMember": {
+                    "memberId": member_id,
+                    "localDisplayName": f"member-{member_id}",
+                },
+            },
+            "meta": {"itemId": 1, "itemTs": "2026-01-01T00:00:00Z"},
+            "content": {
+                "type": "rcvMsgContent",
+                "msgContent": {"type": "text", "text": text},
+            },
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_allowed_group_carries_authorization_to_gateway(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "12")
+    adapter = _adapter()
+    adapter._text_batch_delay = 0
+    dispatched = []
+
+    async def capture(event):
+        dispatched.append(event)
+
+    adapter.handle_message = capture
+    await adapter._handle_chat_item(_group_item(12, 99, "authorized group"))
+    await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
+
+    assert dispatched[0].source.role_authorized is True
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.pairing_store = SimpleNamespace(is_approved=lambda *_a, **_kw: False)
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "42")
+    monkeypatch.delenv("SIMPLEX_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOW_ALL_USERS", raising=False)
+    monkeypatch.delenv("GATEWAY_ALLOWED_USERS", raising=False)
+    assert runner._is_user_authorized(dispatched[0].source) is True
+
+
+@pytest.mark.asyncio
+async def test_unlisted_group_is_dropped_without_authorization(monkeypatch):
+    monkeypatch.setenv("SIMPLEX_GROUP_ALLOWED", "12")
+    adapter = _adapter()
+    adapter._text_batch_delay = 0
+    adapter.handle_message = AsyncMock()
+
+    await adapter._handle_chat_item(_group_item(99, 7, "not authorized"))
+    assert adapter._pending_text_batch_tasks == {}
+    adapter.handle_message.assert_not_awaited()

--- a/tests/gateway/test_simplex_review_fixes.py
+++ b/tests/gateway/test_simplex_review_fixes.py
@@ -78,10 +78,10 @@ async def test_new_text_does_not_cancel_an_inflight_dispatch():
     await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
 
     assert [event.text for event in dispatched] == ["first", "second"]
-    assert dispatched[0].metadata["simplex_batch_items"] == [
+    assert dispatched[0].metadata["correlated_message_items"] == [
         {"message_id": "1", "text": "first"},
     ]
-    assert dispatched[1].metadata["simplex_batch_items"] == [
+    assert dispatched[1].metadata["correlated_message_items"] == [
         {"message_id": "2", "text": "second"},
     ]
 
@@ -113,7 +113,7 @@ async def test_cancelled_inflight_dispatch_retries_when_adapter_is_running():
     await asyncio.gather(*list(adapter._pending_text_batch_tasks.values()))
 
     assert [event.text for event in dispatched] == ["first"]
-    assert dispatched[0].metadata["simplex_batch_items"] == [
+    assert dispatched[0].metadata["correlated_message_items"] == [
         {"message_id": "1", "text": "first"},
     ]
 

--- a/tests/gateway/test_unauthorized_dm_behavior.py
+++ b/tests/gateway/test_unauthorized_dm_behavior.py
@@ -117,11 +117,8 @@ def test_whatsapp_lid_user_matches_phone_allowlist_via_modern_session_mapping(
     assert runner._is_user_authorized(source) is True
 
 
-def test_simplex_allowlist_accepts_display_name(monkeypatch):
-    """SIMPLEX_ALLOWED_USERS should match the contact's display name as well
-    as the numeric contactId. The SimpleX UI surfaces only display names, so
-    operators naturally put those in the env var — and the adapter sets
-    user_id=contactId for stability. Both forms must work. (#TBD)"""
+def test_simplex_allowlist_rejects_display_name_only(monkeypatch):
+    """A mutable SimpleX display name must never grant authorization."""
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("SIMPLEX_ALLOWED_USERS", raising=False)
     monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "hujikuji")
@@ -143,8 +140,6 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
     )
 
-    # contactId in the allowlist would still work — but the operator chose
-    # the display name. Verify the gateway honors it.
     source = SessionSource(
         platform=simplex,
         user_id="4",            # adapter sets this to the numeric contactId
@@ -152,7 +147,65 @@ def test_simplex_allowlist_accepts_display_name(monkeypatch):
         user_name="hujikuji",   # adapter sets this to displayName
         chat_type="dm",
     )
+    assert runner._is_user_authorized(source) is False
+
+
+def test_simplex_allowlist_accepts_numeric_contact_id(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+    source = SessionSource(
+        platform=simplex,
+        user_id="4",
+        chat_id="4",
+        user_name="hujikuji",
+        chat_type="dm",
+    )
     assert runner._is_user_authorized(source) is True
+
+
+def test_simplex_allowlist_rejects_colliding_display_name(monkeypatch):
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("SIMPLEX_ALLOWED_USERS", "4")
+
+    from gateway.platform_registry import platform_registry, PlatformEntry
+    platform_registry.register(PlatformEntry(
+        name="simplex",
+        label="SimpleX Chat",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        allowed_users_env="SIMPLEX_ALLOWED_USERS",
+        allow_all_env="SIMPLEX_ALLOW_ALL_USERS",
+    ))
+
+    simplex = Platform("simplex")
+    runner, _adapter = _make_runner(
+        simplex,
+        GatewayConfig(platforms={simplex: PlatformConfig(enabled=True)}),
+    )
+    source = SessionSource(
+        platform=simplex,
+        user_id="7",
+        chat_id="7",
+        user_name="hujikuji",
+        chat_type="dm",
+    )
+    assert runner._is_user_authorized(source) is False
 
 
 def test_telegram_group_users_legacy_chat_ids_still_authorize(monkeypatch):

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -69,6 +69,11 @@ SIMPLEX_AUTO_ACCEPT=false
 
 After starting the daemon, open a conversation with your agent contact and run `/contacts` in the SimpleX CLI. Copy the numeric `contactId`. A display name shown in the UI may be renamed or collide with another contact, so Hermes deliberately ignores display-name entries in `SIMPLEX_ALLOWED_USERS` and logs a migration warning.
 
+> **Upgrade note:** Older adapter builds accepted display-name entries in
+> `SIMPLEX_ALLOWED_USERS`. They no longer authorize direct messages. Replace
+> every such entry with the numeric `contactId` from `/contacts` before
+> restarting an existing deployment.
+
 ## Authorization
 
 By default **all contacts are denied**. You must either:

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -99,10 +99,11 @@ SIMPLEX_GROUP_ALLOWED=12,34          # specific group IDs
 SIMPLEX_GROUP_ALLOWED=*              # any group the bot is in
 ```
 
-Group messages still pass the sender allowlist. Hermes uses a member's numeric
-`memberContactId` when the group member is also a direct contact. For an
-unlinked member, add that membership's exact opaque `memberId` to
-`SIMPLEX_ALLOWED_USERS`; a display name never authorizes either form.
+An allowed group is the authorization boundary: every member of that group may
+invoke Hermes, even when the member is not listed in `SIMPLEX_ALLOWED_USERS`
+or paired as a direct-message contact. Prefer specific group IDs.
+`SIMPLEX_GROUP_ALLOWED=*` authorizes every member of every group the bot joins.
+Direct-message authorization remains separate and unchanged.
 
 Address groups by prefixing the chat ID with `group:`, e.g.
 `simplex:group:12` as a cron `deliver=` target or in a `hermes send` call.

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -45,6 +45,7 @@ Add these to `~/.hermes/.env`:
 
 ```
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
+SIMPLEX_FILES_FOLDER=/absolute/path/used/by/simplex-chat
 SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
 SIMPLEX_HOME_CHANNEL=<contact-id>
 SIMPLEX_AUTO_ACCEPT=false
@@ -53,6 +54,7 @@ SIMPLEX_AUTO_ACCEPT=false
 | Variable | Required | Description |
 |---|---|---|
 | `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
+| `SIMPLEX_FILES_FOLDER` | Required for inbound files | Exact absolute path passed to `simplex-chat --files-folder`. Keep it on the same filesystem as the daemon's `--temp-folder`; SimpleX completes XFTP downloads with a filesystem rename. |
 | `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated numeric `contactId` allowlist. Display names are mutable labels and are not authorization identities. |
 | `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
 | `SIMPLEX_AUTO_ACCEPT` | Optional | Auto-accept incoming contact requests (default: `true`). Keep this `false` for production identities unless unattended enrollment is intentional. |
@@ -60,7 +62,7 @@ SIMPLEX_AUTO_ACCEPT=false
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact/group ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
-| `platforms.simplex.extra.files_folder` | Optional | Absolute daemon `--files-folder` path used to resolve relative received-file paths |
+| `platforms.simplex.extra.files_folder` | Alternative to `SIMPLEX_FILES_FOLDER` | Absolute daemon `--files-folder` path used to resolve relative received-file paths |
 | `platforms.simplex.extra.file_transfer_timeout` | Optional | Seconds before a stalled inbound transfer is discarded and its caption is delivered without the attachment (default: `300`) |
 | `platforms.simplex.extra.retain_received_files` | Optional | Keep adapter-created inbound transfer files after the turn. Defaults to `false`; unrelated daemon/user files are never removed. |
 | `platforms.simplex.extra.media_cleanup_timeout` | Optional | TTL backstop for adapter-created inbound files and converted outbound previews (default: `3600`, minimum: `60`) |

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -1,6 +1,6 @@
 # SimpleX Chat
 
-[SimpleX Chat](https://simplex.chat/) is a private, decentralised messaging platform where users own their contacts and groups. Unlike other platforms, SimpleX assigns no persistent user IDs — every contact is identified by an opaque internal ID generated at connection time, which makes it one of the most private messengers available.
+[SimpleX Chat](https://simplex.chat/) is a private, decentralised messaging platform where users own their contacts and groups. SimpleX has no global user identifiers; the local daemon assigns each connection an opaque numeric `contactId`. Hermes uses that identity-local, rename-stable ID for authorization.
 
 > Run `hermes gateway setup` and pick **SimpleX** for a guided walk-through.
 
@@ -52,23 +52,25 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | Variable | Required | Description |
 |---|---|---|
 | `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
-| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated allowlist. Each entry can be a numeric `contactId` **or** a display name — both forms work. |
+| `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated numeric `contactId` allowlist. Display names are mutable labels and are not authorization identities. |
 | `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
 | `SIMPLEX_AUTO_ACCEPT` | Optional | Auto-accept incoming contact requests (default: `true`) |
 | `SIMPLEX_GROUP_ALLOWED` | Optional | Comma-separated group IDs the bot participates in, or `*` for any group. Omit to ignore group messages entirely |
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact/group ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
+| `platforms.simplex.extra.files_folder` | Optional | Absolute daemon `--files-folder` path used to resolve relative received-file paths |
+| `platforms.simplex.extra.file_transfer_timeout` | Optional | Seconds before a stalled inbound transfer is discarded and its caption is delivered without the attachment (default: `300`) |
 
-## Find your contact ID or display name
+## Find your contact ID
 
-After starting the daemon, open a conversation with your agent contact. The numeric `contactId` appears in session logs. If you'd rather use the display name shown in the SimpleX UI, that works too — `SIMPLEX_ALLOWED_USERS` accepts either form.
+After starting the daemon, open a conversation with your agent contact and run `/contacts` in the SimpleX CLI. Copy the numeric `contactId`. A display name shown in the UI may be renamed or collide with another contact, so Hermes deliberately ignores display-name entries in `SIMPLEX_ALLOWED_USERS` and logs a migration warning.
 
 ## Authorization
 
 By default **all contacts are denied**. You must either:
 
-1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of `contactId`s and/or display names (e.g. `SIMPLEX_ALLOWED_USERS=4,alice` matches either contactId 4 or the contact whose display name is "alice"), or
+1. Set `SIMPLEX_ALLOWED_USERS` to a comma-separated list of numeric `contactId`s (for example, `SIMPLEX_ALLOWED_USERS=4,7`), or
 2. Use **DM pairing** — send any message to the bot and it will reply with a pairing code. Enter that code via `hermes pairing approve simplex <CODE>`.
 
 ## Group chats
@@ -91,7 +93,7 @@ SimpleX works as a standalone send target — the daemon must be running,
 but a live gateway is not required for plain text:
 
 ```bash
-hermes send --to simplex:alice "hello"          # DM by contact display name
+hermes send --to simplex:4 "hello"              # DM by numeric contactId
 hermes send --to simplex:group:12 "hello"       # group by numeric ID
 hermes send --to simplex "hello"                # SIMPLEX_HOME_CHANNEL
 ```
@@ -106,10 +108,12 @@ hint — direct targets like the ones above work regardless.
 
 The adapter supports native SimpleX attachments in both directions:
 
-- **Inbound** — incoming images, voice notes, and files are accepted via
+- **Inbound** — attachments from authorized senders are accepted via
   the daemon's XFTP flow (`rcvFileDescrReady` → `/freceive` → wait for
   `rcvFileComplete`) and surfaced as `MessageEvent.media_urls` with the
-  appropriate `MessageType` (`PHOTO`, `VOICE`, `TEXT` + document).
+  appropriate `MessageType` (`PHOTO`, `VOICE`, or `DOCUMENT`). Unknown senders
+  cannot trigger a download. Cancelled, failed, or timed-out transfers release
+  their state and preserve any text caption without presenting a missing file.
 - **Outbound** — `send_image_file`, `send_voice`, `send_document`, and
   `send_video` all use the structured `/_send` form with `filePath`, so
   the receiving SimpleX client renders images inline and plays voice

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -47,6 +47,7 @@ Add these to `~/.hermes/.env`:
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
 SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
 SIMPLEX_HOME_CHANNEL=<contact-id>
+SIMPLEX_AUTO_ACCEPT=false
 ```
 
 | Variable | Required | Description |
@@ -54,13 +55,15 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | `SIMPLEX_WS_URL` | Yes | WebSocket URL of the simplex-chat daemon |
 | `SIMPLEX_ALLOWED_USERS` | Recommended | Comma-separated numeric `contactId` allowlist. Display names are mutable labels and are not authorization identities. |
 | `SIMPLEX_ALLOW_ALL_USERS` | Optional | Set `true` to allow every contact (use carefully) |
-| `SIMPLEX_AUTO_ACCEPT` | Optional | Auto-accept incoming contact requests (default: `true`) |
+| `SIMPLEX_AUTO_ACCEPT` | Optional | Auto-accept incoming contact requests (default: `true`). Keep this `false` for production identities unless unattended enrollment is intentional. |
 | `SIMPLEX_GROUP_ALLOWED` | Optional | Comma-separated group IDs the bot participates in, or `*` for any group. Omit to ignore group messages entirely |
 | `SIMPLEX_HOME_CHANNEL` | Optional | Default contact/group ID for cron job delivery |
 | `SIMPLEX_HOME_CHANNEL_NAME` | Optional | Human label for the home channel |
 | `HERMES_SIMPLEX_TEXT_BATCH_DELAY` | Optional | Quiet-period seconds (default: `0.8`) used to concatenate rapid-fire inbound text messages into one event |
 | `platforms.simplex.extra.files_folder` | Optional | Absolute daemon `--files-folder` path used to resolve relative received-file paths |
 | `platforms.simplex.extra.file_transfer_timeout` | Optional | Seconds before a stalled inbound transfer is discarded and its caption is delivered without the attachment (default: `300`) |
+| `platforms.simplex.extra.retain_received_files` | Optional | Keep adapter-created inbound transfer files after the turn. Defaults to `false`; unrelated daemon/user files are never removed. |
+| `platforms.simplex.extra.media_cleanup_timeout` | Optional | TTL backstop for adapter-created inbound files and converted outbound previews (default: `3600`, minimum: `60`) |
 
 ## Find your contact ID
 
@@ -83,6 +86,11 @@ SIMPLEX_GROUP_ALLOWED=12,34          # specific group IDs
 # or
 SIMPLEX_GROUP_ALLOWED=*              # any group the bot is in
 ```
+
+Group messages still pass the sender allowlist. Hermes uses a member's numeric
+`memberContactId` when the group member is also a direct contact. For an
+unlinked member, add that membership's exact opaque `memberId` to
+`SIMPLEX_ALLOWED_USERS`; a display name never authorizes either form.
 
 Address groups by prefixing the chat ID with `group:`, e.g.
 `simplex:group:12` as a cron `deliver=` target or in a `hermes send` call.
@@ -114,6 +122,10 @@ The adapter supports native SimpleX attachments in both directions:
   appropriate `MessageType` (`PHOTO`, `VOICE`, or `DOCUMENT`). Unknown senders
   cannot trigger a download. Cancelled, failed, or timed-out transfers release
   their state and preserve any text caption without presenting a missing file.
+  A caption-less failure becomes an explicit attachment-unavailable notice.
+  By default Hermes deletes only the unique receive path it created after the
+  consuming turn, with a TTL backstop for dropped/abandoned turns. Set
+  `retain_received_files: true` only when persistent local copies are wanted.
 - **Outbound** — `send_image_file`, `send_voice`, `send_document`, and
   `send_video` all use the structured `/_send` form with `filePath`, so
   the receiving SimpleX client renders images inline and plays voice
@@ -145,6 +157,7 @@ hermes send simplex:<contact-id> "Done!"
 - SimpleX never reveals phone numbers or email addresses — contacts use opaque IDs
 - The connection between Hermes and the daemon is local WebSocket (`ws://127.0.0.1:5225`) — no data leaves your machine
 - Messages are end-to-end encrypted by the SimpleX protocol before reaching the daemon
+- For a long-lived production identity, disable automatic contact acceptance and approve new contacts deliberately
 
 ## Troubleshooting
 

--- a/website/docs/user-guide/messaging/simplex.md
+++ b/website/docs/user-guide/messaging/simplex.md
@@ -24,10 +24,15 @@ The SimpleX Chat project does not publish a prebuilt Docker image for the chat c
 ## Start the daemon
 
 ```bash
-simplex-chat -p 5225
+install -d -m 0700 /absolute/path/simplex/files /absolute/path/simplex/temp
+simplex-chat -p 5225 \
+  --files-folder /absolute/path/simplex/files \
+  --temp-folder /absolute/path/simplex/temp
 ```
 
-The daemon listens on WebSocket at `ws://127.0.0.1:5225` by default.
+The daemon listens on WebSocket at `ws://127.0.0.1:5225` by default. Keep the
+files and temporary folders on the same filesystem: SimpleX completes an XFTP
+download with a filesystem rename.
 
 ## Configure Hermes
 
@@ -45,7 +50,7 @@ Add these to `~/.hermes/.env`:
 
 ```
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
-SIMPLEX_FILES_FOLDER=/absolute/path/used/by/simplex-chat
+SIMPLEX_FILES_FOLDER=/absolute/path/simplex/files
 SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
 SIMPLEX_HOME_CHANNEL=<contact-id>
 SIMPLEX_AUTO_ACCEPT=false

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/simplex.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/simplex.md
@@ -22,10 +22,13 @@ SimpleX Chat 项目未发布聊天客户端的预构建 Docker 镜像；如需�
 ## 启动守护进程
 
 ```bash
-simplex-chat -p 5225
+install -d -m 0700 /absolute/path/simplex/files /absolute/path/simplex/temp
+simplex-chat -p 5225 \
+  --files-folder /absolute/path/simplex/files \
+  --temp-folder /absolute/path/simplex/temp
 ```
 
-守护进程默认在 `ws://127.0.0.1:5225` 上监听 WebSocket 连接。
+守护进程默认在 `ws://127.0.0.1:5225` 上监听 WebSocket 连接。文件目录和临时目录必须位于同一文件系统，因为 SimpleX 使用文件系统重命名来完成 XFTP 下载。
 
 ## 配置 Hermes
 
@@ -43,9 +46,10 @@ hermes gateway setup
 
 ```
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
-SIMPLEX_FILES_FOLDER=/simplex-chat/使用的绝对路径
+SIMPLEX_FILES_FOLDER=/absolute/path/simplex/files
 SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
 SIMPLEX_HOME_CHANNEL=<contact-id>
+SIMPLEX_AUTO_ACCEPT=false
 ```
 
 | 变量 | 是否必填 | 说明 |
@@ -54,6 +58,7 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | `SIMPLEX_FILES_FOLDER` | 接收入站文件时必填 | 传给 `simplex-chat --files-folder` 的同一绝对路径；应与守护进程的 `--temp-folder` 位于同一文件系统。 |
 | `SIMPLEX_ALLOWED_USERS` | 建议填写 | 允许使用 Agent 的联系人 ID，以逗号分隔 |
 | `SIMPLEX_ALLOW_ALL_USERS` | 可选 | 设为 `true` 以允许所有联系人（请谨慎使用） |
+| `SIMPLEX_AUTO_ACCEPT` | 可选 | 自动接受联系人请求（默认：`true`）；生产身份应保持为 `false`，除非明确需要无人值守注册。 |
 | `SIMPLEX_HOME_CHANNEL` | 可选 | cron 任务投递的默认联系人 ID |
 | `SIMPLEX_HOME_CHANNEL_NAME` | 可选 | 主频道的可读标签 |
 

--- a/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/simplex.md
+++ b/website/i18n/zh-Hans/docusaurus-plugin-content-docs/current/user-guide/messaging/simplex.md
@@ -43,6 +43,7 @@ hermes gateway setup
 
 ```
 SIMPLEX_WS_URL=ws://127.0.0.1:5225
+SIMPLEX_FILES_FOLDER=/simplex-chat/使用的绝对路径
 SIMPLEX_ALLOWED_USERS=<contact-id-1>,<contact-id-2>
 SIMPLEX_HOME_CHANNEL=<contact-id>
 ```
@@ -50,6 +51,7 @@ SIMPLEX_HOME_CHANNEL=<contact-id>
 | 变量 | 是否必填 | 说明 |
 |---|---|---|
 | `SIMPLEX_WS_URL` | 是 | simplex-chat 守护进程的 WebSocket URL |
+| `SIMPLEX_FILES_FOLDER` | 接收入站文件时必填 | 传给 `simplex-chat --files-folder` 的同一绝对路径；应与守护进程的 `--temp-folder` 位于同一文件系统。 |
 | `SIMPLEX_ALLOWED_USERS` | 建议填写 | 允许使用 Agent 的联系人 ID，以逗号分隔 |
 | `SIMPLEX_ALLOW_ALL_USERS` | 可选 | 设为 `true` 以允许所有联系人（请谨慎使用） |
 | `SIMPLEX_HOME_CHANNEL` | 可选 | cron 任务投递的默认联系人 ID |


### PR DESCRIPTION
## What does this PR do?

This makes the bundled SimpleX adapter delivery-safe and completes its supported messaging lifecycle without changing the existing process boundary:

```text
Hermes -> loopback WebSocket -> simplex-chat daemon -> SMP/XFTP relays
```

The previous adapter treated WebSocket writes as successful delivery, used mutable display names as direct addresses, handled the wrong contact-request event/command, could silently lose oversized replies, and had incomplete streaming, media, reaction, diagnostic, and reconnect behavior.

## Related Issue

Relates to #98949.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add a bounded, correlation-ID command path that validates expected SimpleX response types and item counts. Timeouts, disconnects, `chatCmdError`, partial results, and exhausted retries now fail explicitly.
- Wait for the real WebSocket listener before reporting readiness; fail and clean pending commands/transfers on disconnect or shutdown; reconnect with bounded backoff.
- Handle `receivedContactRequest` with `/_accept <contactReqId>` while preserving Hermes pairing. Contact acceptance does not authorize Hermes access.
- Address DMs by numeric `contactId`; use stable namespaced IDs for group members; retain display names only as labels.
- Preserve item IDs, per-sender batching, replies, edits, deletion, normalized event wrappers, and edit supersession.
- Split oversized text by encoded UTF-8/JSON budget, preserve order and code fences, return every accepted item ID, and support live-message open/edit/finalize with overflow continuations.
- Complete standalone and gateway media handling, XFTP acceptance/completion, daemon-visible file roots, traversal/symlink rejection, bounded transfer state, conversions, thumbnails, and cleanup.
- Add generic reaction events and bind DM reaction approvals to the existing approval resolver, authenticated contact, exact prompt item, expiry, and typed fallback.
- Add redacted runtime diagnostics for listener state, activity, pending commands/transfers, reconnects, and terminal errors.
- Document the loopback WebSocket and `SIMPLEX_FILES_FOLDER` contracts.

No new runtime dependency or SimpleX identity database migration is introduced. Existing identities and messages are not rewritten.

This consolidates and preserves authorship from focused SimpleX fixes in #26480, #27628, #35558, and the edit-supersession work in #97317. I also reviewed the other open SimpleX PRs before submission; this PR supplies the integrated lifecycle and end-to-end test surface rather than silently duplicating them.

## How to Test

1. Install the repository's locked CI extras, then run the canonical suite: `scripts/run_tests.sh`.
2. Run the focused adapter suite: `uv run pytest -q tests/gateway/test_simplex_plugin.py`.
3. Run affected gateway coverage: `uv run pytest -q tests/gateway/test_edit_supersede.py tests/gateway/test_session_race_guard.py tests/gateway/test_unauthorized_dm_behavior.py`.
4. Run Ruff over the changed Python files and `git diff --check upstream/main...HEAD`.
5. With disposable SimpleX identities, exercise contact acceptance + Hermes pairing, text, streaming, Unicode long-message reconstruction, reaction approval, media, daemon outage/reconnect, gateway restart, and preserved state.

Current-upstream results on Linux x86_64, Python 3.11:

```text
tests/gateway/test_simplex_plugin.py: 71 passed
affected gateway files: 46 passed
Ruff: passed
git diff --check: passed
canonical repository suite: 42,895 passed, 20 failed, 389 skipped
```

All SimpleX tests passed. The 20 full-suite failures are outside the diff and confined to ten files: environment-sensitive AF_UNIX path length, locally available credential/provider state, model picker expectations, and updater tests detecting an already-running gateway. They are disclosed here because the PR-template statement that every repository test passes is not true in this local environment.

Disposable two-identity runtime staging additionally proved contact acceptance and pairing; inbound/outbound messaging; reaction approval; streaming finalization; exact 13,000-character Unicode reassembly over four items; standalone outbound media; inbound image completion and cleanup; explicit outage failure; reconnect; gateway restart; and preserved state.

The reviewed pre-rebase implementation received an independent adversarial PASS after its material findings were fixed. The final branch was then cleanly replayed without conflicts onto current upstream `375ce8eee51b9d76714cb6fd1f200c4c9ef83c4a` and the focused/current repository gates above were rerun.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — canonical suite ran; 20 unrelated/environment failures are disclosed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux x86_64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; plugin configuration remains environment-based
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; the existing adapter architecture is retained
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — filesystem validation uses `pathlib`; WebSocket and command behavior remain platform-neutral
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable. This is a headless messaging adapter; test and runtime evidence is summarized above. `ws://` remains appropriate only on loopback. Remote daemon access requires a separately authenticated transport. Unknown direct contacts remain pairing-gated, and groups remain allowlist-gated.
