### PR TITLE
fix(kanban): auto-specify/decompose sweep resurrected tasks the unblock-loop breaker parked in triage

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -135,6 +135,30 @@ BLOCK_RECURRENCE_LIMIT = 2
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
 
+def awaiting_human_after_block_loop(task: "Task") -> bool:
+    """True when this ``triage`` task was put there by the unblock-loop breaker.
+
+    ``block_task`` routes a repeatedly human-blocked task to ``triage`` (see
+    :data:`BLOCK_RECURRENCE_LIMIT`) precisely to take it *out* of the machine
+    loop until a human weighs in. But ``triage`` is also the input queue of the
+    specify/decompose sweep, which re-specifies whatever sits there and
+    promotes it back to ``todo`` — handing the card straight back to a worker
+    that already reported it cannot proceed without a human.
+
+    The escalated state is durable on the row: ``block_kind`` stays set to the
+    human kind and ``block_recurrences`` stays at or above the limit until a
+    successful ``complete_task`` clears them. A card a user dropped into triage
+    by hand has ``block_kind IS NULL`` and ``block_recurrences = 0``, so it is
+    unaffected.
+    """
+    return (
+        task.status == "triage"
+        and task.block_kind is not None
+        and task.block_kind != "dependency"
+        and task.block_recurrences >= BLOCK_RECURRENCE_LIMIT
+    )
+
+
 def normalize_reasoning_effort(effort: Optional[str]) -> Optional[str]:
     """Normalize a per-task reasoning effort into a storable level.
 
@@ -6788,7 +6812,7 @@ def promote_task(
     force: bool = False,
     dry_run: bool = False,
 ) -> tuple[bool, Optional[str]]:
-    """Manually promote a `todo` or `blocked` task to `ready`.
+    """Manually promote a `todo`, `blocked` or `triage` task to `ready`.
 
     Mirrors the automatic promotion done by ``recompute_ready`` but
     drives it from a deliberate operator action with an audit-trail
@@ -6797,6 +6821,19 @@ def promote_task(
     assignee or claim state. Returns ``(True, None)`` on success and
     ``(False, reason)`` if refused. ``dry_run=True`` validates the
     promotion would succeed without mutating state.
+
+    ``triage`` is accepted because it is the only cheap door back for a card
+    the unblock-loop breaker escalated there (see
+    :func:`awaiting_human_after_block_loop`): the specify/decompose sweep
+    deliberately skips those cards, ``unblock`` only applies to
+    ``blocked``/``scheduled``, and re-specifying by id costs an aux-LLM
+    rewrite of a card whose text is already correct. Promotion *is* the human
+    decision the breaker asked for, and it is recorded as an event.
+
+    ``block_kind``/``block_recurrences`` are deliberately NOT reset: if the
+    worker re-blocks for the same human reason, the card lands straight back
+    in ``triage`` instead of burning another unblock/re-block cycle. Only a
+    successful :func:`complete_task` clears the counter.
     """
     row = conn.execute(
         "SELECT status FROM tasks WHERE id = ?", (task_id,)
@@ -6805,10 +6842,10 @@ def promote_task(
         return False, f"task {task_id} not found"
 
     cur_status = row["status"]
-    if cur_status not in ("todo", "blocked"):
+    if cur_status not in ("todo", "blocked", "triage"):
         return False, (
             f"task {task_id} is {cur_status!r}; promote only applies to "
-            f"'todo' or 'blocked'"
+            f"'todo', 'blocked' or 'triage'"
         )
 
     if not force:
@@ -6831,20 +6868,29 @@ def promote_task(
     if dry_run:
         return True, None
 
+    released_escalation = bool(
+        cur_status == "triage"
+        and awaiting_human_after_block_loop(get_task(conn, task_id))
+    )
+
     with write_txn(conn):
         upd = conn.execute(
             "UPDATE tasks SET status = 'ready' "
-            "WHERE id = ? AND status IN ('todo', 'blocked')",
+            "WHERE id = ? AND status IN ('todo', 'blocked', 'triage')",
             (task_id,),
         )
         if upd.rowcount != 1:
             return False, f"task {task_id} status changed during promotion"
-        _append_event(
-            conn,
-            task_id,
-            "promoted_manual",
-            {"actor": actor, "reason": reason, "forced": force},
-        )
+        payload: dict[str, object] = {
+            "actor": actor,
+            "reason": reason,
+            "forced": force,
+            "from_status": cur_status,
+        }
+        if released_escalation:
+            # Audit trail: a human weighed in on a loop-breaker escalation.
+            payload["released_escalation"] = True
+        _append_event(conn, task_id, "promoted_manual", payload)
 
     return True, None
 

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -457,7 +457,13 @@ def decompose_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column."""
+    """Return task ids the sweep may decompose — triage, minus escalations.
+
+    Tasks the unblock-loop breaker escalated into triage are skipped: they wait
+    there for a human, and the gateway's auto-decompose tick would otherwise
+    re-specify and promote them back into the worker pool every ~60s (see
+    ``kb.awaiting_human_after_block_loop``). Decomposing one by id still works.
+    """
     with kb.connect_closing() as conn:
         rows = kb.list_tasks(
             conn,
@@ -465,4 +471,4 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             limit=1000,
         )
-    return [row.id for row in rows]
+    return [row.id for row in rows if not kb.awaiting_human_after_block_loop(row)]

--- a/hermes_cli/kanban_specify.py
+++ b/hermes_cli/kanban_specify.py
@@ -250,9 +250,15 @@ def specify_task(
 
 
 def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
-    """Return task ids currently in the triage column.
+    """Return task ids the sweep may specify — triage, minus escalations.
 
-    ``tenant`` narrows the sweep; ``None`` returns every triage task.
+    ``tenant`` narrows the sweep; ``None`` returns every eligible triage task.
+
+    Tasks the unblock-loop breaker escalated into triage are skipped: they are
+    parked there waiting for a human, and re-specifying them just promotes them
+    back into the worker pool for another futile cycle (see
+    ``kb.awaiting_human_after_block_loop``). Specifying one by id still works —
+    that *is* the human decision the breaker asked for.
     """
     with kb.connect_closing() as conn:
         tasks = kb.list_tasks(
@@ -261,4 +267,4 @@ def list_triage_ids(*, tenant: Optional[str] = None) -> list[str]:
             tenant=tenant,
             include_archived=False,
         )
-    return [t.id for t in tasks]
+    return [t.id for t in tasks if not kb.awaiting_human_after_block_loop(t)]

--- a/tests/hermes_cli/test_kanban_block_loop_sweep_guard.py
+++ b/tests/hermes_cli/test_kanban_block_loop_sweep_guard.py
@@ -1,0 +1,164 @@
+"""The specify/decompose sweep must not resurrect cards the unblock-loop
+breaker escalated into ``triage``.
+
+Observed loop: a worker called ``kanban_block(kind='capability')`` because the
+task needed a live human action. On the second same-cause block ``block_task``
+hit ``BLOCK_RECURRENCE_LIMIT`` and routed the card to ``triage`` — deliberately,
+to force a human decision. But ``triage`` is also the auto-decomposer's input
+queue, so the gateway's auto-decompose tick re-specified the card and promoted
+it back to ``todo`` about a minute later, the dispatcher spawned a worker, and
+the worker blocked again for the same reason. Every cycle burned an aux-LLM
+call, a worker run and a near-duplicate kanban notification.
+
+The fix filters escalated cards out of the *sweep* listings only; specifying or
+decomposing one by id is still allowed, because that is the human-in-the-loop
+decision the breaker was asking for. ``promote_task`` accepts ``triage`` so a
+human has a cheap door out that does not cost an aux-LLM rewrite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+from hermes_cli import kanban_specify as spec
+
+
+@pytest.fixture
+def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _escalate_via_block_loop(conn, *, kind: str = "capability") -> str:
+    """Drive a task through block -> unblock -> same-cause block, i.e. the exact
+    path that trips the loop breaker, and return its id."""
+    tid = kb.create_task(conn, title="needs a live human click", assignee="alice")
+    for _ in range(kb.BLOCK_RECURRENCE_LIMIT):
+        kb.claim_task(conn, tid)
+        assert kb.block_task(
+            conn, tid,
+            reason="needs a human to click the consent screen",
+            kind=kind,
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        if kb.get_task(conn, tid).status == "blocked":
+            kb.unblock_task(conn, tid)
+    return tid
+
+
+def test_block_loop_escalation_lands_in_triage(kanban_home: Path) -> None:
+    """Precondition for everything below: the breaker really does park the
+    card in ``triage`` with its block state intact."""
+    with kb.connect() as conn:
+        tid = _escalate_via_block_loop(conn)
+        task = kb.get_task(conn, tid)
+    assert task.status == "triage"
+    assert task.block_kind == "capability"
+    assert task.block_recurrences >= kb.BLOCK_RECURRENCE_LIMIT
+    assert kb.awaiting_human_after_block_loop(task)
+
+
+@pytest.mark.parametrize("module", [spec, decomp], ids=["specify", "decompose"])
+def test_sweep_skips_block_loop_escalations(kanban_home: Path, module) -> None:
+    """The ``--all`` / gateway sweep must not pick up an escalated card."""
+    with kb.connect() as conn:
+        escalated = _escalate_via_block_loop(conn)
+        fresh = kb.create_task(conn, title="a rough idea", triage=True)
+
+    ids = module.list_triage_ids()
+    assert fresh in ids, "a hand-dropped triage idea must still be swept"
+    assert escalated not in ids, (
+        "card escalated by the unblock-loop breaker must wait for a human, "
+        "not be re-specified back into the worker pool"
+    )
+
+
+def test_dependency_blocks_are_not_treated_as_human_escalations(
+    kanban_home: Path,
+) -> None:
+    """``dependency`` blocks never reach triage via the breaker; a card that
+    merely carries that block_kind must stay sweepable."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="waits on a sibling", triage=True)
+        conn.execute(
+            "UPDATE tasks SET block_kind = 'dependency', block_recurrences = ? "
+            "WHERE id = ?",
+            (kb.BLOCK_RECURRENCE_LIMIT + 1, tid),
+        )
+        conn.commit()
+        assert not kb.awaiting_human_after_block_loop(kb.get_task(conn, tid))
+
+    assert tid in spec.list_triage_ids()
+    assert tid in decomp.list_triage_ids()
+
+
+def test_escalated_card_can_still_be_specified_by_id(kanban_home: Path) -> None:
+    """The guard is sweep-only: a human acting on the card by id still gets the
+    normal triage -> todo promotion."""
+    with kb.connect() as conn:
+        tid = _escalate_via_block_loop(conn)
+        assert kb.specify_triage_task(
+            conn, tid, body="human decided: park it, I will click myself", author="me",
+        )
+        # todo, or ready once the inline recompute_ready pass runs (no parents).
+        assert kb.get_task(conn, tid).status in {"todo", "ready"}
+
+
+def test_promote_is_the_humans_door_out_of_an_escalation(kanban_home: Path) -> None:
+    """Closing the sweep would leave the escalated card with no cheap way back:
+    the sweep skips it, ``unblock`` only applies to blocked/scheduled, and
+    specify costs an aux-LLM rewrite of text that is already correct.
+    ``promote`` is that door, and it records who opened it."""
+    with kb.connect() as conn:
+        tid = _escalate_via_block_loop(conn)
+        assert not kb.unblock_task(conn, tid), "unblock must not touch triage"
+
+        ok, err = kb.promote_task(conn, tid, actor="me", reason="clicked it myself")
+        assert (ok, err) == (True, None)
+        assert kb.get_task(conn, tid).status == "ready"
+
+        ev = [e for e in kb.list_events(conn, tid) if e.kind == "promoted_manual"][-1]
+        assert ev.payload["from_status"] == "triage"
+        assert ev.payload["released_escalation"] is True
+
+
+def test_promote_does_not_reset_the_recurrence_counter(kanban_home: Path) -> None:
+    """A human saying "go" must not hand the card a fresh loop budget: if the
+    worker re-blocks for the same human reason it goes straight back to triage
+    instead of burning another unblock/re-block cycle."""
+    with kb.connect() as conn:
+        tid = _escalate_via_block_loop(conn)
+        assert kb.promote_task(conn, tid, actor="me")[0]
+        after = kb.get_task(conn, tid)
+        assert after.block_kind == "capability"
+        assert after.block_recurrences >= kb.BLOCK_RECURRENCE_LIMIT
+
+        kb.claim_task(conn, tid)
+        kb.block_task(
+            conn, tid, reason="still needs the same live click", kind="capability",
+            expected_run_id=kb.get_task(conn, tid).current_run_id,
+        )
+        assert kb.get_task(conn, tid).status == "triage"
+
+
+def test_promote_still_refuses_terminal_and_unknown_states(kanban_home: Path) -> None:
+    """Widening promote to ``triage`` must not make it a universal status
+    setter."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="already finished", assignee="alice")
+        kb.claim_task(conn, tid)
+        kb.complete_task(conn, tid, summary="done")
+        ok, err = kb.promote_task(conn, tid, actor="me")
+        assert not ok and "promote only applies" in (err or "")
+
+        ok, err = kb.promote_task(conn, "t_nope", actor="me")
+        assert not ok and "not found" in (err or "")


### PR DESCRIPTION
## Problem

When a worker keeps blocking a task for the same human reason, the unblock-loop breaker (`BLOCK_RECURRENCE_LIMIT`) routes the task to `triage`. That is deliberate: take it out of the machine loop until a human decides.

But `triage` is also the input queue of the auto-specify / auto-decompose sweep. The gateway's sweep picked the card up about a minute later, re-specified it with an aux-LLM call, promoted it back to `todo`, the dispatcher spawned a worker, and the worker blocked again for the same reason.

Observed on a live board: 9 cycles in about 4 hours on one card that needed a human to click a consent screen. Each cycle cost an aux-LLM call, a worker run and a near-duplicate kanban notification.

## Fix

- New predicate `kanban_db.awaiting_human_after_block_loop(task)`: status is `triage`, `block_kind` is a human kind (not `dependency`), and `block_recurrences` is at or above the limit. This state is durable on the row until a successful `complete_task()`, and a task a user dropped into triage by hand does not match it.
- `list_triage_ids()` in both `kanban_specify` and `kanban_decompose` skips such tasks. Specifying or decomposing one **by id** still works, because that is the human decision the breaker asked for.
- `promote_task()` now also accepts `triage`, so a human has a cheap way out that does not cost an aux-LLM rewrite of text that is already correct. The `promoted_manual` event records `from_status`, and `released_escalation: true` when it releases a breaker escalation. The recurrence counter is deliberately not reset: if the worker re-blocks for the same reason, the card goes straight back to `triage` instead of starting another unblock/re-block cycle.

## Tests

New `tests/hermes_cli/test_kanban_block_loop_sweep_guard.py` (8 tests): the breaker really parks the card in triage, both sweeps skip it, a fresh triage idea is still swept, `dependency` blocks are not treated as escalations, specifying by id still works, promote releases the card and records who did it, promote does not reset the counter, promote still refuses done/unknown tasks.

Existing triage / promote / specify / decompose tests pass (33 tests).
