### PR TITLE
fix(kanban): apply rate-limit exit code (75) on the chat -q worker path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5059,6 +5059,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
     # on this attribute and is enqueued after the fresh queue exists.
     _seeded_first_message: Optional["_SeededQueryMessage"] = None
 
+    # Last run_conversation result (dict with failed/failure_reason) from
+    # chat(). main()'s single-query path reads it to apply the kanban
+    # rate-limit exit code. See _kanban_rate_limit_exit_code.
+    _last_run_result: Optional[dict] = None
+
     def __init__(
         self,
         model: str = None,
@@ -17021,6 +17026,11 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         persist_user_message=_persist_clean_user_message,
                         moa_config=_moa_cfg,
                     )
+                    # Expose the run result so the single-query wrapper
+                    # (main()) can read failure_reason and apply the kanban
+                    # rate-limit exit code (CR-20260902-01). Read after
+                    # chat() returns (the agent thread has joined by then).
+                    self._last_run_result = result
                     if getattr(self, "_pending_moa_disable_after_turn", False):
                         _restore = getattr(self, "_pending_moa_restore_model", None) or {}
                         for _key, _value in _restore.items():
@@ -21476,6 +21486,36 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
     )
 
 
+def _kanban_rate_limit_exit_code(result) -> "int | None":
+    """Return the kanban rate-limit sentinel exit code (75) when a kanban
+    worker's run failed purely on a provider quota wall; ``None`` otherwise.
+
+    A kanban worker that exhausted the provider's usage/quota must exit with
+    ``KANBAN_RATE_LIMIT_EXIT_CODE`` (75) so the dispatcher's reap classifier
+    requeues the task as ``rate_limited`` without counting a failure. The
+    ``-Q`` quiet path (goal-mode workers) already does this; the plain
+    ``chat -q`` path — how *normal* (non-goal) kanban workers are spawned —
+    had no exit-code handling, so an all-429 worker exited rc=0, which the
+    dispatcher counts as a protocol violation and crash-loops (CR-20260902-01).
+    This lets the ``chat -q`` path apply the same exit code. Returns ``None``
+    when the run is not a kanban rate-limit failure, so callers keep their
+    existing exit behaviour.
+    """
+    if (
+        os.environ.get("HERMES_KANBAN_TASK")
+        and isinstance(result, dict)
+        and result.get("failed")
+        and result.get("failure_reason") in ("rate_limit", "billing")
+    ):
+        try:
+            from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+            return KANBAN_RATE_LIMIT_EXIT_CODE
+        except Exception:
+            return 1
+    return None
+
+
 def main(
     query: str = None,
     q: str = None,
@@ -22105,6 +22145,17 @@ def main(
                 cli._show_security_advisories()
                 cli.chat(query, images=single_query_images or None)
                 cli._print_exit_summary(clear_screen=False)
+                # Kanban workers run through this plain `chat -q` path (NOT
+                # `-Q`), which previously never applied the rate-limit exit
+                # code — so an all-429 worker exited rc=0 and the dispatcher
+                # crash-looped the task as a protocol violation. Exit 75 here
+                # so the run is requeued `rate_limited` without a failure
+                # count instead (CR-20260902-01).
+                _kanban_rc = _kanban_rate_limit_exit_code(
+                    getattr(cli, "_last_run_result", None)
+                )
+                if _kanban_rc is not None:
+                    sys.exit(_kanban_rc)
         finally:
             _finalize_single_query(cli)
         return

--- a/tests/cli/test_kanban_rate_limit_exit.py
+++ b/tests/cli/test_kanban_rate_limit_exit.py
@@ -1,0 +1,62 @@
+"""Tests for the kanban rate-limit exit-code helper.
+
+A kanban worker whose run failed purely on a provider quota wall must exit
+with ``KANBAN_RATE_LIMIT_EXIT_CODE`` (75) so the dispatcher requeues the task
+as ``rate_limited`` instead of counting it as a protocol violation and
+crash-looping it. Regression for CR-20260902-01: the plain ``chat -q`` path
+(normal kanban workers) previously never applied this exit code.
+"""
+
+import pytest
+
+from cli import _kanban_rate_limit_exit_code
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+
+def _run_result(**overrides):
+    result = {
+        "final_response": "",
+        "failed": True,
+        "failure_reason": "billing",
+    }
+    result.update(overrides)
+    return result
+
+
+class TestKanbanRateLimitExitCode:
+    @pytest.mark.parametrize(
+        "reason", ["billing", "rate_limit"]
+    )
+    def test_kanban_quota_wall_returns_75(self, monkeypatch, reason):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test")
+        assert _kanban_rate_limit_exit_code(
+            _run_result(failure_reason=reason)
+        ) == KANBAN_RATE_LIMIT_EXIT_CODE
+
+    def test_non_quota_failure_returns_none(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test")
+        # A generic failure is not a rate-limit/billing wall; keep existing
+        # exit behaviour (do not override to 75).
+        assert (
+            _kanban_rate_limit_exit_code(
+                _run_result(failure_reason="context_overflow")
+            )
+            is None
+        )
+
+    def test_non_failed_run_returns_none(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test")
+        assert _kanban_rate_limit_exit_code(
+            _run_result(failed=False, failure_reason="billing")
+        ) is None
+
+    def test_non_kanban_returns_none(self, monkeypatch):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        assert _kanban_rate_limit_exit_code(
+            _run_result(failure_reason="billing")
+        ) is None
+
+    def test_non_dict_returns_none(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test")
+        assert _kanban_rate_limit_exit_code("not a dict") is None
+        assert _kanban_rate_limit_exit_code(None) is None


### PR DESCRIPTION
## Problem

Normal (non-goal) kanban workers are spawned as `hermes chat -q <prompt>` **without** `-Q`. They take the human single-query path in `main()`, which had **no kanban exit-code handling**. When a worker hit an all-429 (provider usage/quota wall) — e.g. OpenAI/ChatGPT Plus `usage_limit_reached` — it exited `rc=0` with no `kanban_complete`/`kanban_block`. The dispatcher counts a clean `rc=0` exit with no terminal kanban call as a **protocol violation**, crash-loops the task (default 3 retries), and blocks it. A transient provider cap became a task-blocking incident (11 wasted runs observed, PPT Master `default` board, 2026-09-02).

## Root cause

The rate-limit hold machinery already exists and is correct: `KANBAN_RATE_LIMIT_EXIT_CODE = 75` (`hermes_cli/kanban_db.py`), the reap classifier maps exit 75 → `rate_limited` → requeue without a failure count (so the circuit breaker never trips on a throttle). The worker's `-Q` quiet path (goal-mode workers) already exits 75 for `failure_reason in ("rate_limit", "billing")`. But **normal workers never run through the `-Q` path** — `_default_spawn` only appends `-Q` for `goal_mode` cards. So the exit-75 feature was effectively dead for every non-goal kanban worker.

## Fix

- `HermesCLI.chat()` now exposes the last run result (`_last_run_result`) so the single-query wrapper can read `failure_reason`.
- New `_kanban_rate_limit_exit_code()` returns 75 when a kanban worker's run failed with `failure_reason in ("rate_limit", "billing")`, else `None`.
- `main()`'s human `chat -q` path applies it: a kanban worker on a quota wall now exits 75 (→ `rate_limited` requeue) instead of `rc=0` (→ protocol-violation crash-loop).

No behavior change for non-kanban `chat -q` runs, for the `-Q` path, or for generic (non-quota) kanban failures.

## Verification

- New unit test `tests/cli/test_kanban_rate_limit_exit.py` (6 cases): quota wall → 75; non-quota failure → no override; non-failed run → no override; non-kanban → no override; non-dict → no override.
- `pytest tests/cli/test_kanban_rate_limit_exit.py` → 6 passed.
- `pytest tests/hermes_cli/test_kanban_db.py tests/cli/test_cli_init.py` → 67 passed, 2 skipped (no regression).
- `py_compile cli.py` clean.