### PR TITLE
fix(webhook): return durable direct-delivery receipts

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -174,6 +174,10 @@ class WebhookAdapter(BasePlatformAdapter):
         self.gateway_runner = None  # set externally; needed for cross-platform delivery
         # Idempotency: TTL cache of recently processed delivery IDs.
         self._seen_deliveries: Dict[str, float] = {}
+        # Completed direct-delivery receipts share the seen-delivery TTL. This
+        # lets a webhook retry recover the provider receipt without sending the
+        # human-visible message twice.
+        self._delivery_receipts: Dict[str, str] = {}
         self._idempotency_ttl: int = 3600  # 1 hour
         self._seen_deliveries_next_prune_at: float = 0.0
         self._rate_counts: Dict[str, Deque[float]] = {}  # per-route hit timestamps in a fixed window
@@ -282,6 +286,7 @@ class WebhookAdapter(BasePlatformAdapter):
         cutoff = now - self._idempotency_ttl
         for k in [k for k, t in self._seen_deliveries.items() if t < cutoff]:
             self._seen_deliveries.pop(k, None)
+            self._delivery_receipts.pop(k, None)
         self._seen_deliveries_next_prune_at = now + min(60.0, max(1.0, self._idempotency_ttl / 10))
 
     def _record_rate_limit_hit(self, route_name: str, now: float) -> bool:
@@ -302,6 +307,7 @@ class WebhookAdapter(BasePlatformAdapter):
             return False
         if seen_at is not None:
             self._seen_deliveries.pop(delivery_id, None)
+            self._delivery_receipts.pop(delivery_id, None)
         self._seen_deliveries[delivery_id] = now
         if len(self._seen_deliveries) > max(self._rate_limit * 2, 128):
             self._prune_seen_deliveries(now)
@@ -461,9 +467,19 @@ class WebhookAdapter(BasePlatformAdapter):
             logger.exception("[webhook] direct-deliver failed route=%s delivery=%s", route_name, delivery_id)
             return web.json_response(failed, status=502)
         if result.success:
-            return web.json_response({"status": "delivered", "route": route_name, "target": delivery["deliver"],
-                                      "delivery_id": delivery_id}, status=200)
-        # Target rejected it — 502 with a generic error (don't leak adapter detail).
+            response = {"status": "delivered", "route": route_name, "target": delivery["deliver"],
+                        "delivery_id": delivery_id}
+            if result.message_id is not None and str(result.message_id).strip():
+                receipt = str(result.message_id).strip()
+                self._delivery_receipts[delivery_id] = receipt
+                response["message_id"] = receipt
+            return web.json_response(response, status=200)
+        # Target rejected it — 502 with a generic error (don't leak adapter detail). Clear
+        # the in-flight marker so the sender can safely retry the same idempotency key.
+        # Exceptions remain marked because provider outcome is ambiguous and an immediate
+        # resend could duplicate a message.
+        self._seen_deliveries.pop(delivery_id, None)
+        self._delivery_receipts.pop(delivery_id, None)
         logger.warning("[webhook] direct-deliver target rejected route=%s target=%s error=%s", route_name,
                        delivery["deliver"], result.error)
         return web.json_response(failed, status=502)
@@ -552,8 +568,31 @@ class WebhookAdapter(BasePlatformAdapter):
             "svix-id", headers.get("X-Request-ID", str(int(time.time() * 1000)))))
         now = time.time()  # idempotency: skip duplicate deliveries (webhook retries)
         if not self._record_delivery_id(delivery_id, now):
