### PR TITLE
fix(codex): hide watchdog close broken pipes

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -72,6 +72,26 @@ def _context_thread_target(callback):
     return lambda: context.run(callback)
 
 
+def _is_watchdog_close_error(error: BaseException) -> bool:
+    """Whether *error* is the expected result of force-closing a connection."""
+    seen: set[int] = set()
+    current: Optional[BaseException] = error
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(
+            current,
+            (BrokenPipeError, ConnectionResetError, ConnectionAbortedError),
+        ):
+            return True
+        if (
+            type(current).__name__ in {"ReadError", "WriteError"}
+            and "broken pipe" in str(current).lower()
+        ):
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
 def _join_worker_for_relay_teardown(worker, *, label: str) -> None:
     """Bounded worker join before raising InterruptedError (#81521).
 
@@ -1743,7 +1763,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
             )
             # Wait briefly for the worker to notice the closed connection.
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
+            # Prefer a response or unrelated error that won the race, but
+            # replace a transport teardown caused by this forced close.
+            if result["response"] is None and (
+                result["error"] is None
+                or _is_watchdog_close_error(result["error"])
+            ):
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Codex stream produced no bytes within {int(_elapsed)}s "
@@ -1788,7 +1813,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
                 f"codex stream killed after {int(_event_stale_elapsed)}s with no SSE events"
             )
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
+            # Prefer a response or unrelated error that won the race, but
+            # replace a transport teardown caused by this forced close.
+            if result["response"] is None and (
+                result["error"] is None
+                or _is_watchdog_close_error(result["error"])
+            ):
                 result["error"] = TimeoutError(
                     f"Codex stream produced no SSE events for {int(_event_stale_elapsed)}s "
                     f"after first byte (threshold: {int(_codex_idle_timeout)}s)"
@@ -1821,7 +1851,12 @@ def interruptible_api_call(agent, api_kwargs: dict):
             _touch_stale_kill_activity(agent, _elapsed)
             # Wait briefly for the thread to notice the closed connection.
             t.join(timeout=2.0)
-            if result["error"] is None and result["response"] is None:
+            # Prefer a response or unrelated error that won the race, but
+            # replace a transport teardown caused by this forced close.
+            if result["response"] is None and (
+                result["error"] is None
+                or _is_watchdog_close_error(result["error"])
+            ):
                 if _silent_hint:
                     result["error"] = TimeoutError(
                         f"Non-streaming API call timed out after {int(_elapsed)}s "

--- a/tests/agent/test_codex_ttfb_watchdog.py
+++ b/tests/agent/test_codex_ttfb_watchdog.py
@@ -17,10 +17,12 @@ stall.
 from __future__ import annotations
 
 import sys
+import threading
 import time
 import types
 from types import SimpleNamespace
 
+import httpx
 import pytest
 
 # Stub optional heavy imports so run_agent imports cleanly in isolation.
@@ -108,6 +110,134 @@ def test_ttfb_includes_silent_hang_hint_for_gpt_5_5(tmp_path, monkeypatch):
         stop["flag"] = True
 
 
+
+
+def test_idle_watchdog_hides_its_forced_close_broken_pipe(tmp_path, monkeypatch):
+    """A watchdog-triggered socket abort is a timeout, not a provider EPIPE.
+
+    The real httpx worker can unwind quickly enough to store ``BrokenPipeError``
+    during the watchdog's two-second join.  The watchdog initiated that close,
+    so its descriptive timeout must win the race instead of leaking
+    ``[Errno 32] Broken pipe`` to the Desktop.
+    """
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.4")
+
+    aborted = threading.Event()
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda _client, reason=None: aborted.set(),
+    )
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        setattr(agent, "_codex_stream_last_event_ts", time.time())
+        assert aborted.wait(timeout=5), "idle watchdog never aborted the request"
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    with pytest.raises(TimeoutError, match="produced no SSE events") as excinfo:
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert "Broken pipe" not in str(excinfo.value)
+
+
+def test_idle_watchdog_preserves_unrelated_error_during_close_join(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0.2")
+
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(agent, "_abort_request_openai_client", lambda *a, **k: None)
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        setattr(agent, "_codex_stream_last_event_ts", time.time())
+        time.sleep(0.35)
+        raise RuntimeError("provider failure won the race")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    with pytest.raises(RuntimeError, match="provider failure won the race"):
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+
+def test_watchdog_close_error_recognizes_httpx_broken_pipe_wrapper():
+    from agent import chat_completion_helpers as h
+
+    assert h._is_watchdog_close_error(
+        httpx.ReadError("[Errno 32] Broken pipe")
+    )
+
+
+def test_ttfb_watchdog_hides_its_forced_close_broken_pipe(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0.4")
+    monkeypatch.setenv("HERMES_CODEX_TTFB_MAX_SECONDS", "0.4")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "10")
+    monkeypatch.setenv("HERMES_PROVIDER_STALE_TIMEOUT", "10")
+
+    abort_started = threading.Event()
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda _client, reason=None: abort_started.set(),
+    )
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        assert abort_started.wait(timeout=5), "TTFB watchdog did not abort the request"
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    with pytest.raises(TimeoutError, match="produced no bytes") as excinfo:
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert "Broken pipe" not in str(excinfo.value)
+
+
+def test_stale_watchdog_hides_its_forced_close_broken_pipe(tmp_path, monkeypatch):
+    from agent import chat_completion_helpers as h
+
+    agent = _make_codex_agent(tmp_path, monkeypatch)
+    monkeypatch.setattr(agent, "_compute_non_stream_stale_timeout", lambda _kwargs: 0.4)
+    monkeypatch.setenv("HERMES_CODEX_TTFB_TIMEOUT_SECONDS", "0")
+    monkeypatch.setenv("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "0")
+
+    abort_started = threading.Event()
+    dummy_client = SimpleNamespace()
+    monkeypatch.setattr(agent, "_create_request_openai_client", lambda **k: dummy_client)
+    monkeypatch.setattr(
+        agent,
+        "_abort_request_openai_client",
+        lambda _client, reason=None: abort_started.set(),
+    )
+    monkeypatch.setattr(agent, "_close_request_openai_client", lambda *a, **k: None)
+
+    def fake_stream(api_kwargs, client=None, on_first_delta=None):
+        assert abort_started.wait(timeout=5), "stale watchdog did not abort the request"
+        raise BrokenPipeError(32, "Broken pipe")
+
+    monkeypatch.setattr(agent, "_run_codex_stream", fake_stream)
+
+    with pytest.raises(TimeoutError, match="timed out.*no response") as excinfo:
+        h.interruptible_api_call(agent, {"model": "gpt-5.5", "input": "hi"})
+
+    assert "Broken pipe" not in str(excinfo.value)
 
 
 def test_ttfb_does_not_kill_when_events_flow(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

The Codex TTFB, SSE-idle, and non-stream stale watchdogs abort the request-local client and briefly join the worker. If that forced transport close makes the worker record `BrokenPipeError` (or an equivalent wrapped `httpx` close error) during the join, the close artifact currently wins the race and leaks `[Errno 32] Broken pipe` instead of the watchdog's descriptive timeout.

This change recognizes only expected transport-close errors at that post-watchdog boundary and restores the existing `TimeoutError`. It remains fail-open for real provider errors: the classifier is consulted only after the watchdog initiated the close, only when no response won the race, and unrelated exceptions remain untouched.

## Related Issue

Follow-up hardening for the watchdog work in #32042 and the no-first-byte failure mode discussed in #32373. Exact open issue and PR searches found no active duplicate for this close-race mechanism.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `_is_watchdog_close_error()` in `agent/chat_completion_helpers.py` for socket close errors and `httpx` read/write wrappers linked through exception cause/context chains.
- Apply it only at the TTFB, SSE-idle, and non-stream stale watchdog close/join boundaries.
- Add regressions for all three watchdog paths, wrapped `httpx` errors, and preservation of an unrelated provider error that wins the close race.

## How to Test

1. Run `python -m pytest -q tests/agent/test_codex_ttfb_watchdog.py tests/agent/test_non_stream_stale_timeout.py` — **18 passed**.
2. Run the Codex/stream lifecycle set (`test_run_agent_codex_responses.py`, `test_streaming.py`, `test_interrupt_propagation.py`, `test_openai_client_lifecycle.py`, and `test_codex_xai_oauth_recovery.py`) — **133 passed**; the three remaining `test_streaming.py` failures are the clean-upstream baseline caused by the isolated venv not having the optional `anthropic` package.
3. Run `ruff check agent/chat_completion_helpers.py tests/agent/test_codex_ttfb_watchdog.py` and `python -m py_compile ...` — both pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — the isolated full-suite run has unrelated optional-dependency/platform baseline failures; focused and sibling-path results are documented above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS, including a plain Desktop/backend relaunch and controlled watchdog smoke

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior remains the documented timeout path
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses Python's cross-platform connection exception hierarchy
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Controlled post-relaunch smoke covered TTFB, SSE-idle, and non-stream stale aborts. Each surfaced its descriptive timeout, an unrelated provider error remained unchanged, and the post-relaunch log sample contained 10 successful Codex calls with 0 `Broken pipe` entries.
