### PR TITLE
fix(agent): stop completed responses from flooding chats with repeated text

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1460,6 +1460,42 @@ def _content_policy_blocked_result(
     }
 
 
+def _repetition_stopped_result(
+    agent,
+    messages: List[Dict],
+    conversation_history,
+    effective_task_id: Optional[str],
+    api_call_count: int,
+) -> Dict[str, Any]:
+    """Discard a repetition-dominated answer before it becomes durable."""
+    error = (
+        "Model output entered a repetition loop; refusing to return a "
+        "degenerate response."
+    )
+    agent._vprint(
+        f"{agent.log_prefix}🔁 Response dominated by repeated text — stopping "
+        "before delivery.",
+        force=True,
+    )
+    response = (
+        "⚠️ **Response Stopped — Repetition Detected**\n\n"
+        "The model fell into a repetition loop while writing this response, "
+        "so the repeated output was discarded.\n\n"
+        "→ Switch to a different model with `/model`\n"
+        "→ Or resend your message (your conversation history is preserved)"
+    )
+    agent._cleanup_task_resources(effective_task_id)
+    agent._persist_session(messages, conversation_history)
+    return {
+        "final_response": response,
+        "messages": messages,
+        "api_calls": api_call_count,
+        "completed": False,
+        "partial": True,
+        "error": error,
+    }
+
+
 def _compression_deferred_result(
     agent,
     messages: List[Dict],
@@ -3810,37 +3846,13 @@ def run_conversation(
                         and is_repetition_dominated(_visible_trunc)
                     )
                     if _repetition_dominated:
-                        _rep_error = (
-                            "Model output entered a repetition loop and was "
-                            "truncated mid-loop; refusing to continue a "
-                            "degenerate response."
+                        return _repetition_stopped_result(
+                            agent,
+                            messages,
+                            conversation_history,
+                            effective_task_id,
+                            api_call_count,
                         )
-                        agent._vprint(
-                            f"{agent.log_prefix}🔁 Response dominated by "
-                            f"repeated text — stopping instead of "
-                            f"continuing a degenerate response.",
-                            force=True,
-                        )
-                        _rep_response = (
-                            "⚠️ **Response Stopped — Repetition Detected**\n\n"
-                            "The model fell into a repetition loop while "
-                            "writing this response, so continuing would only "
-                            "produce more repeated text. The partial response "
-                            "was discarded.\n\n"
-                            "→ Switch to a different model with `/model`\n"
-                            "→ Or resend your message (your conversation "
-                            "history is preserved)"
-                        )
-                        agent._cleanup_task_resources(effective_task_id)
-                        agent._persist_session(messages, conversation_history)
-                        return {
-                            "final_response": _rep_response,
-                            "messages": messages,
-                            "api_calls": api_call_count,
-                            "completed": False,
-                            "partial": True,
-                            "error": _rep_error,
-                        }
 
                     if agent.api_mode in {"chat_completions", "bedrock_converse", "anthropic_messages"}:
                         assistant_message = _trunc_msg
@@ -8154,6 +8166,23 @@ def run_conversation(
                             _frag.pop("_length_continuation_nudge", None)
                 
                 final_response = agent._strip_think_blocks(final_response).strip()
+
+                # A provider may end a degenerate loop normally with
+                # finish_reason="stop" instead of exhausting its output cap.
+                # Check every completed visible text response before any
+                # verify/kanban interim emission or durable transcript write.
+                if (
+                    final_response
+                    and not assistant_message.tool_calls
+                    and is_repetition_dominated(final_response)
+                ):
+                    return _repetition_stopped_result(
+                        agent,
+                        messages,
+                        conversation_history,
+                        effective_task_id,
+                        api_call_count,
+                    )
                 
                 final_msg = agent._build_assistant_message(assistant_message, finish_reason)
 

--- a/agent/repetition_guard.py
+++ b/agent/repetition_guard.py
@@ -1,4 +1,4 @@
-"""Cheap content-sanity checks for the truncated-response continuation path.
+"""Cheap content-sanity checks for completed model output.
 
 Issue #86581: a model in a degenerate repetition loop can spend its ENTIRE
 output budget echoing one fragment.  The ``finish_reason=length``
@@ -8,9 +8,9 @@ final response with no content-sanity check.  In the incident behind #86581
 a single turn produced a 60,698-char response delivered as 31 Discord
 messages.
 
-These helpers detect repetition-dominated fragments BEFORE the continuation
-nudge is appended so the turn can abort with a clear user-facing error
-(mirroring the existing ``_thinking_exhausted`` guard) instead of flooding.
+These helpers detect repetition-dominated output before it is persisted or
+delivered. Truncated responses are also checked before a continuation nudge is
+appended.
 
 The detection is deliberately conservative: only LONG verbatim repeats
 (60+ chars) whose occurrences cover a majority of the fragment trip the
@@ -19,8 +19,6 @@ repeated, code with similar-looking lines) are never blocked.
 """
 
 from __future__ import annotations
-
-import math
 
 # A fragment must be at least this long before the repetition check runs at
 # all.  Short truncations (a sentence cut mid-word) can trivially contain
@@ -35,20 +33,23 @@ _REPEAT_WINDOW = 60
 # even for short fragments.
 _MIN_REPEAT_COUNT = 5
 
-# A fragment is "repetition-dominated" when repeated windows account for at
-# least this fraction of its characters.
+# A fragment is "repetition-dominated" when one contiguous periodic run
+# accounts for at least this fraction of its characters.
 _DOMINANCE_RATIO = 0.5
+
+# Sampling bounds keep the general path linear in output size with a small,
+# fixed multiplier. A dominant contiguous run necessarily crosses many of
+# these evenly spaced anchors.
+_MAX_ANCHOR_SAMPLES = 32
+_MAX_ANCHOR_MATCHES = 8
 
 
 def is_repetition_dominated(text: str) -> bool:
     """True when ``text`` is dominated by verbatim repeated fragments.
 
-    A truncated response is "repetition-dominated" when a single 60+ char
-    substring appears often enough that its occurrences cover at least half
-    of the fragment.  That shape is the signature of a model repetition
-    loop (issue #86581), and continuing such a fragment is pointless — the
-    continuation nudge would just stitch more repeated text into the final
-    response.
+    A response is "repetition-dominated" when a contiguous run containing at
+    least five exact repetitions covers at least half of the output. That
+    shape is the signature of a model repetition loop (issue #86581).
 
     Returns False for non-string / empty / short inputs (fail-open: never
     blocks a continuation the guard cannot confidently judge).
@@ -65,20 +66,65 @@ def is_repetition_dominated(text: str) -> bool:
     if _line_repetition_dominated(text, n):
         return True
 
-    # General path: fixed-size exact-repeat windows, sliding one char at a
-    # time.  Catches repetition loops that do not align to line boundaries.
+    return _periodic_run_dominated(text, n)
+
+
+def _periodic_run_dominated(text: str, n: int) -> bool:
+    """Detect a dominant exact periodic run from evenly spaced anchors.
+
+    Matching a 60-character anchor at a later position supplies a candidate
+    period. Expanding the equality ``text[i] == text[i + period]`` in both
+    directions recovers the full run, so coverage is measured using the true
+    repeating unit rather than crediting every occurrence with only 60 chars.
+    """
     window = _REPEAT_WINDOW
-    # A window must appear this many times for its occurrences to cover
-    # >= DOMINANCE_RATIO of the fragment (and at least _MIN_REPEAT_COUNT).
-    needed = max(_MIN_REPEAT_COUNT, math.ceil(n * _DOMINANCE_RATIO / window))
-    counts: dict[str, int] = {}
-    for i in range(n - window + 1):
-        key = text[i : i + window]
-        c = counts.get(key, 0) + 1
-        if c >= needed:
-            return True
-        counts[key] = c
+    max_start = n - window
+    if max_start < 1:
+        return False
+
+    sample_step = max(
+        1,
+        (max_start + _MAX_ANCHOR_SAMPLES - 2) // (_MAX_ANCHOR_SAMPLES - 1),
+    )
+    sample_starts = list(range(0, max_start + 1, sample_step))
+    if sample_starts[-1] != max_start:
+        sample_starts.append(max_start)
+
+    for start in sample_starts:
+        anchor = text[start : start + window]
+        search_from = start + 1
+        for _ in range(_MAX_ANCHOR_MATCHES):
+            match = text.find(anchor, search_from)
+            if match < 0:
+                break
+            period = match - start
+            if _candidate_run_dominated(text, n, start, period, window):
+                return True
+            search_from = match + 1
     return False
+
+
+def _candidate_run_dominated(
+    text: str,
+    n: int,
+    start: int,
+    period: int,
+    matched: int,
+) -> bool:
+    """Expand one known equal window and judge its exact run coverage."""
+    left = start
+    while left > 0 and text[left - 1] == text[left - 1 + period]:
+        left -= 1
+
+    right = start + matched
+    while right + period < n and text[right] == text[right + period]:
+        right += 1
+
+    run_length = right + period - left
+    return (
+        run_length >= _MIN_REPEAT_COUNT * period
+        and run_length >= n * _DOMINANCE_RATIO
+    )
 
 
 def _line_repetition_dominated(text: str, n: int) -> bool:

--- a/tests/agent/test_repetition_guard.py
+++ b/tests/agent/test_repetition_guard.py
@@ -1,6 +1,8 @@
-"""Unit tests for the truncated-response repetition guard (issue #86581)."""
+"""Unit tests for repetition-dominated model output detection."""
 
 from __future__ import annotations
+
+import random
 
 from agent.repetition_guard import MIN_FRAGMENT_LENGTH, is_repetition_dominated
 
@@ -19,6 +21,30 @@ class TestRepetitionGuard:
         # Repetition loop with no line breaks — exercises the window path.
         text = _INCIDENT_ECHO * 2000
         assert len(text) >= MIN_FRAGMENT_LENGTH
+        assert is_repetition_dominated(text) is True
+
+    def test_multiline_paragraph_run_uses_true_period_coverage(self):
+        rng = random.Random(11)
+        paragraph = "\n".join(
+            "".join(rng.choice("abcdefghijklmnopqrstuvwxyz ") for _ in range(151))
+            for _ in range(5)
+        ) + "\n"
+
+        # The incident unit was approximately 764 characters. Detection must
+        # remain scale-free as the number of exact repeats grows.
+        for repeat_count in (100, 1_000, 10_000):
+            assert is_repetition_dominated(paragraph * repeat_count) is True
+
+    def test_dominant_run_with_unique_prefix_and_suffix_flags(self):
+        paragraph = (
+            "A deliberately long repeated paragraph has enough distinct text "
+            "to make its period exceed the guard's minimum anchor length.\n"
+            "It also spans multiple lines, matching the real incident shape.\n"
+        )
+        repeated = paragraph * 20
+        text = ("unique introduction " * 20) + repeated + (" unique ending" * 20)
+
+        assert len(repeated) > len(text) * 0.5
         assert is_repetition_dominated(text) is True
 
     def test_long_legitimate_text_not_flagged(self):

--- a/tests/run_agent/test_continuation_repetition_guard.py
+++ b/tests/run_agent/test_continuation_repetition_guard.py
@@ -1,10 +1,8 @@
-"""Regression tests for the truncated-response repetition guard (#86581).
+"""Regression tests for repetition-dominated response handling.
 
-A truncated response (``finish_reason=length``) dominated by verbatim
-repeated text must NOT be continued: the continuation nudge would stitch the
-pathological fragment into the final response (the #86581 incident delivered
-60,698 chars as 31 Discord messages).  The turn aborts with a clear
-user-facing error instead, mirroring the existing thinking-budget guard.
+A response dominated by verbatim repeated text must be discarded whether it
+ends normally or at the output cap. The turn aborts with a clear user-facing
+error instead of persisting and delivering the pathological fragment.
 """
 
 from __future__ import annotations
@@ -44,19 +42,28 @@ def loop_agent():
         return a
 
 
-def _stub(content):
+def _response(
+    content,
+    *,
+    finish_reason=FINISH_REASON_LENGTH,
+    response_id=PARTIAL_STREAM_STUB_ID,
+):
     from tests.run_agent.test_run_agent import _mock_assistant_msg
 
     return SimpleNamespace(
-        id=PARTIAL_STREAM_STUB_ID,
+        id=response_id,
         model="test/model",
         choices=[SimpleNamespace(
             index=0,
             message=_mock_assistant_msg(content=content),
-            finish_reason=FINISH_REASON_LENGTH,
+            finish_reason=finish_reason,
         )],
         usage=None,
     )
+
+
+def _stub(content):
+    return _response(content)
 
 
 def _run(agent, message):
@@ -84,6 +91,28 @@ class TestContinuationRepetitionGuard:
             for m in result["messages"]
         )
         # Exactly one API call — no continuation was attempted.
+        assert loop_agent.client.chat.completions.create.call_count == 1
+
+    def test_repetition_dominated_stop_response_aborts(self, loop_agent):
+        paragraph = (
+            "A long paragraph that should never be delivered hundreds of times "
+            "when a model enters a repetition loop.\n"
+            "The second line makes this a multiline repeating unit.\n"
+        )
+        echo = paragraph * 500
+        loop_agent.client.chat.completions.create.side_effect = [
+            _response(echo, finish_reason="stop", response_id="completed-response")
+        ]
+
+        result = _run(loop_agent, "write me a long report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "Repetition" in (result["final_response"] or "")
+        assert not any(
+            isinstance(m, dict) and m.get("content") == echo
+            for m in result["messages"]
+        )
         assert loop_agent.client.chat.completions.create.call_count == 1
 
     def test_legit_truncation_still_continues(self, loop_agent):


### PR DESCRIPTION
## What does this PR do?

Prevents completed model responses from flooding chats with hundreds of copies of the same multiline paragraph. The repetition guard now measures the exact periodic run's real coverage and runs before every completed visible text response is persisted or finalized, including `finish_reason="stop"`.

### Symptom

A model can return a very large response where one multiline paragraph repeats verbatim hundreds of times. If the provider ends that output with `finish_reason="stop"`, Hermes currently persists and delivers the entire repeated response.

### Impact

The reported WhatsApp turn produced 349,880 characters and 73,303 output tokens over 14.6 minutes, with a roughly 764-character paragraph repeated 458 times. The full response was delivered because the existing guard was only reached for output-cap truncation and separately underestimated multiline-period coverage.

### Bug Cause

**Trigger:** `agent/repetition_guard.py:is_repetition_dominated` and the `finish_reason == "length"` branch in `agent/conversation_loop.py`

**Causal chain:**
1. A model emits a long contiguous run of an exact multiline paragraph and ends with `finish_reason="stop"`.
2. The only call site for `is_repetition_dominated` is inside the `finish_reason="length"` continuation branch, so normal completion bypasses it.
3. Even when called directly, the fixed 60-character window credits each paragraph occurrence with only 60 characters, causing a truly dominant long-period run to fall below the 50% threshold.
4. Hermes persists and delivers the degenerate output to the user.

**Why it is wrong:** Detection scales its required occurrence count with total output length while measuring each occurrence using a fixed window rather than the repeating unit's true period. Increasing the number of long paragraph repeats therefore never makes the detector pass.

**Working sibling / contrast:** Repeated units at most 120 characters and single repeated lines can pass the existing window or line fast paths; multiline units around 764 characters cannot, regardless of repeat count.

**Ruled out:** Provider output limits are not sufficient protection because the reported response ended normally below its configured maximum output token budget.

### Fix

- Recover the true period of sampled exact-match anchors, expand each candidate into its maximal contiguous periodic run, and compare that run's actual coverage against the output length.
- Keep fixed sampling and bounded candidate searches so memory use stays bounded and runtime remains linear with a small constant factor.
- Apply the guard to every finalized visible text response before interim emission or durable transcript writes, while retaining the existing pre-continuation check for truncated output.
- Add regression coverage for 764-character multiline units at 100, 1,000, and 10,000 repeats, unique prefix/suffix boundaries, normal `stop` completion, legitimate text, and non-dominant repetition.

Streaming-time cancellation is intentionally not included: it requires transport-aware incremental checks and overlaps the separate streaming recovery work tracked in #97630. This change prevents final persistence and delivery without changing streaming callback semantics.

## Related Issue

Closes #100716

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/repetition_guard.py` - detect dominant contiguous periodic runs using their true period and coverage.
- `agent/conversation_loop.py` - share the terminal repetition result and guard every completed visible text path before persistence.
- `tests/agent/test_repetition_guard.py` - cover the reported multiline shape, scale, boundaries, and false positives.
- `tests/run_agent/test_continuation_repetition_guard.py` - verify both `length` and `stop` completion paths discard repeated output.

## How to Test

1. Run the detector regression matrix, including a 7.6 MB response made from 10,000 exact multiline paragraph repeats.
2. Run the conversation-loop integration tests for both `finish_reason="length"` and `finish_reason="stop"`.

```bash
scripts/run_tests.sh tests/agent/test_repetition_guard.py tests/run_agent/test_continuation_repetition_guard.py -q
```

Expected result: 11 tests pass.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings
- [x] Config example changes are N/A
- [x] Contributor or architecture guide changes are N/A
- [x] I've considered cross-platform impact; the implementation uses Python string operations only
- [x] Tool description or schema changes are N/A
