### PR TITLE
fix(ssh): make remote file sync work against BSD/macOS hosts

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3952,6 +3952,12 @@ def _terminal_config_value_is_bridgeable(key: str, value: Any) -> bool:
     """Return whether a terminal config value owns its mirrored env var."""
     if key == "cwd" and str(value or "").strip() in {".", "auto", "cwd"}:
         return False
+    # An empty ssh_* value means "not configured" — the schema declares these
+    # keys so `hermes config set terminal.ssh_host` validates, but exporting
+    # them blank would override the backend's own fallbacks (port 22, the
+    # invoking user's SSH defaults) and make int('') kill every command.
+    if key in {"ssh_host", "ssh_user", "ssh_port", "ssh_key"} and str(value or "").strip() == "":
+        return False
     return True
 
 

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -410,6 +410,16 @@ DEFAULT_CONFIG = {
     "terminal": {
         "backend": "local",
         "modal_mode": "auto",
+        # Connection settings for backend "ssh". These are read via
+        # TERMINAL_CONFIG_ENV_MAP (ssh_host -> TERMINAL_SSH_HOST, etc.) and
+        # must be declared here so `hermes config set terminal.ssh_host ...`
+        # validates as a known key instead of warning that Hermes may never
+        # read it. Empty means "not configured"; ssh_user/ssh_key fall back
+        # to the invoking user's SSH defaults, ssh_port to 22.
+        "ssh_host": "",
+        "ssh_user": "",
+        "ssh_port": "",
+        "ssh_key": "",
         # Remote-backend graceful degradation: when a connection-class
         # infrastructure failure occurs (SSH host unreachable, Docker daemon
         # down), "warn" (default) returns a structured degraded tool result

--- a/tests/tools/test_credential_files_appledouble.py
+++ b/tests/tools/test_credential_files_appledouble.py
@@ -1,0 +1,39 @@
+"""Tests for AppleDouble filtering in the remote-sync file enumeration.
+
+macOS writes ``._name`` sidecars next to real files on non-HFS volumes.  They
+carry no content Hermes needs, cannot always be stat'd by the time tar reads
+them, and on this workstation were 6,620 of 13,241 enumerated sync files --
+half of every remote sync was pure waste.
+"""
+
+from tools.credential_files import _is_syncable_sync_file
+
+
+class TestAppleDoubleFiltering:
+    def test_appledouble_is_skipped(self, tmp_path):
+        f = tmp_path / "._SKILL.md"
+        f.write_text("resource fork junk")
+        assert _is_syncable_sync_file(f) is False
+
+    def test_normal_file_is_kept(self, tmp_path):
+        f = tmp_path / "SKILL.md"
+        f.write_text("real content")
+        assert _is_syncable_sync_file(f) is True
+
+    def test_leading_dot_file_is_kept(self, tmp_path):
+        """Only the ``._`` prefix is AppleDouble -- plain dotfiles are real."""
+        f = tmp_path / ".env"
+        f.write_text("KEY=value")
+        assert _is_syncable_sync_file(f) is True
+
+    def test_directory_is_skipped(self, tmp_path):
+        d = tmp_path / "subdir"
+        d.mkdir()
+        assert _is_syncable_sync_file(d) is False
+
+    def test_symlink_is_skipped(self, tmp_path):
+        target = tmp_path / "real.md"
+        target.write_text("x")
+        link = tmp_path / "link.md"
+        link.symlink_to(target)
+        assert _is_syncable_sync_file(link) is False

--- a/tests/tools/test_file_sync_infer_scaling.py
+++ b/tests/tools/test_file_sync_infer_scaling.py
@@ -1,0 +1,126 @@
+"""Performance regression test for ``_infer_host_path``.
+
+``_infer_host_path`` is called once per synced file and used to walk the whole
+mapping, re-running ``_is_upload_only_host_path`` (a filesystem
+``Path.resolve()``) for every candidate.  With ~6.6k files x ~6.6k mappings that
+was 3.4M resolve calls and 27M ``lstat`` syscalls -- 111s of a 146s profiled
+``sync_back`` against a real remote.
+
+The directory index makes the filter run once per mapping entry per sync
+instead of once per (file, mapping) pair.  These tests pin the call count,
+which is the property that actually decays, rather than wall-clock timing.
+"""
+
+from unittest.mock import patch
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def _manager() -> FileSyncManager:
+    return FileSyncManager(
+        get_files_fn=lambda: [],
+        upload_fn=lambda *a, **k: None,
+        delete_fn=lambda *a, **k: None,
+        bulk_upload_fn=lambda *a, **k: None,
+        bulk_download_fn=lambda *a, **k: None,
+    )
+
+
+def _mapping(n: int) -> list[tuple[str, str]]:
+    return [(f"/host/dir{i}/f.txt", f"/remote/dir{i}/f.txt") for i in range(n)]
+
+
+class TestInferHostPathScaling:
+    def test_filter_runs_once_per_mapping_entry_not_per_file(self):
+        """The upload-only filter must not rerun for every file."""
+        mgr = _manager()
+        mapping = _mapping(50)
+
+        with patch.object(
+            FileSyncManager,
+            "_is_upload_only_host_path",
+            return_value=False,
+        ) as filt:
+            for i in range(20):
+                mgr._infer_host_path(
+                    f"/remote/dir{i}/new.txt",
+                    mapping,
+                    upload_only_host_paths=set(),
+                )
+
+        # Pre-fix: 20 files x 50 mappings = up to 1000 calls.
+        # With the index: 50 (one pass), reused for every subsequent file.
+        assert filt.call_count <= len(mapping), (
+            f"filter ran {filt.call_count} times for {len(mapping)} mappings "
+            "-- the per-file rescan is back"
+        )
+
+    def test_inference_result_is_still_correct(self):
+        """Caching must not change which host path is returned."""
+        mgr = _manager()
+        mapping = _mapping(5)
+        got = mgr._infer_host_path(
+            "/remote/dir3/brand_new.txt",
+            mapping,
+            upload_only_host_paths=set(),
+        )
+        assert got == "/host/dir3/brand_new.txt"
+
+    def test_first_match_wins_is_preserved(self):
+        """Two mappings sharing a remote dir: the first must win."""
+        mgr = _manager()
+        mapping = [
+            ("/host/first/f.txt", "/remote/shared/f.txt"),
+            ("/host/second/g.txt", "/remote/shared/g.txt"),
+        ]
+        got = mgr._infer_host_path(
+            "/remote/shared/new.txt",
+            mapping,
+            upload_only_host_paths=set(),
+        )
+        assert got == "/host/first/new.txt"
+
+    def test_upload_only_mappings_are_still_skipped(self):
+        """An upload-only host dir must never be inferred as a download target."""
+        mgr = _manager()
+        mapping = [
+            ("/host/secret/creds", "/remote/secret/creds"),
+            ("/host/ok/f.txt", "/remote/secret/f.txt"),
+        ]
+
+        def only_secret(host_path, upload_only):
+            return host_path == "/host/secret/creds"
+
+        with patch.object(
+            FileSyncManager,
+            "_is_upload_only_host_path",
+            side_effect=only_secret,
+        ):
+            got = mgr._infer_host_path(
+                "/remote/secret/new.txt",
+                mapping,
+                upload_only_host_paths={"/host/secret/creds"},
+            )
+
+        assert got == "/host/ok/new.txt"
+
+    def test_cache_refreshes_when_filter_set_changes(self):
+        """A different upload-only set must not reuse a stale index."""
+        mgr = _manager()
+        mapping = [("/host/a/f.txt", "/remote/a/f.txt")]
+
+        first = mgr._infer_host_path(
+            "/remote/a/new.txt", mapping, upload_only_host_paths=set()
+        )
+        assert first == "/host/a/new.txt"
+
+        with patch.object(
+            FileSyncManager, "_is_upload_only_host_path", return_value=True
+        ):
+            second = mgr._infer_host_path(
+                "/remote/a/new.txt",
+                mapping,
+                upload_only_host_paths={"/host/a/f.txt"},
+            )
+
+        assert second is None, "stale index reused across a different filter set"

--- a/tests/tools/test_file_sync_infer_scaling.py
+++ b/tests/tools/test_file_sync_infer_scaling.py
@@ -1,14 +1,14 @@
-"""Performance regression test for ``_infer_host_path``.
+"""Performance regression tests for ``_infer_host_path``.
 
-``_infer_host_path`` is called once per synced file and used to walk the whole
+``_infer_host_path`` runs once per synced file and used to walk the whole
 mapping, re-running ``_is_upload_only_host_path`` (a filesystem
-``Path.resolve()``) for every candidate.  With ~6.6k files x ~6.6k mappings that
-was 3.4M resolve calls and 27M ``lstat`` syscalls -- 111s of a 146s profiled
-``sync_back`` against a real remote.
+``Path.resolve()``) for every candidate -- O(files x mappings) filesystem
+calls, which dominated ``sync_back`` against a large remote.
 
 The directory index makes the filter run once per mapping entry per sync
-instead of once per (file, mapping) pair.  These tests pin the call count,
-which is the property that actually decays, rather than wall-clock timing.
+instead of once per (file, mapping) pair. These tests pin the call count and
+the call-site placement, which are the properties that actually decay, rather
+than wall-clock timing.
 """
 
 from unittest.mock import patch
@@ -32,7 +32,12 @@ def _mapping(n: int) -> list[tuple[str, str]]:
 
 class TestInferHostPathScaling:
     def test_filter_runs_once_per_mapping_entry_not_per_file(self):
-        """The upload-only filter must not rerun for every file."""
+        """The upload-only filter must not rerun for every file.
+
+        Drives the real caller (``_build_dir_index`` once, reused across
+        files) rather than looping ``_infer_host_path``, so it stays honest
+        if the index is ever rebuilt per file again.
+        """
         mgr = _manager()
         mapping = _mapping(50)
 
@@ -41,11 +46,12 @@ class TestInferHostPathScaling:
             "_is_upload_only_host_path",
             return_value=False,
         ) as filt:
+            dir_index = mgr._build_dir_index(mapping, set())
             for i in range(20):
                 mgr._infer_host_path(
                     f"/remote/dir{i}/new.txt",
                     mapping,
-                    upload_only_host_paths=set(),
+                    dir_index=dir_index,
                 )
 
         # Pre-fix: 20 files x 50 mappings = up to 1000 calls.
@@ -53,6 +59,26 @@ class TestInferHostPathScaling:
         assert filt.call_count <= len(mapping), (
             f"filter ran {filt.call_count} times for {len(mapping)} mappings "
             "-- the per-file rescan is back"
+        )
+
+    def test_sync_back_builds_the_index_once_for_the_whole_run(self):
+        """The production call site must hoist the index out of the file loop.
+
+        The previous test proves the index is reusable; this one proves
+        ``_sync_back_impl`` actually reuses it. Without this, moving the
+        ``_build_dir_index`` call back inside the ``os.walk`` loop restores
+        the O(files x mappings) blowup with every other test still green.
+        """
+        import inspect
+        import textwrap
+
+        src = textwrap.dedent(inspect.getsource(FileSyncManager._sync_back_impl))
+        build_col = src.index("self._build_dir_index(")
+        walk_col = src.index("for dirpath, _dirnames, filenames in os.walk(")
+
+        assert build_col < walk_col, (
+            "_build_dir_index moved into/after the os.walk loop -- the index "
+            "is now rebuilt per file and the O(n*m) rescan is back"
         )
 
     def test_inference_result_is_still_correct(self):

--- a/tests/tools/test_file_sync_infer_scaling.py
+++ b/tests/tools/test_file_sync_infer_scaling.py
@@ -11,6 +11,8 @@ the call-site placement, which are the properties that actually decay, rather
 than wall-clock timing.
 """
 
+import inspect
+import textwrap
 from unittest.mock import patch
 
 from tools.environments.file_sync import FileSyncManager
@@ -69,9 +71,6 @@ class TestInferHostPathScaling:
         ``_build_dir_index`` call back inside the ``os.walk`` loop restores
         the O(files x mappings) blowup with every other test still green.
         """
-        import inspect
-        import textwrap
-
         src = textwrap.dedent(inspect.getsource(FileSyncManager._sync_back_impl))
         build_col = src.index("self._build_dir_index(")
         walk_col = src.index("for dirpath, _dirnames, filenames in os.walk(")

--- a/tests/tools/test_file_sync_shutdown.py
+++ b/tests/tools/test_file_sync_shutdown.py
@@ -1,0 +1,63 @@
+"""Tests for sync_back during interpreter shutdown.
+
+``cleanup()`` can fire from a late atexit hook or ``__del__``, by which point
+Python has torn down module globals -- builtins such as ``open`` included.  The
+old code raised a bare ``NameError`` and then slept through the full retry
+backoff, since every retry hit the same torn-down interpreter.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tools.environments.file_sync import FileSyncManager
+
+
+def _manager(**kw):
+    """A FileSyncManager with a pushed file, so sync_back does not early-exit."""
+    m = FileSyncManager(
+        get_files_fn=lambda: [],
+        upload_fn=lambda *a: None,
+        delete_fn=lambda *a: None,
+        bulk_upload_fn=lambda files: None,
+        bulk_download_fn=lambda dest, paths=None: None,
+        **kw,
+    )
+    m._pushed_hashes = {"/remote/.hermes/skills/a.md": "deadbeef"}
+    return m
+
+
+class TestSyncBackAtShutdown:
+    def test_nameerror_abandons_immediately(self, tmp_path):
+        """No retries, no sleeping -- the interpreter is not coming back."""
+        m = _manager()
+        with patch.object(FileSyncManager, "_sync_back_once",
+                          side_effect=NameError("name 'open' is not defined")) as once, \
+             patch("tools.environments.file_sync._sleep") as sleep:
+            m.sync_back(hermes_home=tmp_path)
+            assert once.call_count == 1, "shutdown must not be retried"
+            sleep.assert_not_called()
+
+    def test_ordinary_failure_still_retries(self, tmp_path):
+        """A transient error keeps the existing retry behaviour."""
+        m = _manager()
+        with patch.object(FileSyncManager, "_sync_back_once",
+                          side_effect=OSError("connection reset")) as once, \
+             patch("tools.environments.file_sync._sleep"):
+            m.sync_back(hermes_home=tmp_path)
+            assert once.call_count > 1, "transient errors should retry"
+
+
+class TestSyncBackSkipsEmptyPush:
+    def test_no_pushed_files_downloads_nothing(self, tmp_path):
+        """Pre-existing early-exit, re-pinned because the targeted-download
+        change made this path newly load-bearing."""
+        download = MagicMock()
+        m = FileSyncManager(
+            get_files_fn=lambda: [],
+            upload_fn=lambda *a: None,
+            delete_fn=lambda *a: None,
+            bulk_upload_fn=lambda files: None,
+            bulk_download_fn=download,
+        )
+        m._pushed_hashes = {}
+        m.sync_back(hermes_home=tmp_path)
+        download.assert_not_called()

--- a/tests/tools/test_ssh_bsd_tar_compat.py
+++ b/tests/tools/test_ssh_bsd_tar_compat.py
@@ -1,0 +1,121 @@
+"""Regression tests for BSD/macOS remotes in the SSH file-sync path.
+
+Each test here pins a bug that made `terminal.backend: ssh` unusable against a
+macOS host (the common case for a Mac-to-Mac fleet):
+
+* the extractor was sent GNU-only ``--no-overwrite-dir``, which BSD tar
+  rejects -- killing the local tar with SIGPIPE and reporting the failure as
+  if the *local* side were at fault;
+* ``_ssh_bulk_download`` tarred the whole remote ``~/.hermes`` (gigabytes,
+  mostly the remote's own install) even though sync-back only ever applies
+  files it previously pushed.
+"""
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools.environments import ssh as ssh_env
+from tools.environments.ssh import SSHEnvironment
+
+
+@pytest.fixture
+def mock_env(monkeypatch):
+    """An SSHEnvironment with connection/sync stubbed out."""
+    monkeypatch.setattr(ssh_env.shutil, "which", lambda _name: "/usr/bin/ssh")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_establish_connection", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_detect_remote_home", lambda self: "/home/testuser")
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "_ensure_remote_dirs", lambda self: None)
+    monkeypatch.setattr(ssh_env.SSHEnvironment, "init_session", lambda self: None)
+    monkeypatch.setattr(
+        ssh_env, "FileSyncManager",
+        lambda **kw: type("M", (), {"sync": lambda self, **k: None})(),
+    )
+    return SSHEnvironment(host="example.com", user="testuser")
+
+
+class TestUploadTarFlagNegotiation:
+    """The extract command must not hard-code the GNU-only flag."""
+
+    def _capture_extract_cmd(self, mock_env, tmp_path):
+        """Run an upload and return the remote extract command."""
+        f = tmp_path / "a.txt"
+        f.write_text("x")
+        seen = {}
+
+        def fake_popen(cmd, **kwargs):
+            # The tar side is a list starting with "tar"; the ssh side carries
+            # the remote command as its final argument.
+            if cmd[0] != "tar":
+                seen["cmd"] = cmd[-1]
+            proc = MagicMock()
+            proc.returncode = 0
+            proc.stdout = MagicMock()
+            proc.stderr = MagicMock()
+            proc.stderr.read.return_value = b""
+            proc.communicate.return_value = (b"", b"")
+            proc.poll.return_value = 0
+            return proc
+
+        with patch.object(subprocess, "run", return_value=MagicMock(returncode=0, stderr="")), \
+             patch.object(subprocess, "Popen", side_effect=fake_popen):
+            mock_env._ssh_bulk_upload([(str(f), "/home/testuser/.hermes/a.txt")])
+        return seen["cmd"]
+
+    def test_offers_both_gnu_and_bsd_forms(self, mock_env, tmp_path):
+        """GNU gets --no-overwrite-dir; BSD gets a plain extract."""
+        cmd = self._capture_extract_cmd(mock_env, tmp_path)
+        assert "--no-overwrite-dir" in cmd, "GNU remotes still need the flag"
+        assert "else exec tar xf -" in cmd, "BSD remotes need a fallback"
+
+    def test_flag_is_guarded_not_unconditional(self, mock_env, tmp_path):
+        """The pre-fix bug: the flag was passed to every remote unconditionally."""
+        cmd = self._capture_extract_cmd(mock_env, tmp_path)
+        head = cmd.split("--no-overwrite-dir", 1)[0]
+        assert "if tar" in head, "the flag must sit behind a capability test"
+
+    def test_negotiation_is_a_single_round_trip(self, mock_env, tmp_path):
+        """No extra probe connection -- the remote shell decides in-band."""
+        f = tmp_path / "a.txt"
+        f.write_text("x")
+        with patch.object(subprocess, "run", return_value=MagicMock(returncode=0, stderr="")) as run, \
+             patch.object(subprocess, "Popen") as popen:
+            proc = popen.return_value
+            proc.returncode = 0
+            proc.stderr.read.return_value = b""
+            proc.communicate.return_value = (b"", b"")
+            proc.poll.return_value = 0
+            mock_env._ssh_bulk_upload([(str(f), "/home/testuser/.hermes/a.txt")])
+            # Exactly one subprocess.run: the batched mkdir.
+            assert run.call_count == 1
+
+
+class TestBulkDownloadScope:
+    """_ssh_bulk_download must not tar the entire remote home."""
+
+    def _capture_remote_cmd(self, mock_env, tmp_path, paths):
+        """Run a download and return the remote command string."""
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["cmd"] = cmd
+            return MagicMock(returncode=0, stdout=b"", stderr=b"")
+
+        with patch.object(subprocess, "run", side_effect=fake_run):
+            mock_env._ssh_bulk_download(tmp_path / "out.tar", paths)
+        return " ".join(seen["cmd"])
+
+    def test_targeted_paths_use_stdin_list(self, mock_env, tmp_path):
+        """Given explicit paths, tar reads them from stdin (-T -), not the whole tree."""
+        cmd = self._capture_remote_cmd(
+            mock_env, tmp_path, ["/home/testuser/.hermes/skills/a/SKILL.md"]
+        )
+        assert "-T -" in cmd
+        # The remote's own multi-GB install must never be walked.
+        assert "hermes-agent" not in cmd
+
+    def test_no_paths_falls_back_to_full_tree(self, mock_env, tmp_path):
+        """Without a path list the old whole-directory behaviour is preserved."""
+        cmd = self._capture_remote_cmd(mock_env, tmp_path, None)
+        assert "-T -" not in cmd

