### PR TITLE
fix(gateway): stop unreadable sessions from silently losing context

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2648,6 +2648,7 @@ from gateway.session import (
     SessionStore,
     SessionSource,
     SessionContext,
+    TranscriptReadError,
     build_session_context,
     build_session_context_prompt,
     build_channel_continuity_note,
@@ -19731,8 +19732,23 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # began processing if the gateway died while it was still waiting.
         await self._mark_durable_active_turn(event, session_entry.session_key)
 
-        # Load conversation history from transcript
-        history = await self.async_session_store.load_transcript(session_entry.session_id)
+        # Load conversation history from transcript. An unreadable canonical
+        # store is not an empty conversation: stop before the agent can invent
+        # continuity from a plausible-looking []. This return happens before
+        # the broad cleanup finally below, so restore task-local context here;
+        # the outer dispatch still clears the durable marker and turn lease.
+        try:
+            history = await self.async_session_store.load_transcript(
+                session_entry.session_id
+            )
+        except TranscriptReadError:
+            self._clear_session_env(_session_env_tokens)
+            return (
+                "⚠️ This session's history is temporarily unavailable, so "
+                "this message was not processed. Ask the operator to inspect "
+                "state.db, then resend after it is healthy. Use /reset only "
+                "if you intentionally want to start a new conversation."
+            )
         
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -23,6 +23,14 @@ from typing import Dict, List, Optional, Any
 logger = logging.getLogger(__name__)
 
 
+class TranscriptReadError(RuntimeError):
+    """Raised when persisted history cannot be read safely."""
+
+    def __init__(self, session_id: str) -> None:
+        self.session_id = session_id
+        super().__init__(f"transcript read failed for session {session_id}")
+
+
 def _now() -> datetime:
     """Return the current local time."""
     return datetime.now()
@@ -4085,15 +4093,17 @@ class SessionStore:
                 session_id, repair_alternation=True
             )
         except Exception as e:
