### PR TITLE
feat(mcp): add Adlicio optional MCP catalog entry

### DIFF
--- a/optional-mcps/adlicio/manifest.yaml
+++ b/optional-mcps/adlicio/manifest.yaml
@@ -1,0 +1,39 @@
+# Nous-approved MCP catalog entry.
+# Presence in this directory = approval. Merged via PR review.
+manifest_version: 1
+
+name: adlicio
+description: >-
+  Customer-voice research: comments and reviews from Reddit, YouTube,
+  Amazon, TikTok, Instagram, Trustpilot, app stores and 20+ other
+  sources, plus Meta Ad Library competitor ads and brand reports.
+source: https://tryadlicio.com/mcp
+
+# Vendor-hosted remote MCP (URL-only, Hermes never spawns a local process
+# for this entry). Native OAuth 2.1 + Dynamic Client Registration, so
+# Hermes's MCP client and mcp_oauth_manager handle discovery, PKCE, token
+# exchange, and refresh. No API key.
+transport:
+  type: http
+  url: https://mcp.tryadlicio.com/mcp
+
+auth:
+  type: oauth
+
+# Composer-suggestion triggers.
+suggest:
+  keywords:
+    - adlicio
+    - voice of customer
+    - customer research
+  hosts:
+    - tryadlicio.com
+
+post_install: |
+  On first connection Hermes opens a browser to authorize with
+  Adlicio (or run `hermes mcp login adlicio`). Approve access,
+  then restart the session so tools load.
+
+  The server needs an Adlicio All Access plan. A free account can
+  connect and see the tools, but most tools spend research credits.
+  search_reddit and search_youtube cost no credits.


### PR DESCRIPTION
## What does this PR do?

Adds one catalog entry, `optional-mcps/adlicio/manifest.yaml`, for Adlicio: a customer-voice research MCP for marketing and ad work. It scrapes comments and reviews from Reddit, YouTube, Amazon, TikTok, Instagram, Trustpilot, app stores and 20+ other sources, searches Reddit and YouTube, pulls top-performing short videos with their on-screen hooks, finds Meta Ad Library competitor ads, and builds brand and voice-of-customer reports. About 27 tools.

## Related Issue

None. Catalog entry only.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `optional-mcps/adlicio/manifest.yaml` (new file, 40 lines)

The entry is shaped exactly like the `stripe` one: vendor-hosted remote MCP, `transport.type: http`, `transport.url: https://mcp.tryadlicio.com/mcp`, `auth.type: oauth`. Native OAuth 2.1 with dynamic client registration, so `mcp_oauth_manager` handles discovery, PKCE, token exchange and refresh, and there is no API key and no `env` block. No `install:` block: Hermes never spawns a local process for this entry.

I searched open and closed issues and PRs for "adlicio" first, no duplicates.

I own Adlicio. Contact: daniel@tryadlicio.com. The server needs an Adlicio All Access plan, which the `post_install` note says plainly so nobody installs it expecting free tools. Happy to add a bundled skill in a follow-up PR if you would rather have one, or to adjust the suggest keywords.
