### PR TITLE
fix(holographic): store the captured span, not the whole user message

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -398,6 +398,9 @@ class HolographicMemoryProvider(MemoryProvider):
             pre = pre.strip()
             return pre or None
 
+        # Each pattern captures the SPAN that carries the preference/decision,
+        # not the sentence containing it. The captured group is what gets
+        # stored — see _extracted_span() below.
         _PREF_PATTERNS = [
             re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
             re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
@@ -407,6 +410,49 @@ class HolographicMemoryProvider(MemoryProvider):
             re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
             re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
         ]
+
+        # Openers that make a match conversational rather than declarative.
+        # "I like that, ship it" and "I want you to add tests" both match
+        # _PREF_PATTERNS but state nothing durable about the user.
+        _FILLER_SPANS = re.compile(
+            r'^(?:'
+            r'that\b|this\b|it\b|these\b|those\b|'      # "I like that"
+            r'you\s+to\b|him\b|her\b|them\b|us\b'       # "I want you to ..."
+            r')',
+            re.IGNORECASE,
+        )
+
+        def _extracted_span(match) -> str | None:
+            """Return the storable fact span from a pattern match, or None.
+
+            Storing ``content[:400]`` — the whole user message — was the
+            defect: fact_store filled with conversational turns that merely
+            contained "I like" or "we decided", and holographic recall then
+            surfaced those chat fragments as learned preferences (#22907).
+
+            The regexes already capture the informative remainder; use it, and
+            drop matches whose span is pronoun-led filler or a question, since
+            neither states anything durable.
+            """
+            span = (match.group(1) or "").strip()
+
+            # A trailing question is a request, not a statement of preference:
+            # "I want you to add tests for the new endpoint?" / "can we ...?"
+            if span.endswith("?"):
+                return None
+
+            # Keep only the first sentence; the rest is narrative context.
+            span = re.split(r'(?<=[.!])\s+', span, maxsplit=1)[0].strip()
+            span = span.rstrip(".,;:!").strip()
+
+            # "we decided to use X" and "I prefer using X" both carry a leading
+            # verb that belongs to the matched phrase, not to the fact.
+            span = re.sub(r'^(?:to\s+)?(?:use|using|go\s+with|adopt)\s+', '', span, flags=re.IGNORECASE).strip()
+
+            if len(span) < 8 or _FILLER_SPANS.match(span):
+                return None
+
+            return span[:400]
 
         extracted = 0
         for msg in messages:
@@ -430,21 +476,27 @@ class HolographicMemoryProvider(MemoryProvider):
                 continue
 
             for pattern in _PREF_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="user_pref")
-                        extracted += 1
-                    except Exception:
-                        pass
+                match = pattern.search(content)
+                if match:
+                    span = _extracted_span(match)
+                    if span:
+                        try:
+                            self._store.add_fact(span, category="user_pref")
+                            extracted += 1
+                        except Exception:
+                            pass
                     break
 
             for pattern in _DECISION_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="project")
-                        extracted += 1
-                    except Exception:
-                        pass
+                match = pattern.search(content)
+                if match:
+                    span = _extracted_span(match)
+                    if span:
+                        try:
+                            self._store.add_fact(span, category="project")
+                            extracted += 1
+                        except Exception:
+                            pass
                     break
 
         if extracted:

--- a/tests/plugins/memory/test_holographic_auto_extract.py
+++ b/tests/plugins/memory/test_holographic_auto_extract.py
@@ -137,3 +137,67 @@ def test_helper_detects_prefix_metadata_and_merged_forms():
     )
     assert not is_compaction_summary_message(_user(DECISION_MSG))
     assert not is_compaction_summary_message(_user(""))
