### PR TITLE
feat(desktop): add WS disconnect diagnostics for 3-minute drop investigation

### DIFF
--- a/apps/shared/src/json-rpc-gateway-diagnostics.test.ts
+++ b/apps/shared/src/json-rpc-gateway-diagnostics.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { JsonRpcGatewayClient } from './json-rpc-gateway'
+
+/**
+ * Node's vitest environment has no CloseEvent global (the existing
+ * json-rpc-gateway-replay.test.ts relies on it and is not wired into CI).
+ * Polyfill the minimal shape the gateway's close handler reads.
+ */
+class FakeCloseEvent extends Event {
+  code = 1006
+  reason = ''
+  wasClean = false
+}
+
+if (typeof globalThis.CloseEvent === 'undefined') {
+  ;(globalThis as Record<string, unknown>).CloseEvent = FakeCloseEvent
+}
+
+class FakeWebSocket extends EventTarget {
+  static OPEN = 1
+  static instances: FakeWebSocket[] = []
+
+  readyState = 0
+  sent: string[] = []
+  url: string
+
+  constructor(url: string) {
+    super()
+    this.url = url
+    FakeWebSocket.instances.push(this)
+  }
+
+  send(data: string): void {
+    this.sent.push(data)
+  }
+
+  close(): void {
+    this.readyState = 3
+    this.dispatchEvent(new CloseEvent('close'))
+  }
+
+  open(): void {
+    this.readyState = 1
+    this.dispatchEvent(new Event('open'))
+  }
+
+  serverFrame(obj: unknown): void {
+    this.dispatchEvent(new MessageEvent('message', { data: JSON.stringify(obj) }))
+  }
+}
+
+let sockets: FakeWebSocket[]
+
+const makeClient = () => {
+  const client = new JsonRpcGatewayClient({
+    socketFactory: url => new FakeWebSocket(url) as unknown as WebSocket,
+    heartbeatIntervalMs: 0,
+    heartbeatDeadlineMs: 0,
+    connectTimeoutMs: 1000
+  })
+
+  return client
+}
+
+describe('JsonRpcGatewayClient WS disconnect diagnostics', () => {
+  beforeEach(() => {
+    FakeWebSocket.instances = []
+    sockets = FakeWebSocket.instances as unknown as FakeWebSocket[]
+  })
+
+  it('logs the socket close event with code and reason', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+
+    sockets[0].close()
+
+    const log = errorSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    expect(log).toContain('[gateway] socket close event')
+    expect(log).toContain('code=1006')
+    expect(log).toContain('reason=')
+
+    errorSpy.mockRestore()
+    client.close()
+  })
+
+  it('logs close() called with the current state', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+
+    client.close()
+
+    const log = errorSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    expect(log).toContain('[gateway] close() called')
+    expect(log).toContain('state=')
+
+    errorSpy.mockRestore()
+  })
+
+  it('logs invalidateSocket with the error message and lastInboundAgeMs', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const client = makeClient()
+    const p = client.connect('ws://x')
+    sockets[0].open()
+    await p
+
+    client.invalidate('drop')
+
+    const log = errorSpy.mock.calls.map(c => c.join(' ')).join('\n')
+    expect(log).toContain('[gateway] invalidateSocket:')
+    expect(log).toContain('drop')
+    expect(log).toContain('lastInboundAgeMs=')
+
+    errorSpy.mockRestore()
+    client.close()
+  })
+})

--- a/apps/shared/src/json-rpc-gateway.ts
+++ b/apps/shared/src/json-rpc-gateway.ts
@@ -202,6 +202,10 @@ export class JsonRpcGatewayClient {
         return
       }
 
+      console.error(
+        `[gateway] socket close event code=${event.code} reason=${JSON.stringify(event.reason)}`
+      )
+
       if (this.options.onSocketClose(event)) {
         return
       }
