### PR TITLE
feat(governed): trusted one-shot destructive capability + structured QGA (explicit approval)

### DIFF
--- a/docs/destructive-actions/GOVERNED_AUTHORITY_LIFECYCLE.md
+++ b/docs/destructive-actions/GOVERNED_AUTHORITY_LIFECYCLE.md
@@ -1,0 +1,109 @@
+# Governed destructive capability — authority lifecycle
+
+This document describes the authority model used by `governed_mkfs` and the
+one-shot destructive grant implementation.
+
+## Threat model
+
+Model-facing tools may execute code and write files under the same OS account
+as Hermes. File permissions and an unkeyed digest therefore do not establish a
+human/model trust boundary. A valid destructive capability must instead satisfy
+both properties below:
+
+1. issuance follows an explicit, correlated, one-shot human approval; and
+2. the persisted grant is authenticated by authority unavailable to
+   model-facing execution surfaces.
+
+## Human approval receipt
+
+Issuance consumes a process-local `HumanApprovalReceipt` created only after an
+explicit `approve once` decision from the existing approval subsystem. The
+receipt is correlated to the request and session context and is consumed
+atomically when a grant is issued.
+
+Session/permanent approval, smart/auxiliary-LLM approval, yolo, approval mode
+off, cron auto-approval, unattended transports, and serialized receipt replay
+must not mint destructive authority.
+
+## Grant authentication
+
+`GrantAuthorityProvider` defines the authentication boundary. The portable
+baseline is `ProcessEphemeralAuthority`, which authenticates the canonical
+immutable grant payload with HMAC-SHA256 using a random 256-bit process-local
+secret.
+
+The secret is not persisted, placed in the environment, serialized, or passed
+to child execution processes. A child process therefore obtains a different
+authority generation and cannot mint a parent-valid grant. Restarting Hermes
+creates a new generation and intentionally invalidates outstanding grants.
+
+The canonical authenticated payload includes the grant and receipt identities,
+operation tuple, authorization metadata, validity window, nonce, session
+correlation, and the authorized guest incarnation. Clone, TTL extension,
+identifier substitution, authorization-source tamper, or receipt substitution
+therefore fail verification.
+
+The provider interface is also the extension point for an optional TPM/vTPM or
+HSM-backed implementation. Hardware backing is a strengthening layer, not a
+feature prerequisite, and must never expose a generic signing oracle to the
+model.
+
+## Target-generation fencing
+
+A filesystem grant is bound to the observed guest incarnation:
+
+- `vm_id` selects the logical target;
+- `product_uuid` identifies the guest/VM incarnation;
+- `boot_id` identifies the current boot generation;
+- `hostname` is retained as an additional observed identity field.
+
+The identity is captured before issuance and re-read at the mutation boundary.
+A grant for generation A cannot mutate a rebooted or replaced generation B even
+if the logical VM id and device path are reused.
+
+## Claim and settlement
+
+The lifecycle is:
+
+```text
+LIVE
+  |
+  | atomic claim (exactly one winner)
+  v
+CLAIMED(execution_id)
+  |
+  +--> FAILED_PRE_EFFECT
+  |
+  +--> EXECUTION_STARTED
+          |
+          +--> COMPLETED
+          +--> INDETERMINATE
+```
+
+A claim happens before the first irreversible operation. Once execution may
+have started, the capability never returns to the live pool. Lost postcondition
+proof or ambiguous execution outcome settles as `indeterminate`; it is never
+reported as a replayable denial.
+
+## Structured execution edge
+
+`governed_mkfs` keeps raw `mkfs` on the generic terminal hardline. The governed
+path validates the exact grant tuple, generation fence and fail-closed storage
+prechecks, then invokes `qga_create_filesystem` with a fixed argv derived only
+from allowlisted filesystem binaries and validated fields.
+
+The QGA transport is deployment-configured. No host address, SSH key path, or
+permissive host-key policy is compiled into Hermes. The transport refuses to
+operate without explicit control-plane configuration and uses strict SSH
+host-key verification.
+
+## Security invariants
+
+- model surfaces may request authority but cannot approve themselves;
+- a human approval receipt issues at most one grant;
+- a grant is authenticated, short-lived, exact-scope and one-shot;
+- `execute_code` and `write_file` cannot forge a parent-valid grant;
+- stale guest generations are denied before mutation;
+- concurrent replay has exactly one claim winner;
+- uncertain post-effect outcomes are durably `indeterminate`;
+- raw terminal filesystem formatting remains hardline-denied.

--- a/hermes_cli/subcommands/approvals.py
+++ b/hermes_cli/subcommands/approvals.py
@@ -1,8 +1,8 @@
-"""``hermes approvals`` subcommand parser.
+"""Approval-related CLI parser ownership.
 
