### PR TITLE
fix(auth): retry transient PermissionError when reading auth.json

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1365,13 +1365,38 @@ def _auth_store_lock(
         yield
 
 
+# A concurrent writer (gateway keepalive, credential rotation) holds auth.json
+# only briefly; these delays bound how long a colliding read waits before the
+# fail-loud path below takes over (#100723).
+_AUTH_READ_RETRY_DELAYS: Tuple[float, ...] = (0.1, 0.25, 0.5)
+
+
+def _read_auth_store_text(auth_file: Path) -> str:
+    # On Windows, a read that collides with a concurrent writer fails with
+    # PermissionError [Errno 13] even though the contents are fine. Retry just
+    # that case: the writer's hold is transient, and treating it as permanent
+    # leaves the in-memory credential pool degraded for the rest of the
+    # process. Other OSErrors (EMFILE, EIO, a stalled mount) are not made
+    # better by retrying and keep the fail-loud path unchanged.
+    for delay in _AUTH_READ_RETRY_DELAYS:
+        try:
+            return auth_file.read_text(encoding="utf-8-sig")
+        except PermissionError:
+            logger.debug(
+                "auth: %s is held by a concurrent writer; retrying read in %.2fs",
+                auth_file, delay,
+            )
+            time.sleep(delay)
+    return auth_file.read_text(encoding="utf-8-sig")
+
+
 def _load_auth_store(auth_file: Optional[Path] = None) -> Dict[str, Any]:
     auth_file = auth_file or _auth_file_path()
     if not auth_file.exists():
         return {"version": AUTH_STORE_VERSION, "providers": {}}
 
     try:
-        raw = json.loads(auth_file.read_text(encoding="utf-8-sig"))
+        raw = json.loads(_read_auth_store_text(auth_file))
     except OSError:
         # The file exists (checked above) but could not be READ: EMFILE under
         # fd exhaustion, EACCES, EIO, a stalled network mount. None of those

--- a/tests/hermes_cli/test_auth_store_read_failure.py
+++ b/tests/hermes_cli/test_auth_store_read_failure.py
@@ -8,15 +8,28 @@ with an empty provider set and destroyed every stored credential.
 
 Genuine corruption still degrades, still preserves a copy, and now only claims
 to have preserved one when the copy actually landed.
+
+``PermissionError`` additionally gets a short bounded retry (#100723): on
+Windows a concurrent writer holds auth.json just long enough to fail a plain
+read, and failing that read permanently poisons the in-memory credential pool
+for the rest of the process. Retries are exhausted -> same fail-loud raise;
+every other ``OSError`` is never retried.
 """
 
 import errno
 import json
 import logging
+from pathlib import Path
 
 import pytest
 
 import hermes_cli.auth as auth
+
+
+@pytest.fixture(autouse=True)
+def _fast_read_retries(monkeypatch):
+    # Keep the real delays in production; tests only care about retry counts.
+    monkeypatch.setattr(auth, "_AUTH_READ_RETRY_DELAYS", (0.0, 0.0, 0.0))
 
 
 @pytest.fixture
@@ -96,3 +109,61 @@ def test_log_does_not_claim_a_backup_that_was_not_written(
     text = caplog.text
     assert "could NOT be preserved" in text
     assert "Corrupt file preserved at" not in text
+
+
+def test_transient_permission_error_is_retried_and_recovers(
+    store_file, monkeypatch
+):
+    """A Windows file-lock collision is transient; the read must recover."""
+    calls = {"n": 0}
+    real_read = Path.read_text
+
+    def _flaky(self, *args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] <= 2:
+            raise PermissionError(errno.EACCES, "Permission denied")
+        return real_read(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", _flaky)
+
+    result = auth._load_auth_store(store_file)
+
+    assert result["providers"]["nous"]["api_key"] == "secret"
+    assert calls["n"] == 3, "two lock collisions should be absorbed by retries"
+
+
+def test_persistent_permission_error_still_raises_after_bounded_retries(
+    store_file, monkeypatch, caplog
+):
+    """Retries must be bounded, and exhaustion keeps the fail-loud raise."""
+    calls = {"n": 0}
+
+    def _always_denied(self, *args, **kwargs):
+        calls["n"] += 1
+        raise PermissionError(errno.EACCES, "Permission denied")
+
+    monkeypatch.setattr(Path, "read_text", _always_denied)
+
+    with caplog.at_level(logging.WARNING, logger="hermes_cli.auth"):
+        with pytest.raises(PermissionError):
+            auth._load_auth_store(store_file)
+
+    assert calls["n"] == len(auth._AUTH_READ_RETRY_DELAYS) + 1
+    assert "could not read" in caplog.text
+    assert not store_file.with_suffix(".json.corrupt").exists()
+
+
+def test_non_permission_oserror_is_not_retried(store_file, monkeypatch):
+    """EMFILE/EIO/stalled-mount failures gain nothing from retrying."""
+    calls = {"n": 0}
+
+    def _always_fails(self, *args, **kwargs):
+        calls["n"] += 1
+        raise OSError(errno.EIO, "Input/output error")
+
+    monkeypatch.setattr(Path, "read_text", _always_fails)
+
+    with pytest.raises(OSError):
+        auth._load_auth_store(store_file)
+
+    assert calls["n"] == 1, "non-PermissionError read failures must not retry"


### PR DESCRIPTION
## What does this PR do?

`_load_auth_store()` treats the first `PermissionError` from `auth_file.read_text()` as a permanent failure: it logs a warning and raises, leaving the caller's in-memory credential pool degraded for the rest of the process. On Windows, however, that error is usually transient — a concurrent writer (gateway keepalive, credential rotation) holds `auth.json` for a moment, and a colliding read fails with `[Errno 13]` even though the contents are fine. Per #100723, one such failed read during a Desktop reconnect's `agent_init` can cascade into refreshing with a stale refresh token and a terminal Nous OAuth revocation (`invalid_grant`).

This PR adds a short bounded retry (`0.1/0.25/0.5s`, 4 attempts total) for `PermissionError` only, via a new `_read_auth_store_text()` helper. Scope is deliberately narrow:

- Other `OSError`s (EMFILE, EIO, a stalled mount) are **not** retried — they gain nothing from retrying and keep the fail-loud raise.
- A file that stays unreadable after all retries **still raises** and leaves the store on disk untouched — the no-silent-degradation guarantee from 31032b4f51 ("a transient read failure is not corruption") is preserved; this change only gives a transient lock collision a chance to clear before that path fires.

## Related Issue

Fixes #100723

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/auth.py`: added `_AUTH_READ_RETRY_DELAYS` constant and `_read_auth_store_text()` helper that retries `PermissionError` with a bounded backoff; `_load_auth_store()` now reads through it. No change to the fail-loud `except OSError` branch or the corruption branch.
- `tests/hermes_cli/test_auth_store_read_failure.py`: added an autouse fixture zeroing the retry delays (tests assert retry counts, not wall-clock), plus three regression tests: transient collision recovers, persistent denial still raises after bounded retries (fail-closed), non-Permission `OSError` is never retried.

## How to Test

1. `pytest tests/hermes_cli/test_auth_store_read_failure.py -v`
   - Observed result: 9 passed (5 pre-existing + 3 new + parametrized variants), including `test_transient_permission_error_is_retried_and_recovers` and `test_persistent_permission_error_still_raises_after_bounded_retries`.
2. `pytest tests/hermes_cli/test_auth_store_lock_concurrent.py tests/hermes_cli/test_auth_store_windows_encoding.py tests/hermes_cli/test_auth_toctou_file_modes.py tests/hermes_cli/test_global_auth_store_memo.py`
   - Observed result: 17 passed, 1 skipped (platform-gated skip, pre-existing).
3. `pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_nous_provider.py`
   - Observed result: 57 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (targeted suites listed above; repo-wide run is CI's job)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); the Windows lock-collision path is covered by mocked `PermissionError` regression tests

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Not applicable — behavior change is covered by the new tests; see How to Test for observed results.