### PR TITLE
fix(skills): fold byte-identical skill_view candidates instead of refusing

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -969,3 +969,58 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+
+    def test_identical_local_and_external_copies_load_first_win(self, tmp_path):
+        """Byte-identical copies across tiers are not a real ambiguity.
+
+        Installs commonly mirror the same skill into both the active
+        profile-local dir and an external dir; ``hermes skills list``
+        dedupes such copies first-win and advertises the name as enabled,
+        so the bare-name lookup must not refuse — otherwise ``--skills``
+        worker spawns hard-fail on exactly the names the list reports as
+        enabled. The surviving copy is the first collected (local before
+        external), matching the list order.
+        """
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(
+            local_dir, "kanban-worker", category="devops", body="SHARED WORKER BODY"
+        )
+        _make_skill(
+            external_dir, "kanban-worker", category="devops", body="SHARED WORKER BODY"
+        )
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("kanban-worker")
+
+        result = json.loads(raw)
+        assert result["success"] is True
+        assert result["path"] == "devops/kanban-worker/SKILL.md"
+        assert "SHARED WORKER BODY" in result["content"]
+
+    def test_divergent_same_layout_copies_still_refuse(self, tmp_path):
+        """Identical directory layout but divergent SKILL.md content keeps
+        the collision refusal — silently picking a side would reintroduce
+        the shadowing bug class the refusal was added to prevent."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(local_dir, "kanban-worker", category="devops", body="LOCAL BODY")
+        _make_skill(
+            external_dir, "kanban-worker", category="devops", body="EXTERNAL BODY"
+        )
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("kanban-worker")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "Ambiguous skill name 'kanban-worker'" in result["error"]
+        assert len(result["matches"]) == 2

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -1367,6 +1367,32 @@ def skill_view(
                 candidates = project_candidates
 
         if len(candidates) > 1:
+            # Content-identical duplicates are not a real ambiguity: installs
+            # commonly mirror the same skill into both the active profile dir
+            # and an external dir, and `skills_list()` dedupes such copies
+            # first-win (so it advertises the name as enabled). Fold
+            # byte-identical SKILL.md candidates — keeping the first
+            # collected, which matches the list's precedence order — so a
+            # name the list advertises also loads by bare name (otherwise
+            # `--skills` worker spawns hard-fail on names `skills list`
+            # reports as enabled). Divergent copies still refuse below; an
+            # unreadable candidate cannot be proven identical and is kept,
+            # failing closed.
+            distinct_candidates: List[Tuple[Optional[Path], Path]] = []
+            seen_skill_md_content: set = set()
+            for cand_dir, cand_md in candidates:
+                try:
+                    cand_content = cand_md.read_bytes()
+                except OSError:
+                    cand_content = None
+                if cand_content is not None:
+                    if cand_content in seen_skill_md_content:
+                        continue
+                    seen_skill_md_content.add(cand_content)
+                distinct_candidates.append((cand_dir, cand_md))
+            candidates = distinct_candidates
+
+        if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]
             logging.getLogger(__name__).warning(
                 "Skill name collision for '%s': %d candidates — %s",


### PR DESCRIPTION
## What does this PR do?

`skill_view()` refuses a bare name as "ambiguous" when the same skill resolves in more than one tier. That guard is right for divergent copies (59da8ec4ec — silent shadowing is a real bug class), but it also fires for **byte-identical copies**: installs commonly mirror the same builtin skill into both the active profile dir (`~/.hermes/profiles/<profile>/skills/`) and an external dir (`~/.hermes/skills/`).

`hermes skills list` dedupes those duplicates first-win and advertises the name as `enabled`, so the two entry points disagree — and the disagreement is fatal for `--skills`: the kanban worker spawn resolves every name via `skill_view()`, all of them come back "not found", and the worker hard-fails with `Error: Unknown skill(s): ...` on a deterministic spawn failure that burns the whole retry budget (#100715).

The fix folds candidates whose SKILL.md bytes are identical before the collision refusal, keeping the first collected (project → profile-local → external, the same precedence order `_find_all_skills()` — and therefore `skills list` — already applies). Divergent copies still refuse exactly as before; an unreadable candidate cannot be proven identical and is kept, failing closed.

## Related Issue

Fixes #100715

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_tool.py` — in `skill_view()`, after the project-tier narrowing and before the collision refusal, collapse candidates with byte-identical SKILL.md content (first-win, matching the list order). Unreadable candidates are kept so a real ambiguity still fails closed.
- `tests/tools/test_skills_tool.py` — two regression tests in `TestSkillViewCollisionDetection`: identical local+external copies load first-win; divergent same-layout copies still refuse.

## How to Test

1. `python3 -m pytest tests/tools/test_skills_tool.py -q` — 44 passed (includes the two new tests).
2. `python3 -m pytest tests/agent/test_skill_commands.py tests/agent/test_skill_commands_reload.py tests/agent/test_skill_utils.py tests/agent/test_external_skills.py tests/agent/test_project_skills.py -q` — 82 passed (downloader/preload callers unaffected).
3. Manual reproduction of the issue scenario: create two skills dirs with a byte-identical `devops/kanban-worker/SKILL.md` in each, register one as `skills.external_dirs`, then `skill_view("kanban-worker")` — Observed result: loads successfully and returns the profile-local copy; with one byte changed it still refuses with the ambiguity error and both paths.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable — behavior change is covered by the regression tests above.