### PR TITLE
feat: native audio and voice routing for multimodal models

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -311,16 +311,9 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             fmt = str(audio_info.get("format") or "").strip().lower()
             if not isinstance(encoded, str) or not encoded:
                 continue
-            if fmt == "mp3" or fmt == "mpeg":
-                mime = "audio/mpeg"
-            elif fmt in {"ogg", "oga", "opus"}:
-                mime = "audio/ogg"
-            elif fmt == "wav":
-                mime = "audio/wav"
-            elif "/" in fmt:
-                mime = fmt
-            else:
-                mime = f"audio/{fmt or 'mpeg'}"
+            from agent.media_routing import normalize_audio_mime
+
+            mime = normalize_audio_mime(fmt)
             parts.append(
                 {
                     "inlineData": {

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -266,6 +266,13 @@ def _coerce_content_to_text(content: Any) -> str:
 
 
 def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
+    """Translate inline OpenAI-style content into Gemini native parts.
+
+    Gateway attachments reach this adapter from local/cache files encoded as
+    ``data:`` URIs. Arbitrary remote HTTP(S) media is intentionally not fetched
+    here (which would create an SSRF boundary) or mislabeled as a Gemini Files
+    API URI; those references remain represented by their accompanying text.
+    """
     if not isinstance(content, list):
         text = _coerce_content_to_text(content)
         return [{"text": text}] if text else []
@@ -285,12 +292,18 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
         elif ptype in {"image_url", "video_url", "file"}:
             url = ""
             if ptype == "image_url":
-                url = ((item.get("image_url") or {}).get("url") or "")
+                url = (item.get("image_url") or {}).get("url") or ""
             elif ptype == "video_url":
-                url = ((item.get("video_url") or {}).get("url") or "")
+                url = (item.get("video_url") or {}).get("url") or ""
             elif ptype == "file":
-                url = ((item.get("file") or {}).get("file_data") or "")
+                url = (item.get("file") or {}).get("file_data") or ""
             if not isinstance(url, str) or not url.startswith("data:"):
+                if isinstance(url, str) and url:
+                    logger.debug(
+                        "Gemini native adapter omitted non-inline %s content; "
+                        "only data URIs are accepted on this path",
+                        ptype,
+                    )
                 continue
             try:
                 header, encoded = url.split(",", 1)

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -281,8 +281,14 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             text = item.get("text")
             if isinstance(text, str) and text:
                 parts.append({"text": text})
-        elif ptype == "image_url":
-            url = ((item.get("image_url") or {}).get("url") or "")
+        elif ptype in {"image_url", "video_url", "file"}:
+            url = ""
+            if ptype == "image_url":
+                url = ((item.get("image_url") or {}).get("url") or "")
+            elif ptype == "video_url":
+                url = ((item.get("video_url") or {}).get("url") or "")
+            elif ptype == "file":
+                url = ((item.get("file") or {}).get("file_data") or "")
             if not isinstance(url, str) or not url.startswith("data:"):
                 continue
             try:
@@ -296,6 +302,30 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
                     "inlineData": {
                         "mimeType": mime,
                         "data": base64.b64encode(raw).decode("ascii"),
+                    }
+                }
+            )
+        elif ptype == "input_audio":
+            audio_info = item.get("input_audio") or {}
+            encoded = audio_info.get("data")
+            fmt = str(audio_info.get("format") or "").strip().lower()
+            if not isinstance(encoded, str) or not encoded:
+                continue
+            if fmt == "mp3" or fmt == "mpeg":
+                mime = "audio/mpeg"
+            elif fmt in {"ogg", "oga", "opus"}:
+                mime = "audio/ogg"
+            elif fmt == "wav":
+                mime = "audio/wav"
+            elif "/" in fmt:
+                mime = fmt
+            else:
+                mime = f"audio/{fmt or 'mpeg'}"
+            parts.append(
+                {
+                    "inlineData": {
+                        "mimeType": mime,
+                        "data": encoded,
                     }
                 }
             )

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -30,6 +30,7 @@ import httpx
 
 from agent.bounded_response import read_streaming_error_body
 from agent.gemini_schema import sanitize_gemini_tool_parameters
+from agent.media_routing import normalize_audio_mime
 
 logger = logging.getLogger(__name__)
 
@@ -309,16 +310,14 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
             audio_info = item.get("input_audio") or {}
             encoded = audio_info.get("data")
             fmt = str(audio_info.get("format") or "").strip().lower()
-            if not isinstance(encoded, str) or not encoded:
+            if not isinstance(encoded, str) or not encoded.strip():
                 continue
-            from agent.media_routing import normalize_audio_mime
-
             mime = normalize_audio_mime(fmt)
             parts.append(
                 {
                     "inlineData": {
                         "mimeType": mime,
-                        "data": encoded,
+                        "data": encoded.strip(),
                     }
                 }
             )

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -10,6 +10,50 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
+# Maximum file size allowed for inline base64 embedding (25 MB).
+# Files exceeding this threshold fall back to STT / tool execution to prevent
+# memory spikes and provider HTTP 413 (Payload Too Large) errors.
+MAX_ATTACHMENT_SIZE_BYTES = 25 * 1024 * 1024
+
+AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
+    "mp3": "audio/mpeg",
+    "mpeg": "audio/mpeg",
+    "mp4": "audio/mp4",
+    "m4a": "audio/mp4",
+    "ogg": "audio/ogg",
+    "oga": "audio/ogg",
+    "opus": "audio/ogg",
+    "wav": "audio/wav",
+    "wave": "audio/wav",
+    "flac": "audio/flac",
+    "aac": "audio/aac",
+    "webm": "audio/webm",
+}
+
+
+def normalize_audio_format(path: Optional[Path] = None, mime: str = "") -> str:
+    """Return the canonical format identifier for OpenAI input_audio (e.g. mp3, ogg, wav, flac)."""
+    fmt = ""
+    if path and path.suffix:
+        fmt = path.suffix.lower().lstrip(".")
+    if not fmt and mime:
+        fmt = mime.rsplit("/", 1)[-1].lower()
+    if fmt in ("mpeg", "mp3"):
+        return "mp3"
+    if fmt in ("ogg", "oga", "opus"):
+        return "ogg"
+    if fmt in ("wav", "wave"):
+        return "wav"
+    return fmt or "mp3"
+
+
+def normalize_audio_mime(fmt_or_ext: str) -> str:
+    """Convert an audio format or extension to a canonical MIME type."""
+    clean = (fmt_or_ext or "").strip().lower().lstrip(".")
+    if "/" in clean:
+        return clean
+    return AUDIO_FORMAT_TO_MIME.get(clean, f"audio/{clean or 'mpeg'}")
+
 
 def supported_input_modalities(provider: str, model: str) -> Set[str]:
     """Return the model's known native input modalities.
@@ -32,8 +76,20 @@ def supported_input_modalities(provider: str, model: str) -> Set[str]:
         return set()
 
 
-def _read_as_base64(path: Path) -> Optional[str]:
+def _read_as_base64(
+    path: Path,
+    max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
+) -> Optional[str]:
     try:
+        size = path.stat().st_size
+        if size > max_size_bytes:
+            logger.warning(
+                "media_routing: file %s exceeds %d MB limit (%d bytes), skipping native attachment",
+                path,
+                max_size_bytes // (1024 * 1024),
+                size,
+            )
+            return None
         return base64.b64encode(path.read_bytes()).decode("ascii")
     except Exception as exc:
         logger.warning("media_routing: failed to read %s: %s", path, exc)
@@ -50,6 +106,7 @@ def _mime_type(path: Path, declared_mime: str) -> str:
 def build_native_media_content_parts(
     user_text: str,
     attachments: Iterable[Dict[str, str]],
+    max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build OpenRouter/OpenAI-style multimodal content parts.
 
@@ -63,17 +120,27 @@ def build_native_media_content_parts(
 
     for attachment in attachments:
         raw_path = str(attachment.get("path") or "")
-        modality = str(attachment.get("modality") or "").lower()
         path = Path(raw_path)
         if not raw_path or not path.is_file():
             skipped.append(raw_path)
             continue
 
-        encoded = _read_as_base64(path)
+        encoded = _read_as_base64(path, max_size_bytes=max_size_bytes)
         if encoded is None:
             skipped.append(raw_path)
             continue
         mime = _mime_type(path, str(attachment.get("mime_type") or ""))
+
+        modality = str(attachment.get("modality") or "").lower()
+        if not modality:
+            if mime.startswith("image/"):
+                modality = "image"
+            elif mime.startswith("audio/"):
+                modality = "audio"
+            elif mime.startswith("video/"):
+                modality = "video"
+            elif mime == "application/pdf" or path.suffix.lower() == ".pdf":
+                modality = "pdf"
 
         if modality == "image":
             media_parts.append({
@@ -89,9 +156,7 @@ def build_native_media_content_parts(
                 },
             })
         elif modality == "audio":
-            audio_format = path.suffix.lower().lstrip(".") or mime.rsplit("/", 1)[-1]
-            if audio_format == "mpeg":
-                audio_format = "mp3"
+            audio_format = normalize_audio_format(path, mime)
             media_parts.append({
                 "type": "input_audio",
                 "input_audio": {"data": encoded, "format": audio_format},
@@ -121,4 +186,12 @@ def build_native_media_content_parts(
     return parts, skipped
 
 
-__all__ = ["build_native_media_content_parts", "supported_input_modalities"]
+__all__ = [
+    "AUDIO_FORMAT_TO_MIME",
+    "MAX_ATTACHMENT_SIZE_BYTES",
+    "build_native_media_content_parts",
+    "normalize_audio_format",
+    "normalize_audio_mime",
+    "supported_input_modalities",
+]
+

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -34,7 +34,20 @@ AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
 def normalize_audio_format(path: Optional[Path] = None, mime: str = "") -> str:
     """Return the canonical format identifier for OpenAI input_audio (e.g. mp3, ogg, wav, flac)."""
     fmt = ""
-    if path and path.suffix:
+    # Sniff magic bytes first if a readable file is provided
+    if path and path.is_file():
+        try:
+            with path.open("rb") as f:
+                header = f.read(32)
+            from tools.audio_container import sniff_container
+
+            container = sniff_container(header)
+            if container:
+                fmt = container
+        except Exception:
+            pass
+
+    if not fmt and path and path.suffix:
         fmt = path.suffix.lower().lstrip(".")
     if not fmt and mime:
         fmt = mime.rsplit("/", 1)[-1].lower()
@@ -53,6 +66,57 @@ def normalize_audio_mime(fmt_or_ext: str) -> str:
     if "/" in clean:
         return clean
     return AUDIO_FORMAT_TO_MIME.get(clean, f"audio/{clean or 'mpeg'}")
+
+
+def transcode_audio_to_supported_format(
+    path: Path,
+    target_format: str = "mp3",
+) -> Optional[Tuple[bytes, str]]:
+    """Transcode an audio file to mp3 or wav using ffmpeg if available.
+
+    Returns (transcoded_bytes, new_format) or None if ffmpeg is unavailable or fails.
+    """
+    import shutil
+    import subprocess
+    import tempfile
+
+    if not shutil.which("ffmpeg") or not path.is_file():
+        return None
+
+    out_suffix = f".{target_format.lstrip('.')}"
+    tmp_out_path: Optional[Path] = None
+    try:
+        with tempfile.NamedTemporaryFile(suffix=out_suffix, delete=False) as tmp_out:
+            tmp_out_path = Path(tmp_out.name)
+        cmd = [
+            "ffmpeg",
+            "-y",
+            "-i",
+            str(path),
+            "-vn",
+            "-ar",
+            "24000",
+            "-ac",
+            "1",
+            str(tmp_out_path),
+        ]
+        res = subprocess.run(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            timeout=15,
+        )
+        if res.returncode == 0 and tmp_out_path.is_file() and tmp_out_path.stat().st_size > 0:
+            data = tmp_out_path.read_bytes()
+            tmp_out_path.unlink(missing_ok=True)
+            return data, target_format
+        if tmp_out_path and tmp_out_path.exists():
+            tmp_out_path.unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("media_routing: audio transcoding failed: %s", exc)
+        if tmp_out_path and tmp_out_path.exists():
+            tmp_out_path.unlink(missing_ok=True)
+    return None
 
 
 def supported_input_modalities(provider: str, model: str) -> Set[str]:
@@ -99,6 +163,18 @@ def _read_as_base64(
 def _mime_type(path: Path, declared_mime: str) -> str:
     if declared_mime and declared_mime != "application/octet-stream":
         return declared_mime
+    # Sniff magic bytes for accurate audio/AV container mime resolution
+    try:
+        if path.is_file():
+            with path.open("rb") as f:
+                header = f.read(32)
+            from tools.audio_container import sniff_container
+
+            container = sniff_container(header)
+            if container and container in AUDIO_FORMAT_TO_MIME:
+                return AUDIO_FORMAT_TO_MIME[container]
+    except Exception:
+        pass
     guessed, _ = mimetypes.guess_type(str(path))
     return guessed or "application/octet-stream"
 
@@ -107,6 +183,7 @@ def build_native_media_content_parts(
     user_text: str,
     attachments: Iterable[Dict[str, str]],
     max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
+    target_provider: str = "",
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build OpenRouter/OpenAI-style multimodal content parts.
 
@@ -157,9 +234,22 @@ def build_native_media_content_parts(
             })
         elif modality == "audio":
             audio_format = normalize_audio_format(path, mime)
+            audio_data = encoded
+            # Transcode to mp3 if required by OpenAI direct input_audio schema
+            if (
+                target_provider in ("openai", "azure")
+                and audio_format not in ("wav", "mp3")
+            ):
+                transcoded = transcode_audio_to_supported_format(path, target_format="mp3")
+                if transcoded:
+                    t_bytes, t_fmt = transcoded
+                    audio_data = base64.b64encode(t_bytes).decode("ascii")
+                    audio_format = t_fmt
+                    mime = "audio/mpeg"
+
             media_parts.append({
                 "type": "input_audio",
-                "input_audio": {"data": encoded, "format": audio_format},
+                "input_audio": {"data": audio_data, "format": audio_format},
             })
         elif modality == "video":
             media_parts.append({
@@ -169,8 +259,15 @@ def build_native_media_content_parts(
         else:
             skipped.append(raw_path)
             continue
+
+        file_size_bytes = path.stat().st_size if path.is_file() else 0
+        size_str = (
+            f"{file_size_bytes / 1024:.1f} KB"
+            if file_size_bytes < 1024 * 1024
+            else f"{file_size_bytes / (1024 * 1024):.1f} MB"
+        )
         hints.append(
-            f"[{modality.title()} attached natively to this model request at: "
+            f"[{modality.title()} attachment ({size_str}, {mime}) attached natively to this model request at: "
             f"{raw_path}. Inspect the native attachment directly. Do not claim "
             "that you used a terminal command or extraction tool unless you "
             "actually called one in this turn.]"
@@ -193,5 +290,7 @@ __all__ = [
     "normalize_audio_format",
     "normalize_audio_mime",
     "supported_input_modalities",
+    "transcode_audio_to_supported_format",
 ]
+
 

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -10,9 +10,9 @@ from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
 
 logger = logging.getLogger(__name__)
 
-# Maximum file size allowed for inline base64 embedding (25 MB).
-# Files exceeding this threshold fall back to STT / tool execution to prevent
-# memory spikes and provider HTTP 413 (Payload Too Large) errors.
+# Maximum encoded Base64 payload allowed for one inline attachment (25 MiB).
+# The raw-file ceiling is therefore about 18.75 MiB; accounting for Base64
+# expansion keeps the request from silently exceeding this guard after read.
 MAX_ATTACHMENT_SIZE_BYTES = 25 * 1024 * 1024
 
 AUDIO_FORMAT_TO_MIME: Dict[str, str] = {
@@ -151,17 +151,32 @@ def _read_as_base64(
     path: Path,
     max_size_bytes: int = MAX_ATTACHMENT_SIZE_BYTES,
 ) -> Optional[str]:
+    """Read *path* as Base64 while enforcing the encoded payload ceiling."""
     try:
         size = path.stat().st_size
-        if size > max_size_bytes:
+        encoded_size = 4 * ((size + 2) // 3)
+        if encoded_size > max_size_bytes:
             logger.warning(
-                "media_routing: file %s exceeds %d MB limit (%d bytes), skipping native attachment",
+                "media_routing: encoded file %s exceeds %d-byte inline payload limit "
+                "(%d raw bytes, %d Base64 bytes), skipping native attachment",
                 path,
-                max_size_bytes // (1024 * 1024),
+                max_size_bytes,
                 size,
+                encoded_size,
             )
             return None
-        return base64.b64encode(path.read_bytes()).decode("ascii")
+        encoded = base64.b64encode(path.read_bytes())
+        # The file can grow between stat() and read_bytes(); enforce the limit
+        # again against the bytes that will actually enter the request.
+        if len(encoded) > max_size_bytes:
+            logger.warning(
+                "media_routing: encoded file %s grew past %d-byte inline payload "
+                "limit while reading, skipping native attachment",
+                path,
+                max_size_bytes,
+            )
+            return None
+        return encoded.decode("ascii")
     except Exception as exc:
         logger.warning("media_routing: failed to read %s: %s", path, exc)
         return None
@@ -216,10 +231,6 @@ def build_native_media_content_parts(
             skipped.append(raw_path)
             continue
 
-        encoded = _read_as_base64(path, max_size_bytes=max_size_bytes)
-        if encoded is None:
-            skipped.append(raw_path)
-            continue
         mime = _mime_type(path, str(attachment.get("mime_type") or ""))
 
         modality = str(attachment.get("modality") or "").lower()
@@ -234,11 +245,34 @@ def build_native_media_content_parts(
                 modality = "pdf"
 
         if modality == "image":
-            media_parts.append({
-                "type": "image_url",
-                "image_url": {"url": f"data:{mime};base64,{encoded}"},
-            })
-        elif modality == "pdf":
+            # Preserve the established image pipeline's safety checks, MIME
+            # sniffing, format transcoding, and reactive provider-size retry.
+            # A voice attachment in the same turn must not downgrade images to
+            # this module's stricter non-image inline payload ceiling.
+            from agent.image_routing import build_native_content_parts
+
+            image_parts, _ = build_native_content_parts("", [raw_path])
+            image_part = next(
+                (part for part in image_parts if part.get("type") == "image_url"),
+                None,
+            )
+            if image_part is None:
+                skipped.append(raw_path)
+                continue
+            media_parts.append(image_part)
+            image_url = (image_part.get("image_url") or {}).get("url") or ""
+            if image_url.startswith("data:"):
+                mime = image_url.split(":", 1)[1].split(";", 1)[0] or mime
+        elif modality not in {"pdf", "audio", "video"}:
+            skipped.append(raw_path)
+            continue
+        else:
+            encoded = _read_as_base64(path, max_size_bytes=max_size_bytes)
+            if encoded is None:
+                skipped.append(raw_path)
+                continue
+
+        if modality == "pdf":
             media_parts.append({
                 "type": "file",
                 "file": {
@@ -250,18 +284,37 @@ def build_native_media_content_parts(
             audio_format = normalize_audio_format(path, mime)
             audio_data = encoded
             # Transcode to mp3 if required by OpenAI direct input_audio schema
-            if target_provider in ("openai", "azure") and audio_format not in (
+            provider = (target_provider or "").strip().lower()
+            if provider in ("openai", "azure") and audio_format not in (
                 "wav",
                 "mp3",
             ):
                 transcoded = transcode_audio_to_supported_format(
                     path, target_format="mp3"
                 )
-                if transcoded:
-                    t_bytes, t_fmt = transcoded
-                    audio_data = base64.b64encode(t_bytes).decode("ascii")
-                    audio_format = t_fmt
-                    mime = "audio/mpeg"
+                if transcoded is None:
+                    logger.warning(
+                        "media_routing: %s audio %s could not be transcoded to "
+                        "an OpenAI-compatible format; skipping native attachment",
+                        provider,
+                        path,
+                    )
+                    skipped.append(raw_path)
+                    continue
+                t_bytes, t_fmt = transcoded
+                encoded_transcode = base64.b64encode(t_bytes)
+                if len(encoded_transcode) > max_size_bytes:
+                    logger.warning(
+                        "media_routing: transcoded audio %s exceeds %d-byte "
+                        "inline payload limit, skipping native attachment",
+                        path,
+                        max_size_bytes,
+                    )
+                    skipped.append(raw_path)
+                    continue
+                audio_data = encoded_transcode.decode("ascii")
+                audio_format = t_fmt
+                mime = "audio/mpeg"
 
             media_parts.append({
                 "type": "input_audio",
@@ -272,10 +325,6 @@ def build_native_media_content_parts(
                 "type": "video_url",
                 "video_url": {"url": f"data:{mime};base64,{encoded}"},
             })
-        else:
-            skipped.append(raw_path)
-            continue
-
         file_size_bytes = path.stat().st_size if path.is_file() else 0
         size_str = (
             f"{file_size_bytes / 1024:.1f} KB"

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -106,14 +106,15 @@ def transcode_audio_to_supported_format(
             stderr=subprocess.DEVNULL,
             timeout=15,
         )
-        if res.returncode == 0 and tmp_out_path.is_file() and tmp_out_path.stat().st_size > 0:
-            data = tmp_out_path.read_bytes()
-            tmp_out_path.unlink(missing_ok=True)
-            return data, target_format
-        if tmp_out_path and tmp_out_path.exists():
-            tmp_out_path.unlink(missing_ok=True)
+        if (
+            res.returncode == 0
+            and tmp_out_path.is_file()
+            and tmp_out_path.stat().st_size > 0
+        ):
+            return tmp_out_path.read_bytes(), target_format
     except Exception as exc:
         logger.debug("media_routing: audio transcoding failed: %s", exc)
+    finally:
         if tmp_out_path and tmp_out_path.exists():
             tmp_out_path.unlink(missing_ok=True)
     return None
@@ -134,9 +135,15 @@ def supported_input_modalities(provider: str, model: str) -> Set[str]:
             info = get_model_info(vendor, bare_model)
         if info is None:
             return set()
-        return {str(item).strip().lower() for item in info.input_modalities if item}
+        modalities = getattr(info, "input_modalities", ()) or ()
+        return {str(item).strip().lower() for item in modalities if item}
     except Exception as exc:  # pragma: no cover - defensive
-        logger.debug("media_routing: capability lookup failed for %s:%s: %s", provider, model, exc)
+        logger.debug(
+            "media_routing: capability lookup failed for %s:%s: %s",
+            provider,
+            model,
+            exc,
+        )
         return set()
 
 
@@ -195,8 +202,15 @@ def build_native_media_content_parts(
     hints: List[str] = []
     skipped: List[str] = []
 
-    for attachment in attachments:
-        raw_path = str(attachment.get("path") or "")
+    for item in attachments:
+        if isinstance(item, (str, Path)):
+            raw_path = str(item)
+            attachment: Dict[str, Any] = {"path": raw_path}
+        elif isinstance(item, dict):
+            attachment = item
+            raw_path = str(attachment.get("path") or "")
+        else:
+            continue
         path = Path(raw_path)
         if not raw_path or not path.is_file():
             skipped.append(raw_path)
@@ -236,11 +250,13 @@ def build_native_media_content_parts(
             audio_format = normalize_audio_format(path, mime)
             audio_data = encoded
             # Transcode to mp3 if required by OpenAI direct input_audio schema
-            if (
-                target_provider in ("openai", "azure")
-                and audio_format not in ("wav", "mp3")
+            if target_provider in ("openai", "azure") and audio_format not in (
+                "wav",
+                "mp3",
             ):
-                transcoded = transcode_audio_to_supported_format(path, target_format="mp3")
+                transcoded = transcode_audio_to_supported_format(
+                    path, target_format="mp3"
+                )
                 if transcoded:
                     t_bytes, t_fmt = transcoded
                     audio_data = base64.b64encode(t_bytes).decode("ascii")
@@ -278,7 +294,9 @@ def build_native_media_content_parts(
         return ([{"type": "text", "text": text}] if text else []), skipped
 
     prompt = text or "Analyze the attached media."
-    parts: List[Dict[str, Any]] = [{"type": "text", "text": f"{prompt}\n\n" + "\n".join(hints)}]
+    parts: List[Dict[str, Any]] = [
+        {"type": "text", "text": f"{prompt}\n\n" + "\n".join(hints)}
+    ]
     parts.extend(media_parts)
     return parts, skipped
 
@@ -292,5 +310,3 @@ __all__ = [
     "supported_input_modalities",
     "transcode_audio_to_supported_format",
 ]
-
-

--- a/agent/media_routing.py
+++ b/agent/media_routing.py
@@ -1,0 +1,124 @@
+"""Native multimodal attachment helpers for inbound gateway messages."""
+
+from __future__ import annotations
+
+import base64
+import logging
+import mimetypes
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def supported_input_modalities(provider: str, model: str) -> Set[str]:
+    """Return the model's known native input modalities.
+
+    An empty set is deliberately conservative: callers retain their existing
+    tool/path fallback when the model is absent from the capability registry.
+    """
+    try:
+        from agent.models_dev import get_model_info
+
+        info = get_model_info(provider, model)
+        if info is None and provider == "openrouter" and "/" in model:
+            vendor, bare_model = model.split("/", 1)
+            info = get_model_info(vendor, bare_model)
+        if info is None:
+            return set()
+        return {str(item).strip().lower() for item in info.input_modalities if item}
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug("media_routing: capability lookup failed for %s:%s: %s", provider, model, exc)
+        return set()
+
+
+def _read_as_base64(path: Path) -> Optional[str]:
+    try:
+        return base64.b64encode(path.read_bytes()).decode("ascii")
+    except Exception as exc:
+        logger.warning("media_routing: failed to read %s: %s", path, exc)
+        return None
+
+
+def _mime_type(path: Path, declared_mime: str) -> str:
+    if declared_mime and declared_mime != "application/octet-stream":
+        return declared_mime
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"
+
+
+def build_native_media_content_parts(
+    user_text: str,
+    attachments: Iterable[Dict[str, str]],
+) -> Tuple[List[Dict[str, Any]], List[str]]:
+    """Build OpenRouter/OpenAI-style multimodal content parts.
+
+    Each attachment dict contains ``path``, ``mime_type`` and ``modality``.
+    Supported modalities are image, pdf, audio and video. Local content is
+    embedded so private gateway cache files never need a public URL.
+    """
+    media_parts: List[Dict[str, Any]] = []
+    hints: List[str] = []
+    skipped: List[str] = []
+
+    for attachment in attachments:
+        raw_path = str(attachment.get("path") or "")
+        modality = str(attachment.get("modality") or "").lower()
+        path = Path(raw_path)
+        if not raw_path or not path.is_file():
+            skipped.append(raw_path)
+            continue
+
+        encoded = _read_as_base64(path)
+        if encoded is None:
+            skipped.append(raw_path)
+            continue
+        mime = _mime_type(path, str(attachment.get("mime_type") or ""))
+
+        if modality == "image":
+            media_parts.append({
+                "type": "image_url",
+                "image_url": {"url": f"data:{mime};base64,{encoded}"},
+            })
+        elif modality == "pdf":
+            media_parts.append({
+                "type": "file",
+                "file": {
+                    "filename": path.name,
+                    "file_data": f"data:{mime};base64,{encoded}",
+                },
+            })
+        elif modality == "audio":
+            audio_format = path.suffix.lower().lstrip(".") or mime.rsplit("/", 1)[-1]
+            if audio_format == "mpeg":
+                audio_format = "mp3"
+            media_parts.append({
+                "type": "input_audio",
+                "input_audio": {"data": encoded, "format": audio_format},
+            })
+        elif modality == "video":
+            media_parts.append({
+                "type": "video_url",
+                "video_url": {"url": f"data:{mime};base64,{encoded}"},
+            })
+        else:
+            skipped.append(raw_path)
+            continue
+        hints.append(
+            f"[{modality.title()} attached natively to this model request at: "
+            f"{raw_path}. Inspect the native attachment directly. Do not claim "
+            "that you used a terminal command or extraction tool unless you "
+            "actually called one in this turn.]"
+        )
+
+    text = (user_text or "").strip()
+    if not media_parts:
+        return ([{"type": "text", "text": text}] if text else []), skipped
+
+    prompt = text or "Analyze the attached media."
+    parts: List[Dict[str, Any]] = [{"type": "text", "text": f"{prompt}\n\n" + "\n".join(hints)}]
+    parts.extend(media_parts)
+    return parts, skipped
+
+
+__all__ = ["build_native_media_content_parts", "supported_input_modalities"]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1188,13 +1188,6 @@ gateway:
   # if an agent has not unwound. Keep it below the service-manager stop budget.
   # signal_interrupt_grace_timeout: 1
 
-  # Let platform adapters honor HTTP_PROXY / HTTPS_PROXY / NO_PROXY (and
-  # SSL_CERT_FILE) from the process environment, plus macOS system-proxy
-  # auto-detection. Set to false when the gateway inherits a proxy it must not
-  # use (e.g. a Windows Scheduled Task picking up a local Clash/V2Ray proxy that
-  # isn't running). Explicit per-platform vars like DISCORD_PROXY still apply.
-  # trust_env: true
-
 # =============================================================================
 # Toolsets
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1179,6 +1179,13 @@ gateway:
   # if an agent has not unwound. Keep it below the service-manager stop budget.
   # signal_interrupt_grace_timeout: 1
 
+  # Let platform adapters honor HTTP_PROXY / HTTPS_PROXY / NO_PROXY (and
+  # SSL_CERT_FILE) from the process environment, plus macOS system-proxy
+  # auto-detection. Set to false when the gateway inherits a proxy it must not
+  # use (e.g. a Windows Scheduled Task picking up a local Clash/V2Ray proxy that
+  # isn't running). Explicit per-platform vars like DISCORD_PROXY still apply.
+  # trust_env: true
+
   # Inbound voice-note routing:
   #   auto   = send audio natively when the active model supports it;
   #            otherwise use the configured STT provider (default)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1179,6 +1179,15 @@ gateway:
   # if an agent has not unwound. Keep it below the service-manager stop budget.
   # signal_interrupt_grace_timeout: 1
 
+  # Inbound voice-note routing:
+  #   auto   = send audio natively when the active model supports it;
+  #            otherwise use the configured STT provider (default)
+  #   native = prefer native audio regardless of capability metadata
+  #   stt    = always transcribe before invoking the model
+  # If a native attachment cannot be read, encoded, or transcoded safely,
+  # Hermes falls back to STT for that attachment instead of dropping it.
+  audio_mode: auto
+
 # =============================================================================
 # Toolsets
 # =============================================================================

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1174,6 +1174,15 @@ agent:
 # Gateway Lifecycle
 # =============================================================================
 gateway:
+  # Inbound voice-note routing:
+  #   auto   = send audio natively when the active model supports it;
+  #            otherwise use the configured STT provider (default)
+  #   native = prefer native audio regardless of capability metadata
+  #   stt    = always transcribe before invoking the model
+  # If a native attachment cannot be read, encoded, or transcoded safely,
+  # Hermes falls back to STT for that attachment instead of dropping it.
+  audio_mode: auto
+
   # Post-interrupt grace for running agents during an unexpected SIGTERM.
   # Adapter, bridge, and database teardown starts after this many seconds even
   # if an agent has not unwound. Keep it below the service-manager stop budget.
@@ -1185,15 +1194,6 @@ gateway:
   # use (e.g. a Windows Scheduled Task picking up a local Clash/V2Ray proxy that
   # isn't running). Explicit per-platform vars like DISCORD_PROXY still apply.
   # trust_env: true
-
-  # Inbound voice-note routing:
-  #   auto   = send audio natively when the active model supports it;
-  #            otherwise use the configured STT provider (default)
-  #   native = prefer native audio regardless of capability metadata
-  #   stt    = always transcribe before invoking the model
-  # If a native attachment cannot be read, encoded, or transcoded safely,
-  # Hermes falls back to STT for that attachment instead of dropping it.
-  audio_mode: auto
 
 # =============================================================================
 # Toolsets

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -257,6 +257,15 @@ def _normalize_unauthorized_dm_behavior(value: Any, default: str = "pair") -> st
     return default
 
 
+def _normalize_audio_mode(value: Any, default: str = "auto") -> str:
+    """Normalize inbound voice routing to auto, native, or STT."""
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"auto", "native", "stt"}:
+            return normalized
+    return default
+
+
 def _normalize_notice_delivery(value: Any, default: str = "public") -> str:
     """Normalize notice delivery mode to a supported value."""
     if isinstance(value, str):
@@ -966,6 +975,9 @@ class GatewayConfig:
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
     stt_echo_transcripts: bool = True  # Whether to echo raw STT transcripts back to the user
+    # auto uses model capabilities; native or stt forces the preferred path.
+    # Native payload-construction failures still fall back to STT.
+    audio_mode: str = "auto"
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -1148,6 +1160,7 @@ class GatewayConfig:
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
+            "audio_mode": self.audio_mode,
             "group_sessions_per_user": self.group_sessions_per_user,
             "thread_sessions_per_user": self.thread_sessions_per_user,
             "max_concurrent_sessions": self.max_concurrent_sessions,
@@ -1217,11 +1230,17 @@ class GatewayConfig:
                 else None
             )
 
+        raw_gateway = data.get("gateway")
+        nested_gateway = raw_gateway if isinstance(raw_gateway, dict) else {}
+        audio_mode = _normalize_audio_mode(
+            data.get("audio_mode")
+            if "audio_mode" in data
+            else nested_gateway.get("audio_mode")
+        )
+
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         multiplex_profiles = data.get("multiplex_profiles")
-        raw_gateway = data.get("gateway")
-        nested_gateway = raw_gateway if isinstance(raw_gateway, dict) else {}
         if "multiplex_profile_allowlist" in data:
             multiplex_profile_allowlist = data.get("multiplex_profile_allowlist")
         else:
@@ -1333,6 +1352,7 @@ class GatewayConfig:
             ),
             stt_enabled=_coerce_bool(stt_enabled, True),
             stt_echo_transcripts=_coerce_bool(stt_echo_transcripts, True),
+            audio_mode=audio_mode,
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             multiplex_profiles=_coerce_bool(multiplex_profiles, False),
@@ -1465,6 +1485,13 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["stt_echo_transcripts"] = yaml_cfg["stt_echo_transcripts"]
             elif isinstance(gateway_section, dict) and "stt_echo_transcripts" in gateway_section:
                 gw_data["stt_echo_transcripts"] = gateway_section["stt_echo_transcripts"]
+
+            # Canonical user surface is gateway.audio_mode. Preserve the
+            # original top-level compatibility form with top-level precedence.
+            if "audio_mode" in yaml_cfg:
+                gw_data["audio_mode"] = yaml_cfg["audio_mode"]
+            elif isinstance(gateway_section, dict) and "audio_mode" in gateway_section:
+                gw_data["audio_mode"] = gateway_section["audio_mode"]
 
             gateway_cfg = yaml_cfg.get("gateway")
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5778,6 +5778,90 @@ class TurnRunner:
                     ctx._cleanup_msg_ids.append(str(mid))
             _fut.add_done_callback(_track_status_id)
 
+    @staticmethod
+    def _prepend_message_text(message: Any, prefix: str) -> Any:
+        """Prepend text without discarding native multimodal content parts."""
+        prefix = str(prefix or "").strip()
+        if not prefix:
+            return message
+
+        if isinstance(message, list):
+            updated = list(message)
+            for index, part in enumerate(updated):
+                if not isinstance(part, dict) or part.get("type") != "text":
+                    continue
+                existing = part.get("text")
+                existing_text = existing if isinstance(existing, str) else ""
+                updated[index] = {
+                    **part,
+                    "text": (
+                        f"{prefix}\n\n{existing_text}"
+                        if existing_text
+                        else prefix
+                    ),
+                }
+                return updated
+            return [{"type": "text", "text": prefix}, *updated]
+
+        if isinstance(message, str) and message:
+            return f"{prefix}\n\n{message}"
+        return prefix
+
+    @staticmethod
+    def _native_audio_fallback_note(audio_paths: List[str]) -> str:
+        """Return a non-empty last-resort note when the STT bridge fails."""
+        try:
+            from tools.credential_files import to_agent_visible_cache_path
+        except Exception:
+            def to_agent_visible_cache_path(path: str) -> str:
+                return path
+
+        notes: List[str] = []
+        seen: set[str] = set()
+        for path in audio_paths:
+            raw_path = str(path or "")
+            if not raw_path or raw_path in seen:
+                continue
+            seen.add(raw_path)
+            agent_path = to_agent_visible_cache_path(os.path.abspath(raw_path))
+            notes.append(
+                "[voice message could not be transcribed automatically; "
+                f"the audio is available at: {agent_path}]"
+            )
+        return "\n\n".join(notes) or (
+            "[voice message could not be processed natively or transcribed "
+            "automatically]"
+        )
+
+    def _transcribe_native_audio_fallback_sync(
+        self,
+        audio_paths: List[str],
+    ) -> str:
+        """Bridge rejected native audio back to the gateway's async STT path."""
+        if not audio_paths:
+            return self._native_audio_fallback_note([])
+
+        ctx = self._ctx
+        fallback_future = safe_schedule_threadsafe(
+            self._runner._transcribe_native_audio_fallback(
+                audio_paths,
+                source=ctx.source,
+                reply_to_message_id=ctx.event_message_id,
+            ),
+            ctx._loop_for_step,
+            logger=logger,
+            log_message="Native audio STT fallback scheduling error",
+            log_level=logging.WARNING,
+        )
+        if fallback_future is not None:
+            try:
+                fallback_text = fallback_future.result()
+                if isinstance(fallback_text, str) and fallback_text.strip():
+                    return fallback_text.strip()
+            except Exception as exc:
+                logger.warning("Native audio STT fallback failed: %s", exc)
+        return self._native_audio_fallback_note(audio_paths)
+
     def run_sync(self):
         ctx = self._ctx
         # Historical note: as a nested closure this body declared