--- a/tests/tools/test_terminal_ssh_config_defaults.py
+++ b/tests/tools/test_terminal_ssh_config_defaults.py
@@ -1,0 +1,55 @@
+"""Tests for empty ``terminal.ssh_*`` config values.
+
+``DEFAULT_CONFIG`` declares ssh_host/ssh_user/ssh_port/ssh_key so that
+``hermes config set terminal.ssh_host ...`` validates as a known key.  Those
+declared defaults are empty, and an empty value must never reach the
+environment: it would override the SSH backend's own fallbacks (port 22, the
+invoking user's identity), and ``TERMINAL_SSH_PORT=''`` reaches ``int('')`` in
+``_parse_env_var`` -- which kills *every* terminal command, not just SSH ones.
+"""
+
+import pytest
+
+from hermes_cli.config import _terminal_config_value_is_bridgeable
+from tools.terminal_tool import _parse_env_var
+
+SSH_KEYS = ["ssh_host", "ssh_user", "ssh_port", "ssh_key"]
+
+
+class TestSshValueBridging:
+    @pytest.mark.parametrize("key", SSH_KEYS)
+    def test_empty_is_not_bridged(self, key):
+        assert _terminal_config_value_is_bridgeable(key, "") is False
+
+    @pytest.mark.parametrize("key", SSH_KEYS)
+    def test_whitespace_is_not_bridged(self, key):
+        assert _terminal_config_value_is_bridgeable(key, "   ") is False
+
+    def test_real_values_are_bridged(self):
+        assert _terminal_config_value_is_bridgeable("ssh_host", "10.0.0.1") is True
+        assert _terminal_config_value_is_bridgeable("ssh_port", 22) is True
+
+    def test_ssh_keys_are_declared_in_defaults(self):
+        """Declared schema keys are what stop `config set` warning on them."""
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+
+        terminal = DEFAULT_CONFIG["terminal"]
+        for key in SSH_KEYS:
+            assert key in terminal, f"terminal.{key} missing from DEFAULT_CONFIG"
+
+
+class TestParseEnvVarEmptyFallback:
+    def test_empty_falls_back_to_default(self, monkeypatch):
+        """int('') used to explode and take every terminal command with it."""
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "")
+        assert _parse_env_var("TERMINAL_SSH_PORT", "22") == 22
+
+    def test_real_value_still_wins(self, monkeypatch):
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "2222")
+        assert _parse_env_var("TERMINAL_SSH_PORT", "22") == 2222
+
+    def test_invalid_value_still_raises(self, monkeypatch):
+        """Only *empty* is forgiven -- a typo must still be reported."""
+        monkeypatch.setenv("TERMINAL_SSH_PORT", "22x")
+        with pytest.raises(ValueError, match="TERMINAL_SSH_PORT"):
+            _parse_env_var("TERMINAL_SSH_PORT", "22")

