### PR TITLE
fix(bot-mode): route only visible Group Chat mentions

### DIFF
--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -10,9 +10,11 @@ from __future__ import annotations
 
 import hashlib
 import re
+import unicodedata
 from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import asdict, dataclass
 from functools import partial
+from html.parser import HTMLParser
 from typing import Any, Literal
 
 from gateway import hosted_room_driver as driver
@@ -35,6 +37,8 @@ DecisionStatus = Literal["idle", "task", "settled", "bounded"]
 TerminalKind = Literal["settled", "failed", "cancelled", "deferred"]
 
 _MENTION_RE = re.compile(r"@([A-Za-z0-9][A-Za-z0-9._:-]*)", re.IGNORECASE)
+_FENCE_START_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})")
+_BARE_URI_START_RE = re.compile(r"(?i)(?:https?://|ftp://|mailto:|www\.)")
 _TURN_ID_RE = re.compile(
     r"^d(?P<source>[1-9][0-9]*)\.r(?P<round>[0-2])\."
     r"p(?P<position>[0-5])\.s(?P<seen>[1-9][0-9]*)\."
@@ -292,37 +296,371 @@ def resolve_mentions(
     texts: Iterable[str], members: Sequence[DiscussionMember], *, default_all: bool = True
 ) -> tuple[DiscussionMember, ...]:
     """Resolve member handles deterministically against the frozen roster."""
+
+    return _mention_resolution(texts, members, default_all=default_all)[0]
+
+
+def _masked_markdown_code(value: str) -> str:
+    """Replace Markdown code with spaces while preserving mention boundaries."""
+
+    chars = list(value)
+
+    def mask(start: int, end: int) -> None:
+        for index in range(start, end):
+            if chars[index] not in "\r\n":
+                chars[index] = " "
+
+    offset = 0
+    fence: tuple[str, int, int] | None = None
+    for line in value.splitlines(keepends=True):
+        body = line.rstrip("\r\n")
+        match = _FENCE_START_RE.match(body)
+        if fence is None and match is not None:
+            marker = match.group(1)
+            fence = (marker[0], len(marker), offset)
+        elif fence is not None and match is not None:
+            marker = match.group(1)
+            trailing = body[match.end():]
+            if (
+                marker[0] == fence[0]
+                and len(marker) >= fence[1]
+                and not trailing.strip(" \t")
+            ):
+                mask(fence[2], offset + len(line))
+                fence = None
+        offset += len(line)
+    if fence is not None:
+        mask(fence[2], len(value))
+
+    visible = "".join(chars)
+    chars = list(visible)
+    escaped = _escaped_positions(visible)
+    index = 0
+    while index < len(visible):
+        if visible[index] != "`":
+            index += 1
+            continue
+        if escaped[index]:
+            index += 1
+            continue
+        run_end = index + 1
+        while run_end < len(visible) and visible[run_end] == "`":
+            run_end += 1
+        run_length = run_end - index
+        cursor = run_end
+        closing_end = None
+        while cursor < len(visible):
+            if visible[cursor] != "`":
+                cursor += 1
+                continue
+            candidate_end = cursor + 1
+            while candidate_end < len(visible) and visible[candidate_end] == "`":
+                candidate_end += 1
+            if candidate_end - cursor == run_length:
+                closing_end = candidate_end
+                break
+            cursor = candidate_end
+        mask(index, closing_end if closing_end is not None else len(visible))
+        index = closing_end if closing_end is not None else len(visible)
+    return "".join(chars)
+
+
+def _escaped_positions(value: str) -> tuple[bool, ...]:
+    """Return whether each character has an odd preceding backslash run."""
+
+    result: list[bool] = []
+    backslashes = 0
+    for char in value:
+        result.append(backslashes % 2 == 1)
+        backslashes = backslashes + 1 if char == "\\" else 0
+    return tuple(result)
+
+
+def _masked_markdown_destinations(value: str) -> str:
+    """Hide inline link destinations while retaining their visible labels."""
+
+    chars = list(value)
+    escaped = _escaped_positions(value)
+    brackets: list[int] = []
+    index = 0
+    while index < len(value):
+        if escaped[index]:
+            index += 1
+            continue
+        if value[index] == "[":
+            brackets.append(index)
+            index += 1
+            continue
+        if value[index] != "]" or not brackets:
+            index += 1
+            continue
+        brackets.pop()
+        if index + 1 >= len(value) or value[index + 1] != "(" or escaped[index + 1]:
+            index += 1
+            continue
+        depth = 1
+        cursor = index + 2
+        angle = False
+        quote = ""
+        title_position = False
+        while cursor < len(value):
+            if escaped[cursor]:
+                cursor += 1
+                continue
+            char = value[cursor]
+            if angle:
+                if char == ">":
+                    angle = False
+            elif quote:
+                if char == quote:
+                    quote = ""
+            elif char == "<":
+                angle = True
+            elif char in {'"', "'"} and title_position:
+                quote = char
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    for masked in range(index + 1, cursor + 1):
+                        if chars[masked] not in "\r\n":
+                            chars[masked] = " "
+                    index = cursor
+                    break
+            if not angle and not quote:
+                title_position = depth == 1 and char in " \t\r\n"
+            cursor += 1
+        if depth:
+            for masked in range(index + 1, len(value)):
+                if chars[masked] not in "\r\n":
+                    chars[masked] = " "
+            break
+        index += 1
+    return "".join(chars)
+
+
+def _masked_bare_uris(value: str) -> str:
+    chars = list(value)
+    cursor = 0
+    while match := _BARE_URI_START_RE.search(value, cursor):
+        end = match.end()
+        parentheses = 0
+        brackets = 0
+        while end < len(value) and value[end] not in "\r\n\t <>{}":
+            char = value[end]
+            if char == "(":
+                parentheses += 1
+            elif char == ")":
+                if end + 1 < len(value) and value[end + 1] == "@" and parentheses == 0:
+                    break
+                parentheses = max(0, parentheses - 1)
+            elif char == "[":
+                brackets += 1
+            elif char == "]":
+                if end + 1 < len(value) and value[end + 1] == "@" and brackets == 0:
+                    break
+                brackets = max(0, brackets - 1)
+            elif (
+                char in {",", "!"}
+                and end + 1 < len(value)
+                and value[end + 1] == "@"
+            ):
+                break
+            end += 1
+        for index in range(match.start(), end):
+            if chars[index] not in "\r\n":
+                chars[index] = " "
+        cursor = max(end, match.end())
+    return "".join(chars)
+
+
+class _VisibleHTMLParser(HTMLParser):
+    """Collect only rendered text from Markdown's embedded HTML."""
+
+    _HIDDEN = frozenset({"script", "style", "template"})
+    _BREAKS = frozenset({
+        "address",
+        "article",
+        "aside",
+        "blockquote",
+        "br",
+        "caption",
+        "dd",
+        "details",
+        "dialog",
+        "div",
+        "dl",
+        "dt",
+        "fieldset",
+        "figcaption",
+        "figure",
+        "footer",
+        "form",
+        "h1",
+        "h2",
+        "h3",
+        "h4",
+        "h5",
+        "h6",
+        "header",
+        "hgroup",
+        "hr",
+        "li",
+        "legend",
+        "main",
+        "menu",
+        "nav",
+        "ol",
+        "p",
+        "pre",
+        "search",
+        "section",
+        "summary",
+        "table",
+        "tbody",
+        "td",
+        "tfoot",
+        "th",
+        "thead",
+        "tr",
+        "ul",
+    })
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.parts: list[str] = []
+        self.hidden: list[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        if tag in self._HIDDEN:
+            self.hidden.append(tag)
+        elif not self.hidden and tag in self._BREAKS:
+            self.parts.append(" ")
+
+    def handle_startendtag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        del attrs
+        if tag in self._HIDDEN:
+            self.hidden.append(tag)
+            if tag in {"script", "style"}:
+                self.set_cdata_mode(tag)
+        elif not self.hidden and tag in self._BREAKS:
+            self.parts.append(" ")
+
+    def handle_endtag(self, tag: str) -> None:
+        if self.hidden:
+            if self.hidden[-1] == tag:
+                self.hidden.pop()
+            return
+        if tag in self._BREAKS:
+            self.parts.append(" ")
+
+    def handle_data(self, data: str) -> None:
+        if not self.hidden:
+            self.parts.append(data)
+
+
+def _visible_html_text(value: str) -> str:
+    parser = _VisibleHTMLParser()
+    parser.feed(value)
+    parser.close()
+    return "".join(parser.parts)
+
+
+def _has_mention_boundary(value: str, index: int) -> bool:
+    if index == 0:
+        return True
+    previous = value[index - 1]
+    category = unicodedata.category(previous)
+    return previous not in "._%+\\-/:?#=&" and category[0] not in {"L", "M", "N"}
+
+
+def _mention_resolution(
+    texts: Iterable[str],
+    members: Sequence[DiscussionMember],
+    *,
+    default_all: bool,
+) -> tuple[tuple[DiscussionMember, ...], bool]:
+    """Return resolved members and whether an explicit token was unresolved."""
+
     by_handle = {member.handle.casefold(): member for member in members}
+    candidates = tuple(sorted(
+        (*by_handle, "all", "everyone"),
+        key=len,
+        reverse=True,
+    ))
     mentioned: set[str] = set()
     everyone = False
+    unresolved = False
     for text in texts:
-        for match in _MENTION_RE.finditer(str(text or "")):
-            handle = match.group(1).casefold()
-            if handle in {"all", "everyone"}:
-                everyone = True
-            elif handle in by_handle:
+        visible = _masked_bare_uris(
+            _masked_markdown_destinations(
+                _visible_html_text(
+                    _masked_markdown_code(str(text or ""))
+                )
+            )
+        )
+        for match in _MENTION_RE.finditer(visible):
+            if not _has_mention_boundary(visible, match.start()):
+                continue
+            token = match.group(1).casefold()
+            handle = next(
+                (
+                    candidate
+                    for candidate in candidates
+                    if token.startswith(candidate)
+                    and set(token[len(candidate):]) <= {".", ":"}
+                ),
+                "",
+            )
+            if handle in by_handle:
                 mentioned.add(handle)
+            elif handle in {"all", "everyone"}:
+                everyone = True
+            else:
+                unresolved = True
+    if unresolved:
+        return (), True
     if everyone or (default_all and not mentioned):
-        return tuple(members)
-    return tuple(member for member in members if member.handle.casefold() in mentioned)
+        return tuple(members), False
+    resolved = tuple(
+        member for member in members if member.handle.casefold() in mentioned
+    )
+    return resolved, False
 
 
 def _unaddressed_member_mentions(
-    messages: Sequence[_ValidatedEvent], room: DiscussionRoom) -> tuple[DiscussionMember, ...]:
+    messages: Sequence[_ValidatedEvent],
+    room: DiscussionRoom,
+) -> tuple[tuple[DiscussionMember, ...], bool]:
     """Return peers explicitly cited by a Bot and not heard from afterward."""
     cited_at: dict[str, int] = {}
     last_post_at: dict[str, int] = {}
+    unresolved = False
     for event in messages:
         if event.kind != "message.member":
             continue
         speaker_id = str(event.payload["member_id"])
         last_post_at[speaker_id] = event.seq
-        for member in resolve_mentions((str(event.payload["text"]),), room.members, default_all=False):
+        cited, message_unresolved = _mention_resolution(
+            (str(event.payload["text"]),),
+            room.members,
+            default_all=False,
+        )
+        unresolved = unresolved or message_unresolved
+        for member in cited:
             if member.member_id != speaker_id:
                 cited_at[member.member_id] = event.seq
-    return tuple(
-        member for member in room.members
-        if member.member_id in cited_at and last_post_at.get(member.member_id, 0) <= cited_at[member.member_id])
+    return (
+        tuple(
+            member
+            for member in room.members
+            if member.member_id in cited_at
+            and last_post_at.get(member.member_id, 0) <= cited_at[member.member_id]
+        ),
+        unresolved,
+    )
 
 
 def _require_gateway_actor(actor: Mapping[str, Any], room: DiscussionRoom, message: str) -> None:
@@ -614,6 +952,10 @@ def plan_next_task(
     decide = partial(
         DiscussionDecision, discussion_event_id=discussion.event_id, source_event_seq=discussion.seq,
         thread_id=thread_id)
+    initial_responders, unresolved_mention = _mention_resolution(
+        (str(discussion.payload["text"]),), room.members, default_all=True)
+    if unresolved_mention:
+        return decide("settled", "unresolved_mention")
     thread_messages, discussion_messages, member_messages = _thread_messages(validated, discussion)
     if len(member_messages) >= MAX_DISCUSSION_MESSAGES:
         return decide("bounded", "max_messages")
@@ -628,9 +970,16 @@ def plan_next_task(
         # Bot and not heard from afterward gets another turn. Every member's
         # watermark remains intact, so a peer cited later still receives the
         # complete bounded transcript delta without consuming turns meanwhile.
-        responders = (
-            resolve_mentions((str(discussion.payload["text"]),), room.members) if round_index == 0
-            else _unaddressed_member_mentions(discussion_messages, room))
+        if round_index == 0:
+            responders = initial_responders
+            unresolved_handoff = False
+        else:
+            responders, unresolved_handoff = _unaddressed_member_mentions(
+                discussion_messages,
+                room,
+            )
+        if unresolved_handoff:
+            return decide("settled", "unresolved_mention")
         for member_index, member in enumerate(_rotate(responders, round_index)):
             if (round_index, member.member_id) in terminals:
                 continue

--- a/tests/gateway/test_hosted_room_discussion.py
+++ b/tests/gateway/test_hosted_room_discussion.py
@@ -274,7 +274,7 @@ def test_deterministic_task_fits_existing_driver_and_reconstructs_after_restart(
         ("@all inspect this", "research"),
         ("@everyone inspect this", "research"),
         ("inspect this", "research"),
-        ("@unknown inspect this", "research"),
+        ("Email ops@example.com, then inspect this", "research"),
     ],
 )
 def test_mentions_select_handles_or_everyone(
@@ -286,6 +286,546 @@ def test_mentions_select_handles_or_everyone(
     _append_user(db, event_id="user-1", text=text)
 
     assert _next_task(room, db).member.profile == expected_profile
+
+
+def test_punctuated_user_mentions_reach_every_addressed_member(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(
+        db,
+        event_id="user-1",
+        text="@research, @build: and @review. Reply independently.",
+    )
+
+    assert _settle_next(room, db, text="Research ready.").member.profile == (
+        "research"
+    )
+    assert _settle_next(room, db, text="Build ready.").member.profile == "build"
+    assert _settle_next(room, db, text="Review ready.").member.profile == "review"
+
+
+def test_unknown_explicit_mention_does_not_broadcast(
+    room_db: tuple[Path, dict],
+):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@unknown inspect this")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    assert decision.status == "settled"
+    assert decision.reason == "unresolved_mention"
+
+
+def test_mentions_use_longest_exact_legacy_handle_before_trailing_punctuation():
+    members = (
+        discussion.DiscussionMember(
+            member_id="member-build",
+            profile="build",
+            handle="build",
+            display_name="Build",
+        ),
+        discussion.DiscussionMember(
+            member_id="member-build-colon",
+            profile="build-colon",
+            handle="build:",
+            display_name="Build Colon",
+        ),
+        discussion.DiscussionMember(
+            member_id="member-all-dot",
+            profile="all-dot",
+            handle="all.",
+            display_name="All Dot",
+        ),
+    )
+
+    assert [member.handle for member in discussion.resolve_mentions(
+        ("@build:. reply",), members, default_all=False
+    )] == ["build:"]
+    assert [member.handle for member in discussion.resolve_mentions(
+        ("@all.. reply",), members, default_all=False
+    )] == ["all."]
+
+
+def test_code_email_escaped_and_unicode_adjacent_tokens_are_not_mentions():
+    members = (
+        discussion.DiscussionMember(
+            member_id="member-build",
+            profile="build",
+            handle="build",
+            display_name="Build",
+        ),
+        discussion.DiscussionMember(
+            member_id="member-review",
+            profile="review",
+            handle="review",
+            display_name="Review",
+        ),
+    )
+
+    text = (
+        "Email ops@example.com and 用户@build. "
+        "Document `@everyone.` and \\@review literally. "
+        "```text\n@build: example only\n```"
+    )
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "@`ignored`everyone.",
+        "````text\n@everyone.\n```\nstill code",
+        "~~~text\n@everyone.\n",
+        "`unterminated @everyone.",
+    ],
+)
+def test_code_masking_never_synthesizes_or_leaks_mentions(text: str):
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
+
+
+def test_code_masking_preserves_a_boundary_before_a_real_mention():
+    members = (
+        discussion.DiscussionMember(
+            member_id="member-build",
+            profile="build",
+            handle="build",
+            display_name="Build",
+        ),
+    )
+
+    assert discussion.resolve_mentions(
+        ("word`ignored`@build",), members, default_all=False
+    ) == members
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "```text\n```not-a-close\n@build\n```",
+        "~~~text\n~~~not-a-close\n@build\n~~~",
+    ],
+)
+def test_fence_closers_with_trailing_text_do_not_expose_mentions(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+def test_escaped_backtick_does_not_hide_a_later_real_mention():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("Use \\` literally, then @build",),
+        (member,),
+        default_all=False,
+    ) == (member,)
+
+
+def test_unknown_token_never_narrows_or_overrides_a_broadcast():
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+
+    resolved, unresolved = discussion._mention_resolution(
+        ("@all @build @typo",), members, default_all=True
+    )
+    assert resolved == ()
+    assert unresolved is True
+
+
+def test_combining_mark_email_and_link_destination_are_not_mentions():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+    text = "cafe\u0301@build [docs](https://example.test/@build)"
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '[docs](url "note ) @build")',
+        "[docs](<mailto:@build(foo>)",
+        "https://example.test/?target=@build",
+        "https://example.test/#@build",
+    ],
+)
+def test_link_titles_angle_destinations_and_bare_urls_do_not_mention(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "https://example.test/(@build)",
+        "https://example.test/~@build",
+        "https://example.test/;@build",
+        "mailto:person@example.test?cc=@build",
+    ],
+)
+def test_bare_uri_spans_do_not_mention_bots(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "查看https://example.test/;@build",
+        "éhttps://example.test/(~@build)",
+    ],
+)
+def test_unicode_adjacent_bare_uri_is_still_masked(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "(https://example.test)@build",
+        "https://example.test,@build",
+        "https://example.test!@build",
+    ],
+)
+def test_visible_mention_after_bare_uri_remains_actionable(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == (member,)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "http://[::1]/;@build",
+        "http://[2001:db8::1]/(~@build)",
+    ],
+)
+def test_ipv6_bare_uri_is_fully_masked(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "<!-- @everyone. -->",
+        '<a title="@everyone">docs</a>',
+        "<script>@everyone.</script>",
+        "<style>.x{@everyone.}</style>",
+    ],
+)
+def test_hidden_html_does_not_mention_bots(text: str):
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
+
+
+def test_visible_text_inside_html_element_can_mention_a_bot():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("<span>@build</span>",), (member,), default_all=False
+    ) == (member,)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        '<script>const x="</scripture>"; @build</script>',
+        "<template><template>x</template>@build</template>",
+        "<script>ß</script> @build",
+        "<!DOCTYPE @build>",
+        "<?xml @build?>",
+    ],
+)
+def test_standard_html_visibility_handles_raw_blocks_and_declarations(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+    expected = (member,) if text == "<script>ß</script> @build" else ()
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == expected
+
+
+def test_hidden_html_cannot_mask_a_later_visible_mention():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("<!-- [x](unterminated --> @build",),
+        (member,),
+        default_all=False,
+    ) == (member,)
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "Intro<br>@build",
+        "<p>Intro</p><p>@build</p>",
+        "&#64;build",
+        "<span>&#64;build</span>",
+    ],
+)
+def test_rendered_html_boundaries_and_entities_preserve_visible_mentions(text: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == (member,)
+
+
+def test_mismatched_hidden_end_tag_does_not_expose_template_content():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("<template></script>@build</template>",),
+        (member,),
+        default_all=False,
+    ) == ()
+
+
+@pytest.mark.parametrize("tag", ["script", "style", "template"])
+def test_self_closing_hidden_tag_remains_hidden_like_html_rendering(tag: str):
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        (f"<{tag}/>@build",),
+        (member,),
+        default_all=False,
+    ) == ()
+
+
+def test_self_closing_script_enters_raw_text_until_matching_close():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("<script/><style/></script>@build",),
+        (member,),
+        default_all=False,
+    ) == (member,)
+
+
+def test_inline_html_does_not_invent_a_text_boundary():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("word<span></span>@build",),
+        (member,),
+        default_all=False,
+    ) == ()
+
+
+@pytest.mark.parametrize(
+    "tag", ["caption", "details", "dialog", "legend", "menu", "summary"]
+)
+def test_standard_block_elements_keep_visible_mentions_separate(tag: str):
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+    text = f"<{tag}>@</{tag}><{tag}>everyone</{tag}>"
+
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
+
+
+def test_url_apostrophe_does_not_hide_a_later_visible_mention():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("[docs](https://example.test/O'Brien) @build",),
+        (member,),
+        default_all=False,
+    ) == (member,)
+
+
+def test_unclosed_link_destination_masks_the_remaining_text_once():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+    text = "[broken](unterminated " + "](" * 10_000 + " @build"
+
+    assert discussion.resolve_mentions((text,), (member,), default_all=False) == ()
+
+
+def test_literal_unmatched_link_syntax_keeps_its_visible_mention():
+    member = discussion.DiscussionMember(
+        member_id="member-build",
+        profile="build",
+        handle="build",
+        display_name="Build",
+    )
+
+    assert discussion.resolve_mentions(
+        ("](@build)",), (member,), default_all=False
+    ) == (member,)
+
+
+def test_malformed_link_syntax_is_linear_and_does_not_fan_out():
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+    text = "](" * (64 * 1024 // 2)
+
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
+
+
+def test_bot_handoff_with_unknown_peer_surfaces_unresolved_mention(room_db):
+    db, room = room_db
+    _append_user(db, event_id="user-1", text="@research lead this")
+    _settle_next(room, db, text="@build @typo please continue")
+
+    decision = discussion.plan_next_task(
+        room,
+        _events(db),
+        local_profiles=LOCAL_PROFILES,
+    )
+
+    assert decision.status == "settled"
+    assert decision.reason == "unresolved_mention"
+
+
+def test_long_unknown_mention_is_bounded():
+    members = tuple(
+        discussion.DiscussionMember(
+            member_id=f"member-{handle}",
+            profile=handle,
+            handle=handle,
+            display_name=handle.title(),
+        )
+        for handle in ("build", "review")
+    )
+    text = "@unknown" + "." * (64 * 1024 - len("@unknown"))
+
+    assert discussion.resolve_mentions((text,), members, default_all=False) == ()
 
 
 def test_member_mention_joins_the_next_round_not_the_current_round(


### PR DESCRIPTION
## Route Group Chat Messages To The Bots You Address

Ordinary punctuation in `@developer:` or `@reviewer.` could select the wrong Bot or none. A mistyped handle could instead wake the whole group. Hidden mentions inside code or link metadata could also trigger unnecessary work.

This fixes mention routing in the deterministic room policy, without new commands, settings or prompt-only rules.

## Changes

- Exact legal handles win, including handles ending in `.` or `:`; otherwise ordinary sentence punctuation resolves the intended handle.
- Unknown explicit handles do not become broadcasts. The room records `unresolved_mention` for actionable client feedback.
- Only visible rendered text directs Bots. Code, link destinations, bare URI spans, comments, HTML metadata and hidden raw-text content remain inert.
- Visible block-boundary and decoded-character mentions still work; malformed input remains bounded at the existing 64 KiB message limit.

## Validation And Reproduction

Head `d2e3003e4f`, based on `245e48008f`: **107 tests pass** in `tests/gateway/test_hosted_room_discussion.py`, without retries. Ruff and diff checks pass; both changed owners are below 2,000 lines.

The tests cover unknown-handle broadcast prevention, punctuation-ending legacy handles, Unicode adjacency, incomplete Markdown, IPv6/URI spans and hidden HTML mentions. Worst-case malformed 64 KiB inputs remain millisecond-scale in the recorded probes. Earlier independent adversarial checks cover the same implementation, not additional test totals.

Run `scripts/run_tests.sh -j 2 --file-retries 0 tests/gateway/test_hosted_room_discussion.py`. In a disposable group, address known Bots with sentence punctuation, then try an unknown handle and a mention inside code: only the intended visible mentions should direct work. The initial three-role field reproduction is not a new packaged-app run on this recut.

## Related Work

#97681 tracks the wider Group Chat product; draft #98307 presents the durable unresolved-mention reason in Desktop. The original author, date and source references remain preserved, with pre-recut history retained on `preserve/pr100755-before-main-refresh-20260906`.

## Type Of Change

- [x] Bug fix
- [x] Tests
