### PR TITLE
fix(cli): honour --in DIR on the one-shot (-z) launch paths

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -252,6 +252,36 @@ def _run_and_exit_oneshot(
         _exit_after_oneshot(rc)
 
 
+def _apply_oneshot_working_dir(args) -> None:
+    """Apply the explicit ``--in`` directory before one-shot startup.
+
+    Top-level ``-z`` bypasses :func:`cmd_chat`; keeping this in a small helper
+    makes the workspace boundary testable and prevents file tools from seeing
+    a different cwd than prompt/plugin discovery.
+    """
+    in_dir = getattr(args, "in_dir", None)
+    if not in_dir:
+        return
+    from tools.environments.local import _msys_to_windows_path
+
+    target = os.path.abspath(os.path.expanduser(_msys_to_windows_path(in_dir)))
+    if not os.path.isdir(target):
+        print(f"Error: --in directory not found: {in_dir}")
+        raise SystemExit(1)
+    try:
+        os.chdir(target)
+    except OSError as exc:
+        print(f"Error: cannot enter --in directory {in_dir}: {exc}")
+        raise SystemExit(1)
+    # Cwd-aware tools consult these explicit runtime anchors rather than only
+    # ``os.getcwd()``. Seed both so one-shot prompt context and terminal/file
+    # execution resolve the same workspace even when config was imported
+    # before the CLI parsed ``--in``.
+    os.environ["TERMINAL_CWD"] = target
+    os.environ["HERMES_CWD"] = target
+    args.no_restore_cwd = True
+
+
 def _project_root_str_fast() -> str:
     return _startup_fast.project_root_str()
 
@@ -12862,6 +12892,8 @@ def _try_fast_chat_launch() -> bool:
 
     if getattr(args, "yolo", False):
         os.environ["HERMES_YOLO_MODE"] = "1"
+    if getattr(args, "oneshot", None) and getattr(args, "in_dir", None):
+        _apply_oneshot_working_dir(args)
     _prepare_agent_startup(args)
 
     if getattr(args, "oneshot", None):
@@ -12920,6 +12952,9 @@ def _try_termux_fast_cli_launch() -> bool:
     if getattr(args, "version", False):
         _print_version_info(check_updates=True)
         return True
+
+    if getattr(args, "oneshot", None) and getattr(args, "in_dir", None):
+        _apply_oneshot_working_dir(args)
 
     if getattr(args, "oneshot", None):
         _prepare_agent_startup(args)
@@ -14915,6 +14950,13 @@ def main():
     # so introspection/management commands (hermes hooks list, cron
     # list, gateway status, mcp add, ...) don't pay discovery cost or
     # trigger consent prompts for hooks the user is still inspecting.
+    # One-shot mode bypasses cmd_chat, so apply its explicit workspace before
+    # plugin discovery and prompt construction. Without this, ``-z --in DIR``
+    # can discover tools in one cwd while file tools resolve writes in the
+    # process cwd (a dangerous workspace-confinement mismatch).
+    if getattr(args, "oneshot", None) and getattr(args, "in_dir", None):
+        _apply_oneshot_working_dir(args)
+
     _prepare_agent_startup(args)
 
     # Handle top-level --oneshot / -z: single-shot mode, stdout = final

--- a/tests/hermes_cli/test_oneshot_workspace.py
+++ b/tests/hermes_cli/test_oneshot_workspace.py
@@ -1,0 +1,33 @@
+"""One-shot workspace confinement regressions."""
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_oneshot_applies_explicit_workspace(tmp_path, monkeypatch):
+    from hermes_cli import main
+
+    monkeypatch.chdir(tmp_path.parent)
+    args = SimpleNamespace(in_dir=str(tmp_path), no_restore_cwd=False)
+
+    main._apply_oneshot_working_dir(args)
+
+    assert tmp_path.samefile(".")
+    assert args.no_restore_cwd is True
+
+
+def test_oneshot_rejects_missing_workspace(tmp_path, monkeypatch, capsys):
+    from hermes_cli import main
+
+    start = tmp_path / "start"
+    start.mkdir()
+    monkeypatch.chdir(start)
+    args = SimpleNamespace(in_dir=str(tmp_path / "missing"), no_restore_cwd=False)
+
+    with pytest.raises(SystemExit) as exc:
+        main._apply_oneshot_working_dir(args)
+
+    assert exc.value.code == 1
+    assert start.samefile(".")
+    assert "--in directory not found" in capsys.readouterr().out


### PR DESCRIPTION
## What / why

One-shot mode bypasses `cmd_chat`, which is where `--in` was applied. So `hermes -z --in DIR ...` discovered plugins and built the prompt in one cwd while file/terminal tools resolved writes in the *process* cwd — a workspace-confinement mismatch.

This applies the explicit workspace before startup on each of the three launch paths that skip `cmd_chat` (fast chat launch, Termux fast launch, main dispatch), and seeds `TERMINAL_CWD` / `HERMES_CWD` so cwd-aware tools agree with prompt construction. A missing directory exits 1 with a clear message and leaves cwd untouched.

## How to test

```bash
mkdir -p /tmp/ws && cd ~
hermes -z --in /tmp/ws "write hello.txt containing hi"
ls /tmp/ws/hello.txt   # before: file lands in ~ ; after: lands in /tmp/ws
hermes -z --in /tmp/does-not-exist "hi"   # exits 1: "--in directory not found"
```

Adds `tests/hermes_cli/test_oneshot_workspace.py` (2 tests).

## Platforms

macOS. The path helper already routes through `_msys_to_windows_path`, so MSYS/Git-Bash paths on Windows are handled the same way `cmd_chat` handles them.

## Duplicate check

Searched open/merged PRs and issues for "oneshot --in cwd workspace" — none found.