### PR TITLE
fix(kanban): coalesce terminal timeout alerts

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -49,6 +49,26 @@ def _safe_review_reason(value: Any, limit: int = 160) -> str:
     return reason
 
 
+def _format_gave_up_message(
+    board_tag: str,
+    assignee_tag: str,
+    task_id: str,
+    payload: Optional[dict[str, Any]],
+) -> str:
+    """Render a truthful circuit-breaker notification.
+
+    ``gave_up`` covers more than spawn failures: iteration exhaustion,
+    timeouts, crashes, and other repeated failures all share this terminal
+    event. Never invent a more specific cause than the event supplies.
+    """
+    error = str((payload or {}).get("error") or "").strip()
+    detail = error[:200] if error else "failure limit reached"
+    return (
+        f"✖ {board_tag}{assignee_tag}Kanban {task_id} gave up\n"
+        f"{detail}"
+    )
+
+
 def _resolve_auto_decompose_settings(
     load_config: Callable[[], Any],
 ) -> "tuple[bool, int]":
@@ -608,12 +628,11 @@ class GatewayKanbanWatchersMixin:
                                 reason = f": {str(ev.payload['reason'])[:160]}"
                             msg = f"⏸ {board_tag}{tag}Kanban {sub['task_id']} blocked{reason}"
                         elif kind == "gave_up":