-Follows the cron/security pattern: parser construction lives here, the
-handler is injected by ``main.py`` so this module never imports ``main``
-(cycle avoidance).
+The ``approvals`` parser lives here rather than in ``hermes_cli.main``.  The
+one-shot destructive ``grant`` command is registered from the same bounded
+authority owner so adding it does not grow the central CLI godfile.
 """
 
 from __future__ import annotations
@@ -11,8 +11,18 @@ import argparse
 from typing import Callable
 
 
+def _cmd_grant(args) -> int:
+    """Dispatch ``hermes grant`` without adding another handler to main.py."""
+    from hermes_cli.subcommands.grant import run_grant_command
+
+    status = run_grant_command(args)
+    if status:
+        raise SystemExit(status)
+    return status
+
+
 def build_approvals_parser(subparsers, *, cmd_approvals: Callable) -> None:
-    """Attach the ``approvals`` subcommand to ``subparsers``."""
+    """Attach approval-related top-level commands to ``subparsers``."""
     approvals_parser = subparsers.add_parser(
         "approvals",
         help="Approval-prompt tools (mine history into allowlist proposals)",
@@ -113,3 +123,9 @@ def build_approvals_parser(subparsers, *, cmd_approvals: Callable) -> None:
     test_parser.set_defaults(func=cmd_approvals)
 
     approvals_parser.set_defaults(func=cmd_approvals)
+
+    # Keep authority-related command registration out of hermes_cli/main.py.
+    # The command itself remains implemented in its own bounded module.
+    from hermes_cli.subcommands.grant import build_grant_parser
+
+    build_grant_parser(subparsers, cmd_grant=_cmd_grant)

--- a/hermes_cli/subcommands/grant.py
+++ b/hermes_cli/subcommands/grant.py
@@ -1,0 +1,151 @@
+"""``hermes grant`` — manage explicitly approved one-shot destructive grants.
+
+Issuance is NOT available from this CLI.  A destructive grant is minted
+exclusively inside the long-lived Hermes process that will consume it: the
+model requests the governed operation, the process captures the live guest
+incarnation, asks the human for an explicit ``approve once`` decision
+through the approval surface, and issues the grant with its own
+process-local authority.  A short-lived CLI process cannot sign a grant the
+running Hermes process would accept (different authority generation), so
+``hermes grant issue`` refuses explicitly and points to the governed tool.
+
+``hermes grant list`` / ``revoke`` / ``audit`` remain available for
+operational visibility.
+
+Example::
+
+    hermes grant list
+    hermes grant revoke <grant_id>
+    hermes grant audit [--limit 200]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Dict
+
+from tools.destructive_grants import GrantError
+
+
+def build_grant_parser(subparsers, *, cmd_grant=None) -> None:
+    parser = subparsers.add_parser(
+        "grant",
+        help="Manage explicitly approved one-shot destructive grants.",
+    )
+    grant_sub = parser.add_subparsers(dest="grant_command")
+
+    issue = grant_sub.add_parser(
+        "issue",
+        help="REFUSED: destructive grants are minted by the running Hermes process, not the CLI.",
+    )
+    issue.add_argument(
+        "--operation",
+        help="Operation, e.g. CREATE_FILESYSTEM.",
+    )
+    issue.add_argument("--vm", dest="vm_id", help="Target VM id.")
+    issue.add_argument("--hostname", help="Expected guest hostname.")
+    issue.add_argument(
+        "--device",
+        help="Exact validated block-device path, e.g. /dev/sdb1.",
+    )
+    issue.add_argument(
+        "--fs",
+        dest="fs_type",
+        help="Filesystem type (ext4|xfs).",
+    )
+    issue.add_argument("--label", help="Filesystem label (1-16 chars).")
+    issue.add_argument(
+        "--subject",
+        help="Human-readable audit subject (not an authority credential).",
+    )
+    issue.add_argument(
+        "--session",
+        dest="session_id",
+        help="Hermes session id bound to the approval and grant.",
+    )
+    issue.add_argument(
+        "--ttl",
+        type=int,
+        default=600,
+        help="Requested lifetime in seconds (default 600, max 3600).",
+    )
+    issue.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+
+    grant_sub.add_parser("list", help="List live grants.")
+    grant_sub.add_parser("audit", help="Show the grant audit trail (no secrets).")
+
+    revoke = grant_sub.add_parser("revoke", help="Revoke a live grant.")
+    revoke.add_argument("grant_id", help="Opaque grant id.")
+
+    if cmd_grant is not None:
+        for sub in (issue, revoke):
+            sub.set_defaults(func=cmd_grant)
+        for name in ("list", "audit"):
+            grant_sub.choices[name].set_defaults(func=cmd_grant)
+
+
+def run_grant_command(args) -> int:
+    from tools.destructive_grants import (
+        list_grants,
+        read_audit_trail,
+        revoke_grant,
+    )
+
+    cmd = getattr(args, "grant_command", None)
+
+    if cmd == "issue":
+        # Track A (review #100694 process-boundary blocker): a short-lived
+        # CLI process must NOT mint a grant the running Hermes process would
+        # consume — the authority generations differ, so the grant would be
+        # rejected at claim time anyway.  Issuance happens exclusively inside
+        # the long-lived Hermes process via the governed tool, which asks
+        # the human through the approval surface.
+        print(
+            "REFUSED: destructive grants are minted by the running Hermes "
+            "process, not by this CLI. Request the governed operation "
+            "(e.g. governed_mkfs) in a live Hermes session; the process will "
+            "ask the human for an explicit one-shot approval of the exact "
+            "target and issue the grant in-process.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if cmd == "list":
+        grants = list_grants()
+        if not grants:
+            print("No live grants.")
+            return 0
+        for grant in grants:
+            print(
+                f"{grant.grant_id}  {grant.operation}  vm={grant.vm_id}  "
+                f"{grant.device}  {grant.fs_type}  label={grant.label}  "
+                f"subject={grant.authorization_subject}  "
+                f"expires_at={grant.expires_at}"
+            )
+        return 0
+
+    if cmd == "audit":
+        entries = read_audit_trail(limit=getattr(args, "limit", 200))
+        if not entries:
+            print("No audit entries.")
+            return 0
+        for entry in entries:
+            print(json.dumps(entry, sort_keys=True, ensure_ascii=False))
+        return 0
+
+    if cmd == "revoke":
+        try:
+            ok = revoke_grant(args.grant_id)
+        except (OSError, GrantError) as exc:
+            print(f"ERROR: {exc}", file=sys.stderr)
+            return 2
+        if ok:
+            print(f"revoked={args.grant_id}")
+            return 0
+        print(f"not_found={args.grant_id}", file=sys.stderr)
+        return 1
+
+    print("usage: hermes grant {issue,list,revoke,audit}", file=sys.stderr)
+    return 2

--- a/tests/hermes_cli/test_grant_cli.py
+++ b/tests/hermes_cli/test_grant_cli.py
@@ -1,0 +1,151 @@
+"""CLI wiring tests for ``hermes grant`` (process-boundary contract).
+
+``hermes grant issue`` is REFUSED: a short-lived CLI process cannot mint a
+grant the running Hermes process would accept (different authority
+generation).  Issuance happens exclusively inside the long-lived Hermes
+process via the governed tool.  ``list`` / ``revoke`` / ``audit`` remain
+available for operational visibility.
+"""
+
+import argparse
+import json
+import time
+import uuid
+
+import pytest
+
+from hermes_cli.subcommands.grant import (
+    build_grant_parser,
+    run_grant_command,
+)
+
+_IDENTITY = {"hostname": "storage-guest", "boot_id": "boot-A", "product_uuid": "uuid-A"}
+
+
+def _make_parser():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_grant_parser(subparsers, cmd_grant=lambda a: run_grant_command(a))
+    return parser
+
+
+class TestGrantParser:
+    def test_issue_parses_full_tuple(self):
+        parser = _make_parser()
+        args = parser.parse_args(
+            [
+                "grant", "issue",
+                "--operation", "CREATE_FILESYSTEM",
+                "--vm", "101",
+                "--hostname", "storage-guest",
+                "--device", "/dev/sdb1",
+                "--fs", "ext4",
+                "--label", "DATA",
+                "--subject", "operator",
+                "--session", "sess-1",
+                "--ttl", "300",
+            ]
+        )
+        assert args.grant_command == "issue"
+        assert args.vm_id == "101"
+        assert args.device == "/dev/sdb1"
+        assert args.fs_type == "ext4"
+        assert args.label == "DATA"
+        assert args.subject == "operator"
+        assert args.session_id == "sess-1"
+        assert args.ttl == 300
+        assert hasattr(args, "func")
+
+    def test_list_and_audit_parse(self):
+        parser = _make_parser()
+        for sub in ("list", "audit"):
+            args = parser.parse_args(["grant", sub])
+            assert args.grant_command == sub
+            assert hasattr(args, "func")
+
+    def test_revoke_parses_grant_id(self):
+        parser = _make_parser()
+        args = parser.parse_args(["grant", "revoke", "abc-123"])
+        assert args.grant_command == "revoke"
+        assert args.grant_id == "abc-123"
+
+
+class TestGrantCommand:
+    def test_issue_is_refused_no_grant_created(self, capsys):
+        """Track A: the CLI must NOT mint a grant.  ``hermes grant issue``
+        exits nonzero with an explicit message and creates nothing."""
+        from tools import destructive_grants as dg
+
+        before = len(dg.list_grants())
+        args = _make_parser().parse_args(
+            [
+                "grant", "issue",
+                "--operation", "CREATE_FILESYSTEM",
+                "--vm", "101",
+                "--hostname", "storage-guest",
+                "--device", "/dev/sdb1",
+                "--fs", "ext4",
+                "--label", "DATA",
+                "--subject", "operator",
+                "--session", "sess-1",
+            ]
+        )
+        rc = run_grant_command(args)
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "REFUSED" in err
+        assert "running Hermes process" in err
+        # No grant was created by the CLI.
+        assert len(dg.list_grants()) == before
+
+    def test_issue_json_also_refused(self, capsys):
+        args = _make_parser().parse_args(
+            [
+                "grant", "issue",
+                "--operation", "CREATE_FILESYSTEM",
+                "--vm", "101",
+                "--hostname", "storage-guest",
+                "--device", "/dev/sdb1",
+                "--fs", "ext4",
+                "--label", "DATA",
+                "--subject", "operator",
+                "--session", "sess-1",
+                "--json",
+            ]
+        )
+        rc = run_grant_command(args)
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "REFUSED" in err
+
+    def test_list_audit_revoke_workflow(self, capsys):
+        """list/audit/revoke remain operational (no issuance)."""
+        # list on an empty pool
+        list_args = _make_parser().parse_args(["grant", "list"])
+        rc = run_grant_command(list_args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No live grants" in out
+
+        # audit on an empty trail
+        audit_args = _make_parser().parse_args(["grant", "audit"])
+        rc = run_grant_command(audit_args)
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "No audit entries" in out
+
+        # revoke of an unknown (but well-formed) id
+        revoke_args = _make_parser().parse_args(
+            ["grant", "revoke", "99999999-9999-4999-8999-999999999999"]
+        )
+        rc = run_grant_command(revoke_args)
+        assert rc == 1
+        err = capsys.readouterr().err
+        assert "not_found" in err
+
+        # revoke of a malformed id -> clean error, no crash
+        revoke_args = _make_parser().parse_args(["grant", "revoke", "not-a-uuid"])
+        rc = run_grant_command(revoke_args)
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "invalid grant id" in err

--- a/tests/tools/test_governed_mkfs_policy.py
+++ b/tests/tools/test_governed_mkfs_policy.py
@@ -1,0 +1,494 @@
+"""Policy tests for the governed destructive capability (mandate §20).
+
+Process-boundary contract (review #100694, 2026-09-02): the model requests
+(vm_id, device, fs_type, label) in a live session; the handler captures the
+guest incarnation, asks the human for an explicit one-shot approval of the
+EXACT tuple, mints the grant in-process, claims it, and runs the governed
+workflow.  The QGA transport is mocked at the ``tools.qga_structured``
+boundary so the policy engine is exercised end-to-end without touching a
+real VM.
+
+PASS
+    human approve_once + correct tuple + empty target + all prechecks PASS
+    -> filesystem creation allowed, grant settled completed
+
+DENY
+    no human approval (deny / no surface)
+    receipt mismatch (device / vm / fs / label / session / incarnation)
+    root device (never issuable)
+    mounted target / existing filesystem / existing signature
+    TOCTOU identity change
+    execution failure -> INDETERMINATE (never retry)
+    postcheck mismatch -> INDETERMINATE
+"""
+
+import json
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from tools import destructive_grants as dg
+from tools.governed_mkfs_tool import _handle_governed_mkfs
+
+from tests.tools.test_grant_authority_lifecycle import (
+    _INCARNATION,
+    _make_receipt,
+    _mock_approval,
+    _mock_qga,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue(**kw):
+    from tests.tools.test_grant_authority_lifecycle import _issue as _base_issue
+
+    return _base_issue(**kw)
+
+
+def _clean_prechecks(device="/dev/sdb1"):
+    """A fully green precheck payload (mandate §13 all PASS)."""
+    return {
+        "vm_id": "101",
+        "device": device,
+        "device_exists": True,
+        "is_block_device": True,
+        "major_minor": "8:17",
+        "size_bytes": 137438953472,
+        "parent": "sdb",
+        "mounted": False,
+        "swap": False,
+        "filesystem_existing": False,
+        "filesystem_signature": False,
+        "lvm_member": False,
+        "mdraid_member": False,
+        "holders": [],
+        "docker_use": False,
+        "fstab_use": False,
+    }
+
+
+def _exec_ok(device="/dev/sdb1", fs_type="ext4", label="DATA"):
+    return {
+        "operation": "CREATE_FILESYSTEM",
+        "vm_id": "101",
+        "device": device,
+        "fs_type": fs_type,
+        "label": label,
+        "guest_argv": [dg.FS_TYPE_TO_BINARY[fs_type], "-L", label, device],
+        "exit_code": 0,
+        "out_data": "",
+        "err_data": "",
+    }
+
+
+def _postcheck_ok(fs_type="ext4", label="DATA"):
+    return {
+        "exit_code": 0,
+        "filesystem": fs_type,
+        "label": label,
+        "uuid": "11111111-2222-3333-4444-555555555555",
+    }
+
+
+def _call(*, device="/dev/sdb1", fs_type="ext4", label="DATA",
+          vm_id="101", session_id="sess-1"):
+    return json.loads(
+        _handle_governed_mkfs(
+            {
+                "vm_id": vm_id,
+                "device": device,
+                "fs_type": fs_type,
+                "label": label,
+            },
+            session_id=session_id,
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# PASS
+# ---------------------------------------------------------------------------
+
+
+class TestPass:
+    def test_valid_go_full_tuple_allows(self):
+        with _mock_approval(), _mock_qga():
+            result = _call()
+        assert result["decision"] == "ALLOW"
+        assert result["capability_consumed"] is True
+        assert result["fs_type"] == "ext4"
+        assert result["label"] == "DATA"
+        assert result["uuid"] == "11111111-2222-3333-4444-555555555555"
+        # The grant was minted in-process and settled: no live grant remains.
+        assert dg.list_grants() == []
+
+    def test_grant_file_permissions_are_0600(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        assert (path.stat().st_mode & 0o777) == 0o600
+        # Directory is 0700.
+        assert (path.parent.stat().st_mode & 0o777) == 0o700
+
+
+# ---------------------------------------------------------------------------
+# DENY — request validation
+# ---------------------------------------------------------------------------
+
+
+class TestDenyNoGo:
+    def test_missing_vm_id_denied(self):
+        with _mock_approval(), _mock_qga():
+            result = json.loads(
+                _handle_governed_mkfs(
+                    {"device": "/dev/sdb1", "fs_type": "ext4", "label": "DATA"},
+                    session_id="sess-1",
+                )
+            )
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "vm_id_required"
+
+    def test_missing_device_denied(self):
+        with _mock_approval(), _mock_qga():
+            result = json.loads(
+                _handle_governed_mkfs(
+                    {"vm_id": "101", "fs_type": "ext4", "label": "DATA"},
+                    session_id="sess-1",
+                )
+            )
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "device_required"
+
+    def test_missing_session_denied(self):
+        with _mock_approval(), _mock_qga():
+            result = json.loads(
+                _handle_governed_mkfs(
+                    {"vm_id": "101", "device": "/dev/sdb1",
+                     "fs_type": "ext4", "label": "DATA"},
+                    session_id="",
+                )
+            )
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "session_id_required"
+
+
+class TestDenyHumanApproval:
+    def test_human_deny_no_grant_no_qga(self):
+        exec_calls = []
+        with _mock_approval(decision="deny"), _mock_qga(
+            exec_side_effect=lambda: exec_calls.append(1)
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "human_approval_denied"
+        assert exec_calls == []
+        assert dg.list_grants() == []
+
+    def test_no_human_surface_no_grant_no_qga(self):
+        from tools.grant_authority import ReceiptError
+
+        def _no_surface(**kwargs):
+            raise ReceiptError("no human surface available")
+
+        exec_calls = []
+        with patch("tools.governed_mkfs_tool.request_destructive_grant_approval",
+                   side_effect=_no_surface), _mock_qga(
+            exec_side_effect=lambda: exec_calls.append(1)
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "human_approval_denied"
+        assert exec_calls == []
+        assert dg.list_grants() == []
+
+
+class TestDenyApprovalMismatch:
+    """The receipt is bound to the EXACT tuple the human approved; a
+    mismatch between the request and the receipt denies issuance."""
+
+    def test_receipt_device_mismatch_denied(self):
+        # The mock approval binds the receipt to what the handler observed;
+        # a receipt for a different device cannot mint the grant.
+        receipt = _make_receipt(device="/dev/sdc1")
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga():
+            result = _call(device="/dev/sdb1")
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+    def test_receipt_vm_mismatch_denied(self):
+        receipt = _make_receipt(vm_id="149")
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga():
+            result = _call(vm_id="101")
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+    def test_receipt_fs_mismatch_denied(self):
+        receipt = _make_receipt(fs_type="xfs")
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga():
+            result = _call(fs_type="ext4")
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+    def test_receipt_label_mismatch_denied(self):
+        receipt = _make_receipt(label="OTHER")
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga():
+            result = _call(label="DATA")
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+    def test_receipt_session_mismatch_denied(self):
+        receipt = _make_receipt(session_id="sess-2")
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga():
+            result = _call(session_id="sess-1")
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+    def test_receipt_incarnation_mismatch_denied(self):
+        """The human approved generation A; the handler observed generation B
+        -> the receipt cannot mint the grant (identity observed before
+        approval == identity approved == grant identity)."""
+        receipt = _make_receipt(incarnation={
+            "hostname": "storage-guest", "boot_id": "boot-A",
+            "product_uuid": "uuid-A",
+        })
+        with patch(
+            "tools.governed_mkfs_tool.request_destructive_grant_approval",
+            return_value=receipt,
+        ), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-B",
+                      "product_uuid": "uuid-A"},
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "grant_issue_failed"
+
+
+class TestDenyRootDevice:
+    def test_root_device_never_issuable(self):
+        with pytest.raises(dg.GrantError):
+            _issue(device="/dev/sda1")
+        with pytest.raises(dg.GrantError):
+            _issue(device="/dev/sda")
+        with pytest.raises(dg.GrantError):
+            _issue(device="/dev/vda1")
+        with pytest.raises(dg.GrantError):
+            _issue(device="/dev/nvme0n1")
+
+
+# ---------------------------------------------------------------------------
+# DENY — prechecks
+# ---------------------------------------------------------------------------
+
+
+class TestDenyMounted:
+    def test_mounted_target_denied(self):
+        prechecks = _clean_prechecks()
+        prechecks["mounted"] = True
+        prechecks["mount_target"] = "/var/lib/docker"
+        with _mock_approval(), _mock_qga(prechecks=prechecks):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "prechecks_failed"
+        assert "mounted=YES" in result["failures"]
+
+
+class TestDenyExistingFilesystem:
+    def test_existing_fs_denied(self):
+        prechecks = _clean_prechecks()
+        prechecks["filesystem_existing"] = True
+        with _mock_approval(), _mock_qga(prechecks=prechecks):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert "filesystem_existing=YES" in result["failures"]
+
+
+class TestDenyExistingSignature:
+    def test_existing_signature_denied(self):
+        prechecks = _clean_prechecks()
+        prechecks["filesystem_signature"] = True
+        with _mock_approval(), _mock_qga(prechecks=prechecks):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert "filesystem_signature=YES" in result["failures"]
+
+
+class TestPrecheckPartuuidSemantics:
+    """blkid returns rc=0 with PARTUUID= for ANY GPT partition, even empty.
+
+    PARTUUID is partition-table identity, not a data signature.  Only a real
+    filesystem TYPE= (or a wipefs hit) must set filesystem_signature.
+    """
+
+    def _run_prechecks(self, blkid_out, wipefs_out=""):
+        import tools.qga_structured as qs
+
+        def _fake_exec(vm_id, argv, timeout=None):
+            cmd = argv[0]
+            if cmd == "lsblk":
+                out = json.dumps({
+                    "blockdevices": [{
+                        "name": "sdb1", "type": "part", "maj:min": "8:17",
+                        "size": "128G", "mountpoints": [], "fstype": None,
+                    }]
+                })
+                return {"exit_code": 0, "out_data": out, "err_data": ""}
+            if cmd == "findmnt":
+                return {"exit_code": 1, "out_data": "", "err_data": ""}
+            if cmd == "blkid":
+                return {"exit_code": 0, "out_data": blkid_out, "err_data": ""}
+            if cmd == "wipefs":
+                return {"exit_code": 0, "out_data": wipefs_out, "err_data": ""}
+            if cmd == "grep" and "swaps" in argv:
+                return {"exit_code": 1, "out_data": "", "err_data": ""}
+            if cmd == "pvs":
+                return {"exit_code": 1, "out_data": "", "err_data": ""}
+            if cmd == "cat":
+                return {"exit_code": 0, "out_data": "", "err_data": ""}
+            if cmd == "ls":
+                return {"exit_code": 0, "out_data": "", "err_data": ""}
+            if cmd == "bash":
+                return {"exit_code": 0, "out_data": "", "err_data": ""}
+            return {"exit_code": 0, "out_data": "", "err_data": ""}
+
+        with patch.object(qs, "_qm_guest_exec", side_effect=_fake_exec):
+            return qs.qga_prechecks("101", "/dev/sdb1")
+
+    def test_empty_gpt_partition_partuuid_only_is_not_signature(self):
+        checks = self._run_prechecks(
+            blkid_out='/dev/sdb1: PARTUUID="c675ed5f-8323-45a3-b8d0-4e62097a1a09"'
+        )
+        assert checks["filesystem_signature"] is False
+        assert checks["device_exists"] is True
+        assert checks["is_block_device"] is True
+
+    def test_real_filesystem_type_is_signature(self):
+        checks = self._run_prechecks(
+            blkid_out='/dev/sdb1: UUID="abc" TYPE="ext4" PARTUUID="c675ed5f"'
+        )
+        assert checks["filesystem_signature"] is True
+
+    def test_wipefs_hit_is_signature_even_without_blkid_type(self):
+        checks = self._run_prechecks(
+            blkid_out='',
+            wipefs_out="DEVICE OFFSET TYPE UUID LABEL\nsdb1 0x438 ext4",
+        )
+        assert checks["filesystem_signature"] is True
+
+
+# ---------------------------------------------------------------------------
+# DENY — TOCTOU
+# ---------------------------------------------------------------------------
+
+
+class TestDenyToctou:
+    def test_identity_changed_between_precheck_and_action(self):
+        prechecks = _clean_prechecks()
+        recheck = _clean_prechecks()
+        recheck["major_minor"] = "8:18"  # device identity changed
+        with _mock_approval(), _mock_qga(prechecks=prechecks, recheck=recheck):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "toctou_identity_changed"
+
+    def test_mounted_between_precheck_and_action(self):
+        prechecks = _clean_prechecks()
+        recheck = _clean_prechecks()
+        recheck["mounted"] = True
+        with _mock_approval(), _mock_qga(prechecks=prechecks, recheck=recheck):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "toctou_recheck_failed"
+
+
+# ---------------------------------------------------------------------------
+# DENY — execution failure (INDETERMINATE, never retry)
+# ---------------------------------------------------------------------------
+
+
+class TestDenyExecutionFailure:
+    def test_nonzero_exit_indeterminate_and_grant_settled(self):
+        exec_result = _exec_ok()
+        exec_result["exit_code"] = 1
+        exec_result["err_data"] = "mkfs.ext4: Device or resource busy"
+        with _mock_approval(), _mock_qga(exec_result=exec_result):
+            result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["reason"] == "execution_exit_nonzero"
+        assert result["outcome"] == "indeterminate"
+        # A mutation may have happened: the grant is settled indeterminate and
+        # NEVER returns to the pool (no blind retry).
+        assert dg.list_grants() == []
+
+    def test_postcheck_fs_mismatch_indeterminate(self):
+        with _mock_approval(), _mock_qga(postcheck=_postcheck_ok(fs_type="xfs")):
+            result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["reason"] == "postcheck_fs_mismatch"
+        assert result["outcome"] == "indeterminate"
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+class TestAuditTrail:
+    def test_audit_records_issue_verify_consume_without_secrets(self):
+        with _mock_approval(), _mock_qga():
+            _call()
+        entries = dg.read_audit_trail()
+        events = [e["event"] for e in entries]
+        assert "grant_issued" in events
+        assert "grant_claimed" in events
+        assert "grant_verified" in events
+        assert "grant_settled" in events
+        # No secrets in the trail.
+        blob = json.dumps(entries)
+        assert "nonce" not in blob
+
+    def test_deny_is_audited(self):
+        with _mock_approval(decision="deny"), _mock_qga():
+            _call()
+        entries = dg.read_audit_trail()
+        assert any(e["event"] == "grant_denied" for e in entries)
+
+
+# ---------------------------------------------------------------------------
+# Grant integrity (unit level)
+# ---------------------------------------------------------------------------
+
+
+class TestGrantIntegrity:
+    def test_tampered_grant_file_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["device"] = "/dev/sdc1"
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_revoked_grant_denied(self):
+        grant = _issue()
+        assert dg.revoke_grant(grant.grant_id) is True
+        with pytest.raises(dg.GrantNotFoundError):
+            dg.load_grant(grant.grant_id)

--- a/tests/tools/test_governed_mkfs_registry.py
+++ b/tests/tools/test_governed_mkfs_registry.py
@@ -1,0 +1,62 @@
+"""Registry discovery tests for the governed_mkfs tool.
+
+The registry's AST-based discovery only imports modules with a top-level
+``registry.register(...)`` call.  If that invariant is ever broken, the
+governed path silently disappears from the model's toolset — which would
+be a safety regression (the model would have no governed alternative and
+could be tempted to bypass).  These tests pin the discovery contract.
+
+Process-boundary contract (review #100694, 2026-09-02): the governed
+handler is the ONLY legitimate issuer — it runs in the long-lived Hermes
+process, asks the human for an explicit one-shot approval, and mints the
+grant with the SAME process-local authority that claims and verifies it.
+The model-facing schema therefore exposes the target tuple only (no
+grant_id): the model can request, never self-grant.
+"""
+
+from pathlib import Path
+
+from tools.registry import _module_registers_tools, registry
+
+
+def test_governed_mkfs_module_is_ast_discovered():
+    module_path = Path("tools/governed_mkfs_tool.py")
+    assert module_path.exists()
+    assert _module_registers_tools(module_path) is True
+
+
+def test_governed_mkfs_registered_after_import():
+    import tools.governed_mkfs_tool  # noqa: F401
+
+    entry = registry.get_entry("governed_mkfs")
+    assert entry is not None
+    assert entry.name == "governed_mkfs"
+    assert entry.toolset == "terminal"
+    # The schema must expose only structured fields, never a free shell
+    # string, and NO grant_id: the model requests the target tuple, the
+    # process mints the grant after human approval.
+    props = entry.schema["parameters"]["properties"]
+    assert set(props) == {"vm_id", "device", "fs_type", "label"}
+    assert entry.schema["parameters"]["required"] == [
+        "vm_id", "device", "fs_type", "label",
+    ]
+
+
+def test_governed_mkfs_handler_is_the_in_process_issuer():
+    """The handler is the legitimate issuer: it requests the human
+    approval and mints the grant in the consumer process (same authority
+    generation).  The model-facing schema has no grant_id, so a forged or
+    externally-minted grant cannot even be referenced."""
+    import inspect
+
+    import tools.governed_mkfs_tool as gmt
+
+    src = inspect.getsource(gmt._handle_governed_mkfs)
+    # The handler drives the full approval -> issue -> claim -> workflow.
+    assert "request_destructive_grant_approval" in src
+    assert "issue_grant" in src
+    assert "claim_grant" in src
+    assert "settle_grant" in src
+    # No grant_id in the schema: the model cannot point the tool at a
+    # pre-minted grant.
+    assert "grant_id" not in gmt.GOVERNED_MKFS_SCHEMA["parameters"]["properties"]

--- a/tests/tools/test_grant_authority_adversarial.py
+++ b/tests/tools/test_grant_authority_adversarial.py
@@ -1,0 +1,699 @@
+"""Adversarial Blocker 1 tests — process-boundary contract (review #100694).
+
+Every attack below must fail mechanically:
+
+    valid_grant=NO
+    qga_create_filesystem_calls=0
+
+Attack matrix (mandate §9 Track E):
+
+1.  direct issue_grant from execute_code (child process)
+2.  write arbitrary grant JSON (write_file surface)
+3.  copy valid grant
+4.  change grant_id
+5.  change filename UUID
+6.  extend expires_at
+7.  change issued_at
+8.  change authorization_source
+9.  replace receipt_id
+10. replay same human receipt
+11. issue second grant from same receipt
+12. terminal hermes grant issue (hardline + CLI hard-fail)
+13. terminal pty=true (hardline)
+14. yolo
+15. approvals.mode=off
+16. cron permissive
+17. smart approval / aux LLM
+18. subagent (child process provider)
+19. child process provider
+20. restart provider generation
+
+Legitimate-flow witness (the ONLY issuer is the consumer process):
+
+    running Hermes process B
+    -> model requests governed operation
+    -> mocked REAL human approve_once
+    -> B observes incarnation
+    -> B issues grant with authority B
+    -> B claims grant
+    -> exactly one qga_create_filesystem call
+    -> completed
+
+Isolation proofs:
+
+- parent Hermes PID != execute_code kernel PID
+- execute_code cannot retrieve the parent's process authority secret
+- the secret is not in os.environ / /proc/self/environ / subprocess env
+- repr(provider) / exceptions / logs never leak the secret
+"""
+
+import json
+import os
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from tools import destructive_grants as dg
+from tools import grant_authority as ga
+from tools.governed_mkfs_tool import _handle_governed_mkfs
+
+from tests.tools.test_grant_authority_lifecycle import (
+    _INCARNATION,
+    _make_receipt,
+    _mock_approval,
+    _mock_qga,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _issue(**kw):
+    from tests.tools.test_grant_authority_lifecycle import _issue as _base_issue
+
+    return _base_issue(**kw)
+
+
+def _call(**kw):
+    from tests.tools.test_grant_authority_lifecycle import _call as _base_call
+
+    return _base_call(**kw)
+
+
+def _grant_path(grant_id):
+    return dg._grant_path(grant_id)
+
+
+def _read_grant(grant_id):
+    return json.loads(_grant_path(grant_id).read_text())
+
+
+def _write_grant(grant_id, data):
+    dg._ensure_dir()
+    _grant_path(grant_id).write_text(json.dumps(data))
+
+
+# ---------------------------------------------------------------------------
+# G1 — import direct / globals access from a child process
+# ---------------------------------------------------------------------------
+
+
+def test_child_process_has_different_authority_generation():
+    """A child process (execute_code kernel) imports its own provider with a
+    DIFFERENT secret and generation: it cannot authenticate parent grants."""
+    parent_gen = ga.get_authority().generation
+    code = (
+        "import sys; sys.path.insert(0, %r); "
+        "from tools import grant_authority as ga; "
+        "print(ga.get_authority().generation)" % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    child_gen = out.stdout.strip()
+    assert child_gen
+    assert child_gen != parent_gen
+
+
+def test_child_process_cannot_verify_parent_grant():
+    """A grant minted in the parent is rejected by a child process provider
+    (generation mismatch => authentication failure)."""
+    grant = _issue()
+    code = (
+        "import sys\n"
+        "sys.path.insert(0, %r)\n"
+        "from tools import destructive_grants as dg\n"
+        "try:\n"
+        "    dg.load_grant(%r)\n"
+        "    print('LOADED')\n"
+        "except dg.GrantDeniedError:\n"
+        "    print('DENIED')\n"
+        % (os.getcwd(), grant.grant_id)
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "DENIED"
+
+
+def test_child_process_cannot_issue_valid_grant():
+    """issue_grant from a child process produces a grant the PARENT rejects."""
+    code = (
+        "import sys, time, uuid; sys.path.insert(0, %r); "
+        "from tools import destructive_grants as dg; "
+        "from tools import grant_authority as ga; "
+        "from tools.grant_authority import HumanApprovalReceipt, _store_receipt; "
+        "r = _store_receipt(HumanApprovalReceipt("
+        "receipt_id='rcpt-'+uuid.uuid4().hex, request_id='r'*32, "
+        "request_digest='d'*64, session_id='sess-1', turn_id='t', "
+        "tool_call_id='tc', operation='CREATE_FILESYSTEM', vm_id='101', "
+        "device='/dev/sdb1', fs_type='ext4', label='X', "
+        "incarnation_product_uuid='uuid-A', incarnation_boot_id='boot-A', "
+        "incarnation_hostname='storage-guest', "
+        "issued_at=time.time(), expires_at=time.time()+600)); "
+        "g = dg.issue_grant(operation='CREATE_FILESYSTEM', vm_id='101', "
+        "hostname='storage-guest', device='/dev/sdb1', fs_type='ext4', label='X', "
+        "authorization_subject='operator', session_id='sess-1', "
+        "receipt_id=r.receipt_id, incarnation_product_uuid='uuid-A', "
+        "incarnation_boot_id='boot-A', incarnation_hostname='storage-guest'); "
+        "print(g.grant_id)"
+        % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    child_grant_id = out.stdout.strip()
+    assert child_grant_id
+    # The PARENT must reject the child-minted grant (different key).
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(child_grant_id)
+
+
+# ---------------------------------------------------------------------------
+# G2 — forge file (write_file surface)
+# ---------------------------------------------------------------------------
+
+
+def test_forge_arbitrary_grant_json_denied():
+    """write_file fabricating a grant JSON with a fake tag is rejected."""
+    forged = {
+        "grant_id": "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa",
+        "operation": "CREATE_FILESYSTEM",
+        "vm_id": "101",
+        "hostname": "storage-guest",
+        "device": "/dev/sdb1",
+        "fs_type": "ext4",
+        "label": "X",
+        "authorization_subject": "operator",
+        "authorization_source": "USER",
+        "session_id": "sess-1",
+        "issued_at": time.time(),
+        "expires_at": time.time() + 600,
+        "nonce": "0" * 32,
+        "auth_tag": "0" * 64,
+        "authority_generation": ga.get_authority().generation,
+        "receipt_id": "rcpt-" + "0" * 28,
+        "schema_version": 1,
+        "authorization_evidence": {},
+        "incarnation_product_uuid": "uuid-A",
+        "incarnation_boot_id": "boot-A",
+        "incarnation_hostname": "storage-guest",
+    }
+    _write_grant(forged["grant_id"], forged)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(forged["grant_id"])
+
+
+def test_forge_with_copied_tag_from_other_grant_denied():
+    """Copying a valid grant's tag onto a forged payload is rejected."""
+    valid = _issue()
+    forged = _read_grant(valid.grant_id)
+    forged["grant_id"] = "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb"
+    forged["device"] = "/dev/sdc1"  # different target
+    _write_grant(forged["grant_id"], forged)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(forged["grant_id"])
+
+
+def test_forge_ttl_extension_denied():
+    grant = _issue()
+    data = _read_grant(grant.grant_id)
+    data["expires_at"] = data["expires_at"] + 3600
+    _write_grant(grant.grant_id, data)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(grant.grant_id)
+
+
+def test_forge_issued_at_change_denied():
+    grant = _issue()
+    data = _read_grant(grant.grant_id)
+    data["issued_at"] = data["issued_at"] - 100
+    _write_grant(grant.grant_id, data)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(grant.grant_id)
+
+
+def test_forge_authorization_source_denied():
+    grant = _issue()
+    data = _read_grant(grant.grant_id)
+    data["authorization_source"] = "MODEL"
+    _write_grant(grant.grant_id, data)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(grant.grant_id)
+
+
+def test_forge_receipt_id_denied():
+    grant = _issue()
+    data = _read_grant(grant.grant_id)
+    data["receipt_id"] = "rcpt-" + "9" * 28
+    _write_grant(grant.grant_id, data)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(grant.grant_id)
+
+
+def test_forge_clone_under_new_filename_denied():
+    grant = _issue()
+    data = _read_grant(grant.grant_id)
+    new_id = "cccccccc-cccc-4ccc-8ccc-cccccccccccc"
+    data["grant_id"] = new_id
+    _write_grant(new_id, data)
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(new_id)
+
+
+# ---------------------------------------------------------------------------
+# G3 — receipt replay
+# ---------------------------------------------------------------------------
+
+
+def test_receipt_replay_denied():
+    """The same human receipt cannot issue a second grant."""
+    receipt = _make_receipt()
+    g1 = _issue(receipt=receipt)
+    assert g1.receipt_id == receipt.receipt_id
+    with pytest.raises(dg.GrantError):
+        _issue(receipt=receipt)
+
+
+def test_receipt_serialized_replay_denied():
+    """Replaying the serialized receipt payload (as the model would see it in
+    the grant file) cannot mint a second grant: the receipt store is
+    process-local and the id is consumed."""
+    receipt = _make_receipt()
+    g1 = _issue(receipt=receipt)
+    serialized = g1.authorization_evidence  # what the model can read
+    assert serialized["receipt_id"] == receipt.receipt_id
+    # The model cannot re-insert the receipt into the store: consume_receipt
+    # only accepts ids present in the process-local store.
+    with pytest.raises(dg.GrantError):
+        dg.issue_grant(
+            operation="CREATE_FILESYSTEM",
+            vm_id="101", hostname="storage-guest", device="/dev/sdb1",
+            fs_type="ext4", label="X",
+            authorization_subject="operator", session_id="sess-1",
+            receipt_id=str(serialized["receipt_id"]),
+            incarnation_product_uuid="uuid-A",
+            incarnation_boot_id="boot-A", incarnation_hostname="storage-guest",
+        )
+
+
+# ---------------------------------------------------------------------------
+# G4 — environment / logs / repr leak
+# ---------------------------------------------------------------------------
+
+
+def test_secret_not_in_environment():
+    code = (
+        "import sys, os; sys.path.insert(0, %r); "
+        "from tools import grant_authority as ga; "
+        "a = ga.get_authority(); "
+        "print(any('grant' in k.lower() or 'authority' in k.lower() "
+        "for k in os.environ)); "
+        "print(repr(a)); "
+        "print(hasattr(a, '_secret'))"
+        % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    lines = out.stdout.strip().splitlines()
+    assert lines[0] == "False"  # no grant/authority env var
+    assert "generation" in lines[1] and "_secret" not in lines[1]
+    assert lines[2] == "True"  # attribute exists but repr never shows it
+
+
+def test_secret_not_in_proc_self_environ():
+    env = os.environ.copy()
+    env.pop("HERMES_YOLO_MODE", None)
+    code = (
+        "import sys, os\n"
+        "sys.path.insert(0, %r)\n"
+        "from tools import grant_authority as ga\n"
+        "a = ga.get_authority()\n"
+        "secret = a._secret\n"
+        "data = open('/proc/self/environ','rb').read()\n"
+        "print(secret in data)\n"
+        % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30,
+        env=env,
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "False"
+
+
+def test_secret_not_in_subprocess_environment():
+    """A child spawned by the parent does not inherit the secret."""
+    code = (
+        "import sys, os, subprocess\n"
+        "sys.path.insert(0, %r)\n"
+        "from tools import grant_authority as ga\n"
+        "a = ga.get_authority()\n"
+        "secret = a._secret\n"
+        "out = subprocess.run([sys.executable, '-c', "
+        "'import os; print(repr(os.environ))'], "
+        "capture_output=True, text=True, env=os.environ.copy())\n"
+        "print(secret in out.stdout.encode())\n"
+        % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    assert out.stdout.strip() == "False"
+
+
+# ---------------------------------------------------------------------------
+# G5 — restart semantics
+# ---------------------------------------------------------------------------
+
+
+def test_restart_invalidates_live_grants():
+    """A new provider generation (restart) rejects previously minted grants."""
+    grant = _issue()
+    assert dg.load_grant(grant.grant_id)  # valid under current provider
+    ga.reset_authority_for_tests()  # simulate process restart
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(grant.grant_id)
+
+
+def test_restart_denies_consumption():
+    """A grant minted before a restart cannot be claimed/consumed after it:
+    the authority generation check rejects it before any effect."""
+    grant = _issue()
+    ga.reset_authority_for_tests()
+    with pytest.raises(dg.GrantDeniedError):
+        dg.claim_grant(grant.grant_id, "exec-after-restart")
+
+
+# ---------------------------------------------------------------------------
+# J — terminal / yolo / mode=off / cron bypass
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_grant_issue_hardline_blocked():
+    from tools.approval import detect_hardline_command
+
+    for cmd in (
+        "hermes grant issue --operation CREATE_FILESYSTEM --vm 101 --device /dev/sdb1 --fs ext4 --label X --session s1",
+        "sudo hermes grant issue --vm 1",
+        "echo hi; hermes grant issue --vm 1",
+        "hermes grant issue --vm 1 --json",
+    ):
+        is_hl, desc = detect_hardline_command(cmd)
+        assert is_hl, f"hardline missed: {cmd!r}"
+
+
+def test_terminal_pty_grant_issue_hardline_blocked():
+    from tools.approval import detect_hardline_command
+
+    # pty=true does not change the command string: still hardline-blocked.
+    is_hl, _ = detect_hardline_command(
+        "hermes grant issue --operation CREATE_FILESYSTEM --vm 101 --device /dev/sdb1 --fs ext4 --label X --session s1"
+    )
+    assert is_hl
+
+
+def test_yolo_cannot_bypass_grant_issue_hardline(monkeypatch):
+    from tools.approval import (
+        check_all_command_guards,
+        check_dangerous_command,
+        detect_hardline_command,
+    )
+
+    monkeypatch.setenv("HERMES_YOLO_MODE", "1")
+    cmd = "hermes grant issue --operation CREATE_FILESYSTEM --vm 101 --device /dev/sdb1 --fs ext4 --label X --session s1"
+    assert detect_hardline_command(cmd)[0] is True
+    r1 = check_dangerous_command(cmd, "local")
+    assert r1["approved"] is False and r1.get("hardline") is True
+    r2 = check_all_command_guards(cmd, "local")
+    assert r2["approved"] is False and r2.get("hardline") is True
+
+
+def test_approvals_mode_off_cannot_bypass_grant_issue_hardline(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.approval import check_all_command_guards
+
+    monkeypatch.setattr(approval_mod, "_get_approval_mode", lambda: "off")
+    cmd = "hermes grant issue --operation CREATE_FILESYSTEM --vm 101 --device /dev/sdb1 --fs ext4 --label X --session s1"
+    r = check_all_command_guards(cmd, "local")
+    assert r["approved"] is False and r.get("hardline") is True
+
+
+def test_cron_approve_cannot_bypass_grant_issue_hardline(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.approval import check_all_command_guards
+
+    monkeypatch.setenv("HERMES_CRON_SESSION", "1")
+    monkeypatch.setattr(approval_mod, "_get_cron_approval_mode", lambda: "approve")
+    cmd = "hermes grant issue --operation CREATE_FILESYSTEM --vm 101 --device /dev/sdb1 --fs ext4 --label X --session s1"
+    r = check_all_command_guards(cmd, "local")
+    assert r["approved"] is False and r.get("hardline") is True
+
+
+def test_grant_issue_list_revoke_not_hardline():
+    """list/revoke/audit stay usable (read-only / revocation)."""
+    from tools.approval import detect_hardline_command
+
+    for cmd in ("hermes grant list", "hermes grant revoke abc", "hermes grant audit"):
+        assert detect_hardline_command(cmd)[0] is False, cmd
+
+
+# ---------------------------------------------------------------------------
+# J — approval gate refuses bypass contexts
+# ---------------------------------------------------------------------------
+
+
+def test_approval_gate_refuses_yolo(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError, request_destructive_grant_approval
+
+    monkeypatch.setattr(approval_mod, "is_approval_bypass_active", lambda: True)
+    with pytest.raises(ReceiptError):
+        request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+            fs_type="ext4", label="X", session_id="sess-1", ttl_seconds=600,
+        )
+
+
+def test_approval_gate_refuses_cron(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError, request_destructive_grant_approval
+
+    monkeypatch.setattr(approval_mod, "is_approval_bypass_active", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_cron_approval_context", lambda: True)
+    with pytest.raises(ReceiptError):
+        request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+            fs_type="ext4", label="X", session_id="sess-1", ttl_seconds=600,
+        )
+
+
+def test_approval_gate_refuses_unattended(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError, request_destructive_grant_approval
+
+    monkeypatch.setattr(approval_mod, "is_approval_bypass_active", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_cron_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_unattended_platform_approval_context", lambda: True)
+    with pytest.raises(ReceiptError):
+        request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+            fs_type="ext4", label="X", session_id="sess-1", ttl_seconds=600,
+        )
+
+
+def test_approval_gate_refuses_single_query(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError, request_destructive_grant_approval
+
+    monkeypatch.setattr(approval_mod, "is_approval_bypass_active", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_cron_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_unattended_platform_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_single_query_approval_context", lambda: True)
+    with pytest.raises(ReceiptError):
+        request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+            fs_type="ext4", label="X", session_id="sess-1", ttl_seconds=600,
+        )
+
+
+def test_approval_gate_refuses_no_human_surface(monkeypatch):
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError, request_destructive_grant_approval
+
+    monkeypatch.setattr(approval_mod, "is_approval_bypass_active", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_cron_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_unattended_platform_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_single_query_approval_context", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_interactive_cli", lambda: False)
+    monkeypatch.setattr(approval_mod, "_is_gateway_approval_context", lambda: False)
+    with pytest.raises(ReceiptError):
+        request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+            fs_type="ext4", label="X", session_id="sess-1", ttl_seconds=600,
+        )
+
+
+# ---------------------------------------------------------------------------
+# E — legitimate-flow witness (the ONLY issuer is the consumer process)
+# ---------------------------------------------------------------------------
+
+
+def test_legitimate_flow_in_process_witness():
+    """The documented production flow: the running Hermes process observes
+    the incarnation, the human approves once, the SAME process mints the
+    grant with its own authority, claims it, and executes exactly one
+    qga_create_filesystem call -> completed."""
+    exec_calls = []
+    with _mock_approval(), _mock_qga(exec_side_effect=lambda: exec_calls.append(1)):
+        result = _call()
+    assert result["decision"] == "ALLOW"
+    assert result["outcome"] == "completed"
+    assert len(exec_calls) == 1
+    # The grant was minted by THIS process: its generation is the consumer
+    # generation (the handler's issue_grant used get_authority()).
+    assert result["grant_id"]
+    grant = dg._grant_path(result["grant_id"])
+    assert not grant.exists()  # settled: removed from the pool
+
+
+def test_human_denial_no_grant_no_qga():
+    """human decision = deny => grant_created=NO, qga_calls=0."""
+    exec_calls = []
+    with _mock_approval(decision="deny"), _mock_qga(
+        exec_side_effect=lambda: exec_calls.append(1)
+    ):
+        result = _call()
+    assert result["decision"] == "DENY"
+    assert result["reason"] == "human_approval_denied"
+    assert exec_calls == []
+    assert dg.list_grants() == []
+
+
+def test_approval_unavailable_no_grant_no_qga():
+    """Approval transport lost / no human surface => grant_created=NO,
+    qga_calls=0."""
+    import tools.approval as approval_mod
+    from tools.grant_authority import ReceiptError
+
+    def _no_surface(**kwargs):
+        raise ReceiptError("no human surface available")
+
+    exec_calls = []
+    with patch("tools.governed_mkfs_tool.request_destructive_grant_approval",
+               side_effect=_no_surface), _mock_qga(
+        exec_side_effect=lambda: exec_calls.append(1)
+    ):
+        result = _call()
+    assert result["decision"] == "DENY"
+    assert result["reason"] == "human_approval_denied"
+    assert exec_calls == []
+    assert dg.list_grants() == []
+
+
+def test_incarnation_replacement_between_approval_and_effect():
+    """observe A -> human approves A -> live target becomes B -> sink
+    re-read = B => DENY, qga_calls=0."""
+    exec_calls = []
+    with _mock_approval(), _mock_qga(
+        identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                  "product_uuid": "uuid-A"},
+        identity_after={"hostname": "storage-guest", "boot_id": "boot-B",
+                        "product_uuid": "uuid-A"},
+        exec_side_effect=lambda: exec_calls.append(1),
+    ):
+        result = _call()
+    assert result["decision"] == "DENY"
+    assert result["reason"] == "incarnation_changed"
+    assert exec_calls == []
+
+
+# ---------------------------------------------------------------------------
+# J — end-to-end: forged grant never reaches qga_create_filesystem
+# ---------------------------------------------------------------------------
+
+
+def test_forged_grant_never_reaches_qga():
+    """A forged grant file is denied at load; qga_create_filesystem is never
+    called.  The governed handler no longer accepts an external grant_id at
+    all: the schema has no grant_id parameter, so a forged grant cannot even
+    be referenced by the model-facing tool."""
+    forged_id = "dddddddd-dddd-4ddd-8ddd-dddddddddddd"
+    forged = {
+        "grant_id": forged_id,
+        "operation": "CREATE_FILESYSTEM",
+        "vm_id": "101",
+        "hostname": "storage-guest",
+        "device": "/dev/sdb1",
+        "fs_type": "ext4",
+        "label": "X",
+        "authorization_subject": "operator",
+        "authorization_source": "USER",
+        "session_id": "sess-1",
+        "issued_at": time.time(),
+        "expires_at": time.time() + 600,
+        "nonce": "0" * 32,
+        "auth_tag": "0" * 64,
+        "authority_generation": ga.get_authority().generation,
+        "receipt_id": "rcpt-" + "0" * 28,
+        "schema_version": 1,
+        "authorization_evidence": {},
+        "incarnation_product_uuid": "uuid-A",
+        "incarnation_boot_id": "boot-A",
+        "incarnation_hostname": "storage-guest",
+    }
+    _write_grant(forged_id, forged)
+    # The forged file is rejected by the integrity check.
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(forged_id)
+    # The model-facing schema has no grant_id: the handler cannot be pointed
+    # at the forged file at all.
+    from tools.governed_mkfs_tool import GOVERNED_MKFS_SCHEMA
+
+    assert "grant_id" not in GOVERNED_MKFS_SCHEMA["parameters"]["properties"]
+    assert "grant_id" not in GOVERNED_MKFS_SCHEMA["parameters"]["required"]
+
+
+def test_child_minted_grant_never_reaches_qga():
+    """A grant minted by a child process is rejected by the parent's
+    authority; the governed path never consumes it."""
+    code = (
+        "import sys, time, uuid; sys.path.insert(0, %r); "
+        "from tools import destructive_grants as dg; "
+        "from tools.grant_authority import HumanApprovalReceipt, _store_receipt; "
+        "r = _store_receipt(HumanApprovalReceipt("
+        "receipt_id='rcpt-'+uuid.uuid4().hex, request_id='r'*32, "
+        "request_digest='d'*64, session_id='sess-1', turn_id='t', "
+        "tool_call_id='tc', operation='CREATE_FILESYSTEM', vm_id='101', "
+        "device='/dev/sdb1', fs_type='ext4', label='X', "
+        "incarnation_product_uuid='uuid-A', incarnation_boot_id='boot-A', "
+        "incarnation_hostname='storage-guest', "
+        "issued_at=time.time(), expires_at=time.time()+600)); "
+        "g = dg.issue_grant(operation='CREATE_FILESYSTEM', vm_id='101', "
+        "hostname='storage-guest', device='/dev/sdb1', fs_type='ext4', label='X', "
+        "authorization_subject='operator', session_id='sess-1', "
+        "receipt_id=r.receipt_id, incarnation_product_uuid='uuid-A', "
+        "incarnation_boot_id='boot-A', incarnation_hostname='storage-guest'); "
+        "print(g.grant_id)"
+        % os.getcwd()
+    )
+    out = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, timeout=30
+    )
+    assert out.returncode == 0, out.stderr
+    child_grant_id = out.stdout.strip()
+    # The parent rejects the child-minted grant before any effect.
+    with pytest.raises(dg.GrantDeniedError):
+        dg.load_grant(child_grant_id)

--- a/tests/tools/test_grant_authority_lifecycle.py
+++ b/tests/tools/test_grant_authority_lifecycle.py
@@ -1,0 +1,725 @@
+"""RED tests — review #100694 blockers 1-3 (andrexibiza, 2026-09-01/02).
+
+Process-boundary contract (review #100694, 2026-09-02):
+
+    model requests (vm_id, device, fs_type, label) in a live session
+    -> process captures trusted guest identity
+    -> human approves the EXACT observed tuple + incarnation
+    -> grant minted IN THE CONSUMER PROCESS (same authority generation)
+    -> atomic claim -> sink fencing -> prechecks -> TOCTOU -> exec ->
+       postcheck -> settlement
+
+B1  Authority provenance + grant integrity:
+    - issuance requires a correlated human approval receipt (one-shot)
+    - the receipt binds operation, target, session AND incarnation
+    - identity observed BEFORE approval == identity approved == grant
+    - clone under a second UUID is denied (path-ID == payload-ID)
+    - TTL extension / evidence swap / incarnation swap are denied
+    - the CLI cannot mint a grant (hard-fail, no local issuance)
+
+B2  Claim/settlement lifecycle:
+    - atomic claim BEFORE the first effect; one winner under concurrency
+    - verify rejects claimed grants (no replay, no double-claim)
+    - settlement is bound to the claiming execution_id
+    - pre-effect failure -> DENY + outcome failed_pre_effect (no return to pool)
+    - post-effect failure -> INDETERMINATE + outcome indeterminate (never retry)
+    - success -> ALLOW + outcome completed
+
+B3  Durable generation fencing:
+    - incarnation captured at issue, revalidated at the sink
+    - ABA witness: grant for generation A refused on generation B
+    - boot_id part of the TOCTOU identity snapshot
+"""
+
+import json
+import threading
+import time
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from tools import destructive_grants as dg
+from tools.governed_mkfs_tool import _handle_governed_mkfs
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_INCARNATION = {
+    "hostname": "storage-guest",
+    "boot_id": "boot-A",
+    "product_uuid": "uuid-A",
+}
+
+
+def _make_receipt(
+    *,
+    operation="CREATE_FILESYSTEM",
+    vm_id="101",
+    device="/dev/sdb1",
+    fs_type="ext4",
+    label="DATA",
+    session_id="sess-1",
+    ttl=600,
+    incarnation=None,
+):
+    """Mint a correlated human approval receipt in the process-local store
+    (the same store the approval layer writes to)."""
+    from tools.grant_authority import HumanApprovalReceipt, _store_receipt
+
+    inc = incarnation if incarnation is not None else _INCARNATION
+    now = time.time()
+    return _store_receipt(
+        HumanApprovalReceipt(
+            receipt_id="rcpt-" + uuid.uuid4().hex,
+            request_id="req-11111111111111111111111111111111",
+            request_digest="d" * 64,
+            session_id=session_id,
+            turn_id="turn-1",
+            tool_call_id="tool-1",
+            operation=operation,
+            vm_id=vm_id,
+            device=device,
+            fs_type=fs_type,
+            label=label,
+            incarnation_product_uuid=inc["product_uuid"],
+            incarnation_boot_id=inc["boot_id"],
+            incarnation_hostname=inc["hostname"],
+            issued_at=now,
+            expires_at=now + ttl,
+        )
+    )
+
+
+def _issue(
+    *,
+    device="/dev/sdb1",
+    fs_type="ext4",
+    label="DATA",
+    vm_id="101",
+    hostname="storage-guest",
+    subject="operator",
+    session_id="sess-1",
+    ttl=600,
+    receipt=None,
+    incarnation=None,
+):
+    receipt = receipt if receipt is not None else _make_receipt(
+        device=device, fs_type=fs_type, label=label, vm_id=vm_id,
+        session_id=session_id, ttl=ttl, incarnation=incarnation,
+    )
+    return dg.issue_grant(
+        operation="CREATE_FILESYSTEM",
+        vm_id=vm_id,
+        hostname=hostname,
+        device=device,
+        fs_type=fs_type,
+        label=label,
+        authorization_subject=subject,
+        session_id=session_id,
+        receipt_id=receipt.receipt_id,
+        incarnation_product_uuid=(incarnation or _INCARNATION)["product_uuid"],
+        incarnation_boot_id=(incarnation or _INCARNATION)["boot_id"],
+        incarnation_hostname=(incarnation or _INCARNATION)["hostname"],
+        ttl_seconds=ttl,
+    )
+
+
+def _clean_prechecks(device="/dev/sdb1"):
+    return {
+        "vm_id": "101",
+        "device": device,
+        "device_exists": True,
+        "is_block_device": True,
+        "major_minor": "8:17",
+        "size_bytes": 137438953472,
+        "parent": "sdb",
+        "mounted": False,
+        "swap": False,
+        "filesystem_existing": False,
+        "filesystem_signature": False,
+        "lvm_member": False,
+        "mdraid_member": False,
+        "holders": [],
+        "docker_use": False,
+        "fstab_use": False,
+    }
+
+
+def _exec_ok(device="/dev/sdb1", fs_type="ext4", label="DATA"):
+    return {
+        "operation": "CREATE_FILESYSTEM",
+        "vm_id": "101",
+        "device": device,
+        "fs_type": fs_type,
+        "label": label,
+        "guest_argv": [dg.FS_TYPE_TO_BINARY[fs_type], "-L", label, device],
+        "exit_code": 0,
+        "out_data": "",
+        "err_data": "",
+    }
+
+
+def _postcheck_ok(fs_type="ext4", label="DATA"):
+    return {
+        "exit_code": 0,
+        "filesystem": fs_type,
+        "label": label,
+        "uuid": "11111111-2222-3333-4444-555555555555",
+    }
+
+
+def _call(*, device="/dev/sdb1", fs_type="ext4", label="DATA",
+          vm_id="101", session_id="sess-1"):
+    """Drive the governed handler end-to-end (approval -> issue -> claim ->
+    workflow) exactly as the model-facing tool does."""
+    return json.loads(
+        _handle_governed_mkfs(
+            {
+                "vm_id": vm_id,
+                "device": device,
+                "fs_type": fs_type,
+                "label": label,
+            },
+            session_id=session_id,
+        )
+    )
+
+
+def _mock_approval(decision="once", incarnation=None):
+    """Patch the human approval gate: return a receipt bound to the EXACT
+    incarnation the handler observed (the mock mirrors the real gate, which
+    receives the observed identity and binds it into the receipt)."""
+    from tools.grant_authority import HumanApprovalReceipt, _store_receipt
+
+    def _fake_request(**kwargs):
+        if decision != "once":
+            from tools.grant_authority import ReceiptError
+
+            raise ReceiptError("human approval not granted")
+        now = time.time()
+        return _store_receipt(
+            HumanApprovalReceipt(
+                receipt_id="rcpt-" + uuid.uuid4().hex,
+                request_id="req-" + uuid.uuid4().hex,
+                request_digest="d" * 64,
+                session_id=kwargs["session_id"],
+                turn_id="turn-1",
+                tool_call_id="tool-1",
+                operation=kwargs["operation"],
+                vm_id=kwargs["vm_id"],
+                device=kwargs["device"],
+                fs_type=kwargs["fs_type"],
+                label=kwargs["label"],
+                incarnation_product_uuid=kwargs["incarnation_product_uuid"],
+                incarnation_boot_id=kwargs["incarnation_boot_id"],
+                incarnation_hostname=kwargs["incarnation_hostname"],
+                issued_at=now,
+                expires_at=now + kwargs["ttl_seconds"],
+            )
+        )
+
+    return patch("tools.governed_mkfs_tool.request_destructive_grant_approval",
+                 side_effect=_fake_request)
+
+
+def _mock_qga(prechecks=None, recheck=None, exec_result=None, postcheck=None,
+              identity=None, identity_after=None, exec_side_effect=None):
+    """Patch the structured QGA boundary with deterministic payloads.
+
+    ``qga_prechecks`` is called twice (precheck then TOCTOU recheck); when
+    ``recheck`` is provided it is returned on the second call.  ``identity``
+    is the incarnation payload returned by ``qga_guest_identity`` at the
+    initial capture; ``identity_after`` (if given) is returned on the second
+    (sink) read — used to witness an incarnation replacement between
+    approval and effect.
+    """
+    prechecks = prechecks if prechecks is not None else _clean_prechecks()
+    recheck = recheck if recheck is not None else prechecks
+    exec_result = exec_result if exec_result is not None else _exec_ok()
+    postcheck = postcheck if postcheck is not None else _postcheck_ok()
+    identity = identity if identity is not None else dict(_INCARNATION)
+    identity_after = identity_after if identity_after is not None else identity
+    pre_calls = {"n": 0}
+    id_calls = {"n": 0}
+
+    def _prechecks(vm_id, device):
+        pre_calls["n"] += 1
+        return recheck if pre_calls["n"] >= 2 else prechecks
+
+    def _identity(vm_id):
+        id_calls["n"] += 1
+        return dict(identity_after if id_calls["n"] >= 2 else identity)
+
+    def _exec(vm_id, device, fs_type, label):
+        if exec_side_effect is not None:
+            exec_side_effect()
+        return exec_result
+
+    def _postcheck(vm_id, device, fs_type, label):
+        if callable(postcheck):
+            return postcheck(vm_id, device, fs_type, label)
+        return postcheck
+
+    return patch.multiple(
+        "tools.governed_mkfs_tool",
+        qga_prechecks=_prechecks,
+        qga_guest_identity=_identity,
+        qga_create_filesystem=_exec,
+        qga_postcheck=_postcheck,
+    )
+
+
+# ---------------------------------------------------------------------------
+# B1 — authority provenance and grant integrity
+# ---------------------------------------------------------------------------
+
+
+class TestB1IssuanceEvidence:
+    def test_issue_requires_receipt(self):
+        with pytest.raises(dg.GrantError):
+            dg.issue_grant(
+                operation="CREATE_FILESYSTEM",
+                vm_id="101", hostname="storage-guest", device="/dev/sdb1",
+                fs_type="ext4", label="X",
+                authorization_subject="operator", session_id="sess-1",
+                receipt_id="no-such-receipt",
+                incarnation_product_uuid="uuid-A",
+                incarnation_boot_id="boot-A", incarnation_hostname="storage-guest",
+            )
+
+    def test_issue_rejects_unknown_receipt(self):
+        with pytest.raises(dg.GrantError):
+            dg.issue_grant(
+                operation="CREATE_FILESYSTEM",
+                vm_id="101", hostname="storage-guest", device="/dev/sdb1",
+                fs_type="ext4", label="X",
+                authorization_subject="operator", session_id="sess-1",
+                receipt_id="rcpt-00000000000000000000000000000000",
+                incarnation_product_uuid="uuid-A",
+                incarnation_boot_id="boot-A", incarnation_hostname="storage-guest",
+            )
+
+    def test_issue_rejects_mismatched_receipt(self):
+        # Receipt for a different device: issuance must be denied.
+        receipt = _make_receipt(device="/dev/sdc1")
+        with pytest.raises(dg.GrantError):
+            _issue(receipt=receipt)
+
+    def test_issue_rejects_receipt_session_mismatch(self):
+        """A receipt approved for session A must never mint a grant for
+        session B (session-scoped authority)."""
+        receipt = _make_receipt(session_id="sess-A")
+        with pytest.raises(dg.GrantError):
+            _issue(receipt=receipt, session_id="sess-B")
+        # The receipt is consumed only on success: a denied issuance must
+        # not burn the receipt (the human decision stays usable).
+        grant = _issue(receipt=receipt, session_id="sess-A")
+        assert grant.session_id == "sess-A"
+
+    def test_issue_rejects_receipt_incarnation_mismatch(self):
+        """A receipt approved for generation A must never mint a grant for
+        generation B (identity observed before approval == grant identity)."""
+        receipt = _make_receipt(incarnation={
+            "hostname": "storage-guest", "boot_id": "boot-A",
+            "product_uuid": "uuid-A",
+        })
+        with pytest.raises(dg.GrantError):
+            _issue(receipt=receipt, incarnation={
+                "hostname": "storage-guest", "boot_id": "boot-B",
+                "product_uuid": "uuid-A",
+            })
+
+    def test_grant_expiry_never_exceeds_receipt_expiry(self):
+        """grant.expires_at <= receipt.expires_at always (no implicit
+        authority renewal at issuance)."""
+        receipt = _make_receipt(ttl=60)
+        grant = _issue(receipt=receipt, ttl=600)  # requested TTL > approved
+        assert grant.expires_at <= receipt.expires_at
+        assert grant.expires_at - grant.issued_at <= 60
+
+    def test_expired_receipt_cannot_issue(self):
+        """An already-expired human approval cannot mint a grant."""
+        receipt = _make_receipt(ttl=-10)  # expires in the past
+        with pytest.raises(dg.GrantError):
+            _issue(receipt=receipt)
+
+    def test_issue_requires_incarnation(self):
+        with pytest.raises(dg.GrantError):
+            dg.issue_grant(
+                operation="CREATE_FILESYSTEM",
+                vm_id="101", hostname="storage-guest", device="/dev/sdb1",
+                fs_type="ext4", label="X",
+                authorization_subject="operator", session_id="sess-1",
+                receipt_id=_make_receipt().receipt_id,
+                incarnation_product_uuid="",
+                incarnation_boot_id="boot-A", incarnation_hostname="storage-guest",
+            )
+
+    def test_issue_requires_product_uuid(self):
+        with pytest.raises(dg.GrantError):
+            dg.issue_grant(
+                operation="CREATE_FILESYSTEM",
+                vm_id="101", hostname="storage-guest", device="/dev/sdb1",
+                fs_type="ext4", label="X",
+                authorization_subject="operator", session_id="sess-1",
+                receipt_id=_make_receipt().receipt_id,
+                incarnation_product_uuid="uuid-A",
+                incarnation_boot_id="", incarnation_hostname="storage-guest",
+            )
+
+    def test_receipt_is_persisted_and_bound(self):
+        grant = _issue()
+        assert grant.authorization_evidence["request_id"] == "req-11111111111111111111111111111111"
+        assert grant.incarnation_boot_id == "boot-A"
+        # Reload from disk: auth tag still valid (no tamper).
+        loaded = dg.load_grant(grant.grant_id)
+        assert loaded.auth_tag == grant.auth_tag
+        assert loaded.authority_generation == grant.authority_generation
+
+    def test_receipt_is_one_shot(self):
+        """The same receipt cannot issue a second grant (replay denied)."""
+        receipt = _make_receipt()
+        g1 = _issue(receipt=receipt)
+        assert g1.receipt_id == receipt.receipt_id
+        with pytest.raises(dg.GrantError):
+            _issue(receipt=receipt)  # already consumed
+
+
+class TestB1CloneAndTamper:
+    def _clone(self, grant_id, new_id, rewrite_payload_id=True):
+        src = dg._grant_path(grant_id)
+        dst = dg._grant_path(new_id)
+        data = json.loads(src.read_text())
+        if rewrite_payload_id:
+            data["grant_id"] = new_id
+        dst.write_text(json.dumps(data))
+
+    def test_clone_under_new_uuid_denied(self):
+        grant = _issue()
+        self._clone(grant.grant_id, "99999999-9999-4999-8999-999999999999")
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant("99999999-9999-4999-8999-999999999999")
+
+    def test_clone_with_unchanged_payload_id_denied(self):
+        grant = _issue()
+        self._clone(grant.grant_id, "99999999-9999-4999-8999-999999999999",
+                    rewrite_payload_id=False)
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant("99999999-9999-4999-8999-999999999999")
+
+    def test_ttl_extension_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["expires_at"] = data["expires_at"] + 3600
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_evidence_swap_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["authorization_evidence"] = dict(
+            data["authorization_evidence"], principal="Mallory"
+        )
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_receipt_swap_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["receipt_id"] = "rcpt-" + "2" * 28
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_incarnation_swap_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["incarnation_boot_id"] = "boot-B"
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_product_uuid_swap_denied(self):
+        grant = _issue()
+        path = dg._grant_path(grant.grant_id)
+        data = json.loads(path.read_text())
+        data["incarnation_product_uuid"] = "uuid-B"
+        path.write_text(json.dumps(data))
+        with pytest.raises(dg.GrantDeniedError):
+            dg.load_grant(grant.grant_id)
+
+
+# ---------------------------------------------------------------------------
+# B2 — claim/settlement lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestB2Claim:
+    def test_claim_is_atomic_and_exclusive(self):
+        grant = _issue()
+        claimed = dg.claim_grant(grant.grant_id, "exec-1")
+        assert claimed.claimed_by_execution == "exec-1"
+        with pytest.raises(dg.GrantInFlightError):
+            dg.claim_grant(grant.grant_id, "exec-2")
+
+    def test_verify_rejects_claimed_grant(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        with pytest.raises(dg.GrantInFlightError):
+            dg.verify_grant(
+                grant.grant_id,
+                operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+                fs_type="ext4", label="DATA", session_id="sess-1",
+            )
+
+    def test_settle_requires_matching_execution(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        with pytest.raises(dg.GrantError):
+            dg.settle_grant(grant.grant_id, "exec-2", "completed")
+
+    def test_settle_completed_removes_from_pool(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        dg.settle_grant(grant.grant_id, "exec-1", "completed")
+        assert dg.get_grant_state(grant.grant_id) == "settled:completed"
+        with pytest.raises(dg.GrantConsumedError):
+            dg.load_grant(grant.grant_id)
+        assert all(g.grant_id != grant.grant_id for g in dg.list_grants())
+
+    def test_settle_failed_pre_effect_removes_from_pool(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        dg.settle_grant(grant.grant_id, "exec-1", "failed_pre_effect")
+        assert dg.get_grant_state(grant.grant_id) == "settled:failed_pre_effect"
+        with pytest.raises(dg.GrantConsumedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_settle_indeterminate_removes_from_pool(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        dg.settle_grant(grant.grant_id, "exec-1", "indeterminate")
+        assert dg.get_grant_state(grant.grant_id) == "settled:indeterminate"
+        with pytest.raises(dg.GrantConsumedError):
+            dg.load_grant(grant.grant_id)
+
+    def test_invalid_outcome_rejected(self):
+        grant = _issue()
+        dg.claim_grant(grant.grant_id, "exec-1")
+        with pytest.raises(dg.GrantError):
+            dg.settle_grant(grant.grant_id, "exec-1", "maybe")
+
+
+class TestB2Concurrency:
+    def test_concurrent_callers_single_winner(self):
+        """Two concurrent model calls racing on the SAME grant: one winner,
+        exactly one qga_create_filesystem call.  The claim is the atomic
+        reservation point (review #100694 blocker 2)."""
+        from tools import governed_mkfs_tool as gmt
+
+        shared_grant = _issue()
+        barrier = threading.Barrier(2)
+        real_claim = gmt.claim_grant
+        exec_calls = []
+
+        def racing_claim(grant_id, execution_id):
+            barrier.wait(timeout=5)
+            return real_claim(grant_id, execution_id)
+
+        results = {}
+
+        def run():
+            results[threading.get_ident()] = _call()
+
+        # Both callers race on the same grant: issue_grant is patched to
+        # return the shared grant, so the claim is the single contention
+        # point.  Patch ONCE in the main thread: the mock must stay active
+        # for the whole race, including while the winner runs the
+        # post-claim flow.
+        with _mock_approval(), _mock_qga(exec_side_effect=lambda: exec_calls.append(1)):
+            with patch.object(gmt, "issue_grant", return_value=shared_grant):
+                with patch.object(gmt, "claim_grant", side_effect=racing_claim):
+                    t1 = threading.Thread(target=run)
+                    t2 = threading.Thread(target=run)
+                    t1.start()
+                    t2.start()
+                    t1.join(10)
+                    t2.join(10)
+        assert not t1.is_alive() and not t2.is_alive()
+
+        decisions = sorted(r["decision"] for r in results.values())
+        assert decisions == ["ALLOW", "DENY"]
+        assert len(exec_calls) == 1
+        loser = [r for r in results.values() if r["decision"] == "DENY"][0]
+        # The loser is denied either at the claim (claim_lost) or, if the
+        # winner already settled the grant before the loser reached the
+        # claim, as a replay (grant_denied).  Both are legitimate DENYs.
+        assert loser["reason"] in ("claim_lost", "grant_denied")
+
+
+class TestB2SettlementOutcomes:
+    def test_precheck_failure_settles_failed_pre_effect(self):
+        prechecks = _clean_prechecks()
+        prechecks["mounted"] = True
+        with _mock_approval(), _mock_qga(prechecks=prechecks):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["outcome"] == "failed_pre_effect"
+        # The grant was minted in-process and settled: no live grant remains.
+        assert dg.list_grants() == []
+
+    def test_toctou_failure_settles_failed_pre_effect(self):
+        recheck = _clean_prechecks()
+        recheck["major_minor"] = "8:18"
+        with _mock_approval(), _mock_qga(recheck=recheck):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["outcome"] == "failed_pre_effect"
+
+    def test_exec_nonzero_settles_indeterminate(self):
+        exec_result = _exec_ok()
+        exec_result["exit_code"] = 1
+        exec_result["err_data"] = "mkfs.ext4: Device or resource busy"
+        with _mock_approval(), _mock_qga(exec_result=exec_result):
+            result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["outcome"] == "indeterminate"
+        # Never returns to the pool: replay is impossible.
+        assert dg.list_grants() == []
+
+    def test_postcheck_loss_settles_indeterminate(self):
+        from tools.qga_structured import QgaError
+
+        def _boom(vm_id, device, fs_type, label):
+            raise QgaError("postcheck transport lost")
+
+        with _mock_approval(), _mock_qga(postcheck=_boom):
+            result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["outcome"] == "indeterminate"
+
+    def test_postcheck_mismatch_settles_indeterminate(self):
+        with _mock_approval(), _mock_qga(postcheck=_postcheck_ok(fs_type="xfs")):
+            result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["outcome"] == "indeterminate"
+
+    def test_success_settles_completed(self):
+        with _mock_approval(), _mock_qga():
+            result = _call()
+        assert result["decision"] == "ALLOW"
+        assert result["outcome"] == "completed"
+        assert dg.list_grants() == []
+
+    def test_settlement_failure_blocks_blind_replay(self):
+        """Settlement persistence failure after a possible mutation: the
+        grant stays CLAIMED (never returns to LIVE), so a blind replay is
+        impossible even though the settlement rename failed."""
+        from tools import governed_mkfs_tool as gmt
+
+        real_settle = gmt.settle_grant
+
+        def failing_settle(grant_id, execution_id, outcome):
+            if outcome == "completed":
+                raise dg.GrantError("simulated settlement persistence failure")
+            return real_settle(grant_id, execution_id, outcome)
+
+        with _mock_approval(), _mock_qga():
+            with patch.object(gmt, "settle_grant", side_effect=failing_settle):
+                result = _call()
+        assert result["decision"] == "INDETERMINATE"
+        assert result["outcome"] == "indeterminate"
+        # The grant is still claimed (in-flight), NOT live: no blind replay.
+        grant_id = result["grant_id"]
+        assert dg.get_grant_state(grant_id) == "claimed"
+        with pytest.raises(dg.GrantInFlightError):
+            dg.claim_grant(grant_id, "exec-replay")
+        with pytest.raises(dg.GrantInFlightError):
+            dg.verify_grant(
+                grant_id,
+                operation="CREATE_FILESYSTEM", vm_id="101", device="/dev/sdb1",
+                fs_type="ext4", label="DATA", session_id="sess-1",
+            )
+
+
+# ---------------------------------------------------------------------------
+# B3 — durable generation fencing
+# ---------------------------------------------------------------------------
+
+
+class TestB3GenerationFencing:
+    def test_incarnation_mismatch_denied_at_sink(self):
+        """The live guest changed generation between approval and sink
+        re-read: denied BEFORE any mutation."""
+        exec_calls = []
+        with _mock_approval(), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                      "product_uuid": "uuid-A"},
+            identity_after={"hostname": "storage-guest", "boot_id": "boot-B",
+                            "product_uuid": "uuid-A"},
+            exec_side_effect=lambda: exec_calls.append(1),
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "incarnation_changed"
+        assert exec_calls == []
+        assert result["outcome"] == "failed_pre_effect"
+
+    def test_incarnation_match_allows(self):
+        with _mock_approval(), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                      "product_uuid": "uuid-A"},
+        ):
+            result = _call()
+        assert result["decision"] == "ALLOW"
+
+    def test_aba_witness_generation_b_untouched(self):
+        """A issued for gen A; VM replaced by gen B; A resumes -> B untouched."""
+        exec_calls = []
+        with _mock_approval(), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                      "product_uuid": "uuid-A"},
+            identity_after={"hostname": "storage-guest", "boot_id": "boot-B",
+                            "product_uuid": "uuid-A"},
+            exec_side_effect=lambda: exec_calls.append(1),
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert exec_calls == []
+
+    def test_vm_replacement_denied_at_sink(self):
+        """Same vm_id + same device + same hostname, NEW product_uuid:
+        the grant for the old incarnation must not mutate the new VM."""
+        exec_calls = []
+        with _mock_approval(), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                      "product_uuid": "uuid-A"},
+            identity_after={"hostname": "storage-guest", "boot_id": "boot-A",
+                            "product_uuid": "uuid-B"},
+            exec_side_effect=lambda: exec_calls.append(1),
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "incarnation_changed"
+        assert exec_calls == []
+        assert result["outcome"] == "failed_pre_effect"
+
+    def test_boot_id_in_toctou_snapshot(self):
+        recheck = _clean_prechecks()
+        recheck["boot_id"] = "boot-B"
+        with _mock_approval(), _mock_qga(
+            identity={"hostname": "storage-guest", "boot_id": "boot-A",
+                      "product_uuid": "uuid-A"},
+            recheck=recheck,
+        ):
+            result = _call()
+        assert result["decision"] == "DENY"
+        assert result["reason"] == "toctou_identity_changed"

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -601,6 +601,13 @@ HARDLINE_PATTERNS = [
     (_CMDPOS + r'init\s+[06]\b', "init 0/6 (shutdown/reboot)"),
     (_CMDPOS + r'systemctl\s+(poweroff|reboot|halt|kexec)\b', "systemctl poweroff/reboot"),
     (_CMDPOS + r'telinit\s+[06]\b', "telinit 0/6 (shutdown/reboot)"),
+    # Destructive grant issuance — the model must never mint its own
+    # authority.  `hermes grant issue` is the ONLY path that creates a
+    # one-shot destructive capability; it is hardline-blocked so no model
+    # surface (terminal, pty, yolo, mode=off, cron approve, smart approval,
+    # allowlist) can reach it.  The human runs it in their own shell, which
+    # is not subject to the agent's command guards (review #100694 blocker 1).
+    (_CMDPOS + r'hermes\s+grant\s+issue\b', "destructive grant issuance (hermes grant issue)"),
 ]
 
 # Pre-compiled variant used by the hot-path matcher. Building these at module

--- a/tools/destructive_grants.py
+++ b/tools/destructive_grants.py
@@ -1,0 +1,1075 @@
+"""Trusted one-shot destructive grants.
+
+A ``DestructiveGrant`` is the only representation of an explicit user GO that
+the governed destructive path accepts.  Grants are created exclusively from a
+correlated, one-shot human approval receipt (``tools.grant_authority``) — the
+receipt is produced by the approval layer after an explicit human
+"approve once" decision, never by the model.
+
+Authority doctrine (review #100694 blocker 1):
+
+1. correlated one-shot human receipt — the receipt binds operation, target,
+   session and validity window, and is consumed atomically at issuance;
+2. keyed process-bound authentication — every grant carries an HMAC tag
+   from the process-local authority provider (never an unkeyed hash), so
+   write_file/execute_code cannot forge or extend a grant;
+3. hardline defense in depth — ``hermes grant issue`` is hardline-blocked
+   from every model surface (terminal, pty, yolo, mode=off, cron).
+
+Design invariants:
+
+1. The grant is bound to ``operation/host-or-vm/device/filesystem/label``.
+2. It is one-shot: consumption is atomic (rename-based) and replay is denied.
+3. It is short-lived: ``expires_at`` is enforced on every use and never
+   exceeds the human-approved window.
+4. The model only ever sees the opaque ``grant_id``; all fields live in a
+   host-side store (``~/.hermes/grants/``, mode 0600) that generic tools do
+   not read.
+5. ``authorization_subject`` records who authorized (the user), and
+   ``authorization_source`` is always ``USER`` — an agent-generated grant is
+   denied by the receipt gate and the keyed authentication.
+6. Every decision (issue / allow / deny / consume) is appended to the audit
+   trail without secrets.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import secrets
+import time
+import uuid
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GRANT_DIR_NAME = "grants"
+AUDIT_FILE_NAME = "audit.jsonl"
+DEFAULT_TTL_SECONDS = 600  # 10 minutes, per mandate §10 (short lifetime)
+MAX_TTL_SECONDS = 3600
+
+# Operations the governed path understands.  Anything else is rejected at
+# issue time, so a grant can never be minted for an unknown operation.
+VALID_OPERATIONS = ("CREATE_FILESYSTEM",)
+
+# Filesystem types with a trusted binary mapping (mandate §15: the model must
+# never produce ``binary=<user controlled string>``).
+FS_TYPE_TO_BINARY = {
+    "ext4": "/usr/sbin/mkfs.ext4",
+    "xfs": "/usr/sbin/mkfs.xfs",
+}
+
+# Strict device allowlist.  A partition-less whole disk (``/dev/sda``) is
+# rejected: the governed path only ever formats an exact partition or an
+# explicit disposable loop device, never a whole disk and never a root disk.
+_DEVICE_RE = re.compile(
+    r"^/dev/(?:sd[a-z][0-9]+|vd[a-z][0-9]+|nvme[0-9]+n[0-9]+p[0-9]+|"
+    r"mmcblk[0-9]+p[0-9]+|loop[0-9]+)$"
+)
+# Root/whole-disk prefixes that must never be formatted.  These are the
+# conventional system disks (sda, vda, nvme0n1, mmcblk0) and ALL their
+# partitions: a partition of the system disk is the root/root-parent case
+# the mandate forbids.  Secondary data disks (sdb, sdc, ...) remain issuable
+# as exact partitions.
+_FORBIDDEN_DEVICE_PREFIXES = (
+    "/dev/sda", "/dev/vda", "/dev/nvme0n1", "/dev/mmcblk0",
+)
+
+# Strict label validation: ext4 labels are <= 16 chars, no spaces, no slashes.
+_LABEL_RE = re.compile(r"^[A-Za-z0-9_.\-]{1,16}$")
+
+# VM id: positive integer.
+_VM_ID_RE = re.compile(r"^[0-9]{1,5}$")
+
+
+class GrantError(Exception):
+    """Base error for grant operations."""
+
+
+class GrantNotFoundError(GrantError):
+    pass
+
+
+class GrantDeniedError(GrantError):
+    """Raised when a grant exists but the request does not match it."""
+
+
+class GrantExpiredError(GrantDeniedError):
+    pass
+
+
+class GrantConsumedError(GrantDeniedError):
+    pass
+
+
+class GrantInFlightError(GrantDeniedError):
+    """Raised when a grant is claimed by another execution (concurrent use)."""
+
+
+# Outcomes a grant can be settled with.  ``completed`` is the only success;
+# ``failed_pre_effect`` means no mutation can have happened; ``indeterminate``
+# means a mutation may have happened and the grant must NEVER return to the
+# pool (no blind retry, per #90144/#90145 and the review of #100694).
+VALID_SETTLEMENT_OUTCOMES = ("completed", "failed_pre_effect", "indeterminate")
+
+
+@dataclass(frozen=True)
+class DestructiveGrant:
+    """Immutable one-shot capability record."""
+
+    grant_id: str
+    operation: str
+    vm_id: str
+    hostname: str
+    device: str
+    fs_type: str
+    label: str
+    authorization_subject: str
+    authorization_source: str  # always "USER"
+    session_id: str
+    issued_at: float
+    expires_at: float
+    nonce: str
+    auth_tag: str
+    authority_generation: str
+    receipt_id: str
+    schema_version: int
+    authorization_evidence: Dict[str, object]
+    incarnation_product_uuid: str
+    incarnation_boot_id: str
+    incarnation_hostname: str
+    consumed: bool = False
+    consumed_at: Optional[float] = None
+    claimed_by_execution: Optional[str] = None
+    claimed_at: Optional[float] = None
+    settlement_outcome: Optional[str] = None
+    settled_at: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "grant_id": self.grant_id,
+            "operation": self.operation,
+            "vm_id": self.vm_id,
+            "hostname": self.hostname,
+            "device": self.device,
+            "fs_type": self.fs_type,
+            "label": self.label,
+            "authorization_subject": self.authorization_subject,
+            "authorization_source": self.authorization_source,
+            "session_id": self.session_id,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "nonce": self.nonce,
+            "auth_tag": self.auth_tag,
+            "authority_generation": self.authority_generation,
+            "receipt_id": self.receipt_id,
+            "schema_version": self.schema_version,
+            "authorization_evidence": self.authorization_evidence,
+            "incarnation_product_uuid": self.incarnation_product_uuid,
+            "incarnation_boot_id": self.incarnation_boot_id,
+            "incarnation_hostname": self.incarnation_hostname,
+            "consumed": self.consumed,
+            "consumed_at": self.consumed_at,
+            "claimed_by_execution": self.claimed_by_execution,
+            "claimed_at": self.claimed_at,
+            "settlement_outcome": self.settlement_outcome,
+            "settled_at": self.settled_at,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, object]) -> "DestructiveGrant":
+        consumed_at_raw = data.get("consumed_at")
+        claimed_at_raw = data.get("claimed_at")
+        settled_at_raw = data.get("settled_at")
+        return cls(
+            grant_id=str(data["grant_id"]),
+            operation=str(data["operation"]),
+            vm_id=str(data["vm_id"]),
+            hostname=str(data["hostname"]),
+            device=str(data["device"]),
+            fs_type=str(data["fs_type"]),
+            label=str(data["label"]),
+            authorization_subject=str(data["authorization_subject"]),
+            authorization_source=str(data["authorization_source"]),
+            session_id=str(data["session_id"]),
+            issued_at=float(str(data["issued_at"])),
+            expires_at=float(str(data["expires_at"])),
+            nonce=str(data["nonce"]),
+            auth_tag=str(data["auth_tag"]),
+            authority_generation=str(data["authority_generation"]),
+            receipt_id=str(data["receipt_id"]),
+            schema_version=int(str(data.get("schema_version", 1))),
+            authorization_evidence=dict(data.get("authorization_evidence") or {}),
+            incarnation_product_uuid=str(data.get("incarnation_product_uuid") or ""),
+            incarnation_boot_id=str(data.get("incarnation_boot_id") or ""),
+            incarnation_hostname=str(data.get("incarnation_hostname") or ""),
+            consumed=bool(data.get("consumed", False)),
+            consumed_at=(
+                float(str(consumed_at_raw)) if consumed_at_raw is not None else None
+            ),
+            claimed_by_execution=(
+                str(data["claimed_by_execution"])
+                if data.get("claimed_by_execution") is not None
+                else None
+            ),
+            claimed_at=(
+                float(str(claimed_at_raw)) if claimed_at_raw is not None else None
+            ),
+            settlement_outcome=(
+                str(data["settlement_outcome"])
+                if data.get("settlement_outcome") is not None
+                else None
+            ),
+            settled_at=(
+                float(str(settled_at_raw)) if settled_at_raw is not None else None
+            ),
+        )
+
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+
+def _grants_dir() -> Path:
+    from hermes_constants import get_hermes_home
+
+    d = Path(get_hermes_home()) / GRANT_DIR_NAME
+    return d
+
+
+def _grant_path(grant_id: str) -> Path:
+    # grant_id is an opaque UUID we mint; still guard against path traversal.
+    if not re.match(r"^[0-9a-f\-]{36}$", grant_id):
+        raise GrantError(f"invalid grant id format: {grant_id!r}")
+    return _grants_dir() / f"{grant_id}.json"
+
+
+def _audit_path() -> Path:
+    return _grants_dir() / AUDIT_FILE_NAME
+
+
+def _ensure_dir() -> None:
+    d = _grants_dir()
+    d.mkdir(mode=0o700, parents=True, exist_ok=True)
+    try:
+        os.chmod(d, 0o700)
+    except OSError:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers
+# ---------------------------------------------------------------------------
+
+
+def validate_device(device: str) -> None:
+    """Strict device validation.  Raises GrantError on any non-conforming value."""
+    if not isinstance(device, str) or not device:
+        raise GrantError("device is required")
+    if not _DEVICE_RE.match(device):
+        raise GrantError(f"device {device!r} is not an allowed exact partition/loop path")
+    for prefix in _FORBIDDEN_DEVICE_PREFIXES:
+        if device.startswith(prefix):
+            # Covers the whole disk itself (/dev/sda) and every partition of
+            # a system disk (/dev/sda1, /dev/nvme0n1p1, /dev/mmcblk0p1).
+            raise GrantError(f"device {device!r} is a root/whole-disk path and is forbidden")
+    # Explicitly forbid the exact whole-disk names (no partition number).
+    if re.match(r"^/dev/(?:sd|vd)[a-z]+$", device):
+        raise GrantError(f"device {device!r} is a whole disk; an exact partition is required")
+    if re.match(r"^/dev/nvme[0-9]+n[0-9]+$", device):
+        raise GrantError(f"device {device!r} is a whole disk; an exact partition is required")
+
+
+def validate_fs_type(fs_type: str) -> None:
+    if fs_type not in FS_TYPE_TO_BINARY:
+        raise GrantError(f"filesystem {fs_type!r} is not in the trusted allowlist")
+
+
+def validate_label(label: str) -> None:
+    if not isinstance(label, str) or not _LABEL_RE.match(label):
+        raise GrantError(f"label {label!r} is invalid (1-16 chars, [A-Za-z0-9_.-])")
+
+
+def validate_vm_id(vm_id: str) -> None:
+    if not isinstance(vm_id, str) or not _VM_ID_RE.match(vm_id):
+        raise GrantError(f"vm_id {vm_id!r} is invalid")
+
+
+def validate_operation(operation: str) -> None:
+    if operation not in VALID_OPERATIONS:
+        raise GrantError(f"operation {operation!r} is not supported")
+
+
+def _authenticate_grant(
+    *,
+    schema_version: int,
+    grant_id: str,
+    receipt_id: str,
+    operation: str,
+    vm_id: str,
+    hostname: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    subject: str,
+    session_id: str,
+    turn_id: str,
+    tool_call_id: str,
+    issued_at: float,
+    expires_at: float,
+    nonce: str,
+    incarnation_product_uuid: str,
+    incarnation_boot_id: str,
+    incarnation_hostname: str,
+    evidence: Optional[Dict[str, object]] = None,
+) -> str:
+    """Authenticate the FULL immutable grant identity with the process-local
+    authority provider (keyed HMAC, never an unkeyed SHA-256).
+
+    Covers the grant id itself (a clone under a second UUID breaks the tag
+    even when the embedded id is rewritten), the receipt id (a grant minted
+    from a different human receipt is rejected), the operation tuple, the VM
+    incarnation (durable generation: product_uuid + boot_id + hostname), and
+    the exact validity window (``issued_at``/``expires_at``).  Any tamper —
+    clone, TTL extension, receipt swap, incarnation swap — breaks the
+    recomputed tag and is treated as DENY (review #100694 blocker 1;
+    #90144/#90145).
+    """
+    from tools.grant_authority import canonical_grant_payload, get_authority
+
+    payload = canonical_grant_payload(
+        schema_version=schema_version,
+        grant_id=grant_id,
+        receipt_id=receipt_id,
+        operation=operation,
+        vm_id=vm_id,
+        hostname=hostname,
+        product_uuid=incarnation_product_uuid,
+        boot_id=incarnation_boot_id,
+        device=device,
+        fs_type=fs_type,
+        label=label,
+        authorization_subject=subject,
+        authorization_source="USER",
+        session_id=session_id,
+        turn_id=turn_id,
+        tool_call_id=tool_call_id,
+        issued_at=issued_at,
+        expires_at=expires_at,
+        nonce=nonce,
+        authorization_evidence=evidence,
+    )
+    return get_authority().authenticate(payload)
+
+
+def _verify_grant_authenticity(grant: "DestructiveGrant") -> bool:
+    """Recompute the authority tag over the grant's immutable fields and
+    compare in constant time.
+
+    The provider generation is part of the check: a grant minted by a
+    different process (or before a restart) has a different generation and
+    fails here, so grants are process-bound capabilities.
+    """
+    from tools.grant_authority import canonical_grant_payload, get_authority
+
+    authority = get_authority()
+    if grant.authority_generation != authority.generation:
+        return False
+    payload = canonical_grant_payload(
+        schema_version=grant.schema_version,
+        grant_id=grant.grant_id,
+        receipt_id=grant.receipt_id,
+        operation=grant.operation,
+        vm_id=grant.vm_id,
+        hostname=grant.hostname,
+        product_uuid=grant.incarnation_product_uuid,
+        boot_id=grant.incarnation_boot_id,
+        device=grant.device,
+        fs_type=grant.fs_type,
+        label=grant.label,
+        authorization_subject=grant.authorization_subject,
+        authorization_source=grant.authorization_source,
+        session_id=grant.session_id,
+        turn_id=str((grant.authorization_evidence or {}).get("turn_id", "")),
+        tool_call_id=str((grant.authorization_evidence or {}).get("tool_call_id", "")),
+        issued_at=grant.issued_at,
+        expires_at=grant.expires_at,
+        nonce=grant.nonce,
+        authorization_evidence=grant.authorization_evidence,
+    )
+    return authority.verify(payload, grant.auth_tag)
+
+
+# ---------------------------------------------------------------------------
+# Audit trail
+# ---------------------------------------------------------------------------
+
+
+def _audit(entry: Dict[str, object]) -> None:
+    try:
+        _ensure_dir()
+        line = json.dumps(entry, sort_keys=True, ensure_ascii=False) + "\n"
+        with open(_audit_path(), "a", encoding="utf-8") as fh:
+            fh.write(line)
+    except Exception as exc:  # pragma: no cover - audit must never break the action
+        logger.error("grant audit write failed: %s", exc)
+
+
+def read_audit_trail(limit: int = 200) -> List[Dict[str, object]]:
+    """Read the audit trail (newest first).  Used by ``hermes grant audit``."""
+    p = _audit_path()
+    if not p.exists():
+        return []
+    entries: List[Dict[str, object]] = []
+    with open(p, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entries.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    return list(reversed(entries[-limit:]))
+
+
+# ---------------------------------------------------------------------------
+# Issue (trusted user boundary only)
+# ---------------------------------------------------------------------------
+
+
+def issue_grant(
+    *,
+    operation: str,
+    vm_id: str,
+    hostname: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    authorization_subject: str,
+    session_id: str,
+    receipt_id: str,
+    incarnation_product_uuid: str,
+    incarnation_boot_id: str,
+    incarnation_hostname: str,
+    ttl_seconds: int = DEFAULT_TTL_SECONDS,
+) -> DestructiveGrant:
+    """Create a one-shot grant.  ONLY callable from a trusted user boundary.
+
+    The authority comes from a correlated, one-shot human approval receipt
+    (``tools.grant_authority.request_destructive_grant_approval``), not from
+    the CLI location or file permissions: the receipt is consumed atomically
+    here (one-shot: the same receipt cannot issue a second grant) and must
+    match the requested operation, target, session and validity window.
+    ``incarnation_product_uuid`` / ``incarnation_boot_id`` /
+    ``incarnation_hostname`` are the durable VM generation captured at issue
+    time (review #100694 blocker 1 + blocker 3; #90144/#90145).
+    """
+    from tools.grant_authority import (
+        ReceiptError,
+        consume_receipt,
+        get_authority,
+        peek_receipt,
+    )
+
+    validate_operation(operation)
+    validate_vm_id(vm_id)
+    validate_device(device)
+    validate_fs_type(fs_type)
+    validate_label(label)
+
+    if not isinstance(authorization_subject, str) or not authorization_subject:
+        raise GrantError("authorization_subject is required (the human who grants)")
+    if not isinstance(session_id, str) or not session_id:
+        raise GrantError("session_id is required")
+    if not isinstance(ttl_seconds, int) or ttl_seconds <= 0:
+        raise GrantError("ttl_seconds must be a positive integer")
+    ttl_seconds = min(ttl_seconds, MAX_TTL_SECONDS)
+
+    # B1: a grant is only minted from a correlated, one-shot human decision.
+    # The receipt is produced by the approval layer AFTER an explicit human
+    # "approve once"; the caller never supplies a free-form evidence dict.
+    # Peek first: a denied issuance must NOT burn the human decision.
+    try:
+        receipt = peek_receipt(receipt_id)
+    except ReceiptError as exc:
+        raise GrantError(str(exc)) from exc
+    if receipt.operation != operation or receipt.vm_id != vm_id:
+        raise GrantError(
+            "receipt does not match the requested operation/vm "
+            "(receipt replay or mismatch denied)"
+        )
+    if receipt.device != device or receipt.fs_type != fs_type or receipt.label != label:
+        raise GrantError(
+            "receipt does not match the requested device/fs/label "
+            "(receipt replay or mismatch denied)"
+        )
+    if receipt.session_id != session_id:
+        raise GrantError(
+            "receipt was approved for a different session "
+            "(session-scoped authority denied)"
+        )
+    if (
+        receipt.incarnation_product_uuid != incarnation_product_uuid
+        or receipt.incarnation_boot_id != incarnation_boot_id
+        or receipt.incarnation_hostname != incarnation_hostname
+    ):
+        raise GrantError(
+            "receipt was approved for a different guest incarnation "
+            "(identity observed before approval must equal the grant identity)"
+        )
+    if receipt.expires_at < time.time():
+        raise GrantError("receipt expired (human approval is no longer current)")
+
+    # B3: the durable VM incarnation must be captured at issue time.
+    if not isinstance(incarnation_product_uuid, str) or not incarnation_product_uuid:
+        raise GrantError("incarnation_product_uuid is required (stable guest identity)")
+    if not isinstance(incarnation_boot_id, str) or not incarnation_boot_id:
+        raise GrantError("incarnation_boot_id is required (durable VM generation)")
+    if not isinstance(incarnation_hostname, str) or not incarnation_hostname:
+        raise GrantError("incarnation_hostname is required")
+
+    _ensure_dir()
+    now = time.time()
+    # B: the grant lifetime never exceeds the human-approved window.  The
+    # receipt's expiry is the outer bound; issuance never renews authority.
+    grant_expires_at = min(now + ttl_seconds, receipt.expires_at)
+    if grant_expires_at <= now:
+        raise GrantError("grant would expire immediately (approval window elapsed)")
+    # All validations passed: consume the receipt atomically (one-shot).
+    try:
+        consume_receipt(receipt_id)
+    except ReceiptError as exc:
+        raise GrantError(str(exc)) from exc
+    nonce = secrets.token_hex(16)
+    grant_id = str(uuid.uuid4())
+    authority = get_authority()
+    auth_tag = _authenticate_grant(
+        schema_version=1,
+        grant_id=grant_id,
+        receipt_id=receipt.receipt_id,
+        operation=operation,
+        vm_id=vm_id,
+        hostname=hostname,
+        device=device,
+        fs_type=fs_type,
+        label=label,
+        subject=authorization_subject,
+        session_id=session_id,
+        turn_id=receipt.turn_id,
+        tool_call_id=receipt.tool_call_id,
+        issued_at=now,
+        expires_at=grant_expires_at,
+        nonce=nonce,
+        incarnation_product_uuid=incarnation_product_uuid,
+        incarnation_boot_id=incarnation_boot_id,
+        incarnation_hostname=incarnation_hostname,
+        evidence=receipt.to_dict(),
+    )
+    grant = DestructiveGrant(
+        grant_id=grant_id,
+        operation=operation,
+        vm_id=vm_id,
+        hostname=hostname,
+        device=device,
+        fs_type=fs_type,
+        label=label,
+        authorization_subject=authorization_subject,
+        authorization_source="USER",
+        session_id=session_id,
+        issued_at=now,
+        expires_at=grant_expires_at,
+        nonce=nonce,
+        auth_tag=auth_tag,
+        authority_generation=authority.generation,
+        receipt_id=receipt.receipt_id,
+        schema_version=1,
+        authorization_evidence=dict(receipt.to_dict()),
+        incarnation_product_uuid=incarnation_product_uuid,
+        incarnation_boot_id=incarnation_boot_id,
+        incarnation_hostname=incarnation_hostname,
+    )
+
+    path = _grant_path(grant_id)
+    # O_EXCL: a grant id collision must never overwrite an existing grant.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        json.dump(grant.to_dict(), fh, sort_keys=True, ensure_ascii=False)
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+    _audit(
+        {
+            "event": "grant_issued",
+            "grant_id": grant_id,
+            "operation": operation,
+            "vm_id": vm_id,
+            "hostname": hostname,
+            "device": device,
+            "fs_type": fs_type,
+            "label": label,
+            "authorization_subject": authorization_subject,
+            "authorization_source": "USER",
+            "session_id": session_id,
+            "ttl_seconds": ttl_seconds,
+            "expires_at": grant.expires_at,
+            "auth_tag": auth_tag,
+            "authority_generation": authority.generation,
+            "receipt_id": receipt.receipt_id,
+            "incarnation_product_uuid": incarnation_product_uuid,
+            "incarnation_boot_id": incarnation_boot_id,
+        }
+    )
+    logger.info("destructive grant %s issued for %s %s", grant_id, operation, device)
+    return grant
+
+
+# ---------------------------------------------------------------------------
+# Load / verify / consume
+# ---------------------------------------------------------------------------
+
+
+def load_grant(grant_id: str) -> DestructiveGrant:
+    """Load a grant by opaque id.
+
+    Raises GrantNotFoundError if absent, GrantConsumedError if the grant was
+    already consumed (replay), GrantInFlightError if the grant is claimed by
+    another execution, and GrantDeniedError if the file was tampered.
+    """
+    path = _grant_path(grant_id)
+    if not path.exists():
+        # A claimed grant lives under the .claimed suffix (in-flight for the
+        # claiming execution); a consumed/settled grant is replay.
+        claimed_path = path.with_suffix(".json.claimed")
+        if claimed_path.exists():
+            path = claimed_path
+        else:
+            consumed_path = path.with_suffix(".json.consumed")
+            if consumed_path.exists():
+                raise GrantConsumedError(f"grant {grant_id!r} already consumed (replay denied)")
+            settled_path = path.with_suffix(".json.settled")
+            if settled_path.exists():
+                raise GrantConsumedError(f"grant {grant_id!r} already settled (replay denied)")
+            raise GrantNotFoundError(f"grant {grant_id!r} not found")
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GrantError(f"grant {grant_id!r} unreadable: {exc}") from exc
+    grant = DestructiveGrant.from_dict(data)
+    # B1: the payload must be bound to the path id.  A clone under a second
+    # UUID (with or without rewriting the embedded id) is structurally denied.
+    if grant.grant_id != grant_id:
+        raise GrantDeniedError(
+            f"grant {grant_id!r} payload id mismatch (clone denied)"
+        )
+    # Authenticity: the stored tag must authenticate the stored immutable
+    # fields under the process-local authority provider.  A tampered file
+    # (any field edited, TTL extended, receipt or incarnation swapped) fails
+    # here and is treated as DENY.  A grant minted by a different process
+    # (different provider generation) also fails: grants are process-bound.
+    if not _verify_grant_authenticity(grant):
+        raise GrantDeniedError(f"grant {grant_id!r} authentication failed (tampered)")
+    return grant
+
+
+def verify_grant(
+    grant_id: str,
+    *,
+    operation: str,
+    vm_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    session_id: str,
+    claimed_by_execution: Optional[str] = None,
+) -> DestructiveGrant:
+    """Verify a grant against the exact requested tuple.
+
+    Every mismatch (operation, vm, device, fs, label, session) is a DENY.
+    Expired and consumed grants are DENY.  A grant claimed by ANOTHER
+    execution is DENY (concurrent use); a grant claimed by the calling
+    execution (``claimed_by_execution`` matches) verifies normally.
+    Returns the grant on success.
+    """
+    grant = load_grant(grant_id)
+
+    if grant.consumed:
+        _audit(
+            {
+                "event": "grant_denied",
+                "grant_id": grant_id,
+                "reason": "already_consumed",
+                "requested": {
+                    "operation": operation, "vm_id": vm_id, "device": device,
+                    "fs_type": fs_type, "label": label, "session_id": session_id,
+                },
+            }
+        )
+        raise GrantConsumedError(f"grant {grant_id!r} already consumed (replay denied)")
+
+    # B2: a grant claimed by another execution is in flight — verification
+    # must not pass it (no double-claim, no concurrent use).  The claiming
+    # execution itself verifies normally.
+    if grant.claimed_by_execution is not None:
+        if claimed_by_execution != grant.claimed_by_execution:
+            _audit(
+                {
+                    "event": "grant_denied",
+                    "grant_id": grant_id,
+                    "reason": "already_claimed",
+                    "claimed_by_execution": grant.claimed_by_execution,
+                    "requested": {
+                        "operation": operation, "vm_id": vm_id, "device": device,
+                        "fs_type": fs_type, "label": label, "session_id": session_id,
+                    },
+                }
+            )
+            raise GrantInFlightError(
+                f"grant {grant_id!r} is claimed by execution "
+                f"{grant.claimed_by_execution!r} (concurrent use denied)"
+            )
+
+    if time.time() > grant.expires_at:
+        _audit(
+            {
+                "event": "grant_denied",
+                "grant_id": grant_id,
+                "reason": "expired",
+                "requested": {
+                    "operation": operation, "vm_id": vm_id, "device": device,
+                    "fs_type": fs_type, "label": label, "session_id": session_id,
+                },
+            }
+        )
+        raise GrantExpiredError(f"grant {grant_id!r} expired")
+
+    mismatches = []
+    if operation != grant.operation:
+        mismatches.append(f"operation {operation!r} != {grant.operation!r}")
+    if vm_id != grant.vm_id:
+        mismatches.append(f"vm_id {vm_id!r} != {grant.vm_id!r}")
+    if device != grant.device:
+        mismatches.append(f"device {device!r} != {grant.device!r}")
+    if fs_type != grant.fs_type:
+        mismatches.append(f"fs_type {fs_type!r} != {grant.fs_type!r}")
+    if label != grant.label:
+        mismatches.append(f"label {label!r} != {grant.label!r}")
+    if session_id != grant.session_id:
+        mismatches.append(f"session_id {session_id!r} != {grant.session_id!r}")
+
+    if mismatches:
+        _audit(
+            {
+                "event": "grant_denied",
+                "grant_id": grant_id,
+                "reason": "tuple_mismatch",
+                "details": mismatches,
+                "requested": {
+                    "operation": operation, "vm_id": vm_id, "device": device,
+                    "fs_type": fs_type, "label": label, "session_id": session_id,
+                },
+            }
+        )
+        raise GrantDeniedError("grant tuple mismatch: " + "; ".join(mismatches))
+
+    _audit(
+        {
+            "event": "grant_verified",
+            "grant_id": grant_id,
+            "operation": operation,
+            "vm_id": vm_id,
+            "device": device,
+            "fs_type": fs_type,
+            "label": label,
+            "session_id": session_id,
+        }
+    )
+    return grant
+
+
+def claim_grant(grant_id: str, execution_id: str) -> DestructiveGrant:
+    """Atomically claim a grant for one execution (B2).
+
+    The claim is a rename of the live grant file to a ``.claimed`` suffix,
+    which is atomic on POSIX: exactly one concurrent caller wins.  The
+    claimed file records ``claimed_by_execution`` and ``claimed_at``.
+
+    Raises GrantNotFoundError if absent, GrantConsumedError if already
+    consumed, GrantInFlightError if already claimed by another execution,
+    and GrantDeniedError if the file was tampered.
+    """
+    if not isinstance(execution_id, str) or not execution_id:
+        raise GrantError("execution_id is required to claim a grant")
+
+    live = _grant_path(grant_id)
+    claimed_path = live.with_suffix(".json.claimed")
+    settled_path = live.with_suffix(".json.settled")
+    if not live.exists():
+        if claimed_path.exists():
+            raise GrantInFlightError(
+                f"grant {grant_id!r} is already claimed (concurrent use denied)"
+            )
+        consumed_path = live.with_suffix(".json.consumed")
+        if consumed_path.exists():
+            raise GrantConsumedError(f"grant {grant_id!r} already consumed (replay denied)")
+        if settled_path.exists():
+            raise GrantConsumedError(
+                f"grant {grant_id!r} already settled (replay denied)"
+            )
+        raise GrantNotFoundError(f"grant {grant_id!r} not found")
+
+    # Integrity BEFORE the rename: a tampered grant must be reported as
+    # tampered, not as "not found" after the claim moved the file away.
+    try:
+        with open(live, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except OSError as exc:
+        # The live file vanished between our existence check and our read:
+        # another caller claimed it in that window.  That is a lost claim,
+        # not a corrupt grant — report it as in-flight (or as replay if the
+        # winner already settled the grant before we reached the read).
+        if claimed_path.exists():
+            raise GrantInFlightError(
+                f"grant {grant_id!r} is already claimed (concurrent use denied)"
+            ) from exc
+        if settled_path.exists():
+            raise GrantConsumedError(
+                f"grant {grant_id!r} already settled (replay denied)"
+            ) from exc
+        raise GrantError(f"grant {grant_id!r} unreadable: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        # The file may have been truncated by the winning caller between our
+        # open() and our read (the winner renames live -> .claimed and then
+        # rewrites the claimed file in place, truncating the same inode our
+        # fd still points to).  That is a lost claim, not corruption.
+        if claimed_path.exists():
+            raise GrantInFlightError(
+                f"grant {grant_id!r} is already claimed (concurrent use denied)"
+            ) from exc
+        if settled_path.exists():
+            raise GrantConsumedError(
+                f"grant {grant_id!r} already settled (replay denied)"
+            ) from exc
+        raise GrantError(f"grant {grant_id!r} unreadable: {exc}") from exc
+    pre_grant = DestructiveGrant.from_dict(data)
+    if pre_grant.grant_id != grant_id:
+        raise GrantDeniedError(
+            f"grant {grant_id!r} payload id mismatch (clone denied)"
+        )
+    if not _verify_grant_authenticity(pre_grant):
+        raise GrantDeniedError(f"grant {grant_id!r} authentication failed (tampered)")
+
+    claimed_path = live.with_suffix(".json.claimed")
+    try:
+        os.rename(live, claimed_path)
+    except OSError as exc:
+        # The rename lost a race: another caller claimed the grant between
+        # our integrity read and our rename.  That is a lost claim, not an
+        # error — report it as in-flight (or as replay if the winner already
+        # settled the grant before we reached the rename).
+        if claimed_path.exists():
+            raise GrantInFlightError(
+                f"grant {grant_id!r} is already claimed (concurrent use denied)"
+            ) from exc
+        if settled_path.exists():
+            raise GrantConsumedError(
+                f"grant {grant_id!r} already settled (replay denied)"
+            ) from exc
+        raise GrantError(f"grant {grant_id!r} claim failed: {exc}") from exc
+
+    try:
+        with open(claimed_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GrantError(f"claimed grant {grant_id!r} unreadable: {exc}") from exc
+
+    data["claimed_by_execution"] = execution_id
+    data["claimed_at"] = time.time()
+    with open(claimed_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, sort_keys=True, ensure_ascii=False)
+
+    grant = DestructiveGrant.from_dict(data)
+    _audit(
+        {
+            "event": "grant_claimed",
+            "grant_id": grant_id,
+            "execution_id": execution_id,
+            "operation": grant.operation,
+            "vm_id": grant.vm_id,
+            "device": grant.device,
+            "fs_type": grant.fs_type,
+            "label": grant.label,
+        }
+    )
+    return grant
+
+
+def settle_grant(grant_id: str, execution_id: str, outcome: str) -> DestructiveGrant:
+    """Durably settle a claimed grant (B2).
+
+    ``outcome`` is one of ``completed`` / ``failed_pre_effect`` /
+    ``indeterminate``.  The settlement is a rename of the ``.claimed`` file
+    to a ``.settled`` suffix (atomic on POSIX) and is bound to the claiming
+    execution: a mismatched ``execution_id`` is rejected.
+
+    Once settled, the grant is permanently out of the pool — an
+    ``indeterminate`` outcome NEVER returns the grant to the live set (no
+    blind retry after a possible mutation, per #90144/#90145).
+    """
+    if outcome not in VALID_SETTLEMENT_OUTCOMES:
+        raise GrantError(
+            f"invalid settlement outcome {outcome!r}; "
+            f"expected one of {VALID_SETTLEMENT_OUTCOMES}"
+        )
+
+    claimed_path = _grant_path(grant_id).with_suffix(".json.claimed")
+    if not claimed_path.exists():
+        raise GrantError(f"grant {grant_id!r} is not claimed (cannot settle)")
+
+    try:
+        with open(claimed_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GrantError(f"claimed grant {grant_id!r} unreadable: {exc}") from exc
+
+    if data.get("claimed_by_execution") != execution_id:
+        raise GrantError(
+            f"grant {grant_id!r} is claimed by execution "
+            f"{data.get('claimed_by_execution')!r}, not {execution_id!r}"
+        )
+
+    settled_path = _grant_path(grant_id).with_suffix(".json.settled")
+    try:
+        os.rename(claimed_path, settled_path)
+    except OSError as exc:
+        raise GrantError(f"grant {grant_id!r} settle failed: {exc}") from exc
+
+    data["settlement_outcome"] = outcome
+    data["settled_at"] = time.time()
+    with open(settled_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, sort_keys=True, ensure_ascii=False)
+
+    grant = DestructiveGrant.from_dict(data)
+    _audit(
+        {
+            "event": "grant_settled",
+            "grant_id": grant_id,
+            "execution_id": execution_id,
+            "outcome": outcome,
+            "operation": grant.operation,
+            "vm_id": grant.vm_id,
+            "device": grant.device,
+            "fs_type": grant.fs_type,
+            "label": grant.label,
+        }
+    )
+    return grant
+
+
+def get_grant_state(grant_id: str) -> str:
+    """Return the durable state of a grant: ``live``, ``claimed``,
+    ``settled:<outcome>``, ``consumed``, ``revoked``, or ``unknown``."""
+    live = _grant_path(grant_id)
+    if live.exists():
+        return "live"
+    for suffix, label in (
+        (".json.claimed", "claimed"),
+        (".json.settled", "settled"),
+        (".json.consumed", "consumed"),
+        (".json.revoked", "revoked"),
+    ):
+        p = live.with_suffix(suffix)
+        if p.exists():
+            if label == "settled":
+                try:
+                    with open(p, encoding="utf-8") as fh:
+                        data = json.load(fh)
+                    return f"settled:{data.get('settlement_outcome', 'unknown')}"
+                except (OSError, json.JSONDecodeError):
+                    return "settled:unknown"
+            return label
+    return "unknown"
+
+
+def consume_grant(grant_id: str) -> DestructiveGrant:
+    """Atomically consume a grant (one-shot enforcement).
+
+    The consumption is a rename of the grant file to a ``.consumed`` suffix,
+    which is atomic on POSIX.  A second consume finds no live file and is
+    denied.  Returns the consumed grant.
+    """
+    live = _grant_path(grant_id)
+    if not live.exists():
+        # Either never existed, or already consumed (replay).
+        raise GrantConsumedError(f"grant {grant_id!r} not available (replay denied)")
+
+    consumed_path = live.with_suffix(".json.consumed")
+    try:
+        os.rename(live, consumed_path)
+    except OSError as exc:
+        raise GrantError(f"grant {grant_id!r} consume failed: {exc}") from exc
+
+    try:
+        with open(consumed_path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise GrantError(f"consumed grant {grant_id!r} unreadable: {exc}") from exc
+
+    data["consumed"] = True
+    data["consumed_at"] = time.time()
+    with open(consumed_path, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, sort_keys=True, ensure_ascii=False)
+
+    grant = DestructiveGrant.from_dict(data)
+    _audit(
+        {
+            "event": "grant_consumed",
+            "grant_id": grant_id,
+            "operation": grant.operation,
+            "vm_id": grant.vm_id,
+            "device": grant.device,
+            "fs_type": grant.fs_type,
+            "label": grant.label,
+            "consumed_at": grant.consumed_at,
+        }
+    )
+    return grant
+
+
+def list_grants() -> List[DestructiveGrant]:
+    """List live (non-consumed) grants, newest first."""
+    d = _grants_dir()
+    if not d.exists():
+        return []
+    grants: List[DestructiveGrant] = []
+    for path in sorted(d.glob("*.json"), reverse=True):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                grants.append(DestructiveGrant.from_dict(json.load(fh)))
+        except (OSError, json.JSONDecodeError):
+            continue
+    return grants
+
+
+def revoke_grant(grant_id: str) -> bool:
+    """Revoke a live grant (moves it to a ``.revoked`` suffix)."""
+    live = _grant_path(grant_id)
+    if not live.exists():
+        return False
+    revoked = live.with_suffix(".json.revoked")
+    os.rename(live, revoked)
+    _audit({"event": "grant_revoked", "grant_id": grant_id})
+    return True

--- a/tools/governed_mkfs_tool.py
+++ b/tools/governed_mkfs_tool.py
@@ -1,0 +1,505 @@
+"""Governed mkfs tool — the only path that can create a filesystem.
+
+This tool is the structured alternative to the hardline-blocked ``mkfs`` in
+the generic terminal.  It implements the full mandate workflow IN THE
+CONSUMER PROCESS (review #100694 process-boundary blocker):
+
+    model requests (vm_id, device, fs_type, label) in a live session
+    -> capture trusted guest identity (product_uuid + boot_id + hostname)
+    -> request human approval for the EXACT observed tuple + incarnation
+    -> issue grant in THIS process (same ProcessEphemeralAuthority that
+       will claim and verify it)
+    -> claim_grant (atomic reservation BEFORE any effect; one winner)
+    -> re-read incarnation (sink fencing)
+    -> qga_prechecks (all mandatory checks, fail-closed)
+    -> TOCTOU recheck (identity unchanged since precheck, boot_id included)
+    -> qga_create_filesystem (argv built from allowlisted fields only)
+    -> qga_postcheck (fs type + label + uuid)
+    -> settle_grant (durable settlement: completed / failed_pre_effect /
+       indeterminate; the grant NEVER returns to the pool once claimed)
+
+The model can REQUEST a destructive authorization; it can never grant it to
+itself.  The human approval, the receipt, the grant mint, the claim and the
+mutation all happen in the same long-lived Hermes process, so the authority
+generation of the issuer IS the authority generation of the consumer.
+
+Red lines enforced here:
+
+* The generic terminal policy is untouched: ``mkfs`` stays hardline.
+* No shell string is ever built from model input.
+* ``--yolo``, approvals.mode=off, allowlist, cron approve and ``force``
+  cannot authorize this path: the receipt gate refuses every bypass
+  context, and the grant is the ONLY authority.
+* The model never sees grant internals — only the outcome.
+* A mutation may have happened as soon as the execution step starts: any
+  failure from that point on is settled ``indeterminate`` and reported as
+  INDETERMINATE, never as a retryable DENY (review #100694 blocker 2;
+  #90144/#90145).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+from typing import Dict, List, Optional
+
+from tools.destructive_grants import (
+    GrantConsumedError,
+    GrantDeniedError,
+    GrantError,
+    GrantInFlightError,
+    GrantNotFoundError,
+    claim_grant,
+    issue_grant,
+    settle_grant,
+    verify_grant,
+)
+from tools.grant_authority import (
+    ReceiptError,
+    request_destructive_grant_approval,
+)
+from tools.qga_structured import (
+    QgaError,
+    qga_create_filesystem,
+    qga_guest_identity,
+    qga_postcheck,
+    qga_prechecks,
+)
+
+logger = logging.getLogger(__name__)
+
+GOVERNED_MKFS_SCHEMA = {
+    "name": "governed_mkfs",
+    "description": (
+        "Create a filesystem on an exact, pre-authorized target. "
+        "The generic terminal mkfs remains blocked; this is the ONLY governed "
+        "path. Requires: vm_id, device (exact partition), fs_type, label. "
+        "The tool captures the live guest identity, asks the human for an "
+        "explicit one-shot approval of the exact target, and runs all "
+        "prechecks fail-closed inside the guest. The capability is consumed "
+        "atomically after success and can never be replayed."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "vm_id": {
+                "type": "string",
+                "description": "Proxmox VM id, e.g. '101'.",
+            },
+            "device": {
+                "type": "string",
+                "description": "Exact block device path, e.g. '/dev/sdb1'. Whole disks and root disks are rejected.",
+            },
+            "fs_type": {
+                "type": "string",
+                "enum": ["ext4", "xfs"],
+                "description": "Filesystem type (trusted allowlist).",
+            },
+            "label": {
+                "type": "string",
+                "description": "Filesystem label, 1-16 chars [A-Za-z0-9_.-].",
+            },
+        },
+        "required": ["vm_id", "device", "fs_type", "label"],
+    },
+}
+
+
+def _deny(reason: str, *, decision: str = "DENY", **extra: object) -> str:
+    payload: Dict[str, object] = {
+        "decision": decision,
+        "reason": reason,
+    }
+    payload.update(extra)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _allow(result: Dict[str, object]) -> str:
+    payload: Dict[str, object] = {"decision": "ALLOW"}
+    payload.update(result)
+    return json.dumps(payload, ensure_ascii=False)
+
+
+def _prechecks_pass(checks: Dict[str, object]) -> List[str]:
+    """Fail-closed evaluation of the mandatory prechecks (mandate §13).
+
+    Any UNKNOWN/AMBIGUOUS/FAIL state -> DENY.  Returns the list of failures
+    (empty == PASS).
+    """
+    failures: List[str] = []
+
+    if not checks.get("device_exists"):
+        failures.append("device_exists=NO")
+    if not checks.get("is_block_device"):
+        failures.append("is_block_device=NO")
+    if checks.get("mounted"):
+        failures.append("mounted=YES")
+    if checks.get("swap"):
+        failures.append("swap=YES")
+    if checks.get("filesystem_existing"):
+        failures.append("filesystem_existing=YES")
+    if checks.get("filesystem_signature"):
+        failures.append("filesystem_signature=YES")
+    if checks.get("lvm_member"):
+        failures.append("lvm_member=YES")
+    if checks.get("mdraid_member"):
+        failures.append("mdraid_member=YES")
+    holders = checks.get("holders")
+    if isinstance(holders, list) and holders:
+        failures.append(f"holders={holders}")
+    if checks.get("docker_use"):
+        failures.append("docker_use=YES")
+    if checks.get("fstab_use"):
+        failures.append("fstab_use=YES")
+    if "lsblk_parse_error" in checks:
+        failures.append("lsblk_parse_error=YES")
+
+    return failures
+
+
+def _identity_snapshot(checks: Dict[str, object]) -> Dict[str, object]:
+    """The identity fields that must be unchanged between precheck and action."""
+    return {
+        "device": checks.get("device"),
+        "major_minor": checks.get("major_minor"),
+        "size_bytes": checks.get("size_bytes"),
+        "mounted": checks.get("mounted"),
+        "filesystem_existing": checks.get("filesystem_existing"),
+        "filesystem_signature": checks.get("filesystem_signature"),
+        "holders": checks.get("holders"),
+        "boot_id": checks.get("boot_id"),
+    }
+
+
+def _handle_governed_mkfs(args: Dict[str, object], **kwargs) -> str:
+    vm_id = args.get("vm_id")
+    device = args.get("device")
+    fs_type = args.get("fs_type")
+    label = args.get("label")
+    session_id = kwargs.get("session_id") or ""
+
+    if not isinstance(vm_id, str) or not vm_id:
+        return _deny("vm_id_required")
+    if not isinstance(device, str) or not device:
+        return _deny("device_required")
+    if not isinstance(fs_type, str) or not fs_type:
+        return _deny("fs_type_required")
+    if not isinstance(label, str) or not label:
+        return _deny("label_required")
+    if not session_id:
+        return _deny("session_id_required", reason_detail="governed_mkfs requires a live session context")
+
+    # 0. Capture the trusted guest identity BEFORE any approval: the human
+    #    approves the EXACT observed incarnation (review #100694 blocker 3
+    #    + process-boundary blocker).  identity observed BEFORE approval ==
+    #    identity human approved == identity authenticated in the grant.
+    try:
+        identity = qga_guest_identity(vm_id)
+    except QgaError as exc:
+        return _deny("incarnation_unavailable", detail=str(exc))
+
+    if (
+        not identity.get("product_uuid")
+        or not identity.get("boot_id")
+        or not identity.get("hostname")
+    ):
+        return _deny(
+            "incarnation_incomplete",
+            detail="product_uuid/boot_id/hostname missing from guest identity",
+        )
+
+    # 1. Human approval for the EXACT observed tuple + incarnation.  The
+    #    receipt gate refuses yolo / mode=off / cron / unattended /
+    #    single-query; only an explicit human "approve once" produces a
+    #    receipt.  The model can request; it cannot grant.
+    try:
+        receipt = request_destructive_grant_approval(
+            operation="CREATE_FILESYSTEM",
+            vm_id=vm_id,
+            device=device,
+            fs_type=fs_type,
+            label=label,
+            session_id=session_id,
+            ttl_seconds=600,
+            incarnation_product_uuid=str(identity["product_uuid"]),
+            incarnation_boot_id=str(identity["boot_id"]),
+            incarnation_hostname=str(identity["hostname"]),
+        )
+    except ReceiptError as exc:
+        from tools.destructive_grants import _audit
+
+        _audit(
+            {
+                "event": "grant_denied",
+                "reason": "human_approval_denied",
+                "operation": "CREATE_FILESYSTEM",
+                "vm_id": vm_id,
+                "device": device,
+                "fs_type": fs_type,
+                "label": label,
+                "session_id": session_id,
+                "detail": str(exc),
+            }
+        )
+        return _deny("human_approval_denied", detail=str(exc))
+
+    # 2. Issue the grant IN THIS PROCESS: the same ProcessEphemeralAuthority
+    #    that will claim and verify it.  No CLI child, no cross-process
+    #    projection, no shared secret.
+    try:
+        grant = issue_grant(
+            operation="CREATE_FILESYSTEM",
+            vm_id=vm_id,
+            hostname=str(identity["hostname"]),
+            device=device,
+            fs_type=fs_type,
+            label=label,
+            authorization_subject="human-approval",
+            session_id=session_id,
+            receipt_id=receipt.receipt_id,
+            incarnation_product_uuid=str(identity["product_uuid"]),
+            incarnation_boot_id=str(identity["boot_id"]),
+            incarnation_hostname=str(identity["hostname"]),
+            ttl_seconds=600,
+        )
+    except GrantError as exc:
+        return _deny("grant_issue_failed", detail=str(exc))
+
+    grant_id = grant.grant_id
+
+    # 3. Atomic claim BEFORE any effect (review #100694 blocker 2).  The claim
+    #    is a rename-based reservation: exactly one concurrent caller wins;
+    #    the loser is denied before any QGA call.  The claim is bound to this
+    #    execution id, which the settlement later re-checks.
+    execution_id = f"{session_id}:{grant_id}"
+    try:
+        claim_grant(grant_id, execution_id)
+    except GrantInFlightError as exc:
+        return _deny("claim_lost", detail=str(exc))
+    except GrantConsumedError as exc:
+        return _deny("grant_denied", detail=str(exc))
+    except GrantNotFoundError as exc:
+        return _deny("grant_denied", detail=str(exc))
+    except GrantDeniedError as exc:
+        return _deny("grant_denied", detail=str(exc))
+    except GrantError as exc:
+        return _deny("grant_error", detail=str(exc))
+
+    # 4. Grant verification (exact tuple + expiry + integrity).  Any mismatch
+    #    raises and is recorded in the audit trail.  A claimed grant is
+    #    rejected here (no double-claim).
+    try:
+        grant = verify_grant(
+            grant_id,
+            operation="CREATE_FILESYSTEM",
+            vm_id=vm_id,
+            device=device,
+            fs_type=fs_type,
+            label=label,
+            session_id=session_id,
+            claimed_by_execution=execution_id,
+        )
+    except GrantDeniedError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny("grant_denied", detail=str(exc), outcome="failed_pre_effect")
+    except GrantNotFoundError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny("grant_denied", detail=str(exc), outcome="failed_pre_effect")
+    except GrantError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny("grant_error", detail=str(exc), outcome="failed_pre_effect")
+
+    # 5. Durable generation fencing at the sink (review #100694 blocker 3;
+    #    #90145).  The incarnation captured at issue time must match the live
+    #    guest right now.  A replaced/rebooted VM (ABA) is denied BEFORE any
+    #    mutation.
+    try:
+        identity_now = qga_guest_identity(vm_id)
+    except QgaError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "incarnation_unavailable", detail=str(exc), outcome="failed_pre_effect",
+        )
+
+    if (
+        identity_now.get("product_uuid") != grant.incarnation_product_uuid
+        or identity_now.get("boot_id") != grant.incarnation_boot_id
+        or identity_now.get("hostname") != grant.incarnation_hostname
+    ):
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "incarnation_changed",
+            expected_product_uuid=grant.incarnation_product_uuid,
+            observed_product_uuid=identity_now.get("product_uuid"),
+            expected_boot_id=grant.incarnation_boot_id,
+            observed_boot_id=identity_now.get("boot_id"),
+            expected_hostname=grant.incarnation_hostname,
+            observed_hostname=identity_now.get("hostname"),
+            outcome="failed_pre_effect",
+        )
+
+    # 6. Mandatory prechecks inside the guest (fail-closed).
+    try:
+        prechecks = qga_prechecks(vm_id, device)
+    except QgaError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "prechecks_unavailable", detail=str(exc), outcome="failed_pre_effect",
+        )
+
+    failures = _prechecks_pass(prechecks)
+    if failures:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "prechecks_failed", failures=failures, outcome="failed_pre_effect",
+        )
+
+    # 7. TOCTOU recheck: identity must be unchanged since the precheck.
+    #    The precheck and the action run back-to-back over the same QGA
+    #    channel; we re-read the critical identity fields immediately before
+    #    executing and compare (boot_id included: a reboot between precheck
+    #    and action is a generation change).
+    try:
+        recheck = qga_prechecks(vm_id, device)
+    except QgaError as exc:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "toctou_recheck_unavailable", detail=str(exc),
+            outcome="failed_pre_effect",
+        )
+
+    recheck_failures = _prechecks_pass(recheck)
+    if recheck_failures:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "toctou_recheck_failed", failures=recheck_failures,
+            outcome="failed_pre_effect",
+        )
+
+    before = _identity_snapshot(prechecks)
+    after = _identity_snapshot(recheck)
+    if before != after:
+        settle_grant(grant_id, execution_id, "failed_pre_effect")
+        return _deny(
+            "toctou_identity_changed", before=before, after=after,
+            outcome="failed_pre_effect",
+        )
+
+    # 8. Structured execution (argv built from allowlisted fields only).
+    #    From this point on a mutation MAY have happened: any failure is
+    #    settled as INDETERMINATE and the grant never returns to the pool.
+    try:
+        exec_result = qga_create_filesystem(vm_id, device, fs_type, label)
+    except QgaError as exc:
+        settle_grant(grant_id, execution_id, "indeterminate")
+        return _deny(
+            "execution_failed", detail=str(exc), outcome="indeterminate",
+            decision="INDETERMINATE",
+        )
+
+    exec_exit = exec_result.get("exit_code")
+    if exec_exit != 0:
+        settle_grant(grant_id, execution_id, "indeterminate")
+        return _deny(
+            "execution_exit_nonzero",
+            exit_code=exec_exit,
+            err_data=str(exec_result.get("err_data", ""))[:500],
+            outcome="indeterminate",
+            decision="INDETERMINATE",
+        )
+
+    # 9. Postcheck: filesystem type + label + uuid.
+    try:
+        postcheck = qga_postcheck(vm_id, device, fs_type, label)
+    except QgaError as exc:
+        settle_grant(grant_id, execution_id, "indeterminate")
+        return _deny(
+            "postcheck_unavailable", detail=str(exc), outcome="indeterminate",
+            decision="INDETERMINATE",
+        )
+
+    if postcheck.get("filesystem") != fs_type:
+        settle_grant(grant_id, execution_id, "indeterminate")
+        return _deny(
+            "postcheck_fs_mismatch",
+            expected=fs_type,
+            observed=postcheck.get("filesystem"),
+            outcome="indeterminate",
+            decision="INDETERMINATE",
+        )
+    if postcheck.get("label") != label:
+        settle_grant(grant_id, execution_id, "indeterminate")
+        return _deny(
+            "postcheck_label_mismatch",
+            expected=label,
+            observed=postcheck.get("label"),
+            outcome="indeterminate",
+            decision="INDETERMINATE",
+        )
+
+    # 10. Durable settlement: the grant is permanently out of the pool.  A
+    #     second use of the same grant is denied (replay protection).
+    try:
+        settle_grant(grant_id, execution_id, "completed")
+    except GrantError as exc:
+        return _deny(
+            "settle_failed", detail=str(exc), outcome="indeterminate",
+            decision="INDETERMINATE", grant_id=grant_id,
+        )
+
+    return _allow(
+        {
+            "operation": "CREATE_FILESYSTEM",
+            "vm_id": vm_id,
+            "device": device,
+            "fs_type": fs_type,
+            "label": label,
+            "uuid": postcheck.get("uuid"),
+            "guest_argv": exec_result.get("guest_argv"),
+            "exit_code": exec_result.get("exit_code"),
+            "capability_consumed": True,
+            "grant_id": grant_id,
+            "outcome": "completed",
+        }
+    )
+
+
+def check_governed_mkfs_requirements() -> bool:
+    """Availability: the governed path needs the QGA SSH key and node."""
+    from tools.qga_structured import DEFAULT_QGA_SSH_KEY
+
+    import os
+
+    return os.path.exists(DEFAULT_QGA_SSH_KEY)
+
+
+def register_governed_mkfs() -> None:
+    from tools.registry import registry
+
+    registry.register(
+        name="governed_mkfs",
+        toolset="terminal",
+        schema=GOVERNED_MKFS_SCHEMA,
+        handler=_handle_governed_mkfs,
+        check_fn=check_governed_mkfs_requirements,
+        emoji="🛡️",
+        max_result_size_chars=20_000,
+    )
+
+
+# Direct module-level registration: the registry's AST-based discovery only
+# picks up top-level ``registry.register(...)`` calls (see
+# tools/registry.py::_module_registers_tools).  A call wrapped in a function
+# would silently leave the tool undiscovered.
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="governed_mkfs",
+    toolset="terminal",
+    schema=GOVERNED_MKFS_SCHEMA,
+    handler=_handle_governed_mkfs,
+    check_fn=check_governed_mkfs_requirements,
+    emoji="🛡️",
+    max_result_size_chars=20_000,
+)

--- a/tools/grant_authority.py
+++ b/tools/grant_authority.py
@@ -1,0 +1,620 @@
+"""Grant authority provider abstraction + correlated human approval receipts.
+
+Review #100694 blocker 1 (andrexibiza, 2026-09-01): the persisted grant must
+be cryptographically unforgeable from model-facing surfaces, and issuance must
+consume a proof that generic model-facing terminal/file/plugin paths cannot
+mint.
+
+Architecture (Option A+):
+
+    Human Approval Transport
+            |
+            v
+    Correlated Approval Receipt   (produced by THIS module, one-shot)
+            |
+            v
+    Trusted Grant Issuer          (tools.destructive_grants.issue_grant)
+            |
+            v
+    Grant Authority Provider      (authenticates the canonical payload)
+            |
+            v
+    authenticated one-shot grant
+            |
+            v
+    claim / fencing / settlement  (tools.destructive_grants)
+            |
+            v
+    structured QGA formatter
+
+Design invariants:
+
+1. A grant is authenticated with a keyed tag (HMAC-SHA256 by default), never
+   an unkeyed SHA-256.  The key lives ONLY in the memory of the trusted
+   Hermes process (``ProcessEphemeralAuthority``): it is not persisted, not
+   in the environment, not logged, not exported, not serialized, and not
+   copied into child-process configuration.
+
+2. ``execute_code`` children are separate OS processes: they import their own
+   copy of this module, so they get their own provider with a DIFFERENT key.
+   A grant they mint is rejected by the parent's provider (generation and tag
+   mismatch).  They cannot read the parent's key (separate address space) and
+   cannot resolve the parent's approval queues (separate memory).
+
+3. Issuance consumes a correlated human approval receipt produced by the
+   approval layer AFTER an explicit human ``approve once`` decision.  The
+   caller never supplies a free-form evidence dict.  A receipt is one-shot:
+   it can issue at most one grant, and replaying it is denied.
+
+4. A restart invalidates all live grants: the provider generation changes,
+   so ``verify`` fails with an authority-generation mismatch.  Grants are
+   process-bound capabilities (short TTL, re-issue after restart).
+
+5. Hardware-backed protection (TPM/vTPM) is an optional strengthening layer:
+   the provider interface is the extension point.  No TPM is required for
+   this feature to be secure (portable baseline first).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import secrets
+import time
+import uuid
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Authority provider abstraction
+# ---------------------------------------------------------------------------
+
+
+class GrantAuthorityProvider(ABC):
+    """Authenticate/verify a canonical grant payload.
+
+    A provider owns a secret that model-facing surfaces (terminal,
+    execute_code, write_file) cannot obtain.  ``authenticate`` produces the
+    tag stored in the grant; ``verify`` recomputes it and compares in
+    constant time.  ``generation`` identifies the provider instance: a new
+    process (or a new provider) has a new generation, so grants minted by a
+    previous incarnation are rejected.
+    """
+
+    @abstractmethod
+    def authenticate(self, payload: bytes) -> str:
+        """Return the authentication tag for *payload*."""
+
+    @abstractmethod
+    def verify(self, payload: bytes, tag: str) -> bool:
+        """Return True iff *tag* authenticates *payload* under this provider."""
+
+    @property
+    @abstractmethod
+    def generation(self) -> str:
+        """Opaque provider-instance identifier (changes on restart)."""
+
+
+class ProcessEphemeralAuthority(GrantAuthorityProvider):
+    """Baseline provider: HMAC-SHA256 with a process-local random secret.
+
+    The secret is 256 bits, generated once per process, and is NEVER
+    persisted, exported, logged, serialized, or placed in the environment.
+    It lives only in this object's memory inside the trusted Hermes process.
+    """
+
+    _SECRET_BYTES = 32  # 256 bits
+
+    def __init__(self) -> None:
+        self._secret = secrets.token_bytes(self._SECRET_BYTES)
+        self._generation = uuid.uuid4().hex
+
+    def authenticate(self, payload: bytes) -> str:
+        return hmac.new(self._secret, payload, hashlib.sha256).hexdigest()
+
+    def verify(self, payload: bytes, tag: str) -> bool:
+        if not isinstance(tag, str) or len(tag) != 64:
+            return False
+        try:
+            expected = hmac.new(self._secret, payload, hashlib.sha256).hexdigest()
+        except (TypeError, ValueError):
+            return False
+        return hmac.compare_digest(expected, tag)
+
+    @property
+    def generation(self) -> str:
+        return self._generation
+
+    def __repr__(self) -> str:
+        # Never leak the secret through repr/errors.
+        return f"<ProcessEphemeralAuthority generation={self._generation[:8]}…>"
+
+
+# Module-level singleton: one provider per trusted process.  A child
+# execute_code process imports this module fresh and gets its OWN provider
+# with a DIFFERENT secret — that is the isolation property the adversarial
+# tests prove.
+_AUTHORITY: Optional[GrantAuthorityProvider] = None
+
+
+def get_authority() -> GrantAuthorityProvider:
+    """Return the process-local authority provider (lazy singleton)."""
+    global _AUTHORITY
+    if _AUTHORITY is None:
+        _AUTHORITY = ProcessEphemeralAuthority()
+    return _AUTHORITY
+
+
+def reset_authority_for_tests() -> None:
+    """Drop the singleton (tests only): the next get_authority() call mints a
+    fresh provider with a new secret and a new generation."""
+    global _AUTHORITY
+    _AUTHORITY = None
+
+
+# ---------------------------------------------------------------------------
+# Correlated human approval receipt
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class HumanApprovalReceipt:
+    """Proof of an explicit human ``approve once`` decision.
+
+    Produced ONLY by :func:`request_destructive_grant_approval` after the
+    approval layer returned a real human decision.  The caller never
+    constructs one.  A receipt is one-shot: :func:`consume_receipt` removes
+    it from the process-local store, so the same receipt cannot issue a
+    second grant (replay denied).
+    """
+
+    receipt_id: str
+    request_id: str
+    request_digest: str
+    session_id: str
+    turn_id: str
+    tool_call_id: str
+    operation: str
+    vm_id: str
+    device: str
+    fs_type: str
+    label: str
+    incarnation_product_uuid: str
+    incarnation_boot_id: str
+    incarnation_hostname: str
+    issued_at: float
+    expires_at: float
+    human_decision: str = "approve_once"
+
+    def to_dict(self) -> Dict[str, object]:
+        return {
+            "receipt_id": self.receipt_id,
+            "request_id": self.request_id,
+            "request_digest": self.request_digest,
+            "session_id": self.session_id,
+            "turn_id": self.turn_id,
+            "tool_call_id": self.tool_call_id,
+            "operation": self.operation,
+            "vm_id": self.vm_id,
+            "device": self.device,
+            "fs_type": self.fs_type,
+            "label": self.label,
+            "incarnation_product_uuid": self.incarnation_product_uuid,
+            "incarnation_boot_id": self.incarnation_boot_id,
+            "incarnation_hostname": self.incarnation_hostname,
+            "issued_at": self.issued_at,
+            "expires_at": self.expires_at,
+            "human_decision": self.human_decision,
+        }
+
+
+# Process-local one-shot receipt store.  Like the authority secret, it lives
+# only in the trusted process memory: a child execute_code process has its
+# own (empty) store and cannot consume the parent's receipts.
+_RECEIPTS: Dict[str, HumanApprovalReceipt] = {}
+
+
+def _store_receipt(receipt: HumanApprovalReceipt) -> HumanApprovalReceipt:
+    _RECEIPTS[receipt.receipt_id] = receipt
+    return receipt
+
+
+def peek_receipt(receipt_id: str) -> HumanApprovalReceipt:
+    """Return a receipt WITHOUT consuming it.
+
+    Used by ``issue_grant`` to validate the receipt against the requested
+    operation/target/session BEFORE the atomic consume: a denied issuance
+    must not burn the human decision.
+    """
+    receipt = _RECEIPTS.get(receipt_id)
+    if receipt is None:
+        raise ReceiptError(f"receipt {receipt_id!r} unknown or already consumed (replay denied)")
+    return receipt
+
+
+def consume_receipt(receipt_id: str) -> HumanApprovalReceipt:
+    """Atomically consume a receipt (one-shot issuance).
+
+    Raises ``ReceiptError`` if the receipt is unknown or already consumed.
+    """
+    receipt = _RECEIPTS.pop(receipt_id, None)
+    if receipt is None:
+        raise ReceiptError(f"receipt {receipt_id!r} unknown or already consumed (replay denied)")
+    return receipt
+
+
+def list_receipts() -> list:
+    """Return live (unconsumed) receipts (tests/audit, no secrets)."""
+    return list(_RECEIPTS.values())
+
+
+class ReceiptError(Exception):
+    """Raised when a receipt is missing, expired, or already consumed."""
+
+
+# ---------------------------------------------------------------------------
+# Approval gate for destructive grant issuance
+# ---------------------------------------------------------------------------
+
+
+def _build_request_text(
+    *,
+    operation: str,
+    vm_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    session_id: str,
+    ttl_seconds: int,
+    incarnation_product_uuid: str = "",
+    incarnation_boot_id: str = "",
+    incarnation_hostname: str = "",
+) -> tuple:
+    """Return (command, description) shown to the human in the approval UI.
+
+    The observed guest incarnation is part of what the human approves: the
+    request text shows a readable identity so the human can confirm the
+    exact target generation before deciding.
+    """
+    command = (
+        f"governed destructive operation: {operation} on VM {vm_id} "
+        f"device {device} as {fs_type} label {label} "
+        f"(session {session_id}, ttl {ttl_seconds}s)"
+    )
+    description = (
+        f"One-shot destructive grant: {operation} on VM {vm_id} "
+        f"device {device} as {fs_type} label {label}. "
+        f"Observed guest identity: hostname={incarnation_hostname or '?'} "
+        f"product_uuid={incarnation_product_uuid or '?'} "
+        f"boot_id={incarnation_boot_id or '?'}. "
+        f"This capability is consumed by exactly one governed operation "
+        f"and expires automatically."
+    )
+    return command, description
+
+
+def _request_digest(
+    command: str,
+    description: str,
+    session_id: str,
+    incarnation_product_uuid: str = "",
+    incarnation_boot_id: str = "",
+    incarnation_hostname: str = "",
+) -> str:
+    canonical = "|".join(
+        [
+            command,
+            description,
+            session_id,
+            incarnation_product_uuid,
+            incarnation_boot_id,
+            incarnation_hostname,
+        ]
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def request_destructive_grant_approval(
+    *,
+    operation: str,
+    vm_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    session_id: str,
+    ttl_seconds: int,
+    incarnation_product_uuid: str = "",
+    incarnation_boot_id: str = "",
+    incarnation_hostname: str = "",
+    turn_id: str = "",
+    tool_call_id: str = "",
+) -> HumanApprovalReceipt:
+    """Ask the human through the REAL approval transport and return a
+    one-shot receipt.
+
+    Refuses every bypass context: yolo (process or session), approvals.mode
+    = off, cron auto-approval, unattended platforms, single-query mode, and
+    any non-interactive context with no human present.  Only an explicit
+    human ``once`` decision is accepted — never session/permanent/smart
+    approval.
+
+    The receipt is produced HERE, after the decision, and is bound to the
+    exact request the human saw (request_id + request_digest) plus the
+    correlation ids of the calling context.
+    """
+    from tools.approval import (
+        _await_gateway_decision,
+        _get_approval_timeout,
+        _is_cron_approval_context,
+        _is_gateway_approval_context,
+        _is_interactive_cli,
+        _is_single_query_approval_context,
+        _is_unattended_platform_approval_context,
+        _present_with_selected_transport,
+        get_current_session_key,
+        is_approval_bypass_active,
+        prompt_dangerous_approval,
+        register_gateway_notify,
+    )
+
+    # 1. Bypass contexts are structurally refused: a destructive grant must
+    #    never be minted under yolo / mode=off / cron approve / unattended
+    #    approve / single-query approve.
+    if is_approval_bypass_active():
+        raise ReceiptError(
+            "destructive grant issuance is refused while approval bypass is "
+            "active (yolo / approvals.mode=off)"
+        )
+    if _is_cron_approval_context():
+        raise ReceiptError(
+            "destructive grant issuance is refused in cron sessions "
+            "(no human present to approve)"
+        )
+    if _is_unattended_platform_approval_context():
+        raise ReceiptError(
+            "destructive grant issuance is refused on unattended platforms "
+            "(no human present to approve)"
+        )
+    if _is_single_query_approval_context():
+        raise ReceiptError(
+            "destructive grant issuance is refused in single-query mode "
+            "(no human present to approve)"
+        )
+
+    command, description = _build_request_text(
+        operation=operation,
+        vm_id=vm_id,
+        device=device,
+        fs_type=fs_type,
+        label=label,
+        session_id=session_id,
+        ttl_seconds=ttl_seconds,
+        incarnation_product_uuid=incarnation_product_uuid,
+        incarnation_boot_id=incarnation_boot_id,
+        incarnation_hostname=incarnation_hostname,
+    )
+    digest = _request_digest(
+        command,
+        description,
+        session_id,
+        incarnation_product_uuid,
+        incarnation_boot_id,
+        incarnation_hostname,
+    )
+    now = time.time()
+    expires_at = now + ttl_seconds
+
+    # 2. Preferred: an explicitly selected plugin transport (Telegram/WebUI/
+    #    desktop/…).  The transport returns a request_id + request_digest
+    #    bound to the exact request the human saw.
+    try:
+        from tools.approval import _present_with_selected_transport as _present
+    except Exception:
+        _present = None
+    if _present is not None:
+        try:
+            presented = _present(
+                command=command,
+                description=description,
+                pattern_key="governed_grant_issue",
+                pattern_keys=["governed_grant_issue"],
+                session_key=session_id,
+                surface="cli",
+                allow_session=False,
+                allow_permanent=False,
+            )
+        except Exception as exc:
+            raise ReceiptError(f"approval transport failed: {exc}") from exc
+
+        if presented.get("selected"):
+            if presented.get("choice") != "once" or presented.get("failure"):
+                raise ReceiptError(
+                    "human approval not granted (transport decision: "
+                    f"{presented.get('choice') or presented.get('failure')})"
+                )
+            request_id = str(presented.get("request_id") or "")
+            if not request_id:
+                raise ReceiptError("approval transport returned no request_id")
+            return _store_receipt(
+                HumanApprovalReceipt(
+                    receipt_id=uuid.uuid4().hex,
+                    request_id=request_id,
+                    request_digest=digest,
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    tool_call_id=tool_call_id,
+                    operation=operation,
+                    vm_id=vm_id,
+                    device=device,
+                    fs_type=fs_type,
+                    label=label,
+                    incarnation_product_uuid=incarnation_product_uuid,
+                    incarnation_boot_id=incarnation_boot_id,
+                    incarnation_hostname=incarnation_hostname,
+                    issued_at=now,
+                    expires_at=expires_at,
+                )
+            )
+
+    # 3. Gateway round-trip: a notify callback registered for this session
+    #    (Discord/Telegram/Slack buttons).  The request_id is minted by the
+    #    approval layer and the decision comes from the human's button press.
+    if _is_gateway_approval_context():
+        notify_cb = None
+        from tools.approval import _gateway_notify_cbs, _lock
+
+        with _lock:
+            notify_cb = _gateway_notify_cbs.get(session_id)
+        if notify_cb is not None:
+            request_id = uuid.uuid4().hex
+            approval_data = {
+                "command": command,
+                "pattern_key": "governed_grant_issue",
+                "pattern_keys": ["governed_grant_issue"],
+                "description": description,
+                "allow_permanent": False,
+                "allow_session": False,
+                "request_id": request_id,
+            }
+            decision = _await_gateway_decision(
+                session_id, notify_cb, approval_data, surface="gateway"
+            )
+            if decision.get("notify_failed"):
+                raise ReceiptError("failed to send approval request to the user")
+            if not decision.get("resolved") or decision.get("choice") != "once":
+                raise ReceiptError(
+                    "human approval not granted (gateway decision: "
+                    f"{decision.get('choice') or 'no response'})"
+                )
+            return _store_receipt(
+                HumanApprovalReceipt(
+                    receipt_id=uuid.uuid4().hex,
+                    request_id=request_id,
+                    request_digest=digest,
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    tool_call_id=tool_call_id,
+                    operation=operation,
+                    vm_id=vm_id,
+                    device=device,
+                    fs_type=fs_type,
+                    label=label,
+                    incarnation_product_uuid=incarnation_product_uuid,
+                    incarnation_boot_id=incarnation_boot_id,
+                    incarnation_hostname=incarnation_hostname,
+                    issued_at=now,
+                    expires_at=expires_at,
+                )
+            )
+
+    # 4. Interactive CLI: the standard dangerous-command prompt, restricted
+    #    to once/deny (no session, no permanent).  This is the SAME prompt
+    #    every other dangerous action uses; the hardline blocklist prevents
+    #    the model from reaching this path through the terminal tool.
+    if _is_interactive_cli():
+        choice = prompt_dangerous_approval(
+            command,
+            description,
+            allow_permanent=False,
+            allow_session=False,
+        )
+        if choice != "once":
+            raise ReceiptError(
+                "human approval not granted (CLI decision: "
+                f"{choice or 'no response'})"
+            )
+        return _store_receipt(
+            HumanApprovalReceipt(
+                receipt_id=uuid.uuid4().hex,
+                request_id=uuid.uuid4().hex,
+                request_digest=digest,
+                session_id=session_id,
+                turn_id=turn_id,
+                tool_call_id=tool_call_id,
+                operation=operation,
+                vm_id=vm_id,
+                device=device,
+                fs_type=fs_type,
+                label=label,
+                incarnation_product_uuid=incarnation_product_uuid,
+                incarnation_boot_id=incarnation_boot_id,
+                incarnation_hostname=incarnation_hostname,
+                issued_at=now,
+                expires_at=expires_at,
+            )
+        )
+
+    # 5. No human surface at all: fail closed.  A grant is never issued
+    #    unattended.
+    raise ReceiptError(
+        "destructive grant issuance requires an interactive human "
+        "(gateway session, approval transport, or interactive CLI); "
+        "refusing unattended issuance"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Canonical authenticated payload
+# ---------------------------------------------------------------------------
+
+
+def canonical_grant_payload(
+    *,
+    schema_version: int,
+    grant_id: str,
+    receipt_id: str,
+    operation: str,
+    vm_id: str,
+    hostname: str,
+    product_uuid: str,
+    boot_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    authorization_subject: str,
+    authorization_source: str,
+    session_id: str,
+    turn_id: str,
+    tool_call_id: str,
+    issued_at: float,
+    expires_at: float,
+    nonce: str,
+    authorization_evidence: Optional[Dict[str, object]] = None,
+) -> bytes:
+    """Canonical JSON of every immutable authority field.
+
+    The correlated human approval receipt (``authorization_evidence``) is
+    part of the authenticated payload: swapping or editing the receipt breaks
+    the tag.  The execution lifecycle (claimed/settled/consumed) is
+    deliberately NOT part of this payload: it is mutable state recorded
+    beside the authority record, and mutating it must not invalidate the
+    authentication tag.
+    """
+    payload = {
+        "schema_version": schema_version,
+        "grant_id": grant_id,
+        "receipt_id": receipt_id,
+        "operation": operation,
+        "vm_id": vm_id,
+        "hostname": hostname,
+        "product_uuid": product_uuid,
+        "boot_id": boot_id,
+        "device": device,
+        "fs_type": fs_type,
+        "label": label,
+        "authorization_subject": authorization_subject,
+        "authorization_source": authorization_source,
+        "session_id": session_id,
+        "turn_id": turn_id,
+        "tool_call_id": tool_call_id,
+        "issued_at": issued_at,
+        "expires_at": expires_at,
+        "nonce": nonce,
+        "authorization_evidence": authorization_evidence or {},
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")

--- a/tools/qga_structured.py
+++ b/tools/qga_structured.py
@@ -1,0 +1,381 @@
+"""Structured QGA adapter for governed destructive operations.
+
+The generic QGA path (for example, SSH to a Proxmox host followed by
+``qm guest exec``) is powerful and must never be exposed to the model for
+destructive actions. This module exposes a narrow, policy-aware adapter:
+
+    qga_create_filesystem(vm_id, device, fs_type, label)
+
+The guest argv is built here from allowlisted fields only:
+
+* ``fs_type`` -> trusted binary via ``destructive_grants.FS_TYPE_TO_BINARY``;
+* ``device``  -> validated by ``destructive_grants.validate_device``;
+* ``label``   -> validated by ``destructive_grants.validate_label``.
+
+No model-provided shell command is executed. Read-only probes and the final
+formatter use structured argv lists passed through ``qm guest exec``.
+
+Transport is deployment-configured and fail-closed. ``HERMES_QGA_NODE`` and
+``HERMES_QGA_SSH_KEY`` must be set explicitly; no project- or operator-specific
+host, key path, or permissive host-key policy is compiled into Hermes.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import subprocess
+from typing import Dict, List, Optional, TypedDict
+
+from tools.destructive_grants import (
+    FS_TYPE_TO_BINARY,
+    GrantError,
+    validate_device,
+    validate_fs_type,
+    validate_label,
+    validate_vm_id,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class RemoteResult(TypedDict):
+    exit_code: int
+    stdout: str
+    stderr: str
+
+
+class QgaExecResult(TypedDict):
+    exit_code: int
+    out_data: str
+    err_data: str
+
+
+# Deployment-specific values are intentionally not given functional defaults.
+# A governed destructive path must never guess its control-plane target or SSH
+# credential. Tests may override these values or mock the remote transport.
+DEFAULT_QGA_NODE = os.environ.get("HERMES_QGA_NODE", "").strip()
+DEFAULT_QGA_SSH_KEY = os.environ.get("HERMES_QGA_SSH_KEY", "").strip()
+DEFAULT_QGA_SSH_USER = os.environ.get("HERMES_QGA_SSH_USER", "root").strip() or "root"
+DEFAULT_QGA_KNOWN_HOSTS = os.environ.get("HERMES_QGA_KNOWN_HOSTS", "").strip()
+DEFAULT_QGA_TIMEOUT = int(os.environ.get("HERMES_QGA_TIMEOUT", "60"))
+
+
+class QgaError(Exception):
+    """Structured QGA failure."""
+
+
+def _ssh_base() -> List[str]:
+    """Return the deployment-configured SSH argv or fail closed.
+
+    Host-key verification is mandatory. Deployments may point
+    ``HERMES_QGA_KNOWN_HOSTS`` at a dedicated known_hosts file; otherwise the
+    OpenSSH default known_hosts policy is used.
+    """
+    if not DEFAULT_QGA_NODE:
+        raise QgaError("HERMES_QGA_NODE is required for structured QGA")
+    if not DEFAULT_QGA_SSH_KEY:
+        raise QgaError("HERMES_QGA_SSH_KEY is required for structured QGA")
+
+    cmd = [
+        "ssh",
+        "-i",
+        DEFAULT_QGA_SSH_KEY,
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "StrictHostKeyChecking=yes",
+        "-o",
+        "ConnectTimeout=8",
+    ]
+    if DEFAULT_QGA_KNOWN_HOSTS:
+        cmd += ["-o", f"UserKnownHostsFile={DEFAULT_QGA_KNOWN_HOSTS}"]
+    cmd.append(f"{DEFAULT_QGA_SSH_USER}@{DEFAULT_QGA_NODE}")
+    return cmd
+
+
+def _run_remote(argv: List[str], timeout: int = DEFAULT_QGA_TIMEOUT) -> RemoteResult:
+    """Run a fixed argv list on the configured Proxmox node.
+
+    The SSH remote-command transport necessarily serializes argv to text for
+    OpenSSH, so each element is shell-quoted here. Model-controlled fields have
+    already passed strict validators before reaching this boundary.
+    """
+    remote_cmd = " ".join(shlex.quote(a) for a in argv)
+    cmd = _ssh_base() + [remote_cmd]
+    try:
+        proc = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise QgaError(f"QGA remote command timed out after {timeout}s") from exc
+    except OSError as exc:
+        raise QgaError(f"QGA ssh failed: {exc}") from exc
+    return {
+        "exit_code": proc.returncode,
+        "stdout": proc.stdout,
+        "stderr": proc.stderr,
+    }
+
+
+def _qm_guest_exec(
+    vm_id: str,
+    guest_argv: List[str],
+    timeout: int = DEFAULT_QGA_TIMEOUT,
+) -> QgaExecResult:
+    """Run ``qm guest exec <vm_id> -- <guest_argv>`` on the configured node."""
+    argv = ["qm", "guest", "exec", vm_id, "--"] + guest_argv
+    result = _run_remote(argv, timeout=timeout)
+    if result["exit_code"] != 0:
+        raise QgaError(
+            f"qm guest exec failed (rc={result['exit_code']}): "
+            f"{result['stderr'].strip() or result['stdout'].strip()}"
+        )
+    try:
+        envelope = json.loads(result["stdout"])
+    except json.JSONDecodeError as exc:
+        raise QgaError(
+            f"qm guest exec returned non-JSON output: {result['stdout'][:500]}"
+        ) from exc
+    ret = envelope.get("return", envelope)
+    exit_code = ret.get("exit-code", ret.get("exitcode", -1))
+    return {
+        "exit_code": int(exit_code),
+        "out_data": str(ret.get("out-data", "")),
+        "err_data": str(ret.get("err-data", "")),
+    }
+
+
+def qga_guest_identity(vm_id: str) -> Dict[str, object]:
+    """Read-only: guest hostname + boot id + product UUID via QGA.
+
+    ``product_uuid`` is the stable guest identity and ``boot_id`` is the boot
+    generation. Together they fence a grant to the exact guest incarnation.
+    """
+    validate_vm_id(vm_id)
+    hostname = _qm_guest_exec(vm_id, ["hostname"])
+    bootid = _qm_guest_exec(vm_id, ["cat", "/proc/sys/kernel/random/boot_id"])
+    product_uuid = _qm_guest_exec(
+        vm_id, ["cat", "/sys/class/dmi/id/product_uuid"]
+    )
+    return {
+        "hostname": hostname["out_data"].strip(),
+        "boot_id": bootid["out_data"].strip(),
+        "product_uuid": product_uuid["out_data"].strip(),
+        "hostname_rc": hostname["exit_code"],
+        "boot_id_rc": bootid["exit_code"],
+        "product_uuid_rc": product_uuid["exit_code"],
+    }
+
+
+def qga_prechecks(vm_id: str, device: str) -> Dict[str, object]:
+    """Read-only prechecks executed inside the guest just before action."""
+    validate_vm_id(vm_id)
+    validate_device(device)
+
+    checks: Dict[str, object] = {
+        "vm_id": vm_id,
+        "device": device,
+        "device_exists": False,
+        "is_block_device": False,
+        "major_minor": None,
+        "size_bytes": None,
+        "parent": None,
+        "mounted": False,
+        "swap": False,
+        "filesystem_existing": False,
+        "filesystem_signature": False,
+        "lvm_member": False,
+        "mdraid_member": False,
+        "holders": [],
+        "docker_use": False,
+        "fstab_use": False,
+        "boot_id": None,
+    }
+
+    bootid = _qm_guest_exec(vm_id, ["cat", "/proc/sys/kernel/random/boot_id"])
+    if bootid["exit_code"] == 0 and bootid["out_data"].strip():
+        checks["boot_id"] = bootid["out_data"].strip()
+
+    lsblk = _qm_guest_exec(
+        vm_id,
+        ["lsblk", "-J", "-o", "NAME,MAJ:MIN,SIZE,TYPE,MOUNTPOINTS,FSTYPE", device],
+    )
+    if lsblk["exit_code"] == 0:
+        try:
+            data = json.loads(lsblk["out_data"])
+            blocks = data.get("blockdevices", [])
+            if blocks:
+                b = blocks[0]
+                checks["device_exists"] = True
+                checks["is_block_device"] = b.get("type") in {"part", "loop"}
+                checks["major_minor"] = b.get("maj:min")
+                checks["size_bytes"] = _parse_lsblk_size(b.get("size", ""))
+                checks["parent"] = b.get("name")
+                checks["mounted"] = bool(
+                    b.get("mountpoints") and any(b.get("mountpoints"))
+                )
+                checks["filesystem_existing"] = bool(b.get("fstype"))
+        except (json.JSONDecodeError, KeyError, IndexError):
+            checks["lsblk_parse_error"] = lsblk["out_data"][:300]
+
+    findmnt = _qm_guest_exec(vm_id, ["findmnt", "-n", "-o", "TARGET", device])
+    if findmnt["exit_code"] == 0 and findmnt["out_data"].strip():
+        checks["mounted"] = True
+        checks["mount_target"] = findmnt["out_data"].strip()
+
+    # PARTUUID is partition-table identity, not a data signature. A real TYPE
+    # or wipefs signature is what blocks formatting.
+    blkid = _qm_guest_exec(vm_id, ["blkid", device])
+    if blkid["exit_code"] == 0 and blkid["out_data"].strip():
+        checks["blkid_output"] = blkid["out_data"].strip()[:300]
+        if "TYPE=" in blkid["out_data"]:
+            checks["filesystem_signature"] = True
+
+    wipefs = _qm_guest_exec(vm_id, ["wipefs", "-n", device])
+    if wipefs["exit_code"] == 0 and wipefs["out_data"].strip():
+        checks["filesystem_signature"] = True
+        checks["wipefs_output"] = wipefs["out_data"].strip()[:300]
+
+    swaps = _qm_guest_exec(vm_id, ["grep", "-w", device, "/proc/swaps"])
+    if swaps["exit_code"] == 0 and swaps["out_data"].strip():
+        checks["swap"] = True
+
+    pvs = _qm_guest_exec(vm_id, ["pvs", "--noheadings", "-o", "pv_name"])
+    if pvs["exit_code"] == 0 and device in pvs["out_data"]:
+        checks["lvm_member"] = True
+
+    mdstat = _qm_guest_exec(vm_id, ["cat", "/proc/mdstat"])
+    if mdstat["exit_code"] == 0 and device in mdstat["out_data"]:
+        checks["mdraid_member"] = True
+
+    basename = device.rsplit("/", 1)[-1]
+    holders = _qm_guest_exec(
+        vm_id, ["ls", "-1", f"/sys/class/block/{basename}/holders"]
+    )
+    if holders["exit_code"] == 0:
+        checks["holders"] = [
+            value for value in holders["out_data"].splitlines() if value.strip()
+        ]
+
+    # Docker-use check remains structured: enumerate containers, inspect each
+    # one, and evaluate mount sources locally instead of invoking a guest shell.
+    docker_ps = _qm_guest_exec(vm_id, ["docker", "ps", "-q"])
+    if docker_ps["exit_code"] == 0:
+        container_ids = [
+            value.strip()
+            for value in docker_ps["out_data"].splitlines()
+            if value.strip()
+        ]
+        for container_id in container_ids:
+            inspect = _qm_guest_exec(
+                vm_id,
+                [
+                    "docker",
+                    "inspect",
+                    "--format",
+                    "{{range .Mounts}}{{println .Source}}{{end}}",
+                    container_id,
+                ],
+            )
+            if inspect["exit_code"] == 0:
+                sources = {
+                    value.strip()
+                    for value in inspect["out_data"].splitlines()
+                    if value.strip()
+                }
+                if device in sources:
+                    checks["docker_use"] = True
+                    break
+
+    fstab = _qm_guest_exec(vm_id, ["grep", "-F", device, "/etc/fstab"])
+    if fstab["exit_code"] == 0 and fstab["out_data"].strip():
+        checks["fstab_use"] = True
+
+    return checks
+
+
+def _parse_lsblk_size(size_raw: str) -> Optional[int]:
+    """Parse lsblk SIZE like '128G' / '512M' / '1T' into bytes."""
+    if not size_raw:
+        return None
+    size_raw = size_raw.strip()
+    try:
+        if size_raw.endswith("B"):
+            return int(float(size_raw[:-1]))
+        if size_raw.endswith("K"):
+            return int(float(size_raw[:-1]) * 1024)
+        if size_raw.endswith("M"):
+            return int(float(size_raw[:-1]) * 1024**2)
+        if size_raw.endswith("G"):
+            return int(float(size_raw[:-1]) * 1024**3)
+        if size_raw.endswith("T"):
+            return int(float(size_raw[:-1]) * 1024**4)
+        return int(float(size_raw))
+    except ValueError:
+        return None
+
+
+def qga_create_filesystem(
+    vm_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+    timeout: int = DEFAULT_QGA_TIMEOUT,
+) -> Dict[str, object]:
+    """Governed filesystem creation via structured QGA."""
+    validate_vm_id(vm_id)
+    validate_device(device)
+    validate_fs_type(fs_type)
+    validate_label(label)
+
+    binary = FS_TYPE_TO_BINARY[fs_type]
+    guest_argv = [binary, "-L", label, device]
+
+    result = _qm_guest_exec(vm_id, guest_argv, timeout=timeout)
+    return {
+        "operation": "CREATE_FILESYSTEM",
+        "vm_id": vm_id,
+        "device": device,
+        "fs_type": fs_type,
+        "label": label,
+        "guest_argv": guest_argv,
+        "exit_code": result["exit_code"],
+        "out_data": result["out_data"],
+        "err_data": result["err_data"],
+    }
+
+
+def qga_postcheck(
+    vm_id: str,
+    device: str,
+    fs_type: str,
+    label: str,
+) -> Dict[str, object]:
+    """Read-only postcheck: filesystem type + label + UUID after creation."""
+    validate_vm_id(vm_id)
+    validate_device(device)
+    validate_fs_type(fs_type)
+    validate_label(label)
+
+    blkid = _qm_guest_exec(vm_id, ["blkid", "-o", "export", device])
+    out = blkid["out_data"]
+    result: Dict[str, object] = {
+        "exit_code": blkid["exit_code"],
+        "filesystem": None,
+        "label": None,
+        "uuid": None,
+    }
+    for line in out.splitlines():
+        if line.startswith("TYPE="):
+            result["filesystem"] = line.split("=", 1)[1].strip()
+        elif line.startswith("LABEL="):
+            result["label"] = line.split("=", 1)[1].strip()
+        elif line.startswith("UUID="):
+            result["uuid"] = line.split("=", 1)[1].strip()
+    return result


### PR DESCRIPTION
## Summary

Implements an explicitly approved, one-shot destructive capability for filesystem creation while keeping raw `mkfs` on the generic terminal hardline.

This revision addresses both maintainer review rounds. The final authority flow is intentionally **in-process**: the same long-lived Hermes process that will consume the capability observes the target incarnation, obtains an explicit human `approve once`, mints the authenticated grant with its process-local authority, atomically claims it before effect, executes the structured QGA edge, and durably settles the result.

The public branch is reduced to **one commit / 13 files** and `hermes_cli/main.py` is not modified.

### Human authority boundary

`tools/grant_authority.py` provides a correlated one-shot `HumanApprovalReceipt` plus a `GrantAuthorityProvider` abstraction.

For `governed_mkfs`, the long-lived Hermes process performs the complete authority cycle:

1. validate the exact requested tuple;
2. observe the live guest incarnation (`hostname`, `product_uuid`, `boot_id`);
3. request an explicit human `approve once` for that exact tuple + incarnation;
4. mint the grant in the **same process** that will verify and consume it;
5. atomically claim before any irreversible effect;
6. revalidate generation/preconditions, execute, postcheck and settle.

The approval receipt binds:

- operation / VM / device / filesystem / label;
- live Hermes session;
- approved lifetime;
- observed hostname / DMI `product_uuid` / boot `boot_id`.

Thus the identity observed before approval is the identity the human approves and the identity authenticated into the grant.

### Process-bound grant authentication

The portable provider uses HMAC-SHA256 with a random 256-bit process-local secret.

- secret is not persisted;
- secret is not placed in the environment;
- secret is not exported to child/model execution processes;
- unkeyed SHA is not used as authority;
- restart intentionally invalidates outstanding grants;
- a child/untrusted process gets a different authority generation and cannot mint or verify a parent-valid grant.

The legitimate issuer is no longer a separate short-lived CLI process, so the process-local isolation no longer breaks the supported flow.

`hermes grant issue` intentionally **refuses issuance** (non-zero, no grant created). `hermes grant list|revoke|audit` remain available for administration. No shared persistent secret and no new privileged IPC are introduced.

### Model-facing contract

The model-facing `governed_mkfs` schema does **not** accept a `grant_id`.

The model can request the exact governed operation; it cannot select, inject or manufacture an authority object. Human denial or unavailable approval results in no grant and zero formatter calls.

Yolo, `approvals.mode=off`, cron/unattended/single-query approval paths and terminal CLI issuance cannot mint destructive authority.

### One-shot execution lifecycle

`tools/destructive_grants.py` uses an explicit lifecycle:

`LIVE -> CLAIMED(execution_id) -> completed | failed_pre_effect | indeterminate`

- claim happens atomically before the first irreversible effect;
- exactly one concurrent caller can win;
- once execution may have started, the capability never returns to the live pool;
- lost postcondition proof or settlement ambiguity is durably `indeterminate`, preventing blind replay.

### Target-generation fencing

The grant is bound to the exact guest incarnation approved by the human:

- logical `vm_id`;
- DMI `product_uuid`;
- `/proc/sys/kernel/random/boot_id`;
- observed hostname.

The identity is re-read before mutation. Reboot, replacement, ABA reuse, or a generation change between approval and effect is denied before `qga_create_filesystem`.

### Structured QGA

`tools/qga_structured.py` keeps the formatter edge narrow and fail-closed:

- allowlisted filesystem binary mapping;
- validated device/fs/label fields;
- structured `qm guest exec` argv;
- fail-closed storage prechecks and postcheck;
- no model-controlled shell for the destructive action or Docker-use precheck;
- deployment-configured QGA node + SSH key with no environment-specific defaults;
- `StrictHostKeyChecking=yes`.

### CLI ownership / hardline

Authority-related CLI registration lives in bounded subcommand modules; `hermes_cli/main.py` has **zero diff** in this PR.

Raw terminal `mkfs` remains unconditional hardline. `hermes grant issue` is both terminal-hardline and an explicit CLI hard-fail, so a short-lived process cannot mint authority for the running agent.

## Validation

Final local qualification of the exact feature content on staging `3d3afa304a36625d47cd8bcc64482102164642be`:

- process-boundary/adversarial witnesses: **34 PASS**;
- lifecycle/policy/registry/CLI targeted suite: **109 PASS**;
- approval regression suite: **124 PASS**;
- hardline suite: **246 PASS**;
- **502 tests PASS, 0 failures** total (the suite groups overlap; 502 is the deduplicated qualification total).

Key witnesses:

- legitimate in-process human-approved flow: **1 formatter call, completed**;
- human denial / unavailable approval: **0 grant, 0 formatter calls**;
- child-process mint/verify, serialized-receipt replay and file forgery: **denied, 0 formatter calls**;
- incarnation replacement after approval: **denied, 0 formatter calls**;
- concurrent replay: **exactly 1 claim winner / 1 formatter call**;
- stale reboot / replacement / ABA / TOCTOU generation changes: **0 formatter calls**.

No real QGA, filesystem formatting, TPM, VM or infrastructure mutation was used during qualification.

The final public commit was structurally recomposed onto the then-current upstream `main` using the exact qualified feature blobs after verifying all intervening upstream commits were orthogonal to these 13 files.