### PR TITLE
fix(update): keep pipe-drain proof off host console

### DIFF
--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -89,10 +89,10 @@ $script:Ui = $null
 $script:UiStage = "Hermes will open once done."   # until the first gate; matches ui.html
 $script:UiStopwatch = [System.Diagnostics.Stopwatch]::StartNew()
 
-function Write-HandoffLog([string]$Message) {
+function Write-HandoffLog([string]$Message, [bool]$EchoToHost = $true) {
     $line = "{0:yyyy-MM-ddTHH:mm:ssK} {1}" -f (Get-Date), $Message
     try { Add-Content -LiteralPath $LogPath -Value $line -Encoding UTF8 } catch {}
-    Write-Host $line
+    if ($EchoToHost) { Write-Host $line }
 }
 
 # ── The shim: repo-owned HTML in a chromeless default-browser app window ───
@@ -971,13 +971,15 @@ function Step-PipeDrain($Reader, [ref]$Task, $Buffer, $Sink, [ref]$Moved) {
     return $false
 }
 
-function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
-    # The window does not stream child output, so no line-pump: both pipes
-    # drain asynchronously (no deadlock however chatty the child) while a small
-    # DoEvents loop keeps the marquee animating through long silent
-    # stretches (pip installs) -- the old EndOfStream pump blocked on quiet
-    # children and froze it. Full output still lands in the hand-off log
-    # afterwards, where `hermes debug share` picks it up.
+function Invoke-HermesStep(
+    [string]$Exe,
+    [string[]]$HermesArgs,
+    [string]$Tag,
+    [bool]$EchoCapturedOutput = $true
+) {
+    # Captured output always lands in desktop-update-handoff.log and in the
+    # returned Output string. EchoCapturedOutput controls only replay to this
+    # process's host console; production callers retain the default ($true).
     #
     # The drain is bounded once the step exits (#90455). Waiting for pipe EOF
     # is waiting on the step's whole surviving descendant tree, and this
@@ -1107,10 +1109,14 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $outText = $outSink.ToString()
     $errText = $errSink.ToString()
     foreach ($ln in ($outText -split "`r?`n")) {
-        if ($ln.Trim()) { Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) }
+        if ($ln.Trim()) {
+            Write-HandoffLog ("{0}| {1}" -f $Tag, $ln) $EchoCapturedOutput
+        }
     }
     foreach ($ln in ($errText -split "`r?`n")) {
-        if ($ln.Trim()) { Write-HandoffLog ("{0}!| {1}" -f $Tag, $ln) }
+        if ($ln.Trim()) {
+            Write-HandoffLog ("{0}!| {1}" -f $Tag, $ln) $EchoCapturedOutput
+        }
     }
     $all = $outText
     if ($errText) { $all += "`n" + $errText }
@@ -1273,10 +1279,11 @@ exit 3
     }
 
     $floodSw = [System.Diagnostics.Stopwatch]::StartNew()
-    $flood = Invoke-HermesStep $powershell @(
+    Write-HandoffLog ("PIPE-DRAIN SELF-TEST: running flood arm ({0}KB; raw payload retained in hand-off log)" -f $floodKb)
+    $flood = Invoke-HermesStep -Exe $powershell -HermesArgs @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $floodPs1,
         "-Kb", [string]$floodKb
-    ) "pipeflood"
+    ) -Tag "pipeflood" -EchoCapturedOutput $false
     $floodSw.Stop()
     $floodElapsed = [Math]::Round($floodSw.Elapsed.TotalSeconds, 2)
     $floodBytes = $flood.Output.Length

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -168,6 +168,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     if not powershell.is_file():
         pytest.skip(f"Windows PowerShell not found at {powershell}")
 
