### PR TITLE
fix(codex): keep final answers out of interim delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1534,8 +1534,16 @@ re-creates a duplicate or a frozen stream:
    exists. A sealed native stream is a regular message — `chat.update` on it
    works (live-verified).
 
-Contract tests: `tests/gateway/test_stream_final_contract.py` (all four
-invariants, mutation-checked). Slack streaming API ground truth (live-probed,
+5. **Codex message phases have one delivery owner.** Completed commentary
+   `agentMessage` items remain interim candidates because a later tool may
+   still follow. A completed `phase=final_answer` item is terminal, so its
+   deltas may animate the draft but the item itself must bypass the interim
+   callback and let the turn finalizer persist the answer once. Phase-less
+   items stay on the legacy interim path.
+
+Contract tests: `tests/gateway/test_stream_final_contract.py` (the first four,
+mutation-checked) plus `tests/agent/test_codex_app_server_event_bridge.py` for
+phase-aware routing. Slack streaming API ground truth (live-probed,
 also encoded in connector comments/tests): `chat.*Stream` speaks STANDARD
 markdown, not mrkdwn; `stopStream.markdown_text` APPENDS (never replaces);
 `startStream`/`stopStream` are rate-limit Tier 2 (~20/min).

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -349,7 +349,8 @@ def _record_codex_app_server_compaction(
 # callbacks the standard runtime fires:
 #   - tool_progress_callback("tool.started"|"tool.completed", name, ...)
 #   - _fire_stream_delta(text) for streaming agentMessage chunks
-#   - _emit_interim_assistant_message({...}) for completed agentMessages
+#   - _emit_interim_assistant_message({...}) for completed non-final
+#     agentMessages
 # ---------------------------------------------------------------------------
 
 # Codex item types that map to a Hermes tool_call in the projector (and
@@ -508,7 +509,7 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
       * ``item/agentMessage/delta`` → ``_fire_stream_delta(text)`` so chat
         adapters can render the assistant's reply as it streams.
       * ``item/reasoning/delta`` → ``_fire_reasoning_delta(text)``
-      * ``item/completed`` for ``agentMessage`` →
+      * ``item/completed`` for a non-final ``agentMessage`` →
         ``_emit_interim_assistant_message({"role": "assistant",
         "content": text})``. The gateway's ``already_streamed`` check
         dedupes against any text the stream-delta callback already
@@ -634,6 +635,16 @@ def make_codex_app_server_event_bridge(agent) -> Callable[[dict], None]:
     def _fire_agent_message_completed(item: dict) -> None:
         text = item.get("text") or ""
         if not isinstance(text, str) or not text.strip():
+            return
+        # A phase=final_answer item is the turn's authoritative terminal
+        # response. Its deltas have already reached the streaming callback,
+        # and run_codex_app_server_turn returns the same text to the normal
+        # finalizer. Replaying the completed item through the interim lane
+        # gives native-draft transports two visible owners for one answer.
+        # Missing phases remain interim-compatible with older app-server
+        # versions, which did not distinguish commentary from final answers.
+        phase = item.get("phase")
+        if isinstance(phase, str) and phase.strip().lower() == "final_answer":
             return
         # display.show_commentary=false — mid-turn narration stays off the
         # visible interim path on this runtime too (same contract as the

--- a/tests/agent/test_codex_app_server_event_bridge.py
+++ b/tests/agent/test_codex_app_server_event_bridge.py
@@ -250,12 +250,42 @@ class TestToolProgressDispatch:
 
 
 class TestAgentMessageInterimDispatch:
-    def test_completed_agent_message_emits_interim(self):
+    def test_completed_final_answer_is_not_replayed_as_interim(self):
+        """The terminal answer already owns the normal final-delivery path.
+
+        Replaying it through the interim callback makes native draft transports
+        show the same answer once as a draft/commentary message and again when
+        the turn finalizes.
+        """
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-final",
+            "phase": "final_answer",
+            "text": "The fix is ready.",
+        }))
+        agent._emit_interim_assistant_message.assert_not_called()
+
+    def test_completed_commentary_message_emits_interim(self):
         agent = _make_stub_agent()
         bridge = make_codex_app_server_event_bridge(agent)
         bridge(_item_completed({
             "type": "agentMessage",
             "id": "am-1",
+            "phase": "commentary",
+            "text": "I'll check the config first.",
+        }))
+        agent._emit_interim_assistant_message.assert_called_once_with(
+            {"role": "assistant", "content": "I'll check the config first."}
+        )
+
+    def test_completed_legacy_message_without_phase_stays_interim(self):
+        agent = _make_stub_agent()
+        bridge = make_codex_app_server_event_bridge(agent)
+        bridge(_item_completed({
+            "type": "agentMessage",
+            "id": "am-legacy",
             "text": "I'll check the config first.",
         }))
         agent._emit_interim_assistant_message.assert_called_once_with(


### PR DESCRIPTION
## Problem

Codex app-server now labels terminal agentMessage items with phase=final_answer. The event bridge ignored that phase and replayed every completed agentMessage through the interim callback. On native draft transports this gave the terminal answer both interim/draft ownership and normal turn-final ownership, which could leave duplicate visible answers.

## Fix

- bypass interim dispatch for completed phase=final_answer items
- preserve interim delivery for commentary items
- preserve the legacy phase-less event behavior for older Codex app-server versions
- document the one-owner streaming invariant

## Regression coverage

The new bridge test fails before the fix because final_answer invokes _emit_interim_assistant_message, then passes after the phase-aware guard.

Validated with:
- scripts/run_tests.sh tests/agent/test_codex_app_server_event_bridge.py tests/gateway/test_stream_consumer_draft.py -q
- 32 passed