### PR TITLE
fix(gateway): suppress repeated backend-unavailable notices

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1656,6 +1656,113 @@ class EphemeralReply(str):
         return str.__str__(self)
 
 
+class BackendUnavailableReply(str):
+    """Sanitized transient-backend failure returned by ``GatewayRunner``.
+
+    This marker crosses the normal handler boundary without provider details.
+    The adapter suppresses repeats per session and records the cooldown only
+    after the platform acknowledges delivery.
+    """
+
+    @property
+    def text(self) -> str:
+        return str.__str__(self)
+
+
+class BackendNoticeState:
+    """Runner-scoped cooldown and in-flight claims for backend notices.
+
+    Adapter generations can overlap during reconnect. A contender waits for
+    the active owner's delivery result: successful delivery suppresses it,
+    while failed or cancelled delivery lets exactly one waiter take over.
+    """
+
+    def __init__(self) -> None:
+        self.posted: dict[str, tuple[str, float]] = {}
+        self.inflight: set[tuple[str, str]] = set()
+        self._claim_results: dict[
+            tuple[str, str], asyncio.Future[bool]
+        ] = {}
+        self._delivery_tasks: set[asyncio.Task[Any]] = set()
+
+    def track_delivery_task(self, task: asyncio.Task[Any]) -> None:
+        """Keep an acknowledgement-ambiguous notice send alive after cancellation."""
+        self._delivery_tasks.add(task)
+
+        def _consume_result(completed: asyncio.Task[Any]) -> None:
+            self._delivery_tasks.discard(completed)
+            if completed.cancelled():
+                return
+            try:
+                completed.exception()
+            except asyncio.CancelledError:
+                pass
+
+        task.add_done_callback(_consume_result)
+
+    def _prune(self, now: float) -> None:
+        expired = [
+            key
+            for key, (_, timestamp) in self.posted.items()
+            if now - timestamp >= _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        ]
+        for key in expired:
+            del self.posted[key]
+
+    def is_suppressed(self, session_key: str, notice_kind: str, now: float) -> bool:
+        self._prune(now)
+        previous = self.posted.get(session_key)
+        return bool(
+            previous is not None
+            and previous[0] == notice_kind
+            and now - previous[1] < _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS
+        )
+
+    async def claim(self, session_key: str, notice_kind: str) -> bool:
+        claim = (session_key, notice_kind)
+        while True:
+            if self.is_suppressed(session_key, notice_kind, time.monotonic()):
+                return False
+
+            owner_result = self._claim_results.get(claim)
+            if owner_result is None:
+                self.inflight.add(claim)
+                self._claim_results[claim] = (
+                    asyncio.get_running_loop().create_future()
+                )
+                return True
+
+            # Cancelling a reconnect generation must not cancel the shared
+            # completion signal and strand the owner or other waiters.
+            delivered = await asyncio.shield(owner_result)
+            if delivered:
+                return False
+            # The owner failed or was cancelled. Race other waiters for a new
+            # claim; one wins and the rest await that new owner.
+
+    def finish_claim(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        delivered: bool,
+    ) -> None:
+        claim = (session_key, notice_kind)
+        owner_result = self._claim_results.pop(claim, None)
+        self.inflight.discard(claim)
+        if delivered:
+            self.record(session_key, notice_kind, now)
+        if owner_result is not None and not owner_result.done():
+            owner_result.set_result(delivered)
+
+    def record(self, session_key: str, notice_kind: str, now: float) -> None:
+        self._prune(now)
+        while len(self.posted) >= _LLM_ERROR_TRACKER_MAX_SESSIONS:
+            oldest = min(self.posted, key=lambda key: self.posted[key][1])
+            del self.posted[oldest]
+        self.posted[session_key] = (notice_kind, now)
+
 def merge_pending_message_event(pending_messages: Dict[str, MessageEvent], session_key: str,
                                 event: MessageEvent, *, merge_text: bool = False) -> None:
     """Store or merge a pending event: photo bursts/albums merge into the queued event so the next
@@ -1709,8 +1816,18 @@ _RETRYABLE_ERROR_PATTERNS = (
     "connecterror", "connectionerror", "connectionreset", "connectionrefused", "connecttimeout",
     "network", "broken pipe", "remotedisconnected", "eoferror")
 
-# Handler result: str (reply), ``EphemeralReply`` (auto-delete) or None (already delivered).
-MessageHandler = Callable[[MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply"]]]]
+# How long to suppress a repeat backend-unavailable notice for the same session. An outage
+# lasting longer than this posts one more notice — the user should be reminded the backend is
+# still down, just not once per message.
+_LLM_CONNECTION_ERROR_COOLDOWN_SECONDS = 300.0
+# Hard cap on tracked sessions. Expired entries are dropped on write, so this only binds when
+# many distinct sessions fail inside one cooldown window; the oldest entry is then evicted.
+_LLM_ERROR_TRACKER_MAX_SESSIONS = 1024
+
+# Handler result: str (reply), ``EphemeralReply`` (auto-delete), ``BackendUnavailableReply``
+# (delivery-aware outage suppression) or None (already delivered).
+MessageHandler = Callable[
+    [MessageEvent], Awaitable[Optional[Union[str, "EphemeralReply", "BackendUnavailableReply"]]]]
 
 
 def resolve_channel_prompt(config_extra: dict, channel_id: str, parent_id: str | None = None) -> str | None:
@@ -1856,6 +1973,13 @@ class BasePlatformAdapter(ABC):
         self._owner_profile: Optional[str] = None
         # Registered by GatewayRunner (see set_authorization_check).
         self._authorization_check: Optional[Callable[[str, Optional[str], Optional[str]], bool]] = None
+        # Runner-shared backend-unavailable notice state: cooldown map + in-flight claims,
+        # shared across adapter generations so a reconnect keeps one notice per session.
+        self._backend_notice_state = BackendNoticeState()
+        # Logical profile namespace for the shared notice state only; the adapter's local
+        # session key keeps the legacy ``agent:main`` namespace even when multiplexed.
+        self._backend_notice_profile: Optional[str] = None
+        self._llm_error_last_posted = self._backend_notice_state.posted
         # Auto-TTS on voice input: ``voice.auto_tts`` default plus per-chat /voice on|tts / off.
         self._auto_tts_default: bool = False
         self._auto_tts_enabled_chats, self._auto_tts_disabled_chats = set(), set()
@@ -3123,6 +3247,70 @@ class BasePlatformAdapter(ABC):
         if eph_ttl > 0 and result.success and result.message_id:
             self._schedule_ephemeral_delete(event.source.chat_id, result.message_id, eph_ttl)
 
+    def _llm_error_notice_suppressed(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        source: Optional[SessionSource] = None,
+    ) -> bool:
+        """True when this session already saw this notice inside the cooldown."""
+        session_key = self._backend_notice_session_key(session_key, source)
+        return self._backend_notice_state.is_suppressed(
+            session_key, notice_kind, now
+        )
+
+    def _backend_notice_session_key(
+        self,
+        session_key: str,
+        source: Optional[SessionSource] = None,
+    ) -> str:
+        """Return an injective profile/session key for runner-wide notice state.
+
+        Adapter-local session keys are built before multiplex routing stamps the
+        source profile. Always prefix the logical profile, including ``default``.
+        Length-prefixing keeps the encoding unambiguous even if plugin profiles
+        or session keys contain separators.
+        """
+        profile = str(
+            (getattr(source, "profile", None) if source is not None else None)
+            or self._backend_notice_profile
+            or "default"
+        ).strip() or "default"
+        return f"profile:{len(profile)}:{profile}:{session_key}"
+
+    def set_backend_notice_state(
+        self,
+        state: BackendNoticeState,
+        profile_name: Optional[str] = None,
+    ) -> None:
+        """Share claims across reconnects within one logical profile."""
+        self._backend_notice_state = state
+        self._backend_notice_profile = str(profile_name or "").strip() or None
+        # Compatibility for diagnostics/tests that inspect the old map.
+        self._llm_error_last_posted = state.posted
+
+    def _record_llm_error_notice(
+        self,
+        session_key: str,
+        notice_kind: str,
+        now: float,
+        *,
+        source: Optional[SessionSource] = None,
+    ) -> None:
+        """Record a posted notice, dropping expired and surplus entries.
+
+        Called only on backend failures, so the O(n) prune is cheap and
+        keeps the map from retaining every session key for the lifetime of
+        the adapter.
+        """
+        self._backend_notice_state.record(
+            self._backend_notice_session_key(session_key, source),
+            notice_kind,
+            now,
+        )
+
     def _final_delivery_adapter(self, source: Optional[SessionSource]) -> "BasePlatformAdapter":
         """The runner's CURRENT adapter for a new final-response send: a reconnect can swap the
         registry adapter mid-task; an unsent final response belongs on the replacement transport,
