### PR TITLE
fix(google_meet): register cleanup on on_session_finalize, not on_session_end

### DIFF
--- a/plugins/google_meet/__init__.py
+++ b/plugins/google_meet/__init__.py
@@ -47,19 +47,24 @@ _TOOLS = (
 )
 
 
-def _on_session_end(**kwargs) -> None:
+def _on_session_finalize(**kwargs) -> None:
     """Best-effort cleanup — if a meet bot is still running when the session
-    ends, leave the call so we don't orphan a headless Chromium.
+    actually ends (CLI/TUI/gateway teardown or /reset), leave the call so we
+    don't orphan a headless Chromium.
 
-    No-ops when nothing is active. Swallows all exceptions — session end must
-    not fail because the bot cleanup hit an edge case.
+    Registered on ``on_session_finalize`` — the real session-boundary hook —
+    NOT ``on_session_end``, which fires at the end of every agent turn and
+    would kill the bot right after the first turn completes.
+
+    No-ops when nothing is active. Swallows all exceptions — session finalize
+    must not fail because the bot cleanup hit an edge case.
     """
     try:
         status = pm.status()
         if status.get("ok") and status.get("alive"):
-            pm.stop(reason="session ended")
+            pm.stop(reason="session finalized")
     except Exception as e:  # pragma: no cover — defensive
-        logger.debug("google_meet on_session_end cleanup failed: %s", e)
+        logger.debug("google_meet on_session_finalize cleanup failed: %s", e)
 
 
 def register(ctx) -> None:
@@ -100,4 +105,4 @@ def register(ctx) -> None:
         ),
     )
 
-    ctx.register_hook("on_session_end", _on_session_end)
+    ctx.register_hook("on_session_finalize", _on_session_finalize)

--- a/plugins/google_meet/process_manager.py
+++ b/plugins/google_meet/process_manager.py
@@ -2,8 +2,8 @@
 
 Single active meeting at a time. Stores the running pid + out_dir in a
 session-scoped state file under ``$HERMES_HOME/workspace/meetings/.active.json``
-so tool calls across turns can find the bot, and ``on_session_end`` can clean
-it up.
+so tool calls across turns can find the bot, and ``on_session_finalize`` can
+clean it up at the real session boundary.
 
 The bot runs as a detached subprocess — we don't hold file descriptors open,
 so the parent agent loop can't block on it. We communicate via files only.

--- a/tests/plugins/test_google_meet_plugin.py
+++ b/tests/plugins/test_google_meet_plugin.py
@@ -7,7 +7,7 @@ Covers the safety-gated pieces that don't require Playwright:
   * Status / transcript writes round-trip through the file-backed state
   * Tool handlers return well-formed JSON under all branches
   * Process manager refuses unsafe URLs and clears stale state cleanly
-  * ``_on_session_end`` hook is defensive (no-ops when no bot active)
+  * ``_on_session_finalize`` hook is defensive (no-ops when no bot active)
 
 Does NOT spawn a real Chromium — we mock ``subprocess.Popen`` where needed.
 """
@@ -181,14 +181,14 @@ def test_meet_join_handler_missing_url_returns_error():
 
 
 # ---------------------------------------------------------------------------
-# _on_session_end — defensive cleanup
+# _on_session_finalize — defensive cleanup
 # ---------------------------------------------------------------------------
 
-def test_on_session_end_noop_when_nothing_active():
-    from plugins.google_meet import _on_session_end
+def test_on_session_finalize_noop_when_nothing_active():
+    from plugins.google_meet import _on_session_finalize
     # Should not raise and should not call stop().
     with patch("plugins.google_meet.pm.stop") as stop_mock:
-        _on_session_end()
+        _on_session_finalize()
     stop_mock.assert_not_called()
 
 


### PR DESCRIPTION
## Summary
Register the google_meet bot cleanup on `on_session_finalize` instead of `on_session_end`, so the Meet bot isn't killed at the end of every agent turn.

## Problem
`plugins/google_meet/__init__.py` registered the cleanup callback on `on_session_end`:

```python
ctx.register_hook("on_session_end", _on_session_end)
```

But `on_session_end` fires at the end of every agent turn (see `agent/turn_finalizer.py`: "Fired at the very end of every run_conversation call"), not at the real session boundary. The callback calls `pm.stop()`, which SIGTERMs the detached Meet bot.

So the bot joins, gets admitted, goes `realtimeReady`, then gets killed as soon as the agent finishes its first turn. `meet_status` then reports `exited: true` with no `leaveReason` and no `error`. The plugin can't survive any meeting longer than one agent turn.

## Fix
Register the cleanup on `on_session_finalize` — the hook fired at real session boundaries (CLI/TUI/gateway teardown and `/reset`). Renamed `_on_session_end` -> `_on_session_finalize` and updated the docstrings and the test.

## Verification
- Bug confirmed on upstream `main` (still registers `on_session_end`).
- Manual end-to-end: joined a live Meet in realtime mode with the fix; the bot stayed alive past the first turn boundary (`exited: false`, `inCall: true`) instead of dying.
- `register()` smoke check: emits `on_session_finalize`, no `on_session_end`.
