### PR TITLE
fix(tools): cleanup daemons idle on an Event so a patched time.sleep cannot turn them into a busy loop

### DIFF
--- a/tests/tools/test_browser_orphan_reaper.py
+++ b/tests/tools/test_browser_orphan_reaper.py
@@ -596,7 +596,7 @@ class TestPeriodicOrphanReap:
                        side_effect=lambda: reap_calls.append(1)), \
                  patch("tools.browser_tool._cleanup_inactive_browser_sessions",
                        side_effect=fake_cleanup), \
-                 patch("tools.browser_tool.time.sleep"):
+                 patch("tools.browser_tool._idle_between_sweeps"):
                 bt._browser_cleanup_thread_worker()
         finally:
             bt._cleanup_running = orig_running

--- a/tests/tools/test_cleanup_daemon_sleep_immunity.py
+++ b/tests/tools/test_cleanup_daemon_sleep_immunity.py
@@ -1,0 +1,95 @@
+"""The cleanup daemons must not be turnable into a full-speed spin.
+
+Both ``tools.terminal_tool`` and ``tools.browser_tool`` run a background
+cleanup daemon that idles between sweeps. The daemon outlives whatever started
+it, so *any* later code — in practice a test doing
+``patch("<module>.time.sleep")``, which rebinds the attribute on the shared
+``time`` module and therefore unblocks every sleeper in the process — used to
+be able to turn that idle wait into a busy loop. Each turn recorded a ``_Call``
+on the MagicMock; measured in the test suite, about two minutes of that was
+13.7 GB of RSS and a hard OOM that took the whole run down.
+
+These tests pin the property that makes the class impossible: the daemons idle
+on ``threading.Event.wait``, which a patched ``time.sleep`` cannot touch, and
+stopping them is immediate instead of costing up to one idle interval.
+"""
+
+import contextlib
+import time
+from unittest.mock import MagicMock, patch
+
+import tools.browser_tool as browser_tool
+import tools.terminal_tool as terminal_tool
+
+#: Captured before any test can patch it, so the observation window below is a
+#: genuine wait even while ``time.sleep`` is mocked.
+_REAL_SLEEP = time.sleep
+
+#: How long to let a daemon idle while ``time.sleep`` is a no-op. A spinning
+#: loop reaches millions of calls in this window; a correct one reaches zero.
+_OBSERVE_SECONDS = 0.4
+
+#: Generous ceiling: a daemon may legitimately touch a patched sleep a handful
+#: of times through code it calls, but never thousands.
+_SANE_CALL_CEILING = 100
+
+
+def _calls_while_idling(start, stop, sweep_targets):
+    """Run a cleanup daemon with ``time.sleep`` mocked; return the mock."""
+    fake_sleep = MagicMock(name="time.sleep")
+    with contextlib.ExitStack() as stack:
+        for target in sweep_targets:
+            stack.enter_context(patch(target))
+        stack.enter_context(patch("time.sleep", fake_sleep))
+        start()
+        try:
+            _REAL_SLEEP(_OBSERVE_SECONDS)
+        finally:
+            stop()
+    return fake_sleep
+
+
+def test_terminal_cleanup_daemon_ignores_a_globally_patched_sleep():
+    fake_sleep = _calls_while_idling(
+        terminal_tool._start_cleanup_thread,
+        terminal_tool._stop_cleanup_thread,
+        ["tools.terminal_tool._cleanup_inactive_envs"],
+    )
+
+    assert fake_sleep.call_count <= _SANE_CALL_CEILING, (
+        "the terminal cleanup daemon spun on a patched time.sleep "
+        f"({fake_sleep.call_count} calls in {_OBSERVE_SECONDS}s) — it must idle "
+        "on threading.Event.wait, which patching time.sleep cannot disable"
+    )
+
+
+def test_browser_cleanup_daemon_ignores_a_globally_patched_sleep():
+    fake_sleep = _calls_while_idling(
+        browser_tool._start_browser_cleanup_thread,
+        browser_tool._stop_browser_cleanup_thread,
+        [
+            "tools.browser_tool._cleanup_inactive_browser_sessions",
+            "tools.browser_tool._reap_orphaned_browser_sessions",
+        ],
+    )
+
+    assert fake_sleep.call_count <= _SANE_CALL_CEILING, (
+        "the browser cleanup daemon spun on a patched time.sleep "
+        f"({fake_sleep.call_count} calls in {_OBSERVE_SECONDS}s)"
+    )
+
+
+def test_stopping_the_terminal_daemon_does_not_wait_out_the_idle_interval():
+    """Event-based idling also means shutdown is immediate, not up to a cycle."""
+    assert terminal_tool._CLEANUP_INTERVAL_SECONDS >= 30, (
+        "this test is only meaningful while the idle interval is long"
+    )
+    with patch("tools.terminal_tool._cleanup_inactive_envs"):
+        terminal_tool._start_cleanup_thread()
+        thread = terminal_tool._cleanup_thread
+        started = time.monotonic()
+        terminal_tool._stop_cleanup_thread()
+        elapsed = time.monotonic() - started
+
+    assert not thread.is_alive()
+    assert elapsed < 5, f"stopping the daemon took {elapsed:.1f}s"

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2260,6 +2260,10 @@ def _browser_session_backend(session_key: str) -> _BrowserSessionBackend:
 # Background cleanup thread state
 _cleanup_thread = None
 _cleanup_running = False