--- a/tools/credential_files.py
+++ b/tools/credential_files.py
@@ -344,6 +344,20 @@ def _safe_skills_path(skills_dir: Path) -> str:
     return str(safe_dir)
 
 
+def _is_syncable_sync_file(item) -> bool:
+    """Return whether a directory entry should be synced to a remote env.
+
+    Skips symlinks, non-files, and macOS AppleDouble sidecars (``._name``).
+    AppleDouble files carry only HFS metadata, never skill content, and are
+    created by the OS on any non-native filesystem. On a real install they are
+    ~50% of the sync set; they also disappear between enumeration and transfer,
+    which makes tar emit "Cannot stat" errors and exit non-zero mid-stream.
+    """
+    if item.is_symlink() or not item.is_file():
+        return False
+    return not item.name.startswith("._")
+
+
 def iter_skills_files(
     container_base: str = "/root/.hermes",
 ) -> List[Dict[str, str]]:
@@ -361,7 +375,7 @@ def iter_skills_files(
     if skills_dir.is_dir():
         container_root = f"{container_base.rstrip('/')}/skills"
         for item in skills_dir.rglob("*"):
-            if item.is_symlink() or not item.is_file():
+            if not _is_syncable_sync_file(item):
                 continue
             rel = item.relative_to(skills_dir)
             result.append({
@@ -377,7 +391,7 @@ def iter_skills_files(
                 continue
             container_root = f"{container_base.rstrip('/')}/external_skills/{idx}"
             for item in ext_dir.rglob("*"):
-                if item.is_symlink() or not item.is_file():
+                if not _is_syncable_sync_file(item):
                     continue
                 rel = item.relative_to(ext_dir)
                 result.append({
@@ -389,7 +403,7 @@ def iter_skills_files(
                 continue
             container_root = f"{container_base.rstrip('/')}/project_skills/{idx}"
             for item in proj_dir.rglob("*"):
-                if item.is_symlink() or not item.is_file():
+                if not _is_syncable_sync_file(item):
                     continue
                 rel = item.relative_to(proj_dir)
                 result.append({
@@ -586,7 +600,7 @@ def iter_cache_files(
             continue
         container_root = f"{container_base.rstrip('/')}/{new_subpath}"
         for item in host_dir.rglob("*"):
-            if item.is_symlink() or not item.is_file():
+            if not _is_syncable_sync_file(item):
                 continue
             rel = item.relative_to(host_dir)
             result.append({

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -438,6 +438,9 @@ class FileSyncManager:
                 upload_only_host_paths = (
                     self._upload_only_host_paths | _credential_host_paths()
                 )
+                dir_index = self._build_dir_index(
+                    file_mapping, upload_only_host_paths
+                )
                 for dirpath, _dirnames, filenames in os.walk(staging):
                     for fname in filenames:
                         staged_file = os.path.join(dirpath, fname)
@@ -460,7 +463,7 @@ class FileSyncManager:
                             host_path = self._infer_host_path(
                                 remote_path,
                                 file_mapping,
-                                upload_only_host_paths=upload_only_host_paths,
+                                dir_index=dir_index,
                             )
                             if host_path is None:
                                 logger.debug(
@@ -507,7 +510,8 @@ class FileSyncManager:
     def _infer_host_path(self, remote_path: str,
                          file_mapping: list[tuple[str, str]] | None = None,
                          *,
-                         upload_only_host_paths: set[str] | None = None) -> str | None:
+                         upload_only_host_paths: set[str] | None = None,
+                         dir_index: list[tuple[str, str]] | None = None) -> str | None:
         """Infer a host path for a new remote file by matching path prefixes.
 
         Uses the existing file mapping to find a remote->host directory
@@ -515,11 +519,16 @@ class FileSyncManager:
         For example, if the mapping has ``/root/.hermes/skills/a.md`` →
         ``~/.hermes/skills/a.md``, a new remote file at
         ``/root/.hermes/skills/b.md`` maps to ``~/.hermes/skills/b.md``.
+
+        ``dir_index`` is the precomputed result of :meth:`_build_dir_index`;
+        callers resolving many files should build it once and pass it in.
         """
-        mapping = file_mapping if file_mapping is not None else []
-        upload_only_host_paths = upload_only_host_paths or set()
-        index = self._build_dir_index(mapping, upload_only_host_paths)
-        for remote_dir, host_dir in index:
+        if dir_index is None:
+            dir_index = self._build_dir_index(
+                file_mapping if file_mapping is not None else [],
+                upload_only_host_paths or set(),
+            )
+        for remote_dir, host_dir in dir_index:
             if remote_path.startswith(remote_dir + "/"):
                 suffix = remote_path[len(remote_dir):]
                 return host_dir + suffix
@@ -530,21 +539,13 @@ class FileSyncManager:
         mapping: list[tuple[str, str]],
         upload_only_host_paths: set[str],
     ) -> list[tuple[str, str]]:
-        """Precompute the (remote_dir, host_dir) pairs used for inference.
+        """Collapse the file mapping to deduplicated (remote_dir, host_dir) pairs.
 
-        Both the upload-only filter and the ``Path(..).parent`` calls are
-        loop-invariant per sync, but ``_infer_host_path`` used to redo them
-        for every candidate mapping of every file: 6.6k files x 6.6k mappings
-        drove 3.4M ``_is_upload_only_host_path`` calls and 27M ``lstat``
-        syscalls (111s of a 146s profiled sync_back).  Cache the result,
-        keyed on the mapping identity plus the filter set, preserving the
-        original first-match-wins order.
+        The upload-only filter and the ``Path(..).parent`` calls are constant
+        for a whole sync, so this is built once per ``sync_back`` and reused
+        for every file rather than recomputed per candidate mapping. Preserves
+        first-match-wins order.
         """
-        cache_key = (id(mapping), len(mapping), frozenset(upload_only_host_paths))
-        cached = getattr(self, "_dir_index_cache", None)
-        if cached is not None and cached[0] == cache_key:
-            return cached[1]
-
         seen: set[tuple[str, str]] = set()
         index: list[tuple[str, str]] = []
         for host, remote in mapping:
@@ -555,8 +556,6 @@ class FileSyncManager:
                 continue
             seen.add(pair)
             index.append(pair)
-
-        self._dir_index_cache = (cache_key, index)
         return index
 
     @staticmethod

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -518,15 +518,46 @@ class FileSyncManager:
         """
         mapping = file_mapping if file_mapping is not None else []
         upload_only_host_paths = upload_only_host_paths or set()
-        for host, remote in mapping:
-            if self._is_upload_only_host_path(host, upload_only_host_paths):
-                continue
-            remote_dir = str(Path(remote).parent)
+        index = self._build_dir_index(mapping, upload_only_host_paths)
+        for remote_dir, host_dir in index:
             if remote_path.startswith(remote_dir + "/"):
-                host_dir = str(Path(host).parent)
                 suffix = remote_path[len(remote_dir):]
                 return host_dir + suffix
         return None
+
+    def _build_dir_index(
+        self,
+        mapping: list[tuple[str, str]],
+        upload_only_host_paths: set[str],
+    ) -> list[tuple[str, str]]:
+        """Precompute the (remote_dir, host_dir) pairs used for inference.
+
+        Both the upload-only filter and the ``Path(..).parent`` calls are
+        loop-invariant per sync, but ``_infer_host_path`` used to redo them
+        for every candidate mapping of every file: 6.6k files x 6.6k mappings
+        drove 3.4M ``_is_upload_only_host_path`` calls and 27M ``lstat``
+        syscalls (111s of a 146s profiled sync_back).  Cache the result,
+        keyed on the mapping identity plus the filter set, preserving the
+        original first-match-wins order.
+        """
+        cache_key = (id(mapping), len(mapping), frozenset(upload_only_host_paths))
+        cached = getattr(self, "_dir_index_cache", None)
+        if cached is not None and cached[0] == cache_key:
+            return cached[1]
+
+        seen: set[tuple[str, str]] = set()
+        index: list[tuple[str, str]] = []
+        for host, remote in mapping:
+            if self._is_upload_only_host_path(host, upload_only_host_paths):
+                continue
+            pair = (str(Path(remote).parent), str(Path(host).parent))
+            if pair in seen:
+                continue
+            seen.add(pair)
+            index.append(pair)
+
+        self._dir_index_cache = (cache_key, index)
+        return index
 
     @staticmethod
     def _is_upload_only_host_path(host_path: str, upload_only_host_paths: set[str]) -> bool:

--- a/tools/environments/file_sync.py
+++ b/tools/environments/file_sync.py
@@ -7,6 +7,7 @@ view) and don't need this.
 """
 
 import hashlib
+import inspect
 import logging
 import os
 import posixpath
@@ -23,7 +24,7 @@ try:
 except ImportError:
     fcntl = None  # Windows — file locking skipped
 from pathlib import Path
-from typing import Callable
+from typing import Any, Callable
 
 from hermes_constants import get_hermes_home
 from tools.environments.base import _file_mtime_key
@@ -45,7 +46,7 @@ _FORCE_SYNC_ENV = "HERMES_FORCE_FILE_SYNC"
 # Transport callbacks provided by each backend
 UploadFn = Callable[[str, str], None]  # (host_path, remote_path) -> raises on failure
 BulkUploadFn = Callable[[list[tuple[str, str]]], None]  # [(host_path, remote_path), ...] -> raises on failure
-BulkDownloadFn = Callable[[Path], None]  # (dest_tar_path) -> writes tar archive, raises on failure
+BulkDownloadFn = Callable[..., None]  # (dest_tar_path, paths=None) -> writes tar archive, raises on failure
 DeleteFn = Callable[[list[str]], None]  # (remote_paths) -> raises on failure
 GetFilesFn = Callable[[], list[tuple[str, str]]]  # () -> [(host_path, remote_path), ...]
 
@@ -129,6 +130,30 @@ def _sha256_file(path: str) -> str:
 _SYNC_BACK_MAX_RETRIES = 3
 _SYNC_BACK_BACKOFF = (2, 4, 8)  # seconds between retries
 _SYNC_BACK_MAX_BYTES = 2 * 1024 * 1024 * 1024  # 2 GiB — refuse to extract larger tars
+
+
+def _accepts_paths_arg(fn: Callable[..., Any]) -> bool:
+    """Return whether *fn* takes a second positional arg (the path list).
+
+    Lets sync_back request a targeted tar from backends that support it while
+    still working with older single-argument download callbacks. Introspection
+    rather than catching TypeError, so a genuine TypeError raised inside the
+    callback is not mistaken for a signature mismatch and silently retried.
+    """
+    try:
+        sig = inspect.signature(fn)
+    except (TypeError, ValueError):
+        return False
+    positional = 0
+    for param in sig.parameters.values():
+        if param.kind is inspect.Parameter.VAR_POSITIONAL:
+            return True
+        if param.kind in (
+            inspect.Parameter.POSITIONAL_ONLY,
+            inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        ):
+            positional += 1
+    return positional >= 2
 
 
 class FileSyncManager:
@@ -288,6 +313,12 @@ class FileSyncManager:
                 return
             except Exception as exc:
                 last_exc = exc
+                # A NameError here means the interpreter is tearing down its
+                # globals; every remaining attempt will fail identically, so
+                # stop instead of sleeping through the backoff schedule.
+                if isinstance(exc, NameError):
+                    logger.debug("sync_back: interpreter shutting down — abandoning")
+                    return
                 if attempt < _SYNC_BACK_MAX_RETRIES - 1:
                     delay = _SYNC_BACK_BACKOFF[attempt]
                     logger.warning(
@@ -339,7 +370,15 @@ class FileSyncManager:
             # Windows: no flock — run without serialization
             self._sync_back_impl()
             return
-        lock_fd = open(lock_path, "w", encoding="utf-8")
+        # During interpreter shutdown module globals (including builtins such
+        # as ``open``) are torn down, so a cleanup() firing from a late atexit
+        # or __del__ raises a bare NameError that no retry can fix. Detect it
+        # and skip rather than burning the retry budget on a lost cause.
+        try:
+            lock_fd = open(lock_path, "w", encoding="utf-8")
+        except NameError:  # pragma: no cover - shutdown-only path
+            logger.debug("sync_back: interpreter shutting down — skipping")
+            return
         try:
             fcntl.flock(lock_fd, fcntl.LOCK_EX)
             self._sync_back_impl()
@@ -362,7 +401,21 @@ class FileSyncManager:
             file_mapping = []
 
         with tempfile.NamedTemporaryFile(suffix=".tar") as tf:
-            self._bulk_download_fn(Path(tf.name))
+            # Only files previously pushed can produce an applied change (the
+            # loop below requires a _pushed_hashes entry), so ask the backend
+            # for just those. With nothing pushed there is nothing sync_back
+            # could apply, so skip the transfer entirely rather than dragging
+            # the whole remote tree across the wire to discard it.
+            wanted = sorted(self._pushed_hashes.keys())
+            targeted = _accepts_paths_arg(self._bulk_download_fn)
+            if targeted:
+                if not wanted:
+                    logger.debug("sync_back: nothing was pushed — skipping download")
+                    return
+                self._bulk_download_fn(Path(tf.name), wanted)
+            else:
+                # Backend predates the `paths` argument: full-tree tar.
+                self._bulk_download_fn(Path(tf.name))
 
             # Defensive size cap: a misbehaving sandbox could produce an
             # arbitrarily large tar. Refuse to extract if it exceeds the cap.

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -288,7 +288,19 @@ class SSHEnvironment(BaseEnvironment):
             # existing directories (e.g. /home/<user>) with the staging
             # directory's mode.  Without this, a umask 002 produces 0775
             # dirs which breaks sshd StrictModes (refuses authorized_keys).
-            ssh_cmd.append(f"tar xf - --no-overwrite-dir -C {shlex.quote(base)}")
+            #
+            # It is a GNU tar flag.  BSD tar (macOS, FreeBSD remotes) rejects
+            # it outright, exits immediately, and the local tar then dies of
+            # SIGPIPE reporting a misleading "tar: Write error".  Probe the
+            # remote tar once and only pass the flag where it is supported;
+            # BSD tar does not overwrite existing directory modes anyway, so
+            # omitting it there preserves the same property.
+            extract_cmd = f"tar xf - -C {shlex.quote(base)}"
+            if self._remote_tar_supports_no_overwrite_dir():
+                extract_cmd = (
+                    f"tar xf - --no-overwrite-dir -C {shlex.quote(base)}"
+                )
+            ssh_cmd.append(extract_cmd)
 
             tar_proc = subprocess.Popen(
                 tar_cmd,
@@ -332,9 +344,16 @@ class SSHEnvironment(BaseEnvironment):
                 )
 
             if tar_proc.returncode != 0:
+                # A remote-side rejection (bad flag, missing dir) closes the
+                # pipe and kills the local tar with SIGPIPE, so tar's own
+                # message is a misleading "Write error". Surface the remote
+                # stderr too — it carries the actual cause.
+                remote_err = ssh_stderr.decode(errors='replace').strip()
+                detail = tar_stderr_raw.decode(errors='replace').strip()
+                if remote_err:
+                    detail = f"{detail} | remote: {remote_err}"
                 raise RuntimeError(
-                    f"tar create failed (rc={tar_proc.returncode}): "
-                    f"{tar_stderr_raw.decode(errors='replace').strip()}"
+                    f"tar create failed (rc={tar_proc.returncode}): {detail}"
                 )
             if ssh_proc.returncode != 0:
                 raise EnvironmentConnectionError(
@@ -348,17 +367,69 @@ class SSHEnvironment(BaseEnvironment):
 
         logger.debug("SSH: bulk-uploaded %d file(s) via tar pipe", len(files))
 
-    def _ssh_bulk_download(self, dest: Path) -> None:
-        """Download remote .hermes/ as a tar archive."""
+    def _remote_tar_supports_no_overwrite_dir(self) -> bool:
+        """Return whether the remote tar accepts GNU's --no-overwrite-dir.
+
+        Probed once per connection and cached. BSD tar (macOS, FreeBSD)
+        rejects the flag and exits immediately, which makes the local tar
+        in the upload pipe die of SIGPIPE with a misleading write error.
+        Failure to probe is treated as "unsupported" so the sync still runs.
+        """
+        cached = getattr(self, "_tar_no_overwrite_dir", None)
+        if cached is not None:
+            return cached
+
+        supported = False
+        try:
+            cmd = self._build_ssh_command()
+            cmd.append("tar --help 2>&1 | grep -q -- --no-overwrite-dir")
+            result = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True, encoding="utf-8", errors="replace",
+                stdin=subprocess.DEVNULL,
+                timeout=15,
+            )
+            supported = result.returncode == 0
+        except Exception:
+            supported = False
+
+        self._tar_no_overwrite_dir = supported
+        return supported
+
+    def _ssh_bulk_download(self, dest: Path, paths: list[str] | None = None) -> None:
+        """Download remote .hermes/ as a tar archive.
+
+        *paths* limits the archive to specific absolute remote paths. sync_back
+        only ever applies files it previously pushed, so restricting the tar to
+        those keeps it proportional to what was sent rather than to the size of
+        the remote ~/.hermes (multi-GB on a real install: the Hermes checkout,
+        bundled node, LSP servers). Without it the tar reliably exceeds both
+        timeout=120 and the 2 GiB extraction cap, so sync-back never completes.
+        """
         # Tar from / with the full path so archive entries preserve absolute
         # paths (e.g. home/user/.hermes/skills/f.py), matching _pushed_hashes keys.
         rel_base = f"{self._remote_home}/.hermes".lstrip("/")
         ssh_cmd = self._build_ssh_command()
-        ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
+
+        stdin_data: bytes | None = None
+        if paths:
+            # Feed the explicit list on stdin (-T -). Supported by both GNU and
+            # BSD tar. Paths are relative to / to match the -C / archive root.
+            rel_paths = [p.lstrip("/") for p in paths if p]
+            if not rel_paths:
+                dest.write_bytes(b"")
+                return
+            stdin_data = ("\n".join(rel_paths) + "\n").encode()
+            ssh_cmd.append("tar cf - -C / -T -")
+        else:
+            ssh_cmd.append(f"tar cf - -C / {shlex.quote(rel_base)}")
+
         with open(dest, "wb") as f:
             result = subprocess.run(
                 ssh_cmd,
-                stdin=subprocess.DEVNULL,
+                input=stdin_data,
+                stdin=subprocess.DEVNULL if stdin_data is None else None,
                 stdout=f,
                 stderr=subprocess.PIPE,
                 timeout=120,

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -374,9 +374,8 @@ class SSHEnvironment(BaseEnvironment):
         *paths* limits the archive to specific absolute remote paths. sync_back
         only ever applies files it previously pushed, so restricting the tar to
         those keeps it proportional to what was sent rather than to the size of
-        the remote ~/.hermes (multi-GB on a real install: the Hermes checkout,
-        bundled node, LSP servers). Without it the tar reliably exceeds both
-        timeout=120 and the 2 GiB extraction cap, so sync-back never completes.
+        the remote ~/.hermes, which on a real install holds the Hermes checkout,
+        a bundled node, and LSP servers and runs to multiple GB.
         """
         # Tar from / with the full path so archive entries preserve absolute
         # paths (e.g. home/user/.hermes/skills/f.py), matching _pushed_hashes keys.

--- a/tools/environments/ssh.py
+++ b/tools/environments/ssh.py
@@ -291,16 +291,17 @@ class SSHEnvironment(BaseEnvironment):
             #
             # It is a GNU tar flag.  BSD tar (macOS, FreeBSD remotes) rejects
             # it outright, exits immediately, and the local tar then dies of
-            # SIGPIPE reporting a misleading "tar: Write error".  Probe the
-            # remote tar once and only pass the flag where it is supported;
-            # BSD tar does not overwrite existing directory modes anyway, so
-            # omitting it there preserves the same property.
-            extract_cmd = f"tar xf - -C {shlex.quote(base)}"
-            if self._remote_tar_supports_no_overwrite_dir():
-                extract_cmd = (
-                    f"tar xf - --no-overwrite-dir -C {shlex.quote(base)}"
-                )
-            ssh_cmd.append(extract_cmd)
+            # SIGPIPE reporting a misleading "tar: Write error".  Let the
+            # remote shell pick: GNU takes the flag, BSD falls back without
+            # it -- BSD tar does not overwrite existing directory modes
+            # anyway, so the property is preserved either way.  Negotiating
+            # in-band keeps this a single round trip (no capability probe).
+            quoted_base = shlex.quote(base)
+            ssh_cmd.append(
+                f"if tar --no-overwrite-dir --version >/dev/null 2>&1; "
+                f"then exec tar xf - --no-overwrite-dir -C {quoted_base}; "
+                f"else exec tar xf - -C {quoted_base}; fi"
+            )
 
             tar_proc = subprocess.Popen(
                 tar_cmd,
@@ -366,36 +367,6 @@ class SSHEnvironment(BaseEnvironment):
                 )
 
         logger.debug("SSH: bulk-uploaded %d file(s) via tar pipe", len(files))
-
-    def _remote_tar_supports_no_overwrite_dir(self) -> bool:
-        """Return whether the remote tar accepts GNU's --no-overwrite-dir.
-
-        Probed once per connection and cached. BSD tar (macOS, FreeBSD)
-        rejects the flag and exits immediately, which makes the local tar
-        in the upload pipe die of SIGPIPE with a misleading write error.
-        Failure to probe is treated as "unsupported" so the sync still runs.
-        """
-        cached = getattr(self, "_tar_no_overwrite_dir", None)
-        if cached is not None:
-            return cached
-
-        supported = False
-        try:
-            cmd = self._build_ssh_command()
-            cmd.append("tar --help 2>&1 | grep -q -- --no-overwrite-dir")
-            result = subprocess.run(
-                cmd,
-                capture_output=True,
-                text=True, encoding="utf-8", errors="replace",
-                stdin=subprocess.DEVNULL,
-                timeout=15,
-            )
-            supported = result.returncode == 0
-        except Exception:
-            supported = False
-
-        self._tar_no_overwrite_dir = supported
-        return supported
 
     def _ssh_bulk_download(self, dest: Path, paths: list[str] | None = None) -> None:
         """Download remote .hermes/ as a tar archive.

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1607,6 +1607,12 @@ def _parse_env_var(name: str, default: str, converter: Any = int, type_label: st
     causes an unhandled ValueError that kills every terminal command.
     """
     raw = os.getenv(name, default)
+    # An env var that is set-but-empty (blank line in .env, an unset shell
+    # expansion, or a config default that means "not configured") should fall
+    # back to *default* rather than blowing up every terminal command on
+    # int('').
+    if raw == "" and default != "":
+        raw = default
     try:
         return converter(raw)
     except (ValueError, json.JSONDecodeError):


### PR DESCRIPTION
## What does this PR do?

`terminal.backend: "ssh"` is documented in `cli-config.yaml.example`, and macOS
is a supported platform — but pointing the SSH backend at a **macOS or BSD
remote** fails. This PR fixes four independent bugs on that path, plus the
`O(files × mappings)` rescan that made sync-back slow once the first three were
out of the way.

Each is small, but together they mean file sync against a BSD remote never
completes.

**1. GNU-only tar flag against a BSD remote.** Uploads run
`tar --no-overwrite-dir` on the remote. That flag is GNU-specific; BSD tar
(macOS, FreeBSD) rejects it and exits immediately, closing the pipe. The local
`tar` then dies of `SIGPIPE` and reports `tar: Write error` — which points at
the local side and hides the real cause.

Fixed by negotiating in-band, in the same SSH round trip rather than adding a
capability probe:

```sh
tar --no-overwrite-dir --version >/dev/null 2>&1 && exec tar --no-overwrite-dir -xf - || exec tar -xf -
```

The remote shell picks: GNU takes the flag, BSD falls back without it. The
property is preserved either way — BSD tar does not overwrite existing
directory modes to begin with. Remote stderr is now surfaced alongside the
local `SIGPIPE`, so the next person sees the actual error.

**2. `sync_back` tarred the entire remote `~/.hermes`.** On a real install that
directory holds the Hermes checkout, a bundled node, and LSP servers — multiple
GB. The transfer exceeded both the 120s timeout and the 2 GiB extraction cap, so
sync-back never finished.

`sync_back` can only apply files it previously pushed (the apply loop requires a
`_pushed_hashes` entry), so the download is now restricted to exactly those
paths, fed to remote `tar` on stdin via `-T -` (supported by both GNU and BSD).
With nothing pushed, the transfer is skipped rather than dragging the tree
across the wire to discard it. Backends whose `bulk_download_fn` predates the
`paths` argument keep the old full-tree behaviour.

**3. AppleDouble sidecars doubled the file count.** macOS writes `._*` metadata
files onto non-native filesystems. They were being treated as syncable
credential files: 6,620 of 13,241 synced entries were `._*` sidecars carrying no
useful content.

**4. Empty `terminal.ssh_*` config broke every terminal command.** The
`ssh_host` / `ssh_user` / `ssh_port` / `ssh_key` keys are documented in
`cli-config.yaml.example` but were not declared in the config schema, so
`hermes config set terminal.ssh_host ...` warned that Hermes may never read the
key. Declaring them surfaced a second bug: an unset key bridged as `""`, and
`int("")` then raised on **every** terminal command, including local ones. Empty
now means "not configured" and falls back (port 22, the invoking user's SSH
defaults).

**5. Performance: `_infer_host_path` rescanned the mapping per file.** For each
synced file it walked the whole file mapping, calling `_is_upload_only_host_path`
— a `Path.expanduser().resolve()`, i.e. filesystem syscalls — for every
candidate. That is `O(files × mappings)` `lstat` calls, and it dominated
`sync_back` on a real remote.

The `(remote_dir, host_dir)` pairs are constant for a whole sync, so they are
now built once in `_sync_back_impl` and passed down. First-match-wins order is
preserved.

## Related Issue

No existing issue — happy to open one if preferred.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/environments/ssh.py`
  - `_ssh_bulk_upload()` — negotiate `--no-overwrite-dir` in-band; surface remote
    stderr when the local tar dies of `SIGPIPE`.
  - `_ssh_bulk_download()` — accept an optional `paths` list and archive only
    those entries (`tar -T -`).
- `tools/environments/file_sync.py`
  - `_sync_back_impl()` — request only previously pushed paths; skip the
    transfer entirely when nothing was pushed; build the directory index once.
  - `_infer_host_path()` — accept a prebuilt `dir_index`.
  - `_build_dir_index()` — new; collapses the mapping to deduplicated
    `(remote_dir, host_dir)` pairs.
  - `cleanup()` — a `NameError` during interpreter shutdown now stops the retry
    loop instead of burning the backoff schedule (module globals, including
    `open`, are gone at that point; no retry can succeed).
- `tools/credential_files.py` — `_is_syncable_sync_file()` filters AppleDouble
  `._*` sidecars.
- `hermes_cli/config_defaults.py` — declare `terminal.ssh_host` / `ssh_user` /
  `ssh_port` / `ssh_key`.
- `hermes_cli/config.py` — do not bridge empty `ssh_*` values into the
  environment.
- `tools/terminal_tool.py` — `_parse_env_var()` treats a set-but-empty value as
  unset and returns the default.
- Tests: `test_ssh_bsd_tar_compat.py`, `test_terminal_ssh_config_defaults.py`,
  `test_credential_files_appledouble.py`, `test_file_sync_shutdown.py`,
  `test_file_sync_infer_scaling.py`.

## How to Test

Requires a macOS or BSD host reachable over SSH.

```yaml
# ~/.hermes/config.yaml
terminal:
  backend: ssh
  ssh_host: <macos-or-bsd-host>
  ssh_user: <user>
```

```bash
HERMES_FORCE_FILE_SYNC=1 hermes -q "run: hostname"
```

Before: upload fails with `tar: Write error` (misleading — the remote rejected
`--no-overwrite-dir`), and `sync_back` hangs trying to tar the whole remote
`~/.hermes`. After: the command completes and sync-back returns.

Regression suites:

```bash
bash scripts/run_tests.sh \
  tests/tools/test_ssh_bsd_tar_compat.py \
  tests/tools/test_ssh_bulk_upload.py \
  tests/tools/test_file_sync_infer_scaling.py \
  tests/tools/test_file_sync_shutdown.py \
  tests/tools/test_credential_files_appledouble.py \
  tests/tools/test_terminal_ssh_config_defaults.py \
  tests/tools/test_terminal_tool.py \
  tests/hermes_cli/test_config.py -q
# === Summary: 8 files, 165 tests passed, 0 failed, 4 skipped ===
```

Every fix here was mutation-checked: reverting the production change makes the
corresponding test fail. The perf test asserts the call-site placement (the
index is built outside the per-file loop), which is the property that actually
decays — not wall-clock timing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo gate on the affected suites (see above) — all pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.1 (Apple Silicon) client → macOS remote, Python 3.11

> On `pytest tests/ -q`: the full suite has pre-existing failures on my machine
> unrelated to this change (optional SDKs such as `daytona` are not installed
> and `security.allow_lazy_installs=false`). I verified via
> `scripts/run_tests.sh` on the owning suites, and confirmed the same failures
> reproduce on an unmodified `main`.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings updated; no user-facing doc change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A: `ssh_host`/`ssh_user`/`ssh_port`/`ssh_key` were **already** documented there (lines 375–378). This PR declares them in the schema so they stop warning.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — see note below
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

**Cross-platform notes.** The tar negotiation runs in the *remote* shell, so it
adapts to whatever the remote provides rather than assuming a platform; `-T -`
is supported by both GNU and BSD tar. `_is_syncable_sync_file()` filters a
`._*` basename pattern, which is inert on non-macOS. No new local process
spawning, and no `os.kill(pid, 0)` — the existing `shutil.which("ssh")` guard
in `ssh.py` is untouched.

## Screenshots / Logs

The misleading error this fixes — the local tar reporting a write error when the
actual failure was the remote rejecting a GNU flag:

```
tar: Write error
```

Remote stderr, now surfaced alongside it (captured from a real macOS remote):

```
tar: Option --no-overwrite-dir is not supported
Usage:
  List:    tar -tf <archive-filename>
  Extract: tar -xf <archive-filename>
```
