### PR TITLE
fix(tools): dedupe byte-identical skill_view candidates instead of refusing

### DIFF
--- a/tests/agent/test_external_skills.py
+++ b/tests/agent/test_external_skills.py
@@ -115,3 +115,65 @@ class TestExternalSkillView:
             result = json.loads(skill_view("my-external-skill"))
         assert result["success"] is True
         assert "external things" in result["content"]
+
+
+class TestDuplicateSkillAcrossTiersE2E:
+    """E2E for #100715: a builtin skill byte-identical in BOTH the active
+    profile's tree and a registered external_dir must stay loadable.
+
+    This exercises the real worker-spawn ``--skills`` resolution path
+    (``build_preloaded_skills_prompt`` -> ``_load_skill_payload`` ->
+    ``skill_view``) against a temp HERMES_HOME — no mocks on the lookup
+    chain. Before the fix, skill_view refused the name as ambiguous,
+    every requested skill landed in ``missing``, and the CLI hard-raised
+    ``ValueError('Unknown skill(s): ...')``, crash-looping spawned workers
+    even though ``skills_list`` showed the skill as enabled.
+    """
+
+    def test_preloaded_skills_prompt_loads_duplicated_builtin(self, tmp_path):
+        hermes_home = tmp_path / ".hermes"
+        external_dir = tmp_path / "shared-skills"
+        hermes_home.mkdir()
+        local_skills = hermes_home / "skills"
+        local_skills.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            f"skills:\n  external_dirs:\n    - {external_dir}\n"
+        )
+
+        body = (
+            "---\n"
+            "name: kanban-worker\n"
+            "description: Pitfalls and examples for Hermes Kanban workers.\n"
+            "---\n"
+            "\n"
+            "# Kanban Worker\n\n"
+            "Orient, work, heartbeat, complete.\n"
+        )
+        # The same skill exists in both tiers, byte-identical — mirroring
+        # builtin seeds copied into a profile tree that also registers the
+        # shared tree as an external_dir.
+        for root in (local_skills, external_dir):
+            skill_dir = root / "devops" / "kanban-worker"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(body)
+
+        with (
+            patch.dict(os.environ, {"HERMES_HOME": str(hermes_home)}),
+            patch("tools.skills_tool.SKILLS_DIR", local_skills),
+        ):
+            from agent.skill_commands import build_preloaded_skills_prompt
+
+            prompt, loaded, missing = build_preloaded_skills_prompt(
+                ["kanban-worker"]
+            )
+            from tools.skills_tool import skills_list
+
+            listed = json.loads(skills_list())
+
+        assert missing == [], f"skill resolved as missing: {missing}"
+        assert loaded == ["kanban-worker"]
+        assert "Kanban Worker" in prompt
+        # Enumeration and lookup must agree: the skill the list advertises
+        # is the skill the loader serves.
+        entry = [s for s in listed["skills"] if s["name"] == "kanban-worker"]
+        assert len(entry) == 1

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -969,3 +969,70 @@ class TestSkillViewCollisionDetection:
         assert result["success"] is False
         assert "Ambiguous" in result["error"]
         assert len(result["matches"]) == 2