@@ -288,6 +292,8 @@ export class JsonRpcGatewayClient {
     if (!socket) {
       return
     }
+
+    console.error(`[gateway] close() called state=${this.state}`)
 
     try {
       socket.close()
@@ -696,6 +702,10 @@ export class JsonRpcGatewayClient {
     if (this.socket !== socket) {
       return
     }
+
+    console.error(
+      `[gateway] invalidateSocket: ${error.message} lastInboundAgeMs=${Date.now() - this.lastInboundAt}`
+    )
 
     this.socket = null
     this.stopHeartbeat()

--- a/tui_gateway/ws.py
+++ b/tui_gateway/ws.py
@@ -89,6 +89,7 @@ class WSTransport:
         #: for legacy-token/stdio. RPC params can never populate it: sole identity authority for browser controllers.
         self.auth_identity = auth_identity
         self._closed = False
+        self._last_inbound_at = time.monotonic()
         # Token-coalescing buffer. The lock guards the buffer + "armed" flag against worker threads
         # calling write(); the timer handle is only ever touched on the loop thread.
         self._token_lock = threading.Lock()
@@ -161,6 +162,13 @@ class WSTransport:
     @property
     def closed(self) -> bool:
         return self._closed
+
+    @property
+    def last_inbound_at(self) -> float:
+        return self._last_inbound_at
+
+    def mark_inbound(self) -> None:
+        self._last_inbound_at = time.monotonic()
 
     async def write_async(self, obj: dict) -> bool:
         """Send from the owning loop; awaits until the frame is on the wire. Buffered tokens are flushed
@@ -242,6 +250,7 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
     authority for browser-controller registration); callers that omit it (harnesses, embedded TUI child) get None."""
     peer, transport = _ws_peer_label(ws), None
     messages = parse_errors = dispatch_crashes = send_failures = 0
+    heartbeat_pings = 0
     disconnect_reason = "not_connected"
 
     async def _reply(frame: dict, reason: str, msg: str, *args: Any) -> None:
@@ -311,6 +320,7 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
             line = raw.strip()
             if not line:
                 continue
+            transport.mark_inbound()
             messages += 1
             try:
                 req = json.loads(line)
@@ -323,6 +333,7 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
             req_id = req.get("id") if isinstance(req, dict) else None
             req_method = req.get("method") if isinstance(req, dict) else None
             if req_method == "gateway.ping":
+                heartbeat_pings += 1
                 await _reply({"jsonrpc": "2.0", "result": {"ok": True}, "id": req_id}, "send_failed_after_heartbeat",
                              "ws heartbeat reply send failed peer=%s id=%s", peer, req_id)
                 continue
@@ -373,8 +384,14 @@ async def handle_ws(ws: Any, *, auth_identity: dict | None = None, subprotocol: 
             await ws.close()
         except Exception as exc:
             _log.debug("ws close failed peer=%s error=%s", peer, exc)
+        if transport is not None:
+            last_inbound_ago = time.monotonic() - transport.last_inbound_at
+        else:
+            last_inbound_ago = -1.0
         _log.info(
             "ws closed peer=%s reason=%s messages=%d parse_errors=%d "
-            "dispatch_crashes=%d send_failures=%d reaped_sessions=%d detached_sessions=%d",
-            peer, disconnect_reason, messages, parse_errors, dispatch_crashes, send_failures, reaped_sessions, detached_sessions,
+            "dispatch_crashes=%d send_failures=%d heartbeat_pings=%d "
+            "last_inbound_ago=%.1fs reaped_sessions=%d detached_sessions=%d",
+            peer, disconnect_reason, messages, parse_errors, dispatch_crashes, send_failures, heartbeat_pings,
+            last_inbound_ago, reaped_sessions, detached_sessions,
         )


### PR DESCRIPTION
## What changed

Adds server- and client-side instrumentation to diagnose the intermittent 3-minute disconnect/reconnect cycle seen on Windows.

- `tui_gateway/ws.py`: count `heartbeat_pings` and log `last_inbound_ago` on close.
- `json-rpc-gateway.ts`: log socket close code/reason, `close()` state, and `invalidateSocket` error + `lastInboundAgeMs`.

## How to test

Run a session with WS stability issues; verify the enriched close log lines appear.

## Platforms tested

Windows 11, Hermes Desktop v0.21.0.

## Related

Fixes #100778