### PR TITLE
fix(serve): never arm the parent-death watchdog under pytest

### DIFF
--- a/contributors/emails/contact@patrykkopycinski.com
+++ b/contributors/emails/contact@patrykkopycinski.com
@@ -1,0 +1,2 @@
+patrykkopycinski
+# PR #100760 (fix(serve): never arm the parent-death watchdog under pytest)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19408,14 +19408,26 @@ def _start_parent_death_watchdog() -> None:
     Desktop versions that provide only ``HERMES_PARENT_PID`` retain PID-only
     tracking.
     """
-    # Never arm under pytest.  The watchdog's whole job is to os._exit(0) the
-    # process it runs in, which under a test runner means killing the runner:
-    # the suite stops mid-file, pytest never reaches sessionfinish, no summary
-    # or --junit-xml is written, and the shell still sees exit 0 — a passing
-    # run that executed a fraction of the tests.  A test process inherits
-    # HERMES_PARENT_PID from whatever launched it, so any test calling
-    # start_server() would otherwise arm a killer aimed at an unrelated parent.
-    if os.environ.get("PYTEST_CURRENT_TEST"):
+    # Never arm inside a pytest RUNNER process.  The watchdog's terminal
+    # action is os._exit(0); in the runner that kills the run itself: the
+    # suite stops mid-file, sessionfinish never fires, no summary and no
+    # --junit-xml are written, and the shell still sees exit 0 — a truncated
+    # run indistinguishable from a green one.  A test process inherits
+    # HERMES_PARENT_PID from whatever launched it, so any in-process test
+    # reaching start_server() would otherwise aim a killer at an unrelated
+    # parent.
+    #
+    # Both conditions are required, and the sys.modules half is the load
+    # bearing one.  PYTEST_CURRENT_TEST is exported into the environment and
+    # therefore INHERITED by subprocess children: a production-shaped
+    # `hermes serve` spawned from an integration test carries it even when
+    # the caller scrubs the HERMES_PARENT_* family (as
+    # tests/hermes_cli/test_serve_port_in_use.py does), so an env-only guard
+    # would silently disarm the watchdog in exactly the child processes whose
+    # lifecycle contract we are supposed to be testing.  `pytest` in
+    # sys.modules is per-interpreter and never crosses a process boundary, so
+    # it distinguishes "I am the runner" from "my ancestor was a runner".
+    if "pytest" in sys.modules and os.environ.get("PYTEST_CURRENT_TEST"):
         return
 
     raw_pid = os.environ.get("HERMES_PARENT_PID")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -19408,6 +19408,16 @@ def _start_parent_death_watchdog() -> None:
     Desktop versions that provide only ``HERMES_PARENT_PID`` retain PID-only
     tracking.
     """
+    # Never arm under pytest.  The watchdog's whole job is to os._exit(0) the
+    # process it runs in, which under a test runner means killing the runner:
+    # the suite stops mid-file, pytest never reaches sessionfinish, no summary
+    # or --junit-xml is written, and the shell still sees exit 0 — a passing
+    # run that executed a fraction of the tests.  A test process inherits
+    # HERMES_PARENT_PID from whatever launched it, so any test calling
+    # start_server() would otherwise arm a killer aimed at an unrelated parent.
+    if os.environ.get("PYTEST_CURRENT_TEST"):
+        return
+
     raw_pid = os.environ.get("HERMES_PARENT_PID")
     start_marker = os.environ.get("HERMES_PARENT_START_MARKER")
     nonce = os.environ.get("HERMES_PARENT_NONCE")

