### PR TITLE
fix(agent): resolve reasoning_config at the init chokepoint, not per call site

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -962,6 +962,21 @@ def init_agent(
     
     # Model response configuration
     agent.max_tokens = max_tokens  # None = use model default
+    if reasoning_config is None:
+        # No caller-supplied config: resolve the user's configured effort here
+        # rather than leaving it None. A None reaches build_anthropic_kwargs as
+        # "no thinking key at all", so adaptive Claude falls back to the API
+        # default display:"omitted" and returns thinking blocks with empty text
+        # and only an opaque signature — which hosts render as garbled bytes
+        # where reasoning should be. Resolving at this single chokepoint keeps
+        # every construction site correct, including ones that forget the kwarg.
+        try:
+            from hermes_cli.config import load_config_readonly as _load_rc_cfg
+            from hermes_constants import resolve_reasoning_config as _resolve_rc
+
+            reasoning_config = _resolve_rc(_load_rc_cfg() or {}, agent.model or "")
+        except Exception:
+            reasoning_config = None
     agent.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
     # Per-provider reasoning_content echo opt-in (see _reasoning_echo_opt_in).
     # Read once at init; switch_model / try_activate_fallback / restore

--- a/tests/agent/test_agent_init_reasoning_config.py
+++ b/tests/agent/test_agent_init_reasoning_config.py
@@ -1,0 +1,111 @@
+"""``init_agent`` must resolve reasoning_config when no caller supplies one.
+
+Regression guard for a bug CLASS, not a single call site. Every ``AIAgent(...)``
+construction site has to remember a ``reasoning_config=`` kwarg; a site that
+omits it stores ``None``, and ``build_anthropic_kwargs`` gates its whole
+thinking mapping on a truthiness check — so ``None`` means no ``thinking`` key
+on the wire at all. Adaptive Claude then falls back to the API default
+``display: "omitted"`` and returns thinking blocks whose text is empty with only
+an opaque signature populated, which hosts render as garbled characters where
+reasoning text should be.
+
+Patching individual call sites has not converged; ``init_agent`` is the single
+chokepoint every surface passes through, so the resolution belongs there.
+
+The resolution lives inline inside ``init_agent``, a function far too large to
+invoke in a unit test, so this asserts the *structure* of the chokepoint via
+AST. Deliberately structural rather than a substring search: the explanatory
+comment beside the fix names ``resolve_reasoning_config``, so a plain
+``in source`` check would pass against reverted code.
+"""
+
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+
+
+def _init_agent_ast() -> ast.FunctionDef:
+    from agent import agent_init
+
+    tree = ast.parse(textwrap.dedent(inspect.getsource(agent_init)))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.FunctionDef) and node.name == "init_agent":
+            return node
+    raise AssertionError("agent_init.init_agent not found")
+
+
+def _names_bound_to_resolver(fn: ast.FunctionDef) -> set[str]:
+    """Local names bound to ``resolve_reasoning_config``, alias included.
+
+    The fix imports it inside the guard as ``_resolve_rc``; a later cleanup may
+    hoist the import to module scope or drop the alias. Resolving the binding
+    keeps this guard from tripping on cosmetic churn.
+    """
+    names = {"resolve_reasoning_config"}
+    for node in ast.walk(fn):
+        if isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                if alias.name == "resolve_reasoning_config":
+                    names.add(alias.asname or alias.name)
+    return names
+
+
+def test_chokepoint_guards_assignment_with_resolution():
+    """A ``reasoning_config is None`` guard must resolve before the assignment."""
+    fn = _init_agent_ast()
+    resolver_names = _names_bound_to_resolver(fn)
+
+    assignments = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.Assign)
+        and any(
+            isinstance(t, ast.Attribute)
+            and t.attr == "reasoning_config"
+            and isinstance(t.value, ast.Name)
+            and t.value.id == "agent"
+            for t in node.targets
+        )
+    ]
+    assert assignments, "init_agent no longer assigns agent.reasoning_config"
+
+    guards = [
+        node
+        for node in ast.walk(fn)
+        if isinstance(node, ast.If)
+        and isinstance(node.test, ast.Compare)
+        and isinstance(node.test.left, ast.Name)
+        and node.test.left.id == "reasoning_config"
+        and len(node.test.ops) == 1
+        and isinstance(node.test.ops[0], ast.Is)
+        and isinstance(node.test.comparators[0], ast.Constant)
+        and node.test.comparators[0].value is None
+    ]
+    assert guards, (
+        "init_agent must guard on `reasoning_config is None` and resolve the "
+        "user's configured effort there; without it, every surface that omits "
+        "the kwarg silently drops thinking text"
+    )
+
+    resolving_guards = [
+        guard
+        for guard in guards
+        if any(
+            isinstance(call, ast.Call)
+            and (getattr(call.func, "id", None) or getattr(call.func, "attr", None))
+            in resolver_names
+            for call in ast.walk(guard)
+        )
+    ]
+    assert resolving_guards, (
+        "the `reasoning_config is None` branch must call "
+        "resolve_reasoning_config — a guard that leaves it None is the bug"
+    )
+
+    earliest_assignment = min(node.lineno for node in assignments)
+    assert any(guard.lineno < earliest_assignment for guard in resolving_guards), (
+        "the resolution must run BEFORE agent.reasoning_config is assigned, "
+        "otherwise the resolved value never reaches the agent"
+    )


