### PR TITLE
fix(error_classifier): read FastAPI-style {"detail": ...} error bodies; recognise session/weekly usage limits

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -235,6 +235,13 @@ _OVERLOADED_PATTERNS = [
 # Usage-limit patterns that need disambiguation (could be billing OR rate_limit)
 _USAGE_LIMIT_PATTERNS = [
     "usage limit",
+    # Subscription-backed providers name the wall by its window rather than
+    # by the literal "usage limit": "You've hit your session limit · resets
+    # 2:20pm", "You've hit your weekly limit ...". Without these the error
+    # classified as `unknown` — no adaptive backoff, no Retry-After — or as a
+    # permanent billing failure.
+    "session limit",
+    "weekly limit",
     "quota",
     "limit exceeded",
     "key limit exceeded",
@@ -248,6 +255,9 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "reset in",
     "resets in",
     "reset after",
+    # Bare form with the time glued on: "resets 2:20pm" — matches neither
+    # "resets at" nor "resets in", so the wall read as permanent (billing).
+    "resets ",
     "available in",
     "wait",
     "requests remaining",
@@ -883,6 +893,11 @@ def classify_api_error(
                         pass
         if not _body_msg:
             _body_msg = str(body.get("message") or "").lower()
+        # FastAPI/Starlette proxies: {"detail": "..."}. Usually also present
+        # in str(error), but not every SDK (or wrapped re-raise) carries the
+        # body into the string form — pattern matching must not depend on it.
+        if not _body_msg:
+            _body_msg = _detail_message(body).lower()
     # Combine all message sources for pattern matching
     parts = [_raw_msg]
     if _body_msg and _body_msg not in _raw_msg:
@@ -1816,6 +1831,13 @@ def _classify_400(
             _args = body.get("errorArgs")
             if isinstance(_args, dict):
                 err_body_msg = str(_args.get("reason") or "").strip().lower()
+        # FastAPI/Starlette proxies (Open WebUI, LiteLLM, most self-hosted
+        # gateways) report as {"detail": "..."}.  Same failure mode as the
+        # litellm/Bedrock shape above: without this key a descriptive
+        # upstream rejection reads as blank and a healthy session is routed
+        # into the compression loop until it is auto-reset.
+        if not err_body_msg:
+            err_body_msg = _detail_message(body).lower()
     is_generic = len(err_body_msg) < 30 or err_body_msg in {"error", ""}
     # Absolute token/message-count thresholds are only a proxy for smaller
     # context windows.  Large-context sessions can have many messages while
@@ -2172,6 +2194,63 @@ def _extract_error_code(body: dict) -> str:
     return ""
 
 
+def _detail_message(body: Any) -> str:
+    """Extract a FastAPI-style ``detail`` payload as flat text.
+
+    Starlette/FastAPI proxies — Open WebUI, LiteLLM, and most self-hosted
+    gateways in front of an OpenAI-compatible upstream — report errors as
+    ``{"detail": "..."}``.  None of the keys the rest of this module knows
+    (``error.message``, ``message``, ``errorMessage``, ``errorArgs.reason``)
+    are present, so a long, perfectly descriptive rejection looked *blank*
+    and tripped the "generic 400 on a large session = context overflow"
+    heuristic — pushing a healthy session into the compression loop until
+    it was auto-reset.  Read the carrier so the message length and content
+    are judged on what the proxy actually said.
+
+    Three shapes occur in the wild:
+      - ``str``  — the common case;
+      - ``dict`` — proxies nesting an OpenAI-ish object under ``detail``;
+      - ``list`` — FastAPI's own request-validation errors (``[{"msg": …}]``).
+    """
+    if not isinstance(body, dict):
+        return ""
+    detail = body.get("detail")
+    if isinstance(detail, str):
+        return detail.strip()
+    if isinstance(detail, dict):
+        for key in ("message", "msg", "detail", "reason", "error"):
+            value = detail.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+        return ""
+    if isinstance(detail, list):
+        parts = []
+        for item in detail:
+            if isinstance(item, str) and item.strip():
+                parts.append(item.strip())
+            elif isinstance(item, dict):
+                value = item.get("msg") or item.get("message") or ""
+                if not (isinstance(value, str) and value.strip()):
+                    continue
+                # Keep ``loc`` and ``type``: on their own FastAPI's messages
+                # ("field required") are short enough to read as a bare error
+                # downstream, while the field path and the validator name are
+                # exactly what makes the rejection actionable.
+                loc = item.get("loc")
+                where = ""
+                if isinstance(loc, (list, tuple)):
+                    where = ".".join(str(p) for p in loc if p is not None)
+                elif isinstance(loc, str):
+                    where = loc
+                kind = item.get("type")
+                text = f"{where}: {value.strip()}" if where else value.strip()
+                if isinstance(kind, str) and kind.strip():
+                    text = f"{text} ({kind.strip()})"
+                parts.append(text)
+        return "; ".join(parts)
+    return ""
+
+
 def _extract_message(error: Exception, body: dict) -> str:
     """Extract the most informative error message."""
     # Try structured body first
@@ -2194,6 +2273,10 @@ def _extract_message(error: Exception, body: dict) -> str:
             reason = args.get("reason", "")
             if isinstance(reason, str) and reason.strip():
                 return reason.strip()[:500]
+        # FastAPI/Starlette proxies (Open WebUI, LiteLLM): {"detail": "..."}
+        detail = _detail_message(body)
+        if detail:
+            return detail[:500]
     # Fallback to str(error)
     return str(error)[:500]
 

--- a/tests/agent/test_error_classifier_detail_body.py
+++ b/tests/agent/test_error_classifier_detail_body.py
@@ -1,0 +1,153 @@
+"""FastAPI-style ``{"detail": "..."}`` error bodies must not read as blank.
+
+Open WebUI, LiteLLM and most self-hosted gateways sit behind FastAPI/Starlette,
+which reports errors as ``{"detail": "..."}``. ``_classify_400`` only knew
+``error.message`` / ``message`` / ``errorMessage`` / ``errorArgs.reason``. With
+none of those keys present ``err_body_msg`` stayed ``""``, the ``is_generic``
+heuristic declared the error bare, and the "generic 400 on a large session =
+context overflow" rule fired. A healthy session was pushed into the compression
+loop and then auto-reset with "max compression attempts reached", while the
+real cause (a descriptive upstream router error) never reached the user.
+
+The trap is silent and window-dependent: ``is_large`` is true for *any* session
+over 80 messages once ``context_length <= 256_000``, so the same error is a
+harmless ``format_error`` on a 262 144-token window and a session-killer on a
+200 000-token one. These tests pin the message extraction, which is
+window-independent.
+
+Controls matter as much as the fix: a genuinely bare 400 must still route into
+compression, and a real overflow reported *through* ``detail`` must still be
+recognised as an overflow.
+"""
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+
+
+class _FakeAPIError(Exception):
+    def __init__(self, message, status_code=None, body=None):
+        super().__init__(message)
+        if status_code is not None:
+            self.status_code = status_code
+        self.body = body if body is not None else {}
+
+
+# Shape of a real LiteLLM router error as forwarded by a FastAPI proxy.
+_LITELLM_DETAIL = (
+    "litellm.InternalServerError: InternalServerError: OpenAIException - "
+    "Failed to generate completions. No fallback model group found for "
+    "original model_group=my-model. Fallbacks=[{'my-model_8k': "
+    "['my-model_NoRouting']}, {'my-model_16k': ['my-model_NoRouting']}]. "
+    "Received Model Group=my-model"
+)
+
+# A session that is nowhere near its window but over the absolute
+# message/token thresholds that ``is_large`` applies below 256k.
+_LIVE_SESSION = dict(
+    provider="custom",
+    model="my-model",
+    approx_tokens=81_520,
+    context_length=200_000,
+    num_messages=84,
+)
+
+
+def _classify(body, message="Error code: 400", **overrides):
+    kwargs = dict(_LIVE_SESSION)
+    kwargs.update(overrides)
+    return classify_api_error(
+        _FakeAPIError(message, status_code=400, body=body),
+        **kwargs,
+    )
+
+
+# -- The fix ---------------------------------------------------------------
+
+def test_detail_string_is_not_treated_as_a_bare_error():
+    """A descriptive ``detail`` must never enter the compression loop."""
+    result = _classify({"detail": _LITELLM_DETAIL})
+    assert result.reason is FailoverReason.format_error
+    assert result.should_compress is False
+    assert result.should_fallback is True
+
+
+def test_detail_survives_when_the_sdk_does_not_stringify_the_body():
+    """``str(error)`` is not a reliable carrier — the body must stand alone.
+
+    The OpenAI SDK happens to render the body into ``str(error)``, which would
+    mask a body-only fix. Any SDK that does not (or a wrapped re-raise that
+    loses it) must still be classified from the body.
+    """
+    result = _classify({"detail": _LITELLM_DETAIL}, message="Error code: 400")
+    assert result.reason is FailoverReason.format_error
+
+
+def test_detail_reaches_the_reported_message():
+    """The operator must see the router error, not ``Error code: 400``."""
+    result = _classify({"detail": _LITELLM_DETAIL})
+    assert "no fallback model group found" in result.message.lower()
+
+
+@pytest.mark.parametrize("detail", [
+    # FastAPI request-validation shape.
+    [{"loc": ["body", "messages"], "msg": "field required", "type": "value_error.missing"}],
+    # Proxies that nest an OpenAI-ish object under detail.
+    {"message": "upstream connector refused the request", "code": "connector_down"},
+])
+def test_non_string_detail_shapes_do_not_crash(detail):
+    result = _classify({"detail": detail})
+    assert result.reason is not FailoverReason.context_overflow
+
+
+# -- Controls: the heuristic this fix narrows must still work --------------
+
+def test_genuinely_bare_400_on_a_large_session_still_compresses():
+    """Anthropic's bare ``Error`` body is why the heuristic exists."""
+    result = _classify({"error": {"message": "Error"}})
+    assert result.reason is FailoverReason.context_overflow
+    assert result.should_compress is True
+
+
+def test_empty_body_on_a_large_session_still_compresses():
+    result = _classify({})
+    assert result.reason is FailoverReason.context_overflow
+
+
+def test_real_overflow_reported_through_detail_is_still_an_overflow():
+    """``detail`` is a carrier, not a verdict — read what is inside it."""
+    result = _classify({
+        "detail": (
+            "This model's maximum context length is 262144 tokens. However, "
+            "your messages resulted in 402156 tokens."
+        ),
+    })
+    assert result.reason is FailoverReason.context_overflow
+    assert result.should_compress is True
+
+
+def test_error_message_still_wins_over_detail():
+    """Standard OpenAI shape must keep its precedence when both are present."""
+    result = _classify({
+        "error": {"message": "Error"},
+        "detail": _LITELLM_DETAIL,
+    })
+    assert result.reason is FailoverReason.context_overflow
+
+
+# -- Subscription usage walls ---------------------------------------------
+
+@pytest.mark.parametrize("message", [
+    "You've hit your session limit · resets 2:20pm",
+    "You've hit your weekly limit · resets 2:20pm",
+])
+def test_session_and_weekly_limits_are_transient_rate_limits(message):
+    """Subscription backends name the wall by its window, not by the literal
+    "usage limit". Without these patterns the error classified as ``unknown``
+    (no backoff, no Retry-After) or as a permanent billing failure."""
+    result = classify_api_error(
+        _FakeAPIError(message, status_code=429, body={"error": {"message": message}}),
+        provider="custom",
+        model="my-model",
+    )
+    assert result.reason is FailoverReason.rate_limit


### PR DESCRIPTION
## Problem 1: FastAPI-style error bodies read as blank

Proxies built on FastAPI / Starlette (Open WebUI, LiteLLM, most self-hosted OpenAI-compatible gateways) report errors as `{"detail": "..."}`.

`_classify_400()` only looked at `error.message`, `message`, `errorMessage` and `errorArgs.reason`. With none of those present, a long and perfectly descriptive rejection looked like an empty message, the "generic 400 on a large session means context overflow" heuristic fired, and a healthy session was pushed into the compression loop until it was auto-reset with "max compression attempts reached". The real cause (an upstream router error) never reached the user.

This only triggers when `context_length <= 256_000` and the session has more than 80 messages, so the same error is harmless on one model and kills the session on another. That made it hard to reproduce and easy to blame on the wrong thing.

## Problem 2: subscription usage walls classified as unknown or billing

Subscription-backed providers name the wall by its window: "You've hit your session limit · resets 2:20pm", "You've hit your weekly limit ...". Neither matched the usage-limit patterns, so the error classified as `unknown` (no backoff, no Retry-After) or, when it did match, as a permanent billing failure because "resets 2:20pm" matched neither "resets at" nor "resets in".

## Fix

- New `_detail_message(body)` reads `detail` as a string, a dict (proxies nesting an OpenAI-ish object) or a list (FastAPI's own validation errors, keeping `loc` and `type` so the message stays actionable).
- It is consulted after the existing keys in `classify_api_error()`, `_classify_400()` and `_extract_message()`, so the standard OpenAI shape keeps precedence.
- `"session limit"` and `"weekly limit"` added to the usage-limit patterns; bare `"resets "` added to the transient signals.

## Tests

New `tests/agent/test_error_classifier_detail_body.py` (11 tests). The fix: a descriptive `detail` is a `format_error`, not a compression trigger, even when `str(error)` does not carry the body; the operator sees the router text; dict and list shapes do not crash. Controls: a genuinely bare 400 on a large session still compresses; a real overflow reported through `detail` is still an overflow; `error.message` still wins over `detail`. Session and weekly limits classify as `rate_limit`.

Existing error-classifier / failover tests pass (191 tests).