@@ -6917,6 +7001,9 @@ class TurnRunner:
                 ctx.session_key
             )
             _run_message: Any = ctx.message
+            _native_audio_survived = False
+            _failed_native_audio_paths: List[str] = []
+            _native_audio_marker = "[Voice message attached natively]"
 
             def _build_native_image_message() -> Optional[List[Dict[str, Any]]]:
                 """Build the established image-only path after mixed-media failure."""
@@ -6945,6 +7032,15 @@ class TurnRunner:
                 return None
 
             if _native_audio:
+                _native_audio_paths = [
+                    (
+                        str(item.get("path") or "")
+                        if isinstance(item, dict)
+                        else str(item or "")
+                    )
+                    for item in _native_audio
+                    if isinstance(item, (dict, str, Path))
+                ]
                 try:
                     from agent.media_routing import build_native_media_content_parts
 
@@ -6964,24 +7060,31 @@ class TurnRunner:
                             "Native media attachment: skipped %d attachment(s): %s",
                             len(_skipped), _skipped,
                         )
+                    _skipped_paths = {str(path) for path in _skipped}
+                    _failed_native_audio_paths = [
+                        path
+                        for path in _native_audio_paths
+                        if path and path in _skipped_paths
+                    ]
+                    _native_audio_survived = any(
+                        p.get("type") == "input_audio" for p in _parts
+                    )
+                    # A builder that returns neither an audio part nor an
+                    # explicit skipped path must still fail closed to STT. It
+                    # must never turn a media-only voice event into an empty
+                    # user message.
+                    if (
+                        not _native_audio_survived
+                        and not _failed_native_audio_paths
+                    ):
+                        _failed_native_audio_paths = [
+                            path for path in _native_audio_paths if path
+                        ]
                     if any(
                         p.get("type") in {"image_url", "file", "input_audio", "video_url"}
                         for p in _parts
                     ):
                         _run_message = _parts
