### PR TITLE
fix(gateway): restore account limits in status

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -573,6 +573,29 @@ class GatewaySlashCommandsMixin:
             output = output[:3800] + "\n" + t("gateway.kanban.truncated_suffix")
         return output or t("gateway.kanban.no_output")
 
+    async def _fetch_account_usage_lines(
+        self,
+        provider: Optional[str],
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+    ) -> list[str]:
+        """Fetch account-limit lines without blocking the gateway event loop."""
+        if not provider:
+            return []
+        try:
+            snapshot = await asyncio.to_thread(
+                fetch_account_usage,
+                provider,
+                base_url=base_url,
+                api_key=api_key,
+            )
+        except Exception:
+            return []
+        if not snapshot:
+            return []
+        return render_account_usage_lines(snapshot, markdown=True)
+
     async def _handle_status_command(self, event: MessageEvent) -> str:
         """Handle /status command."""
         from gateway.run import _AGENT_PENDING_SENTINEL, _load_gateway_config, _resolve_gateway_model
@@ -767,6 +790,17 @@ class GatewaySlashCommandsMixin:
             "",
             t("gateway.status.platforms", platforms=', '.join(connected_platforms)),
         ])
+
+        # Keep /status aligned with /usage.  status_agent covers both a live
+        # turn and the between-turn cache; provider_name/base_url already use
+        # the persisted dominant route and active profile config fallbacks.
+        account_lines = await self._fetch_account_usage_lines(
+            provider_name or None,
+            base_url=base_url or None,
+            api_key=getattr(status_agent, "api_key", None) if status_agent else None,
+        )
+        if account_lines:
+            lines.extend(["", *account_lines])
 
         return "\n".join(lines)
 
@@ -5746,22 +5780,13 @@ class GatewaySlashCommandsMixin:
             )
             return result.message
 
-        # Fetch account usage off the event loop so slow provider APIs don't
-        # block the gateway. Failures are non-fatal -- account_lines stays [].
-        account_lines: list[str] = []
+        # Shared with /status so the two commands cannot drift apart again.
+        account_lines = await self._fetch_account_usage_lines(
+            provider,
+            base_url=base_url,
+            api_key=api_key,
+        )
         credits_lines: list[str] = []
-        if provider:
-            try:
-                account_snapshot = await asyncio.to_thread(
-                    fetch_account_usage,
-                    provider,
-                    base_url=base_url,
-                    api_key=api_key,
-                )
-            except Exception:
-                account_snapshot = None
-            if account_snapshot:
-                account_lines = render_account_usage_lines(account_snapshot, markdown=True)
 
         # ── Nous credits magnitudes + monthly-grant % gauge ─────────────
         # Shared with the CLI / TUI /usage block via nous_credits_lines(): a single

--- a/tests/gateway/test_status_command.py
+++ b/tests/gateway/test_status_command.py
@@ -190,6 +190,85 @@ async def test_status_command_uses_dominant_persisted_model_route(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_status_command_includes_account_limits_from_cached_agent(monkeypatch):
+    session_key = build_session_key(_make_source())
+    session_entry = SessionEntry(
+        session_key=session_key,
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    agent = SimpleNamespace(
+        model="gpt-5.6",
+        provider="openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-token",
+        context_compressor=SimpleNamespace(last_prompt_tokens=123, context_length=272_000),
+    )
+    runner._agent_cache[session_key] = (agent, "sig")
+    snapshot = object()
+    fetch = MagicMock(return_value=snapshot)
+    monkeypatch.setattr("gateway.slash_commands.fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        "gateway.slash_commands.render_account_usage_lines",
+        MagicMock(return_value=["📈 **Account limits**", "Weekly: 87% remaining"]),
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    fetch.assert_called_once_with(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="test-token",
+    )
+    assert "📈 **Account limits**" in result
+    assert "Weekly: 87% remaining" in result
+
+
+@pytest.mark.asyncio
+async def test_status_command_includes_account_limits_from_persisted_route(monkeypatch):
+    session_entry = SessionEntry(
+        session_key=build_session_key(_make_source()),
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.TELEGRAM,
+        chat_type="dm",
+    )
+    runner = _make_runner(session_entry)
+    runner._session_db._db.get_session.return_value = {
+        "model": "gpt-5.6",
+        "billing_provider": "openai-codex",
+        "billing_base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    runner._session_db._db.get_dominant_session_model_route.return_value = {
+        "model": "gpt-5.6",
+        "billing_provider": "openai-codex",
+        "billing_base_url": "https://chatgpt.com/backend-api/codex",
+    }
+    snapshot = object()
+    fetch = MagicMock(return_value=snapshot)
+    monkeypatch.setattr("gateway.slash_commands.fetch_account_usage", fetch)
+    monkeypatch.setattr(
+        "gateway.slash_commands.render_account_usage_lines",
+        MagicMock(return_value=["📈 **Account limits**", "Session: 100% remaining"]),
+    )
+
+    result = await runner._handle_message(_make_event("/status"))
+
+    fetch.assert_called_once_with(
+        "openai-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key=None,
+    )
+    assert "📈 **Account limits**" in result
+    assert "Session: 100% remaining" in result
+
+
+@pytest.mark.asyncio
 async def test_agents_command_reports_active_agents_and_processes(monkeypatch):
     session_key = build_session_key(_make_source())
     session_entry = SessionEntry(


### PR DESCRIPTION
## Summary
- restore the provider account-limits block in gateway `/status`
- share the non-blocking account-usage fetch/render helper with `/usage`
- resolve `/status` account limits from cached-agent and persisted-route paths

## Regression
The earlier gateway implementation appended account limits to both `/usage` and `/status`. During the gateway slash-command refactor, `/usage` retained the fetch while `/status` lost it, so Discord users no longer saw their Codex session/weekly allowance in `/status`.

## Tests
- `python -m pytest tests/gateway/test_status_command.py tests/gateway/test_usage_command.py -q -o 'addopts='`
- `python -m compileall -q gateway/slash_commands.py gateway/run.py`

Result: 19 passed.