-            # A failed read must be distinguishable from an empty transcript:
-            # downstream guards treat [] as "nothing persisted" and may make
-            # routing decisions on it (#82616). WARNING, not DEBUG.
-            logger.warning(
-                "Transcript read failed for session %s (returning empty; "
-                "downstream must not treat this as data loss): %s",
-                session_id, e,
+            # Empty history is valid data; a failed canonical read is not.
+            # Preserve that distinction so live-replay callers can fail closed
+            # instead of starting the model with a plausible-looking [].
+            logger.error(
+                "Transcript read failed for session %s; refusing to treat the "
+                "conversation as empty: %s",
+                session_id,
+                e,
+                exc_info=True,
             )
-            return []
+            raise TranscriptReadError(session_id) from e
 
     def rewind_session(
         self,

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -24,7 +24,7 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource
+from gateway.session import SessionEntry, SessionSource, TranscriptReadError
 
 
 def _bootstrap(monkeypatch, tmp_path):
@@ -183,6 +183,24 @@ async def test_not_new_messages_skip_db_when_agent_has_session_db(
     _assert_user_call_has_skip_db(
         runner.session_store.append_to_transcript.call_args_list, True
     )
+
+
+@pytest.mark.asyncio
+async def test_transcript_read_failure_stops_turn_before_agent_or_append(
+    monkeypatch, tmp_path
+):
+    runner = _bootstrap(monkeypatch, tmp_path)
+    runner.session_store.load_transcript.side_effect = TranscriptReadError("sess-dedup")
+    runner._run_agent = AsyncMock()
+
+    response = await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert "history is temporarily unavailable" in response
+    assert "not processed" in response
+    runner._run_agent.assert_not_awaited()
+    runner.session_store.append_to_transcript.assert_not_called()
 
 
 # ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────

--- a/tests/gateway/test_42039_duplicate_user_message.py
+++ b/tests/gateway/test_42039_duplicate_user_message.py
@@ -24,7 +24,13 @@ import pytest
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform
 from gateway.platforms.base import MessageEvent
-from gateway.session import SessionEntry, SessionSource, TranscriptReadError
+from gateway.session import (
+    AsyncSessionStore,
+    SessionEntry,
+    SessionSource,
+    SessionStore,
+    TranscriptReadError,
+)
 
 
 def _bootstrap(monkeypatch, tmp_path):
@@ -201,6 +207,66 @@ async def test_transcript_read_failure_stops_turn_before_agent_or_append(
     assert "not processed" in response
     runner._run_agent.assert_not_awaited()
     runner.session_store.append_to_transcript.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_real_sqlite_read_failure_releases_outer_gateway_turn(
+    monkeypatch, tmp_path
+):
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+    monkeypatch.setattr("hermes_cli.lifecycle.invoke_hook", lambda *_a, **_kw: [])
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    config = GatewayConfig()
+    runner = gateway_run.GatewayRunner(config)
+    store = SessionStore(sessions_dir=tmp_path / "sessions", config=config)
+    runner.session_store = store
+    runner._async_session_store = AsyncSessionStore(store)
+    runner._is_user_authorized_for_source = lambda _source: True
+    runner._run_agent = AsyncMock()
+
+    source = _source()
+    existing = await runner.async_session_store.get_or_create_session(source)
+    await runner.async_session_store.append_to_transcript(
+        existing.session_id, {"role": "user", "content": "persisted history"}
+    )
+    history = await runner.async_session_store.load_transcript(existing.session_id)
+    assert len(history) == 1
+    assert history[0]["role"] == "user"
+    assert history[0]["content"] == "persisted history"
+
+    empty_source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1002",
+        chat_type="group",
+        user_id="12345",
+    )
+    empty = await runner.async_session_store.get_or_create_session(empty_source)
+    assert await runner.async_session_store.load_transcript(empty.session_id) == []
+
+    append_spy = MagicMock(wraps=store.append_to_transcript)
+    store.append_to_transcript = append_spy
+    db = store._db
+    assert db is not None
+    with db._lock:
+        db._conn.execute("DROP TABLE messages")
+        db._conn.commit()
+
+    response = await runner._handle_message(_event())
+
+    assert "history is temporarily unavailable" in response
+    assert "not processed" in response
+    runner._run_agent.assert_not_awaited()
+    append_spy.assert_not_called()
+
+    session_key = existing.session_key
+    state = runner._peek_session_state(session_key)
+    assert state is not None
+    assert state.turn.agent is None
+    assert state.turn.lease is None
+    assert not any(key[0] == session_key for key in runner._turn_lease_tokens)
 
 
 # ── Post-stream MEDIA delivery keeps prior-turn deduplication ──────────

--- a/tests/gateway/test_session_continuity_82616.py
+++ b/tests/gateway/test_session_continuity_82616.py
@@ -201,6 +201,28 @@ class TestPeerResolutionRecency:
 
 
 class TestLoadTranscriptReroutes:
+    def test_load_transcript_raises_when_message_read_fails(self, tmp_path, monkeypatch):
+        from gateway.session import SessionStore, TranscriptReadError
+
+        from gateway.config import GatewayConfig
+
+        store = SessionStore(sessions_dir=tmp_path / "gw-failed-read", config=GatewayConfig())
+        db = store._db
+        assert db is not None
+        monkeypatch.setattr(db, "get_compression_tip", lambda _session_id: None)
+
+        def _malformed(_session_id, *, repair_alternation):
+            assert repair_alternation is True
+            raise RuntimeError("database disk image is malformed")
+
+        monkeypatch.setattr(db, "get_messages_as_conversation", _malformed)
+
+        with pytest.raises(TranscriptReadError) as exc_info:
+            store.load_transcript("existing-session")
+
+        assert exc_info.value.session_id == "existing-session"
+        assert isinstance(exc_info.value.__cause__, RuntimeError)
+
     def test_load_transcript_follows_reroute_chain(self, tmp_path):
         from gateway.session import SessionStore
 


### PR DESCRIPTION
## What does this PR do?

A failed `state.db` transcript read no longer looks like a new conversation. The gateway now preserves the failure as `TranscriptReadError`, stops the inbound turn before the model can run without prior context, and tells the user that the message was not processed.

### Symptom

When `SessionStore.load_transcript()` encountered an error such as `database disk image is malformed`, it logged a warning and returned `[]`. After a gateway restart removed the live in-memory fallback, the next Telegram turn ran as though the existing session had no history.

### Impact

Users with an unreadable session database could receive context-free answers from an existing conversation without any visible indication that history loading failed. The model could also guess what prior short replies referred to because the failed read was indistinguishable from a genuinely empty session.

### Bug Cause

**Trigger:** `gateway/session.py:SessionStore.load_transcript()` catches an exception from `get_messages_as_conversation()`.

**Causal chain:**
1. An existing gateway session has persisted messages, but its canonical transcript read raises a database error.
2. `load_transcript()` converts that failure to `[]`, the same value used for a valid empty session.
3. `GatewayRunner._handle_message_with_agent()` passes the empty history to the model, which processes the turn without the prior conversation.

**Why it is wrong:** The return value erased the distinction between valid data and failed I/O, so the live replay path could not fail closed.

**Working sibling / contrast:** A genuinely empty session still returns `[]` normally; only exceptional reads now raise the dedicated failure type.

**Ruled out:** Compression rerouting was not the cause. The reported path reaches the resolved session and fails inside the canonical message query itself.

### Fix

`SessionStore.load_transcript()` now raises `TranscriptReadError` with the original database exception chained for operator diagnostics. The main gateway turn path catches that dedicated error before agent execution, avoids appending the inbound message to the unhealthy store, and returns a safe user-facing recovery notice without exposing raw database details.

## Related Issue

Closes #100788

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/session.py` - preserve failed transcript reads as a dedicated exception instead of an empty list.
- `gateway/run.py` - stop affected turns before model execution and return a visible recovery notice.
- `tests/gateway/test_session_continuity_82616.py` - cover the read-error contract and exception chaining.
- `tests/gateway/test_42039_duplicate_user_message.py` - prove failed reads do not invoke the agent or append the inbound message.

## How to Test

1. Force `get_messages_as_conversation()` to raise for an existing session and verify `load_transcript()` raises `TranscriptReadError` rather than returning `[]`.
2. Trigger the gateway message path with that failure and verify the agent and transcript append paths are not called.
3. Run:

```bash
scripts/run_tests.sh tests/gateway/test_session_continuity_82616.py tests/gateway/test_42039_duplicate_user_message.py tests/gateway/test_compress_command.py tests/gateway/test_compress_focus.py -q
```

Result: 24 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the change uses platform-independent Python exception handling
- [x] Tool description and schema updates are N/A because no tool behavior changed

## Screenshots / Logs

N/A - automated regression tests exercise the failed-read and gateway-turn paths.