-                        # Persist a compact marker instead of embedding Base64
-                        # audio in the session database/history. Do not stamp a
-                        # voice marker when audio failed and only an image made
-                        # it through the mixed-media turn.
-                        if (
-                            any(p.get("type") == "input_audio" for p in _parts)
-                            and _persist_user_message_override is None
-                        ):
-                            _persist_user_message_override = (
-                                ctx.message.strip()
-                                if isinstance(ctx.message, str) and ctx.message.strip()
-                                else "[Voice message attached natively]"
-                            )
                     else:
                         _run_message = _build_native_image_message() or ctx.message
                 except Exception as _media_exc:
@@ -6989,9 +7092,70 @@ class TurnRunner:
                         "Native media attachment failed, falling back to text: %s",
                         _media_exc,
                     )
+                    _failed_native_audio_paths = [
+                        path for path in _native_audio_paths if path
+                    ]
                     _run_message = _build_native_image_message() or ctx.message
             elif _native_imgs:
                 _run_message = _build_native_image_message() or ctx.message
+
+            if _failed_native_audio_paths or (
+                _native_audio and not _native_audio_survived
+            ):
+                # Native routing is only a lossless optimization. If payload
+                # construction rejects an attachment (unreadable, oversized,
+                # unsupported container/transcode, or an unexpected builder
+                # error), reuse the established STT path for exactly those
+                # files. Successful native audio and images remain attached.
+                _audio_fallback_text = self._transcribe_native_audio_fallback_sync(
+                    _failed_native_audio_paths
+                )
+                _run_message = self._prepend_message_text(
+                    _run_message,
+                    _audio_fallback_text,
+                )
+
+                # Preserve an existing clean-persistence override. When any
+                # audio still travels natively, force a compact text override
+                # so Base64 never enters SQLite; include both the fallback
+                # transcript and a marker for the surviving native clip(s).
+                if (
+                    _persist_user_message_override is not None
+                    or _native_audio_survived
+                ):
+                    _persist_base = (
+                        _persist_user_message_override
+                        if _persist_user_message_override is not None
+                        else ctx.message
+                    )
+                    if _native_audio_survived:
+                        _persist_base = self._prepend_message_text(
+                            _persist_base,
+                            _native_audio_marker,
+                        )
+                    _persist_user_message_override = self._prepend_message_text(
+                        _persist_base,
+                        _audio_fallback_text,
+                    )
+
+            # Persist a compact marker instead of embedding Base64 audio in
+            # the session database/history. Do not stamp a voice marker when
+            # audio failed and only images/text survived.
+            if (
+                _native_audio_survived
+                and _persist_user_message_override is None
+            ):
+                _persist_user_message_override = (
+                    ctx.message.strip()
+                    if isinstance(ctx.message, str) and ctx.message.strip()
+                    else _native_audio_marker
+                )
+            elif (
+                _native_audio_survived
+                and isinstance(_persist_user_message_override, str)
+                and not _persist_user_message_override.strip()
+            ):
+                _persist_user_message_override = _native_audio_marker
 
             _api_run_message = _wrap_current_message_with_observed_context(
                 _run_message,
@@ -19810,12 +19974,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         preprocessing pipeline so sender attribution, image enrichment, STT,
         document notes, reply context, and @ references all behave the same.
 
-        Side effect: buffers per-session native image paths when the active
-        model supports native vision AND the user has images attached. The
-        caller consumes and clears that session-scoped buffer at the
-        ``run_conversation`` site to build a multimodal user turn. When the
-        list is empty, the ``_enrich_message_with_vision`` text path has
-        already run and images are represented in-text.
+        Side effect: buffers per-session native image paths and voice
+        attachments when the active model supports those modalities. The
+        caller consumes and clears those session-scoped buffers at the
+        ``run_conversation`` site to build a multimodal user turn. Images on
+        the text path are already represented by vision enrichment; native
+        audio rejected during final payload construction falls back to STT.
         """
         history = history or []
         _pending_stt_prepared = hasattr(event, "_gateway_pending_stt_text")
@@ -19980,21 +20144,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     # when configured. Lets users verify STT quality in real-time,
                     # while allowing quiet STT for users who only want the agent to
                     # receive the transcription.
-                    if _successful_transcripts and self._should_echo_stt_transcripts():
-                        _echo_adapter = self._adapter_for_source(source)
-                        _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                        if _echo_adapter:
-                            for _tx in _successful_transcripts:
-                                try:
-                                    await _echo_adapter.send(
-                                        source.chat_id,
-                                        f'🎙️ "{_tx}"',
-                                        metadata=_echo_meta,
-                                    )
-                                except Exception as _echo_exc:
-                                    logger.debug(
-                                        "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                    )
+                    await self._echo_stt_transcripts(
+                        source,
+                        _successful_transcripts,
+                        reply_to_message_id=self._reply_anchor_for_event(event),
+                    )
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -26769,12 +26923,30 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.config import load_config
 
             cfg = user_config if isinstance(user_config, dict) else load_config()
-            # Explicit user preference override (gateway.audio_mode / audio_mode)
-            user_pref = (
-                (cfg.get("gateway") or {}).get("audio_mode")
-                if isinstance(cfg.get("gateway"), dict)
-                else None
-            ) or cfg.get("audio_mode") or getattr(getattr(self, "config", None), "audio_mode", None)
+            # Explicit user preference override (gateway.audio_mode; the
+            # top-level audio_mode form remains accepted for compatibility).
+            # Inspect raw key presence rather than the DEFAULT_CONFIG-merged
+            # dict: its gateway.audio_mode="auto" default must not mask a
+            # legacy top-level value or a gateway.json-backed runtime value.
+            preference_cfg = (
+                user_config
+                if isinstance(user_config, dict)
+                else _load_gateway_config()
+            )
+            raw_gateway_pref = preference_cfg.get("gateway")
+            nested_gateway_pref = (
+                raw_gateway_pref if isinstance(raw_gateway_pref, dict) else {}
+            )
+            if "audio_mode" in preference_cfg:
+                user_pref = preference_cfg.get("audio_mode")
+            elif "audio_mode" in nested_gateway_pref:
+                user_pref = nested_gateway_pref.get("audio_mode")
+            else:
+                user_pref = getattr(
+                    getattr(self, "config", None),
+                    "audio_mode",
+                    "auto",
+                )
             if isinstance(user_pref, str):
                 _pref_norm = user_pref.strip().lower()
                 if _pref_norm == "stt":
@@ -26783,6 +26955,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if _pref_norm == "native":
                     logger.info("Audio routing decision: mode=native (user config override)")
                     return "native"
+                if _pref_norm not in {"", "auto"}:
+                    logger.warning(
+                        "Ignoring invalid gateway.audio_mode=%r "
+                        "(expected auto, native, or stt)",
+                        user_pref,
+                    )
 
             resolved_provider = (provider or "").strip()
             resolved_model = (model or "").strip()
@@ -26924,6 +27102,53 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 return f"{prefix}\n\n{user_text}"
             return prefix
         return user_text
+
+    async def _echo_stt_transcripts(
+        self,
+        source: SessionSource,
+        transcripts: List[str],
+        *,
+        reply_to_message_id: Optional[str] = None,
+        log_context: str = "Transcript",
+    ) -> None:
+        """Echo fresh STT transcripts for a single inbound processing pass."""
+        if not transcripts or not self._should_echo_stt_transcripts():
+            return
+        adapter = self._adapter_for_source(source)
+        if adapter is None:
+            return
+        metadata = self._thread_metadata_for_source(
+            source,
+            reply_to_message_id,
+        )
+        for transcript in transcripts:
+            try:
+                await adapter.send(
+                    source.chat_id,
+                    f'🎙️ "{transcript}"',
+                    metadata=metadata,
+                )
+            except Exception as exc:
+                logger.debug("%s echo failed (non-fatal): %s", log_context, exc)
+
+    async def _transcribe_native_audio_fallback(
+        self,
+        audio_paths: List[str],
+        *,
+        source: SessionSource,
+        reply_to_message_id: Optional[str] = None,
+    ) -> str:
+        """Transcribe native attachments rejected during payload construction."""
+        fallback_text, successful_transcripts = (
+            await self._enrich_message_with_transcription("", audio_paths)
+        )
+        await self._echo_stt_transcripts(
+            source,
+            successful_transcripts,
+            reply_to_message_id=reply_to_message_id,
+            log_context="Native audio STT fallback",
+        )
+        return fallback_text
 
     async def _enrich_message_with_transcription(
         self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -26757,6 +26757,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             from hermes_cli.config import load_config
 
             cfg = user_config if isinstance(user_config, dict) else load_config()
+            # Explicit user preference override (gateway.audio_mode / audio_mode)
+            user_pref = (
+                (cfg.get("gateway") or {}).get("audio_mode")
+                if isinstance(cfg.get("gateway"), dict)
+                else None
+            ) or cfg.get("audio_mode") or getattr(getattr(self, "config", None), "audio_mode", None)
+            if isinstance(user_pref, str):
+                _pref_norm = user_pref.strip().lower()
+                if _pref_norm == "stt":
+                    logger.info("Audio routing decision: mode=stt (user config override)")
+                    return "stt"
+                if _pref_norm == "native":
+                    logger.info("Audio routing decision: mode=native (user config override)")
+                    return "native"
+
             resolved_provider = (provider or "").strip()
             resolved_model = (model or "").strip()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6925,9 +6925,11 @@ class TurnRunner:
                         for path in _native_imgs
                     ]
                     _media_attachments.extend(_native_audio)
+                    _target_provider = getattr(agent, "provider", "") or ""
                     _parts, _skipped = build_native_media_content_parts(
                         ctx.message,
                         _media_attachments,
+                        target_provider=_target_provider,
                     )
                     if _skipped:
                         logger.warning(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6916,6 +6916,34 @@ class TurnRunner:
             _native_audio = self._runner._consume_pending_native_audio_attachments(
                 ctx.session_key
             )
+            _run_message: Any = ctx.message
+
+            def _build_native_image_message() -> Optional[List[Dict[str, Any]]]:
+                """Build the established image-only path after mixed-media failure."""
+                if not _native_imgs:
+                    return None
+                try:
+                    from agent.image_routing import build_native_content_parts
+
+                    _image_parts, _image_skipped = build_native_content_parts(
+                        ctx.message,
+                        _native_imgs,
+                    )
+                    if _image_skipped:
+                        logger.warning(
+                            "Native image attachment: skipped %d unreadable path(s): %s",
+                            len(_image_skipped),
+                            _image_skipped,
+                        )
+                    if any(p.get("type") == "image_url" for p in _image_parts):
+                        return _image_parts
+                except Exception as _img_exc:
+                    logger.warning(
+                        "Native image attachment failed, falling back to text: %s",
+                        _img_exc,
+                    )
+                return None
+
             if _native_audio:
                 try:
                     from agent.media_routing import build_native_media_content_parts
@@ -6933,55 +6961,37 @@ class TurnRunner:
                     )
                     if _skipped:
                         logger.warning(
-                            "Native media attachment: skipped %d unreadable path(s): %s",
+                            "Native media attachment: skipped %d attachment(s): %s",
                             len(_skipped), _skipped,
                         )
                     if any(
                         p.get("type") in {"image_url", "file", "input_audio", "video_url"}
                         for p in _parts
                     ):
-                        _run_message: Any = _parts
+                        _run_message = _parts
                         # Persist a compact marker instead of embedding Base64
-                        # audio in the session database/history.
-                        if _persist_user_message_override is None:
+                        # audio in the session database/history. Do not stamp a
+                        # voice marker when audio failed and only an image made
+                        # it through the mixed-media turn.
+                        if (
+                            any(p.get("type") == "input_audio" for p in _parts)
+                            and _persist_user_message_override is None
+                        ):
                             _persist_user_message_override = (
                                 ctx.message.strip()
                                 if isinstance(ctx.message, str) and ctx.message.strip()
                                 else "[Voice message attached natively]"
                             )
                     else:
-                        _run_message = ctx.message
+                        _run_message = _build_native_image_message() or ctx.message
                 except Exception as _media_exc:
                     logger.warning(
                         "Native media attachment failed, falling back to text: %s",
                         _media_exc,
                     )
-                    _run_message = ctx.message
+                    _run_message = _build_native_image_message() or ctx.message
             elif _native_imgs:
-                try:
-                    from agent.image_routing import build_native_content_parts
-                    _parts, _skipped = build_native_content_parts(
-                        ctx.message,
-                        _native_imgs,
-                    )
-                    if _skipped:
-                        logger.warning(
-                            "Native image attachment: skipped %d unreadable path(s): %s",
-                            len(_skipped), _skipped,
-                        )
-                    if any(p.get("type") == "image_url" for p in _parts):
-                        _run_message: Any = _parts
-                    else:
-                        # All images failed to read — fall back to plain text.
-                        _run_message = ctx.message
-                except Exception as _img_exc:
-                    logger.warning(
-                        "Native image attachment failed, falling back to text: %s",
-                        _img_exc,
-                    )
-                    _run_message = ctx.message
-            else:
-                _run_message = ctx.message
+                _run_message = _build_native_image_message() or ctx.message
 
             _api_run_message = _wrap_current_message_with_observed_context(
                 _run_message,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6908,12 +6908,54 @@ class TurnRunner:
         _approval_session_token = set_current_session_key(_approval_session_key)
         register_gateway_notify(_approval_session_key, _approval_notify_sync)
         try:
-            # If _prepare_inbound_message_text buffered image paths for native
+            # If _prepare_inbound_message_text buffered media for native
             # attachment, wrap the user turn as an OpenAI-style multimodal
             # content list. Consume-and-clear so subsequent turns on the same
-            # runner instance don't re-attach stale images.
+            # runner instance don't re-attach stale media.
             _native_imgs = self._runner._consume_pending_native_image_paths(ctx.session_key)
-            if _native_imgs:
+            _native_audio = self._runner._consume_pending_native_audio_attachments(
+                ctx.session_key
+            )
+            if _native_audio:
+                try:
+                    from agent.media_routing import build_native_media_content_parts
+
+                    _media_attachments = [
+                        {"path": path, "mime_type": "", "modality": "image"}
+                        for path in _native_imgs
+                    ]
+                    _media_attachments.extend(_native_audio)
+                    _parts, _skipped = build_native_media_content_parts(
+                        ctx.message,
+                        _media_attachments,
+                    )
+                    if _skipped:
+                        logger.warning(
+                            "Native media attachment: skipped %d unreadable path(s): %s",
+                            len(_skipped), _skipped,
+                        )
+                    if any(
+                        p.get("type") in {"image_url", "file", "input_audio", "video_url"}
+                        for p in _parts
+                    ):
+                        _run_message: Any = _parts
+                        # Persist a compact marker instead of embedding Base64
+                        # audio in the session database/history.
+                        if _persist_user_message_override is None:
+                            _persist_user_message_override = (
+                                ctx.message.strip()
+                                if isinstance(ctx.message, str) and ctx.message.strip()
+                                else "[Voice message attached natively]"
+                            )
+                    else:
+                        _run_message = ctx.message
+                except Exception as _media_exc:
+                    logger.warning(
+                        "Native media attachment failed, falling back to text: %s",
+                        _media_exc,
+                    )
+                    _run_message = ctx.message
+            elif _native_imgs:
                 try:
                     from agent.image_routing import build_native_content_parts
                     _parts, _skipped = build_native_content_parts(
@@ -7356,6 +7398,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     _pending_messages = legacy_dict_property("_pending_messages")
     _pending_native_image_paths_by_session = legacy_dict_property(
         "_pending_native_image_paths_by_session"
+    )
+    _pending_native_audio_attachments_by_session = legacy_dict_property(
+        "_pending_native_audio_attachments_by_session"
     )
     _session_ephemeral_pin = legacy_dict_property("_session_ephemeral_pin")
     _session_vc_last = legacy_dict_property("_session_vc_last")
@@ -19776,6 +19821,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Reset only this session's per-call buffer; other sessions may be
         # concurrently preparing multimodal turns on the same runner.
         self._consume_pending_native_image_paths(session_key)
+        self._consume_pending_native_audio_attachments(session_key)
 
         _is_shared_multi_user = is_shared_multi_user_session(
             source,
@@ -19817,6 +19863,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if event.media_urls:
             image_paths = []
             audio_paths = []
+            audio_attachments: List[Dict[str, str]] = []
             for i, path in enumerate(event.media_urls):
                 mtype = event.media_types[i] if i < len(event.media_types) else ""
                 # Classify images per-attachment: trust this attachment's own
@@ -19829,11 +19876,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 # MessageType.AUDIO = audio file attachment (e.g. .mp3, .m4a) — never STT.
                 # Mixed DOCUMENT events also preserve audio as a file path instead of
                 # dropping it or treating it as a voice note.
+                # MessageType.VOICE is routed natively when the effective model
+                # accepts audio; otherwise it falls back to configured STT.
                 if _event_media_is_audio(event, i):
                     if event.message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
                         audio_file_paths.append(path)
                     elif not _pending_stt_prepared and _event_media_is_stt_input(event, i):
                         audio_paths.append(path)
+                        audio_attachments.append({
+                            "path": path,
+                            "mime_type": mtype,
+                            "modality": "audio",
+                        })
                 if mtype.startswith("video/") or (not mtype and event.message_type == MessageType.VIDEO):
                     video_paths.append(path)
 
@@ -19890,29 +19944,45 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         )
 
             if audio_paths:
-                message_text, _successful_transcripts = await self._enrich_message_with_transcription(
-                    message_text,
-                    audio_paths,
+                _audio_mode = await asyncio.to_thread(
+                    self._decide_audio_input_mode,
+                    source=source,
+                    session_key=session_key,
                 )
-                # Echo each successful transcript back to the user immediately
-                # when configured. Lets users verify STT quality in real-time,
-                # while allowing quiet STT for users who only want the agent to
-                # receive the transcription.
-                if _successful_transcripts and self._should_echo_stt_transcripts():
-                    _echo_adapter = self._adapter_for_source(source)
-                    _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
-                    if _echo_adapter:
-                        for _tx in _successful_transcripts:
-                            try:
-                                await _echo_adapter.send(
-                                    source.chat_id,
-                                    f'🎙️ "{_tx}"',
-                                    metadata=_echo_meta,
-                                )
-                            except Exception as _echo_exc:
-                                logger.debug(
-                                    "Transcript echo failed (non-fatal): %s", _echo_exc,
-                                )
+                if _audio_mode == "native":
+                    self._session_state(
+                        session_key
+                    ).persistent.native_audio_attachments = [
+                        dict(item) for item in audio_attachments
+                    ]
+                    logger.info(
+                        "Audio routing: native. %d voice attachment(s) will be sent inline.",
+                        len(audio_attachments),
+                    )
+                else:
+                    message_text, _successful_transcripts = await self._enrich_message_with_transcription(
+                        message_text,
+                        audio_paths,
+                    )
+                    # Echo each successful transcript back to the user immediately
+                    # when configured. Lets users verify STT quality in real-time,
+                    # while allowing quiet STT for users who only want the agent to
+                    # receive the transcription.
+                    if _successful_transcripts and self._should_echo_stt_transcripts():
+                        _echo_adapter = self._adapter_for_source(source)
+                        _echo_meta = self._thread_metadata_for_source(source, self._reply_anchor_for_event(event))
+                        if _echo_adapter:
+                            for _tx in _successful_transcripts:
+                                try:
+                                    await _echo_adapter.send(
+                                        source.chat_id,
+                                        f'🎙️ "{_tx}"',
+                                        metadata=_echo_meta,
+                                    )
+                                except Exception as _echo_exc:
+                                    logger.debug(
+                                        "Transcript echo failed (non-fatal): %s", _echo_exc,
+                                    )
                 # NOTE: Previously, when transcription failed (e.g. no STT
                 # provider configured), the gateway also emitted a hardcoded
                 # English notice via `_stt_adapter.send()`. That bypassed the
@@ -20201,6 +20271,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         paths = list(state.persistent.native_image_paths)
         state.persistent.native_image_paths = []
         return paths
+
+    def _consume_pending_native_audio_attachments(
+        self,
+        session_key: str,
+    ) -> List[Dict[str, str]]:
+        """Consume this session's one-shot native audio attachment buffer."""
+        state = self._peek_session_state(session_key)
+        if state is None or not state.persistent.native_audio_attachments:
+            return []
+        attachments = [dict(item) for item in state.persistent.native_audio_attachments]
+        state.persistent.native_audio_attachments = []
+        return attachments
 
     def _cache_session_source(self, session_key: str, source) -> None:
         if not session_key or source is None:
@@ -26653,6 +26735,97 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         except Exception as exc:
             logger.debug("image_routing: decision failed, falling back to text — %s", exc)
             return "text"
+
+    def _decide_audio_input_mode(
+        self,
+        *,
+        source: Optional[SessionSource] = None,
+        session_key: Optional[str] = None,
+        user_config: Optional[dict] = None,
+        provider: Optional[str] = None,
+        model: Optional[str] = None,
+    ) -> str:
+        """Return ``native`` when this turn's model accepts audio, else ``stt``.
+
+        The decision follows the same session-aware runtime resolution used by
+        image routing, including per-chat and ``/model`` overrides. Unknown
+        capability data is treated conservatively and falls back to STT.
+        """
+        try:
+            from agent.auxiliary_client import _read_main_model, _read_main_provider
+            from agent.media_routing import supported_input_modalities
+            from hermes_cli.config import load_config
+
+            cfg = user_config if isinstance(user_config, dict) else load_config()
+            resolved_provider = (provider or "").strip()
+            resolved_model = (model or "").strip()
+
+            needs_session_runtime = not resolved_provider or not resolved_model
+            if needs_session_runtime and (source is not None or session_key):
+                try:
+                    turn_model, runtime_kwargs = self._resolve_session_agent_runtime(
+                        source=source,
+                        session_key=session_key,
+                        user_config=cfg,
+                    )
+                    if not resolved_model and isinstance(turn_model, str):
+                        resolved_model = turn_model.strip()
+                    runtime_provider = (
+                        runtime_kwargs.get("provider")
+                        if isinstance(runtime_kwargs, dict)
+                        else None
+                    )
+                    if not resolved_provider and isinstance(runtime_provider, str):
+                        resolved_provider = runtime_provider.strip()
+                except Exception as exc:
+                    logger.debug(
+                        "audio_routing: session runtime resolution failed, "
+                        "falling back to process runtime — %s",
+                        exc,
+                    )
+
+            if not resolved_provider:
+                resolved_provider = _read_main_provider()
+            if not resolved_model:
+                resolved_model = _read_main_model()
+
+            # Force STT for Meta / Muse Spark: api.meta.ai rejects
+            # ``input_audio`` (400: messages[N].content[2] did not match any
+            # supported type) for Telegram Ogg Opus voice notes even though
+            # models.dev advertises audio. Groq STT handles ogg correctly.
+            _prov_norm = (resolved_provider or "").strip().lower()
+            _model_norm = (resolved_model or "").strip().lower()
+            if _prov_norm in ("meta", "meta-ai"):
+                logger.info(
+                    "Audio routing decision: mode=stt (forced for meta) provider=%s model=%s",
+                    resolved_provider or "unknown",
+                    resolved_model or "unknown",
+                )
+                return "stt"
+            if "muse-spark" in _model_norm or "muse_spark" in _model_norm:
+                logger.info(
+                    "Audio routing decision: mode=stt (forced for muse-spark) provider=%s model=%s",
+                    resolved_provider or "unknown",
+                    resolved_model or "unknown",
+                )
+                return "stt"
+
+            modalities = supported_input_modalities(
+                resolved_provider,
+                resolved_model,
+            )
+            mode = "native" if "audio" in modalities else "stt"
+            logger.info(
+                "Audio routing decision: mode=%s provider=%s model=%s modalities=%s",
+                mode,
+                resolved_provider or "unknown",
+                resolved_model or "unknown",
+                sorted(modalities),
+            )
+            return mode
+        except Exception as exc:
+            logger.debug("audio_routing: decision failed, falling back to STT — %s", exc)
+            return "stt"
 
     async def _enrich_message_with_vision(
         self,

--- a/gateway/session_state.py
+++ b/gateway/session_state.py
@@ -140,6 +140,9 @@ class PersistentState:
     update_prompt_pending: bool = False
     # Image paths staged for native (inline) attachment; consumed one-shot.
     native_image_paths: List[str] = field(default_factory=list)
+    # Audio attachments staged for native (inline) attachment; consumed one-shot.
+    # Each item contains path, mime_type and modality="audio".
+    native_audio_attachments: List[Dict[str, str]] = field(default_factory=list)
     # Legacy runner-level pending message text (write-mostly; flushed to
     # disk on shutdown — see #72680).  NOTE: distinct from the adapter-level
     # ``_pending_messages`` (Dict[str, MessageEvent]) in gateway/base.py,
@@ -405,6 +408,9 @@ LEGACY_FIELD_SPECS: Dict[str, _FieldSpec] = {
     ),
     "_pending_native_image_paths_by_session": _FieldSpec(
         "persistent", "native_image_paths", list, _present_nonzero
+    ),
+    "_pending_native_audio_attachments_by_session": _FieldSpec(
+        "persistent", "native_audio_attachments", list, _present_nonzero
     ),
     "_pending_messages": _FieldSpec(
         "persistent", "pending_command_text", lambda: None, _present_not_none

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2331,6 +2331,7 @@ _EXTRA_KNOWN_ROOT_KEYS = {
     "group_sessions_per_user",   # top-level form bridged by gateway/config.py
     "thread_sessions_per_user",  # top-level form bridged by gateway/config.py
     "stt_echo_transcripts",      # top-level form bridged by gateway/config.py
+    "audio_mode",                # top-level compatibility form bridged by gateway/config.py
     "reset_triggers",            # top-level form bridged by gateway/config.py
     "always_log_local",          # top-level form bridged by gateway/config.py
     "filter_silence_narration",  # top-level form bridged by gateway/config.py

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3337,6 +3337,12 @@ DEFAULT_CONFIG = {
             "enabled": False,
         },
 
+        # Inbound voice-note routing: "auto" uses the active model's declared
+        # audio capability, "native" prefers inline audio, and "stt" always
+        # transcribes first. Native payload-construction failures fall back to
+        # the configured STT path so an attachment is never silently dropped.
+        "audio_mode": "auto",
+
         # Maximum bytes for an inbound image / audio / video payload the
         # gateway will buffer into memory and cache to disk. Inbound media is
         # read fully into RAM before being written, so an unbounded upload

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -74,3 +74,56 @@ def test_unreadable_attachment_falls_back_without_fake_media(tmp_path):
     )
     assert parts == [{"type": "text", "text": "read this"}]
     assert skipped == [str(missing)]
+
+
+def test_attachment_exceeding_size_ceiling_is_skipped(tmp_path):
+    oversized = tmp_path / "large_voice.ogg"
+    oversized.write_bytes(b"x" * 200)
+
+    # Test with custom max_size_bytes
+    parts, skipped = build_native_media_content_parts(
+        "listen",
+        [{"path": str(oversized), "mime_type": "audio/ogg", "modality": "audio"}],
+        max_size_bytes=100,
+    )
+    assert parts == [{"type": "text", "text": "listen"}]
+    assert skipped == [str(oversized)]
+
+
+def test_audio_format_and_mime_normalization():
+    from agent.media_routing import normalize_audio_format, normalize_audio_mime
+    from pathlib import Path
+
+    assert normalize_audio_format(Path("audio.mp3")) == "mp3"
+    assert normalize_audio_format(Path("audio.ogg")) == "ogg"
+    assert normalize_audio_format(Path("audio.opus")) == "ogg"
+    assert normalize_audio_format(Path("audio.wav")) == "wav"
+    assert normalize_audio_format(Path("audio.flac")) == "flac"
+    assert normalize_audio_format(mime="audio/mpeg") == "mp3"
+    assert normalize_audio_format(mime="audio/ogg") == "ogg"
+
+    assert normalize_audio_mime("mp3") == "audio/mpeg"
+    assert normalize_audio_mime("mpeg") == "audio/mpeg"
+    assert normalize_audio_mime("ogg") == "audio/ogg"
+    assert normalize_audio_mime("opus") == "audio/ogg"
+    assert normalize_audio_mime("wav") == "audio/wav"
+    assert normalize_audio_mime("flac") == "audio/flac"
+    assert normalize_audio_mime("audio/custom") == "audio/custom"
+
+
+def test_modality_auto_derived_when_omitted(tmp_path):
+    img = tmp_path / "screenshot.png"
+    img.write_bytes(b"png-data")
+    audio = tmp_path / "memo.ogg"
+    audio.write_bytes(b"ogg-data")
+
+    parts, skipped = build_native_media_content_parts(
+        "check",
+        [
+            {"path": str(img), "mime_type": "image/png"},
+            {"path": str(audio), "mime_type": "audio/ogg"},
+        ],
+    )
+    assert skipped == []
+    assert [part["type"] for part in parts] == ["text", "image_url", "input_audio"]
+

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -127,3 +127,29 @@ def test_modality_auto_derived_when_omitted(tmp_path):
     assert skipped == []
     assert [part["type"] for part in parts] == ["text", "image_url", "input_audio"]
 
+
+def test_magic_bytes_audio_format_and_mime_detection(tmp_path):
+    from agent.media_routing import _mime_type, normalize_audio_format
+
+    # An audio file with no extension or misleading extension
+    audio_unknown = tmp_path / "voice_cache_123"
+    audio_unknown.write_bytes(b"OggS" + b"\x00" * 28)
+
+    assert normalize_audio_format(audio_unknown) == "ogg"
+    assert _mime_type(audio_unknown, "") == "audio/ogg"
+
+
+def test_rich_hint_contains_size_and_mime(tmp_path):
+    photo = tmp_path / "photo.png"
+    photo.write_bytes(b"x" * 2048)  # 2.0 KB
+
+    parts, _ = build_native_media_content_parts(
+        "describe",
+        [{"path": str(photo), "mime_type": "image/png", "modality": "image"}],
+    )
+    assert len(parts) == 2
+    hint_text = parts[0]["text"]
+    assert "2.0 KB" in hint_text
+    assert "image/png" in hint_text
+
+

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -104,6 +104,20 @@ def test_attachment_exceeding_size_ceiling_is_skipped(tmp_path):
     assert skipped == [str(oversized)]
 
 
+def test_attachment_size_ceiling_includes_base64_expansion(tmp_path):
+    audio = tmp_path / "voice.mp3"
+    audio.write_bytes(b"x" * 76)  # 104 bytes after Base64 encoding.
+
+    parts, skipped = build_native_media_content_parts(
+        "listen",
+        [{"path": str(audio), "mime_type": "audio/mpeg", "modality": "audio"}],
+        max_size_bytes=100,
+    )
+
+    assert parts == [{"type": "text", "text": "listen"}]
+    assert skipped == [str(audio)]
+
+
 def test_audio_format_and_mime_normalization():
     from agent.media_routing import normalize_audio_format, normalize_audio_mime
     from pathlib import Path
@@ -190,6 +204,67 @@ def test_openai_target_provider_triggers_audio_transcoding(tmp_path, monkeypatch
     assert audio_part["input_audio"]["data"] == base64.b64encode(
         b"fake-mp3-bytes"
     ).decode("ascii")
+
+
+def test_openai_transcode_failure_skips_unsupported_audio(tmp_path, monkeypatch):
+    import agent.media_routing as mr
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 28)
+    monkeypatch.setattr(
+        mr, "transcode_audio_to_supported_format", lambda *_a, **_k: None
+    )
+
+    for target_provider in ("openai", "azure"):
+        parts, skipped = build_native_media_content_parts(
+            "listen to voice",
+            [{"path": str(audio), "mime_type": "audio/ogg", "modality": "audio"}],
+            target_provider=target_provider,
+        )
+
+        assert parts == [{"type": "text", "text": "listen to voice"}]
+        assert skipped == [str(audio)]
+
+
+def test_failed_audio_keeps_images_on_existing_native_pipeline(tmp_path):
+    image = tmp_path / "photo.png"
+    image.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+    missing_audio = tmp_path / "missing.ogg"
+
+    parts, skipped = build_native_media_content_parts(
+        "look and listen",
+        [
+            {"path": str(image), "mime_type": "image/png", "modality": "image"},
+            {
+                "path": str(missing_audio),
+                "mime_type": "audio/ogg",
+                "modality": "audio",
+            },
+        ],
+        # The established image pipeline handles provider limits reactively;
+        # this ceiling applies to newly inlined non-image payloads only.
+        max_size_bytes=16,
+    )
+
+    assert any(part.get("type") == "image_url" for part in parts)
+    assert not any(part.get("type") == "input_audio" for part in parts)
+    assert skipped == [str(missing_audio)]
+
+
+def test_gemini_adapter_does_not_fetch_arbitrary_remote_media_urls():
+    parts = _extract_multimodal_parts([
+        {"type": "text", "text": "inspect these references"},
+        {
+            "type": "video_url",
+            "video_url": {"url": "https://example.com/video.mp4"},
+        },
+        {
+            "type": "file",
+            "file": {"file_data": "https://example.com/document.pdf"},
+        },
+    ])
+
+    assert parts == [{"text": "inspect these references"}]
 
 
 def test_transcode_audio_when_ffmpeg_missing(tmp_path, monkeypatch):

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -1,15 +1,23 @@
 import base64
 
 from agent.gemini_native_adapter import _extract_multimodal_parts
-from agent.media_routing import build_native_media_content_parts, supported_input_modalities
+from agent.media_routing import (
+    build_native_media_content_parts,
+    supported_input_modalities,
+)
 
 
-def test_active_gemini_flash_lite_declares_all_multimodal_inputs(monkeypatch):
+def test_active_gemini_flash_lite_declares_all_multimodal_inputs():
     from types import SimpleNamespace
     from unittest.mock import patch
-    fake_info = SimpleNamespace(input_modalities=["text", "image", "pdf", "video", "audio"])
+
+    fake_info = SimpleNamespace(
+        input_modalities=["text", "image", "pdf", "video", "audio"]
+    )
     with patch("agent.models_dev.get_model_info", return_value=fake_info):
-        modalities = supported_input_modalities("openrouter", "google/gemini-3.5-flash-lite")
+        modalities = supported_input_modalities(
+            "openrouter", "google/gemini-3.5-flash-lite"
+        )
         assert {"text", "image", "pdf", "video", "audio"} <= modalities
 
 
@@ -33,7 +41,11 @@ def test_builds_openrouter_native_parts_for_all_media(tmp_path):
 
     assert skipped == []
     assert [part["type"] for part in parts] == [
-        "text", "image_url", "file", "input_audio", "video_url",
+        "text",
+        "image_url",
+        "file",
+        "input_audio",
+        "video_url",
     ]
     assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
     assert parts[2]["file"]["file_data"].startswith("data:application/pdf;base64,")
@@ -62,7 +74,9 @@ def test_gemini_native_adapter_converts_non_image_media_to_inline_data(tmp_path)
     native = _extract_multimodal_parts(parts)
     assert native[0] == {"text": parts[0]["text"]}
     assert [part["inlineData"]["mimeType"] for part in native[1:]] == [
-        "application/pdf", "audio/mpeg", "video/mp4",
+        "application/pdf",
+        "audio/mpeg",
+        "video/mp4",
     ]
 
 
@@ -153,3 +167,140 @@ def test_rich_hint_contains_size_and_mime(tmp_path):
     assert "image/png" in hint_text
 
 
+def test_openai_target_provider_triggers_audio_transcoding(tmp_path, monkeypatch):
+    import agent.media_routing as mr
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 28)
+
+    monkeypatch.setattr(
+        mr,
+        "transcode_audio_to_supported_format",
+        lambda *args, **kwargs: (b"fake-mp3-bytes", "mp3"),
+    )
+
+    parts, skipped = build_native_media_content_parts(
+        "listen to voice",
+        [{"path": str(audio), "mime_type": "audio/ogg", "modality": "audio"}],
+        target_provider="openai",
+    )
+    assert skipped == []
+    audio_part = next(p for p in parts if p.get("type") == "input_audio")
+    assert audio_part["input_audio"]["format"] == "mp3"
+    assert audio_part["input_audio"]["data"] == base64.b64encode(
+        b"fake-mp3-bytes"
+    ).decode("ascii")
+
+
+def test_transcode_audio_when_ffmpeg_missing(tmp_path, monkeypatch):
+    import shutil
+    from agent.media_routing import transcode_audio_to_supported_format
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 28)
+
+    monkeypatch.setattr(shutil, "which", lambda *_: None)
+    assert transcode_audio_to_supported_format(audio) is None
+
+
+def test_transcode_audio_successful_subprocess(tmp_path, monkeypatch):
+    from pathlib import Path
+    import shutil
+    import subprocess
+    from agent.media_routing import transcode_audio_to_supported_format
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 28)
+
+    monkeypatch.setattr(shutil, "which", lambda *_: "/usr/bin/ffmpeg")
+
+    def fake_run(cmd, **kwargs):
+        out_file = Path(cmd[-1])
+        out_file.write_bytes(b"fake-mp3-output")
+        return subprocess.CompletedProcess(cmd, returncode=0)
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    result = transcode_audio_to_supported_format(audio, target_format="mp3")
+    assert result is not None
+    data, fmt = result
+    assert data == b"fake-mp3-output"
+    assert fmt == "mp3"
+
+
+def test_transcode_audio_subprocess_failure(tmp_path, monkeypatch):
+    import shutil
+    import subprocess
+    from agent.media_routing import transcode_audio_to_supported_format
+
+    audio = tmp_path / "voice.ogg"
+    audio.write_bytes(b"OggS" + b"\x00" * 28)
+
+    monkeypatch.setattr(shutil, "which", lambda *_: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, returncode=1),
+    )
+    assert transcode_audio_to_supported_format(audio, target_format="mp3") is None
+
+
+def test_rich_hint_formats_megabytes_for_large_files(tmp_path):
+    big_file = tmp_path / "recording.wav"
+    big_file.write_bytes(b"x" * int(2.5 * 1024 * 1024))
+
+    parts, skipped = build_native_media_content_parts(
+        "listen",
+        [{"path": str(big_file), "mime_type": "audio/wav", "modality": "audio"}],
+    )
+    assert skipped == []
+    assert len(parts) == 2
+    hint_text = parts[0]["text"]
+    assert "2.5 MB" in hint_text
+    assert "audio/wav" in hint_text
+
+
+def test_supported_input_modalities_openrouter_vendor_fallback():
+    from types import SimpleNamespace
+    from unittest.mock import patch
+
+    fake_info = SimpleNamespace(input_modalities=["text", "audio"])
+
+    def mock_get_info(provider, model):
+        if provider == "openrouter":
+            return None
+        if provider == "openai" and model == "gpt-4o":
+            return fake_info
+        return None
+
+    with patch("agent.models_dev.get_model_info", side_effect=mock_get_info):
+        modalities = supported_input_modalities("openrouter", "openai/gpt-4o")
+        assert "audio" in modalities
+        assert "text" in modalities
+
+    with patch("agent.models_dev.get_model_info", return_value=None):
+        modalities = supported_input_modalities("openrouter", "unknown/model")
+        assert modalities == set()
+
+
+def test_unsupported_modality_is_skipped(tmp_path):
+    f = tmp_path / "unknown.bin"
+    f.write_bytes(b"binary-data")
+    parts, skipped = build_native_media_content_parts(
+        "check",
+        [{"path": str(f), "mime_type": "application/octet-stream", "modality": "custom_binary"}],
+    )
+    assert skipped == [str(f)]
+    assert parts == [{"type": "text", "text": "check"}]
+
+
+def test_bare_string_paths_accepted_in_attachments(tmp_path):
+    img = tmp_path / "simple.png"
+    img.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+
+    parts, skipped = build_native_media_content_parts(
+        "look",
+        [str(img)],
+    )
+    assert skipped == []
+    assert len(parts) == 2
+    assert parts[1]["type"] == "image_url"

