### PR TITLE
fix(google_meet): handle response.output_audio.delta in realtime speaker

### DIFF
--- a/plugins/google_meet/realtime/openai_client.py
+++ b/plugins/google_meet/realtime/openai_client.py
@@ -166,7 +166,7 @@ class RealtimeSession:
                 if not isinstance(frame, dict):
                     continue
                 ftype = frame.get("type")
-                if ftype == "response.audio.delta":
+                if ftype == "response.output_audio.delta":
                     b64 = frame.get("delta") or frame.get("audio") or ""
                     if b64 and sink_fp is not None:
                         try:


### PR DESCRIPTION
## Summary
The realtime speaker loop was listening for the wrong server event name, so generated audio was never decoded or written to the PCM sink.

## Problem
OpenAI Realtime streams audio chunks as the `response.output_audio.delta` server event (see the server-events reference: `.../realtime-server-events/response/output_audio.delta`). The speaker loop in `plugins/google_meet/realtime/openai_client.py` was matching the old name `response.audio.delta`, which never arrives — so every frame fell through, no bytes were written, and the bot stayed silent in realtime mode even though the session connected fine (`realtimeReady: true`, `audioBytesOut: 0`).

## Fix
Match `response.output_audio.delta` instead of `response.audio.delta`.

## Verification
- Event name confirmed against the OpenAI Realtime server-events reference (`response.output_audio.delta`).
- One-line change in `RealtimeSession.speak`; the delta is still read from either the `delta` or `audio` field, unchanged.
