### PR TITLE
fix(profiles): make deleted distribution profiles live after reinstall

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -71,6 +71,7 @@ from pathlib import Path, PurePosixPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
+from hermes_constants import clear_named_profile_deleted
 from hermes_cli._subprocess_compat import noninteractive_git_env
 
 
@@ -699,6 +700,7 @@ def install_distribution(
             if collision is None:
                 create_wrapper_script(plan.manifest.name)
 
+        clear_named_profile_deleted(plan.target_dir)
         return plan
 
 

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -230,6 +230,34 @@ class TestInstall:
         assert m.name == "installed"
         assert m.source == str(staged)
 
+    def test_reinstall_after_delete_restores_live_profile(self, profile_env):
+        from unittest.mock import patch
+
+        from hermes_cli.profiles import (
+            delete_profile,
+            list_profiles,
+            profile_exists,
+            resolve_profile_env,
+        )
+        from hermes_constants import named_profile_is_deleted
+
+        staged = _make_staging_dir(profile_env, "reinstall")
+        original = install_distribution(str(staged), name="reinstalled")
+        with patch("hermes_cli.profiles._cleanup_gateway_service"), patch(
+            "hermes_cli.profiles._stop_profile_backends"
+        ):
+            delete_profile("reinstalled", yes=True)
+
+        assert named_profile_is_deleted(original.target_dir)
+        assert not profile_exists("reinstalled")
+
+        reinstalled = install_distribution(str(staged), name="reinstalled")
+
+        assert not named_profile_is_deleted(reinstalled.target_dir)
+        assert profile_exists("reinstalled")
+        assert "reinstalled" in {profile.name for profile in list_profiles()}
+        assert Path(resolve_profile_env("reinstalled")) == reinstalled.target_dir
+
     def test_install_respects_distribution_owned_allowlist(self, profile_env):
         """Install must only copy paths listed in distribution_owned."""
         mf = DistributionManifest(


### PR DESCRIPTION
## What does this PR do?

Reinstalling a deleted distribution profile under the same name now makes the profile live again. Previously, installation restored the files but left the deletion tombstone in place, so profile listing and profile-scoped routing continued to reject the profile.

### Symptom

After `hermes profile delete <name>` followed by `hermes profile install <source> --name <name>`, the install exits successfully and restores the profile files, but the profile remains absent from `profile list` and unavailable to profile-scoped commands.

### Impact

Users cannot use a successfully reinstalled distribution profile without manually removing internal tombstone state.

### Bug Cause

**Trigger:** `hermes_cli/profile_distribution.py:662` / `install_distribution()` when installing a distribution with the same name as a deleted profile.

**Causal chain:**
1. `delete_profile()` records `profiles/.deleted/<name>` before removing the profile directory.
2. `install_distribution()` recreates the directory and copies the distribution payload but does not remove that marker.
3. Live-profile checks continue to treat the restored profile as deleted, so listing and profile-scoped routing reject it.

**Why it is wrong:** A successful reinstall recreates a complete profile but leaves its authoritative deletion marker unchanged.

**Working sibling / contrast:** `create_profile()` already clears the same tombstone when explicitly recreating a deleted profile.

**Ruled out:** Distribution payload copying is not the failure. The manifest and profile files are present after reinstall; the remaining tombstone alone keeps the profile non-live.

### Fix

Clear the named-profile tombstone only after the distribution payload and optional alias installation steps complete successfully. Add a regression test that installs, deletes, and reinstalls a distribution, then verifies tombstone state, profile existence, listing, and profile-scoped environment resolution.

## Related Issue

Closes #100772

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profile_distribution.py` - clear a deleted profile's tombstone after a successful distribution install.
- `tests/hermes_cli/test_profile_distribution.py` - cover delete-to-reinstall lifecycle consistency across profile lookup paths.

## How to Test

1. Run the distribution profile tests:
   `scripts/run_tests.sh tests/hermes_cli/test_profile_distribution.py -q`
2. Run the deleted-profile tombstone tests:
   `scripts/run_tests.sh tests/hermes_cli/test_deleted_profile_tombstone.py -q`
3. Confirm the suites report 67 passed and no failures.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated lifecycle coverage verifies the fix.
