### PR TITLE
fix(background-review): keep bare manual refine active when auto review is off

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3030,6 +3030,7 @@ class GatewaySlashCommandsMixin:
                 review_memory=True,
                 review_skills=review_skills,
                 focus=args or None,
+                explicit=True,
             )
         except Exception as exc:
             return f"/refine failed to start: {exc}"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1990,18 +1990,17 @@ class AIAgent:
         immediately, exactly as before.
 
         ``explicit`` marks a user-initiated review (/refine, with or
-        without focus text): never deferred. It does NOT touch the
-        delegate/enabled gates below — those stay keyed on ``focus`` so a
-        bare /refine keeps its historical gating behavior.
+        without focus text). Manual reviews bypass automatic-only delegate,
+        enabled, and idle-defer gates.
         """
-        # Delegation-subagent and enabled gates run here at enqueue/spawn
-        # time; the idle dispatcher re-checks the enabled gate again at
-        # dispatch time so a review queued for minutes cannot be
-        # resurrected after the user disables reviews.
-        if focus is None and getattr(self, "_delegate_depth", 0) > 0:
+        # Automatic delegation-subagent and enabled gates run here at
+        # enqueue/spawn time; the idle dispatcher re-checks the enabled gate
+        # at dispatch time so a review queued for minutes cannot be
+        # resurrected after the user disables automatic reviews.
+        if not explicit and focus is None and getattr(self, "_delegate_depth", 0) > 0:
             return
         task_cfg = None
-        if focus is None:
+        if not explicit and focus is None:
             from agent.background_review import load_background_review_settings
             enabled, task_cfg = load_background_review_settings()
             if not enabled:

--- a/tests/gateway/test_refine_command.py
+++ b/tests/gateway/test_refine_command.py
@@ -1,0 +1,42 @@
+"""Behavior tests for the gateway /refine command."""
+
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.slash_commands import GatewaySlashCommandsMixin
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("args", ["", "review the deploy workflow"])
+async def test_refine_marks_bare_and_focused_requests_explicit(args):
+    agent = SimpleNamespace(
+        _session_messages=[{"role": "user", "content": "hello"}],
+        valid_tool_names={"skill_manage"},
+        _spawn_background_review=MagicMock(),
+    )
+    host = SimpleNamespace(
+        _agent_cache={"session-key": (agent, 0.0)},
+        _agent_cache_lock=threading.Lock(),
+        _running_agents={},
+        _session_key_for_source=lambda _source: "session-key",
+    )
+    event = SimpleNamespace(
+        source=object(),
+        get_command_args=lambda: args,
+    )
+
+    response = await GatewaySlashCommandsMixin._handle_refine_command(host, event)
+
+    assert response.startswith("⚗ Reviewing this conversation in the background")
+    agent._spawn_background_review.assert_called_once_with(
+        messages_snapshot=agent._session_messages,
+        review_memory=True,
+        review_skills=True,
+        focus=args or None,
+        explicit=True,
+    )

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -340,9 +340,8 @@ def test_background_review_runs_at_top_level(monkeypatch):
     assert len(forks) == 1, "top-level review must still spawn the fork"
 
 
-def test_background_review_disabled_skips_automatic_spawn(monkeypatch):
-    """``auxiliary.background_review.enabled: false`` must skip automatic
-    post-turn forks while leaving ``/refine`` (focus set) working (#87250)."""
+def test_background_review_disabled_skips_only_automatic_spawn(monkeypatch):
+    """The config switch must not suppress either form of manual /refine."""
     from unittest.mock import patch
 
     forks = []
@@ -380,8 +379,17 @@ def test_background_review_disabled_skips_automatic_spawn(monkeypatch):
             messages_snapshot=[{"role": "user", "content": "hello"}],
             review_memory=True,
             focus="save the deploy workflow",
+            explicit=True,
         )
-        assert len(forks) == 1, "/refine must still run when enabled=false"
+        assert len(forks) == 1, "focused /refine must run when enabled=false"
+
+        AIAgent._spawn_background_review(
+            agent,
+            messages_snapshot=[{"role": "user", "content": "hello"}],
+            review_memory=True,
+            explicit=True,
+        )
+        assert len(forks) == 2, "bare /refine must run when enabled=false"
 
 
 def test_background_review_explicit_focus_runs_even_in_subagent(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

A bare manual `/refine` now starts its review even when `auxiliary.background_review.enabled` is false. The automatic post-turn review remains disabled, while CLI, Desktop, and messaging command paths consistently mark manual requests as explicit.

### Symptom

After disabling automatic background review, bare `/refine` reports that review started but creates no review fork and produces no memory or skill updates. Supplying focus text avoids the failure.

### Impact

Users who disable automatic review cannot manually trigger an unfocused review from affected shared gateway surfaces, despite receiving a success message.

### Bug Cause

**Trigger:** `run_agent.py` / `AIAgent._spawn_background_review` / `focus is None` automatic-review gates

**Causal chain:**
1. A user sends bare `/refine`, so the command passes `focus=None`.
2. `_spawn_background_review` treats the missing focus as an automatic trigger and applies the disabled automatic-review gate.
3. The method returns without spawning after the command handler has already prepared a success response.

**Why it is wrong:** Manual intent and optional focus text are independent. The existing `explicit` flag represented manual intent for idle deferral but was not used by the delegate and enabled gates.

**Working sibling / contrast:** Focused `/refine` bypassed the `focus is None` gates, and the CLI already passed `explicit=True`.

**Ruled out:** Review thread construction is not the failure point; the disabled gate returns before `_spawn_background_review_now` is called, as reproduced by the regression test.

### Fix

Use `explicit` to bypass all automatic-only gates, and have the gateway `/refine` handler pass `explicit=True` for both bare and focused requests. Regression coverage verifies automatic reviews remain disabled and both manual forms spawn.

## Related Issue

Closes #100762

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `run_agent.py` - separate manual review intent from optional focus text at automatic-review gates.
- `gateway/slash_commands.py` - mark gateway `/refine` requests as explicit.
- `tests/run_agent/test_background_review.py` - cover disabled automatic review alongside bare and focused manual review.
- `tests/gateway/test_refine_command.py` - verify shared gateway command intent propagation.

## How to Test

1. Set `auxiliary.background_review.enabled: false`.
2. Send bare `/refine` after a completed conversation and confirm a background review is spawned.
3. Run the related automated suite:

```bash
scripts/run_tests.sh tests/run_agent/test_background_review.py tests/run_agent/test_background_review_cost_controls.py tests/agent/test_background_review_usage.py tests/agent/test_review_idle_queue.py tests/agent/test_refine_focus.py tests/gateway/test_refine_command.py -q
```

Result: 59 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repo test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A beyond the corrected method contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - host-independent logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A
