### PR TITLE
fix(ci): repair disabled desktop condition

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## Summary

- restore the correctly closed GitHub expression for the disabled Desktop E2E job
- keep the job disabled and preserve all existing change-detection behavior

## Reproduction

Current main run 33566197979 and PR run 33570273213 both fail before creating any jobs with a workflow-file error. The malformed condition was introduced by 24f5a60ed1dd382ee453567a9abe1b72316d5e65.

## Validation

- actionlint no longer reports the expression lexer error at ci.yaml:126
- the two pre-existing local-action input warnings remain unchanged
- git diff --check passes

This is a provider-neutral CI-only fix; it changes no runtime or application behavior.