### PR TITLE
fix(teams): restore emoji as Unicode from the html body mirror

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -28,6 +28,7 @@ import html
 import json
 import logging
 import os
+import re
 import sys
 from contextlib import contextmanager
 from typing import Any, Dict, Iterator, Optional
@@ -148,6 +149,88 @@ _MAX_BODY_BYTES = 1_048_576
 # (d542894ad). Pin a host via TEAMS_HOST or extra.host.
 _DEFAULT_HOST = None
 _WEBHOOK_PATH = "/api/messages"
+# ── Teams emoji → Unicode ────────────────────────────────────────────────
+# Teams never sends an emoji as a Unicode character. It sends a 20x20 PNG
+# from its CDN as an ordinary image attachment, and mirrors the message body
+# as a ``text/html`` attachment where the emoji carries the real character in
+# the ``alt`` of an ``<img itemtype="http://schema.skype.com/Emoji">``.
+#
+# Reading only ``activity.text`` therefore drops the emoji outright and hands
+# the model an unreadable 20x20 "screenshot" in its place. It also breaks the
+# turn on providers that enforce a minimum image size: xAI rejects anything
+# under 512 total pixels with a 400 ``invalid_image``, which the retry loop
+# escalates into a model failover the fallback provider cannot "fix" — the
+# request is malformed, not the provider.
+#
+# The HTML mirror is authoritative: ``alt`` carries the character, ``itemid``
+# the shortcode fallback for tenant-custom emoji that have no Unicode
+# equivalent, and ``src`` identifies exactly which image attachments to drop
+# (no CDN-hostname heuristic, so custom emoji hosted elsewhere are covered).
+_TEAMS_EMOJI_ITEMTYPE = "http://schema.skype.com/Emoji"
+_TEAMS_MENTION_ITEMTYPE = "http://schema.skype.com/Mention"
+
+_HTML_IMG_RE = re.compile(r"<img\b[^>]*>", re.IGNORECASE)
+_HTML_TAG_RE = re.compile(r"<[^>]+>")
+_HTML_ATTR_RE = re.compile(r'''([\w:-]+)\s*=\s*(?:"([^"]*)"|\'([^\']*)\')''')
+_HTML_BREAK_RE = re.compile(r"</p\s*>|<br\s*/?>", re.IGNORECASE)
+_HTML_MENTION_RE = re.compile(
+    r"<span\b[^>]*itemtype=[\"\']" + re.escape(_TEAMS_MENTION_ITEMTYPE)
+    + r"[\"\'][^>]*>.*?</span\s*>",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _html_tag_attrs(tag: str) -> Dict[str, str]:
+    """Parse the attributes of a single HTML tag into a lowercased-key dict."""
+    return {
+        m.group(1).lower(): (m.group(2) if m.group(2) is not None else m.group(3))
+        for m in _HTML_ATTR_RE.finditer(tag)
+    }
+
+
+def _teams_html_to_text(html_body: str) -> tuple[str, list, set]:
+    """Flatten a Teams ``text/html`` body mirror, restoring emoji as Unicode.
+
+    Returns ``(text, emoji_chars, emoji_srcs)``:
+    - ``text`` — the body as plain text, each emoji back **in place**;
+    - ``emoji_chars`` — the substituted characters, in document order;
+    - ``emoji_srcs`` — the ``src`` URLs of the emoji images, so the caller can
+      drop the matching attachments instead of forwarding 20x20 sprites.
+
+    Non-emoji ``<img>`` tags (genuinely pasted images) are removed from the
+    text and deliberately left in ``attachments`` — they are real content and
+    the existing inline-image path already handles them.
+    """
+    emoji_chars: list = []
+    emoji_srcs: set = set()
+
+    def _swap_img(match: "re.Match") -> str:
+        attrs = _html_tag_attrs(match.group(0))
+        if attrs.get("itemtype", "").strip().lower() != _TEAMS_EMOJI_ITEMTYPE.lower():
+            return ""
+        src = (attrs.get("src") or "").strip()
+        if src:
+            emoji_srcs.add(src)
+        char = html.unescape(attrs.get("alt") or "").strip()
+        if not char:
+            itemid = (attrs.get("itemid") or "").strip()
+            char = f":{itemid}:" if itemid else ""
+        if char:
+            emoji_chars.append(char)
+        return char
+
+    body = _HTML_MENTION_RE.sub("", html_body)
+    body = _HTML_IMG_RE.sub(_swap_img, body)
+    body = _HTML_BREAK_RE.sub("\n", body)
+    body = _HTML_TAG_RE.sub("", body)
+    text = html.unescape(body).replace("\u00a0", " ")
+    lines = [" ".join(line.split()) for line in text.split("\n")]
+    return "\n".join(lines).strip(), emoji_chars, emoji_srcs
+
+
+def _collapse_ws(value: str) -> str:
+    """Whitespace-insensitive form, for comparing two renderings of one body."""
+    return " ".join((value or "").split())
 
 
 def _parse_bool(value: Any, *, default: bool = False) -> bool:
@@ -1036,8 +1119,38 @@ class TeamsAdapter(BasePlatformAdapter):
             text = activity.text
         # Strip <at>BotName</at> HTML tags that Teams prepends for @mentions
         if "<at>" in text:
-            import re
             text = re.sub(r"<at>[^<]*</at>\s*", "", text).strip()
+
+        # Restore Teams emoji as Unicode from the text/html body mirror that
+        # Teams attaches to every message (see _teams_html_to_text). Without
+        # this the emoji is lost from the text and forwarded as an unreadable
+        # 20x20 sprite attachment instead.
+        emoji_srcs: set = set()
+        html_mirror = ""
+        for att in getattr(activity, "attachments", None) or []:
+            att_type = (getattr(att, "content_type", None) or "").lower()
+            if att_type.startswith("text/html") and not getattr(att, "content_url", None):
+                content = getattr(att, "content", None)
+                if isinstance(content, str):
+                    html_mirror = content
+                break
+
+        if html_mirror and _TEAMS_EMOJI_ITEMTYPE.lower() in html_mirror.lower():
+            html_text, emoji_chars, emoji_srcs = _teams_html_to_text(html_mirror)
+            if emoji_chars:
+                without_emoji = html_text
+                for char in emoji_chars:
+                    without_emoji = without_emoji.replace(char, "", 1)
+                if _collapse_ws(without_emoji) == _collapse_ws(text):
+                    # The mirror is a faithful rendering of activity.text, so
+                    # adopting it puts every emoji back at its exact position.
+                    text = html_text
+                else:
+                    # The two renderings disagree — an unhandled Teams
+                    # construct, or formatting that survives in one and not
+                    # the other. Never drop the emoji over a position we
+                    # cannot place with confidence: append it instead.
+                    text = f"{text} {''.join(emoji_chars)}".strip()
 
         # Determine chat type from conversation
         conv = activity.conversation
@@ -1073,6 +1186,13 @@ class TeamsAdapter(BasePlatformAdapter):
             content_url = getattr(att, "content_url", None)
             content_type = (getattr(att, "content_type", None) or "").lower()
             att_name = getattr(att, "name", None) or ""
+
+            # Teams emoji sprite: already restored as a Unicode character in
+            # the message text above. Forwarding the 20x20 PNG would hand the
+            # model an unreadable "screenshot" and trips providers that
+            # enforce a minimum image size.
+            if content_url and content_url in emoji_srcs:
+                continue
 
             # Skip non-file payloads: Teams mirrors the message body as a
             # text/html attachment on every message, and adaptive/hero cards

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -1106,3 +1106,228 @@ class TestTeamsMediaAttachments:
         adapter._app.send.assert_awaited_once()
 
 
+class TestTeamsEmojiUnicode:
+    """Teams sends emoji as 20x20 CDN sprites plus a text/html body mirror
+    carrying the real character in the img's ``alt``. The adapter must restore
+    the character into the text and drop the sprite attachment: forwarding it
+    loses the meaning and 400s on providers with a minimum image size."""
+
+    # Captured verbatim from production on 2026-08-19 (Teams, DM, 👍).
+    REAL_MIRROR = (
+        '<p>OK <span title="Oui" type="(yes)" class="animated-emoticon-20-yes" itemscope="">'
+        '<img itemscope="" itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+        'src="https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/'
+        'assets/emoticons/yes/default/20_f.png" title="Oui" alt="\U0001F44D" '
+        'style="width:20px; height:20px"></span>&nbsp;Pas grave; merci d\'avoir cherché.</p>'
+    )
+    REAL_SRC = (
+        "https://statics.teams.cdn.office.net/evergreen-assets/personal-expressions/v2/"
+        "assets/emoticons/yes/default/20_f.png"
+    )
+
+    # -- _teams_html_to_text --------------------------------------------
+
+    def test_real_production_mirror(self):
+        text, chars, srcs = _teams_mod._teams_html_to_text(self.REAL_MIRROR)
+        assert text == "OK \U0001F44D Pas grave; merci d'avoir cherché."
+        assert chars == ["\U0001F44D"]
+        assert srcs == {self.REAL_SRC}
+
+    def test_emoji_position_is_preserved(self):
+        html_body = (
+            '<p>avant <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            'src="https://cdn/y.png" alt="\U0001F44D"> apres</p>'
+        )
+        text, _, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "avant \U0001F44D apres"
+
+    def test_custom_emoji_without_alt_falls_back_to_shortcode(self):
+        html_body = (
+            '<p>ship it <img itemtype="http://schema.skype.com/Emoji" '
+            'itemid="tenantrocket" src="https://cdn/custom.png" alt=""></p>'
+        )
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "ship it :tenantrocket:"
+        assert chars == [":tenantrocket:"]
+        # Custom emoji live off the Teams CDN — matching on itemtype, not on
+        # the hostname, is what makes them work.
+        assert srcs == {"https://cdn/custom.png"}
+
+    def test_pasted_image_is_not_treated_as_emoji(self):
+        html_body = '<p>regarde <img src="https://smba.trafficmanager.net/x/views/original"></p>'
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "regarde"
+        assert chars == []
+        assert srcs == set()  # stays in attachments, real content
+
+    def test_multiple_emoji_in_order(self):
+        html_body = (
+            '<p><img itemtype="http://schema.skype.com/Emoji" itemid="yes" src="https://c/a.png" '
+            'alt="\U0001F44D"> et <img itemtype="http://schema.skype.com/Emoji" itemid="think" '
+            'src="https://c/b.png" alt="\U0001F914"></p>'
+        )
+        text, chars, srcs = _teams_mod._teams_html_to_text(html_body)
+        assert text == "\U0001F44D et \U0001F914"
+        assert chars == ["\U0001F44D", "\U0001F914"]
+        assert srcs == {"https://c/a.png", "https://c/b.png"}
+
+    def test_entities_and_breaks(self):
+        html_body = '<p>a&nbsp;&amp;&nbsp;b<br>ligne 2</p>'
+        text, _, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "a & b\nligne 2"
+
+    def test_mention_span_is_dropped(self):
+        html_body = (
+            '<p><span itemtype="http://schema.skype.com/Mention" itemid="0"><at>Hermes</at></span>'
+            ' salut <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            'src="https://c/a.png" alt="\U0001F44D"></p>'
+        )
+        text, chars, _ = _teams_mod._teams_html_to_text(html_body)
+        assert text == "salut \U0001F44D"
+        assert chars == ["\U0001F44D"]
+
+    # -- end to end through _on_message ---------------------------------
+
+    def _make_adapter(self):
+        adapter = TeamsAdapter(_make_config(
+            client_id="bot-id", client_secret="secret", tenant_id="tenant",
+        ))
+        adapter._app = MagicMock()
+        adapter._app.id = "bot-id"
+        adapter.handle_message = AsyncMock()
+        return adapter
+
+    def _html_attachment(self, content):
+        att = MagicMock()
+        att.content_type = "text/html"
+        att.content_url = None
+        att.content = content
+        att.name = ""
+        return att
+
+    def _sprite_attachment(self, content_url):
+        att = MagicMock()
+        att.content_type = "image/png"
+        att.content_url = content_url
+        att.name = "20_f.png"
+        return att
+
+    def _make_activity(self, attachments, text):
+        activity = MagicMock()
+        activity.text = text
+        activity.id = "activity-emoji-001"
+        activity.from_ = MagicMock()
+        activity.from_.id = "user-123"
+        activity.from_.aad_object_id = "aad-456"
+        activity.from_.name = "Test User"
+        activity.conversation = MagicMock()
+        activity.conversation.id = "19:abc@thread.v2"
+        activity.conversation.conversation_type = "personal"
+        activity.conversation.name = "Test Chat"
+        activity.conversation.tenant_id = "tenant-789"
+        activity.attachments = attachments
+        return activity
+
+    @pytest.mark.anyio
+    async def test_sprite_dropped_and_emoji_restored_in_text(self, monkeypatch):
+        adapter = self._make_adapter()
+        # The sprite lives on the Teams CDN (not a Bot Framework host), so it
+        # would take the anonymous ``cache_image_from_url`` path; both fetch
+        # paths are probed so a sprite that slips through fails loudly.
+        fetch = AsyncMock(return_value=b"never-called")
+        monkeypatch.setattr(adapter, "_fetch_attachment_bytes", fetch)
+        cache_url = AsyncMock(return_value="/cache/sprite.png")
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", cache_url)
+
+        activity = self._make_activity(
+            [self._html_attachment(self.REAL_MIRROR), self._sprite_attachment(self.REAL_SRC)],
+            text="OK  Pas grave; merci d'avoir cherché.",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "OK \U0001F44D Pas grave; merci d'avoir cherché."
+        assert not (event.media_urls or [])
+        fetch.assert_not_awaited()  # the sprite was never fetched
+        cache_url.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_real_pasted_image_still_attached(self, monkeypatch):
+        adapter = self._make_adapter()
+        # The pasted image is Bot-Framework-hosted: it goes through the
+        # authenticated fetch and ``cache_media_bytes``. The sprite is on the
+        # CDN and must be skipped before it reaches ``cache_image_from_url``.
+        monkeypatch.setattr(
+            adapter, "_fetch_attachment_bytes", AsyncMock(return_value=b"\x89PNG-bytes"),
+        )
+        monkeypatch.setattr(
+            _teams_mod,
+            "cache_media_bytes",
+            lambda *a, **k: SimpleNamespace(
+                path="/cache/img_1.png", media_type="image/png", kind="image"
+            ),
+        )
+        cache_url = AsyncMock(return_value="/cache/sprite.png")
+        monkeypatch.setattr(_teams_mod, "cache_image_from_url", cache_url)
+
+        pasted = "https://smba.trafficmanager.net/fr/v3/attachments/abc/views/original"
+        mirror = (
+            '<p>vois <img itemtype="http://schema.skype.com/Emoji" itemid="yes" '
+            f'src="{self.REAL_SRC}" alt="\U0001F44D"> ca <img src="{pasted}"></p>'
+        )
+        activity = self._make_activity(
+            [
+                self._html_attachment(mirror),
+                self._sprite_attachment(self.REAL_SRC),
+                self._sprite_attachment(pasted),
+            ],
+            text="vois  ca",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "vois \U0001F44D ca"
+        assert event.media_urls == ["/cache/img_1.png"]  # sprite out, real image in
+        cache_url.assert_not_awaited()
+
+    @pytest.mark.anyio
+    async def test_mismatched_mirror_appends_rather_than_dropping(self, monkeypatch):
+        """When the two renderings disagree the emoji must still survive."""
+        adapter = self._make_adapter()
+        monkeypatch.setattr(adapter, "_fetch_attachment_bytes", AsyncMock(return_value=b""))
+        monkeypatch.setattr(
+            _teams_mod, "cache_image_from_url", AsyncMock(return_value="/cache/sprite.png"),
+        )
+
+        mirror = (
+            '<p>un corps qui ne correspond pas <img itemtype="http://schema.skype.com/Emoji" '
+            f'itemid="yes" src="{self.REAL_SRC}" alt="\U0001F44D"></p>'
+        )
+        activity = self._make_activity(
+            [self._html_attachment(mirror), self._sprite_attachment(self.REAL_SRC)],
+            text="texte totalement different",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "texte totalement different \U0001F44D"
+
+    @pytest.mark.anyio
+    async def test_message_without_emoji_is_untouched(self, monkeypatch):
+        adapter = self._make_adapter()
+        activity = self._make_activity(
+            [self._html_attachment("<p>rien de special</p>")],
+            text="rien de special",
+        )
+        ctx = MagicMock()
+        ctx.activity = activity
+        await adapter._on_message(ctx)
+
+        event = adapter.handle_message.await_args.args[0]
+        assert event.text == "rien de special"


### PR DESCRIPTION
## Summary

Teams never sends an emoji as a Unicode character. It sends a 20×20 PNG from its CDN as an ordinary `image/*` attachment, and mirrors the message body as a `text/html` attachment where the emoji carries the real character in the `alt` of an `<img itemtype="http://schema.skype.com/Emoji">`.

The adapter reads only `activity.text`, so the emoji disappears from the text and the sprite is forwarded as if it were pasted content. Since #97677 authenticates connector downloads this matters more, not less: on `main` today the sprite is fetched from the CDN and cached as a real image. In production a single 👍 produced a `400 invalid_image` from a provider that enforces a minimum image size (xAI rejects anything under 512 total pixels), and the retry loop escalated that into a model failover — which cannot help, the request being malformed rather than the provider unhealthy.

This is the emoji half of #58476, resubmitted standalone as suggested in the close comment. Rebased on current `main`, on top of #97677.

## Changes

`plugins/platforms/teams/adapter.py`:

- The `text/html` body mirror — already received and skipped — becomes the source of truth for emoji. `_teams_html_to_text()` flattens it, swapping each `<img itemtype=".../Emoji">` for its `alt` character (fallback `:itemid:` for tenant-custom emoji with no Unicode equivalent) and collecting the `src` of every emoji image.
- Matching is on `itemtype`, not on the CDN hostname, so custom emoji hosted elsewhere are covered too.
- The collected `src` set identifies exactly which attachments to skip at the top of the attachment loop; genuinely pasted images (no emoji `itemtype`) keep their existing path, including the authenticated Bot Framework branch from #97677.
- **Position guard**: the mirror is adopted as the message text only when its emoji-stripped rendering matches `activity.text` (whitespace-insensitive). Then every emoji lands back at its exact position in the sentence. On any disagreement (unknown Teams construct, asymmetric formatting) the characters are appended to `activity.text` instead — a misparsed mirror can never silently drop meaning.
- Mentions (`<span itemtype=".../Mention">`) are stripped from the mirror so they don't leak into the text.

`tests/gateway/test_teams.py`: 11 tests, one of them replaying verbatim a production capture (the real `text/html` mirror and sprite URL Teams sent for `OK 👍 Pas grave; merci d'avoir cherché.`). Covers: position preserved, multiple emoji in order, custom emoji shortcode fallback, pasted image not treated as emoji, entities and `<br>`/`</p>` breaks, mention span dropped, sprite skipped end-to-end through `_on_message` (both fetch paths probed so a sprite that slips through fails loudly), real pasted image still attached alongside an emoji, mismatched mirror appends rather than drops, message without emoji untouched.

## Validation

- `tests/gateway/test_teams.py`: 43 passed (32 existing + 11 new); `ruff check` clean.
- Mutation: removing the `emoji_srcs` skip fails the end-to-end sprite test; removing the position guard fails the mismatched-mirror test.

## Notes

- No new dependency, no config, no behavior change for messages without an emoji.
- The `text/html` mirror is attached to every Teams message; it's a free source of inbound fidelity (bold, links, quotes) that this PR only uses for emoji.
