### PR TITLE
fix(codex_responses): skip empty assistant stub when reasoning turn has tool calls

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -486,8 +486,17 @@ def _chat_messages_to_responses_input(
         message_items = _replay_message_items(msg, is_github_responses=is_github_responses)
         emit(message_items, msg)
         if not message_items:
-            # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback.
-            fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
+            # Every reasoning item needs a following item (else missing_following_item), hence the "" fallback —
+            # but only when nothing else follows. The function_call items already satisfy the rule, and translating
+            # gateways turn an empty assistant message into an empty text block that Anthropic/Bedrock reject
+            # (HTTP 400 "text content blocks must be non-empty"). Trigger was any Claude turn that thinks, writes
+            # no prose, and calls a tool. Same filter as _replay_tool_call_items so the two agree on "has calls".
+            has_tool_calls = any(
+                isinstance(tc, dict) and _nonblank((tc.get("function") or {}).get("name"))
+                for tc in _as_list(msg.get("tool_calls"))
+            )
+            needs_stub = bool(reasoning_items) and not has_tool_calls
+            fallback = content_parts or (content_text if content_text.strip() else "" if needs_stub else None)
             if fallback is not None:
                 emit([{"role": "assistant", "content": fallback}], msg)
         emit(_replay_tool_call_items(msg, start_index=len(items)), msg)

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2222,6 +2222,38 @@ def test_chat_messages_to_responses_input_reasoning_only_has_following_item(monk
     assert following.get("role") == "assistant"
 
 
+def test_chat_messages_to_responses_input_reasoning_with_tool_calls_skips_empty_stub():
+    """A reasoning turn that ALSO carries tool calls must not emit an empty assistant message.
+    The function_call items already satisfy the "following item" rule, and translating gateways
+    turn the empty message into an empty text block that Anthropic/Bedrock reject with HTTP 400
+    "text content blocks must be non-empty"."""
+    from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+    messages = [
+        {"role": "user", "content": "run a command"},
+        {
+            "role": "assistant",
+            "content": "",
+            "codex_reasoning_items": [
+                {"type": "reasoning", "id": "rs_1", "encrypted_content": "enc_abc", "summary": []},
+            ],
+            "tool_calls": [
+                {"id": "call_1", "type": "function", "function": {"name": "terminal", "arguments": "{}"}},
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_1", "name": "terminal", "content": "ok"},
+    ]
+    items = _chat_messages_to_responses_input(messages)
+    kinds = [it.get("type") or f"message:{it.get('role')}" for it in items]
+    assert kinds == ["message:user", "reasoning", "function_call", "function_call_output"], kinds
+
+    # Malformed tool_calls (no function name) produce no function_call item, so the stub is still required.
+    messages[1]["tool_calls"] = [{"id": "call_1", "type": "function", "function": {"arguments": "{}"}}]
+    items = _chat_messages_to_responses_input(messages[:2])
+    kinds = [it.get("type") or f"message:{it.get('role')}" for it in items]
+    assert kinds == ["message:user", "reasoning", "message:assistant"], kinds
+
+
 
 
 def test_duplicate_detection_distinguishes_different_codex_reasoning(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Stops `_chat_messages_to_responses_input` from emitting an empty assistant message (`{"role": "assistant", "content": ""}`) after replayed reasoning items when the same assistant turn also carries tool calls.

The empty stub exists to satisfy the Responses API rule that a `reasoning` item must be followed by another item (`missing_following_item`). When the turn has tool calls, the `function_call` items emitted right after already satisfy that rule, so the stub is redundant.

OpenAI models tolerate the redundant empty message. Gateways that translate Responses input to the Anthropic Messages API do not: Anthropic and the Bedrock fallback both reject it with

```
HTTP 400: messages: text content blocks must be non-empty
```

Observed on a corporate Aperture gateway (`codex_responses` transport, `anthropic/claude-*` models): every turn where the model reasoned and then called tools without writing prose first caused the **next** request to fail, because the replayed history contained the stub between the `reasoning` item and the `function_call`. Hermes' error classifier already names this shape ("empty-content assistant stub is in the transcript") and fails fast without retry, so the turn is lost.

Captured failing `input` (indices from the gateway request log):

```
15 reasoning (encrypted_content)
16 reasoning (encrypted_content)
17 {"role": "assistant", "content": ""}      <-- rejected by Anthropic and Bedrock
18 function_call execute_code
19 function_call_output
```

The pure reasoning-only case (no text, no tool calls) is unchanged and still emits the stub, since nothing else would follow the reasoning item.

## Related Issue

Fixes #31583 (empty assistant content with tool_calls causes HTTP 400 from strict upstreams — the Responses-adapter instance of that class)
Related: #75202, #9486

Overlaps with open PR #75250 (same `tool_calls` guard, no tests). That PR also changes the remaining reasoning-only stub from `""` to `" "`; a whitespace-only text block is itself rejected by Bedrock (#39829), so this PR keeps that path untouched and only removes the redundant stub. Happy to close this in favor of #75250 if the maintainers prefer to land that one with the whitespace change dropped and a test added.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/codex_responses_adapter.py` — compute `has_tool_calls` for the assistant message before the following-item branch; emit the empty stub only when `has_codex_reasoning and not has_tool_calls`. Comment documents why.
- `tests/run_agent/test_run_agent_codex_responses.py` — new `test_chat_messages_to_responses_input_reasoning_with_tool_calls_skips_empty_stub`: reasoning + tool_calls turn must serialize as `[user, reasoning, function_call, function_call_output]` with no empty assistant item, and the reasoning item must still be followed by an item.

## How to Test

1. `pytest tests/run_agent/test_run_agent_codex_responses.py tests/agent/test_codex_responses_adapter.py tests/run_agent/test_provider_parity.py tests/run_agent/test_native_compaction*.py tests/run_agent/test_codex_multimodal_tool_result.py tests/run_agent/test_codex_xai_oauth_recovery.py tests/agent/test_estimator_parity_84371.py -q` → 282 passed (281 existing + 1 new). The existing `test_chat_messages_to_responses_input_reasoning_only_has_following_item` still passes, so the OpenAI reasoning-only path is unchanged.
2. Live: on a `codex_responses` custom provider that fronts Anthropic (Aperture / Vercel AI Gateway style), select a `claude-*` model, ask for something that requires a tool call, and let the model call a tool without any preceding text. Before this change the following request returns HTTP 400 `messages: text content blocks must be non-empty`; after it, the request succeeds. Verified against `claude-fable-5-1` on such a gateway: 0 failures over a 47-message history containing many reasoning + tool-call turns.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (see note on #75250 above)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `tests/agent` (5898 passed, 22 skipped) shows 182 failures on this machine, but the failed-test set is **byte-identical on an unmodified `main` worktree** (182 vs 182, empty diff both directions), so they are pre-existing/environmental (models.dev network, local `~/.hermes` state) and not introduced here. Targeted Codex/Responses, provider-parity, and native-compaction suites: 282 passed.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 27.0, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (inline comment updated)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure serialization logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Hermes side, before the fix:

```
agent.error_classifier: Malformed message array 400 (invalid request body) classified as format_error, NOT context overflow — failing fast + falling back instead of entering the compression loop. This usually means an empty-content assistant stub is in the transcript; num_messages=16 approx_tokens=38226. error=error code: 400 - {'error': {'message': 'messages: text content blocks must be non-empty', ...
agent.conversation_loop: API call failed (attempt 1/3) error_type=BadRequestError provider=custom base_url=https://<gateway>/v1 model=claude-fable-5-1 summary=HTTP 400: messages: text content blocks must be non-empty
```

Gateway side, same request (`providerMetadata.gateway.routing`): `anthropic` attempt → 400 `messages: text content blocks must be non-empty`; `bedrock` fallback attempt → same 400.

