### PR TITLE
fix(agent): overflow recovery no longer resends a still-oversized request (salvage #100614)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1624,6 +1624,41 @@ def _compression_deferred_result(
     }
 
 
+def _provider_overflow_exhausted_result(
+    agent,
+    messages: List[Dict],
+    conversation_history,
+    api_call_count: int,
+    request_pressure_tokens: int,
+    max_compression_attempts: int,
+) -> Dict[str, Any]:
+    """Fail closed when a rebuilt request is still too large after recovery."""
+    agent._flush_status_buffer()
+    logger.error(
+        "%sContext compression failed after %d attempts; rebuilt request "
+        "remains over threshold at ~%s tokens.",
+        agent.log_prefix,
+        max_compression_attempts,
+        f"{request_pressure_tokens:,}",
+    )
+    agent._persist_session(messages, conversation_history)
+    final_response = (
+        "Context length exceeded: compression could not reduce the rebuilt "
+        "request below the safe threshold."
+    )
+    return {
+        "final_response": final_response,
+        "messages": messages,
+        "completed": False,
+        "api_calls": api_call_count,
+        "error": final_response,
+        "partial": True,
+        "failed": True,
+        "compression_exhausted": True,
+        "turn_exit_reason": "context_compression_exhausted",
+    }
+
+
 def _rewrite_system_content_blocks(system_message: dict, effective: str) -> bool:
     """Rewrite a cache-decorated system message in place, keeping its blocks.
 
@@ -2142,6 +2177,13 @@ def run_conversation(
     max_compression_attempts = getattr(agent, "max_compression_attempts", 3)
     _last_preflight_pressure: Optional[int] = None
     _preflight_compression_blocked = _ctx.preflight_compression_blocked
+    # A provider overflow is stronger evidence than the rough-estimate
+    # calibration that normally defers preflight immediately after compaction.
+    # Keep recovery armed until the rebuilt, complete request is below the
+    # configured compression threshold. Without this handoff, a compaction
+    # that drops rows but grows the actual prompt can be sent straight back to
+    # the provider while awaiting_real_usage_after_compression is true.
+    _provider_overflow_recovery_pending = False
     # Armed when a compression host-timeout terminates the turn (#98722,
     # salvaged from #98741); finalize below reuses the gateway's existing
     # context-recovery contract (error/partial/compression_exhausted).
@@ -2866,6 +2908,21 @@ def run_conversation(
         _preflight_threshold = int(
             getattr(_compressor, "threshold_tokens", 0) or 0
         )
+        _provider_overflow_preflight = (
+            _provider_overflow_recovery_pending
+            and (
+                _preflight_threshold <= 0
+                or request_pressure_tokens >= _preflight_threshold
+            )
+        )
+        if (
+            _provider_overflow_recovery_pending
+            and not _provider_overflow_preflight
+        ):
+            # The outer-loop rebuild includes the active system prompt,
+            # request-only injections, and tool schemas. Once that complete
+            # request has real output runway again, the provider may be tried.
+            _provider_overflow_recovery_pending = False
         # A previous mid-turn preflight pass deliberately continued the loop so
         # API-only context and all sanitization could be rebuilt. Compare that
         # fully assembled request with the fully assembled request that caused
@@ -2905,8 +2962,14 @@ def run_conversation(
             and not _review_fork_first_request_pending(agent)
             and len(messages) > 1
             and compression_attempts < max_compression_attempts
-            and not _preflight_compression_blocked
-            and not _defer_preflight(request_pressure_tokens)
+            and (
+                not _preflight_compression_blocked
+                or _provider_overflow_preflight
+            )
+            and (
+                not _defer_preflight(request_pressure_tokens)
+                or _provider_overflow_preflight
+            )
             and not _compression_cooldown
             and _compressor.should_compress(request_pressure_tokens)
         ):
@@ -3073,6 +3136,34 @@ def run_conversation(
                     _turn_exit_reason = "compaction_handoff_not_actionable"
                     break
                 continue
+        elif _provider_overflow_preflight and _compression_cooldown:
+            # The provider already proved this request cannot fit, while the
+            # compressor is temporarily unavailable. Do not send the known-
+            # oversized request again; let the next user turn retry after the
+            # cooldown instead of turning this into compression exhaustion.
+            agent._persist_session(messages, conversation_history)
+            return _compression_deferred_result(
+                agent,
+                messages,
+                api_call_count,
+                reason="transient_block",
+            )
+        elif (
+            _provider_overflow_preflight
+            and compression_attempts >= max_compression_attempts
+        ):
+            # Every bounded recovery pass has been consumed and the rebuilt
+            # request is still over threshold. Fail closed before another
+            # provider call; llama.cpp can silently truncate an oversized
+            # retry instead of returning a second actionable overflow error.
+            return _provider_overflow_exhausted_result(
+                agent,
+                messages,
+                conversation_history,
+                api_call_count,
+                request_pressure_tokens,
+                max_compression_attempts,
+            )
         elif (
             agent.compression_enabled
             and len(messages) > 1
@@ -3126,6 +3217,20 @@ def run_conversation(
                 )
                 if callable(_warn_fn):
                     _warn_fn(request_pressure_tokens, _ctx_len)
+
+        if _provider_overflow_preflight:
+            # Any other gate that prevented the forced preflight (for example,
+            # an uncompressible one-message request) must also fail closed.
+            # Falling through would send a request that the provider already
+            # proved cannot fit.
+            return _provider_overflow_exhausted_result(
+                agent,
+                messages,
+                conversation_history,
+                api_call_count,
+                request_pressure_tokens,
+                max_compression_attempts,
+            )
 
         # Thinking spinner for quiet mode (animated during API call)
         thinking_spinner = None
@@ -6407,6 +6512,11 @@ def run_conversation(
                         elif new_tokens > 0 and new_tokens < original_tokens * 0.95:
                             agent._buffer_status(COMPRESSION_RETRY_TOKENS_STATUS_TEMPLATE.format(before=original_tokens, after=new_tokens))
                         time.sleep(2)  # Brief pause between compression retries
+                        # Rebuild the complete request before the next provider
+                        # call and force normal preflight to honor it. Message
+                        # count alone is not proof that system/tool-inclusive
+                        # token pressure fell.
+                        _provider_overflow_recovery_pending = True
                         _retry.restart_with_compressed_messages = True
                         break
                     else:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5825,6 +5825,12 @@ def run_conversation(
                                 )
                             )
                             time.sleep(2)
+                            # Same class as the generic overflow handler below:
+                            # the provider proved the request does not fit the
+                            # (now-reduced) window, and row count alone is not
+                            # proof the rebuilt request does. Recheck the
+                            # complete request before the next provider call.
+                            _provider_overflow_recovery_pending = True
                             _retry.restart_with_compressed_messages = True
                             break
                     # Fall through to normal error handling if compression

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -1051,6 +1051,84 @@ class TestPreflightCompression:
         assert mock_compress.call_count == 2
         assert agent.client.chat.completions.create.call_count == 1
 
+    def test_long_context_tier_recovery_rechecks_complete_request_before_retry(self, agent):
+        """The Anthropic long-context 429 handler is the same recovery class.
+
+        It compacts and restarts on row count alone, exactly like the generic
+        overflow handler. The rebuilt request must be measured against the
+        (now-reduced) window before the provider is retried, so a compaction
+        that drops rows but stays oversized fails closed instead of being
+        sent again.
+        """
+        agent.compression_enabled = True
+        agent.max_compression_attempts = 2
+        agent.context_compressor.context_length = 1_000_000
+        agent.context_compressor.threshold_tokens = 500_000
+
+        tier_error = Exception(
+            "Extra usage is required for long context requests."
+        )
+        tier_error.status_code = 429
+        agent.client.chat.completions.create.side_effect = [tier_error]
+
+        history = [
+            {"role": "user", "content": "earlier question"},
+            {"role": "assistant", "content": "earlier answer"},
+        ]
+        compress_calls = 0
+
+        def _request_pressure(*_args, **_kwargs):
+            if agent.client.chat.completions.create.call_count == 0:
+                return 30_000
+            return 250_000
+
+        def _compress(_messages, *_args, **_kwargs):
+            nonlocal compress_calls
+            compress_calls += 1
+            return (
+                [
+                    {"role": "user", "content": f"summary {compress_calls}"},
+                    {"role": "assistant", "content": "summary acknowledged"},
+                ],
+                "rebuilt prompt remains oversized",
+            )
+
+        def _update_model(*, context_length, **_kwargs):
+            agent.context_compressor.context_length = context_length
+            agent.context_compressor.threshold_tokens = context_length // 2
+
+        with (
+            patch(
+                "agent.turn_context.estimate_request_tokens_rough",
+                return_value=30_000,
+            ),
+            patch(
+                "agent.conversation_loop._midturn_request_pressure_tokens",
+                side_effect=_request_pressure,
+            ),
+            patch.object(
+                agent.context_compressor,
+                "should_defer_preflight_to_real_usage",
+                return_value=True,
+            ),
+            patch.object(
+                agent.context_compressor, "update_model", side_effect=_update_model
+            ),
+            patch.object(agent, "_compress_context", side_effect=_compress) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=history,
+            )
+
+        assert result["completed"] is False
+        assert result["compression_exhausted"] is True
+        assert mock_compress.call_count == 2
+        assert agent.client.chat.completions.create.call_count == 1
+
 
     def test_interrupt_before_first_provider_call_restores_preflight_display_seed(self, agent):
         """Interrupted turns must not keep a speculative preflight display seed.

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -989,6 +989,7 @@ class TestPreflightCompression:
         bounded preflight pass first.
         """
         agent.compression_enabled = True
+        agent.max_compression_attempts = 2
         agent.context_compressor.context_length = 65_536
         agent.context_compressor.threshold_tokens = 34_078
 
@@ -997,39 +998,28 @@ class TestPreflightCompression:
             "(65536 tokens)"
         )
         overflow.status_code = 400
-        recovered = _mock_response(
-            content="Recovered after complete-request recheck",
-            finish_reason="stop",
-        )
-        agent.client.chat.completions.create.side_effect = [overflow, recovered]
+        agent.client.chat.completions.create.side_effect = [overflow]
 
         history = [
             {"role": "user", "content": "earlier question"},
             {"role": "assistant", "content": "earlier answer"},
         ]
-        pressure_readings = iter((30_000, 70_000, 28_000, 28_000))
+        compress_calls = 0
 
         def _request_pressure(*_args, **_kwargs):
-            return next(pressure_readings, 28_000)
-
-        compress_calls = 0
+            if agent.client.chat.completions.create.call_count == 0:
+                return 30_000
+            return 70_000
 
         def _compress(_messages, *_args, **_kwargs):
             nonlocal compress_calls
             compress_calls += 1
-            if compress_calls == 1:
-                # Fewer rows, but a larger rebuilt system/tool-inclusive
-                # request. This used to be sent directly back to llama.cpp.
-                return (
-                    [
-                        {"role": "user", "content": "large summary"},
-                        {"role": "user", "content": "continue"},
-                    ],
-                    "larger rebuilt prompt",
-                )
             return (
-                [{"role": "user", "content": "small summary"}],
-                "smaller rebuilt prompt",
+                [
+                    {"role": "user", "content": f"summary {compress_calls}"},
+                    {"role": "assistant", "content": "summary acknowledged"},
+                ],
+                "rebuilt prompt remains oversized",
             )
 
         with (
@@ -1056,10 +1046,10 @@ class TestPreflightCompression:
                 conversation_history=history,
             )
 
-        assert result["completed"] is True
-        assert result["final_response"] == "Recovered after complete-request recheck"
+        assert result["completed"] is False
+        assert result["compression_exhausted"] is True
         assert mock_compress.call_count == 2
-        assert agent.client.chat.completions.create.call_count == 2
+        assert agent.client.chat.completions.create.call_count == 1
 
 
     def test_interrupt_before_first_provider_call_restores_preflight_display_seed(self, agent):

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -979,6 +979,88 @@ class TestPreflightCompression:
         assert result["final_response"] == "Recovered after overflow"
         assert mock_compress.call_count == 2
 
+    def test_provider_overflow_rechecks_complete_request_before_retry(self, agent):
+        """Provider-proven overflow bypasses post-compaction estimate deferral.
+
+        The first recovery pass drops message rows but rebuilds a larger
+        request. The compressor then awaits real usage, so the old path sent
+        that oversized request back to llama.cpp, which may silently truncate
+        instead of returning another overflow error. Recovery must run another
+        bounded preflight pass first.
+        """
+        agent.compression_enabled = True
+        agent.context_compressor.context_length = 65_536
+        agent.context_compressor.threshold_tokens = 34_078
+
+        overflow = Exception(
+            "request (70000 tokens) exceeds the available context size "
+            "(65536 tokens)"
+        )
+        overflow.status_code = 400
+        recovered = _mock_response(
+            content="Recovered after complete-request recheck",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [overflow, recovered]
+
+        history = [
+            {"role": "user", "content": "earlier question"},
+            {"role": "assistant", "content": "earlier answer"},
+        ]
+        pressure_readings = iter((30_000, 70_000, 28_000, 28_000))
+
+        def _request_pressure(*_args, **_kwargs):
+            return next(pressure_readings, 28_000)
+
+        compress_calls = 0
+
+        def _compress(_messages, *_args, **_kwargs):
+            nonlocal compress_calls
+            compress_calls += 1
+            if compress_calls == 1:
+                # Fewer rows, but a larger rebuilt system/tool-inclusive
+                # request. This used to be sent directly back to llama.cpp.
+                return (
+                    [
+                        {"role": "user", "content": "large summary"},
+                        {"role": "user", "content": "continue"},
+                    ],
+                    "larger rebuilt prompt",
+                )
+            return (
+                [{"role": "user", "content": "small summary"}],
+                "smaller rebuilt prompt",
+            )
+
+        with (
+            patch(
+                "agent.turn_context.estimate_request_tokens_rough",
+                return_value=30_000,
+            ),
+            patch(
+                "agent.conversation_loop._midturn_request_pressure_tokens",
+                side_effect=_request_pressure,
+            ),
+            patch.object(
+                agent.context_compressor,
+                "should_defer_preflight_to_real_usage",
+                return_value=True,
+            ),
+            patch.object(agent, "_compress_context", side_effect=_compress) as mock_compress,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation(
+                "continue",
+                conversation_history=history,
+            )
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Recovered after complete-request recheck"
+        assert mock_compress.call_count == 2
+        assert agent.client.chat.completions.create.call_count == 2
+
 
     def test_interrupt_before_first_provider_call_restores_preflight_display_seed(self, agent):
         """Interrupted turns must not keep a speculative preflight display seed.

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -319,6 +319,8 @@ If this happens on the first long conversation, Hermes may have the wrong contex
 
 Look at the CLI startup line — it shows the detected context length (e.g., `📊 Context limit: 128000 tokens`). You can also check with `/usage` during a session.
 
