### PR TITLE
ci.yaml parses again — every run since Sep 1 21:20 UTC zero-jobbed on a transposed '})}'

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -123,7 +123,7 @@ jobs:
     # single job in the workflow — while still running the full pytest lanes.
     #
     # Re-disabled (Sep 2026): the Sep 1 re-enable is still incredibly flaky.
-    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true' })}
+    if: ${{ false && (needs.detect.outputs.python_prod == 'true' || needs.detect.outputs.frontend == 'true') }}
     uses: ./.github/workflows/e2e-desktop.yml
 
   docs-site:


### PR DESCRIPTION
## Summary
Every `ci.yaml` run since 21:20 UTC Sep 1 (main pushes AND all PRs) concludes `failure` with 0 jobs. Root cause: commit 24f5a60ed1 ("fix: re-disable e2e") transposed the expression closers in the e2e-desktop gate — `'true' })}` instead of `'true') }}` — so `${{` never closes and GitHub can't parse the workflow.

## Changes
- `.github/workflows/ci.yaml`: fix the closer to `) }}`. The gate stays disabled (`false &&`), exactly as 24f5a60ed1 intended.

## Validation
| | Before | After |
|---|---|---|
| ci.yaml runs (main + PRs) | failure, 0 jobs, 'workflow file issue' | this PR's own ci.yaml run dispatches jobs |

Probe #100786 (git-mv rename, identical content) also 0-jobbed — ruled out the Aug-19-style server-side identity wedge; the file itself was broken.

This also unblocks CI for PR #100775.

## Infographic

![ci.yaml parse fix](https://v3b.fal.media/files/b/0aa8be7d/0D6X6lbG38OIAblViIWcF_cy0UJlM3.png)
