### PR TITLE
fix(kanban): refresh dashboard worker logs

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -4073,7 +4073,11 @@
           );
         }),
       ),
-      h(WorkerLogSection, { taskId: t.id, boardSlug: props.boardSlug }),
+      h(WorkerLogSection, {
+        taskId: t.id,
+        boardSlug: props.boardSlug,
+        running: t.status === "running",
+      }),
       h(RunHistorySection, { runs: props.data.runs || [] }),
     );
   }
@@ -4149,20 +4153,29 @@
     );
   }
 
-  // Worker log: loads lazily (one GET on mount), refresh button, tail cap.
+  // Worker log: loads lazily, polls while the drawer is open, and keeps a
+  // manual refresh button for an immediate read.
   function WorkerLogSection(props) {
     const { t } = useI18n();
     const [state, setState] = useState({ loading: false, data: null, err: null });
     const load = useCallback(function () {
-      setState({ loading: true, data: null, err: null });
+      setState(function (prev) {
+        return { loading: !prev.data, data: prev.data, err: null };
+      });
       SDK.fetchJSON(withBoard(`${API}/tasks/${encodeURIComponent(props.taskId)}/log?tail=100000`, props.boardSlug))
         .then(function (d) { setState({ loading: false, data: d, err: null }); })
-        .catch(function (e) { setState({ loading: false, data: null, err: String(e.message || e) }); });
+        .catch(function (e) {
+          setState(function (prev) {
+            return { loading: false, data: prev.data, err: String(e.message || e) };
+          });
+        });
     }, [props.taskId, props.boardSlug]);
 
-    // Auto-load when the section mounts; the user opened the drawer so the
-    // cost is one small HTTP round-trip.
-    useEffect(function () { load(); }, [load]);
+    useEffect(function () {
+      load();
+      const interval = window.setInterval(load, props.running ? 3000 : 15000);
+      return function () { window.clearInterval(interval); };
+    }, [load, props.running]);
 
     const data = state.data;
     let body;

--- a/tests-js/kanban-worker-log-refresh.test.ts
+++ b/tests-js/kanban-worker-log-refresh.test.ts
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import React, {
+  type ComponentType,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
+
+interface PassthroughProps {
+  children?: ReactNode
+}
+
+const Box = ({ children }: PassthroughProps) => React.createElement('div', null, children)
+
+const Button = ({ children, ...props }: PassthroughProps & React.ButtonHTMLAttributes<HTMLButtonElement>) =>
+  React.createElement('button', props, children)
+
+const Input = (props: React.InputHTMLAttributes<HTMLInputElement>) => React.createElement('input', props)
+
+const Label = ({ children, ...props }: PassthroughProps & React.LabelHTMLAttributes<HTMLLabelElement>) =>
+  React.createElement('label', props, children)
+
+const task = {
+  id: 'task-1',
+  title: 'Live worker task',
+  body: 'Exercise the worker log.',
+  status: 'running',
+  priority: 1,
+  assignee: 'worker',
+  tenant: 'default',
+  created_at: '2026-09-01T00:00:00Z',
+  updated_at: '2026-09-01T00:00:00Z',
+}
+
+let KanbanPage: ComponentType | null = null
+let logReads = 0
+
+const fetchJSON = vi.fn((url: string) => {
+  const path = String(url).split('?')[0]
+
+  if (path.endsWith('/tasks/task-1/log')) {
+    logReads += 1
+
+    return Promise.resolve({
+      exists: true,
+      size_bytes: logReads === 1 ? 0 : 14,
+      content: logReads === 1 ? '' : 'worker output\n',
+      path: '/tmp/task-1.log',
+      truncated: false,
+    })
+  }
+
+  if (path.endsWith('/tasks/task-1')) {
+    return Promise.resolve({
+      task,
+      comments: [],
+      events: [],
+      attachments: [],
+      links: { parents: [], children: [] },
+      child_results: [],
+      runs: [],
+    })
+  }
+
+  if (path.endsWith('/home-channels')) {return Promise.resolve({ home_channels: [] })}
+
+  if (path.endsWith('/config')) {return Promise.resolve({ render_markdown: false })}
+
+  if (path.endsWith('/boards')) {
+    return Promise.resolve({ boards: [{ slug: 'default', name: 'Default' }], current: 'default' })
+  }
+
+  if (path.endsWith('/board')) {
+    return Promise.resolve({
+      columns: [{ name: 'running', tasks: [task] }],
+      assignees: ['worker'],
+      tenants: ['default'],
+      latest_event_id: 0,
+    })
+  }
+
+  if (path.endsWith('/orchestration')) {return Promise.resolve({})}
+
+  if (path.endsWith('/profiles')) {return Promise.resolve({ profiles: [] })}
+
+  return Promise.reject(new Error(`Unexpected request: ${url}`))
+})
+
+class FakeWebSocket {
+  onclose: null | ((event: { code: number }) => void) = null
+  onmessage: null | ((event: { data: string }) => void) = null
+  onopen: null | (() => void) = null
+
+  close() {}
+}
+
+async function flushUpdates() {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+describe('Kanban dashboard worker log refresh', () => {
+  beforeEach(async () => {
+    vi.useFakeTimers()
+    logReads = 0
+    fetchJSON.mockClear()
+    KanbanPage = null
+
+    Object.assign(window, {
+      __HERMES_PLUGIN_SDK__: {
+        React,
+        hooks: { useCallback, useEffect, useMemo, useRef, useState },
+        components: {
+          Badge: Box,
+          Button,
+          Card: Box,
+          CardContent: Box,
+          Checkbox: Input,
+          ConfirmDialog: () => null,
+          Input,
+          Label,
+          Select: Box,
+          SelectOption: Box,
+        },
+        utils: {
+          cn: (...parts: Array<false | null | string | undefined>) => parts.filter(Boolean).join(' '),
+          timeAgo: () => 'now',
+        },
+        useI18n: () => ({ t: { kanban: null }, locale: 'en' }),
+        fetchJSON,
+        buildWsUrl: () => Promise.resolve('ws://localhost/kanban'),
+      },
+      __HERMES_PLUGINS__: {
+        register: (_name: string, page: ComponentType) => {
+          KanbanPage = page
+        },
+      },
+      WebSocket: FakeWebSocket,
+    })
+
+    vi.resetModules()
+    // The dashboard plugin is a runtime IIFE that registers its page globally.
+    // @ts-expect-error The plain JavaScript plugin intentionally has no TS declarations.
+    await import('../plugins/kanban/dashboard/dist/index.js')
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  test('shows new output from a running worker without manual refresh', async () => {
+    expect(KanbanPage).not.toBeNull()
+    const page = KanbanPage as ComponentType
+    const view = render(React.createElement(page))
+    await flushUpdates()
+
+    fireEvent.click(screen.getByRole('button', { name: /Live worker task/ }))
+    await flushUpdates()
+
+    expect(screen.getByText('(empty)')).toBeTruthy()
+    expect(logReads).toBe(1)
+
+    await act(async () => {
+      vi.advanceTimersByTime(3000)
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(screen.getByText('worker output')).toBeTruthy()
+    expect(logReads).toBe(2)
+    view.unmount()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

The browser Dashboard Kanban drawer fetched a worker log only once when the task card opened. A running task could continue producing task events and worker output while the log stayed stuck on its initial `(empty)` result until the user clicked Refresh.

This polls the worker log while the drawer is open, every 3 seconds for a running task and every 15 seconds otherwise. Background reads keep the current content visible and preserve it if a refresh fails.

This supersedes #48994, which identified the same stale-log path but currently conflicts with `main`. The commit credits its original contributor; this version applies the narrow fix to current code and uses a runtime JS regression instead of source-text assertions.

## Related Issue

Supersedes #48994

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Pass the task's running state into `WorkerLogSection`.
- Poll the worker-log endpoint while the drawer is open and clean up the interval when it closes or changes tasks.
- Keep existing log content visible during background reads and after transient refresh failures.
- Add a jsdom behavior test that opens a live task with an initially empty log and observes later output without clicking Refresh.

## How to Test

1. Run `npm exec --workspace tests-js -- vitest run kanban-worker-log-refresh.test.ts`.
2. Run `npm run typecheck --workspace tests-js`.
3. Run `node_modules\.bin\eslint.cmd tests-js\kanban-worker-log-refresh.test.ts` on Windows, or the equivalent workspace ESLint command on another platform.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (frontend-only change; focused JS checks are listed above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused Vitest regression, TypeScript typecheck, and ESLint all pass locally.