--- a/tests/agent/test_media_routing.py
+++ b/tests/agent/test_media_routing.py
@@ -1,0 +1,76 @@
+import base64
+
+from agent.gemini_native_adapter import _extract_multimodal_parts
+from agent.media_routing import build_native_media_content_parts, supported_input_modalities
+
+
+def test_active_gemini_flash_lite_declares_all_multimodal_inputs(monkeypatch):
+    from types import SimpleNamespace
+    from unittest.mock import patch
+    fake_info = SimpleNamespace(input_modalities=["text", "image", "pdf", "video", "audio"])
+    with patch("agent.models_dev.get_model_info", return_value=fake_info):
+        modalities = supported_input_modalities("openrouter", "google/gemini-3.5-flash-lite")
+        assert {"text", "image", "pdf", "video", "audio"} <= modalities
+
+
+def test_builds_openrouter_native_parts_for_all_media(tmp_path):
+    files = {
+        "image": (tmp_path / "photo.png", "image/png"),
+        "pdf": (tmp_path / "notes.pdf", "application/pdf"),
+        "audio": (tmp_path / "sample.mp3", "audio/mpeg"),
+        "video": (tmp_path / "clip.mp4", "video/mp4"),
+    }
+    for path, _mime in files.values():
+        path.write_bytes(b"test-bytes")
+
+    parts, skipped = build_native_media_content_parts(
+        "analyze everything",
+        [
+            {"path": str(path), "mime_type": mime, "modality": modality}
+            for modality, (path, mime) in files.items()
+        ],
+    )
+
+    assert skipped == []
+    assert [part["type"] for part in parts] == [
+        "text", "image_url", "file", "input_audio", "video_url",
+    ]
+    assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
+    assert parts[2]["file"]["file_data"].startswith("data:application/pdf;base64,")
+    assert parts[3]["input_audio"]["format"] == "mp3"
+    assert parts[3]["input_audio"]["data"] == base64.b64encode(b"test-bytes").decode()
+    assert parts[4]["video_url"]["url"].startswith("data:video/mp4;base64,")
+
+
+def test_gemini_native_adapter_converts_non_image_media_to_inline_data(tmp_path):
+    pdf = tmp_path / "notes.pdf"
+    audio = tmp_path / "sample.mp3"
+    video = tmp_path / "clip.mp4"
+    for path in (pdf, audio, video):
+        path.write_bytes(b"native-data")
+
+    parts, skipped = build_native_media_content_parts(
+        "analyze",
+        [
+            {"path": str(pdf), "mime_type": "application/pdf", "modality": "pdf"},
+            {"path": str(audio), "mime_type": "audio/mpeg", "modality": "audio"},
+            {"path": str(video), "mime_type": "video/mp4", "modality": "video"},
+        ],
+    )
+    assert skipped == []
+
+    native = _extract_multimodal_parts(parts)
+    assert native[0] == {"text": parts[0]["text"]}
+    assert [part["inlineData"]["mimeType"] for part in native[1:]] == [
+        "application/pdf", "audio/mpeg", "video/mp4",
+    ]
+
+
+def test_unreadable_attachment_falls_back_without_fake_media(tmp_path):
+    missing = tmp_path / "missing.pdf"
+    parts, skipped = build_native_media_content_parts(
+        "read this",
+        [{"path": str(missing), "mime_type": "application/pdf", "modality": "pdf"}],
+    )
+    assert parts == [{"type": "text", "text": "read this"}]
+    assert skipped == [str(missing)]

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -209,6 +209,22 @@ class TestStreamingConfig:
 
 class TestGatewayConfigRoundtrip:
 