@@ -3639,11 +3827,12 @@ class BasePlatformAdapter(ABC):
 
     async def _record_delivery_obligation(
         self, event: MessageEvent, session_key: str, text_content: str,
-        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool) -> Optional[str]:
+        delivery_adapter: "BasePlatformAdapter", is_ephemeral_response: bool,
+        *, backend_notice: bool = False) -> Optional[str]:
         """Ledger the final response BEFORE the send so a crash before platform ACK redelivers on
         next boot; best-effort, skips slash-command and ephemeral replies. Returns the obligation id
         or None."""
-        if is_ephemeral_response or str(event.text or "").lstrip().startswith(
+        if is_ephemeral_response or backend_notice or str(event.text or "").lstrip().startswith(
             ("/", self.typed_command_prefix or "!")):
             return None
         try:
@@ -3756,35 +3945,86 @@ class BasePlatformAdapter(ABC):
 
     async def _send_final_text(
         self, event: MessageEvent, session_key: str, text_content: str, metadata: Dict[str, Any],
-        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable) -> None:
+        is_ephemeral_response: bool, ephemeral_ttl: int, record_delivery: Callable,
+        *, backend_notice: bool = False) -> bool:
         """Send the final text on the CURRENT transport (a reconnect may have replaced
-        this adapter), ledger-bracketed; the message-id owner owns the ephemeral delete."""
+        this adapter), ledger-bracketed; the message-id owner owns the ephemeral delete.
+        Returns True when a duplicate backend-unavailable notice was suppressed."""
+        # Resolve and retain the exact adapter that will send: a reconnect can replace the
+        # transport between handler completion and delivery, and checking an old adapter's
+        # cooldown before sending through a new one would bypass the replacement's state.
         delivery_adapter = self._final_delivery_adapter(event.source)
+        notice_key = None
+        if backend_notice:
+            notice_key = delivery_adapter._backend_notice_session_key(session_key, event.source)
+            if not await delivery_adapter._backend_notice_state.claim(
+                    notice_key, "backend_unavailable"):
+                logger.info("[%s] Suppressing duplicate backend-unavailable notice for session %s",
+                            delivery_adapter.name, session_key)
+                return True
         logger.info("[%s] Sending response (%d chars) to %s", delivery_adapter.name,
                     len(text_content), event.source.chat_id)
         _obligation_id = await self._record_delivery_obligation(
-            event, session_key, text_content, delivery_adapter, is_ephemeral_response)
-        result = await delivery_adapter._send_with_retry(
-            chat_id=event.source.chat_id, content=text_content,
-            reply_to=_reply_anchor_for_event(event), metadata=metadata)
+            event, session_key, text_content, delivery_adapter, is_ephemeral_response,
+            backend_notice=backend_notice)
+        if notice_key is not None:
+            result = await self._send_backend_notice(
+                delivery_adapter, event, text_content, metadata, notice_key)
+        else:
+            result = await delivery_adapter._send_with_retry(
+                chat_id=event.source.chat_id, content=text_content,
+                reply_to=_reply_anchor_for_event(event), metadata=metadata)
         record_delivery(result)
         if _obligation_id is not None:
             await self._finalize_delivery_obligation(_obligation_id, result, event, delivery_adapter)
         if ephemeral_ttl and ephemeral_ttl > 0 and result.success and result.message_id:
             delivery_adapter._schedule_ephemeral_delete(
                 event.source.chat_id, result.message_id, ephemeral_ttl)
+        return False
+
+    async def _send_backend_notice(
+        self, delivery_adapter: "BasePlatformAdapter", event: MessageEvent, text_content: str,
+        metadata: Dict[str, Any], notice_key: str):
+        """Send a claimed backend-unavailable notice and resolve the claim on the outcome.
+
+        Once platform delivery has started, cancellation is acknowledgement-ambiguous: the
+        runner-scoped state holds the send task across adapter replacement and resolves
+        contenders only when the platform result is known, while this processor unwinds."""
+        async def _send_and_finish():
+            try:
+                send_result = await delivery_adapter._send_with_retry(
+                    chat_id=event.source.chat_id, content=text_content,
+                    reply_to=_reply_anchor_for_event(event), metadata=metadata)
+            except BaseException:
+                delivery_adapter._backend_notice_state.finish_claim(
+                    notice_key, "backend_unavailable", time.monotonic(), delivered=False)
+                raise
+            delivery_adapter._backend_notice_state.finish_claim(
+                notice_key, "backend_unavailable", time.monotonic(),
+                delivered=bool(getattr(send_result, "success", False)))
+            return send_result
+
+        send_task = asyncio.create_task(_send_and_finish())
+        try:
+            return await asyncio.shield(send_task)
+        except asyncio.CancelledError:
+            delivery_adapter._backend_notice_state.track_delivery_task(send_task)
+            raise
 
     async def _notify_turn_error(self, event: MessageEvent, e: BaseException) -> Optional[dict]:
         """Tell the user a turn failed rather than leaving radio silence (last resort:
         a failing notice is logged, never raised). Returns the thread metadata used."""
         _thread_metadata = None
         try:
-            error_detail = str(e)[:300] if str(e) else "no details available"
+            # Exceptions reaching here may be platform, media, storage or hook failures, not
+            # an AI-backend outage (GatewayRunner marks those upstream). Keep the notice generic:
+            # the type/detail leaked internal endpoint and provider strings into chat.
             _thread_metadata = _thread_metadata_for_event(event)
             await self.send(
                 chat_id=event.source.chat_id,
-                content=(f"Sorry, I encountered an error ({type(e).__name__}).\n{error_detail}\n"
-                "Try again or use /reset to start a fresh session."), metadata=_thread_metadata)
+                content=("Sorry, I encountered an internal error. "
+                "Please try again or use /reset to start a fresh session."),
+                metadata=_thread_metadata)
         except Exception as notify_err:
             logger.error(
                 "[%s] Failed to send error notification to user: %s", self.name, notify_err, exc_info=True)
@@ -3922,6 +4162,9 @@ class BasePlatformAdapter(ABC):
             await self._run_processing_hook("on_processing_start", event)
             response = await self._message_handler(event)
             is_ephemeral_response = isinstance(response, EphemeralReply)
+            # GatewayRunner marks transient backend outages explicitly; the adapter suppresses
+            # repeats per session and arms the cooldown only after the platform ACKs delivery.
+            is_backend_unavailable_response = isinstance(response, BackendUnavailableReply)
             # Unwrap EphemeralReply for downstream text processing; TTL applies after send.
             response, _ephemeral_ttl = self._unwrap_ephemeral(response)
             # None/empty is normal (streamed/queued). Suppress a stale response after an interrupt.
@@ -3938,7 +4181,7 @@ class BasePlatformAdapter(ABC):
                 # Final content gets notify=True; typing metadata stays unmarked (thread-strict).
                 _final_thread_metadata = _mark_notify_metadata(_thread_metadata)
                 _tts_paths, _tts_requested_path = [], None
-                if self._wants_auto_tts(
+                if not is_backend_unavailable_response and self._wants_auto_tts(
                         event, session_key, interrupt_event, text_content, media_files):
                     _tts_paths, _tts_requested_path = await self._synthesize_auto_tts(text_content)
                 # TTS plays before text; generated files are removed afterwards.
@@ -3954,14 +4197,20 @@ class BasePlatformAdapter(ABC):
                 if not _tts_paths and _tts_requested_path is not None:
                     with contextlib.suppress(OSError):
                         os.remove(_tts_requested_path)
+                backend_notice_suppressed = False
                 if text_content and not _tts_caption_delivered:
-                    await self._send_final_text(
+                    backend_notice_suppressed = await self._send_final_text(
                         event, session_key, text_content, _final_thread_metadata,
-                        is_ephemeral_response, _ephemeral_ttl, _record_delivery)
+                        is_ephemeral_response, _ephemeral_ttl, _record_delivery,
+                        backend_notice=is_backend_unavailable_response)
                 await self._deliver_attachments(
                     event, extracted, _final_thread_metadata,
-                    anything_sent=delivery_attempted or _tts_caption_delivered)
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+                    anything_sent=(delivery_attempted or _tts_caption_delivered
+                                   or backend_notice_suppressed))
+            # A delivered backend-unavailable notice is still a failed agent turn.
+            processing_ok = (
+                False if is_backend_unavailable_response
+                else (delivery_succeeded if delivery_attempted else not bool(response)))
             # Clean up the per-turn streaming-TTS flag.
             self._streaming_tts_completed_turns.discard(self._streaming_tts_turn_key(
                 session_key, getattr(interrupt_event, "_hermes_run_generation", None),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -363,6 +363,22 @@ def _gateway_surface_passes_raw_text(platform: Any) -> bool:
     return _gateway_platform_value(platform) in _GATEWAY_RAW_TEXT_PLATFORMS
 
 
+# Transient backend outages, as classified by the agent retry loop. Do NOT infer this from
+# exceptions at the adapter layer, where a connection failure may equally belong to Slack,
+# Telegram, media delivery, storage or another subsystem.
+_BACKEND_UNAVAILABLE_FAILURE_REASONS = frozenset({"overloaded", "server_error", "timeout"})
+_BACKEND_UNAVAILABLE_NOTICE = (
+    "The AI backend is temporarily unavailable. "
+    "Please try sending your message again in a moment.")
+
+
+def _is_backend_unavailable_agent_result(agent_result: dict) -> bool:
+    """Whether a failed agent result represents a transient backend outage."""
+    return bool(
+        agent_result.get("failed")
+        and agent_result.get("failure_reason") in _BACKEND_UNAVAILABLE_FAILURE_REASONS)
+
+
 _GATEWAY_PROVIDER_POLICY_RE = re.compile(
     r"("  # raw provider policy/safety bodies are noisy and may be sensitive
     r"cybersecurity\s+risk"
@@ -2062,6 +2078,8 @@ from gateway.run_inbound import GatewayInboundMixin
 from gateway.run_goals import GatewayGoalsMixin
 from gateway.run_agent_cache import GatewayAgentCacheMixin
 from gateway.platforms.base import (
+    BackendNoticeState,
+    BackendUnavailableReply,
     BasePlatformAdapter,
     _reply_anchor_for_event,
 )
@@ -3330,6 +3348,9 @@ class GatewayRunner(
         # channel(s) after connecting so the user learns persistence is broken before /resume fails.
         # See #88235.
         self._session_db_init_error: Optional[str] = None
+        # Runner-owned backend-notice cooldown/claims, shared with every adapter generation so
+        # a reconnect mid-outage cannot re-post a notice this session already saw.
+        self._backend_notice_state = BackendNoticeState()
         # Non-default profiles' adapters by profile then Platform; self.adapters stays the default's map.
         self._profile_adapters: Dict[str, Dict[Platform, BasePlatformAdapter]] = {}
         self._warn_if_docker_media_delivery_is_risky()

--- a/gateway/run_adapters.py
+++ b/gateway/run_adapters.py
@@ -1029,14 +1029,37 @@ class GatewayAdapterLifecycleMixin:
             logger.info("✓ %s connected (profile: %s)", platform.value, profile_name)
         return connected
 
+    def _backend_notice_state_for_adapters(self):
+        """Return the runner-owned notice state, tolerating partially-built test runners."""
+        from gateway.platforms.base import BackendNoticeState
+        state = self.__dict__.get("_backend_notice_state")
+        if state is None:
+            state = BackendNoticeState()
+            self.__dict__["_backend_notice_state"] = state
+        return state
+
+    def _share_backend_notice_state(
+        self, adapter: BasePlatformAdapter, profile_name: Optional[str] = None) -> None:
+        """Wire runner routing and profile-scoped notice state so the cooldown survives a
+        reconnect replacing this adapter generation."""
+        # Every adapter participates in replacement routing, including built-ins created
+        # outside plugin factories.
+        adapter.gateway_runner = self
+        if not profile_name:
+            profile_name = getattr(adapter, "_owner_profile", None)
+        setter = getattr(adapter, "set_backend_notice_state", None)
+        if callable(setter):
+            setter(self._backend_notice_state_for_adapters(), profile_name=profile_name)
+
     def _wire_adapter_handlers(
         self, adapter: BasePlatformAdapter, *, message_handler=None, fatal_error_handler=None,
         busy_session_handler=None, authorization_check=None, platform_event_handler=None,
-        busy_text_mode: Optional[str] = None,
+        busy_text_mode: Optional[str] = None, profile_name: Optional[str] = None,
     ) -> None:
         """Install the runner callbacks every adapter needs (defaults = primary handlers;
         secondary wiring passes profile-scoped variants). ``set_reaction_handler`` is optional."""
         adapter.set_message_handler(message_handler or self._primary_message_handler())
+        self._share_backend_notice_state(adapter, profile_name)
         adapter.set_fatal_error_handler(fatal_error_handler or self._handle_adapter_fatal_error)
         adapter.set_session_store(self.session_store)
         adapter.set_busy_session_handler(busy_session_handler or self._handle_active_session_busy_message)
@@ -1076,6 +1099,7 @@ class GatewayAdapterLifecycleMixin:
                 if isinstance(text_modes, dict)
                 else self._busy_text_mode
             ),
+            profile_name=profile_name,
         )
         # Voice transcripts from this bot's channels dispatch through THIS adapter.
         self._bind_voice_input_callback(adapter)

--- a/gateway/run_turn.py
+++ b/gateway/run_turn.py
@@ -1717,6 +1717,17 @@ class GatewayTurnMixin:
             logger.info("Suppressing intentional silence marker for session %s", session_entry.session_id)
             response = ""
 
+        # The retry loop already classified provider failures. Mark transient backend outages
+        # explicitly so the adapter suppresses only this safe notice and arms its cooldown
+        # after delivery, instead of the delivery layer guessing from an exception.
+        from gateway.run import (
+            _gateway_surface_passes_raw_text, _is_backend_unavailable_agent_result,
+            BackendUnavailableReply, _BACKEND_UNAVAILABLE_NOTICE,
+        )
+        if (not _gateway_surface_passes_raw_text(source.platform)
+                and _is_backend_unavailable_agent_result(agent_result)):
+            return BackendUnavailableReply(_BACKEND_UNAVAILABLE_NOTICE)
+
         adapter = self._adapter_for_source(source)
         # Auto voice reply (TTS audio before the text) unless streaming TTS already delivered audio.
         _streaming_tts_done = adapter is not None and bool(

--- a/tests/gateway/test_backend_unavailable_notices.py
+++ b/tests/gateway/test_backend_unavailable_notices.py
@@ -1,0 +1,753 @@
+"""Regression coverage for backend-unavailable notices at the real gateway boundary."""
+
+import asyncio
+import time
+from datetime import datetime
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import gateway.run as gateway_run
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import (
+    BackendNoticeState,
+    BackendUnavailableReply,
+    _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS,
+    _LLM_ERROR_TRACKER_MAX_SESSIONS,
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    ProcessingOutcome,
+    SendResult,
+)
+from gateway.session import SessionEntry, SessionSource, build_session_key
+
+
+_NOTICE = (
+    "The AI backend is temporarily unavailable. "
+    "Please try sending your message again in a moment."
+)
+
+
+class CaptureSlackAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="fake-token"), Platform.SLACK
+        )
+        self.sent = []
+        self.processing_hooks = []
+        self.delivery_results = []
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id=f"slack-{len(self.sent)}")
+
+    async def send_typing(self, chat_id: str, metadata=None) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        self.processing_hooks.append(("start", event.message_id))
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        self.processing_hooks.append(("complete", event.message_id, outcome))
+
+
+class FailingDeliverySlackAdapter(CaptureSlackAdapter):
+    async def _send_with_retry(self, *args, **kwargs) -> SendResult:
+        result = self.delivery_results.pop(0)
+        if result.success:
+            self.sent.append(
+                {
+                    "chat_id": kwargs["chat_id"],
+                    "content": kwargs["content"],
+                    "reply_to": kwargs.get("reply_to"),
+                    "metadata": kwargs.get("metadata"),
+                }
+            )
+        return result
+
+
+def _backend_failure(error: str) -> dict:
+    return {
+        "final_response": f"API call failed after 3 retries: {error}",
+        "messages": [{"role": "user", "content": "hello"}],
+        "tools": [],
+        "history_offset": 0,
+        "api_calls": 3,
+        "failed": True,
+        "failure_reason": "timeout",
+        "completed": False,
+        "interrupted": False,
+        "error": error,
+        "last_prompt_tokens": 0,
+    }
+
+
+def _successful_result(text: str = "normal response") -> dict:
+    return {
+        "final_response": text,
+        "messages": [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": text},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "api_calls": 1,
+        "failed": False,
+        "completed": True,
+        "interrupted": False,
+        "last_prompt_tokens": 0,
+    }
+
+
+def _make_runner(adapter: CaptureSlackAdapter, results: list[dict]) -> gateway_run.GatewayRunner:
+    runner = cast(Any, object.__new__(gateway_run.GatewayRunner))
+    runner.config = GatewayConfig(
+        platforms={Platform.SLACK: PlatformConfig(enabled=True, token="fake-token")}
+    )
+    runner.adapters = {Platform.SLACK: adapter}
+    runner._backend_notice_state = BackendNoticeState()
+    runner._share_backend_notice_state(adapter, profile_name="default")
+    runner._voice_mode = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock(), loaded_hooks=False)
+    runner.session_store = MagicMock()
+    runner.session_store.get_or_create_session.return_value = SessionEntry(
+        session_key="agent:main:slack:channel:C123:171717",
+        session_id="sess-1",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        platform=Platform.SLACK,
+        chat_type="channel",
+    )
+    runner.session_store.load_transcript.return_value = []
+    runner.session_store.has_any_sessions.return_value = True
+    runner.session_store.rewrite_transcript = MagicMock()
+    runner.session_store.append_to_transcript = MagicMock()
+    runner.session_store.update_session = MagicMock()
+    runner.session_store.has_platform_message_id = MagicMock(return_value=False)
+    runner._running_agents = {}
+    runner._pending_messages = {}
+    runner._pending_approvals = {}
+    runner._session_db = None
+    runner._is_user_authorized = lambda source: True
+    runner._set_session_env = lambda context: []
+    runner._run_agent = AsyncMock(side_effect=results)
+    return runner
+
+
+def _make_event(message_id: str) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=Platform.SLACK,
+            chat_id="C123",
+            chat_type="channel",
+            thread_id="171717",
+            user_id="U123",
+        ),
+        message_id=message_id,
+    )
+
+
+def _wire_runner(monkeypatch, tmp_path, adapter, results):
+    runner = _make_runner(adapter, results)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "fake"}
+    )
+    monkeypatch.setattr(
+        "agent.model_metadata.get_model_context_length", lambda *_args, **_kwargs: 100
+    )
+    monkeypatch.setenv("SLACK_HOME_CHANNEL", "C123")
+    adapter.set_message_handler(runner._handle_message)
+    adapter._keep_typing = lambda *_args, **_kwargs: asyncio.Event().wait()
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_real_gateway_path_sanitizes_backend_transport_failure(monkeypatch, tmp_path):
+    raw_error = "APIConnectionError: connection refused at https://api.example.com/v1"
+    adapter = CaptureSlackAdapter()
+    _wire_runner(monkeypatch, tmp_path, adapter, [_backend_failure(raw_error)])
+
+    event = _make_event("m-1")
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+    assert "api.example.com" not in adapter.sent[0]["content"]
+    assert adapter.processing_hooks[-1] == (
+        "complete",
+        "m-1",
+        ProcessingOutcome.FAILURE,
+    )
+
+
+@pytest.mark.asyncio
+async def test_mixed_transport_exceptions_share_one_cooldown(
+    monkeypatch, tmp_path, caplog
+):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("APITimeoutError: read timed out"),
+        ],
+    )
+
+    for message_id in ("m-1", "m-2"):
+        event = _make_event(message_id)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+    assert "response_delivery_dropped" not in caplog.text
+    assert [hook for hook in adapter.processing_hooks if hook[0] == "complete"] == [
+        ("complete", "m-1", ProcessingOutcome.FAILURE),
+        ("complete", "m-2", ProcessingOutcome.FAILURE),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_notice_posts_again_after_cooldown(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("ConnectError: connection refused"),
+        ],
+    )
+
+    first = _make_event("m-1")
+    await adapter._process_message_background(first, build_session_key(first.source))
+    (session_key,) = adapter._llm_error_last_posted
+    kind, timestamp = adapter._llm_error_last_posted[session_key]
+    adapter._llm_error_last_posted[session_key] = (
+        kind,
+        timestamp - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0,
+    )
+
+    second = _make_event("m-2")
+    await adapter._process_message_background(second, build_session_key(second.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE, _NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_failed_notice_delivery_does_not_arm_cooldown(monkeypatch, tmp_path):
+    adapter = FailingDeliverySlackAdapter()
+    adapter.delivery_results = [
+        SendResult(success=False, error="Slack unavailable"),
+        SendResult(success=True, message_id="slack-2"),
+    ]
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [
+            _backend_failure("ConnectError: connection refused"),
+            _backend_failure("ConnectError: connection refused"),
+        ],
+    )
+
+    for message_id in ("m-1", "m-2"):
+        event = _make_event(message_id)
+        await adapter._process_message_background(event, build_session_key(event.source))
+
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_notice_delivery_releases_inflight_claim(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    event = _make_event("m-1")
+    session_key = build_session_key(event.source)
+
+    async def cancel_delivery(*_args, **_kwargs):
+        raise asyncio.CancelledError
+
+    adapter._send_with_retry = cancel_delivery
+
+    with pytest.raises(asyncio.CancelledError):
+        await adapter._process_message_background(event, session_key)
+
+    assert adapter._backend_notice_state.inflight == set()
+    assert adapter._llm_error_last_posted == {}
+
+
+@pytest.mark.asyncio
+async def test_reconnect_rechecks_cooldown_on_adapter_that_will_send(
+    monkeypatch, tmp_path
+):
+    stale_adapter = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        stale_adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, stale_adapter).gateway_runner = runner
+
+    replacement = CaptureSlackAdapter()
+    cast(Any, replacement).gateway_runner = runner
+    replacement.set_backend_notice_state(runner._backend_notice_state)
+    event = _make_event("m-1")
+    session_key = build_session_key(event.source)
+    replacement._record_llm_error_notice(
+        session_key,
+        "backend_unavailable",
+        time.monotonic(),
+    )
+
+    original_unwrap = stale_adapter._unwrap_ephemeral
+
+    def replace_before_delivery(response):
+        runner.adapters[Platform.SLACK] = replacement
+        return original_unwrap(response)
+
+    stale_adapter._unwrap_ephemeral = replace_before_delivery
+
+    await stale_adapter._process_message_background(event, session_key)
+
+    assert replacement.sent == []
+    assert stale_adapter.sent == []
+
+
+@pytest.mark.asyncio
+async def test_concurrent_adapter_generations_share_one_inflight_claim(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def hold_first_send(*args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        first.sent.append({"content": kwargs["content"]})
+        return SendResult(success=True, message_id="first")
+
+    first._send_with_retry = hold_first_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+    assert second_task.done() is False
+    release_send.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert len(first.sent) == 1
+    assert second.sent == []
+
+
+@pytest.mark.asyncio
+async def test_replacement_retries_notice_after_inflight_owner_delivery_fails(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def fail_first_send(*_args, **_kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=False, error="stale transport disconnected")
+
+    first._send_with_retry = fail_first_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+    assert second_task.done() is False
+
+    release_send.set()
+    await asyncio.gather(first_task, second_task)
+
+    assert first.sent == []
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_owner_waits_for_ambiguous_send_success_before_suppressing(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def ambiguous_send(*_args, **kwargs):
+        send_started.set()
+        await release_send.wait()
+        first.sent.append({"content": kwargs["content"]})
+        return SendResult(success=True, message_id="first")
+
+    first._send_with_retry = ambiguous_send
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+
+    first_task.cancel()
+    await asyncio.sleep(0)
+    assert first_task.done() is False
+    assert second_task.done() is False
+    release_send.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    await second_task
+
+    assert [message["content"] for message in first.sent] == [_NOTICE]
+    assert second.sent == []
+
+
+@pytest.mark.asyncio
+async def test_cancelled_owner_releases_waiter_after_definite_send_failure(
+    monkeypatch, tmp_path
+):
+    first = CaptureSlackAdapter()
+    runner = _wire_runner(
+        monkeypatch,
+        tmp_path,
+        first,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    cast(Any, first).gateway_runner = runner
+
+    second = CaptureSlackAdapter()
+    second.set_backend_notice_state(runner._backend_notice_state)
+    cast(Any, second).gateway_runner = runner
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    second._keep_typing = keep_typing
+    send_started = asyncio.Event()
+    release_send = asyncio.Event()
+
+    async def definite_failure(*_args, **_kwargs):
+        send_started.set()
+        await release_send.wait()
+        return SendResult(success=False, error="stale transport disconnected")
+
+    first._send_with_retry = definite_failure
+    first_event = _make_event("m-1")
+    second_event = _make_event("m-2")
+    session_key = build_session_key(first_event.source)
+    first_task = asyncio.create_task(
+        first._process_message_background(first_event, session_key)
+    )
+    await send_started.wait()
+    runner.adapters[Platform.SLACK] = second
+    second_task = asyncio.create_task(
+        second._process_message_background(second_event, session_key)
+    )
+    await asyncio.sleep(0)
+
+    first_task.cancel()
+    await asyncio.sleep(0)
+    assert first_task.done() is False
+    assert second_task.done() is False
+    release_send.set()
+    with pytest.raises(asyncio.CancelledError):
+        await first_task
+    await second_task
+
+    assert first.sent == []
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_shared_runner_state_does_not_cross_suppress_profiles():
+    state = BackendNoticeState()
+    first = CaptureSlackAdapter()
+    second = CaptureSlackAdapter()
+    first.set_backend_notice_state(state, profile_name="alpha")
+    second.set_backend_notice_state(state, profile_name="beta")
+    first.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+    second.set_message_handler(AsyncMock(return_value=BackendUnavailableReply(_NOTICE)))
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    first._keep_typing = keep_typing
+    second._keep_typing = keep_typing
+    first_event = _make_event("m-alpha")
+    second_event = _make_event("m-beta")
+    raw_session_key = build_session_key(first_event.source)
+
+    await first._process_message_background(first_event, raw_session_key)
+    await second._process_message_background(second_event, raw_session_key)
+
+    assert [message["content"] for message in first.sent] == [_NOTICE]
+    assert [message["content"] for message in second.sent] == [_NOTICE]
+    assert set(state.posted) == {
+        "profile:5:alpha:agent:main:slack:channel:C123:171717",
+        "profile:4:beta:agent:main:slack:channel:C123:171717",
+    }
+
+
+@pytest.mark.asyncio
+async def test_default_profile_does_not_collide_with_named_main_profile():
+    state = BackendNoticeState()
+    default_adapter = CaptureSlackAdapter()
+    named_main_adapter = CaptureSlackAdapter()
+    default_adapter.set_backend_notice_state(state, profile_name="default")
+    named_main_adapter.set_backend_notice_state(state, profile_name="main")
+    default_adapter.set_message_handler(
+        AsyncMock(return_value=BackendUnavailableReply(_NOTICE))
+    )
+    named_main_adapter.set_message_handler(
+        AsyncMock(return_value=BackendUnavailableReply(_NOTICE))
+    )
+
+    async def keep_typing(*_args, **_kwargs):
+        await asyncio.Event().wait()
+
+    default_adapter._keep_typing = keep_typing
+    named_main_adapter._keep_typing = keep_typing
+    default_event = _make_event("m-default")
+    named_main_event = _make_event("m-main")
+    raw_session_key = build_session_key(default_event.source)
+
+    await default_adapter._process_message_background(default_event, raw_session_key)
+    await named_main_adapter._process_message_background(
+        named_main_event, raw_session_key
+    )
+
+    assert [message["content"] for message in default_adapter.sent] == [_NOTICE]
+    assert [message["content"] for message in named_main_adapter.sent] == [_NOTICE]
+    assert set(state.posted) == {
+        "profile:7:default:agent:main:slack:channel:C123:171717",
+        "profile:4:main:agent:main:slack:channel:C123:171717",
+    }
+
+
+def test_shared_notice_state_wiring_attaches_runner_for_direct_builtins():
+    adapter = CaptureSlackAdapter()
+    runner = cast(Any, object.__new__(gateway_run.GatewayRunner))
+    runner._backend_notice_state = BackendNoticeState()
+
+    runner._share_backend_notice_state(adapter, profile_name="default")
+
+    assert cast(Any, adapter).gateway_runner is runner
+
+
+@pytest.mark.asyncio
+async def test_backend_notice_skips_auto_tts(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(
+        monkeypatch,
+        tmp_path,
+        adapter,
+        [_backend_failure("ConnectError: connection refused")],
+    )
+    adapter._should_auto_tts_for_chat = lambda chat_id: True
+    adapter.play_tts = AsyncMock(
+        side_effect=AssertionError("backend notice must stay on text delivery path")
+    )
+    event = _make_event("m-1")
+    event.message_type = MessageType.VOICE
+
+    await adapter._process_message_background(
+        event,
+        build_session_key(event.source),
+    )
+
+    adapter.play_tts.assert_not_awaited()
+    assert [message["content"] for message in adapter.sent] == [_NOTICE]
+
+
+@pytest.mark.asyncio
+async def test_platform_send_connection_error_is_not_backend_outage(monkeypatch, tmp_path):
+    adapter = CaptureSlackAdapter()
+    _wire_runner(monkeypatch, tmp_path, adapter, [_successful_result()])
+
+    async def fail_platform_delivery(*args, **kwargs):
+        raise ConnectionError(
+            "Slack socket disconnected at "
+            "https://hooks.slack.com/services/private?token=super-secret-token"
+        )
+
+    adapter._send_with_retry = fail_platform_delivery
+    event = _make_event("m-1")
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    contents = [message["content"] for message in adapter.sent]
+    assert _NOTICE not in contents
+    assert contents == [
+        "Sorry, I encountered an internal error. "
+        "Please try again or use /reset to start a fresh session."
+    ]
+    assert "hooks.slack.com" not in contents[0]
+    assert "super-secret-token" not in contents[0]
+
+
+@pytest.mark.parametrize(
+    ("failure_reason", "expected"),
+    [
+        ("timeout", True),
+        ("overloaded", True),
+        ("server_error", True),
+        ("rate_limit", False),
+        ("auth_permanent", False),
+        ("billing", False),
+        ("context_overflow", False),
+    ],
+)
+def test_only_transient_backend_failures_get_outage_marker(failure_reason, expected):
+    result = _backend_failure("provider failed")
+    result["failure_reason"] = failure_reason
+    assert gateway_run._is_backend_unavailable_agent_result(result) is expected
+
+
+@pytest.mark.parametrize(
+    "platform",
+    [Platform.LOCAL, Platform.API_SERVER, Platform.WEBHOOK, Platform.MSGRAPH_WEBHOOK],
+)
+def test_programmatic_surfaces_are_excluded_from_notice_marker(platform):
+    assert gateway_run._gateway_surface_passes_raw_text(platform) is True
+
+
+def test_notice_tracker_prunes_expired_sessions():
+    adapter = CaptureSlackAdapter()
+    now = time.monotonic()
+    stale = now - _LLM_CONNECTION_ERROR_COOLDOWN_SECONDS - 1.0
+    for index in range(50):
+        adapter._llm_error_last_posted[f"stale-{index}"] = (
+            "backend_unavailable",
+            stale,
+        )
+
+    adapter._record_llm_error_notice("live", "backend_unavailable", now)
+
+    assert set(adapter._llm_error_last_posted) == {"profile:7:default:live"}
+
+
+def test_notice_tracker_is_bounded():
+    adapter = CaptureSlackAdapter()
+    now = time.monotonic()
+    overflow = _LLM_ERROR_TRACKER_MAX_SESSIONS + 200
+
+    for index in range(overflow):
+        adapter._record_llm_error_notice(
+            f"session-{index}",
+            "backend_unavailable",
+            now + index * 0.001,
+        )
+
+    assert len(adapter._llm_error_last_posted) <= _LLM_ERROR_TRACKER_MAX_SESSIONS
+    assert (
+        f"profile:7:default:session-{overflow - 1}"
+        in adapter._llm_error_last_posted
+    )
+    assert "session-0" not in adapter._llm_error_last_posted

--- a/tests/gateway/test_delivery_ledger_producer.py
+++ b/tests/gateway/test_delivery_ledger_producer.py
@@ -15,7 +15,7 @@ import pytest
 
 from gateway import delivery_ledger as dl
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import BackendUnavailableReply, BasePlatformAdapter, SendResult
 from gateway.platforms.event import MessageEvent, MessageType
 from gateway.session import SessionSource
 
@@ -151,6 +151,14 @@ class TestProducerHook:
             Platform.SLACK, profile="reviewer"
         )
 
+
+    @pytest.mark.asyncio
+    async def test_backend_notice_is_not_durably_replayed_as_plain_text(self):
+        adapter = _Adapter()
+        await _run(adapter, _event(), BackendUnavailableReply("backend unavailable"))
+
+        assert adapter.sent == ["backend unavailable"]
+        assert _rows() == []
 
     @pytest.mark.asyncio
     async def test_slow_ledger_record_does_not_block_event_loop(self):


### PR DESCRIPTION
## Problem

During an LLM backend outage the gateway adapters posted raw exception detail for every inbound message. That both exposed internal endpoint/provider strings and flooded the chat for as long as the backend stayed down.

## Approach

Handle the signal at the delivery boundary rather than classifying arbitrary adapter exceptions:

- `BackendNoticeState` tracks per-session notice claims with a 300s cooldown and a 1024-session cap, so one sanitized notice is posted per session per outage window instead of one per inbound message.
- Transient backend failures are identified from the structured `failure_reason` the agent retry loop **already emits on main** (`overloaded`, `server_error`, `timeout`), not sniffed from exceptions at the adapter layer — where a connection failure may equally belong to Slack, Telegram, media delivery, or storage.
- `BackendUnavailableReply` marks the notice so it is not durably recorded and replayed later as plain assistant text.
- Non-connection exceptions keep their existing detailed reporting.

## Relationship to #31239

This supersedes the delivery-boundary half of #31239. That PR accumulated three separable concerns across 11 files (1,873 lines) while sitting unreviewed, which made it a large cold read. This is the first of three, scoped to what the title actually claims:

| | scope | status |
|---|---|---|
| **this PR** | delivery-boundary suppression | 4 files, +1,163 |
| follow-up | Codex app-server failure taxonomy (`codexErrorInfo` status/code precedence) | to be stacked |
| follow-up | transport-owner (`_transport_profile`) + authz resolution after reconnect | to be stacked |

The third is deliberately split out: it changes `GatewayAuthorizationMixin`'s adapter/profile resolution, which deserves review on its own 28 lines rather than buried inside an error-suppression change. Consequently this PR does **not** carry cooldown-survival across reconnects; that arrives with it.

#31239 stays open for now and will be closed or retargeted once this lands.

## Testing

- `tests/gateway/test_backend_unavailable_notices.py` (new) + `tests/gateway/test_delivery_ledger_producer.py` — **35 passed**.
- `ruff check` clean on all four changed files.
- Regression control: ran the 23 `tests/gateway/` files with failures at this branch's exact base and on the branch — **68 failed / 323 passed on both**, byte-identical. The failures are pre-existing environment gaps (`aiohttp` and other optional deps absent), not introduced here.
- Rebased onto current `main` (`180291162f`).

CI has never run on the predecessor branch — this is a fork PR, so it needs the first-contributor workflow approval to go green.
