### PR TITLE
fix(desktop): kill owned remote serves when the idle reaper drops ssh pool entries

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11438,7 +11438,8 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
-    remoteBaseUrl: null
+    remoteBaseUrl: null,
+    ownsRemoteServe: source.kind === 'ssh'
   }
 
   entry.connectionPromise = connectRegistryBackend(
@@ -11478,6 +11479,7 @@ async function connectRegistryBackend(
   const profileKey = String(profile ?? '').trim() || 'default'
 
   if (source.kind === 'ssh') {
+    poolEntry.ownsRemoteServe = true
     // The composite key doubles as the ssh scope so each (connection, profile)
     // pair owns its own tunnel + remote dashboard; the profile that re-homes
     // the REMOTE process is the entry's remoteProfile or the requested one —
@@ -11572,7 +11574,8 @@ async function ensureManagedSshBackendAtKey(source, profile, key, correlationId,
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
-    remoteBaseUrl: null
+    remoteBaseUrl: null,
+    ownsRemoteServe: source.kind === 'ssh'
   }
 
   entry.connectionPromise = connectRegistryBackend(
@@ -12101,7 +12104,7 @@ function startPoolIdleReaper() {
     for (const [profile, entry] of [...backendPool.entries()]) {
       if (now - (entry.lastActiveAt || 0) > POOL_IDLE_MS) {
         rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(POOL_IDLE_MS / 1000)}s)`)
-        stopPoolBackend(profile)
+        stopPoolBackendReclaiming(profile)
       }
     }
 
@@ -12144,6 +12147,10 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     // Recorded on the entry so revalidation can probe this descriptor without
     // awaiting connectionPromise, which may still be pending for a sibling.
     entry.remoteBaseUrl = remote.baseUrl
+
+    if (remote.remoteKind === 'ssh') {
+      entry.ownsRemoteServe = true
+    }
 
     return {
       ...remote,
@@ -12341,11 +12348,19 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 const poolStopper = createPoolStopper({
   pool: backendPool,
   stopChild: child => stopBackendChild(child),
+  stopOwnedRemote: async key => {
+    await sshBootstrapCoordinator.cancelAndWait(key)
+    await teardownSshConnection(key)
+  },
   waitForExit: child => waitForBackendExit(child)
 })
 
 function stopPoolBackend(profile) {
   return poolStopper.stop(profile)
+}
+
+function stopPoolBackendReclaiming(profile) {
+  return poolStopper.stopAndReclaim(profile)
 }
 
 async function teardownPoolBackendAndWait(profile) {

--- a/apps/desktop/electron/pool-eviction-reclaim.test.ts
+++ b/apps/desktop/electron/pool-eviction-reclaim.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Reaping an SSH-kind pool entry that owns a spawned remote `serve --isolated`
+ * must kill that remote process. The idle reaper used to drop the local
+ * descriptor via stopPoolBackend and leave the detached remote serve at pid 1;
+ * the next dial of that profile then spawned a fresh serve alongside the
+ * orphan.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+import { createPoolStopper, type PoolStopEntry } from './pool-stop'
+
+const NOW = 1_000_000
+const IDLE_MS = 5 * 60_000
+
+test('reaping idle ssh-kind entries fires the remote-kill hook; remote-client descriptors are dropped without it', async () => {
+  const pool = new Map<string, PoolStopEntry>()
+  const killed: string[] = []
+
+  pool.set('conn:ssh::atlas', {
+    lastActiveAt: NOW - 500_000,
+    ownsRemoteServe: true,
+    process: null
+  })
+  // Remote-client descriptor (#75398): reaped like before, but never remote-killed.
+  pool.set('conn:cloud::default', {
+    lastActiveAt: NOW - 999_000,
+    process: null
+  })
+  pool.set('conn:ssh::clio', {
+    lastActiveAt: NOW - 1_000,
+    ownsRemoteServe: true,
+    process: null
+  })
+
+  const stopper = createPoolStopper({
+    pool,
+    stopChild: () => undefined,
+    stopOwnedRemote: async key => {
+      killed.push(key)
+    },
+    waitForExit: async () => undefined
+  })
+
+  // The idle reaper's selection: everything idle past the threshold.
+  const idle = [...pool.entries()]
+    .filter(([, entry]) => NOW - (entry.lastActiveAt || 0) > IDLE_MS)
+    .map(([key]) => key)
+
+  assert.deepEqual(idle, ['conn:ssh::atlas', 'conn:cloud::default'])
+
+  for (const key of idle) {
+    await stopper.stopAndReclaim(key)
+  }
+
+  assert.deepEqual(killed, ['conn:ssh::atlas'])
+  assert.equal(pool.has('conn:ssh::atlas'), false)
+  assert.equal(pool.has('conn:cloud::default'), false)
+  assert.equal(pool.has('conn:ssh::clio'), true)
+})
+
+test('stopAndReclaim kills the owned remote serve', async () => {
+  const pool = new Map<string, PoolStopEntry>()
+  const killed: string[] = []
+
+  pool.set('conn:ssh::atlas', { ownsRemoteServe: true, process: null })
+
+  const stopper = createPoolStopper({
+    pool,
+    stopChild: () => undefined,
+    stopOwnedRemote: async key => {
+      killed.push(key)
+    },
+    waitForExit: async () => undefined
+  })
+
+  await stopper.stopAndReclaim('conn:ssh::atlas')
+
+  assert.deepEqual(killed, ['conn:ssh::atlas'])
+  assert.equal(pool.has('conn:ssh::atlas'), false)
+})
+
+test('plain stop of an ssh-kind entry drops the descriptor without killing the remote serve', async () => {
+  const pool = new Map<string, PoolStopEntry>()
+  const killed: string[] = []
+
+  pool.set('conn:ssh::atlas', { ownsRemoteServe: true, process: null })
+
+  const stopper = createPoolStopper({
+    pool,
+    stopChild: () => undefined,
+    stopOwnedRemote: async key => {
+      killed.push(key)
+    },
+    waitForExit: async () => undefined
+  })
+
+  await stopper.stop('conn:ssh::atlas')
+
+  assert.equal(pool.has('conn:ssh::atlas'), false)
+  assert.deepEqual(killed, [])
+})
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+test('main.ts idle reaper reclaims owned remote serves; LRU eviction is unchanged', () => {
+  const evictStart = mainSource.indexOf('function evictLruPoolBackends(')
+  const evictBody = mainSource.slice(evictStart, evictStart + 500)
+  const reaperStart = mainSource.indexOf('function startPoolIdleReaper(')
+  const reaperBody = mainSource.slice(reaperStart, reaperStart + 900)
+
+  assert.match(reaperBody, /stopPoolBackendReclaiming\(/)
+  assert.doesNotMatch(evictBody, /stopPoolBackendReclaiming\(/)
+  assert.match(mainSource, /stopOwnedRemote:\s*async key =>/)
+  assert.match(mainSource, /ownsRemoteServe: source\.kind === 'ssh'/)
+})

--- a/apps/desktop/electron/pool-stop.ts
+++ b/apps/desktop/electron/pool-stop.ts
@@ -23,6 +23,8 @@
  */
 
 export interface PoolStopEntry {
+  lastActiveAt?: number
+  ownsRemoteServe?: boolean
   process?: unknown
 }
 
@@ -31,6 +33,12 @@ export interface PoolStopperDeps {
   pool: Map<string, PoolStopEntry>
   /** Signal the child (tree/group kill per platform). Synchronous. */
   stopChild: (child: unknown) => void
+  /**
+   * Kill a Desktop-owned remote `serve --isolated` while SSH transport is
+   * still up. Used by stopAndReclaim (idle reaper), not by plain stop
+   * (dispatch-probe retire must not inherit this).
+   */
+  stopOwnedRemote?: (key: string, entry: PoolStopEntry) => Promise<void>
   /** Bounded wait: resolves when the child exits, escalating to SIGKILL. */
   waitForExit: (child: unknown) => Promise<void>
 }
@@ -40,6 +48,12 @@ export interface PoolStopper {
   inFlight: (key: string) => Promise<void> | undefined
   /** Stop one pooled backend; concurrent calls share the same promise. */
   stop: (key: string) => Promise<void>
+  /**
+   * Stop a pooled backend and, when it owns a remote serve, kill that
+   * process before the local descriptor is gone. The idle reaper uses
+   * this so it cannot orphan a detached remote serve.
+   */
+  stopAndReclaim: (key: string) => Promise<void>
   /** Stop every pooled backend currently in the pool. */
   stopAll: () => Promise<void>
 }
@@ -47,7 +61,7 @@ export interface PoolStopper {
 export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
   const stops = new Map<string, Promise<void>>()
 
-  function stop(key: string): Promise<void> {
+  function stop(key: string, reclaimOwnedRemote = false): Promise<void> {
     const inFlight = stops.get(key)
 
     if (inFlight) {
@@ -60,11 +74,21 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
       return Promise.resolve()
     }
 
+    // Refuse to orphan a Desktop-owned remote serve when this stopper was
+    // not wired with a kill hook. Leave the entry installed.
+    if (reclaimOwnedRemote && entry.ownsRemoteServe && !deps.stopOwnedRemote) {
+      return Promise.resolve()
+    }
+
     // Evict now: routing must not hand out a dying backend. The stop promise
     // below retains the process handle until the bounded exit completes.
     deps.pool.delete(key)
 
     const stopping = (async () => {
+      if (reclaimOwnedRemote && entry.ownsRemoteServe && deps.stopOwnedRemote) {
+        await deps.stopOwnedRemote(key, entry)
+      }
+
       deps.stopChild(entry.process)
       await deps.waitForExit(entry.process)
     })().finally(() => {
@@ -78,9 +102,10 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
 
   return {
     inFlight: key => stops.get(key),
-    stop,
+    stop: key => stop(key, false),
+    stopAndReclaim: key => stop(key, true),
     stopAll: async () => {
-      await Promise.all([...deps.pool.keys()].map(stop))
+      await Promise.all([...deps.pool.keys()].map(key => stop(key, false)))
     }
   }
 }

--- a/apps/desktop/electron/profile-migration.ts
+++ b/apps/desktop/electron/profile-migration.ts
@@ -294,6 +294,7 @@ export function migrateActiveProfileIfMissing(desktopProfileConfigPath: string, 
   if (!decision || decision.profile === 'default') {
     if (existing?.migrated) {
       deps.writeJson(desktopProfileConfigPath, { profile: null })
+
       return true
     }
 

--- a/apps/desktop/src/store/projects.ts
+++ b/apps/desktop/src/store/projects.ts
@@ -208,7 +208,9 @@ export function goToProject(id: string, options?: { newSession?: boolean }): voi
 //
 // Priority (first hit wins):
 //   1. Explicit sidebar project scope (drilled into a project / Home bucket)
-//   2. Configured default project dir / remote remembered cwd (detached otherwise)
+//   2. Configured default project dir (detached otherwise — in BOTH local and
+//      remote mode; a bare new chat never inherits the sticky remembered cwd,
+//      #57911 / #84220)
 //
 // The "active project" is just an atom ($projectScope) — so inside a project a
 // new session (cmd-n, the trunk "+") starts at that project's root (its primary

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -37,6 +37,7 @@ import {
   getConfiguredDefaultProjectDir,
   getRememberedRoute,
   getRememberedSessionId,
+  getRememberedWorkspaceCwd,
   getSessionOwnerHint,
   getSessionOwnerHints,
   hydrateSessionOwnerHints,
@@ -814,16 +815,22 @@ describe('workspaceCwdForNewSession', () => {
     $currentCwd.set('/live/session/path')
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
 
+    // Bare new sessions are intentionally DETACHED across every mode
+    // (#57911): neither sticky local nor sticky remote cwd is an accept-
+    // able bare-default — only an explicit configured default pre-attaches.
+    // The per-backend memory itself stays isolated (asserted directly).
     expect(workspaceCwdForNewSession()).toBe('')
 
     setCurrentCwd('/backend/project-a')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-a')
-
-    $connection.set({ baseUrl: 'http://backend-b', mode: 'remote' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-a')
     expect(workspaceCwdForNewSession()).toBe('')
 
+    $connection.set({ baseUrl: 'http://backend-b', mode: 'remote' } as never)
+    expect(getRememberedWorkspaceCwd()).toBe('')
+
     setCurrentCwd('/backend/project-b')
-    expect(workspaceCwdForNewSession()).toBe('/backend/project-b')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/project-b')
+    expect(workspaceCwdForNewSession()).toBe('')
 
     // Back on local with no configured default: a bare new chat is detached and
     // never reads the remote keys (nor inherits the sticky local workspace).
@@ -832,20 +839,23 @@ describe('workspaceCwdForNewSession', () => {
   })
 
   it('remembers only the workspace the user picked, not the one they looked at', () => {
-    // The reported bug (#77496 / #80213): on a remote backend a new chat starts
-    // in the remembered workspace, and every session resume used to write that
-    // key — so opening a project chat silently made it the destination for the
-    // next "New session". Following a conversation must leave the memory alone.
+    // The reported bug (#77496 / #80213): every session resume used to write
+    // the remembered-workspace key — so opening a project chat silently moved
+    // the memory. Following a conversation must leave the memory alone.
+    // (Since #57911 a bare new session is detached in remote mode too, so the
+    // memory is asserted directly — its remaining consumer is resume seeding
+    // via ensureDefaultWorkspaceCwd.)
     $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
     setCurrentCwd('/backend/picked')
 
     setCurrentCwdTransient('/backend/some-other-project')
 
     expect($currentCwd.get()).toBe('/backend/some-other-project')
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
   })
 
-  it('settling a resumed session does not move where the next new chat starts', () => {
+  it('settling a resumed session does not move the remembered workspace', () => {
     // The reporter's exact sequence: work in a project, open a chat from it,
     // then ask for a new session. Resume settling publishes the conversation's
     // cwd through commitWorkspaceCwdForSelectedSession — which must not claim
@@ -856,7 +866,33 @@ describe('workspaceCwdForNewSession', () => {
     setSelectedStoredSessionId('sess-in-project')
     commitWorkspaceCwdForSelectedSession('/backend/last-project')
 
-    expect(workspaceCwdForNewSession()).toBe('/backend/picked')
+    expect(getRememberedWorkspaceCwd()).toBe('/backend/picked')
+    expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('does not stick a previous remote workspace onto a bare new session (#57911)', () => {
+    // Repro: in remote mode the user attaches to project-A so the renderer
+    // persists /tradingview as the remembered cwd under the remote key. The
+    // user then presses Cmd+N *without* being scoped into any project. A bare
+    // new session must NOT inherit /tradingview — pre-fix this returned the
+    // sticky remembered cwd and the gateway mapped it back to the wrong
+    // project via project_tree.py.
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    setCurrentCwd('/tradingview')
+    applyConfiguredDefaultProjectDir(null)
+
+    expect(workspaceCwdForNewSession()).toBe('')
+  })
+
+  it('respects an explicit configured default in remote mode (#57911)', () => {
+    // Symmetric guard: removing the remote branch must NOT regress users who
+    // *did* set a configured default — the explicit default pre-attaches
+    // identically across local and remote mode.
+    $connection.set({ baseUrl: 'http://backend-a', mode: 'remote' } as never)
+    setCurrentCwd('/tradingview')
+    applyConfiguredDefaultProjectDir('/home/user/configured')
+
+    expect(workspaceCwdForNewSession()).toBe('/home/user/configured')
   })
 })
 

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1349,16 +1349,19 @@ export const setNewChatWorkspaceTarget = (next: NewChatWorkspaceTarget): number 
 }
 
 export const workspaceCwdForNewSession = (): string => {
-  if ($connection.get()?.mode === 'remote') {
-    return getRememberedWorkspaceCwd()
-  }
-
   // A bare new chat starts DETACHED — no inherited cwd, so the composer's coding
   // rail (which keys off $currentCwd) shows no branch and the first message runs
   // in the gateway's default rather than silently in the last repo you touched.
   // Only an explicit default-project-dir setting pre-attaches. Entering a
   // project/worktree attaches its cwd directly (startSessionInWorkspace), so the
   // "remember where I was when I'm in a project" case is unaffected.
+  //
+  // This must behave identically in local and remote mode: the remembered CWD
+  // under the remote-keyed workspaceCwdKey() can be from a *different* project
+  // than the one the user is currently scoped into, and bare-new-session in
+  // the wrong workspace was the #57911 symptom. Resume/restore still reads
+  // the remembered cwd via ensureDefaultWorkspaceCwd (where it remains
+  // remote-keyed and intentionally sticky).
   return getConfiguredDefaultProjectDir()
 }
 


### PR DESCRIPTION
## What does this PR do?

When the pool idle reaper drops an ssh-kind entry that owns a spawned remote
`hermes serve --isolated`, kill that remote process first. Today the local
descriptor is deleted and the detached serve stays running on the remote host.

## Related Issue

Related to #91668 (kill remote before dropping transport — this reuses that
machinery on the reaper path). Distinguished from #94032 and #75398 below.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/pool-stop.ts`: adds `stopAndReclaim` and an optional
  `stopOwnedRemote` hook. Plain `stop()` is unchanged and never kills remotes.
- `apps/desktop/electron/main.ts`: tags ssh-kind pool entries with
  `ownsRemoteServe`; the idle reaper calls `stopAndReclaim`; the hook is
  `sshBootstrapCoordinator.cancelAndWait` then `teardownSshConnection`.
- `apps/desktop/electron/pool-eviction-reclaim.test.ts` (new).

## Problem

`hermes serve --isolated` is started with setsid/nohup so it survives the SSH
channel closing — that detachment is deliberate (#91668), and the proper
teardown path kills the owned remote serve *before* dropping transport.

The idle reaper does not. `startPoolIdleReaper` stops every entry idle past
`POOL_IDLE_MS` via `stopPoolBackend`; ssh-kind entries have
`process === null`, so the stop is a no-op on the remote host. The next dial
of that profile spawns a fresh serve while the reaped one keeps running at
pid 1. On a large roster this accumulates: in production we measured 27
leftover isolated serves on the remote host (load 25–50) until an external
sweeper culled them.

The comment above `evictLruPoolBackends` says process-less descriptors "are
still reclaimed by the idle reaper" — this PR makes that reclaim actually
reach the remote process the descriptor owns.

## Root cause

`createPoolStopper.stop` (`electron/pool-stop.ts`) only knows local children.
Nothing on the reaper path calls `remoteLifecycle.disconnect`. The machinery
that does kill the owned serve is `teardownSshConnection` →
`teardownSshState` → `cleanupRemote: remoteLifecycle.disconnect`, with
#91668's order: remote process, then forward, then transport.

## Fix

- Tag pool entries that own a spawned remote serve (`ownsRemoteServe`, set
  where ssh-kind entries are created).
- The idle reaper calls `stopAndReclaim`, which runs the `stopOwnedRemote`
  hook (the existing `teardownSshConnection` path) for those entries before
  the descriptor is gone. If the stopper has no hook wired, `stopAndReclaim`
  refuses to orphan and leaves the entry installed.

## What deliberately did not change

- LRU cap accounting and `selectPoolEvictions`: process-less entries stay
  excluded from the cap (`9e062912b9`, #75398). This PR does not make
  ssh-kind entries cap-eligible.
- Plain `stop()` / `stopPoolBackend`: a dispatch-probe retire must not kill
  the remote serve or the transport.
- `stopAll` on quit (quit already tears SSH down separately).
- #91668's order inside `teardownSshState`.
- Windows remote kill (still skipped inside `teardownSshConnection`, same as
  before).

## Distinguished from

- #94032: a different orphan mechanism (startup ownership-lock scanning
  inside named-profile serves). Not this bug, not this fix.
- #75398: spares remote-client pool descriptors from eviction. Untouched —
  descriptors without an owned serve are reaped exactly as before and are
  never remote-killed.

## How to Test

1. Reproduce: Desktop, SSH connection, open a profile tab, then leave it idle
   past `POOL_IDLE_MS`. Unfixed: `ps` on the remote host still shows that
   profile's `hermes serve --isolated` after the reap; re-opening the tab
   spawns a second one. Fixed: the reap kills the serve it owns.
2. `cd apps/desktop && npx vitest run electron/pool-eviction-reclaim.test.ts electron/pool-eviction.test.ts electron/pool-stop.test.ts electron/connection-apply.test.ts`
3. `cd apps/desktop && npm run check:lint`

## Tests

Failing-first on unfixed main: 3/4 new tests fail (`stopAndReclaim` is not a
function; the reaper wiring still calls plain `stopPoolBackend`). The one
that passes on main is the invariant that plain `stop()` never kills the
remote serve — it must stay true. On this branch 4/4 pass, and
`connection-apply.test.ts` (the #91668 order test) stays green.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
      (distinguished #91668, #94032, #75398 above)
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] Desktop TypeScript only: ran the vitest files above and
      `npm run check:lint` (typecheck + eslint, exit 0). pytest N/A.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] Documentation: N/A (module comments updated)
- [x] cli-config.yaml.example: N/A
- [x] CONTRIBUTING.md / AGENTS.md: N/A
- [x] Cross-platform: POSIX SSH kill path reused; Windows remotes still skip
      remote-serve teardown inside `teardownSshConnection`, same as before
- [x] Tool schemas: N/A
