### PR TITLE
fix(agent): honor explicit stale_timeout_seconds over reasoning floor in streaming path (#99707)

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -847,7 +847,7 @@ def _derive_stream_stale_timeout(agent, api_kwargs: dict) -> float:
     _reasoning_floor = get_reasoning_stale_timeout_floor(_model_id)
     if _reasoning_floor is None and api_kwargs.get("modelId"):
         _reasoning_floor = _bedrock_reasoning_stale_floor(api_kwargs["modelId"])
-    if _reasoning_floor is not None:
+    if _reasoning_floor is not None and _cfg_stale is None:
         _timeout = max(_timeout, _reasoning_floor)
     return _timeout
 
@@ -5311,11 +5311,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         # xAI Grok reasoning, etc.) routinely exceed the default 180s chat-
         # model threshold during their thinking phase.  The cloud gateway
         # upstream kills the socket first, surfacing as BrokenPipeError.
-        # Raises the floor only — never overrides explicit user config
-        # (handled by get_provider_stale_timeout above).
+        # Apply the floor only when the user has NOT set an explicit
+        # per-model stale_timeout_seconds (#99707) — explicit config
+        # must take precedence over the heuristic floor.
         from agent.reasoning_timeouts import get_reasoning_stale_timeout_floor
         _reasoning_floor = get_reasoning_stale_timeout_floor(api_kwargs.get("model"))
-        if _reasoning_floor is not None:
+        if _reasoning_floor is not None and _cfg_stale is None:
             _stream_stale_timeout = max(_stream_stale_timeout, _reasoning_floor)
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)


### PR DESCRIPTION
Fixes #99707

**Problem:** An explicit per-model `stale_timeout_seconds: 120` was ignored in the streaming path — the wait notice and detector still used 600s, so failover to the fallback model happened 8 minutes late.

**Root cause:** The streaming stale derivation computed `_cfg_stale=120` then did `max(_timeout, _reasoning_floor)` where `_reasoning_floor=600` for Nemotron 3 Ultra, unconditionally raising it back. The floor is intended as a default, not an override for explicit config.

**Fix:** Guard both floor applications (`_derive_stream_stale_timeout` for Bedrock and the main `chat_completion_helpers` streaming watchdog) with `_cfg_stale is None` so the reasoning floor only applies when the user has not set an explicit per-model timeout.

Test: py_compile + `pytest -k reasoning_stale` (46 passed, 5 skipped).