### PR TITLE
fix(ci): close the re-disabled e2e expression broken in 24f5a60

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## What does this PR do?

`24f5a60` ("fix: re-disable e2e") rewrote the `e2e-desktop` guard in `.github/workflows/ci.yaml` as:

```yaml
if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
```

The trailing `})}` leaves the `${{` sequence unclosed, so **every** `ci.yaml` run now fails at parse time — including on unrelated PRs:

```
Invalid workflow file .github/workflows/ci.yaml
(Line: 126, Col: 9): The expression is not closed. An unescaped ${{ sequence was found, but the closing }} sequence was not found.
```

This PR restores the `'true') }}` ordering so the expression closes correctly, which un-breaks CI for the whole repo while keeping the e2e job disabled exactly as `24f5a60` intended.

## Related Issue

Fixes #100748

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `.github/workflows/ci.yaml` (line 126): closed the `${{ ... }}` expression of the re-disabled `e2e-desktop` guard — `...'true' })}` → `...'true') }}`. No behavioral change: the job stays disabled (`false &&` short-circuits), only the workflow file parses again.

## How to Test

1. On `main` (`24f5a60`), open any recent PR run: the CI workflow fails immediately with `Invalid workflow file .github/workflows/ci.yaml (Line: 126, Col: 9): The expression is not closed`. Observed result: parse failure repo-wide.
2. Apply this one-line change: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))"` passes, and a scan over every line confirms each `${{` now has its matching `}}`. Observed result: YAML parses, all expression delimiters pair up.
3. Push this branch: the `CI` workflow on this very PR starts scheduling jobs again instead of failing at parse time. Observed result: checks report per-job outcomes (no workflow-file error).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — workflow-file-only change, no Python code touched)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features) (N/A — GitHub parses workflow expressions; no test harness covers workflow syntax)
- [x] I've tested on my platform: macOS 15 (arm64) — YAML/expression pairing verified locally; parse fix confirmed by the workflow running on this PR

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Validation of the fixed line (local):

```
$ python3 -c "import yaml; yaml.safe_load(open('.github/workflows/ci.yaml'))" && echo OK
OK
$ # per-line ${{ / }} pairing scan: all lines balanced (line 126 was the only mismatch before)
```