### PR TITLE
fix(models): keep root anyOf typeless for Moonshot tool schemas

### DIFF
--- a/agent/moonshot_schema.py
+++ b/agent/moonshot_schema.py
@@ -206,8 +206,13 @@ def sanitize_moonshot_tool_parameters(parameters: Any) -> Dict[str, Any]:
     if not isinstance(repaired, dict):
         return {"type": "object", "properties": {}, "required": []}
 
-    # Top-level must be an object schema
-    if repaired.get("type") != "object":
+    # Top-level must be an object schema — unless the repaired root itself
+    # carries ``anyOf``: Rule 2 puts type on the anyOf children and forbids
+    # it on the parent, so forcing ``type: object`` back here recreates the
+    # exact "At path 'root': when using anyOf, type should be defined in
+    # anyOf items instead of the parent schema" rejection the sanitizer
+    # exists to prevent (#100688).
+    if "anyOf" not in repaired and repaired.get("type") != "object":
         repaired["type"] = "object"
     if "properties" not in repaired:
         repaired["properties"] = {}

--- a/tests/agent/test_moonshot_schema.py
+++ b/tests/agent/test_moonshot_schema.py
@@ -158,6 +158,82 @@ class TestAnyOfParentType:
         assert db_type["enum"] == ["mysql", "postgresql"]  # "" stripped by enum cleanup
 
 
+class TestRootLevelAnyOf:
+    """Rule 2 at the ROOT: a tool whose parameters are themselves a union
+    (Pydantic ``Union`` models / MCP inputSchema anyOf) must not get
+    ``type`` forced back onto the root. The repair walk strips the parent
+    type correctly; re-adding ``type: object`` afterwards recreated
+    Moonshot's "At path 'root': when using anyOf, type should be defined
+    in anyOf items instead of the parent schema" rejection (#100688)."""
+
+    def test_root_type_plus_anyof_stays_typeless(self):
+        params = {
+            "type": "object",
+            "anyOf": [
+                {"type": "object", "properties": {"a": {"type": "string"}}},
+                {"type": "object", "properties": {"b": {"type": "integer"}}},
+            ],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert "type" not in out  # root stays typeless beside anyOf
+        assert "anyOf" in out  # multi-branch union preserved
+        for branch in out["anyOf"]:
+            assert branch["type"] == "object"
+            assert branch["required"] == []
+
+    def test_root_anyof_only_union(self):
+        """Pydantic v2 union models emit a bare root anyOf with no type."""
+        params = {
+            "anyOf": [
+                {"type": "object", "properties": {"a": {"type": "string"}}},
+                {"type": "object", "properties": {"b": {"type": "integer"}}},
+            ]
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert "type" not in out
+        assert len(out["anyOf"]) == 2
+
+    def test_root_single_non_null_branch_still_promotes(self):
+        """Single non-null root branch collapses away the anyOf wrapper —
+        the promoted root keeps the normal ``type: object`` guarantee."""
+        params = {
+            "type": "object",
+            "anyOf": [
+                {"type": "object", "properties": {"a": {"type": "string"}}},
+                {"type": "null"},
+            ],
+        }
+        out = sanitize_moonshot_tool_parameters(params)
+        assert "anyOf" not in out
+        assert out["type"] == "object"
+        assert out["properties"]["a"]["type"] == "string"
+
+    def test_root_without_anyof_still_forced_object(self):
+        params = {"properties": {"q": {"type": "string"}}}
+        out = sanitize_moonshot_tool_parameters(params)
+        assert out["type"] == "object"
+
+    def test_tool_entry_root_anyof_survives_full_pipeline(self):
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "lookup",
+                    "description": "union params",
+                    "parameters": {
+                        "anyOf": [
+                            {"type": "object", "properties": {"a": {"type": "string"}}},
+                            {"type": "object", "properties": {"b": {"type": "integer"}}},
+                        ]
+                    },
+                },
+            }
+        ]
+        out = sanitize_moonshot_tools(tools)
+        assert "type" not in out[0]["function"]["parameters"]
+        assert "anyOf" in out[0]["function"]["parameters"]
+
+
 class TestTopLevelGuarantees:
     """The returned top-level schema is always a well-formed object."""
 


### PR DESCRIPTION
## What does this PR do?

`sanitize_moonshot_tool_parameters()` forced `type: object` onto **every** repaired root — including roots that legitimately carry `anyOf` (Pydantic `Union` parameter models, MCP `inputSchema` unions). `_repair_schema()` correctly strips the parent-level type per Rule 2, but the "top-level must be an object schema" guarantee then blindly re-added it, recreating the exact rejection the sanitizer exists to prevent:

```
tools.function.parameters is not a valid moonshot flavored json schema,
details: <At path 'root': when using anyOf, type should be defined in anyOf items instead of the parent schema>
```

This is the failure reported in #100688: the sanitizer *does* run on the Kimi fallback route (verified on current `main`: `is_moonshot_model("k3")` matches and both the profile and legacy `build_kwargs` paths sanitize), but for tools whose **root** is a union it emits the illegal `type` + `anyOf` shape itself — which is why plain K3 inference succeeds while any turn with such tools 400s.

The fix skips the root type coercion only when the repaired root still carries `anyOf`, so the multi-branch union survives sanitization with type on the branches (and nowhere else). Roots without `anyOf` keep the existing `type: object` guarantee unchanged, and single-non-null-branch roots still collapse/promote as before.

## Related Issue

Fixes #100688

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/moonshot_schema.py` — `sanitize_moonshot_tool_parameters()`: skip the forced root `type: object` when the repaired root carries `anyOf` (Rule 2 puts type on the children and forbids it on the parent; re-adding it recreated the "At path 'root'" rejection)
- `tests/agent/test_moonshot_schema.py` — new `TestRootLevelAnyOf` class: root `type`+`anyOf` stays typeless with typed branches, bare root `anyOf` union preserved, single-non-null-branch promotion still yields `type: object`, no-`anyOf` roots still coerced, and the full `sanitize_moonshot_tools()` pipeline round-trip

## How to Test

1. `python -c "from agent.moonshot_schema import sanitize_moonshot_tool_parameters as s; p = s({'type':'object','anyOf':[{'type':'object','properties':{'a':{'type':'string'}}},{'type':'object','properties':{'b':{'type':'integer'}}}]}); assert 'type' not in p and 'anyOf' in p; print(p)"` — Observed result: root has no `type`, both branches typed (previously the root also got `"type": "object"` beside `anyOf`).
2. `pytest tests/agent/test_moonshot_schema.py -q` — 42 passed (37 pre-existing + 5 new).
3. `pytest tests/agent/transports/ -q` — 347 passed (the sanitizer's call sites in `ChatCompletionsTransport.build_kwargs`/`_build_kwargs_from_profile` are exercised here).
4. End-to-end shape check through the real request path: `ChatCompletionsTransport().build_kwargs(model="k3", messages=[...], tools=[<root-union tool>], provider_profile=get_provider_profile("kimi-coding"))` — Observed result: the emitted `tools[0].function.parameters` no longer contains `type` alongside `anyOf` at the root.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (code comment added at the fix site)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
