### PR TITLE
fix(tts): send consent_attestation for OpenAI-compatible cloned voices (#99775)

### DIFF
--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1914,8 +1914,18 @@ def _generate_openai_tts(
             create_kwargs["speed"] = max(0.25, min(4.0, speed))
         if instructions:
             create_kwargs["instructions"] = instructions
+        # Build extra_body for OpenAI-compatible servers that need extra fields.
+        # `lang_code` is Hermes's own extension, `consent_attestation` is
+        # required by some self-hosted cloned-voice servers (e.g. Qwen3-TTS)
+        # that reject 400 consent_required when it is missing (#99775).
+        extra_body: Dict[str, Any] = {}
         if language:
-            create_kwargs["extra_body"] = {"lang_code": language}
+            extra_body["lang_code"] = language
+        consent_attestation = oai_config.get("consent_attestation")
+        if isinstance(consent_attestation, str) and consent_attestation.strip():
+            extra_body["consent_attestation"] = consent_attestation.strip()
+        if extra_body:
+            create_kwargs["extra_body"] = extra_body
         response = client.audio.speech.create(**create_kwargs)
 
         response.stream_to_file(output_path)


### PR DESCRIPTION
Fixes #99775

**Problem:** OpenAI-compatible TTS servers with cloned voices return 400 consent_required when `consent_attestation` is missing. Hermes never sent this field, so requests fell back to Edge TTS even with a valid local endpoint.

**Root cause:** `_generate_openai_tts` only populated `extra_body.lang_code` and ignored the cloned-voice consent field. Workaround required manual patching of `create_kwargs`.

**Fix:** Read `tts.openai.consent_attestation` from config and merge it into `extra_body` alongside `lang_code`. When set (e.g. `"I have the speaker's consent"`), it is forwarded to `audio.speech.create` so Qwen3-TTS and similar servers accept the request.

Test: syntax/compile check + `test_tts_registry` (25 passed).