### PR TITLE
fix(oneshot): pass resolved max_iterations to AIAgent (#99957)

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -489,7 +489,23 @@ def _run_agent(
         # gateway sessions.
         _fb = get_fallback_chain(cfg)
 
+        # Resolve max_iterations the same way cli.py does: agent.max_turns
+        # → root max_turns (back-compat) → HERMES_MAX_ITERATIONS env var
+        # → unlimited. Without this, every -z run fell back to the
+        # AIAgent constructor default regardless of config/env (fixes #99957).
+        from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
+
+        _agent_mt = cfg.get("agent", {}).get("max_turns") if isinstance(cfg.get("agent"), dict) else None
+        _root_mt = cfg.get("max_turns")
+        if _agent_mt is not None:
+            _max_iterations = _resolve_turn_limit(_agent_mt)
+        elif _root_mt is not None:
+            _max_iterations = _resolve_turn_limit(_root_mt)
+        else:
+            _max_iterations = _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
+
         agent = AIAgent(
+            max_iterations=_max_iterations,
             api_key=runtime.get("api_key"),
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),


### PR DESCRIPTION
Fixes #99957.

The non-interactive oneshot (-z) path built `AIAgent` without `max_iterations`, so `agent.max_turns` from config.yaml, root-level `max_turns`, and `HERMES_MAX_ITERATIONS` were silently discarded and every run fell back to the constructor default (`sys.maxsize`; historically 90).

This patch resolves the limit the same way `cli.py` does — `agent.max_turns` → root `max_turns` → `HERMES_MAX_ITERATIONS` env → unlimited — via `resolve_turn_limit()`, and passes it as `max_iterations` to `AIAgent`.

Evidence: patched \_run_agent was exercised with mocked config/env against a capturing AIAgent stub; config 150 → 150, env 4 → 4, unset → unlimited. Existing turn-limit and oneshot tests remain green (50 and 11 passed respectively).