### PR TITLE
fix(classifier): LiteLLM 'No deployments available' 429 → upstream_rate_limit

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -232,6 +232,15 @@ _OVERLOADED_PATTERNS = [
     "over capacity",
 ]
 
+# LiteLLM-proxy-style gateway phrases meaning "every deployment in the
+# requested model group is cooled down" — model-group-scoped, not
+# account-scoped. Distinct from generic rate-limit wording on purpose.
+_GATEWAY_MODEL_GROUP_COOLDOWN_PATTERNS = [
+    "no deployments available",
+    "no healthy deployments available",
+    "all deployments are cooling down",
+]
+
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
 _USAGE_LIMIT_PATTERNS = [
     "usage limit",
@@ -1386,6 +1395,24 @@ def _classify_by_status(
                 should_fallback=True,
                 error_context=ctx,
             )
+        # A self-hosted LLM gateway (LiteLLM proxy and similar) returns 429
+        # "No deployments available for selected model" when EVERY deployment
+        # in the requested model group is in the gateway's cooldown window.
+        # This is the same failure class as the OpenRouter upstream 429 above:
+        # the user's gateway key is healthy, the requested model group is
+        # benched gateway-side, and credential rotation is the wrong recovery
+        # (it can only exhaust the pool while the group stays benched). The
+        # correct recovery is an immediate fallback to a different model group.
+        # Match on the distinctive body phrase so generic "rate limit reached"
+        # 429s from the same gateway still take the normal rate-limit path.
+        if _is_gateway_model_group_cooldown(error_msg):
+            return result_fn(
+                FailoverReason.upstream_rate_limit,
+                retryable=True,
+                should_rotate_credential=False,
+                should_fallback=True,
+                error_context={"upstream_provider": "gateway-model-group"},
+            )
         # Account/subscription usage exhaustion is a quota wall, not a
         # request-rate throttle. Anthropic returns this as 429, so the generic
         # branch below used to retry it and Desktop rendered a provider error
@@ -2226,6 +2253,22 @@ def _is_openrouter_upstream_error(body: Any, provider: str) -> bool:
     ):
         return True
     return False
+
+
+def _is_gateway_model_group_cooldown(error_msg: str) -> bool:
+    """Detect a gateway-side model-group cooldown (LiteLLM-proxy style).
+
+    LiteLLM (and similar self-hosted gateways) return 429 with
+    ``No deployments available for selected model, Try again in N seconds``
+    when every deployment in the requested model group is in the gateway's
+    cooldown window. The caller's API key is healthy — the *model group* is
+    benched gateway-side — so this is an upstream/gateway failure of the
+    same class as the OpenRouter aggregator 429, not an account rate limit.
+    """
+    if not error_msg:
+        return False
+    msg = error_msg.lower()
+    return any(p in msg for p in _GATEWAY_MODEL_GROUP_COOLDOWN_PATTERNS)
 
 
 def _extract_upstream_provider_name(body: Any) -> Optional[str]:

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -1240,6 +1240,58 @@ class TestOpenRouterUpstreamRateLimit:
         assert result.should_rotate_credential is True
 
 
+class TestGatewayModelGroupCooldown:
+    """Gateway-side model-group cooldown 429s (LiteLLM-proxy style).
+
+    LiteLLM returns 429 "No deployments available for selected model" when
+    every deployment in the requested model group is in the gateway's
+    cooldown window. The user's gateway key is healthy — the model group is
+    benched gateway-side — so the recovery is an immediate fallback to a
+    different model group, NOT credential rotation (which can only exhaust
+    the pool while the group stays benched).
+    """
+
+    def test_no_deployments_429_classified_as_upstream_rate_limit(self):
+        """Verbatim LiteLLM cooldown 429 → upstream_rate_limit, no rotation."""
+        msg = (
+            "HTTP 429: No deployments available for selected model, "
+            "Try again in 300 seconds. Passed model=glm-4.5-flash. "
+            "pre-call-checks=False, cooldown_list=['abc', 'def']"
+        )
+        e = MockAPIError(
+            msg,
+            status_code=429,
+            body={"error": {"message": msg, "code": 429}},
+        )
+        result = classify_api_error(e, provider="litellm", model="glm-4.5-flash")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+        assert result.should_fallback is True
+
+    def test_no_deployments_429_without_body_uses_exception_message(self):
+        """The signature is also caught when only str(error) carries it."""
+        e = MockAPIError(
+            "Error code: 429 - {'error': {'message': 'No deployments available "
+            "for selected model, Try again in 120 seconds', 'type': 'None'}}",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="litellm", model="glm-4.6v")
+        assert result.reason == FailoverReason.upstream_rate_limit
+        assert result.should_rotate_credential is False
+
+    def test_gateway_generic_rate_limit_still_rotates(self):
+        """A plain account-level 429 from the same gateway → rate_limit path."""
+        msg = "Rate limit exceeded: 200 requests per minute"
+        e = MockAPIError(
+            msg,
+            status_code=429,
+            body={"error": {"message": msg, "code": 429}},
+        )
+        result = classify_api_error(e, provider="litellm", model="glm-4.5-flash")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.should_rotate_credential is True
+
+
 
 
 


### PR DESCRIPTION
## Problem

A LiteLLM-proxy 429 `No deployments available for selected model` means every deployment in the requested model group is in the gateway's cooldown window. The caller's gateway key is healthy — the model group is benched gateway-side.

Tonight this misclassification caused a production incident on a self-hosted Hermes fleet: worker sessions pinned to a cooled-down model group burned their **entire retry budget (3×300s) on the same benched model**, because the error classified as generic `rate_limit` → credential-rotation path (useless — the key is healthy; it just exhausts the pool) and the pool-rotation wait kept re-serving the same benched group.

## Change

Map the distinctive body phrase to `FailoverReason.upstream_rate_limit` (`should_rotate_credential=False`, `should_fallback=True`) so the existing eager-fallback path engages immediately — the exact same treatment the OpenRouter aggregator 429 already gets. Generic 'rate limit reached' 429s from the same gateway still take the normal account-level rate-limit path.

Patterns matched (case-insensitive substring on the error message):
- `no deployments available`
- `no healthy deployments available`
- `all deployments are cooling down`

## Test plan

- [x] 3 new tests in `TestGatewayModelGroupCooldown` (verbatim production error string, str(error)-only variant, generic-429 control)
- [x] Full classifier suite: **125/125 passed** (`uv run --with pytest --with pyyaml`)
- [x] Smoke-verified against the verbatim error string from the 2026-09-01 fleet cooldown storm

Fixes the client half of the cooldown-storm failure mode; the gateway half is being hardened separately via fallback chains.