-                            err = ""
-                            if ev.payload and ev.payload.get("error"):
-                                err = f"\n{str(ev.payload['error'])[:200]}"
-                            msg = (
-                                f"✖ {board_tag}{tag}Kanban {sub['task_id']} gave up "
-                                f"after repeated spawn failures{err}"
+                            msg = _format_gave_up_message(
+                                board_tag,
+                                tag,
+                                sub["task_id"],
+                                ev.payload,
                             )
                         elif kind == "crashed":
                             msg = (

--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -21,6 +21,10 @@ from pathlib import Path
 from typing import Any, Callable, Optional
 
 from agent.i18n import t
+from hermes_cli.kanban_notifications import (
+    coalesce_notification_events,
+    format_gave_up_notification,
+)
 
 # Match the logger run.py uses (logging.getLogger(__name__) where __name__ ==
 # "gateway.run") so extracted log records keep their original logger name.
@@ -55,17 +59,12 @@ def _format_gave_up_message(
     task_id: str,
     payload: Optional[dict[str, Any]],
 ) -> str:
-    """Render a truthful circuit-breaker notification.
-
-    ``gave_up`` covers more than spawn failures: iteration exhaustion,
-    timeouts, crashes, and other repeated failures all share this terminal
-    event. Never invent a more specific cause than the event supplies.
-    """
-    error = str((payload or {}).get("error") or "").strip()
-    detail = error[:200] if error else "failure limit reached"
-    return (
-        f"✖ {board_tag}{assignee_tag}Kanban {task_id} gave up\n"
-        f"{detail}"
+    """Compatibility wrapper for the shared Kanban notifier formatter."""
+    return format_gave_up_notification(
+        board_tag,
+        assignee_tag,
+        task_id,
+        payload,
     )
 
 
@@ -591,7 +590,8 @@ class GatewayKanbanWatchersMixin:
                     # exists on the board.
                     wake_handoff = ""
                     wake_review_detail = ""
-                    for ev in d["events"]:
+                    notification_events = coalesce_notification_events(d["events"])
+                    for ev in notification_events:
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
                         # worker that did the work. Makes fleets (where one
@@ -864,7 +864,7 @@ class GatewayKanbanWatchersMixin:
                             "block_loop_detected",
                         )
                         _wake_kinds = (
-                            {ev.kind for ev in d["events"] if ev.kind in _WAKE_KINDS}
+                            {ev.kind for ev in notification_events if ev.kind in _WAKE_KINDS}
                             if wake_agent
                             else set()
                         )

--- a/hermes_cli/kanban_notifications.py
+++ b/hermes_cli/kanban_notifications.py
@@ -1,0 +1,99 @@
+"""Shared notification coalescing and wording for Kanban surfaces."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+
+def _payload(event: Any) -> dict[str, Any]:
+    value = getattr(event, "payload", None)
+    return value if isinstance(value, dict) else {}
+
+
+def _is_superseded_timeout(event: Any, successor: Any) -> bool:
+    """Return whether ``successor`` terminally supersedes ``event``.
+
+    Runtime enforcement writes the retry-shaped ``timed_out`` event and the
+    breaker-shaped ``gave_up`` event as adjacent rows for the same task.  Exact
+    row adjacency is the primary correlation key.  Run and payload fields are
+    additional guards when both events carry them; older timeout breaker rows
+    intentionally have no ``gave_up.run_id``.
+    """
+    if getattr(event, "kind", None) != "timed_out":
+        return False
+    if getattr(successor, "kind", None) != "gave_up":
+        return False
+    if _payload(successor).get("trigger_outcome") != "timed_out":
+        return False
+
+    event_id = getattr(event, "id", None)
+    successor_id = getattr(successor, "id", None)
+    if not isinstance(event_id, int) or not isinstance(successor_id, int):
+        return False
+    if successor_id != event_id + 1:
+        return False
+
+    task_id = getattr(event, "task_id", None)
+    successor_task_id = getattr(successor, "task_id", None)
+    if task_id is not None and successor_task_id is not None:
+        if task_id != successor_task_id:
+            return False
+
+    run_id = getattr(event, "run_id", None)
+    successor_run_id = getattr(successor, "run_id", None)
+    if run_id is not None and successor_run_id is not None:
+        if run_id != successor_run_id:
+            return False
+
+    event_payload = _payload(event)
+    successor_payload = _payload(successor)
+    for key in ("pid", "retry_status"):
+        if key in event_payload and key in successor_payload:
+            if event_payload[key] != successor_payload[key]:
+                return False
+    return True
+
+
+def coalesce_notification_events(events: Iterable[Any]) -> list[Any]:
+    """Drop only timeout alerts superseded by an adjacent terminal breaker."""
+    ordered = list(events)
+    return [
+        event
+        for index, event in enumerate(ordered)
+        if not (
+            index + 1 < len(ordered)
+            and _is_superseded_timeout(event, ordered[index + 1])
+        )
+    ]
+
+
+def format_gave_up_notification(
+    board_tag: str,
+    assignee_tag: str,
+    task_id: str,
+    payload: dict[str, Any] | None,
+) -> str:
+    """Render a truthful circuit-breaker notification."""
+    data = payload if isinstance(payload, dict) else {}
+    trigger = str(data.get("trigger_outcome") or "")
+    failures = data.get("failures")
+
+    if trigger == "timed_out":
+        attempts = f"{failures} attempts" if isinstance(failures, int) else "repeated attempts"
+        detail = f"timed out after {attempts} and is blocked"
+        return f"✖ {board_tag}{assignee_tag}Kanban {task_id} {detail}"
+
+    if trigger == "spawn_failed":
+        count = f"{failures} " if isinstance(failures, int) else "repeated "
+        detail = f"gave up after {count}spawn failures and is blocked"
+        error = str(data.get("error") or "").strip()
+        suffix = f"\n{error[:200]}" if error else ""
+        return f"✖ {board_tag}{assignee_tag}Kanban {task_id} {detail}{suffix}"
+
+    error = str(data.get("error") or "").strip()
+    detail = error[:200] if error else "failure limit reached"
+    return (
+        f"✖ {board_tag}{assignee_tag}Kanban {task_id} gave up\n"
+        f"{detail}"
+    )

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import inspect
 
-from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.kanban_watchers import (
+    GatewayKanbanWatchersMixin,
+    _format_gave_up_message,
+)
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -26,3 +29,20 @@ def test_mixin_defines_kanban_methods():
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
 
 
+def test_gave_up_notification_uses_exact_iteration_exhaustion_cause():
+    msg = _format_gave_up_message(
+        "[dsbmx04] ",
+        "@dsbmx04-coder ",
+        "t_1319666b",
+        {"error": "Iteration budget exhausted (80/80)"},
+    )
+
+    assert "Iteration budget exhausted (80/80)" in msg
+    assert "spawn" not in msg.lower()
+
+
+def test_gave_up_notification_without_error_is_cause_neutral():
+    msg = _format_gave_up_message("", "", "t_deadbeef", None)
+
+    assert "failure limit reached" in msg
+    assert "spawn" not in msg.lower()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -314,10 +314,57 @@ def test_max_runtime_terminates_overrun_worker(kanban_home):
         _kb._pid_alive = original_alive
 
 
+def test_terminal_timeout_events_are_adjacent_and_correlated(kanban_home, monkeypatch):
+    """The notifier correlation keys match the real timeout producer."""
+    monkeypatch.setattr(kb, "_pid_alive", lambda _pid: False)
 
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="terminal timeout event batch",
+            assignee="worker",
+            max_runtime_seconds=1,
+            max_retries=2,
+        )
 
+        for attempt in range(2):
+            claimed = kb.claim_task(conn, tid)
+            assert claimed is not None
+            pid = 9100 + attempt
+            kb._set_worker_pid(conn, tid, pid)
+            with kb.write_txn(conn):
+                conn.execute(
+                    "UPDATE task_runs SET started_at = ? "
+                    "WHERE id = (SELECT current_run_id FROM tasks WHERE id = ?)",
+                    (int(time.time()) - 30, tid),
+                )
+            assert tid in kb.enforce_max_runtime(
+                conn,
+                signal_fn=lambda *_args: None,
+            )
 
+        task = kb.get_task(conn, tid)
+        assert task is not None
+        assert task.status == "blocked"
 
+        events = [
+            event
+            for event in kb.list_events(conn, tid)
+            if event.kind in {"timed_out", "gave_up"}
+        ]
+
+    terminal_timeout, gave_up = events[-2:]
+    assert [terminal_timeout.kind, gave_up.kind] == ["timed_out", "gave_up"]
+    assert gave_up.id == terminal_timeout.id + 1
+    assert terminal_timeout.run_id is not None
+    assert gave_up.run_id is None
+    assert terminal_timeout.payload is not None
+    assert gave_up.payload is not None
+    assert gave_up.payload["trigger_outcome"] == "timed_out"
+    assert gave_up.payload["failures"] == 2
+    assert gave_up.payload["effective_limit"] == 2
+    assert gave_up.payload["pid"] == terminal_timeout.payload["pid"]
+    assert gave_up.payload["retry_status"] == terminal_timeout.payload["retry_status"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_notifications.py
+++ b/tests/hermes_cli/test_kanban_notifications.py
@@ -1,0 +1,128 @@
+"""Behavior contracts for shared Kanban notification projection."""
+
+from hermes_cli.kanban_db import Event
+from hermes_cli.kanban_notifications import (
+    coalesce_notification_events,
+    format_gave_up_notification,
+)
+
+
+def _event(
+    event_id: int,
+    kind: str,
+    payload: dict | None = None,
+    *,
+    run_id: int | None = None,
+) -> Event:
+    return Event(
+        id=event_id,
+        task_id="t_timeout",
+        kind=kind,
+        payload=payload,
+        created_at=100,
+        run_id=run_id,
+    )
+
+
+def test_standalone_timeout_is_preserved_for_retry_alert():
+    timed_out = _event(
+        10,
+        "timed_out",
+        {"pid": 1, "limit_seconds": 30, "retry_status": "ready"},
+        run_id=1,
+    )
+
+    assert coalesce_notification_events([timed_out]) == [timed_out]
+
+
+def test_only_adjacent_terminal_timeout_is_superseded_in_repeated_batch():
+    earlier = _event(
+        10,
+        "timed_out",
+        {"pid": 1, "retry_status": "ready"},
+        run_id=1,
+    )
+    terminal = _event(
+        11,
+        "timed_out",
+        {"pid": 2, "retry_status": "ready"},
+        run_id=2,
+    )
+    gave_up = _event(
+        12,
+        "gave_up",
+        {
+            "pid": 2,
+            "retry_status": "ready",
+            "trigger_outcome": "timed_out",
+            "failures": 2,
+        },
+    )
+
+    assert coalesce_notification_events([earlier, terminal, gave_up]) == [
+        earlier,
+        gave_up,
+    ]
+
+
+def test_intervening_event_prevents_timeout_suppression():
+    timed_out = _event(
+        20,
+        "timed_out",
+        {"pid": 3, "retry_status": "ready"},
+        run_id=3,
+    )
+    crashed = _event(21, "crashed", {"pid": 4}, run_id=4)
+    gave_up = _event(
+        22,
+        "gave_up",
+        {
+            "pid": 3,
+            "retry_status": "ready",
+            "trigger_outcome": "timed_out",
+            "failures": 2,
+        },
+    )
+
+    events = [timed_out, crashed, gave_up]
+    assert coalesce_notification_events(events) == events
+
+
+def test_spawn_failure_breaker_does_not_supersede_timeout():
+    timed_out = _event(30, "timed_out", {"pid": 5}, run_id=5)
+    gave_up = _event(
+        31,
+        "gave_up",
+        {"trigger_outcome": "spawn_failed", "failures": 2},
+    )
+
+    assert coalesce_notification_events([timed_out, gave_up]) == [
+        timed_out,
+        gave_up,
+    ]
+
+
+def test_gave_up_wording_distinguishes_timeout_and_spawn_failure():
+    timeout_text = format_gave_up_notification(
+        "[main] ",
+        "@worker ",
+        "t_timeout",
+        {"trigger_outcome": "timed_out", "failures": 2},
+    )
+    spawn_text = format_gave_up_notification(
+        "[main] ",
+        "@worker ",
+        "t_spawn",
+        {
+            "trigger_outcome": "spawn_failed",
+            "failures": 3,
+            "error": "profile worker not found",
+        },
+    )
+
+    assert "timed out after 2 attempts and is blocked" in timeout_text
+    assert "will retry" not in timeout_text
+    assert "spawn" not in timeout_text
+    assert "gave up after 3 spawn failures and is blocked" in spawn_text
+    assert "profile worker not found" in spawn_text
+    assert "timed out" not in spawn_text

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -538,7 +538,10 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
     # The user is notified about the abnormal event...
     fake_adapter.send.assert_called_once()
-    assert kind.replace('_', ' ') in fake_adapter.send.call_args[0][1]
+    delivered_message = fake_adapter.send.call_args[0][1]
+    assert kind.replace('_', ' ') in delivered_message
+    if kind == "timed_out":
+        assert "will retry" in delivered_message
 
     # ...but the subscription survives so a respawn-then-same-event cycle
     # reaches the user too. The cursor (last_event_id) advanced inside
@@ -564,6 +567,78 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
 
 
 
+
+
+@pytest.mark.asyncio
+async def test_notifier_coalesces_terminal_timeout_batch(kanban_home):
+    """One timeout that trips the breaker produces one truthful alert."""
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="terminal timeout", assignee="worker1")
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="chat1",
+        )
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                task_id,
+                "timed_out",
+                {
+                    "pid": 4242,
+                    "elapsed_seconds": 1800,
+                    "limit_seconds": 1800,
+                    "retry_status": "ready",
+                },
+                run_id=41,
+            )
+            kb._append_event(
+                conn,
+                task_id,
+                "gave_up",
+                {
+                    "failures": 2,
+                    "effective_limit": 2,
+                    "trigger_outcome": "timed_out",
+                    "retry_status": "ready",
+                    "pid": 4242,
+                    "error": "elapsed 1800s > limit 1800s",
+                },
+            )
+
+    runner = object.__new__(GatewayRunner)
+    runner._owns_kanban_dispatcher_lock = lambda: True
+    runner._running = True
+    runner._kanban_sub_fail_counts = {}
+    delivered: list[str] = []
+
+    async def _send(_chat_id, message, metadata=None):
+        delivered.append(message)
+        runner._running = False
+
+    adapter = MagicMock()
+    adapter.send = AsyncMock(side_effect=_send)
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    real_sleep = asyncio.sleep
+
+    async def _fast_sleep(_seconds):
+        await real_sleep(0)
+
+    with patch("gateway.run.asyncio.sleep", side_effect=_fast_sleep):
+        await asyncio.wait_for(
+            runner._kanban_notifier_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    assert len(delivered) == 1
+    assert "timed out after 2 attempts and is blocked" in delivered[0]
+    assert "will retry" not in delivered[0]
+    assert "spawn failures" not in delivered[0]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tui_gateway/test_kanban_notify_poller.py
+++ b/tests/tui_gateway/test_kanban_notify_poller.py
@@ -138,6 +138,46 @@ class TestCollectKanbanNotifications:
         assert len(rows) == 1
         assert rows[0]["last_event_id"] > pre_cursor
 
+    def test_terminal_timeout_batch_coalesces_to_blocked_alert(self):
+        tid = _create_subscribed_task()
+        conn = kb.connect()
+        try:
+            with kb.write_txn(conn):
+                kb._append_event(
+                    conn,
+                    tid,
+                    "timed_out",
+                    {
+                        "pid": 4242,
+                        "elapsed_seconds": 1800,
+                        "limit_seconds": 1800,
+                        "retry_status": "ready",
+                    },
+                    run_id=41,
+                )
+                kb._append_event(
+                    conn,
+                    tid,
+                    "gave_up",
+                    {
+                        "failures": 2,
+                        "effective_limit": 2,
+                        "trigger_outcome": "timed_out",
+                        "retry_status": "ready",
+                        "pid": 4242,
+                        "error": "elapsed 1800s > limit 1800s",
+                    },
+                )
+        finally:
+            conn.close()
+
+        texts = _collect_kanban_notifications(_session())
+
+        assert len(texts) == 1
+        assert "timed out after 2 attempts and is blocked" in texts[0]
+        assert "will retry" not in texts[0]
+        assert "spawn failures" not in texts[0]
+
     def test_non_tui_subscription_does_not_open_board_writable(self):
         tid = _create_subscribed_task(platform="telegram", chat_id="chat-1")
         # New subs start caught up at creation time (issue #29905); record the
@@ -260,7 +300,9 @@ class TestFormatKanbanEventText:
     def test_timed_out_with_bad_payload_does_not_raise(self):
         ev = SimpleNamespace(kind="timed_out", payload={"limit_seconds": "not-a-number"})
         text = _format_kanban_event_text(self.SUB, self.TASK, ev, "")
+        assert text is not None
         assert "timed out" in text
+        assert "will retry" in text
 
 
 class TestNotificationPollerLoopKanbanWiring:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -32,6 +32,10 @@ from hermes_constants import (
     set_hermes_home_override,
 )
 from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.kanban_notifications import (
+    coalesce_notification_events,
+    format_gave_up_notification,
+)
 from utils import is_truthy_value
 from tools.environments.local import hermes_subprocess_env
 from agent.replay_cleanup import sanitize_replay_history
@@ -12162,8 +12166,7 @@ def _format_kanban_event_text(sub: dict, task, ev, board_slug: str) -> Optional[
         reason = f": {str(payload.get('reason'))[:160]}" if payload.get("reason") else ""
         return f"⏸ {board_tag}{tag}Kanban {task_id} blocked{reason}"
     if kind == "gave_up":
-        err = f"\n{str(payload.get('error'))[:200]}" if payload.get("error") else ""
-        return f"✖ {board_tag}{tag}Kanban {task_id} gave up after repeated spawn failures{err}"
+        return format_gave_up_notification(board_tag, tag, task_id, payload)
     if kind == "crashed":
         return f"✖ {board_tag}{tag}Kanban {task_id} worker crashed (pid gone); dispatcher will retry"
     if kind == "timed_out":
@@ -12263,7 +12266,7 @@ def _collect_kanban_notifications(session: dict) -> list:
                 if not events:
                     continue
                 task = _kb.get_task(conn, sub["task_id"])
-                for ev in events:
+                for ev in coalesce_notification_events(events):
                     text = _format_kanban_event_text(sub, task, ev, slug)
                     if text:
                         texts.append(text)


### PR DESCRIPTION
## Summary

- coalesce only an adjacent `timed_out` → `gave_up` notification pair when the breaker payload says `trigger_outcome='timed_out'`
- share truthful `gave_up` wording across gateway/Slack and TUI/Desktop notification paths
- preserve standalone timeout retry alerts, unrelated/repeated events, and spawn-failure cause/error wording
- prove the real `enforce_max_runtime` producer emits the deterministic adjacency and payload correlation keys the notifier consumes

## Root cause

`enforce_max_runtime` intentionally records a retry-shaped `timed_out` event before the unified failure counter may record a terminal `gave_up` event. Notification pollers rendered both rows independently, so the final timeout emitted both “will retry” and “gave up after repeated spawn failures.”

The coalescer now treats only the exact adjacent terminal timeout pair as one operator outcome. It requires adjacent event ids, matching task identity, compatible run identity when both rows carry it, matching pid/retry phase when both payloads carry them, and the explicit `trigger_outcome='timed_out'` discriminator.

## Verification

RED (before implementation):

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/hermes_cli/test_kanban_notify.py -k test_notifier_coalesces_terminal_timeout_batch -q` → failed: 2 alerts rendered
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/tui_gateway/test_kanban_notify_poller.py -k test_terminal_timeout_batch_coalesces_to_blocked_alert -q` → failed: 2 alerts rendered

GREEN:

- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/gateway/test_kanban_watchers_mixin.py tests/hermes_cli/test_kanban_notifications.py tests/hermes_cli/test_kanban_notify.py tests/tui_gateway/test_kanban_notify_poller.py tests/hermes_cli/test_kanban_core_functionality.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle_complete.py -q` → 127 passed, 2 skipped (Windows-only), 0 failed
- `/Users/spencerlee/.local/bin/ruff check .` → passed (two pre-existing malformed-noqa warnings)
- `python scripts/check-windows-footguns.py --all` → passed, 1,060 files scanned
- `python -m py_compile gateway/kanban_watchers.py hermes_cli/kanban_notifications.py tui_gateway/server.py` → passed
- `git diff --check upstream/main...HEAD` → passed

Court Jester 0.2.16:

- `doctor --language python --runtime-profile local-trusted` → PASS
- shared helper `analyze`, `lint`, and `execute` → passed
- shared helper `verify` → pass / property_checked, 2 of 2 exported surfaces behaviorally checked
- branch `ci --gate all` → inconclusive: all 8 files parsed/linted and authoritative test stages passed with zero findings; execute was skipped/inconclusive on application/test wiring, including harness/context diagnostics. Repository-native tests above are authoritative.
- replay not applicable: no Court Jester finding id exists; none was invented

## Credit

Includes a rebased salvage of `stevenbaert`'s commit from #64605 for truthful generic `gave_up` cause rendering, preserving contributor authorship, then extends it to timeout-specific coalescing and TUI/Desktop parity.

## Preview

Static notification projection generated by executing the exact candidate helper at `2a0750cc3fa3a22e534b1e4f900a5675716a7222` (tree `d2fda3eccd26b026017b731246b02731dc146e79`):

https://htmlpreview.github.io/?https://gist.githubusercontent.com/slee1996/b9c77a23d4f95bf8e3716a8189ffffdc/raw/29e85e00d1c15dd86645ac77c1254a22d4cf9d61/kanban-timeout-alert-preview-2a0750cc3fa3a22e534b1e4f900a5675716a7222.html

Read-back: the immutable raw gist matched the locally generated artifact byte-for-byte (`sha256 cf33e4a4e7966399dece96450d906ff0d7c96a528646b652396916fec3ab9e3a`), and the HTTPS renderer returned 200. The artifact includes `noindex,nofollow` and an exact candidate-SHA meta tag. This is a text-projection preview, not a deployed gateway runtime.

## Risk

Low, notification-only. Runtime timeout policy, failure counting, task state transitions, and existing task records are unchanged.
