### PR TITLE
fix(kanban): a task created with initial_status='blocked' was auto-promoted on the next dispatcher tick

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -124,6 +124,12 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
 VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
 
+# Kinds accepted by ``create_task(initial_status="blocked")``. ``dependency``
+# is excluded on purpose: ``block_task`` routes that kind to ``todo``, so
+# accepting it at create time would turn "create this card blocked" into
+# "create this card runnable".
+VALID_INITIAL_BLOCK_KINDS = VALID_BLOCK_KINDS - {"dependency"}
+
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
 # unblocker (usually a cron) and routes the task to ``triage`` instead of back
@@ -3190,6 +3196,8 @@ def create_task(
     goal_mode: bool = False,
     goal_max_turns: Optional[int] = None,
     initial_status: str = "running",
+    initial_block_kind: str = "needs_input",
+    initial_block_reason: Optional[str] = None,
     session_id: Optional[str] = None,
     board: Optional[str] = None,
     project_id: Optional[str] = None,
@@ -3202,6 +3210,14 @@ def create_task(
     If ``triage=True``, status is forced to ``triage`` regardless of
     parents — a specifier/triager is expected to promote the task to
     ``todo`` once the spec is fleshed out.
+
+    ``initial_status="blocked"`` parks the card for a human straight away.
+    The block is recorded the same way ``block_task`` records one (a
+    ``blocked`` event plus ``block_kind``), so the dispatcher treats it as a
+    sticky handoff and does not auto-promote it on the next tick.
+    ``initial_block_kind`` types that block (``needs_input`` by default;
+    ``dependency`` is refused because it would route the card to ``todo``)
+    and ``initial_block_reason`` is stored on the event.
 
     If ``idempotency_key`` is provided and a non-archived task with the
     same key already exists, returns the existing task's id instead of
@@ -3245,6 +3261,11 @@ def create_task(
     if initial_status not in VALID_INITIAL_STATUSES:
         raise ValueError(
             f"initial_status must be one of {sorted(VALID_INITIAL_STATUSES)}"
+        )
+    if initial_block_kind not in VALID_INITIAL_BLOCK_KINDS:
+        raise ValueError(
+            "initial_block_kind must be one of "
+            f"{sorted(VALID_INITIAL_BLOCK_KINDS)}"
         )
     if workspace_kind not in VALID_WORKSPACE_KINDS:
         raise ValueError(
@@ -3565,6 +3586,37 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # A card created as ``blocked`` is a deliberate handoff to a
+                # human. Writing only the status is not enough to make it
+                # hold: ``_has_sticky_block`` looks for a ``blocked`` event
+                # row, and without one the block reads as a circuit-breaker
+                # block that ``recompute_ready`` auto-promotes on the next
+                # dispatcher tick — spawning a worker on a card whose brief
+                # says "wait for the human". Record the block the way
+                # ``block_task`` does so the handoff is the one the caller
+                # asked for.
+                #
+                # ``kanban_swarm`` also creates its root blocked and flips it
+                # to ``done`` in the same transaction; a sticky row on a done
+                # card is inert, and if that flip ever fails, staying blocked
+                # is the right outcome rather than a silent promotion.
+                if task_status == "blocked":
+                    conn.execute(
+                        "UPDATE tasks SET block_kind = ? WHERE id = ?",
+                        (initial_block_kind, task_id),
+                    )
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": initial_block_reason,
+                            "kind": initial_block_kind,
+                            "recurrences": 0,
+                            "source_status": "ready",
+                            "at_create": True,
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_create_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_create_blocked_sticky.py
@@ -1,0 +1,145 @@
+"""A card created with ``initial_status="blocked"`` must actually stay blocked.
+
+``create_task(initial_status="blocked")`` is the documented way to park work
+that needs a human ("tasks that require immediate human ops"). It used to write
+``status='blocked'`` straight into the row and emit only a ``created`` event.
+``_has_sticky_block`` decides stickiness by looking for a ``blocked`` /
+``unblocked`` event row and returns False when there is none — by design, so
+the crash circuit-breaker can auto-recover. A create-time block was therefore
+indistinguishable from a circuit-breaker block, and ``recompute_ready``
+promoted the card on the next dispatcher tick, spawning a worker on a brief
+that said "do not start until the human answers".
+
+The fix records the block the way ``block_task`` does (a ``blocked`` event
+plus ``block_kind``), so the handoff the caller asked for is the handoff the
+dispatcher sees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _events(conn, task_id: str) -> list[str]:
+    return [
+        r["kind"]
+        for r in conn.execute(
+            "SELECT kind FROM task_events WHERE task_id = ? ORDER BY id",
+            (task_id,),
+        ).fetchall()
+    ]
+
+
+def test_created_blocked_emits_sticky_block_event(kanban_home: Path) -> None:
+    """The event row is the whole mechanism — assert it exists, not just the
+    status, because the status alone was already correct before the fix."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="waiting on a human decision",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).status == "blocked"
+        assert "blocked" in _events(conn, tid)
+        assert kb._has_sticky_block(conn, tid) is True
+
+
+def test_created_blocked_survives_recompute_ready(kanban_home: Path) -> None:
+    """The actual failure: the dispatcher's promote pass ran and the card
+    started running."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="do not start until the human answers",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status == "blocked"
+
+
+def test_created_blocked_is_typed_needs_input(kanban_home: Path) -> None:
+    """Untyped blocks work as generic human blockers but leave diagnostics
+    unable to say *why*. The only reason to create a card already blocked is
+    that it waits on a human, so ``needs_input`` is the default."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="waiting on a human decision",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        assert kb.get_task(conn, tid).block_kind == "needs_input"
+
+
+def test_capability_kind_is_accepted(kanban_home: Path) -> None:
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="needs a human to hand over a paywalled PDF",
+            assignee="alice",
+            initial_status="blocked",
+            initial_block_kind="capability",
+            initial_block_reason="paywall — no agent can fetch it",
+        )
+        assert kb.get_task(conn, tid).block_kind == "capability"
+        row = conn.execute(
+            "SELECT payload FROM task_events WHERE task_id = ? AND kind = 'blocked'",
+            (tid,),
+        ).fetchone()
+        assert "paywall" in (row["payload"] or "")
+
+
+def test_dependency_kind_is_refused_at_create(kanban_home: Path) -> None:
+    """``dependency`` routes to ``todo`` in ``block_task``. Accepting it here
+    would turn "create this blocked" into "create this runnable"."""
+    with kb.connect() as conn:
+        with pytest.raises(ValueError, match="initial_block_kind"):
+            kb.create_task(
+                conn,
+                title="x",
+                assignee="alice",
+                initial_status="blocked",
+                initial_block_kind="dependency",
+            )
+
+
+def test_unblock_clears_the_sticky_row(kanban_home: Path) -> None:
+    """A human answering must still be able to release the card — otherwise the
+    fix trades a runaway worker for a card nobody can start."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="waiting on a human decision",
+            assignee="alice",
+            initial_status="blocked",
+        )
+        assert kb.unblock_task(conn, tid)
+        assert kb._has_sticky_block(conn, tid) is False
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, tid).status in ("ready", "todo")
+
+
+def test_normal_create_is_untouched(kanban_home: Path) -> None:
+    """The fix must not leak into the default path: an ordinary card carries
+    no block event and no block kind."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="ordinary work", assignee="alice")
+        assert kb.get_task(conn, tid).block_kind is None
+        assert "blocked" not in _events(conn, tid)
+        assert kb.get_task(conn, tid).status == "ready"


### PR DESCRIPTION
## Problem

`create_task(initial_status="blocked")` is the documented way to create a task that must wait for a human ("tasks that require immediate human ops"). It wrote `status='blocked'` into the row but did not emit a `blocked` event.

`_has_sticky_block()` decides whether a block should hold by looking for that event. A block with no event is treated as a circuit-breaker block that is allowed to auto-recover. So `recompute_ready()` promoted the card on the next dispatcher tick and spawned a worker on a brief whose first line was "do not start until the human answers".

We hit this on a live board: two cards created blocked at 10:12 and 10:13 were both promoted and running by 10:15.

## Fix

When a task is created blocked, record the block the same way `block_task()` does: stamp `block_kind` and append a `blocked` event.

Two new keyword arguments on `create_task`:

- `initial_block_kind` (default `needs_input`, the honest reason to create a card already blocked)
- `initial_block_reason` (stored on the event)

`dependency` is refused at create time on purpose: `block_task()` routes that kind to `todo`, so accepting it would make "create this blocked" mean "create this runnable".

`kanban_swarm` also creates its root blocked and flips it to `done` in the same transaction. A sticky row on a done card is inert, and if that flip ever failed, staying blocked is the right outcome rather than a silent promotion.

## Tests

New `tests/hermes_cli/test_kanban_create_blocked_sticky.py` (7 tests): the event is emitted, the card survives `recompute_ready()`, default kind is `needs_input`, `capability` kind and reason are stored, `dependency` is refused, `unblock_task()` still releases the card, and an ordinary create carries no block state.

Existing kanban tests matching blocked / sticky / swarm / recompute pass (85 tests).
