### PR TITLE
fix(memory): forward model kwarg through on_turn_start to memory providers

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1527,7 +1527,10 @@ def build_turn_context(
     if agent._memory_manager:
         try:
             _turn_msg = original_user_message if isinstance(original_user_message, str) else ""
-            agent._memory_manager.on_turn_start(agent._user_turn_count, _turn_msg)
+            agent._memory_manager.on_turn_start(
+                agent._user_turn_count, _turn_msg,
+                model=getattr(agent, "model", "") or "",
+            )
         except Exception:
             pass
 

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -292,6 +292,39 @@ def test_prefetch_runs_for_substantive_user_message():
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 
+# ── on_turn_start model kwarg (issue: model_id always null in memory
+# providers) ─────────────────────────────────────────────────────────────
+#
+# MemoryProvider.on_turn_start()'s docstring promises `model` as one of the
+# kwargs a provider may receive, and MemoryManager.on_turn_start() already
+# fans **kwargs through to every registered provider. But the prologue's
+# only call site never actually passed it, so every provider that records
+# model attribution (e.g. the Ragger plugin) silently got an empty string
+# for every turn. Assert the call site itself, not just the manager's
+# fan-out (which was already covered elsewhere) — the manager forwarding
+# kwargs correctly doesn't help if the prologue never supplies one.
+
+
+def test_on_turn_start_forwards_model_kwarg():
+    agent, mm = _agent_with_memory_manager()
+    _build(agent, user_message="what did we decide about the deploy pipeline?")
+    mm.on_turn_start.assert_called_once()
+    _args, kwargs = mm.on_turn_start.call_args
+    assert kwargs.get("model") == agent.model == "test/model"
+
+
+def test_on_turn_start_model_kwarg_defaults_to_empty_string_when_absent():
+    """Agents whose `model` attribute is falsy (e.g. unset during subagent
+    scaffolding) must not raise — the call site falls back to "" rather
+    than propagating None into the memory-provider contract."""
+    agent, mm = _agent_with_memory_manager()
+    agent.model = None
+    _build(agent, user_message="what did we decide about the deploy pipeline?")
+    mm.on_turn_start.assert_called_once()
+    _args, kwargs = mm.on_turn_start.call_args
+    assert kwargs.get("model") == ""
+
+
 def test_turn_start_replaces_stale_parent_history_with_compression_child():
     agent = _FakeAgent()
     stale_history = [{"role": "user", "content": "stale parent"}]


### PR DESCRIPTION
## Problem

`turn_context.py` notifies memory providers via `on_turn_start()` but never passes the live model name, even though:

- `MemoryProvider.on_turn_start()`'s docstring documents a `model=` kwarg
- `MemoryManager.on_turn_start()` already fans `**kwargs` through to every registered provider

Without this, memory providers that track which model produced each turn (e.g. external backends storing per-turn model attribution) always received an empty string. The model name is available on `agent.model` at the call site in `build_turn_context()` — it just wasn't being passed.

## Fix

Pass `model=getattr(agent, "model", "") or ""` at the `on_turn_start` call site in `build_turn_context()` (agent/turn_context.py). Falls back to `""` if `agent.model` is absent or falsy (e.g. subagent scaffolding, tests).

## Supersedes #43208

That PR was closed without landing after review feedback (hermes-sweeper, `keep_open salvageability=high`) — its regression test called `MemoryManager.on_turn_start()` directly, which doesn't exercise the actual call site in `build_turn_context()` that was missing the kwarg. This PR adds tests against `build_turn_context()` itself using the existing `_FakeAgent`/`_build` harness already in `tests/agent/test_turn_context.py`.

## Tests

- `test_on_turn_start_forwards_model_kwarg` — asserts `build_turn_context()` calls `on_turn_start(..., model=agent.model)`
- `test_on_turn_start_model_kwarg_defaults_to_empty_string_when_absent` — asserts a falsy `agent.model` degrades to `""` rather than raising or passing `None`

```
22 passed in tests/agent/test_turn_context.py
74 passed in tests/agent/test_memory_provider.py + test_memory_async_sync.py
```

## Impact

No behaviour change for providers that don't use the `model` kwarg (the base class `on_turn_start` is a no-op). Providers that opt in (e.g. the Ragger plugin, which stores `model_id`/`turn_model_id` per turn) now get the data the interface already promised them.