### PR TITLE
fix(web): buffer private-mode and multi-param CSI in PTY resume sanitizer

### DIFF
--- a/web/src/lib/pty-resume-sanitizer.test.ts
+++ b/web/src/lib/pty-resume-sanitizer.test.ts
@@ -108,6 +108,57 @@ describe("PtyResumeSanitizer — stateful frame handling", () => {
     expect(s.next("2Ky")).toBe("y");
   });
 
+  it("buffers a private-mode CSI split across frames (DECRST ends in 'l')", () => {
+    // Regression: PARTIAL_ESC used to match only \d*, so "\x1b[?25" was not
+    // recognised as incomplete. It was emitted, leaving xterm mid-escape, and
+    // the terminating "l" arrived alone as literal text — the stray "l"
+    // characters seen next to the cursor during session resume.
+    const s = new PtyResumeSanitizer();
+    expect(s.next("x\x1b[?25")).toBe("x");
+    expect(s.next("ly")).toBe("\x1b[?25ly");
+  });
+
+  it("never emits a frame ending mid-escape, at any split point", () => {
+    // The invariant that matters is per-emission, not concatenated: xterm
+    // receives each returned string as its own write(). A piece ending in an
+    // unterminated CSI leaves the parser in an "in-escape" state (see the
+    // flush() docstring), which strands the sequence's final byte. Asserting
+    // on the joined output would hide this — the bytes do reassemble there.
+    const endsMidEscape = (piece: string): boolean => {
+      const esc = piece.lastIndexOf("\x1b");
+      if (esc === -1) return false;
+      // Complete iff a CSI final byte (0x40-0x7e) appears after the params.
+      // eslint-disable-next-line no-control-regex -- intentional ESC byte in ANSI sequence parser
+      return !/^\x1b\[[\x30-\x3f]*[\x20-\x2f]*[\x40-\x7e]/.test(piece.slice(esc));
+    };
+
+    const seq = "\x1b[?25l";
+    for (let cut = 1; cut < seq.length; cut++) {
+      const s = new PtyResumeSanitizer();
+      const pieces = [s.next("A" + seq.slice(0, cut)), s.next(seq.slice(cut) + "B")];
+      for (const piece of pieces) {
+        expect(endsMidEscape(piece), `cut=${cut} piece=${JSON.stringify(piece)}`).toBe(false);
+      }
+      expect(pieces.join("") + s.flush()).toBe("A" + seq + "B");
+    }
+  });
+
+  it("buffers multi-parameter and intermediate-byte CSI tails", () => {
+    const s = new PtyResumeSanitizer();
+    expect(s.next("a\x1b[38;5")).toBe("a");
+    expect(s.next(";9mb")).toBe("\x1b[38;5;9mb");
+
+    const t = new PtyResumeSanitizer();
+    expect(t.next("c\x1b[1;2")).toBe("c");
+    expect(t.next("Hd")).toBe("\x1b[1;2Hd");
+  });
+
+  it("still collapses a split erase code (numeric path unchanged)", () => {
+    const s = new PtyResumeSanitizer();
+    expect(s.next("p\x1b[2")).toBe("p");
+    expect(s.next("Kq")).toBe("q");
+  });
+
   it("passes through when no partial escape is buffered", () => {
     const s = new PtyResumeSanitizer();
     expect(s.next("chunk1 ")).toBe("chunk1 ");

--- a/web/src/lib/pty-resume-sanitizer.ts
+++ b/web/src/lib/pty-resume-sanitizer.ts
@@ -30,9 +30,26 @@ const ERASE_LINE = /\x1b\[\d*K/g;
 // eslint-disable-next-line no-control-regex -- intentional ESC byte in ANSI sequence parser
 const ERASE_CHAR = /\x1b\[\d*X/g;
 
-/** Still-incomplete trailing escape: "\x1b", "\x1b[", "\x1b[\d*". */
+/**
+ * Still-incomplete trailing escape: "\x1b", "\x1b[", or "\x1b[" followed by any
+ * run of CSI parameter and intermediate bytes.
+ *
+ * Per ECMA-48 a CSI sequence is `ESC [` , parameter bytes `0x30-0x3f`
+ * (digits plus `:;<=>?`), intermediate bytes `0x20-0x2f`, then a final byte
+ * `0x40-0x7e`. Only the final byte terminates it, so anything short of one is
+ * still incomplete and must be held back.
+ *
+ * Matching only `\d*` missed every private-mode sequence (`ESC[?25l`,
+ * `ESC[?2004l`, `ESC[?1049l`) and every multi-parameter one (`ESC[1;2H`,
+ * `ESC[38;5;9m`), because `?` and `;` are not digits. Those fragments were
+ * emitted instead of buffered, which is precisely what `flush()` documents as
+ * unsafe: it leaves xterm's parser mid-escape, swallowing subsequent output,
+ * and strands the sequence's final byte as literal text. Since DECRST
+ * sequences all end in `l`, the visible symptom was stray `l` characters
+ * during resume replay.
+ */
 // eslint-disable-next-line no-control-regex -- intentional ESC byte in ANSI sequence parser
-const PARTIAL_ESC = /^\x1b(?:\[\d*)?$/;
+const PARTIAL_ESC = /^\x1b(?:\[[\x30-\x3f]*[\x20-\x2f]*)?$/;
 
 /**
  * A trailing run of newlines that may continue into the next frame. Held back


### PR DESCRIPTION
## What does this PR do?

`PtyResumeSanitizer` buffers an escape sequence that straddles a WebSocket frame
boundary -- its own header explains why this is required:

> **Reads are chunked, not message-framed.** `bridge.read()` does `os.read(fd, 65536)`
> per drain tick and `pty_session.py` forwards each read as its own binary WebSocket
> frame. A CSI escape ... can straddle a frame boundary, so all three need
> trailing-state buffering to survive reassembly.

But the detector matched only *numeric* CSI parameters:

```ts
const PARTIAL_ESC = /^\x1b(?:\[\d*)?$/;
```

`\d*` misses every private-mode tail (`ESC[?25`, `ESC[?2004`, `ESC[?1049`) and every
multi-parameter one (`ESC[38;5`, `ESC[1;2`), because `?` and `;` are not digits. Those
fragments get emitted instead of held back -- which is exactly what the `flush()`
docstring in the same file identifies as unsafe:

> emitting one would leave xterm's parser in an "in-escape" state that swallows
> subsequent output after reconnect

**Every DECRST sequence ends in `l`** (`ESC[?25l` hide-cursor is emitted constantly by
spinners), so the user-visible symptom is a session resume that stalls partway through
with stray `l` characters next to the cursor -- one, or several, depending on how many
frame boundaries happened to fall inside a hide-cursor sequence during replay.

The fix widens the matcher to the actual ECMA-48 CSI grammar: parameter bytes
`0x30-0x3f` (digits plus `:;<=>?`), intermediate bytes `0x20-0x2f`, terminated only by
a final byte `0x40-0x7e`.

This is the same class of defect as b8ceba97 ("make PTY resume sanitizer work against
real PTY output"): a regex in this file that reads correctly in isolation but does not
match what a real terminal actually emits.

Nothing is corrupted on disk -- I checked `state.db` on an affected install and there
are no ESC bytes in any stored message. It is purely a render-time artifact.

## Related Issue

No existing issue. Searched before opening, per the Contributing Guide:

```
gh search prs    --repo NousResearch/hermes-agent --state all "pty-resume-sanitizer"
gh search prs    --repo NousResearch/hermes-agent --state all "PARTIAL_ESC"
gh search issues --repo NousResearch/hermes-agent "DECRST" / "25l" / "private mode escape resume"
```

`PARTIAL_ESC` returns only #47772 (the closed original, salvaged into #74137). The file
has two commits total -- 88e67508 and b8ceba97, both July -- and no open PR touches it.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/lib/pty-resume-sanitizer.ts` -- widen `PARTIAL_ESC` to the ECMA-48 CSI
  grammar; expand the comment to record why `\d*` was insufficient and what the
  visible symptom was.
- `web/src/lib/pty-resume-sanitizer.test.ts` -- four regression tests.

## How to Test

1. `cd web && npx vitest run src/lib/pty-resume-sanitizer.test.ts` -> 33 passed.
2. Revert `PARTIAL_ESC` to `/^\x1b(?:\[\d*)?$/` and re-run -> **3 of the 4 new tests
   fail**, confirming they cover the defect rather than restating current behaviour:
   - `buffers a private-mode CSI split across frames (DECRST ends in 'l')`
   - `never emits a frame ending mid-escape, at any split point`
   - `buffers multi-parameter and intermediate-byte CSI tails`
3. Manually: open a session with spinner output in the dashboard chat and reload it a
   few times. Before: replay intermittently stalls with stray `l` at the cursor.
   After: clean.

A note on the fourth test. My first version asserted on the *concatenated* output
across frames and passed against the buggy regex -- the bytes do reassemble there even
when emitted broken, so it proved nothing. It now asserts the invariant that actually
matters: xterm receives each returned string as its own `write()`, so no individual
emission may end mid-escape.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` -- **not run: this change is TypeScript-only and
      touches no Python.** I ran the suite that covers it instead: `vitest`
      (33 passed), `npm run typecheck` (clean), and `eslint` on both changed files
      (clean).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 24.04, aarch64 (NVIDIA GB10)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings) -- the `PARTIAL_ESC` comment now
      records the grammar and the failure mode
- [x] `cli-config.yaml.example` -- N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` -- N/A
- [x] Cross-platform impact -- none; the sequences involved are emitted by any
      VT-capable child process on every platform, and the change only widens what is
      buffered
- [x] Tool descriptions/schemas -- N/A

## Screenshots / Logs

Old regex vs. fixed, against real trailing fragments (ESC written out):

```
tail                shipped  fixed
ESC                 true     true
ESC[                true     true
ESC[2               true     true
ESC[?               false    true
ESC[?25             false    true
ESC[?1049           false    true
ESC[1;2             false    true
ESC[38;5            false    true
```

Sequences the shipped regex fails to buffer, and their final byte:

```
ESC[?25l    -> "l"    hide cursor
ESC[?2004l  -> "l"    bracketed paste off
ESC[?1049l  -> "l"    leave alt screen
ESC[?7l     -> "l"    autowrap off
```
