### PR TITLE
fix(local-runtime): use Vulkan builds on AMD and Intel GPUs

### DIFF
--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
 import subprocess
 import time
 from pathlib import Path
@@ -27,24 +28,63 @@ logger = logging.getLogger(__name__)
 _SUPERVISOR = None  # process-wide singleton; one router per Hermes process
 
 
+def _vulkaninfo_path() -> str | None:
+    """Resolve vulkaninfo without assuming an interactive PATH."""
+    found = shutil.which("vulkaninfo")
+    if found is None and os.name == "nt":
+        candidate = (
+            Path(os.environ.get("SystemRoot", r"C:\Windows"))
+            / "System32" / "vulkaninfo.exe"
+        )
+        if candidate.exists():
+            found = str(candidate)
+    return found
+
+
+def _vulkan_gpu_vendor(summary: str) -> str | None:
+    """Recognized non-NVIDIA vendor from vulkaninfo's deviceName rows."""
+    for line in summary.splitlines():
+        if "devicename" not in line.lower():
+            continue
+        name = line.lower()
+        if "amd" in name or "radeon" in name:
+            return "amd"
+        if "intel" in name:
+            return "intel"
+    return None
+
+
 def _detect_gpu_vendor() -> str | None:
-    """Best-effort GPU vendor for backend selection. NVIDIA via nvidia-smi
-    (resolved by the hardware probe's PATH-independent ladder — a stripped
-    service PATH must not demote an NVIDIA box to vulkan/cpu); anything
-    else defers to select_backend's fallback ladder."""
+    """Best-effort GPU vendor for backend selection.
+
+    NVIDIA keeps priority via the PATH-independent nvidia-smi ladder. A
+    successful vulkaninfo device query then proves that an AMD or Intel GPU
+    can use the Vulkan build rather than merely inferring support from its
+    adapter name.
+    """
     from hermes_cli.local_runtime.hardware import _nvidia_smi_path
 
     smi = _nvidia_smi_path()
-    if smi is None:
-        return None
-    try:
-        out = subprocess.run(
-            [smi, "--query-gpu=name", "--format=csv,noheader"],
-            capture_output=True, text=True, timeout=10)
-        if out.returncode == 0 and out.stdout.strip():
-            return "nvidia " + out.stdout.strip().splitlines()[0]
-    except (OSError, subprocess.TimeoutExpired):
-        pass
+    if smi is not None:
+        try:
+            out = subprocess.run(
+                [smi, "--query-gpu=name", "--format=csv,noheader"],
+                capture_output=True, text=True, timeout=10)
+            if out.returncode == 0 and out.stdout.strip():
+                return "nvidia " + out.stdout.strip().splitlines()[0]
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    vulkaninfo = _vulkaninfo_path()
+    if vulkaninfo is not None:
+        try:
+            out = subprocess.run(
+                [vulkaninfo, "--summary"], capture_output=True, text=True,
+                timeout=10)
+            if out.returncode == 0:
+                return _vulkan_gpu_vendor(out.stdout + "\n" + out.stderr)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
     return None
 
 

--- a/tests/hermes_cli/test_local_runtime.py
+++ b/tests/hermes_cli/test_local_runtime.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 import threading
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -226,6 +227,31 @@ def test_install_dir_is_profile_scoped(tmp_path, monkeypatch):
 ])
 def test_backend_selection(vendor, os_name, expected):
     assert select_backend(vendor, os_name=os_name) == expected
+
+
+@pytest.mark.parametrize("device_name,expected", [
+    ("AMD Radeon RX 580 Series", "amd"),
+    ("Intel(R) Arc(TM) A770 Graphics", "intel"),
+])
+def test_gpu_vendor_detection_uses_vulkan_devices(
+        monkeypatch, device_name, expected):
+    """A working Vulkan device must reach the existing Vulkan backend
+    branch even when the host has no nvidia-smi installation."""
+    from hermes_cli.local_runtime import bootstrap, hardware
+
+    monkeypatch.setattr(hardware, "_nvidia_smi_path", lambda: None)
+    monkeypatch.setattr(bootstrap, "_vulkaninfo_path", lambda: "vulkaninfo")
+
+    def _run(argv, **kwargs):
+        assert argv == ["vulkaninfo", "--summary"]
+        return subprocess.CompletedProcess(
+            argv, 0, stdout=f"deviceName = {device_name}\n", stderr="")
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", _run)
+
+    vendor = bootstrap._detect_gpu_vendor()
+    assert vendor == expected
+    assert select_backend(vendor, os_name="win") == "vulkan"
 
 
 def test_sha256_mismatch_rejects(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

AMD and Intel GPU users can now receive the Vulkan llama.cpp runtime instead of silently installing the CPU build. The auto-selection probe keeps NVIDIA as the first choice, then uses a successful `vulkaninfo --summary` device query to identify Vulkan-capable AMD and Intel devices.

### Symptom

On a Windows machine with an AMD or Intel GPU but no NVIDIA device, automatic local-runtime installation selected `cpu` even when the installed driver exposed a working Vulkan device.

### Impact

Affected users ran local inference on the CPU rather than the available GPU. The exact affected population and performance delta are unmeasured.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/bootstrap.py:30` / `_detect_gpu_vendor()` when `_nvidia_smi_path()` returns `None`.

**Causal chain:**
1. Automatic runtime installation asks `_detect_gpu_vendor()` for the host GPU vendor.
2. The function immediately returned `None` whenever `nvidia-smi` was absent, without probing non-NVIDIA devices.
3. `select_backend(None)` selected `cpu`, so installation downloaded the CPU asset instead of the Vulkan asset.

**Why it is wrong:** The vendor detector implemented only the NVIDIA half of the backend-selection contract even though `select_backend()` already maps AMD, Radeon, Intel, and Arc devices to Vulkan.

**Working sibling / contrast:** Explicit `local_runtime.backend: vulkan` already resolves and runs the Vulkan asset. The broken path was only automatic backend selection.

**Ruled out:** Asset resolution is not the failure point; the existing Windows Vulkan resolver produces the correct x64 asset, and the reporter confirmed that manually selecting that asset works.

### Fix

- Resolve `vulkaninfo` from PATH or the Windows System32 location so service sessions with a stripped PATH still work.
- After the NVIDIA probe, run `vulkaninfo --summary` and parse only `deviceName` rows for AMD/Radeon or Intel devices.
- Keep probe failures and unrecognized devices on the existing safe CPU fallback.
- Add a regression test that covers AMD Radeon RX 580 and Intel Arc device output through the complete vendor-to-backend decision.

## Related Issue

Closes #100740

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/bootstrap.py` - add a PATH-independent Vulkan capability probe for AMD and Intel GPUs.
- `tests/hermes_cli/test_local_runtime.py` - cover AMD and Intel auto-selection from Vulkan device summaries.

## How to Test

1. On an AMD or Intel Windows host with a working Vulkan driver, leave `local_runtime.backend` set to `auto`.
2. Trigger local-runtime installation and verify that the selected install path ends in `vulkan`, not `cpu`.
3. Run the automated regression suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_local_runtime.py tests/hermes_cli/test_local_runtime_updates.py -q
```

Local result: 61 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A; behavior and probe contracts are documented in code.
- [x] `cli-config.yaml.example` update: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A; no architecture or workflow changed.
- [x] I've considered cross-platform impact; non-Windows hosts keep PATH lookup and all probe failures preserve the CPU fallback.
- [x] Tool descriptions/schemas update: N/A; no model tool changed.
