### PR TITLE
fix(desktop): don't replay finished todo snapshot when idle-restoring…

### DIFF
--- a/apps/desktop/src/store/todos.test.ts
+++ b/apps/desktop/src/store/todos.test.ts
@@ -135,6 +135,25 @@ describe('revisioned snapshots', () => {
     expect($todosBySession.get().s1?.[0]?.id).toBe('active')
   })
 
+  it('does not replay a finished snapshot when idle-restoring a session (no flash on reopen)', () => {
+    const snapshot = { revision: 3, todos: [todo('a', 'completed'), todo('b', 'cancelled')] }
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, false)
+
+    expect($todosBySession.get().s1).toBeUndefined()
+
+    vi.advanceTimersByTime(10_000)
+    expect($todosBySession.get().s1).toBeUndefined()
+  })
+
+  it('restores a finished snapshot when the session is reported running', () => {
+    const snapshot = { revision: 3, todos: [todo('a', 'completed'), todo('b', 'cancelled')] }
+
+    restoreSessionTodosFromSnapshot('s1', snapshot, true)
+
+    expect($todosBySession.get().s1).toHaveLength(2)
+  })
+
   it('applies an unversioned update after a revisioned snapshot (tool.start merge)', () => {
     setSessionTodos('s1', [todo('a', 'pending'), todo('b', 'pending')], 5)
     setSessionTodos('s1', [todo('a', 'completed'), todo('b', 'pending')])

--- a/apps/desktop/src/store/todos.ts
+++ b/apps/desktop/src/store/todos.ts
@@ -147,9 +147,19 @@ export function clearActiveSessionTodos(sid: string) {
   dropSessionTodos(sid, false)
 }
 
-/** Apply a session.resume/activate or todo.updated full snapshot. Idle
- * sessions keep the existing stale-active guard; running sessions restore the
- * active plan because the backend has proved that turn is still live. */
+/** Apply a session.resume/activate or todo.updated full snapshot.
+ *
+ * `running` reflects whether the backend reports this turn as still live —
+ * not whether the list itself looks finished. A snapshot restored while idle
+ * is always historical presentation state (the thread's last known plan, not
+ * something that just happened), so it must never be published: doing so
+ * would start the finished-list linger timer from the moment the thread was
+ * *opened* rather than from when the work actually completed, replaying an
+ * old completed plan as if it had just finished. Only a running session
+ * restores its snapshot, because the backend has proved that turn is still
+ * live. The linger for a genuinely fresh completion is preserved separately,
+ * via live `todo.updated` events and post-turn hydration (see
+ * `todosForHydration`), neither of which goes through this function. */
 export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, running: boolean) {
   const todos = parseTodos(snapshot)
 
@@ -166,10 +176,8 @@ export function restoreSessionTodosFromSnapshot(sid: string, snapshot: unknown, 
     return
   }
 
-  const visible = running ? todos : todosForHydration(todos)
-
-  if (visible !== null) {
-    setSessionTodos(sid, visible, revision)
+  if (running) {
+    setSessionTodos(sid, todos, revision)
   } else if (acceptRevision(sid, revision)) {
     dropSessionTodos(sid, false)
   }


### PR DESCRIPTION
… a session

Idle session.resume/activate hydration was restoring a finished todo snapshot and starting the 4s finished-list linger from the moment the thread was opened, replaying old completed work as if it just finished. Only running sessions now restore their snapshot; the live completion linger is unaffected (it flows through todo.updated / post-turn hydration, not this path).

Fixes #100652

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

