### PR TITLE
fix(security): require one explicit human approval before any outbound email send

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1138,6 +1138,13 @@ class EmailAdapter(BasePlatformAdapter):
     ) -> SendResult:
         """Send an email reply to the given address."""
         try:
+            from tools.approval import request_outbound_approval
+            approval = request_outbound_approval(
+                "email", chat_id, content,
+                approval_callback=(metadata or {}).get("approval_callback"),
+            )
+            if not approval.get("approved"):
+                return SendResult(success=False, error=approval.get("message") or "Email send requires approval")
             loop = asyncio.get_running_loop()
             message_id = await loop.run_in_executor(
                 None, self._send_email, chat_id, content, reply_to
@@ -1443,6 +1450,10 @@ async def _standalone_send(
     from email.utils import formatdate
 
     extra = getattr(pconfig, "extra", {}) or {}
+    from tools.approval import request_outbound_approval
+    approval = request_outbound_approval("email", chat_id, message)
+    if not approval.get("approved"):
+        return {"error": approval.get("message") or "Email send requires explicit approval"}
     address = extra.get("address") or _get_secret("EMAIL_ADDRESS", "")
     password = _get_secret("EMAIL_PASSWORD", "")
     smtp_host = extra.get("smtp_host") or _get_secret("EMAIL_SMTP_HOST", "")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -815,7 +815,11 @@ class TestSendEmailStandalone(unittest.TestCase):
         async def _send_email(extra, chat_id, message):
             return await _email_send(SimpleNamespace(token=None, api_key=None, extra=extra or {}), chat_id, message)
 
-        with patch("smtplib.SMTP") as mock_smtp:
+        # Outbound mail needs one explicit human approval per send; this test
+        # is about the SMTP path, so stand in for the approver.
+        approved = {"approved": True, "message": ""}
+        with patch("tools.approval.request_outbound_approval", return_value=approved), \
+             patch("smtplib.SMTP") as mock_smtp:
             mock_server = MagicMock()
             mock_smtp.return_value = mock_server
 
@@ -832,6 +836,29 @@ class TestSendEmailStandalone(unittest.TestCase):
             self.assertIn("Date", send_call)
             self.assertEqual(send_call["To"], "user@test.com")
             self.assertEqual(send_call["From"], "hermes@test.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_SMTP_PORT": "587",
+    })
+    def test_send_email_tool_blocked_without_human_approval(self):
+        """With no interactive approver present, nothing may leave the machine."""
+        import asyncio
+        from plugins.platforms.email.adapter import _standalone_send as _email_send
+        from types import SimpleNamespace
+
+        blocked = {"approved": False, "message": "BLOCKED: outbound email delivery requires explicit human approval. Nothing was sent."}
+        with patch("tools.approval.request_outbound_approval", return_value=blocked), \
+             patch("smtplib.SMTP") as mock_smtp:
+            result = asyncio.run(
+                _email_send(SimpleNamespace(token=None, api_key=None, extra={"address": "hermes@test.com", "smtp_host": "smtp.test.com"}), "user@test.com", "Hello")
+            )
+
+            self.assertIn("error", result)
+            self.assertIn("Nothing was sent", result["error"])
+            mock_smtp.assert_not_called()
 
 
 class TestSmtpConnectionCleanup(unittest.TestCase):

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -10,7 +10,6 @@ This module is the single source of truth for the dangerous command system:
 
 import contextlib
 import contextvars
-import ast
 import fnmatch
 import functools
 import hashlib

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -10,6 +10,7 @@ This module is the single source of truth for the dangerous command system:
 
 import contextlib
 import contextvars
+import ast
 import fnmatch
 import functools
 import hashlib
@@ -30,6 +31,7 @@ from tools.interrupt import is_interrupted
 from utils import env_var_enabled, is_truthy_value
 
 logger = logging.getLogger(__name__)
+
 
 # Freeze YOLO mode at module import time. Reading os.environ on every call
 # would allow any skill running inside the process to set this variable and
@@ -183,7 +185,6 @@ def _observe_smart_approval_verdict(payload: dict | None, verdict: str) -> None:
         choice=f"smart_{verdict}",
         decided_by="aux_llm",
     )
-
 
 
 def set_current_session_key(session_key: str) -> contextvars.Token[str]:
@@ -1575,7 +1576,6 @@ _MAX_SEPARATOR_FREE_COMMAND_CHARS = 4_096
 _MAX_DETECTION_SEGMENTS = 25_000
 _PARSER_LIMIT_DESCRIPTION = "command parser limit exceeded"
 _MALFORMED_EXEC_DESCRIPTION = "command parser limit or malformed executable payload"
