### PR TITLE
fix(matrix): stream replies via m.replace edits instead of single final send (#100708)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -29732,7 +29732,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _buffer_only = False
         if source.platform == Platform.MATRIX:
             _effective_cursor = ""
-            _buffer_only = True
         # Fresh-final applies to Telegram only — other
         # platforms either edit in place cheaply (Discord,
         # Slack) or don't have the timestamp-on-edit /


### PR DESCRIPTION
Fixes #100708

Matrix gateway had `buffer_only=True` for `Platform.MATRIX` which suppressed all intermediate edits from `GatewayStreamConsumer`, so replies arrived as a single final `m.room.message` with no `m.replace` chain. Status edits worked because they bypass the consumer.

Remove the `buffer_only` override for Matrix — keep cursor suppressed (prevents tofu artifact on some clients) but allow progressive edits every 0.8s / 24 chars as documented ("Streaming = progressive message updates via editing").

- Changed `gateway/run.py:_build_stream_consumer_config`: Matrix now only sets `_effective_cursor=""`, no longer forces `_buffer_only=True`
- Verified: `tests/gateway/test_stream_consumer*.py` + `tests/gateway/test_matrix.py` — 249 passed
- Single-line fix, no workflow changes