-            logger.info("[webhook] Skipping duplicate delivery %s", delivery_id)
-            return web.json_response({"status": "duplicate", "delivery_id": delivery_id}, status=200)
+            logger.info(
+                "[webhook] Skipping duplicate delivery %s", delivery_id
+            )
+            if route_config.get("deliver_only"):
+                receipt = self._delivery_receipts.get(delivery_id)
+                if receipt:
+                    return web.json_response(
+                        {
+                            "status": "duplicate",
+                            "delivery_id": delivery_id,
+                            "message_id": receipt,
+                        },
+                        status=200,
+                    )
+                # A first direct-delivery request may still be awaiting its
+                # provider response. Tell the caller to retry rather than
+                # sending twice or falsely claiming completion.
+                return web.json_response(
+                    {"status": "in_progress", "delivery_id": delivery_id},
+                    status=425,
+                )
+            return web.json_response(
+                {"status": "duplicate", "delivery_id": delivery_id},
+                status=200,
+            )
         if route_config.get("deliver_only"):
             return await self._handle_deliver_only(prompt, payload, route_config, route_name, event_type, delivery_id)
         return self._dispatch_agent_run(request, route_config, route_name, profile, payload, prompt, event_type,

--- a/tests/gateway/test_webhook_deliver_only.py
+++ b/tests/gateway/test_webhook_deliver_only.py
@@ -47,7 +47,9 @@ def _create_app(adapter: WebhookAdapter) -> web.Application:
 def _wire_mock_target(adapter: WebhookAdapter, platform_name: str = "telegram"):
     """Attach a gateway_runner with a mocked target adapter."""
     mock_target = AsyncMock()
-    mock_target.send = AsyncMock(return_value=SendResult(success=True))
+    mock_target.send = AsyncMock(
+        return_value=SendResult(success=True, message_id="provider-message-42")
+    )
 
     mock_runner = MagicMock()
     mock_runner.adapters = {Platform(platform_name): mock_target}
@@ -105,6 +107,7 @@ class TestDeliverOnlyBypassesAgent:
             assert data["status"] == "delivered"
             assert data["route"] == "match-alert"
             assert data["target"] == "telegram"
+            assert data["message_id"] == "provider-message-42"
 
         # Let any background tasks settle before asserting no agent call
         await asyncio.sleep(0.05)
@@ -120,11 +123,98 @@ class TestDeliverOnlyBypassesAgent:
         assert content_arg == "alice matched with bob!"
 
 
+    @pytest.mark.asyncio
+    async def test_completed_duplicate_returns_same_receipt_without_resending(self):
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hello",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        app = _create_app(adapter)
+        headers = {"X-GitHub-Delivery": "stable-delivery-1"}
+
+        async with TestClient(TestServer(app)) as cli:
+            first = await cli.post("/webhooks/r", json={}, headers=headers)
+            duplicate = await cli.post("/webhooks/r", json={}, headers=headers)
+            assert first.status == 200
+            assert duplicate.status == 200
+            assert (await first.json())["message_id"] == "provider-message-42"
+            duplicate_body = await duplicate.json()
+            assert duplicate_body["status"] == "duplicate"
+            assert duplicate_body["message_id"] == "provider-message-42"
+
+        mock_target.send.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_in_flight_duplicate_is_retryable_without_resending(self):
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hello",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        adapter._seen_deliveries["in-flight-1"] = 1e20
+        app = _create_app(adapter)
+
+        async with TestClient(TestServer(app)) as cli:
+            response = await cli.post(
+                "/webhooks/r",
+                json={},
+                headers={"X-GitHub-Delivery": "in-flight-1"},
+            )
+            assert response.status == 425
+            assert (await response.json())["status"] == "in_progress"
+
+        mock_target.send.assert_not_awaited()
+
+
 # ===================================================================
 # HTTP status codes
 # ===================================================================
 
 class TestDeliverOnlyStatusCodes:
+
+    @pytest.mark.asyncio
+    async def test_failed_delivery_can_retry_same_id(self):
+        routes = {
+            "r": {
+                "secret": _INSECURE_NO_AUTH,
+                "deliver": "telegram",
+                "deliver_only": True,
+                "deliver_extra": {"chat_id": "c-1"},
+                "prompt": "hi",
+            }
+        }
+        adapter = _make_adapter(routes)
+        mock_target = _wire_mock_target(adapter)
+        mock_target.send = AsyncMock(
+            side_effect=[
+                SendResult(success=False, error="temporary"),
+                SendResult(success=True, message_id="provider-retry-1"),
+            ]
+        )
+        app = _create_app(adapter)
+        headers = {"X-GitHub-Delivery": "retry-delivery-1"}
+
+        async with TestClient(TestServer(app)) as cli:
+            failed = await cli.post("/webhooks/r", json={}, headers=headers)
+            retried = await cli.post("/webhooks/r", json={}, headers=headers)
+            assert failed.status == 502
+            assert retried.status == 200
+            assert (await retried.json())["message_id"] == "provider-retry-1"
+
+        assert mock_target.send.await_count == 2
 
     @pytest.mark.asyncio
     async def test_delivery_failure_returns_502(self):

--- a/website/docs/user-guide/messaging/webhooks.md
+++ b/website/docs/user-guide/messaging/webhooks.md
@@ -379,8 +379,9 @@ hermes webhook subscribe antenna-matches \
 
 | Status | Meaning |
 |--------|---------|
-| `200 OK` | Delivered successfully. Body: `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "..."}` |
-| `200 OK` (status=duplicate) | Duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered. |
+| `200 OK` | Delivered successfully. Body includes `{"status": "delivered", "route": "...", "target": "...", "delivery_id": "...", "message_id": "..."}` when the target adapter returns a provider message ID. |
+| `200 OK` (status=duplicate) | Completed duplicate `X-GitHub-Delivery` ID within the idempotency TTL (1 hour). Not re-delivered; returns the cached `message_id` when available. |
+| `425 Too Early` | A duplicate direct-delivery request arrived while the original provider call is still in flight. Retry the same delivery ID later; Hermes does not re-deliver concurrently. |
 | `401 Unauthorized` | HMAC signature invalid or missing. |
 | `400 Bad Request` | Malformed JSON body. |
 | `404 Not Found` | Unknown route name. |


### PR DESCRIPTION
## Summary
- return adapter-native message IDs from deliver-only webhook routes
- replay the same durable receipt for completed duplicate delivery IDs
- return 425 while the first direct delivery is still in flight
- allow explicit target rejection to retry the same idempotency key

## Verification
- focused deliver-only suite: 8 passed
- webhook regression set: 70 passed
- ruff: pass
- git diff --check: pass

This closes the post-send receipt gap for callers that require a provider-native message receipt before canonical finalization.