### PR TITLE
fix(whatsapp): classify bridge logged_out exit as non-retryable fatal

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -61,6 +61,13 @@ logger = logging.getLogger(__name__)
 # transcripts stay disambiguated even if downstream plugins fail before silent_ingest.
 _OWNER_REPLY_PREFIX = "[owner reply] "
 
+# Exit code the Node bridge uses for a terminal logout (Baileys loggedOut /
+# HTTP 401, incl. the device being unlinked). Reconnecting cannot recover from
+# it — a re-pair is required — so the adapter treats it as non-retryable and
+# the gateway reconnect watcher stops re-spawning the bridge (#80088).
+# Must match LOGGED_OUT_EXIT_CODE in scripts/whatsapp-bridge/bridge.js.
+BRIDGE_EXIT_LOGGED_OUT = 86
+
 
 def _listener_pids_on_port(port: int) -> list:
     """PIDs of processes *listening* on ``port`` (POSIX) — never clients.
@@ -907,6 +914,23 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 returncode,
             )
             return None
+
+        # Terminal logout: the bridge exits with BRIDGE_EXIT_LOGGED_OUT when
+        # Baileys reports loggedOut (HTTP 401, incl. the device being unlinked).
+        # That state never clears by restarting the process, so mark it
+        # non-retryable — the gateway watcher stops re-spawning the bridge and
+        # the user gets a re-pair instruction instead of a silent loop (#80088).
+        if returncode == BRIDGE_EXIT_LOGGED_OUT:
+            message = (
+                "WhatsApp session was logged out (device unlinked the bridge). "
+                "Re-pair required: run `hermes whatsapp` or pair from the dashboard."
+            )
+            if not self.has_fatal_error:
+                logger.error("[%s] %s", self.name, message)
+                self._set_fatal_error("whatsapp_logged_out", message, retryable=False)
+                self._close_bridge_log()
+                await self._notify_fatal_error()
+            return self.fatal_error_message or message
 
         message = f"WhatsApp bridge process exited unexpectedly (code {returncode})."
         if not self.has_fatal_error:

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -125,6 +125,14 @@ const CHUNK_DELAY_MS = parseInt(process.env.WHATSAPP_CHUNK_DELAY_MS || '300', 10
 // fires. Fail fast instead so the gateway can surface a real error and retry.
 const SEND_TIMEOUT_MS = parseInt(process.env.WHATSAPP_SEND_TIMEOUT_MS || '60000', 10);
 
+// Terminal-logout exit code. Baileys' loggedOut (HTTP 401, incl. the device
+// being unlinked) cannot be recovered by reconnecting — a re-pair is required.
+// Exit with a distinct code so the adapter can tell a logout apart from an
+// ordinary crash exit(1) and stop the reconnect watcher instead of re-spawning
+// forever (#80088). Must match BRIDGE_EXIT_LOGGED_OUT in
+// plugins/platforms/whatsapp/adapter.py.
+const LOGGED_OUT_EXIT_CODE = 86;
+
 // --- Send queue: serialise all sock.sendMessage() calls across concurrent
 //     HTTP handlers so a single Baileys socket never has overlapping sends.
 //     Overlapping sends are the root cause of cross-chat contamination
@@ -443,7 +451,7 @@ async function startSocket() {
         if (!PAIR_JSON) {
           console.log('❌ Logged out. Delete session and restart to re-authenticate.');
         }
-        process.exit(1);
+        process.exit(LOGGED_OUT_EXIT_CODE);
       } else {
         // 515 = restart requested (common after pairing). Always reconnect.
         emitPairEvent({ event: 'disconnected', reason });

--- a/tests/gateway/test_whatsapp_connect.py
+++ b/tests/gateway/test_whatsapp_connect.py
@@ -251,6 +251,39 @@ class TestBridgeRuntimeFailure:
         assert adapter._bridge_log_fh is None
 
     @pytest.mark.asyncio
+    async def test_send_marks_non_retryable_fatal_when_bridge_reports_logout(self):
+        """Bridge exit code 86 (Baileys loggedOut / 401) is terminal (#80088).
+
+        Reconnecting can never recover a logged-out session — without the
+        non-retryable classification the gateway watcher re-spawns the bridge
+        on its backoff forever with no visible re-pair signal.
+        """
+        from plugins.platforms.whatsapp.adapter import BRIDGE_EXIT_LOGGED_OUT
+
+        adapter = _make_adapter()
+        fatal_handler = AsyncMock()
+        adapter.set_fatal_error_handler(fatal_handler)
+        adapter._running = True
+        adapter._http_session = MagicMock()  # Persistent session active
+        mock_fh = MagicMock()
+        adapter._bridge_log_fh = mock_fh
+
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = BRIDGE_EXIT_LOGGED_OUT
+        adapter._bridge_process = mock_proc
+
+        result = await adapter.send("chat-123", "hello")
+
+        assert result.success is False
+        assert "logged out" in result.error
+        assert adapter.fatal_error_code == "whatsapp_logged_out"
+        assert adapter.fatal_error_retryable is False
+        assert "hermes whatsapp" in (adapter.fatal_error_message or "")
+        fatal_handler.assert_awaited_once()
+        mock_fh.close.assert_called_once()
+        assert adapter._bridge_log_fh is None
+
+    @pytest.mark.asyncio
     async def test_send_normalizes_bare_phone_numbers_to_jid(self):
         """A bare phone target (with or without +) becomes a full JID.
 


### PR DESCRIPTION
## What does this PR do?

When Baileys reports `loggedOut` (HTTP 401, including the device being unlinked from the phone side), the bridge exits with code 1. `_check_managed_bridge_exit()` cannot distinguish that from an ordinary crash, so it records a **retryable** fatal — and the gateway reconnect watcher re-spawns the bridge on its 30s→5min backoff indefinitely against dead credentials, with no visible re-pair signal (300+ spawn cycles observed over ~3 days in production, per the issue thread).

This PR implements the exit-reason contract suggested in the issue:

- The bridge exits with a dedicated `LOGGED_OUT_EXIT_CODE` (86) on `DisconnectReason.loggedOut` instead of the generic 1.
- The adapter maps that exit code to a **non-retryable** `whatsapp_logged_out` fatal whose message tells the user to re-pair (`hermes whatsapp` or the dashboard), so the watcher stops after a single exit and the fatal-error notification is actionable instead of looping silently.

Baileys' documented lifecycle is `shouldReconnect = statusCode !== DisconnectReason.loggedOut` — logout is terminal by definition, so classifying it non-retryable matches upstream semantics rather than papering over it with a circuit breaker.

## Related Issue

Fixes #80088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `scripts/whatsapp-bridge/bridge.js`: add `LOGGED_OUT_EXIT_CODE = 86` constant (cross-referenced with the adapter) and use it in the `loggedOut` branch of the `connection === 'close'` handler (previously `process.exit(1)`).
- `plugins/platforms/whatsapp/adapter.py`: add matching `BRIDGE_EXIT_LOGGED_OUT = 86` constant; in `_check_managed_bridge_exit()`, classify that exit code as a non-retryable `whatsapp_logged_out` fatal with re-pair instructions, before the generic retryable `whatsapp_bridge_exited` path.
- `tests/gateway/test_whatsapp_connect.py`: regression test — a bridge child exiting with 86 through `send()` yields `fatal_error_code == "whatsapp_logged_out"`, `fatal_error_retryable is False`, the re-pair hint in the message, one fatal notification, and the bridge log handle closed.

## How to Test

1. `python -m pytest tests/gateway/test_whatsapp_connect.py -q` — 10 passed, 5 skipped on macOS (15 tests total, includes the new `test_send_marks_non_retryable_fatal_when_bridge_reports_logout`).
2. `python -m pytest tests/gateway/ tests/plugins/ -q -k whatsapp` — 180 passed, 10 skipped; no regressions in the WhatsApp suites.
3. `node --check scripts/whatsapp-bridge/bridge.js` — passes.
4. Manual verification of the failure mode (matches the issue's steps): pair a session, revoke it from the phone, and watch `gateway.log` — before the fix the bridge exit 1 is re-spawned forever; after the fix the adapter flips to a single non-retryable `whatsapp_logged_out` fatal, the watcher stops, and the notification says to re-pair. Observed result: covered by the new regression test for the classification path (exit code 86 → non-retryable + notification); the watcher-side behavior follows from `fatal_error_retryable=False`, which `_queue_retryable_fatal_platform` already excludes from reconnect queuing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full local run is blocked by pre-existing environment issues on this machine (11 `tests/acp*` collection errors reproduce identically on a clean unmodified checkout; a repo test cleanup routine also deletes `/tmp/hermes-bugfix-*` worktrees mid-run), so I ran the affected suites instead: `tests/gateway/test_whatsapp_connect.py` (10 passed, 5 skipped) and `tests/gateway/ tests/plugins/ -k whatsapp` (180 passed, 10 skipped); CI will run the full suite
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (no UI change).