+#: Seconds the cleanup daemon idles between sweeps.
+_CLEANUP_CYCLE_SECONDS = 30.0
+#: Set to wake the cleanup daemon for shutdown; doubles as its idle timer.
+_cleanup_stop = threading.Event()
 # Protects _session_last_activity AND _active_sessions for thread safety
 # (subagents run concurrently via ThreadPoolExecutor)
 _cleanup_lock = threading.Lock()
@@ -2725,7 +2729,7 @@ def _browser_cleanup_thread_worker():
     at any point in a long-lived process, and a startup-only reap can never
     recover from that.
     """
-    reap_every_cycles = max(1, round(BROWSER_ORPHAN_REAP_INTERVAL / 30))
+    reap_every_cycles = max(1, round(BROWSER_ORPHAN_REAP_INTERVAL / _CLEANUP_CYCLE_SECONDS))
     cycle = 0
 
     while _cleanup_running:
@@ -2742,11 +2746,27 @@ def _browser_cleanup_thread_worker():
         except Exception as e:
             logger.warning("Cleanup thread error: %s", e)
 
-        # Sleep in 1-second intervals so we can stop quickly if needed
-        for _ in range(30):
-            if not _cleanup_running:
-                break
-            time.sleep(1)
+        _idle_between_sweeps(_CLEANUP_CYCLE_SECONDS)
+
+
+def _idle_between_sweeps(seconds: float) -> None:
+    """Block for up to *seconds* unless the daemon is told to stop first.
+
+    Idles on the stop Event, not on ``time.sleep()``: ``Event.wait`` is a
+    C-level timed wait that patching in another module cannot turn into a
+    no-op. The previous ``for _ in range(30): time.sleep(1)`` could — this
+    daemon outlives the test that started it, and ``patch("<mod>.time.sleep")``
+    rebinds the attribute on the shared ``time`` module, i.e. process-wide.
+    The twin of this loop in ``tools/terminal_tool.py`` spun at full CPU that
+    way and grew a MagicMock's call log to ~14 GB before the OOM killer took
+    the test run down.
+
+    Still polls ``_cleanup_running`` once a second so callers that only flip
+    the flag keep working; ``_cleanup_stop`` makes shutdown immediate.
+    """
+    for _ in range(max(1, int(seconds))):
+        if not _cleanup_running or _cleanup_stop.wait(1.0):
+            return
 
 
 def _start_browser_cleanup_thread():
@@ -2755,6 +2775,7 @@ def _start_browser_cleanup_thread():
 
     with _cleanup_lock:
         if _cleanup_thread is None or not _cleanup_thread.is_alive():
+            _cleanup_stop.clear()
             _cleanup_running = True
             _cleanup_thread = threading.Thread(
                 target=_browser_cleanup_thread_worker,
@@ -2769,6 +2790,7 @@ def _stop_browser_cleanup_thread():
     """Stop the background cleanup thread."""
     global _cleanup_running
     _cleanup_running = False
+    _cleanup_stop.set()
     if _cleanup_thread is not None:
         _cleanup_thread.join(timeout=5)
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1149,6 +1149,10 @@ _creation_locks: Dict[str, threading.Lock] = {}  # Per-task locks for sandbox cr
 _creation_locks_lock = threading.Lock()  # Protects _creation_locks dict itself
 _cleanup_thread = None
 _cleanup_running = False
+#: Seconds the cleanup daemon idles between sweeps.
+_CLEANUP_INTERVAL_SECONDS = 60.0
+#: Set to wake the cleanup daemon for shutdown; doubles as its idle timer.
+_cleanup_stop = threading.Event()
 
 # Once-per-process guard for the docker orphan reaper (issue #20561).
 # Set when _maybe_reap_docker_orphans first runs; concurrent _create_environment
@@ -2231,10 +2235,27 @@ def _cleanup_thread_worker():
         except Exception as e:
             logger.warning("Error in cleanup thread: %s", e, exc_info=True)
 
-        for _ in range(60):
-            if not _cleanup_running:
-                break
-            time.sleep(1)
+        _idle_between_sweeps(_CLEANUP_INTERVAL_SECONDS)
+
+
+def _idle_between_sweeps(seconds: float) -> None:
+    """Block for up to *seconds* unless the daemon is told to stop first.
+
+    Idles on the stop Event, not on ``time.sleep()``: ``Event.wait`` is a
+    C-level timed wait that patching in another module cannot turn into a
+    no-op. The previous ``for _ in range(60): time.sleep(1)`` could — this
+    daemon outlives the test that started it, so once any later test did
+    ``patch("<somemodule>.time.sleep")`` (which rebinds the attribute on the
+    shared ``time`` module, i.e. process-wide) the loop spun at full CPU speed
+    and the MagicMock recorded a call per turn; about two minutes of that is
+    ~14 GB of RSS and an OOM kill of the whole test run.
+
+    Still polls ``_cleanup_running`` once a second so callers that only flip
+    the flag keep working; ``_cleanup_stop`` makes shutdown immediate.
+    """
+    for _ in range(max(1, int(seconds))):
+        if not _cleanup_running or _cleanup_stop.wait(1.0):
+            return
 
 
 def _start_cleanup_thread():
@@ -2243,6 +2264,7 @@ def _start_cleanup_thread():
 
     with _env_lock:
         if _cleanup_thread is None or not _cleanup_thread.is_alive():
+            _cleanup_stop.clear()
             _cleanup_running = True
             _cleanup_thread = threading.Thread(target=_cleanup_thread_worker, daemon=True)
             _cleanup_thread.start()
@@ -2252,6 +2274,7 @@ def _stop_cleanup_thread():
     """Stop the background cleanup thread."""
     global _cleanup_running
     _cleanup_running = False
+    _cleanup_stop.set()
     if _cleanup_thread is not None:
         try:
             _cleanup_thread.join(timeout=5)


### PR DESCRIPTION
## Problem

`tools/terminal_tool.py` and `tools/browser_tool.py` each run a background cleanup daemon that idled with `for _ in range(N): time.sleep(1)`.

The daemon outlives the test that started it. Any later test that does `patch("<some_module>.time.sleep")` rebinds the attribute on the shared `time` module, which is process-wide, so the daemon's sleep becomes a no-op and the loop spins at full speed. Because the patched sleep is a `MagicMock`, every turn of the loop records a call.

In our test run that grew the pytest process to 13.7 GB in about two minutes and the kernel OOM-killed the whole run. Finding the cause meant bisecting OOMs, because nothing in the failing test pointed at the daemon.

## Fix

Both daemons now idle in a small `_idle_between_sweeps(seconds)` helper that waits on a `threading.Event` in one-second slices. `Event.wait` is a C-level timed wait that patching `time.sleep` cannot affect.

- `_cleanup_running` is still polled every second, so existing code that only flips the flag keeps working.
- The stop functions set the Event, so shutdown is immediate instead of costing up to one interval.
- `test_browser_orphan_reaper` used to patch `time.sleep` to make cycles instant; it now patches `_idle_between_sweeps` instead.

## Tests

New `tests/tools/test_cleanup_daemon_sleep_immunity.py` (3 tests): each daemon runs for 0.4 s with `time.sleep` mocked and touches the mock at most a handful of times instead of millions; stopping the terminal daemon returns immediately.

`test_browser_orphan_reaper.py` and `test_approved_command_clean_slate.py` (the existing tests that drive these daemons or patch `time.sleep`) pass: 35 tests total.