### PR DESCRIPTION
> Supersedes #89496 (same author), which fixed only the ACP call site. Closing that one in favour of this.

## What does this PR do?

Resolves `reasoning_config` once inside `init_agent`, instead of requiring every `AIAgent(...)` construction site to remember to pass it.

### The bug

`build_anthropic_kwargs` gates its entire thinking mapping on a truthiness check ([`agent/anthropic_adapter.py:1111`](https://github.com/NousResearch/hermes-agent/blob/main/agent/anthropic_adapter.py#L1111)):

```python
if reasoning_config and isinstance(reasoning_config, dict):
```

So `reasoning_config=None` does not mean "send a default" — it means **no `thinking` key on the wire at all**. Two things follow, both of which the adapter's own comments already describe:

1. **Reasoning text disappears.** The adapter deliberately sends `display: "summarized"` because *"On 4.7+ the `thinking.display` field defaults to `omitted`, which silently hides reasoning text that Hermes surfaces in its CLI."* With no `thinking` key, that line never runs, the API default `omitted` applies, and the model returns thinking blocks whose text is empty with only an opaque base64 `signature` populated. Hosts render that signature where reasoning text should be — i.e. garbled characters.

2. **It is not "thinking off" either.** From the same file: *"Adaptive models think by DEFAULT, so omitting the parameter is not a disable — it silently leaves thinking on and the user keeps paying for it."* On 4.6+ the reasoning tokens are still generated and still billed; they are just no longer legible.

### Why fix it at the chokepoint

An AST audit over all non-test, non-eval, non-script code finds **20 production `AIAgent(...)` construction sites**:

| | count | |
|---|---|---|
| pass `reasoning_config=` explicitly | 8 | correct today |
| omit it entirely | 4 | `hermes_cli/oneshot.py:492`, `run_agent.py:9898`, `hermes_cli/prompt_size.py:72`, `plugins/platforms/feishu/feishu_comment.py:1074` |
| build via `**kwargs` | 8 | of which `acp_adapter/session.py`, `agent/curator.py` and `tui_gateway/methods_prompt.py` (×2) never mention `reasoning_config` at all |

That is **8 affected surfaces**, including `hermes chat -q` / `-z` one-shot runs, the `run_agent.py` entrypoint, ACP sessions, the curator, and the TUI gateway prompt path.

The stronger argument is the PR queue itself. Five open PRs — #78295, #85164, #89496, #100006, #100380 — from five different contributors, spanning a month, all patch `acp_adapter/session.py` for this same bug; one is already labelled `duplicate`. That is what a missing chokepoint looks like from the outside: the fix keeps being rediscovered per call site and never converges. Credit where due — #85164 (@Chinmayrawat15) is the closest prior art and independently covers three of the four omitting sites.

Fixing it once in `init_agent` covers all of them, and every site added after this merges.

### Safety

Purely additive — 15 lines, no deletions, so it merges through churn.

- An explicitly-passed `reasoning_config` short-circuits the block entirely; no existing caller changes behaviour.
- `None` already meant "use the default", so this only changes *which* default: the user's configured effort instead of the provider's.
- `reasoning_effort: none` and YAML `false` both resolve to `{"enabled": False}`, not `None`, so the disable still reaches the transport explicitly. This matters — a non-reasoning model 400s on a thinking parameter it doesn't support, so the disable must not be silently re-enabled.
- The resolution is wrapped in `try/except` falling back to `None`, i.e. exactly today's behaviour if config loading fails for any reason.

`resolve_reasoning_config` already handles per-model `agent.reasoning_overrides`, spelling variants, and the disable vocabulary; this change only calls it.

## Related Issue

Fixes #85153

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/agent_init.py` — when `reasoning_config is None`, resolve it via `resolve_reasoning_config(load_config_readonly(), agent.model)` before assigning `agent.reasoning_config`. Wrapped in `try/except` → `None`.
- `tests/agent/test_agent_init_reasoning_config.py` — new, one test. The resolution lives inline in `init_agent`, a function far too large to invoke in a unit test, so `test_chokepoint_guards_assignment_with_resolution` asserts the *structure* via AST: a `reasoning_config is None` guard that calls `resolve_reasoning_config`, positioned before the assignment to `agent.reasoning_config`. Deliberately structural rather than a substring search, since the explanatory comment beside the fix names the symbol and would satisfy an `in source` check against reverted code. Import aliases are resolved so it doesn't trip on cosmetic churn.

## How to Test

Reproduce the mechanism without a network call — ask the real adapter what it would put on the wire, same model and config, only `reasoning_config` differing:

```bash
python - <<'PY'
from agent.anthropic_adapter import build_anthropic_kwargs
common = dict(model="claude-sonnet-4-6", messages=[{"role":"user","content":"hi"}],
              tools=None, max_tokens=1024)
before = build_anthropic_kwargs(reasoning_config=None, **common)
after  = build_anthropic_kwargs(reasoning_config={"enabled": True, "effort": "high"}, **common)
dis    = build_anthropic_kwargs(reasoning_config={"enabled": False}, **common)
print("BEFORE (None):    ", before.get("thinking"), before.get("output_config"))
print("AFTER  (resolved):", after.get("thinking"), after.get("output_config"))
print("DISABLED:         ", dis.get("thinking"), dis.get("output_config"))
PY
```

```
BEFORE (None):     None None
AFTER  (resolved): {'type': 'adaptive', 'display': 'summarized'} {'effort': 'high'}
DISABLED:          {'type': 'disabled'} None
```

`BEFORE` sends no thinking parameter at all — that's the bug. The third line shows the disable direction still works: an explicit `{"enabled": False}` reaches the transport as a real disable rather than being lost.

End to end: set `agent.reasoning_effort: high` in `config.yaml`, then run `hermes chat -q "..."` (a one-shot, one of the omitting sites) against a Claude 4.6+ model and confirm reasoning text is legible rather than an opaque signature.

The new tests:

```bash
pytest tests/agent/test_agent_init_reasoning_config.py -v
```

Mutation-checked: reverting the `agent_init.py` hunk turns `test_chokepoint_guards_assignment_with_resolution` RED, and restoring it returns the file byte-identical.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — see the discussion of #78295 / #85164 / #89496 / #100006 / #100380 above. This PR is deliberately the general form of those, not another instance of them.
- [x] My PR contains **only** changes related to this fix (two files, 126 insertions, 0 deletions)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not claiming a fully green local suite**, so leaving this unchecked rather than overclaiming. What I did verify: I ran `tests/agent tests/run_agent` on this branch *and* on the unmodified base commit and diffed the failure sets. Both produce an **identical** set of 279 pre-existing failures — this change introduces zero new ones. Those 279 are whole-suite interference in my environment, not real: re-running the 70 affected files in isolation gives 1424 passed / 0 failed on both base and branch. Separately, `tests/acp` and `tests/acp_adapter` can't be collected here at all (`ModuleNotFoundError: No module named 'acp.agent'` — the optional `acp` dependency isn't installed), also pre-existing. Happy for CI to be the arbiter.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A, no user-facing config keys or behaviour names change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — no platform-specific code paths touched
- [x] I've updated tool descriptions/schemas — N/A
