### PR TITLE
fix(desktop): route window.open from embedded preview <webview> to the system browser

### DIFF
--- a/apps/desktop/electron/browser-windows.test.ts
+++ b/apps/desktop/electron/browser-windows.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict'
 
 import { test } from 'vitest'
 
-import { buildBrowserWindowUrl } from './browser-windows'
+import { buildBrowserWindowUrl, installPreviewGuestWindowOpenHandler } from './browser-windows'
 
 test('buildBrowserWindowUrl puts win=browser before the hash (dev server)', () => {
   const url = buildBrowserWindowUrl('url:browser-1', { devServer: 'http://localhost:5173' })
@@ -38,4 +38,27 @@ test('buildBrowserWindowUrl builds a packaged file URL with the flag before the 
   const url = buildBrowserWindowUrl('abc', { rendererIndexPath: '/opt/app/index.html' })
 
   assert.match(url, /^file:\/\/.*index\.html\?win=browser&tab=abc#\/$/)
+})
+
+test('embedded preview links open externally and never create an Electron window', () => {
+  let handler: ((details: { url: string }) => { action: 'deny' }) | undefined
+
+  const openExternal = (url: string) => {
+    assert.equal(url, 'https://example.com/from-preview')
+
+    return true
+  }
+
+  installPreviewGuestWindowOpenHandler(
+    {
+      setWindowOpenHandler: next => {
+        handler = next
+      }
+    },
+    openExternal
+  )
+
+  assert.ok(handler)
+
+  assert.deepEqual(handler?.({ url: 'https://example.com/from-preview' }), { action: 'deny' })
 })

--- a/apps/desktop/electron/browser-windows.ts
+++ b/apps/desktop/electron/browser-windows.ts
@@ -9,6 +9,30 @@ export const BROWSER_WINDOW_HEIGHT = 720
 export const BROWSER_WINDOW_MIN_WIDTH = 480
 export const BROWSER_WINDOW_MIN_HEIGHT = 400
 
+/** The small part of Electron's guest WebContents needed by the browser
+ *  window policy. Keeping this seam separate from main.ts makes the rule
+ *  testable without booting Electron. */
+export interface PreviewGuestWebContents {
+  setWindowOpenHandler: (
+    handler: (details: { url: string }) => { action: 'deny' }
+  ) => void
+}
+
+/** Keep links opened by an embedded preview page out of uncontrolled Electron
+ *  windows. `wireCommonWindowHandlers` applies the same policy to the host
+ *  window, but a `<webview>` is a separate WebContents and needs its own
+ *  handler after `did-attach-webview` fires. */
+export function installPreviewGuestWindowOpenHandler(
+  guest: PreviewGuestWebContents,
+  openExternal: (url: string) => boolean
+): void {
+  guest.setWindowOpenHandler(({ url }) => {
+    openExternal(url)
+
+    return { action: 'deny' }
+  })
+}
+
 /**
  * Renderer URL for a popped-out Browser. `tab` is the `$previewTabs` id the
  * window should show — the tab stays in storage so closing the window can

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -85,7 +85,8 @@ import {
   BROWSER_WINDOW_MIN_HEIGHT,
   BROWSER_WINDOW_MIN_WIDTH,
   BROWSER_WINDOW_WIDTH,
-  buildBrowserWindowUrl
+  buildBrowserWindowUrl,
+  installPreviewGuestWindowOpenHandler
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
@@ -12932,6 +12933,12 @@ function wireCommonWindowHandlers(win, { zoom = true }: { zoom?: boolean } = {})
     openExternalUrl(details.url)
 
     return { action: 'deny' }
+  })
+  // A <webview> has its own WebContents, so the host handler above does not
+  // cover `target="_blank"` or `window.open()` from an embedded preview page.
+  // Install the same system-browser policy as soon as each guest attaches.
+  win.webContents.on('did-attach-webview', (_event, guestContents) => {
+    installPreviewGuestWindowOpenHandler(guestContents, openExternalUrl)
   })
   win.webContents.on('will-navigate', (event, url) => {
     if ((DEV_SERVER && url.startsWith(DEV_SERVER)) || (!DEV_SERVER && url.startsWith('file:'))) {


### PR DESCRIPTION
## What / why

A `<webview>` owns its own `WebContents`, so the host window's `setWindowOpenHandler` never sees `target="_blank"` links or `window.open()` calls made from an embedded preview page. Those opened a bare, chromeless Electron window inside the app instead of the user's browser.

This installs the same system-browser policy on each guest as it attaches (`did-attach-webview`), through a shared helper (`installPreviewGuestWindowOpenHandler`) so the host and guest paths cannot drift.

## How to test

1. Open any session with a preview pane showing a page that has an external link with `target="_blank"` (or run `window.open('https://example.com')` in its devtools).
2. Before: a blank Electron window opens inside Hermes.
3. After: the link opens in the system browser; the app window is untouched.

`apps/desktop/electron/browser-windows.test.ts` covers the helper (6 tests).

## Platforms

macOS 26 (Electron 40). The handler is platform-neutral Electron API.

## Duplicate check

Searched open/merged PRs and issues for "webview window.open external browser" — none found.