### PR TITLE
fix(cli): give Windows a reachable exit backstop on Ctrl+C

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1175,6 +1175,28 @@ def _arm_exit_watchdog_on_shutdown_signal() -> None:
         pass  # never let the backstop break signal handling
 
 
+def _windows_sigint_is_escalation(cli_obj) -> bool:
+    """True when a Windows console SIGINT means "get me out", not console noise.
+
+    Windows delivers spurious ``CTRL_C_EVENT`` whenever a background thread
+    spawns a ``.cmd`` child, so ``run()`` binds SIGINT to a silent absorber
+    and lets prompt_toolkit's ``c-c`` binding drive real cancellation. Once
+    shutdown intent already exists that ambiguity is gone: the TUI is on its
+    way out (or already gone), nothing is spawning children, and a Ctrl+C can
+    only be the user escalating a shutdown that is taking too long.
+
+    SIGINT is the only shutdown signal a Windows console can deliver — there
+    is no ``SIGHUP``, and Ctrl+C never raises ``SIGTERM`` — so this is the
+    sole place the #65998 exit backstop can be armed on Windows. Without it a
+    graceful unwind that wedges before ``_run_cleanup`` (a prompt_toolkit
+    teardown that never returns, an agent worker blocking the ``finally``)
+    leaves a CLI that no keystroke can end.
+    """
+    if _cleanup_in_progress or _cleanup_done:
+        return True
+    return bool(getattr(cli_obj, "_should_exit", False))
+
+
 def _run_cleanup(*, notify_session_finalize: bool = True):
     """Run resource cleanup exactly once."""
     global _cleanup_done, _cleanup_in_progress
@@ -21329,6 +21351,19 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # time. Real user Ctrl+C routes through prompt_toolkit's
                     # own c-c key binding at the TUI layer (same pattern as
                     # Claude Code's Windows handling).
+                    #
+                    # Still absorbed either way — but once shutdown intent is
+                    # already established the press is unambiguous escalation,
+                    # so arm the exit backstop. SIGINT is the only shutdown
+                    # signal a Windows console can deliver (no SIGHUP; Ctrl+C
+                    # never raises SIGTERM), which makes this the sole place
+                    # the #65998 watchdog _signal_handler arms on POSIX can be
+                    # armed here. See _windows_sigint_is_escalation.
+                    try:
+                        if _windows_sigint_is_escalation(self):
+                            _arm_exit_watchdog_on_shutdown_signal()
+                    except Exception:
+                        pass  # never raise from a signal handler
                     return
                 _signal.signal(_signal.SIGINT, _sigint_absorb)
         except Exception:

--- a/tests/cli/test_exit_watchdog_signal_arm.py
+++ b/tests/cli/test_exit_watchdog_signal_arm.py
@@ -166,3 +166,76 @@ def test_signal_watchdog_is_skipped_once_cleanup_starts():
     finally:
         if p.poll() is None:
             p.kill()
