### PR TITLE
ci: every ci.yaml run 0-jobbed since 24f5a60ed1 — e2e-desktop disable as bare if: false

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,13 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    # Keep this a bare `if: false`. The earlier
+    # `${{ false && (... || ...) }}` form on this reusable-workflow job made
+    # GitHub's workflow parser fail at startup ("An unexpected error has
+    # occurred") — every ci.yaml run repo-wide dispatched 0 jobs from
+    # 24f5a60ed1 until this line changed. To re-enable, restore:
+    #   if: ${{ needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' }}
+    if: false
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## Summary

CI dispatches again: every `ci.yaml` run since 24f5a60ed1 ("fix: re-disable e2e", 22:08 UTC) — main and every PR branch — was a 0-job startup failure. The `if: ${{ false && (... || ...) }}` expression on the reusable-workflow `e2e-desktop` job makes GitHub's parser fail at startup ("An unexpected error has occurred"), which is why it never surfaced as a validation message and no local YAML lint catches it.

## Changes
- `.github/workflows/ci.yaml`: `e2e-desktop` disable is now a bare `if: false`, with the re-enable line documented in the comment. Lane behaviour unchanged (still skipped).

## Validation
Same branch, minutes apart:

| ci.yaml blob | jobs dispatched |
|---|---|
| main since 24f5a60ed1 (`false && (...) })}`) | 0 (13+ runs across all branches) |
| paren moved inside braces (`false && (...) }}`) | 0 |
| pre-24f5a60ed1 blob (lane enabled) | 26 |
| bare `if: false` (this PR) | 25 (e2e skipped) |

## Infographic

![CI dispatch restored](https://v3b.fal.media/files/b/0aa8bc97/Kwbpw-xHYCQWY-4BCsxD8_1UQdz2FU.png)