+    flood_kb = 8192
     env = {
         **os.environ,
         # The fixture writes its child scripts, pid file and hand-off log under
@@ -180,6 +181,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
         "HERMES_UPDATE_PIPE_DRAIN_SECONDS": "3",
         "HERMES_UPDATE_STEP_IDLE_SECONDS": "3",
         "HERMES_SELFTEST_HOLD_SECONDS": "45",
+        "HERMES_SELFTEST_FLOOD_KB": str(flood_kb),
     }
 
     result = subprocess.run(
@@ -204,7 +206,7 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
 
     assert "PIPE-DRAIN SELF-TEST: PASS" in result.stdout, (
         "The Windows update hand-off's step drain regressed: it either waited "
-        "on a descendant holding the pipe open (the Desktop parks on 'Updating "
+        "on a descendant holding the pipe open (the Desktop parks on 'Updating "  # windows-footgun: ok -- prose, not open()
         "Hermes' forever) or metered a chatty step (backpressure on the running "
         f"update). Fixture diagnosis follows.\n--- stdout ---\n{result.stdout}\n"
         f"--- stderr ---\n{result.stderr}"
@@ -213,3 +215,17 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
         f"-SelfTestPipeDrain exited {result.returncode}.\n"
         f"--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
     )
+    handoff_log = tmp_path / "logs" / "desktop-update-handoff.log"
+    emitted_stdout_bytes = len(result.stdout.encode("utf-8"))
+    assert emitted_stdout_bytes < 64 * 1024, (
+        "GitHub Actions throttling risk: self-test emitted "
+        f"{emitted_stdout_bytes} stdout bytes"
+    )
+    if "pipeflood| " in result.stdout:
+        pytest.fail("GitHub Actions throttling risk: flood output was replayed")
+    assert "pipedrain| pipe-drain step output" in result.stdout
+    assert "stepstall| step entered silent finalization" in result.stdout
+    assert handoff_log.is_file()
+    assert handoff_log.stat().st_size >= flood_kb * 1024
+    with handoff_log.open(encoding="utf-8-sig") as log_handle:
+        assert any("pipeflood| " in line for line in log_handle)


### PR DESCRIPTION
## What changed and why

`-SelfTestPipeDrain` intentionally captures an 8 MiB flood to prove the Windows handoff drains child pipes without backpressure. `Invoke-HermesStep` then replayed that full capture through `Write-Host`; GitHub Actions throttled its 128 KiB lines, pushed the fixture over its wall-clock budget, and kept the job draining long after the fixture exited.

This change separates durable logging from host-console replay. Production callers keep the existing default. Only the fixture's flood arm suppresses raw console replay; its bytes remain in `desktop-update-handoff.log` and `Invoke-HermesStep(...).Output`, while concise progress and the final verdict remain visible.

## Why this matters to users

This does not change the updater users run. It makes the real Windows watchdog proof reliable on the same hosted Windows environment that gates Hermes changes, so future pipe-drain regressions fail in CI instead of forcing maintainers to rely on suites that skip the executable fixture.

## How to test

- `scripts/run_tests.sh tests/test_desktop_update_windows_pipe_drain.py tests/test_desktop_update_windows_python_handoff.py tests/test_desktop_update_windows_progress.py tests/test_desktop_update_windows_timestamp.py` (12 tests total; verified serially with disjoint pytest roots on native Windows)
- PowerShell 5.1 AST parse
- Ruff, compileall, Windows-footgun scan, `git diff --check`, attribution audit

## Platforms tested

- Native Windows 11 / Windows PowerShell 5.1

## TDD receipt

- RED: unchanged production code emitted 8,391,826 bytes to fixture stdout after the fixture's own PASS marker and zero exit-code assertions succeeded.
- GREEN: fixture stdout is bounded below 64 KiB, `pipeflood|` is absent from stdout, full flood bytes remain in the durable handoff log, and all four fixture arms pass.

## Related work and credit

- Report and retained hosted-runner evidence: #95971 by @teknium1.
- Underlying watchdog and executable fixture: #95625 by @fangliquanflq, integrated through #95897 by @teknium1.
- Original bounded pipe-drain diagnosis and fixture: #90564 by @jackulau, salvaged and extended through merged #90937 by @OutThisLife.
- Current same-file open PRs checked at their live heads: #84025, #84771, #89317, #93042, #94107, #95156, #95719, #96340, #96458, #97056, #99662. None implements this durable-log/host-replay split. #95719 adds child-environment state inside `Invoke-HermesStep`; #95156 carries a broad stale version of the same function. Whichever lands later must preserve the default-true replay parameter and the single `pipeflood` opt-out.
- Merge order: standalone; no dependency. Later same-file PRs rebase onto current main and retain their own disjoint mechanisms.

Fixes #95971

## Prior Work / Attribution

**Prior credit** - the humans whose work this builds on, before anyone else:
- **@kgice918** - reported the original Windows pipe-EOF deadlock and supplied the decisive handoff-log evidence (#90455).
- **@jackulau** - proved pipe EOF outlives process exit, built the bounded chunked drain, and added the first executable `-SelfTestPipeDrain` fixture (#90564).
- **@OutThisLife** - preserved that work and added the unmetered flood arm in the merged implementation (#90937).
- **@fangliquanflq** - added the live-child stall watchdog and job-object cancellation proof (#95625).
- **@teknium1** - integrated the watchdog work with preserved credit (#95897), retained the hosted-runner evidence, and filed this fixture transport defect (#95971).

**Related work searched** (multiple methods, all states, before finalizing this PR):

- **GraphQL dedup - PR/issue graph** (`SelfTestPipeDrain`, `pipeflood`, `Invoke-HermesStep`, `windows.ps1`, host-console replay): no open PR implements this replay split; the current same-file collision set is listed above.
- **Source-tree search** of `scripts/desktop-update/windows.ps1` and the Windows handoff tests confirmed `Write-HandoffLog`, `Invoke-HermesStep`, and the `pipeflood` arm are the complete relevant path.
- **External search** for `SelfTestPipeDrain` / pipe-drain evidence found the original #90455/#90564/#90937 lineage and the retained Actions evidence attached to #95897/#95971.
- **File-collision dedup**: both changed paths were checked against every open PR updated since the prior complete census, with nested file connections fully paginated; no new exact output-replay or flood-call implementation exists.

**Unlinked related work (stars not bound to this PR by keywords):**
- **@jackulau - #90564 [CLOSED]** - original bounded-drain implementation and fixture, superseded with preserved credit.
- **@OutThisLife - #90937 [MERGED]** - shipped the bounded drain and flood proof now refined here.
- **@fangliquanflq - #95625 [CLOSED]** - watchdog source later integrated through #95897.

**Builds on:** @jackulau (#90564), @OutThisLife (#90937), @fangliquanflq (#95625), and @teknium1 (#95897/#95971).
**Merge-order / dependency:** standalone; later same-file work must preserve this default-true parameter and fixture-only opt-out.
**Duplicates:** none; the live FILE-LIST and behavior searches found no existing PR that separates durable capture from host-console replay.