+
+
+class TestWindowsSigintEscalation:
+    """The Windows-only half of the backstop (#100747).
+
+    ``run()`` binds SIGINT to a silent absorber on Windows because the console
+    fires spurious ``CTRL_C_EVENT`` whenever a background thread spawns a
+    ``.cmd`` child. That absorber is the ONLY handler a Windows console can
+    reach — there is no ``SIGHUP`` and Ctrl+C never raises ``SIGTERM`` — so if
+    it never arms the backstop, a wedge before ``_run_cleanup`` leaves a CLI
+    no keystroke can end.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clean_cleanup_flags(self, monkeypatch):
+        monkeypatch.setattr(cli, "_cleanup_in_progress", False)
+        monkeypatch.setattr(cli, "_cleanup_done", False)
+
+    def test_idle_press_is_console_noise(self):
+        """No shutdown intent: the press stays fully absorbed."""
+        stub = type("Stub", (), {"_should_exit": False})()
+        assert cli._windows_sigint_is_escalation(stub) is False
+
+    def test_press_after_exit_requested_is_escalation(self):
+        """``handle_ctrl_c`` set ``_should_exit`` and ``app.exit()`` wedged."""
+        stub = type("Stub", (), {"_should_exit": True})()
+        assert cli._windows_sigint_is_escalation(stub) is True
+
+    def test_press_during_cleanup_is_escalation(self, monkeypatch):
+        monkeypatch.setattr(cli, "_cleanup_in_progress", True)
+        stub = type("Stub", (), {"_should_exit": False})()
+        assert cli._windows_sigint_is_escalation(stub) is True
+
+    def test_press_after_cleanup_is_escalation(self, monkeypatch):
+        monkeypatch.setattr(cli, "_cleanup_done", True)
+        stub = type("Stub", (), {"_should_exit": False})()
+        assert cli._windows_sigint_is_escalation(stub) is True
+
+    def test_missing_attribute_is_not_escalation(self):
+        """A CLI object without ``_should_exit`` must not arm a hard kill."""
+        assert cli._windows_sigint_is_escalation(object()) is False
+
+
+def test_windows_absorber_arms_backstop_only_on_escalation(monkeypatch):
+    """End-to-end handler shape: absorb always, arm only when escalating.
+
+    Mirrors the closure installed in ``HermesCLI.run()`` without booting the
+    whole TUI: the absorber must return ``None`` in both cases (never raise,
+    never interrupt the agent) and reach the backstop only once shutdown
+    intent exists.
+    """
+    calls = []
+    monkeypatch.setattr(
+        cli, "_arm_exit_watchdog_on_shutdown_signal", lambda: calls.append(1)
+    )
+    monkeypatch.setattr(cli, "_cleanup_in_progress", False)
+    monkeypatch.setattr(cli, "_cleanup_done", False)
+    stub = type("Stub", (), {"_should_exit": False})()
+
+    def _sigint_absorb(signum, frame):
+        try:
+            if cli._windows_sigint_is_escalation(stub):
+                cli._arm_exit_watchdog_on_shutdown_signal()
+        except Exception:
+            pass
+        return
+
+    assert _sigint_absorb(signal.SIGINT, None) is None
+    assert calls == []
+
+    stub._should_exit = True
+    assert _sigint_absorb(signal.SIGINT, None) is None
+    assert calls == [1]


### PR DESCRIPTION
Fixes #100747

## Problem

`HermesCLI.run()` binds SIGINT to a **silent absorber** on Windows (`cli.py:21323-21333`). That is correct and deliberate: Windows fires spurious `CTRL_C_EVENT` whenever a background thread spawns a `.cmd` child, and real cancellation rides prompt_toolkit's `c-c` key binding instead.

The problem is what the absorber is *also* the only path to. `_arm_exit_watchdog_on_shutdown_signal()` — the backstop written for the #65998 class, where the graceful unwind wedges *before* `_run_cleanup()` ever arms its own watchdog — is armed exclusively from `_signal_handler`, which is bound only to SIGTERM and SIGHUP (`cli.py:21301-21303`).

A Windows console can deliver neither. There is no `SIGHUP`, and Ctrl+C never raises `SIGTERM`. So on Windows the backstop is unreachable, and a wedged unwind leaves a CLI that no keystroke can end — the observed shape being a "dead" process lingering at low CPU until Task Manager.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A["🩸 User presses Ctrl+C"] --> B{"Is the prompt_toolkit app reading keys?"}
    B -->|Yes| C["⚔️ c-c binding: interrupt agent / exit"]
    C --> D["🔥 _should_exit = True, app.exit()"]
    D --> E{"Does the unwind reach _run_cleanup?"}
    E -->|Yes| F["✅ _arm_exit_watchdog: bounded shutdown"]
    E -->|"No — teardown wedges"| G["💀 SIGINT hits _sigint_absorb"]
    B -->|"No — app already torn down"| G
    G --> H["☠️ BEFORE: return; no watchdog, unkillable CLI"]
    G --> I["🛡️ AFTER: escalation detected, backstop armed"]
    I --> F
```

## Fix

Keep absorbing exactly as before — the spurious-`CTRL_C_EVENT` immunity is untouched, and the handler still never calls `agent.interrupt()` — but arm the existing backstop once shutdown intent is already established.

New module-level predicate `_windows_sigint_is_escalation(cli_obj)`:

| State | Verdict | Why |
|---|---|---|
| idle session, `_should_exit` false | absorb only | could be a background thread spawning a `.cmd` |
| `_should_exit` set by `handle_ctrl_c` | escalation | the TUI is already on its way out |
| `_cleanup_in_progress` / `_cleanup_done` | escalation | nothing is spawning children during teardown |
| object with no `_should_exit` | absorb only | fail safe — never arm a hard kill on a guess |

At escalation time the press cannot be a background-thread artefact, so the healthy path is byte-identical and Windows gets the same last-resort exit POSIX already has. `_arm_exit_watchdog_on_shutdown_signal()` is idempotent and uses a 2× leash, so it never cuts short a slow-but-progressing `_run_cleanup` that armed its own tighter timer.

## Scope

Windows-only behaviour change, inside a `sys.platform == "win32"` branch that POSIX never enters. No signature changes.

## Test plan

- [x] `tests/cli/test_exit_watchdog_signal_arm.py` — 6 new cases covering the escalation matrix above plus an end-to-end handler-shape test asserting the absorber returns `None` in both states and reaches the backstop only when escalating.
- [x] Full file: **9 passed, 2 skipped** on Windows (the 2 skips are the pre-existing POSIX-signal e2e tests).
- [x] `ast.parse(cli.py)` clean.