+    @pytest.mark.parametrize(
+        ("raw", "expected"),
+        [
+            ("AUTO", "auto"),
+            (" native ", "native"),
+            ("stt", "stt"),
+            ("unsupported", "auto"),
+            (False, "auto"),
+        ],
+    )
+    def test_audio_mode_is_normalized_and_roundtrips(self, raw, expected):
+        config = GatewayConfig.from_dict({"audio_mode": raw})
+
+        assert config.audio_mode == expected
+        assert GatewayConfig.from_dict(config.to_dict()).audio_mode == expected
+
     def test_systemd_watchdog_from_dict_disables_invalid_values(self):
         invalid_values = [
             None,
@@ -489,6 +505,20 @@ class TestLoadGatewayConfig:
         config = load_gateway_config()
 
         assert config.stt_enabled is False
+
+    def test_audio_mode_from_nested_gateway_section(self, tmp_path, monkeypatch):
+        """The documented gateway.audio_mode path must reach runtime config."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "gateway:\n  audio_mode: native\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.audio_mode == "native"
 
 
     @staticmethod

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -59,6 +59,19 @@ def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
         user_config={},
     ) == "stt"
 
+    # User explicit config overrides
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="text-only-test",
+        user_config={"gateway": {"audio_mode": "native"}},
+    ) == "native"
+
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="google/gemini-test",
+        user_config={"gateway": {"audio_mode": "stt"}},
+    ) == "stt"
+
 
 @pytest.mark.asyncio
 async def test_voice_message_stages_native_audio_without_stt(tmp_path):

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -4,7 +4,7 @@ import importlib
 import sys
 import types
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -84,6 +84,20 @@ def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
         == "stt"
     )
 
+    # The DEFAULT_CONFIG-merged gateway.audio_mode="auto" must not mask the
+    # compatibility top-level form when both keys are present.
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="google/gemini-test",
+            user_config={
+                "audio_mode": "stt",
+                "gateway": {"audio_mode": "auto"},
+            },
+        )
+        == "stt"
+    )
+
 
 @pytest.mark.asyncio
 async def test_voice_message_stages_native_audio_without_stt(tmp_path):
@@ -133,6 +147,7 @@ class _CaptureAgent:
     def __init__(self, **kwargs):
         self.tools = []
         self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.provider = kwargs.get("provider", "")
 
     def run_conversation(self, message, **kwargs):
         type(self).calls.append((message, kwargs))
@@ -217,6 +232,200 @@ async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
     assert audio_part["input_audio"]["format"] == "ogg"
     assert kwargs["persist_user_message"] == "[Voice message attached natively]"
     assert runner._consume_pending_native_audio_attachments(session_key) == []
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_falls_back_to_stt_when_native_audio_is_rejected(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *_, **__: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    media_routing = importlib.import_module("agent.media_routing")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openai"},
+    )
+    monkeypatch.setattr(
+        media_routing,
+        "transcode_audio_to_supported_format",
+        lambda *_args, **_kwargs: None,
+    )
+
+    runner = _pipeline_runner()
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=('"fallback transcript"', ["fallback transcript"])
+    )
+    source = _source()
+    session_key = build_session_key(source)
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    runner._session_state(session_key).persistent.native_audio_attachments = [
+        {
+            "path": str(audio_path),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        }
+    ]
+
+    result = await runner._run_agent(
+        message="",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-native-stt-fallback",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    message, kwargs = _CaptureAgent.calls[0]
+    assert message == '"fallback transcript"'
+    assert kwargs.get("persist_user_message") is None
+    runner._enrich_message_with_transcription.assert_awaited_once_with(
+        "",
+        [str(audio_path)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_partial_native_audio_failure_transcribes_only_rejected_clip(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *_, **__: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    media_routing = importlib.import_module("agent.media_routing")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openai"},
+    )
+    monkeypatch.setattr(
+        media_routing,
+        "transcode_audio_to_supported_format",
+        lambda *_args, **_kwargs: None,
+    )
+
+    runner = _pipeline_runner()
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=('"second clip transcript"', ["second clip transcript"])
+    )
+    source = _source()
+    session_key = build_session_key(source)
+    native_path = tmp_path / "first.mp3"
+    native_path.write_bytes(b"ID3-native-audio")
+    rejected_path = tmp_path / "second.ogg"
+    rejected_path.write_bytes(b"OggS-rejected-audio")
+    runner._session_state(session_key).persistent.native_audio_attachments = [
+        {
+            "path": str(native_path),
+            "mime_type": "audio/mpeg",
+            "modality": "audio",
+        },
+        {
+            "path": str(rejected_path),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        },
+    ]
+
+    result = await runner._run_agent(
+        message="",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-partial-native-stt-fallback",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    message, kwargs = _CaptureAgent.calls[0]
+    assert isinstance(message, list)
+    assert sum(part.get("type") == "input_audio" for part in message) == 1
+    text_part = next(part for part in message if part.get("type") == "text")
+    assert '"second clip transcript"' in text_part["text"]
+    assert kwargs["persist_user_message"] == (
+        '"second clip transcript"\n\n[Voice message attached natively]'
+    )
+    runner._enrich_message_with_transcription.assert_awaited_once_with(
+        "",
+        [str(rejected_path)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_audio_stt_fallback_echoes_each_transcript_once():
+    runner = _bare_runner()
+    adapter = SimpleNamespace(send=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._thread_metadata_for_source = lambda *_args: {"thread_id": "topic-1"}
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=('"one"\n\n"two"', ["one", "two"])
+    )
+
+    fallback_text = await runner._transcribe_native_audio_fallback(
+        ["one.ogg", "two.ogg"],
+        source=_source(),
+        reply_to_message_id="reply-1",
+    )
+
+    assert fallback_text == '"one"\n\n"two"'
+    assert adapter.send.await_count == 2
+    assert [call.args[1] for call in adapter.send.await_args_list] == [
+        '🎙️ "one"',
+        '🎙️ "two"',
+    ]
+    assert all(
+        call.kwargs["metadata"] == {"thread_id": "topic-1"}
+        for call in adapter.send.await_args_list
+    )
+
+
+@pytest.mark.asyncio
+async def test_native_audio_fallback_remains_nonempty_when_stt_is_disabled(
+    monkeypatch,
+    tmp_path,
+):
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(
+        gateway_run,
+        "_probe_audio_duration",
+        AsyncMock(return_value=None),
+    )
+    runner = _bare_runner()
+    runner.config.stt_enabled = False
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+
+    fallback_text = await runner._transcribe_native_audio_fallback(
+        [str(audio_path)],
+        source=_source(),
+    )
+
+    assert fallback_text.strip()
+    assert "The user sent a voice message" in fallback_text
+    assert str(audio_path.resolve()) in fallback_text
 
 
 def test_audio_routing_forces_stt_for_meta_and_muse_spark(monkeypatch):
@@ -352,6 +561,9 @@ async def test_agent_pipeline_falls_back_to_native_image_when_all_audio_is_skipp
     )
 
     runner = _pipeline_runner()
+    runner._enrich_message_with_transcription = AsyncMock(
+        return_value=('"fallback transcript"', ["fallback transcript"])
+    )
     source = _source()
     session_key = build_session_key(source)
     image_path = tmp_path / "photo.png"
@@ -379,4 +591,6 @@ async def test_agent_pipeline_falls_back_to_native_image_when_all_audio_is_skipp
     assert isinstance(message, list)
     assert any(part.get("type") == "image_url" for part in message)
     assert not any(part.get("type") == "input_audio" for part in message)
+    text_part = next(part for part in message if part.get("type") == "text")
+    assert '"fallback transcript"' in text_part["text"]
     assert kwargs.get("persist_user_message") is None

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -1,0 +1,187 @@
+"""Regression tests for session-aware native audio routing in the gateway."""
+
+import importlib
+import sys
+import types
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource, build_session_key
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="1",
+        chat_type="dm",
+    )
+
+
+def _bare_runner():
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(stt_enabled=True)
+    runner.adapters = {}
+    runner._model = "google/gemini-test"
+    runner._base_url = None
+    runner._has_setup_skill = lambda: False
+    return runner
+
+
+def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
+    runner = _bare_runner()
+    media_routing = importlib.import_module("agent.media_routing")
+
+    monkeypatch.setattr(
+        media_routing,
+        "supported_input_modalities",
+        lambda provider, model: {"text", "audio"},
+    )
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="google/gemini-test",
+        user_config={},
+    ) == "native"
+
+    monkeypatch.setattr(
+        media_routing,
+        "supported_input_modalities",
+        lambda provider, model: {"text", "image"},
+    )
+    assert runner._decide_audio_input_mode(
+        provider="openrouter",
+        model="text-only-test",
+        user_config={},
+    ) == "stt"
+
+
+@pytest.mark.asyncio
+async def test_voice_message_stages_native_audio_without_stt(tmp_path):
+    runner = _bare_runner()
+    runner._decide_audio_input_mode = lambda **_: "native"
+    source = _source()
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.VOICE,
+        source=source,
+        media_urls=[str(audio_path)],
+        media_types=["audio/ogg"],
+    )
+
+    with patch(
+        "tools.transcription_tools.transcribe_audio",
+        side_effect=AssertionError("native audio must not invoke STT"),
+    ):
+        result = await runner._prepare_inbound_message_text(
+            event=event,
+            source=source,
+            history=[],
+        )
+
+    assert result == ""
+    attachments = runner._consume_pending_native_audio_attachments(
+        build_session_key(source)
+    )
+    assert attachments == [{
+        "path": str(audio_path),
+        "mime_type": "audio/ogg",
+        "modality": "audio",
+    }]
+    assert runner._consume_pending_native_audio_attachments(build_session_key(source)) == []
+
+
+class _CaptureAgent:
+    calls = []
+
+    def __init__(self, **kwargs):
+        self.tools = []
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+
+    def run_conversation(self, message, **kwargs):
+        type(self).calls.append((message, kwargs))
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _pipeline_runner():
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=True,
+    )
+    runner._model = "google/gemini-test"
+    runner._base_url = None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openrouter"},
+    )
+
+    runner = _pipeline_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    runner._session_state(session_key).persistent.native_audio_attachments = [{
+        "path": str(audio_path),
+        "mime_type": "audio/ogg",
+        "modality": "audio",
+    }]
+
+    result = await runner._run_agent(
+        message="",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-native-audio",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(_CaptureAgent.calls) == 1
+    message, kwargs = _CaptureAgent.calls[0]
+    assert isinstance(message, list)
+    assert any(part.get("type") == "input_audio" for part in message)
+    audio_part = next(part for part in message if part.get("type") == "input_audio")
+    assert audio_part["input_audio"]["format"] == "ogg"
+    assert kwargs["persist_user_message"] == "[Voice message attached natively]"
+    assert runner._consume_pending_native_audio_attachments(session_key) == []

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -40,37 +40,49 @@ def test_audio_routing_uses_native_only_for_audio_capable_model(monkeypatch):
     monkeypatch.setattr(
         media_routing,
         "supported_input_modalities",
-        lambda provider, model: {"text", "audio"},
+        lambda *_: {"text", "audio"},
     )
-    assert runner._decide_audio_input_mode(
-        provider="openrouter",
-        model="google/gemini-test",
-        user_config={},
-    ) == "native"
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="google/gemini-test",
+            user_config={},
+        )
+        == "native"
+    )
 
     monkeypatch.setattr(
         media_routing,
         "supported_input_modalities",
-        lambda provider, model: {"text", "image"},
+        lambda *_: {"text", "image"},
     )
-    assert runner._decide_audio_input_mode(
-        provider="openrouter",
-        model="text-only-test",
-        user_config={},
-    ) == "stt"
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="text-only-test",
+            user_config={},
+        )
+        == "stt"
+    )
 
     # User explicit config overrides
-    assert runner._decide_audio_input_mode(
-        provider="openrouter",
-        model="text-only-test",
-        user_config={"gateway": {"audio_mode": "native"}},
-    ) == "native"
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="text-only-test",
+            user_config={"gateway": {"audio_mode": "native"}},
+        )
+        == "native"
+    )
 
-    assert runner._decide_audio_input_mode(
-        provider="openrouter",
-        model="google/gemini-test",
-        user_config={"gateway": {"audio_mode": "stt"}},
-    ) == "stt"
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="google/gemini-test",
+            user_config={"gateway": {"audio_mode": "stt"}},
+        )
+        == "stt"
+    )
 
 
 @pytest.mark.asyncio
@@ -102,12 +114,17 @@ async def test_voice_message_stages_native_audio_without_stt(tmp_path):
     attachments = runner._consume_pending_native_audio_attachments(
         build_session_key(source)
     )
-    assert attachments == [{
-        "path": str(audio_path),
-        "mime_type": "audio/ogg",
-        "modality": "audio",
-    }]
-    assert runner._consume_pending_native_audio_attachments(build_session_key(source)) == []
+    assert attachments == [
+        {
+            "path": str(audio_path),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        }
+    ]
+    assert (
+        runner._consume_pending_native_audio_attachments(build_session_key(source))
+        == []
+    )
 
 
 class _CaptureAgent:
@@ -154,7 +171,7 @@ async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
     _CaptureAgent.calls = []
 
     fake_dotenv = types.ModuleType("dotenv")
-    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    fake_dotenv.load_dotenv = lambda *_, **__: None
     monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
 
     fake_run_agent = types.ModuleType("run_agent")
@@ -174,11 +191,13 @@ async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
     session_key = build_session_key(source)
     audio_path = tmp_path / "voice.ogg"
     audio_path.write_bytes(b"OggS-test-audio")
-    runner._session_state(session_key).persistent.native_audio_attachments = [{
-        "path": str(audio_path),
-        "mime_type": "audio/ogg",
-        "modality": "audio",
-    }]
+    runner._session_state(session_key).persistent.native_audio_attachments = [
+        {
+            "path": str(audio_path),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        }
+    ]
 
     result = await runner._run_agent(
         message="",
@@ -197,4 +216,104 @@ async def test_agent_pipeline_sends_input_audio_and_persists_compact_marker(
     audio_part = next(part for part in message if part.get("type") == "input_audio")
     assert audio_part["input_audio"]["format"] == "ogg"
     assert kwargs["persist_user_message"] == "[Voice message attached natively]"
+    assert runner._consume_pending_native_audio_attachments(session_key) == []
+
+
+def test_audio_routing_forces_stt_for_meta_and_muse_spark(monkeypatch):
+    runner = _bare_runner()
+    media_routing = importlib.import_module("agent.media_routing")
+
+    monkeypatch.setattr(
+        media_routing,
+        "supported_input_modalities",
+        lambda *_: {"text", "audio"},
+    )
+
+    # Meta providers forced to STT
+    assert (
+        runner._decide_audio_input_mode(
+            provider="meta",
+            model="llama-3.2-audio",
+            user_config={},
+        )
+        == "stt"
+    )
+    assert (
+        runner._decide_audio_input_mode(
+            provider="meta-ai",
+            model="llama-3.2-audio",
+            user_config={},
+        )
+        == "stt"
+    )
+
+    # Muse spark model forced to STT
+    assert (
+        runner._decide_audio_input_mode(
+            provider="openrouter",
+            model="vendor/muse-spark-v1",
+            user_config={},
+        )
+        == "stt"
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_sends_mixed_image_and_audio(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *_, **__: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openrouter"},
+    )
+
+    runner = _pipeline_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    audio_path = tmp_path / "voice.ogg"
+    audio_path.write_bytes(b"OggS-test-audio")
+    img_path = tmp_path / "photo.png"
+    img_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+
+    runner._session_state(session_key).persistent.native_image_paths = [str(img_path)]
+    runner._session_state(session_key).persistent.native_audio_attachments = [
+        {
+            "path": str(audio_path),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        }
+    ]
+
+    result = await runner._run_agent(
+        message="look and listen",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-mixed-media",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    assert len(_CaptureAgent.calls) == 1
+    message, kwargs = _CaptureAgent.calls[0]
+    assert isinstance(message, list)
+    types_in_msg = [part.get("type") for part in message]
+    assert "text" in types_in_msg
+    assert "image_url" in types_in_msg
+    assert "input_audio" in types_in_msg
+    assert runner._consume_pending_native_image_paths(session_key) == []
     assert runner._consume_pending_native_audio_attachments(session_key) == []

--- a/tests/gateway/test_native_audio_routing.py
+++ b/tests/gateway/test_native_audio_routing.py
@@ -317,3 +317,66 @@ async def test_agent_pipeline_sends_mixed_image_and_audio(
     assert "input_audio" in types_in_msg
     assert runner._consume_pending_native_image_paths(session_key) == []
     assert runner._consume_pending_native_audio_attachments(session_key) == []
+
+
+@pytest.mark.asyncio
+async def test_agent_pipeline_falls_back_to_native_image_when_all_audio_is_skipped(
+    monkeypatch,
+    tmp_path,
+):
+    _CaptureAgent.calls = []
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *_, **__: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = _CaptureAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    media_routing = importlib.import_module("agent.media_routing")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "***", "provider": "openrouter"},
+    )
+    monkeypatch.setattr(
+        media_routing,
+        "build_native_media_content_parts",
+        lambda text, *_args, **_kwargs: (
+            [{"type": "text", "text": text}],
+            ["voice.ogg"],
+        ),
+    )
+
+    runner = _pipeline_runner()
+    source = _source()
+    session_key = build_session_key(source)
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\n" + b"\x00" * 32)
+    runner._session_state(session_key).persistent.native_image_paths = [str(image_path)]
+    runner._session_state(session_key).persistent.native_audio_attachments = [
+        {
+            "path": str(tmp_path / "voice.ogg"),
+            "mime_type": "audio/ogg",
+            "modality": "audio",
+        }
+    ]
+
+    result = await runner._run_agent(
+        message="look and listen",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-image-fallback",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    message, kwargs = _CaptureAgent.calls[0]
+    assert isinstance(message, list)
+    assert any(part.get("type") == "image_url" for part in message)
+    assert not any(part.get("type") == "input_audio" for part in message)
+    assert kwargs.get("persist_user_message") is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2093,6 +2093,26 @@ Direct OpenAI API requests and custom proxy endpoints are unchanged.
 
 ## Speech-to-Text (STT)
 
+Inbound voice notes use the active session model's declared input modalities by
+default. An audio-capable model receives the voice note directly, preserving
+prosody and other non-text information; other models use STT. Configure the
+routing policy separately from the STT provider:
+
+```yaml
+gateway:
+  audio_mode: auto             # "auto" (default) | "native" | "stt"
+```
+
+- `auto` uses native audio only when the active model advertises audio input.
+- `native` prefers inline native audio regardless of capability metadata.
+- `stt` always transcribes voice notes before invoking the model.
+
+If native payload construction cannot safely read, encode, or transcode an
+attachment, Hermes falls back to STT for that attachment. Other valid audio or
+image attachments in the same message remain native. Regular audio-file
+attachments are still exposed as files; this routing policy applies to voice
+notes.
+
 ```yaml
 stt:
   enabled: true                # Auto-transcribe inbound voice messages (default: true)


### PR DESCRIPTION
## What does this PR do?

Supersedes #90206.

Adds session-aware native audio routing for inbound **voice notes** in the messaging gateway. When the active session model advertises audio input, Hermes sends the voice note as native multimodal content; otherwise it uses the existing STT path. Regular audio-file attachments remain files.

This follows the existing image-routing architecture and does not add a core model tool or mutate the system prompt/toolset during a conversation.

## Behavior

- `gateway.audio_mode: auto` (default) uses native audio only when the active session model advertises audio input.
- `gateway.audio_mode: native` prefers native audio regardless of capability metadata.
- `gateway.audio_mode: stt` always transcribes voice notes first.
- Session and `/model` overrides participate in the decision; unknown capability data fails conservatively to STT.
- Meta and Muse Spark endpoints remain on STT because they do not reliably accept binary audio input.
- OpenAI/Azure inputs outside wav/mp3 are transcoded to mp3. If transcoding fails, the unsupported attachment is not sent to the provider.
- The inline ceiling applies to encoded Base64 data (25 MiB, approximately 18.75 MiB raw) and is rechecked after reads and transcoding.
- Gemini-native conversion accepts the gateway's local/cache `data:` payloads. It does not fetch arbitrary HTTP(S) media or mislabel URLs as Gemini Files API URIs.

## Failure handling and invariants

- Native payload-construction failures (unreadable, oversized, unsupported/transcode failure, or builder error) fall back through the existing STT pipeline for **only the rejected voice attachments**.
- Valid audio and images in the same turn stay native; mixed turns never consume-and-drop a valid image because audio failed.
- If STT is disabled or also fails, the model still receives a non-empty neutral note with the agent-visible cached path.
- Successful fallback transcripts honor `stt_echo_transcripts` and are echoed at most once per processing pass.
- SQLite history never stores Base64 audio. Native clips persist as a compact marker; partial fallback also persists the transcript.
- Pending native media remains session-scoped and one-shot. Historical roles, strict alternation, and the byte-stable conversation prefix are unchanged.

The fallback covers failures detected while constructing the native payload. It does not claim to retry a request after an arbitrary downstream provider rejection.

## Main changes

- `agent/media_routing.py`: capability discovery, container/MIME normalization, inline payload construction, size enforcement, and strict-provider transcoding.
- `agent/gemini_native_adapter.py`: conversion of inline audio/video/file parts to Gemini `inlineData`.
- `gateway/session_state.py`: session-scoped native-audio staging.
- `gateway/run.py`: routing decision, one-shot turn integration, per-attachment STT fallback, echo handling, and compact persistence.
- `gateway/config.py`, `hermes_cli/config_defaults.py`, `hermes_cli/config.py`: canonical `audio_mode` configuration, normalization, defaults, and compatibility handling.
- `cli-config.yaml.example` and the configuration guide: documented `auto | native | stt` behavior and fallback semantics.
- Focused unit/integration regressions cover native, STT, mixed image/audio, partial failure, all-audio failure, echo, persistence, and configuration propagation.

## Verification

Run through the repository test wrapper on Windows 11 / Python 3.11.15:

```bash
scripts/run_tests.sh tests/agent/test_media_routing.py tests/gateway/test_native_audio_routing.py -q
# 31 passed

scripts/run_tests.sh tests/gateway/test_config.py -k audio_mode -q
# 6 passed

scripts/run_tests.sh tests/hermes_cli/test_config_validation.py -q
# 11 passed
```

The same 48 tests and Ruff also pass after a clean simulated merge of this PR onto current `upstream/main` (`3a980a431b`). The merge simulation has no conflicts.

```bash
python -m ruff check agent/media_routing.py agent/gemini_native_adapter.py gateway/session_state.py gateway/run.py gateway/config.py hermes_cli/config.py hermes_cli/config_defaults.py tests/agent/test_media_routing.py tests/gateway/test_native_audio_routing.py tests/gateway/test_config.py
# All checks passed
```

`py_compile`, `git diff --check`, and parsing `cli-config.yaml.example` as YAML also pass.

Broader local runs expose five unrelated Windows/environment failures that reproduce unchanged at the previous PR head (`20ae14f0ab`): two Windows path-extraction assertions, two 100 ms subprocess-timeout assertions, and one Slack config test when optional `aiohttp` is absent. No live paid-provider request was made.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs; this supersedes #90206
- [x] My PR contains only changes related to native voice routing and its safety/configuration contracts
- [ ] I've run the entire `pytest tests/ -q` suite with every optional dependency on every platform
- [x] I've added focused unit and integration tests for the changes
- [x] I've tested the focused paths on Windows 11 (Python 3.11.15)

### Documentation & housekeeping

- [x] Relevant runtime documentation and docstrings are updated
- [x] `cli-config.yaml.example` documents the new config key
- [x] Cross-platform and provider-format behavior was considered
- [x] No tool schema or production dependency was added
