### PR TITLE
fix(tools): log boot-time UnscopedSecretError probes at debug, not warning

### DIFF
--- a/tests/tools/test_terminal_tool_requirements.py
+++ b/tests/tools/test_terminal_tool_requirements.py
@@ -360,3 +360,73 @@ class TestCheckFnTransientFailureSuppression:
 
         assert "terminal" not in names
         assert "execute_code" not in names
+
+
+class TestUnscopedSecretReadLogging:
+    """#100697: with multiplexing on, boot-time check_fns run before any
+    profile secret scope exists, so get_secret fails closed with
+    UnscopedSecretError. That expected signal must not be logged like a
+    crashed check_fn (WARNING + traceback); an unscoped read reported while
+    the scope was *resolved* is a genuinely lost scope and stays loud."""
+
+    @pytest.fixture(autouse=True)
+    def _reset(self):
+        from tools.registry import invalidate_check_fn_cache
+
+        invalidate_check_fn_cache()
+        yield
+        invalidate_check_fn_cache()
+
+    def test_unresolved_scope_unscoped_read_logs_debug_without_traceback(
+        self, caplog
+    ):
+        import logging
+
+        import tools.registry as reg
+        from agent.secret_scope import get_secret, set_multiplex_active
+
+        def probe():
+            return bool(get_secret("REGISTRY_LOG_PROBE_TOKEN", ""))
+
+        set_multiplex_active(True)
+        try:
+            with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+                assert reg._run_check_fn_uncached(probe, unresolved_scope=True) is False
+        finally:
+            set_multiplex_active(False)
+
+        registry_records = [
+            r for r in caplog.records if r.name == "tools.registry"
+        ]
+        assert not [
+            r for r in registry_records if r.levelno >= logging.WARNING
+        ], "expected fail-closed probe must not be logged as a check_fn crash"
+        quiet = [
+            r
+            for r in registry_records
+            if r.levelno == logging.DEBUG and "fail-closed path" in r.getMessage()
+        ]
+        assert quiet, "the fail-closed probe should leave a debug breadcrumb"
+        assert all(r.exc_info is None for r in quiet)
+
+    def test_resolved_scope_unscoped_read_stays_loud(self, caplog):
+        import logging
+
+        import tools.registry as reg
+        from agent.secret_scope import UnscopedSecretError
+
+        def probe():
+            raise UnscopedSecretError(
+                "get_secret('REGISTRY_LOG_PROBE_TOKEN') called with no "
+                "profile secret scope active"
+            )
+
+        with caplog.at_level(logging.DEBUG, logger="tools.registry"):
+            assert reg._run_check_fn_uncached(probe, unresolved_scope=False) is False
+
+        loud = [
+            r for r in caplog.records
+            if r.name == "tools.registry" and r.levelno >= logging.WARNING
+        ]
+        assert loud, "a resolved-scope unscoped read is a lost scope and must warn"
+        assert any(r.exc_info for r in loud), "the lost-scope warning keeps its traceback"

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -348,8 +348,33 @@ def check_fn_cache_scope() -> Optional[str]:
 
 def _run_check_fn_uncached(fn: Callable, *, unresolved_scope: bool = False) -> bool:
     """Run an availability check without cache/grace handling."""
+    from agent.secret_scope import UnscopedSecretError
+
     try:
         return bool(fn())
+    except UnscopedSecretError:
+        if unresolved_scope:
+            # Expected fail-closed probe: with multiplexing on, boot-time
+            # check_fns run before any profile secret scope exists, so
+            # get_secret raises by design. The tool re-probes on the first
+            # scoped turn — log without a traceback so this cannot be
+            # mistaken for a crashed check_fn (#100697).
+            logger.debug(
+                "check_fn %s hit the multiplex fail-closed path with no "
+                "profile secret scope active; dependent tools re-probe on "
+                "the first scoped turn",
+                getattr(fn, "__qualname__", fn),
+            )
+            return False
+        # The scope resolved but the read still failed closed: a genuinely
+        # lost scope. Keep the loud crash-style report.
+        logger.warning(
+            "check_fn %s raised UnscopedSecretError while the profile cache "
+            "scope was resolved; dependent tools will be unavailable this turn",
+            getattr(fn, "__qualname__", fn),
+            exc_info=True,
+        )
+        return False
     except Exception:
         detail = " while profile cache scope was unresolved" if unresolved_scope else ""
         logger.warning(


### PR DESCRIPTION
## What does this PR do?

Under multiplexing, the tool registry evaluates availability `check_fn`s at gateway boot, before any profile secret scope exists. Those probes read credentials via `get_secret()`, which fails closed by design and raises `UnscopedSecretError`; the tool simply re-probes on the first scoped turn and becomes available. `_run_check_fn_uncached()` logged that expected signal exactly like a crashed `check_fn` (WARNING + `exc_info=True`), so every multiplexed gateway start printed three full tracebacks (`discord`, `homeassistant`, `web_api`) that drowned genuine `check_fn` failures in the journal.

This splits the handler in `_run_check_fn_uncached()`:

- An `UnscopedSecretError` reported while the profile cache scope was **unresolved** (the boot/bypass path) logs one debug line without a traceback — "hit the multiplex fail-closed path … re-probe on the first scoped turn".
- The same error with the scope **resolved** is a genuinely lost scope and keeps the loud warning + traceback.

Behavior is unchanged otherwise: the `check_fn` still returns `False` (fail-closed preserved), only the log classification changes.

## Related Issue

Fixes #100697

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/registry.py`: added an `UnscopedSecretError` branch to `_run_check_fn_uncached()` — debug (no `exc_info`) when `unresolved_scope=True`, warning + traceback when the scope was resolved.
- `tests/tools/test_terminal_tool_requirements.py`: new `TestUnscopedSecretReadLogging` covering both sides (quiet debug breadcrumb for the unresolved boot probe; loud traceback for the resolved-scope lost-scope case).

## How to Test

1. Run the issue's in-process reproduction against this branch:
   ```python
   import logging
   logging.basicConfig(level=logging.DEBUG)
   from agent.secret_scope import set_multiplex_active, get_secret
   from tools.registry import _run_check_fn_uncached

   set_multiplex_active(True)
   _run_check_fn_uncached(lambda: bool(get_secret("EXAMPLE_TOKEN", "")), unresolved_scope=True)
   ```
   Observed result on main: `WARNING tools.registry: check_fn ... raised while profile cache scope was unresolved` followed by a full traceback. Observed result on this branch: a single `DEBUG` line (`hit the multiplex fail-closed path...`), no traceback, return value still `False`.
2. `pytest tests/tools/test_terminal_tool_requirements.py tests/tools/test_registry.py tests/test_secret_scope_plugin_families.py -q` — Observed result: 64 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (logging-only change, no platform-specific code paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A