### PR TITLE
fix(cli): skip stale MEMORY.md/USER.md report when an external memory…

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1233,6 +1233,28 @@ def check_macos_full_disk_access() -> None:
     )
 
 
+def _read_configured_memory_provider(hermes_home: Path) -> str:
+    """Return the configured ``memory.provider`` value, or "" for the
+    built-in (file-based MEMORY.md/USER.md) store. Best-effort: any read or
+    parse failure is swallowed and treated as "no external provider
+    configured" -- callers only use this to decide whether the built-in
+    memory files are the canonical store, never to gate a hard failure."""
+    try:
+        from hermes_cli.config import read_user_config_raw
+        cfg_path = hermes_home / "config.yaml"
+        if not cfg_path.exists():
+            return ""
+        raw_cfg = read_user_config_raw(cfg_path)
+        try:
+            from hermes_cli import managed_scope
+            raw_cfg = managed_scope.apply_managed_overlay(raw_cfg)
+        except Exception:
+            pass
+        return (raw_cfg.get("memory") or {}).get("provider", "")
+    except Exception:
+        return ""
+
+
 def run_doctor(args):
     """Run diagnostic checks."""
     should_fix = getattr(args, 'fix', False)
@@ -2020,18 +2042,33 @@ def run_doctor(args):
     memories_dir = hermes_home / "memories"
     if memories_dir.exists():
         check_ok(f"{_DHH}/memories/ directory exists")
-        memory_file = memories_dir / "MEMORY.md"
-        user_file = memories_dir / "USER.md"
-        if memory_file.exists():
-            size = len(memory_file.read_text(encoding="utf-8").strip())
-            check_ok(f"MEMORY.md exists ({size} chars)")
+
+        # MEMORY.md/USER.md are only the canonical memory store for the
+        # built-in provider. When an external provider (Honcho, Mem0, or a
+        # third-party plugin) is configured, these files may be absent,
+        # stale leftovers from before migration, or a provider-specific
+        # mirror -- reporting on them unqualified misleadingly implies
+        # they're what's actually in use. The Memory Provider section below
+        # reports on whichever provider is actually active.
+        _dir_memory_provider = _read_configured_memory_provider(hermes_home)
+        if _dir_memory_provider:
+            check_info(
+                f"MEMORY.md/USER.md check skipped -- '{_dir_memory_provider}' is the active memory "
+                "provider, not the built-in store (see Memory Provider section below)"
+            )
         else:
-            check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
-        if user_file.exists():
-            size = len(user_file.read_text(encoding="utf-8").strip())
-            check_ok(f"USER.md exists ({size} chars)")
-        else:
-            check_info("USER.md not created yet (will be created when the agent first writes a memory)")
+            memory_file = memories_dir / "MEMORY.md"
+            user_file = memories_dir / "USER.md"
+            if memory_file.exists():
+                size = len(memory_file.read_text(encoding="utf-8").strip())
+                check_ok(f"MEMORY.md exists ({size} chars)")
+            else:
+                check_info("MEMORY.md not created yet (will be created when the agent first writes a memory)")
+            if user_file.exists():
+                size = len(user_file.read_text(encoding="utf-8").strip())
+                check_ok(f"USER.md exists ({size} chars)")
+            else:
+                check_info("USER.md not created yet (will be created when the agent first writes a memory)")
     else:
         check_warn(f"{_DHH}/memories/ not found", "(will be created on first use)")
         if should_fix:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -341,6 +341,97 @@ class TestDoctorMemoryProviderSection:
         assert "Built-in memory active" not in out
 
 
+# ── Directory Structure memory-file check (#100668) ──
+#
+# hermes doctor's "Directory Structure" section unconditionally reported
+# memories/MEMORY.md and memories/USER.md as the canonical memory store, even
+# when an external memory.provider was configured. When migrating to a
+# provider such as Honcho, Mem0, or a third-party plugin, those files may be
+# absent, stale leftovers, or a provider-specific mirror -- reporting on them
+# unqualified misled users about which store is actually in use. The check
+# must now be skipped (in favor of the Memory Provider section, which already
+# reports on whichever provider is active) whenever an external provider is
+# configured.
+
+
+def _run_doctor_with_memory_files(monkeypatch, tmp_path, *, provider, memory_files):
+    """Set up a HERMES_HOME with config.yaml + memories/*.md and run doctor,
+    returning captured stdout. `memory_files` maps filename -> content."""
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+
+    import yaml
+    (home / "config.yaml").write_text(yaml.dump({"memory": {"provider": provider}} if provider else {"memory": {}}))
+
+    memories_dir = home / "memories"
+    memories_dir.mkdir(parents=True, exist_ok=True)
+    for name, content in memory_files.items():
+        (memories_dir / name).write_text(content)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", tmp_path / "project")
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    (tmp_path / "project").mkdir(exist_ok=True)
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status_local", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_xai_oauth_auth_status", lambda: {})
+    except Exception:
+        pass
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    return buf.getvalue()
+
+
+def test_read_configured_memory_provider_defaults_to_empty(tmp_path):
+    assert doctor_mod._read_configured_memory_provider(tmp_path) == ""
+
+
+def test_read_configured_memory_provider_reads_config(tmp_path):
+    import yaml
+    (tmp_path / "config.yaml").write_text(yaml.dump({"memory": {"provider": "mnemosyne"}}))
+
+    assert doctor_mod._read_configured_memory_provider(tmp_path) == "mnemosyne"
+
+
+def test_run_doctor_builtin_provider_still_reports_memory_files(monkeypatch, tmp_path):
+    """No memory.provider configured -> unchanged behavior."""
+    out = _run_doctor_with_memory_files(
+        monkeypatch, tmp_path, provider="", memory_files={"MEMORY.md": "x" * 11}
+    )
+
+    assert "MEMORY.md exists (11 chars)" in out
+    assert "USER.md not created yet" in out
+    assert "check skipped" not in out
+
+
+def test_run_doctor_external_provider_skips_stale_memory_file_check(monkeypatch, tmp_path):
+    """#100668: an external/third-party memory provider must not have
+    leftover or mirrored MEMORY.md/USER.md files reported as the canonical
+    store."""
+    out = _run_doctor_with_memory_files(
+        monkeypatch,
+        tmp_path,
+        provider="mnemosyne",
+        memory_files={"MEMORY.md": "x" * 1823, "USER.md": "x" * 1151},
+    )
+
+    assert "MEMORY.md/USER.md check skipped" in out
+    assert "'mnemosyne' is the active memory provider" in out
+    assert "MEMORY.md exists (1823 chars)" not in out
+    assert "USER.md exists (1151 chars)" not in out
+
+
 def test_run_doctor_termux_treats_docker_and_browser_warnings_as_expected(monkeypatch, tmp_path):
     helper = TestDoctorMemoryProviderSection()
     monkeypatch.setenv("TERMUX_VERSION", "0.118.3")


### PR DESCRIPTION
… provider is active

hermes doctor's Directory Structure section unconditionally reported memories/MEMORY.md and memories/USER.md as the canonical memory store, even when an external memory.provider (Honcho, Mem0, or a third-party plugin) was configured. After migrating away from the built-in store, those files may be absent, stale leftovers, or a provider-specific mirror -- reporting on them unqualified misled users about which store is actually in use.

Add _read_configured_memory_provider() and skip the file-existence check whenever an external provider is configured, deferring to the Memory Provider section (which already reports on whichever provider is active) instead.

Fixes #100668

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