--- a/tests/test_web_server_watchdog_pytest_guard.py
+++ b/tests/test_web_server_watchdog_pytest_guard.py
@@ -14,10 +14,15 @@ aimed at a parent that has nothing to do with the test run.
 """
 
 import os
+import subprocess
+import sys
 import threading
+from pathlib import Path
 from unittest.mock import patch
 
 from hermes_cli import web_server
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 def _watchdog_threads():
@@ -63,3 +68,63 @@ class TestWatchdogNeverArmsUnderPytest:
             web_server._start_parent_death_watchdog()
             assert not fake_thread.called, "watchdog thread must not be constructed"
             assert not fake_exit.called
+
+
+class TestGuardDoesNotLeakIntoChildProcesses:
+    """The guard must not disarm production processes spawned BY a test.
+
+    ``PYTEST_CURRENT_TEST`` is an environment variable, so it is inherited by
+    every subprocess a test starts -- including a production-shaped
+    ``hermes serve`` whose parent-death watchdog is the very thing under test
+    (``tests/hermes_cli/test_serve_port_in_use.py`` spawns exactly this, and
+    scrubbing the ``HERMES_PARENT_*`` family does not remove the pytest var).
+    An env-only guard would therefore weaken the lifecycle contract in the
+    child while claiming to only affect tests.  Pairing it with an
+    in-interpreter ``sys.modules`` check keeps the guard scoped to the runner.
+    """
+
+    def test_pytest_env_var_is_inherited_by_children(self):
+        """Baseline: the env half alone cannot distinguish runner from child."""
+        proc = subprocess.run(
+            [sys.executable, "-c",
+             "import os; print('PYTEST_CURRENT_TEST' in os.environ)"],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert proc.stdout.strip() == "True", (
+            "expected the pytest env var to leak into the child; if this ever "
+            "fails the guard's second condition may no longer be needed"
+        )
+
+    def test_child_process_still_arms_the_watchdog(self):
+        """A serve-shaped child spawned from pytest must NOT be disarmed.
+
+        Bites the env-only guard: that version returns early here (the var is
+        inherited) and the watchdog never arms, so the assertion fails.
+        """
+        code = (
+            "import os, sys, threading\n"
+            "from hermes_cli import web_server\n"
+            "os.environ['HERMES_PARENT_PID'] = str(os.getppid())\n"
+            "os.environ.pop('HERMES_PARENT_START_MARKER', None)\n"
+            "os.environ.pop('HERMES_PARENT_NONCE', None)\n"
+            "assert 'PYTEST_CURRENT_TEST' in os.environ, 'env var did not inherit'\n"
+            "assert 'pytest' not in sys.modules, 'child must not have pytest loaded'\n"
+            "web_server._start_parent_death_watchdog()\n"
+            "armed = [t for t in threading.enumerate()\n"
+            "         if t.name == 'serve-parent-watchdog']\n"
+            # Distinct tokens on purpose: 'ARMED' is a substring of 'DISARMED',
+            # so a naive membership check would pass in BOTH directions and the
+            # test would never bite.
+            "print('WATCHDOG_RESULT=' + ('armed' if armed else 'not-armed'))\n"
+        )
+        proc = subprocess.run(
+            [sys.executable, "-c", code],
+            cwd=str(REPO_ROOT), capture_output=True, text=True, timeout=120,
+        )
+        assert proc.returncode == 0, f"child failed: {proc.stdout}\n{proc.stderr}"
+        assert "WATCHDOG_RESULT=armed" in proc.stdout, (
+            "the parent-death watchdog must still arm in a production-shaped "
+            "child spawned from a test -- the guard must scope to the pytest "
+            f"runner, not to anything that merely inherits its environment. "
+            f"stdout={proc.stdout!r} stderr={proc.stderr[-2000:]!r}"
+        )

--- a/tests/test_web_server_watchdog_pytest_guard.py
+++ b/tests/test_web_server_watchdog_pytest_guard.py
@@ -1,0 +1,65 @@
+"""The parent-death watchdog must never arm inside a test process.
+
+``_start_parent_death_watchdog`` spawns a thread whose terminal action is
+``os._exit(0)`` -- an unconditional, unwindable process kill.  Inside pytest
+that kills the *runner*: the session stops mid-file, ``pytest_sessionfinish``
+never fires, no summary line and no ``--junit-xml`` are written, and the
+shell still observes exit status 0.  A truncated run is indistinguishable
+from a green one unless you notice the missing summary.
+
+The trigger is ordinary inheritance: a test process launched from the Hermes
+desktop app inherits ``HERMES_PARENT_PID`` (plus marker/nonce) pointing at
+the desktop.  Any test that reaches ``start_server()`` then arms a watchdog
+aimed at a parent that has nothing to do with the test run.
+"""
+
+import os
+import threading
+from unittest.mock import patch
+
+from hermes_cli import web_server
+
+
+def _watchdog_threads():
+    return [t for t in threading.enumerate() if t.name == "serve-parent-watchdog"]
+
+
+class TestWatchdogNeverArmsUnderPytest:
+    def test_no_thread_started_with_full_parent_identity(self):
+        """Marker+nonce present and valid -- still must not arm under pytest."""
+        before = len(_watchdog_threads())
+        env = {
+            "HERMES_PARENT_PID": str(os.getpid()),
+            "HERMES_PARENT_START_MARKER": "123456",
+            "HERMES_PARENT_NONCE": "abc123",
+            "PYTEST_CURRENT_TEST": "test_x (call)",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            web_server._start_parent_death_watchdog()
+        assert len(_watchdog_threads()) == before
+
+    def test_no_thread_started_with_legacy_pid_only(self):
+        """The PID-only legacy path is guarded too."""
+        before = len(_watchdog_threads())
+        env = {
+            "HERMES_PARENT_PID": str(os.getpid()),
+            "PYTEST_CURRENT_TEST": "test_x (call)",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            for stale in ("HERMES_PARENT_START_MARKER", "HERMES_PARENT_NONCE"):
+                os.environ.pop(stale, None)
+            web_server._start_parent_death_watchdog()
+        assert len(_watchdog_threads()) == before
+
+    def test_os_exit_is_never_reached(self):
+        """The guard returns before any thread that could _exit is created."""
+        env = {
+            "HERMES_PARENT_PID": str(os.getpid()),
+            "PYTEST_CURRENT_TEST": "test_x (call)",
+        }
+        with patch.dict(os.environ, env, clear=False), \
+             patch.object(os, "_exit") as fake_exit, \
+             patch.object(threading, "Thread") as fake_thread:
+            web_server._start_parent_death_watchdog()
+            assert not fake_thread.called, "watchdog thread must not be constructed"
+            assert not fake_exit.called


### PR DESCRIPTION
## What does this PR do?

`_start_parent_death_watchdog()` arms a daemon thread whose job is to call
`os._exit(0)` when the desktop app that launched `hermes serve` disappears.
It keys off `HERMES_PARENT_PID` / `HERMES_PARENT_START_MARKER`, which a child
process **inherits from whatever launched it**.

That includes pytest. Any test that calls `start_server()` arms a killer inside
the *test runner* aimed at an unrelated parent, and when it fires it takes the
runner down with `os._exit(0)`.

The failure mode is silent and reads as success:

- the suite stops mid-file, wherever the thread happens to fire;
- pytest never reaches `sessionfinish`, so **no summary line and no
  `--junit-xml` are written**;
- the shell sees **exit code 0**.

A run that executed ~60% of the suite is indistinguishable from a green one, on
the exit code CI actually gates on. Selections of the same tests pass, so it
looks like flake rather than a systematic kill.

The fix is a one-line guard: never arm the watchdog when `PYTEST_CURRENT_TEST`
is set. That variable is set by pytest for the duration of every test, so it is
a precise signal for "this process is a test runner". Production behaviour is
untouched — outside pytest the watchdog arms exactly as before.

## Related Issue

No existing issue — happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/web_server.py` — `_start_parent_death_watchdog()` returns early
  when `PYTEST_CURRENT_TEST` is present in the environment, with a comment
  recording why the guard exists.
- `tests/test_web_server_watchdog_pytest_guard.py` — new test asserting no
  watchdog thread is started under pytest, and that the guard is keyed on the
  env var rather than on an unrelated condition.

## How to Test

Reproduce the original failure:

```bash
# Simulate a desktop-launched environment (this is what the desktop app sets)
export HERMES_PARENT_PID=$$
export HERMES_PARENT_START_MARKER=whatever

# Before this change: stops early, prints no summary, writes no junit, exits 0
pytest tests/ -k "environment or terminal or config" -q --junit-xml=/tmp/j.xml
echo "exit=$?"     # 0
ls /tmp/j.xml      # missing
```

With the guard applied, the same command runs to completion and writes the
JUnit file.

Targeted verification:

```bash
bash scripts/run_tests.sh \
  tests/test_web_server_watchdog_pytest_guard.py \
  tests/test_web_server.py \
  tests/hermes_cli/test_web_server.py -q
# === Summary: 3 files, 193 tests passed, 0 failed, 3 skipped ===
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo gate on the affected suites (see below) — all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1 (Apple Silicon), Python 3.11

> On `pytest tests/ -q`: the full suite has pre-existing failures on my machine
> unrelated to this change (optional SDKs such as `daytona` are not installed
> and `security.allow_lazy_installs=false`). I verified via
> `scripts/run_tests.sh` on the owning suites, and confirmed the same failures
> reproduce on an unmodified `main`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, internal guard
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — `PYTEST_CURRENT_TEST` is set by pytest on every platform; the guard has no OS-specific behaviour
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Root cause, traced with a throwaway exit-tracing plugin that wraps `os._exit`
and logs test boundaries:

```
tests/tools/test_approval.py::test_... <-- last test to start
os._exit(0) called from hermes_cli/web_server.py:19389
  in _parent_death_watchdog (daemon thread)
```

The thread was armed ~2s earlier by `tests/test_web_server.py`, which calls the
real `start_server()`; it fired while an unrelated later file was executing,
which is why the cut point moves with collection order.