-
 
 
 def _command_parser_limit_exceeded(command: str) -> bool:
@@ -3171,7 +3171,6 @@ def _command_matches_permanent_allowlist(command: str) -> bool:
     return False
 
 
-
 # =========================================================================
 # Config persistence for permanent allowlist
 # =========================================================================
@@ -3769,6 +3768,9 @@ def _run_approval_gate(
     autoapprove_log_prefix: str,
     fail_closed_when_no_human: bool = False,
     no_human_block_message: str = "",
+    honor_yolo: bool = True,
+    allow_session: bool = True,
+    allow_permanent: bool = True,
 ) -> dict:
     """Shared human-approval gate for a flagged action (command or tool).
 
@@ -3807,6 +3809,12 @@ def _run_approval_gate(
             plugin-flagged action never runs ungated without a human.
         no_human_block_message: Message returned when
             ``fail_closed_when_no_human`` blocks.
+        honor_yolo: Whether a yolo/session-yolo setting may bypass this gate.
+            Safety-critical outbound actions set this to ``False``.
+        allow_session: Whether the approval UI may grant a session-wide
+            approval. When false, the approval is one operation only.
+        allow_permanent: Whether the approval UI may grant a permanent
+            approval. When false, the approval is one operation only.
 
     Returns:
         ``{"approved": bool, "message": str|None, ...}`` — shape shared with
@@ -3815,7 +3823,7 @@ def _run_approval_gate(
     # --yolo bypasses all approval prompts (session- or process-scoped).
     # Hardline blocks are handled by the caller BEFORE this gate, so yolo
     # here only skips the recoverable approval layer.
-    if _YOLO_MODE_FROZEN or is_current_session_yolo_enabled():
+    if honor_yolo and (_YOLO_MODE_FROZEN or is_current_session_yolo_enabled()):
         return {"approved": True, "message": None}
 
     session_key = get_current_session_key()
@@ -3930,8 +3938,8 @@ def _run_approval_gate(
                 "pattern_key": pattern_key,
                 "pattern_keys": [pattern_key],
                 "description": redact_sensitive_text(description),
-                "allow_permanent": True,
-                "allow_session": True,
+                "allow_permanent": allow_permanent,
+                "allow_session": allow_session,
             }
             decision = _await_gateway_decision(
                 session_key, notify_cb, approval_data, surface="gateway"
@@ -3976,9 +3984,9 @@ def _run_approval_gate(
                     "deny_reason": deny_reason,
                 }
 
-            if choice == "session":
+            if choice == "session" and allow_session:
                 approve_session(session_key, pattern_key)
-            elif choice == "always":
+            elif choice == "always" and allow_permanent:
                 approve_session(session_key, pattern_key)
                 approve_permanent(pattern_key)
                 save_permanent_allowlist(_permanent_approved)
@@ -4020,8 +4028,13 @@ def _run_approval_gate(
         session_key=session_key,
         surface="cli",
     )
-    choice = prompt_dangerous_approval(display_target, description,
-                                       approval_callback=approval_callback)
+    choice = prompt_dangerous_approval(
+        display_target,
+        description,
+        approval_callback=approval_callback,
+        allow_permanent=allow_permanent,
+        allow_session=allow_session,
+    )
     _fire_approval_hook(
         "post_approval_response",
         command=display_target,
@@ -4062,9 +4075,9 @@ def _run_approval_gate(
             "user_consent": False,
         }
 
-    if choice == "session":
+    if choice == "session" and allow_session:
         approve_session(session_key, pattern_key)
-    elif choice == "always":
+    elif choice == "always" and allow_permanent:
         approve_session(session_key, pattern_key)
         approve_permanent(pattern_key)
         save_permanent_allowlist(_permanent_approved)
@@ -4254,6 +4267,97 @@ def request_tool_approval(
             "but no interactive user or gateway is present to approve it. "
             "A plugin flagged this action for human confirmation."
         ),
+    )
+
+
+def request_outbound_approval(
+    channel: str,
+    target: str,
+    content: str = "",
+    *,
+    approval_callback=None,
+) -> dict:
+    """Require one explicit human approval before an outbound delivery.
+
+    This is deliberately stricter than the normal dangerous-command gate:
+    outbound communication must never be unlocked by ``--yolo``, an
+    ``approvals.mode: off`` setting, or a previously-approved session/pattern.
+    The approval is one-operation-only, and unattended/cron/single-query
+    contexts fail closed because there is no human who can consent to the
+    exact recipient and content.
+
+    The caller should invoke this immediately before it performs the network
+    send and must stop when ``approved`` is false.
+    """
+    channel_name = str(channel or "message").strip().lower() or "message"
+    target_text = str(target or "").strip() or "(unspecified recipient)"
+    # Keep the approval card useful without dumping an arbitrarily large body
+    # into a chat or log. The actual message is still sent unchanged after a
+    # successful one-shot approval.
+    content_text = str(content or "")
+    preview = content_text[:2000]
+    display = f"{channel_name} to {target_text}\n\n{preview}"
+    description = (
+        f"send an outbound {channel_name} message to {target_text}; "
+        "the recipient and message must be reviewed by you"
+    )
+
+    # A fresh key prevents old session/permanent approvals from authorizing a
+    # new outbound message. No persistence options are offered below either.
+    pattern_key = f"outbound:{channel_name}:{uuid.uuid4().hex}"
+
+    # These execution modes have no user present to approve this exact send;
+    # even an operator-wide "approve" mode for ordinary command guards must
+    # not silently authorize outbound communication.
+    if (
+        _is_cron_approval_context()
+        or _is_single_query_approval_context()
+        or _is_unattended_platform_approval_context()
+    ):
+        return {
+            "approved": False,
+            "message": (
+                f"BLOCKED: outbound {channel_name} delivery to {target_text} "
+                "requires explicit human approval, but this session has no "
+                "interactive approver. Nothing was sent."
+            ),
+            "pattern_key": pattern_key,
+            "description": description,
+            "outcome": "no_human",
+            "user_consent": False,
+        }
+
+    return _run_approval_gate(
+        pattern_key=pattern_key,
+        description=description,
+        display_target=display,
+        approval_callback=approval_callback,
+        cron_deny_message=(
+            f"BLOCKED: outbound {channel_name} delivery requires explicit "
+            "human approval; cron jobs have no user present. Nothing was sent."
+        ),
+        single_query_deny_message=(
+            f"BLOCKED: outbound {channel_name} delivery requires explicit "
+            "human approval; single-query mode has no user present. Nothing "
+            "was sent."
+        ),
+        unattended_deny_message=(
+            f"BLOCKED: outbound {channel_name} delivery requires explicit "
+            "human approval; this unattended session has no user present. "
+            "Nothing was sent."
+        ),
+        autoapprove_log_prefix=(
+            f"outbound {channel_name} delivery approval"
+        ),
+        fail_closed_when_no_human=True,
+        no_human_block_message=(
+            f"BLOCKED: outbound {channel_name} delivery to {target_text} "
+            "requires explicit human approval, but no interactive user or "
+            "gateway is present. Nothing was sent."
+        ),
+        honor_yolo=False,
+        allow_session=False,
+        allow_permanent=False,
     )
 
 


### PR DESCRIPTION
## What / why

The email platform adapter could send mail under `--yolo`, under `approvals.mode: off`, or under a session/permanent approval granted earlier for an unrelated command. Outbound communication should never inherit a blanket approval: the recipient and the exact content need a human's eyes each time.

This adds `tools.approval.request_outbound_approval(channel, target, content)`:

- one-operation only — no "session" / "always" persistence is offered
- ignores yolo and `approvals.mode: off`
- fails closed in cron, single-query and unattended platform contexts (there is no human to consent), with a clear `BLOCKED … Nothing was sent.` message

The existing approval helpers gain `honor_yolo` / `allow_session` / `allow_permanent` keyword parameters (defaults preserve current behaviour) so a caller can ask for the stricter shape. The email adapter calls the gate immediately before the network send on both send paths and stops when not approved.

## How to test

1. Configure the email platform, run with `--yolo`.
2. Ask the agent to send an email. Before: it sends. After: an approval card shows the recipient and a preview of the body; only "approve once" is offered.
3. Same request from a cron job or `hermes -q`: blocked with `BLOCKED: outbound email delivery … Nothing was sent.`

## Platforms

macOS. Pure Python, no platform-specific code.

## Tests

`tests/tools/test_approval.py`, `test_smart_approval_policy.py`, `test_approval_mode_parity.py`, `tests/gateway/test_email*.py` pass. `TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous` fails on current `main` before this change as well.

## Duplicate check

Searched open/merged PRs and issues for "outbound approval email send yolo" — none found.