+
+    def test_identical_duplicates_dedupe_instead_of_refuse(self, tmp_path):
+        """Byte-identical copies across tiers are one skill, not a collision.
+
+        Real-world regression (#100715): builtin skills seeded into the
+        profile's own tree ALSO live in a shared external_dir the profile
+        registers (``skills.external_dirs``). Both copies are byte-identical,
+        yet skill_view refused the bare name — and, worse, also refused the
+        categorized form, so the refusal hint's own recovery was unusable.
+        ``skills_list`` dedupes first-win and shows the skill as enabled, so
+        lookup refusing what enumeration advertises is the inconsistency:
+        identical candidates are not ambiguity — any of them serves the
+        same bytes, so serve one (first, matching _find_all_skills'
+        project > local > external order) instead of guessing.
+        """
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        body = "---\nname: dup-skill\ndescription: A duplicated builtin.\n---\n\n# dup-skill\n\nSame bytes twice.\n"
+        for root in (local_dir, external_dir):
+            skill_dir = root / "devops" / "dup-skill"
+            skill_dir.mkdir(parents=True)
+            (skill_dir / "SKILL.md").write_text(body)
+
+        # Bare name resolves.
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("dup-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert "Same bytes twice." in result["content"]
+        # First-win: the local (profile) copy wins, matching _find_all_skills.
+        assert str(local_dir) in str(Path(result["skill_dir"]))
+
+        # The categorized form resolves too — the duplicate must not make
+        # the documented recovery path ("use the categorized path") a lie.
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("devops/dup-skill")
+
+        result = json.loads(raw)
+        assert result["success"] is True, result
+        assert "Same bytes twice." in result["content"]
+
+    def test_identical_duplicates_with_divergent_frontmatter_still_refuse(self, tmp_path):
+        """The dedupe gate must compare actual bytes, not paths — two
+        copies with the same name but different content stay a refused
+        collision (59da8ec4ec's protection is untouched)."""
+        local_dir = tmp_path / "local"
+        external_dir = tmp_path / "external"
+        local_dir.mkdir()
+        external_dir.mkdir()
+
+        _make_skill(local_dir, "divergent", body="LOCAL VERSION")
+        _make_skill(external_dir, "divergent", body="EXTERNAL VERSION")
+
+        p1, p2 = self._patch_dirs(local_dir, [external_dir])
+        with p1, p2:
+            raw = skill_view("divergent")
+
+        result = json.loads(raw)
+        assert result["success"] is False
+        assert "Ambiguous" in result["error"]
+        assert len(result["matches"]) == 2

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -70,6 +70,7 @@ import json
 import logging
 import time
 import threading
+import hashlib
 
 from hermes_constants import get_hermes_home, display_hermes_home
 import os
@@ -1365,6 +1366,28 @@ def skill_view(
             ]
             if project_candidates:
                 candidates = project_candidates
+
+        if len(candidates) > 1:
+            # Identical duplicates are not ambiguity. A builtin skill can
+            # exist byte-identically in several tiers — e.g. seeded into the
+            # active profile's own tree while the shared default tree is
+            # also registered as an external_dir (#100715). Refusing those
+            # names made skills that skills_list advertises as enabled
+            # (first-win dedupe, see _find_all_skills) un-loadable by bare
+            # name — and the refusal hit the categorized form too, so the
+            # hint's own recovery path was unusable. Serving any copy
+            # serves the same bytes, so collapse identical candidates to
+            # the first (matching _find_all_skills' project > local >
+            # external first-win order). Divergent content still refuses
+            # below.
+            hashes: List[Optional[str]] = []
+            for _, smd in candidates:
+                try:
+                    hashes.append(hashlib.md5(smd.read_bytes()).hexdigest())
+                except OSError:
+                    hashes.append(None)
+            if all(h is not None for h in hashes) and len(set(hashes)) == 1:
+                candidates = candidates[:1]
 
         if len(candidates) > 1:
             paths = [str(smd) for _, smd in candidates]


### PR DESCRIPTION
## Problem

`hermes kanban create --skill <builtin-name>` crash-looped spawned workers with `Error: Unknown skill(s): kanban-worker, test-driven-development`, even though `hermes skills list` showed both skills as enabled (details in #100715).

Root cause: a builtin skill existed **byte-identically in two tiers** on the affected profile — a copy in the profile's own skills tree plus the shared default tree registered via `skills.external_dirs`. Since 59da8ec4ec, `skill_view` refuses a name that resolves to multiple candidates (good — that guards against silent shadowing), but identical duplicates are not ambiguity:

- `skills_list` dedupes first-win (`_find_all_skills`: project > local > external) and advertises the skill as enabled,
- `skill_view` refused the bare name **and** the categorized form — so even the refusal hint's own recovery path ("use the categorized path") was unusable for verbatim duplicates,
- `_load_skill_payload` (`agent/skill_commands.py`) maps any lookup failure to `missing`, and `finalize_preloaded_skills` hard-raises when every requested skill is missing → worker exits 1 → dispatcher crash-retry loop.

Enumeration and lookup disagreed about the same skill.

## Fix

In the collision narrowing in `tools/skills_tool.py`, collapse candidates whose `SKILL.md` bytes are identical (hash-compare) to the **first** candidate, matching `_find_all_skills`' first-win order. Serving any copy serves the same bytes, so there is nothing to guess between.

- Divergent content still refuses with the full candidate list — 59da8ec4ec's shadowing protection is untouched.
- The identical-duplicate case changes from refusal to serving the first copy; no other behavior changes.
- Chosen over tier-narrowing ("local wins") deliberately: 59da8ec4ec rejected local-first precedence because two *externals* with the same name must still refuse; hash-dedupe keeps that property while fixing the verbatim-duplicate case for both bare and categorized lookups.

## Tests

Behavior-contract tests (no snapshots), per repo conventions:

- `tests/tools/test_skills_tool.py::TestSkillViewCollisionDetection`
  - `test_identical_duplicates_dedupe_instead_of_refuse` — RED before the fix: byte-identical copies in local + external dir must resolve by bare name (first-win = local copy) and by categorized form.
  - `test_identical_duplicates_with_divergent_frontmatter_still_refuse` — the guard: same name, different content still refuses (passes on main too).
- `tests/agent/test_external_skills.py::TestDuplicateSkillAcrossTiersE2E` — E2E against a temp `HERMES_HOME` with **no mocks on the lookup chain**: the real worker-spawn path `build_preloaded_skills_prompt` → `_load_skill_payload` → `skill_view` must load the duplicated skill, and the result must agree with `skills_list` (one entry).

TDD: both regression tests were written first and confirmed failing on `main` (RED), then passing after the fix (GREEN).

Local verification: `tests/tools/test_skills_tool.py`, `tests/agent/test_external_skills.py`, `tests/agent/test_skill_commands.py`, `tests/agent/test_skill_utils.py`, `tests/tools/test_skill_manager_tool.py`, `tests/tools/test_skills_sync.py`, `tests/tools/test_skill_create_dir.py`, `tests/tools/test_skill_view_*.py`, `tests/tools/test_skill_size_limits.py`, `tests/tools/test_skill_env_passthrough.py`, `tests/test_session_skill_previews.py` — **263 passed, 1 skipped**. Also live-verified on the originally affected profile: `skill_view('kanban-worker')`, `skill_view('devops/kanban-worker')`, and `skill_view('test-driven-development')` all resolve now.

## CI state

CI on this PR has not run yet at the time of opening (no gh CLI on the submitting machine; CI status will be visible in the checks panel). The affected suites were run locally against the repo venv and pass as listed above; I will watch the checks and report the outcome honestly in this PR. Rebase-merge friendly: the branch is exactly one commit on top of current `main`.

Fixes #100715
