### PR TITLE
feat(desktop): add a `thread.tail` contribution area at the foot of the transcript

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread-tail-slot.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-tail-slot.test.tsx
@@ -1,0 +1,56 @@
+/**
+ * The `thread.tail` slot mounts EVERY contributor and lets each decline —
+ * the same contract as `chat.empty`, because ownership of a session's tail is
+ * only known once each plugin has loaded its own data.
+ */
+
+import { render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { registry } from '@/contrib'
+import { THREAD_TAIL_AREA, type ThreadTailContribution } from '@/lib/thread-tail'
+
+import { ThreadTailSlot } from './thread-tail-slot'
+
+const disposers: (() => void)[] = []
+
+function contribute(id: string, render: ThreadTailContribution['render']) {
+  disposers.push(registry.register({ area: THREAD_TAIL_AREA, data: { render }, id }))
+}
+
+afterEach(() => {
+  for (const dispose of disposers.splice(0)) {
+    dispose()
+  }
+})
+
+describe('the transcript tail asks every contributor', () => {
+  it('renders the owner even when an earlier contributor declined', () => {
+    contribute('declines', () => null)
+    contribute('owns', ({ sessionId }) => <span data-testid="owner">tail of {sessionId}</span>)
+
+    render(<ThreadTailSlot contributions={registry.getArea(THREAD_TAIL_AREA)} sessionId="s-1" />)
+
+    expect(screen.getByTestId('owner').textContent).toBe('tail of s-1')
+    expect(screen.queryByText(/declines/)).toBeNull()
+  })
+
+  it('renders nothing for a contribution without a render payload', () => {
+    disposers.push(registry.register({ area: THREAD_TAIL_AREA, data: {}, id: 'empty' }))
+
+    const { container } = render(<ThreadTailSlot contributions={registry.getArea(THREAD_TAIL_AREA)} sessionId="s-2" />)
+
+    expect(container.textContent).toBe('')
+  })
+
+  it('walls off a contributor that throws, without taking the slot down', () => {
+    contribute('crashes', () => {
+      throw new Error('boom')
+    })
+    contribute('fine', () => <span data-testid="fine">still here</span>)
+
+    render(<ThreadTailSlot contributions={registry.getArea(THREAD_TAIL_AREA)} sessionId="s-3" />)
+
+    expect(screen.getByTestId('fine')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/components/assistant-ui/thread-tail-slot.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread-tail-slot.tsx
@@ -1,0 +1,44 @@
+import type { FC } from 'react'
+import { useMemo } from 'react'
+
+import type { Contribution } from '@/contrib'
+import { ContribBoundary, ContribRender } from '@/contrib/react/boundary'
+import { type ThreadTailContribution, type ThreadTailProps } from '@/lib/thread-tail'
+
+/**
+ * The transcript tail's contributed slot. Mounts every registration and lets
+ * each decide whether this session is one it has something to say in — the
+ * same shape as `ChatEmptySlot`, for the same reason: ownership is per session
+ * and not known until each plugin has loaded, so first-wins would let a
+ * plugin that declines suppress the one that owns the tail.
+ */
+const ThreadTailEntry: FC<{ id: string; render: ThreadTailContribution['render']; sessionId: string }> = ({
+  id,
+  render,
+  sessionId
+}) => {
+  // Stable component identity: ContribRender mounts this AS a component, so a
+  // fresh closure per render would remount the tail on every tick.
+  const renderTail = useMemo(() => () => render({ sessionId } satisfies ThreadTailProps), [render, sessionId])
+
+  return (
+    <ContribBoundary id={id} variant="chip">
+      <ContribRender render={renderTail} />
+    </ContribBoundary>
+  )
+}
+
+export const ThreadTailSlot: FC<{ contributions: readonly Contribution[]; sessionId: string }> = ({
+  contributions,
+  sessionId
+}) => (
+  <>
+    {contributions.map(contribution => {
+      const render = (contribution.data as ThreadTailContribution | undefined)?.render
+
+      return render ? (
+        <ThreadTailEntry id={contribution.id} key={contribution.id} render={render} sessionId={sessionId} />
+      ) : null
+    })}
+  </>
+)

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -18,8 +18,10 @@ import {
 import { type GetTargetScrollTop, useStickToBottom } from 'use-stick-to-bottom'
 
 import { usePaneLifecycle, usePaneVisible } from '@/components/pane-shell/pane-visibility'
+import { useContributions } from '@/contrib'
 import { useI18n } from '@/i18n'
 import { messagePaintWeight } from '@/lib/render-weight'
+import { THREAD_TAIL_AREA } from '@/lib/thread-tail'
 import { cn } from '@/lib/utils'
 import {
   onScrollToBottomRequest,
@@ -31,6 +33,7 @@ import {
 import { isSecondaryWindow } from '@/store/windows'
 
 import { MessageRenderBoundary } from '../message-render-boundary'
+import { ThreadTailSlot } from '../thread-tail-slot'
 
 import { resolveShowEarlierAction, useTranscriptWindow } from './transcript-window'
 
@@ -395,6 +398,13 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   sessionId = null,
   sessionKey
 }) => {
+  // The contributed transcript tail (lib/thread-tail.ts). Read here rather
+  // than passed in so the transcript decides its own layout: with nothing
+  // registered every class below is exactly what it was, and the tail block is
+  // not rendered at all.
+  const tail = useContributions(THREAD_TAIL_AREA)
+  const hasTail = tail.length > 0
+
   // TWO signatures, deliberately split. The STRUCTURAL one (ids/roles/count)
   // changes only when messages are added/removed/swapped — it keys the error
   // boundaries and the row identity. The WEIGHT one (parts + character cost)
@@ -813,14 +823,21 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
         />
       )}
       <div
-        className="size-full overflow-x-hidden overflow-y-auto overscroll-contain"
+        // A flex COLUMN when a tail is present: it renders after both branches,
+        // and the empty branch is `h-full` — in a block context the tail would be
+        // laid out a full viewport below the fold, mounted and invisible. As a
+        // column the empty branch flexes down to leave the tail its own height.
+        className={cn('size-full overflow-x-hidden overflow-y-auto overscroll-contain', hasTail && 'flex flex-col')}
         data-following={isAtBottom ? 'true' : 'false'}
         data-slot="aui_thread-viewport"
         ref={scrollRef as React.RefCallback<HTMLDivElement>}
       >
         {renderEmpty ? (
           <div
-            className="mx-auto grid h-full w-full max-w-(--composer-width) grid-rows-[minmax(0,1fr)_auto] min-w-0 gap-(--conversation-turn-gap) px-6 py-8"
+            className={cn(
+              'mx-auto grid w-full max-w-(--composer-width) grid-rows-[minmax(0,1fr)_auto] min-w-0 gap-(--conversation-turn-gap) px-6 py-8',
+              hasTail ? 'min-h-0 flex-1' : 'h-full'
+            )}
             data-slot="aui_thread-content"
           >
             {emptyPlaceholder}
@@ -842,7 +859,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             )}
             {rows}
             {loadingIndicator}
-            {clampToComposer && (
+            {/* COMPOSER CLEARANCE, ONCE. The tail block below reserves a composer's
+                height of its own padding for the same reason; rendering both
+                would put a composer's worth of blank transcript between the
+                last message and the tail. Whoever is last owns the clearance. */}
+            {clampToComposer && !hasTail && (
               <div
                 aria-hidden="true"
                 className="shrink-0"
@@ -852,6 +873,19 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
             )}
           </div>
         )}
+        {/* Same column geometry as a message, so a tail sits on the transcript's
+            own left edge rather than on the viewport's. The composer floats over
+            the bottom of this viewport, so the tail needs its measured height as
+            clearance or it renders underneath the input. */}
+        {hasTail ? (
+          <div
+            className="mx-auto w-full max-w-(--composer-width) shrink-0 px-6"
+            data-slot="aui_thread-tail"
+            style={{ paddingBottom: 'calc(var(--composer-measured-height, 0px) + 0.5rem)' }}
+          >
+            <ThreadTailSlot contributions={tail} sessionId={sessionId ?? ''} />
+          </div>
+        ) : null}
       </div>
     </div>
   )

--- a/apps/desktop/src/lib/thread-tail.ts
+++ b/apps/desktop/src/lib/thread-tail.ts
@@ -1,0 +1,41 @@
+/**
+ * THREAD TAIL — the foot of the transcript as a contribution area.
+ *
+ * `chat.empty` lets a plugin own a session's blank transcript. It has no
+ * counterpart once messages exist: nothing a plugin registers can sit AFTER
+ * the last message and stay there. Anything with a life of its own in the
+ * conversation — a presence indicator that appears while the user is still
+ * typing, a "someone is reading" row that lingers after the reply landed, a
+ * per-session hint — has nowhere to live, because every other hook is scoped
+ * to one message's lifecycle and `loadingIndicator` only renders inside the
+ * populated branch.
+ *
+ * This area renders after BOTH branches (empty and populated) and reserves
+ * composer clearance for itself, so a contribution is visible above the
+ * floating composer whether the transcript has zero messages or a thousand.
+ * With no contributions registered the transcript lays out exactly as before:
+ * the slot costs nothing until a plugin claims it.
+ *
+ * Every registration is mounted and answers for itself (return `null` to
+ * decline a session), mirroring `chat.empty`: ownership is per session and is
+ * only known once each plugin has loaded its own data.
+ */
+
+import type { ReactNode } from 'react'
+
+export const THREAD_TAIL_AREA = 'thread.tail'
+
+/** Props handed to a thread-tail contribution's `render`. */
+export interface ThreadTailProps {
+  /** The live session whose transcript this tail belongs to. */
+  sessionId: string
+}
+
+/** Payload of a `thread.tail` contribution's `data`. */
+export interface ThreadTailContribution {
+  /** Renders the tail content, or returns `null` to stand down for this
+   *  session. Mounted as a component inside the contribution error boundary,
+   *  so it may subscribe to its own stores; a throw degrades to an inline
+   *  error, not a dead transcript. */
+  render: (props: ThreadTailProps) => ReactNode
+}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1646,8 +1646,6 @@ export { PROFILE_SWATCHES, profileColor, profileColorSoft } from '@/lib/profile-
  *  `ctx.socket` frame invalidating a query). Inside components keep using
  *  `useQueryClient`. */
 export { queryClient } from '@/lib/query-client'
-
-export const PANES_AREA = 'panes'
 /** Hermes' reasoning levels + their compact labels, so a plugin surfacing a
  *  thinking depth uses the same scale and spelling as the rest of the app. */
 export {
@@ -1657,13 +1655,19 @@ export {
   type ReasoningEffort,
   reasoningEffortLabel
 } from '@/lib/reasoning-effort'
-export const STATUSBAR_AREAS = { left: 'statusBar.left', right: 'statusBar.right' } as const
-export const TITLEBAR_AREAS = { center: 'titleBar.center', left: 'titleBar.left', right: 'titleBar.right' } as const
 
+export const PANES_AREA = 'panes'
 /** The app's own gateway-readiness evaluation (setup.status +
  *  setup.runtime_check, reconciled) — pass `host.request`. Don't hand-roll
  *  readiness from raw RPC shapes. */
 export { evaluateRuntimeReadiness, type RuntimeReadinessResult } from '@/lib/runtime-readiness'
+export const STATUSBAR_AREAS = { left: 'statusBar.left', right: 'statusBar.right' } as const
+export const TITLEBAR_AREAS = { center: 'titleBar.center', left: 'titleBar.left', right: 'titleBar.right' } as const
+
+/** The foot of the transcript as a contribution area: render something that
+ *  lives AFTER the last message — before the first one exists, and after the
+ *  reply has landed — for the sessions you own. Costs nothing when unclaimed. */
+export { THREAD_TAIL_AREA, type ThreadTailContribution, type ThreadTailProps } from '@/lib/thread-tail'
 /** Canonical time formatting — every surface pulls from here so timestamps read
  *  the same app-wide. For a row's AGE, bucket with `coarseElapsed` and render
  *  the compact suffixes (`t.sidebar.row.ageMin` → "52m"), which is what the


### PR DESCRIPTION
## What / why

`chat.empty` lets a plugin own a session's blank transcript. It has no counterpart once messages exist: nothing a plugin registers can sit **after** the last message and stay there. Every other hook is scoped to one message's lifecycle, and `loadingIndicator` only renders inside the populated branch.

Concrete things that have nowhere to live today: a presence row that appears while the user is still typing (before any message exists) and lingers after the reply landed; a "someone is reading" indicator; a per-session hint under the conversation.

This adds `THREAD_TAIL_AREA` (`'thread.tail'`), exported from the plugin SDK beside `CHAT_EMPTY_AREA` with the same contract:

- every registration is mounted and answers for itself: `render({ sessionId })`, return `null` to stand down
- mounted inside `ContribBoundary`, so a throwing contributor degrades to an inline chip, not a dead transcript

The transcript list reads the area itself (`useContributions`), so **with nothing registered the layout is unchanged** — same classes, no extra DOM. With a contribution present, the viewport becomes a flex column so the tail sits under both the empty and the populated branch, and the tail block takes over the composer clearance (rendering both would leave a composer's height of blank transcript between the last message and the tail).

## How to test

```ts
ctx.register({
  id: 'demo',
  area: THREAD_TAIL_AREA,
  data: { render: ({ sessionId }) => <span>tail for {sessionId}</span> }
})
```
Open any session: the span sits under the last message, above the composer, in both an empty and a populated transcript. Remove the registration: the transcript renders exactly as before.

`apps/desktop/src/components/assistant-ui/thread-tail-slot.test.tsx` (3 tests); the existing `chat-empty-slot` tests and the full `assistant-ui` suite pass; `tsc` and `eslint` clean.

## Platforms

macOS (Electron 40). Pure renderer code.

## Duplicate check

Searched open/merged PRs and issues for "thread tail contribution area", "transcript slot plugin" — none found.