### PR TITLE
fix(desktop,i18n): sync stale Russian locale keys

### DIFF
--- a/apps/desktop/src/i18n/ru.test.ts
+++ b/apps/desktop/src/i18n/ru.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+
+import { ru } from './ru'
+
+describe('russian locale catalog', () => {
+  it('translates the live terminal-selection keybind and drops the retired key', () => {
+    expect(ru.keybinds.actions['view.selectionToComposer']).toBe('Отправить выделенный текст в композер')
+    expect(ru.keybinds.actions).not.toHaveProperty('view.terminalSelection')
+  })
+
+  it('translates the live auxiliary review task and drops the retired one', () => {
+    expect(ru.settings.model.tasks.review).toEqual({ label: 'Ревью', hint: '/review — субагент-рецензент' })
+    expect(ru.settings.model.tasks).not.toHaveProperty('web_extract')
+  })
+
+  it('declines the starmap node count in the instrumental case', () => {
+    const importSuccess = ru.starmap.importSuccess
+
+    expect(importSuccess(1)).toBe('Загружена карта с 1 узлом.')
+    expect(importSuccess(2)).toBe('Загружена карта с 2 узлами.')
+    expect(importSuccess(5)).toBe('Загружена карта с 5 узлами.')
+    expect(importSuccess(11)).toBe('Загружена карта с 11 узлами.')
+    expect(importSuccess(12)).toBe('Загружена карта с 12 узлами.')
+    expect(importSuccess(21)).toBe('Загружена карта с 21 узлом.')
+    expect(importSuccess(22)).toBe('Загружена карта с 22 узлами.')
+  })
+
+  it('picks the right plural form at 1/2/5/11/12/21/22 across count strings', () => {
+    expect([1, 2, 5, 11, 12, 21, 22].map(ru.agents.agentsCount)).toEqual([
+      '1 агент',
+      '2 агента',
+      '5 агентов',
+      '11 агентов',
+      '12 агентов',
+      '21 агент',
+      '22 агента'
+    ])
+
+    expect([1, 2, 5, 11, 12, 21, 22].map(ru.settings.about.minAgo)).toEqual([
+      '1 минуту назад',
+      '2 минуты назад',
+      '5 минут назад',
+      '11 минут назад',
+      '12 минут назад',
+      '21 минуту назад',
+      '22 минуты назад'
+    ])
+
+    expect([1, 2, 5, 11, 12, 21, 22].map(ru.zones.tabCount)).toEqual([
+      '1 вкладка',
+      '2 вкладки',
+      '5 вкладок',
+      '11 вкладок',
+      '12 вкладок',
+      '21 вкладка',
+      '22 вкладки'
+    ])
+  })
+})

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -307,7 +307,7 @@ export const ru = defineLocale({
       'view.nextTerminal': 'Следующий терминал',
       'view.prevTerminal': 'Предыдущий терминал',
       'view.closeTerminal': 'Закрыть терминал',
-      'view.terminalSelection': 'Отправить выделенное из терминала в композер',
+      'view.selectionToComposer': 'Отправить выделенный текст в композер',
       'view.terminalCopy': 'Копировать выделенное из терминала',
       'view.terminalPaste': 'Вставить в терминал',
       'view.closeTab': 'Закрыть вкладку',
@@ -1328,12 +1328,12 @@ export const ru = defineLocale({
       notInCatalog: 'нет в списке моделей этого провайдера — вызовы могут уходить на запасную.',
       tasks: {
         vision: { label: 'Зрение', hint: 'Анализ изображений' },
-        web_extract: { label: 'Веб-извлечение', hint: 'Суммаризация страниц' },
         compression: { label: 'Сжатие', hint: 'Компрессия контекста' },
         skills_hub: { label: 'Хаб навыков', hint: 'Поиск навыков' },
         approval: { label: 'Одобрение', hint: 'Умное авто-одобрение' },
         mcp: { label: 'MCP', hint: 'Маршрутизация MCP-инструментов' },
         title_generation: { label: 'Ген. заголовка', hint: 'Заголовки сеансов' },
+        review: { label: 'Ревью', hint: '/review — субагент-рецензент' },
         curator: { label: 'Куратор', hint: 'Просмотр использования навыков' }
       }
     },
@@ -1616,7 +1616,7 @@ export const ru = defineLocale({
     importMap: 'Импортировать карту',
     importBtn: 'Загрузить',
     importEmpty: 'Вставьте код карты для загрузки.',
-    importSuccess: nodes => `Загружена карта с ${nodes} ${RU_NOUN(nodes, 'узлом', 'узла', 'узлов')}.`,
+    importSuccess: nodes => `Загружена карта с ${nodes} ${RU_NOUN(nodes, 'узлом', 'узлами', 'узлами')}.`,
     importedBadge: 'импортированная карта',
     resetToMine: 'Вернуться к моей карте'
   },

--- a/apps/desktop/src/i18n/runtime.test.ts
+++ b/apps/desktop/src/i18n/runtime.test.ts
@@ -52,6 +52,13 @@ describe('desktop i18n runtime translator', () => {
     )
   })
 
+  it('resolves russian copy through the runtime locale', () => {
+    setRuntimeI18nLocale('ru')
+
+    expect(translateNow('settings.model.tasks.review.label')).toBe('Ревью')
+    expect(translateNow('starmap.importSuccess', 21)).toBe('Загружена карта с 21 узлом.')
+  })
+
   it('keeps translated settings field copy addressable from schema keys', () => {
     const field = ['display', 'show_reasoning'].join('.')
 


### PR DESCRIPTION
## Summary

Keep the accepted Russian Desktop locale in sync with recent upstream changes.

- replace the retired `view.terminalSelection` key with
  `view.selectionToComposer`
- replace the retired `web_extract` auxiliary task copy with `review`
- correct the instrumental case in the starmap import confirmation
- add focused regression coverage for Russian runtime resolution, live
  dynamic keys, and plural boundaries

## Why

The Russian locale was prepared before several upstream key changes landed.
Because these sections use `Record<string, ...>`, TypeScript does not detect
stale keys. Russian users consequently received English fallback labels for
“Send selection to composer” and “Review”.

The starmap confirmation also used genitive plural forms after `с`, producing
phrases such as `с 5 узлов` instead of `с 5 узлами`.

## Testing

- `npx vitest run --project ui src/i18n/ru.test.ts src/i18n/runtime.test.ts src/i18n/languages.test.ts`
  - 3 files passed
  - 16 tests passed
- `npx prettier --check src/i18n/ru.ts src/i18n/ru.test.ts src/i18n/runtime.test.ts`
- `npx eslint src/i18n/ru.ts src/i18n/ru.test.ts src/i18n/runtime.test.ts`
- `git diff --check`

All targeted checks passed.