+**Local servers (llama.cpp, Ollama) that go silent instead of erroring:** when a provider rejects a request as too large, Hermes compacts the conversation and rebuilds the request. Hermes re-measures the *complete* rebuilt request (system prompt + tool schemas + messages) before retrying, and runs further bounded compaction passes if it is still over the threshold. If the request still cannot fit, the turn ends with `Context length exceeded: compression could not reduce the rebuilt request below the safe threshold` rather than sending an oversized request that llama.cpp would silently truncate (`stop processing: n_tokens = 65535, truncated = 1` in the server log). If you hit that message, the fix is almost always the configured `context_length` above: make it match the server's actual `-c` / `--ctx-size`.
+
 To fix context detection, set it explicitly:
 
 ```yaml


### PR DESCRIPTION
## Summary

Overflow recovery no longer sends a still-oversized request back to the provider after a compaction that dropped rows but left the rebuilt request over the limit (salvage of #100614 by @helix4u, widened to the long-context 429 sibling).

Root cause: the overflow handler treated "fewer message rows" as enough progress to retry, and the pre-API preflight defers itself right after a compaction while waiting for real usage (`awaiting_real_usage_after_compression`). Together they let a request whose system prompt + tool schemas + summary still exceeded the window go straight back out. llama.cpp does not 400 on that; it silently truncates at `n_ctx` (`stop processing: n_tokens = 65535, truncated = 1`), so Bot Mode sessions went silent. Reported on Discord by JapanFreak, diagnosed by @helix4u.

## Changes

- `agent/conversation_loop.py`
  - `_provider_overflow_recovery_pending` is armed when an overflow handler restarts with compressed messages. On the next rebuild the complete request is measured; if still at/over threshold the flag forces preflight compression past the post-compaction deferral and the insufficient-progress block. Compressor cooldown → soft defer; attempts exhausted or uncompressible request → fail closed (`compression_exhausted`, `turn_exit_reason=context_compression_exhausted`) instead of another provider call. (@helix4u)
  - Same flag armed at the Anthropic long-context-tier 429 handler, which restarted on row count alone with the same shape. 413 (byte-scored) and output-cap (max_tokens) handlers use a different yardstick and are untouched. (follow-up)
- `tests/run_agent/test_413_compression.py`: regression for the generic overflow path (@helix4u) and a sibling for the 429 tier path. Both fail without their respective fix (KeyError `compression_exhausted` on main; sabotage run of the 429 arm fails the sibling).
- `website/docs/reference/faq.md`: note under "Context length exceeded" for servers that truncate instead of erroring.

## Validation

| | origin/main | this branch |
|---|---|---|
| Live A/B (mock llama.cpp: one overflow 400, then accept; 65,536 window; ~50k-token system prompt) | compaction dropped rows, oversized request sent again, server "accepted" it (the silent-truncation path) | 1 provider call, second compaction pass, then `context_compression_exhausted`; no oversized retry sent |
| `test_413_compression.py` (29) + overflow/preflight/429/budget files | new tests fail | 48/48 pass |
| ruff | | clean |

Live repro: `/tmp/overflow_ab.py` harness (in-process OpenAI-compatible mock, isolated `HERMES_HOME`, real `AIAgent.run_conversation`) run against an `origin/main` worktree and this branch.

Closes #100614 (salvaged with authorship preserved).

## Infographic

![Oversized retry, closed](https://v3b.fal.media/files/b/0aa8bc26/PrXaL9xHa9hVg6iIHhshQ_fj8MGbFX.png)