+
+
+# ---------------------------------------------------------------------------
+# Defect 3 (#22907) — whole user messages stored verbatim instead of the span
+# ---------------------------------------------------------------------------
+
+
+def test_only_the_captured_span_is_stored_not_the_whole_message(tmp_path):
+    """The reported defect: add_fact received ``content[:400]`` — the entire
+    user turn — so fact_store filled with conversational text rather than
+    facts, and recall surfaced those fragments as learned preferences."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end(
+        [_user("Since we're rewriting it anyway, I prefer tabs over spaces for indentation")]
+    )
+    facts = _fact_contents(provider)
+    assert facts == ["tabs over spaces for indentation"]
+    provider.shutdown()
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "I like that, sounds good",
+        "I like the approach, would you set it up on the staging server?",
+        "I want you to add tests for the new endpoint",
+        "I need it by Friday",
+        "we decided to go with that",
+    ],
+)
+def test_conversational_filler_is_not_stored(tmp_path, message):
+    """Every one of these matches a pattern but states nothing durable —
+    pronoun-led spans, second-person requests, and questions."""
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user(message)])
+    assert _fact_contents(provider) == []
+    provider.shutdown()
+
+
+def test_trailing_narrative_is_trimmed_to_the_first_sentence(tmp_path):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end(
+        [_user("I use PostgreSQL for everything. Anyway, back to the deploy question.")]
+    )
+    assert _fact_contents(provider) == ["PostgreSQL for everything"]
+    provider.shutdown()
+
+
+def test_decision_span_is_stored_without_the_surrounding_turn(tmp_path):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end(
+        [_user("After weighing the options we decided to use Redis for the queue backend")]
+    )
+    assert _fact_contents(provider) == ["Redis for the queue backend"]
+    provider.shutdown()
+
+
+def test_stored_span_never_exceeds_the_length_cap(tmp_path):
+    provider = _make_provider(tmp_path, auto_extract=True)
+    provider.on_session_end([_user("I prefer " + "x" * 900)])
+    facts = _fact_contents(provider)
+    assert len(facts) == 1
+    assert len(facts[0]) <= 400
+    provider.shutdown()


### PR DESCRIPTION
Fixes #22907.

## The defect

`_auto_extract_facts` matched user messages against the preference/decision regexes and then called:

```python
self._store.add_fact(content[:400], category="user_pref")
```

`content` is the **whole user message**. The `(.+)` capture group each pattern defines was computed and thrown away, so there was no extraction step — pattern match, then raw dump.

`fact_store` filled with conversational turns rather than facts, and holographic recall surfaced those fragments in later sessions as learned preferences. The patterns are permissive enough that ordinary replies qualify: `I like that, sounds good` matches `\bI\s+like\s+(.+)`, so any back-and-forth turn was a candidate.

## The fix

A `_extracted_span()` helper shared by both pattern families:

- **uses `match.group(1)`** rather than `content[:400]` — the issue's option (1)
- **drops spans ending in `?`** — "I want you to add tests …?" is a request, not a preference
- **drops pronoun-led spans** (`that`, `this`, `it`, `you to`, `them`, …) — the false-positive class from the issue, the issue's option (2)
- **keeps only the first sentence**, so trailing narrative isn't stored
- **strips a leading `to use` / `using` / `go with` / `adopt`**, so "we decided to use Redis for the queue" stores the thing, not the verb
- **requires ≥ 8 chars** after trimming

I stopped short of option (3), the LLM summarisation pass. It's the better feature but it's a design decision about spending a model call on every session end, and that belongs to a maintainer rather than a bug fix.

## Behaviour on the issue's own examples

Running the reporter's message set through the real provider:

```
INPUT MESSAGES: 6
FACTS STORED:   3
   -> 'check git status before committing'
   -> 'tabs over spaces for indentation'
   -> 'Redis for the queue backend'
```

| input | before | after |
|---|---|---|
| `I like that, sounds good` | stored verbatim | dropped |
| `I like the approach, would you set it up on the staging server?` | stored verbatim | dropped |
| `I want you to add tests for the new endpoint` | stored verbatim | dropped |
| `I always check git status before committing` | stored verbatim | `check git status before committing` |
| `I prefer tabs over spaces for indentation` | stored verbatim | `tabs over spaces for indentation` |
| `we decided to use Redis for the queue backend` | stored verbatim | `Redis for the queue backend` |

## Tests

9 added to the existing #57682 regression file — span extraction, each filler class named in the issue, first-sentence trimming, and the 400-char cap. They assert the invariant (*only the informative span is stored*) rather than freezing a string, per the contribution rubric.

```
22 passed
```

The 5 pre-existing #57682/#57690 regression tests are untouched and still green.

The 7 failures elsewhere in `tests/plugins/memory/` (hindsight, mem0) are **pre-existing on main** — verified by stashing this branch and re-running:

```
7 failed, 77 passed   # with this change stashed
7 failed, 385 passed  # with it applied (full memory suite)
```

## Scope

Plugin-local. No core files, no new config, no new tools, no schema change. Default remains `auto_extract: false`, so this only affects users who have opted in — for whom the current behaviour is actively harmful, since contamination persists across sessions once written.

---

Found this while enabling `auto_extract` on my own install, reading the issue, and turning it straight back off. The store is small enough that I could verify no contamination had landed; a user who enabled it earlier would need the SQL cleanup from the issue's workaround section.
