### PR TITLE
fix(desktop): keep Agent Plugins on shared profile scope

### DIFF
--- a/apps/desktop/src/app/settings/plugins-settings.test.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.test.tsx
@@ -29,6 +29,7 @@ import {
 } from '@/store/agent-plugins'
 import { $activeGatewayProfile } from '@/store/profile'
 import { $connection, $gatewayState } from '@/store/session'
+import { $settingsScopeOverride } from '@/store/settings-scope'
 
 import { PluginsSettings } from './plugins-settings'
 
@@ -60,6 +61,7 @@ beforeEach(() => {
   $gatewayState.set('idle')
   $connection.set(null)
   $activeGatewayProfile.set('default')
+  $settingsScopeOverride.set(null)
 })
 
 afterEach(() => {
@@ -166,6 +168,23 @@ describe('PluginsSettings', () => {
 
     await waitFor(() => expect(getProfiles).toHaveBeenCalled())
     expect(screen.queryByText('Applies to:')).toBeNull()
+  })
+
+  it('follows the shared Settings profile scope', async () => {
+    getProfiles.mockResolvedValue({
+      profiles: [
+        { name: 'default', is_default: true },
+        { name: 'work', is_default: false }
+      ]
+    })
+    requestGateway.mockResolvedValue({ plugins: [legacyRow] })
+    $settingsScopeOverride.set('work')
+    $gatewayState.set('open')
+
+    renderSettings()
+
+    await waitFor(() => expect(screen.getByRole('combobox').textContent).toContain('work'))
+    expect(requestGateway).toHaveBeenCalledWith('plugins.manage', { action: 'list', profile: 'work' })
   })
 
   it('lists the active profile scope without a profile param and reloads scoped on change', async () => {

--- a/apps/desktop/src/app/settings/plugins-settings.tsx
+++ b/apps/desktop/src/app/settings/plugins-settings.tsx
@@ -27,8 +27,8 @@ import {
   toggleAgentPlugin
 } from '@/store/agent-plugins'
 import { notifyError } from '@/store/notifications'
-import { $activeGatewayProfile } from '@/store/profile'
 import { $connection, $gatewayState } from '@/store/session'
+import { $settingsRequestProfile, $settingsScopeProfile, setSettingsScope } from '@/store/settings-scope'
 
 import { EmptyState, ListRowSkeleton, Pill, SettingsContent, SettingsSection } from './primitives'
 import { useDeepLinkHighlight } from './use-deep-link-highlight'
@@ -181,17 +181,10 @@ function AgentPluginsSection() {
   const error = useStore($agentPluginsError)
   const [query, setQuery] = useState('')
 
-  // 'Applies to' profile scope: which profile's plugins we list/toggle.
-  // Defaults to the app-wide active profile; overriding it here lets the user
-  // manage ANY profile's plugins without switching the whole app (same
-  // pattern as the Capabilities scope selector in app/skills). null = the
-  // active profile — the RPC is sent without a profile param so older
-  // backends keep working unchanged.
-  const activeProfile = useStore($activeGatewayProfile)
-  const [scopeOverride, setScopeOverride] = useState<null | string>(null)
-  const scopeProfile = scopeOverride ?? activeProfile ?? null
-  // The param we actually send: omit it for the active profile.
-  const requestProfile = scopeOverride && scopeOverride !== activeProfile ? scopeOverride : null
+  // Reuse the Settings-wide profile scope so navigating between pages keeps
+  // every read and toggle aimed at the same profile.
+  const scopeProfile = useStore($settingsScopeProfile)
+  const requestProfile = useStore($settingsRequestProfile) ?? null
 
   const { data: profilesData } = useQuery({
     queryKey: ['agent-plugins-profiles'],
@@ -200,12 +193,6 @@ function AgentPluginsSection() {
   })
 
   const profiles = profilesData?.profiles ?? []
-
-  // An app-wide profile switch retargets the default scope — drop the
-  // override so the list reloads for the profile the user just switched to.
-  useEffect(() => {
-    setScopeOverride(null)
-  }, [activeProfile])
 
   useEffect(() => {
     if (gatewayState !== 'open') {
@@ -243,10 +230,7 @@ function AgentPluginsSection() {
           <span className="text-[length:var(--conversation-caption-font-size)] font-medium text-(--ui-text-tertiary)">
             {p.agent.appliesTo}
           </span>
-          <Select
-            onValueChange={name => setScopeOverride(name === activeProfile ? null : name)}
-            value={scopeProfile ?? ''}
-          >
+          <Select onValueChange={setSettingsScope} value={scopeProfile}>
             <SelectTrigger className="h-7 w-56 text-xs">
               <SelectValue />
             </SelectTrigger>


### PR DESCRIPTION
## Summary

- make Settings > Plugins reuse the existing shared Settings profile scope
- keep Agent Plugin list and toggle RPCs on the profile selected elsewhere in Settings
- remove the duplicate page-local scope state and its separate reset path

## Problem

Settings already has a shared `Applies to` selection that persists across pages. The Agent Plugins section kept its own local selector instead, so selecting a profile on Model, Tools & Keys, or another Settings page was lost when opening Plugins. The page displayed and queried the active profile instead of the selected Settings profile.

This is separate from #89818, which scopes the command-palette Settings search catalog but does not change the Plugins page itself.

## Verification

- regression test failed before the fix: expected `work`, received `Hermes (default)`
- `npm --workspace apps/desktop exec vitest run src/app/settings/plugins-settings.test.tsx` (10/10)
- `npm --workspace apps/desktop exec vitest run src/app/settings` (314/314)
- `npm --workspace apps/desktop run typecheck`
- changed-file ESLint
- production Desktop build
- isolated Desktop QA with separate user data and mock profiles: selecting `work` on Model, then opening Plugins, kept `work` selected and showed only its `work-only` Agent Plugin
- independent review: no security or logic findings
