### PR TITLE
fix(desktop): label sealed interim commentary as working and de-emphasize it

### DIFF
--- a/apps/desktop/electron/backend-claim.ts
+++ b/apps/desktop/electron/backend-claim.ts
@@ -37,12 +37,25 @@ export function execText(command: string, args: string[], { timeout = 3000 } = {
 }
 
 /**
+ * Probe budget for the ORPHAN-REAP path (matchesParent / matchesIdentity /
+ * stopOwnedBackend). The claim path keeps the full 30s headroom — a freshly
+ * spawned backend's marker is load-bearing and a slow probe must not kill a
+ * healthy child (#93608). Reap only needs to tell "same process" from "gone
+ * or reused" for OLD records, and the ownership file can accumulate dozens of
+ * them (one per profile per launch), so a 30s budget per record would let a
+ * cold PowerShell 5.1 stall boot for minutes (#87169). 5s is plenty for a
+ * warm probe; a timeout degrades to "unknown" and the record is preserved for
+ * the next launch instead of blocking boot.
+ */
+export const REAP_PROBE_TIMEOUT_MS = 5_000
+
+/**
  * Cross-platform process start marker: a value that changes when a PID is
  * reused, so `pid + marker` identifies one specific process incarnation.
  * Throws when the probe fails — callers decide what a failure means (see
  * `claimDecision` / `probeStartMarker`).
  */
-export async function processStartMarker(pid: number): Promise<string> {
+export async function processStartMarker(pid: number, timeoutMs: number = 30_000): Promise<string> {
   // Cheap native dead-PID gate. Windows Get-Process / macOS `ps -p` exit 1
   // on a missing PID (not ESRCH), so the identity matchers used to keep the
   // orphan and re-probe it every launch (#92875). ESRCH is the code those
@@ -85,7 +98,9 @@ export async function processStartMarker(pid: number): Promise<string> {
       ],
       // PowerShell 5.1 cold starts routinely exceed the default 3s execText
       // budget (2.4-8s observed in #87169); give the marker probe headroom.
-      { timeout: 30_000 }
+      // The claim path keeps this 30s budget; the orphan-reap path passes
+      // REAP_PROBE_TIMEOUT_MS so a slow probe cannot stall boot.
+      { timeout: timeoutMs }
     )
 
     if (!/^\d+$/.test(ticks)) {

--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -178,6 +178,49 @@ test('startup reap preserves failed stops for the next launch', async () => {
   assert.deepEqual(parseBackendOwnership(store.value()), [entry])
 })
 
+test('startup reap stops at the deadline and preserves the unprocessed records', async () => {
+  const first = ownershipEntry({ pid: 60 })
+  const second = ownershipEntry({ pid: 61 })
+  const store = memoryStore(stored([first, second]))
+  const stop = vi.fn()
+
+  const ownership = createOwnership(store, {
+    // Each probe is slow enough to blow a 1ms budget after the first entry.
+    matchesIdentity: async () => {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return false
+    },
+    stop,
+    reapDeadlineMs: 1
+  })
+
+  assert.deepEqual(await ownership.reapOrphans(), [])
+  // The first entry was processed (dropped); the second was preserved for the
+  // next launch instead of stalling boot on a slow identity probe.
+  assert.deepEqual(parseBackendOwnership(store.value()), [second])
+})
+
+test('startup reap preserves would-be-reaped records when the budget runs out', async () => {
+  const first = ownershipEntry({ pid: 62 })
+  const second = ownershipEntry({ pid: 63 })
+  const store = memoryStore(stored([first, second]))
+  const stop = vi.fn()
+
+  const ownership = createOwnership(store, {
+    matchesIdentity: async () => {
+      await new Promise(resolve => setTimeout(resolve, 10))
+      return true
+    },
+    stop,
+    reapDeadlineMs: 1
+  })
+
+  assert.deepEqual(await ownership.reapOrphans(), [62])
+  // The second would have been reaped too, but the budget ran out — it is
+  // preserved so a later launch retries it.
+  assert.deepEqual(parseBackendOwnership(store.value()), [second])
+})
+
 test('startup reap never stops a backend whose parent Electron is still alive', async () => {
   const entry = { ...ownershipEntry({ pid: 54 }), parentPid: 100, parentStartMarker: 'os-start-parent' }
   const store = memoryStore(stored([entry]))

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -28,7 +28,21 @@ export interface BackendOwnershipDeps {
   matchesParent: (entry: BackendOwnershipEntry) => Promise<boolean | undefined>
   stop: (identity: BackendIdentity) => Promise<void> | void
   store: BackendOwnershipStore
+  /**
+   * Overall time budget for one reap sweep. The ownership file legitimately
+   * accumulates one record per profile per launch, and each record can cost
+   * up to two identity probes (parent + backend) plus a stop — on Windows
+   * those shell out to PowerShell, whose 5.1 cold starts are slow (#87169).
+   * Without a bound, a large roster could stall boot for minutes while the
+   * renderer's 45s backend-boot budget expires and the user stares at the
+   * connecting screen. When the budget is exhausted the sweep preserves the
+   * unprocessed records for the next launch and returns what it reaped.
+   */
+  reapDeadlineMs?: number
 }
+
+/** Default budget for one reap sweep (see `reapDeadlineMs`). */
+export const REAP_ORPHANS_DEADLINE_MS = 5_000
 
 export interface BackendClaim extends BackendIdentity {
   command?: string
@@ -222,8 +236,21 @@ export function createBackendOwnership(deps: BackendOwnershipDeps) {
 
       const survivors: BackendOwnershipEntry[] = []
       const reaped: number[] = []
+      const deadline = Date.now() + (deps.reapDeadlineMs ?? REAP_ORPHANS_DEADLINE_MS)
 
-      for (const entry of entries) {
+      for (let i = 0; i < entries.length; i += 1) {
+        // Budget exhausted: preserve the unprocessed records so a later launch
+        // can retry them. A slow identity probe must never stall boot — the
+        // renderer's backend-boot budget is 45s and the spawn itself needs
+        // most of it.
+        if (Date.now() >= deadline) {
+          survivors.push(...entries.slice(i))
+
+          break
+        }
+
+        const entry = entries[i]
+
         // A backend whose Electron parent is still running is NOT an orphan:
         // reaping it would kill a live instance's session. This is what stops
         // a second launch from SIGTERMing the running instance's backend even

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -42,7 +42,8 @@ import {
   isPidOnlyStartMarker,
   pidOnlyStartMarker,
   probeStartMarker,
-  processStartMarker
+  processStartMarker,
+  REAP_PROBE_TIMEOUT_MS
 } from './backend-claim'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -3338,7 +3339,7 @@ async function backendCommandForPid(pid) {
   }
 }
 
-async function processIdentityMatches(identity) {
+async function processIdentityMatches(identity, timeoutMs: number = 30_000) {
   // Degraded PID-only identity (#93608): the start-marker probe failed while
   // the child was verifiably alive, so only PID liveness can be checked here.
   // backendIdentityMatches layers the command-line check on top before
@@ -3356,14 +3357,14 @@ async function processIdentityMatches(identity) {
   }
 
   try {
-    return (await processStartMarker(identity.pid)) === identity.startMarker
+    return (await processStartMarker(identity.pid, timeoutMs)) === identity.startMarker
   } catch (error) {
     return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
   }
 }
 
 async function backendIdentityMatches(identity) {
-  const processMatches = await processIdentityMatches(identity)
+  const processMatches = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
 
   if (processMatches !== true) {
     return processMatches
@@ -3384,15 +3385,24 @@ async function backendParentMatches(entry) {
   }
 
   try {
-    return (await processStartMarker(entry.parentPid)) === entry.parentStartMarker
+    return (await processStartMarker(entry.parentPid, REAP_PROBE_TIMEOUT_MS)) === entry.parentStartMarker
   } catch (error) {
     return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
   }
 }
 
 async function stopOwnedBackend(identity) {
-  if ((await processIdentityMatches(identity)) !== true) {
+  const matches = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
+
+  if (matches === false) {
     return
+  }
+
+  if (matches !== true) {
+    // Identity probe failed (not confirmed gone): preserve the record so a
+    // later launch retries the stop instead of dropping it and leaking the
+    // backend. reapOrphans keeps the entry when stop() throws.
+    throw new Error(`Could not verify backend PID ${identity.pid} before stopping it.`)
   }
 
   if (IS_WINDOWS) {
@@ -3411,7 +3421,7 @@ async function stopOwnedBackend(identity) {
     const deadline = Date.now() + 1500
 
     while (Date.now() < deadline) {
-      if ((await processIdentityMatches(identity)) !== true) {
+      if ((await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)) !== true) {
         return
       }
 
@@ -3420,7 +3430,7 @@ async function stopOwnedBackend(identity) {
 
     // Revalidate immediately before escalation so PID reuse cannot target a
     // replacement process.
-    if ((await processIdentityMatches(identity)) === true) {
+    if ((await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)) === true) {
       try {
         process.kill(-identity.pid, 'SIGKILL')
       } catch {
@@ -3430,7 +3440,7 @@ async function stopOwnedBackend(identity) {
   }
 
   await new Promise(resolve => setTimeout(resolve, 50))
-  const remaining = await processIdentityMatches(identity)
+  const remaining = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
 
   if (remaining !== false) {
     throw new Error(`Backend PID ${identity.pid} did not stop cleanly.`)

--- a/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/assistant-message.tsx
@@ -228,8 +228,22 @@ const AssistantMessageBody: FC<AssistantMessageProps & { collapsedNotice?: null 
     >
       {collapsedNotice ?? (
         <>
+          {isInterim && (
+            <div
+              className="flex items-center gap-1.5 px-(--message-text-indent) pb-1 text-[0.6875rem] font-medium uppercase tracking-wide text-muted-foreground/60"
+              data-slot="aui_interim-label"
+            >
+              <span className="size-1.5 rounded-full bg-muted-foreground/50" />
+              {t.assistant.thread.working}
+            </div>
+          )}
           <div
-            className="wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground"
+            className={cn(
+              'wrap-anywhere min-w-0 max-w-full overflow-hidden text-pretty',
+              isInterim
+                ? 'text-[0.8125rem] leading-5 text-muted-foreground/80'
+                : 'text-[length:var(--conversation-text-font-size)] leading-(--dt-line-height) text-foreground'
+            )}
             data-slot="aui_assistant-message-content"
           >
             {/* Todos render in the composer status stack now, not inline. */}

--- a/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/streaming.test.tsx
@@ -538,6 +538,37 @@ describe('assistant-ui streaming renderer', () => {
     expect(finalRoot?.querySelector('[data-slot="aui_msg-actions"]')).toBeTruthy()
   })
 
+  it('labels sealed interim commentary as working and de-emphasizes it, keeping the final reply full-weight', () => {
+    const { container } = render(
+      <TranscriptHarness
+        messages={[
+          userMessage(),
+          assistantInterimMessage('Let me check the files.'),
+          assistantInterimMessage('Now applying the patch.', 'assistant-interim-2'),
+          assistantMessage('All done — patch applied.', false)
+        ]}
+      />
+    )
+
+    const roots = [...container.querySelectorAll('[data-slot="aui_assistant-message-root"]')]
+    const interimRoots = roots.filter(root => root.querySelector('[data-slot="aui_interim-label"]'))
+    const finalRoot = roots.find(root => root.textContent?.includes('All done — patch applied.'))
+
+    // Every sealed interim carries the working label; the final reply does not.
+    expect(interimRoots).toHaveLength(2)
+    expect(interimRoots.every(root => root.textContent?.includes('Working'))).toBe(true)
+    expect(finalRoot?.querySelector('[data-slot="aui_interim-label"]')).toBeNull()
+
+    // Interim content is de-emphasized (smaller, muted); the final keeps the
+    // full-weight conversation text.
+    const interimContent = interimRoots[0]?.querySelector('[data-slot="aui_assistant-message-content"]')
+    const finalContent = finalRoot?.querySelector('[data-slot="aui_assistant-message-content"]')
+    expect(interimContent?.className).toContain('text-muted-foreground/80')
+    expect(interimContent?.className).toContain('text-[0.8125rem]')
+    expect(finalContent?.className).toContain('text-foreground')
+    expect(finalContent?.className).not.toContain('text-muted-foreground/80')
+  })
+
   it('puts the turn duration on the action bar row instead of a line of its own', () => {
     const settled = {
       ...assistantMessage('All done.', false),

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2514,6 +2514,7 @@ export const ar = defineLocale({
       thinking: 'يفكر...',
       thought: 'فكّر',
       thoughtBriefly: 'فكّر قليلاً',
+      working: 'يعمل',
       thoughtFor: duration => `فكّر لمدة ${duration}`,
       turnDuration: duration => `استغرقت هذه الجولة ${duration}`,
       today: time => `اليوم ${time}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3222,6 +3222,7 @@ export const en: Translations = {
       thinking: 'Thinking',
       thought: 'Thought',
       thoughtBriefly: 'Thought briefly',
+      working: 'Working',
       thoughtFor: duration => `Thought for ${duration}`,
       turnDuration: duration => `This turn took ${duration}`,
       today: time => `Today, ${time}`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2840,6 +2840,7 @@ export const ja = defineLocale({
       thinking: '考え中',
       thought: '思考済み',
       thoughtBriefly: '少し思考',
+      working: '作業中',
       thoughtFor: duration => `${duration} 思考`,
       turnDuration: duration => `このターンの所要時間: ${duration}`,
       today: time => `今日 ${time}`,

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2780,6 +2780,9 @@ export interface Translations {
       thinking: string
       thought: string
       thoughtBriefly: string
+      /** Label on a sealed interim commentary bubble (mid-turn working note,
+       *  not the turn's final answer). */
+      working: string
       thoughtFor: (duration: string) => string
       turnDuration: (duration: string) => string
       today: (time: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2742,6 +2742,7 @@ export const zhHant = defineLocale({
       thinking: '思考中',
       thought: '已思考',
       thoughtBriefly: '思考了片刻',
+      working: '工作中',
       thoughtFor: duration => `思考了 ${duration}`,
       turnDuration: duration => `本輪耗時 ${duration}`,
       today: time => `今天，${time}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3380,6 +3380,7 @@ export const zh: Translations = {
       thinking: '思考中',
       thought: '已思考',
       thoughtBriefly: '思考了片刻',
+      working: '工作中',
       thoughtFor: duration => `思考了 ${duration}`,
       turnDuration: duration => `本轮耗时 ${duration}`,
       today: time => `今天，${time}`,


### PR DESCRIPTION
## What changed

Label each sealed interim bubble with a muted 'Working' tag and de-emphasize its text, keeping the final reply full-weight.

- Add `aui_interim-label` slot with a muted 'Working' label on interim bubbles.
- Interim text renders smaller and muted; final reply keeps full weight.
- Add `working` key to all 6 locales (ar/en/ja/zh-hant/zh + types).

## How to test

Run a tool-heavy turn; verify interim commentary shows a 'Working' tag + single final answer.

## Platforms tested

Windows 11, Hermes Desktop v0.21.0.

## Related

Fixes #100776

Note: #98864 addresses the event-stream deduplication layer; this PR is a complementary UI-layer fix.