### PR TITLE
fix(gateway): drop the duplicate request_overrides key in the route literals

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3227,13 +3227,12 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
-        "request_overrides": dict(runtime.get("request_overrides") or {}),
-        "max_tokens": max_tokens,
         # Per-provider request_overrides (e.g. a custom_providers ``extra_body``
         # carrying ``chat_template_kwargs``) resolved by resolve_runtime_provider().
         # Must flow through to the per-turn route or the provider's configured
         # request body never reaches the model on the gateway path.
-        "request_overrides": runtime.get("request_overrides"),
+        "request_overrides": dict(runtime.get("request_overrides") or {}),
+        "max_tokens": max_tokens,
         "capabilities": capabilities,
     }
 
@@ -3450,7 +3449,6 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "credential_pool": runtime.get("credential_pool"),
                     "request_overrides": dict(runtime.get("request_overrides") or {}),
                     "model": entry.get("model"),
-                    "request_overrides": runtime.get("request_overrides"),
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)

--- a/tests/gateway/test_custom_provider_request_overrides.py
+++ b/tests/gateway/test_custom_provider_request_overrides.py
@@ -305,3 +305,30 @@ async def test_reused_agent_turn_merges_request_overrides_not_overwrite(monkeypa
     assert agent.request_overrides == {
         "extra_body": {"text": {"verbosity": "low"}},
     }
+
+
+def test_resolve_runtime_agent_kwargs_defaults_request_overrides_to_a_copy(monkeypatch):
+    """A provider without request_overrides must yield {}, and never the caller's dict."""
+    provider_overrides = {"extra_body": {"text": {"verbosity": "low"}}}
+    runtime = {
+        "api_key": "***",
+        "base_url": "https://example.test/v1",
+        "provider": "custom",
+        "api_mode": "codex_responses",
+        "command": None,
+        "args": [],
+        "credential_pool": None,
+        "request_overrides": None,
+    }
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda: runtime,
+    )
+
+    assert gateway_run._resolve_runtime_agent_kwargs()["request_overrides"] == {}
+
+    runtime["request_overrides"] = provider_overrides
+    result = gateway_run._resolve_runtime_agent_kwargs()["request_overrides"]
+    assert result == provider_overrides
+    result["service_tier"] = "priority"
+    assert "service_tier" not in provider_overrides


### PR DESCRIPTION
## What does this PR do?

I was following how a custom provider's `extra_body` reaches a turn and noticed the dict literal returned by `_resolve_runtime_agent_kwargs` sets `request_overrides` twice. Python keeps the later one, so the guarded form a few lines above it has never run, and the route ends up holding the resolver's own dict, or `None` when the provider has no overrides. Every other key in that literal uses the guarded form, `args` included, and so does the same key at the third build site. I kept the guarded line and moved the comment that explains why the key has to be there onto it. `_try_resolve_fallback_provider` carries the same pair.

I don't think anything downstream breaks today, both readers do `dict(... or {})` themselves, so what this restores is the copy: the route no longer hands out a reference into the resolver's dict.

## Related Issue

None, found by reading.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`: drop the second `request_overrides` entry in both route literals, keep the guarded one
- `tests/gateway/test_custom_provider_request_overrides.py`: cover the `None` default and the copy

## How to Test

1. `uv run pytest tests/gateway/test_custom_provider_request_overrides.py`
2. On `main` the new test fails at the first assertion, `None == {}`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (ran `tests/gateway/test_custom_provider_request_overrides.py`, 6 passed; the full suite I did not run)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
