### PR TITLE
fix(acp): clear is_running in finally so a cancelled turn never bricks the session (#86798)

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2129,64 +2129,71 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
-        if result.get("messages"):
-            state.history = result["messages"]
-            # Persist updated history so sessions survive process restarts.
-            self.session_manager.save_session(session_id)
+        try:
+            if result.get("messages"):
+                state.history = result["messages"]
+                # Persist updated history so sessions survive process restarts.
+                self.session_manager.save_session(session_id)
 
-        # Detect a compression-driven internal session rotation. If the agent's
-        # DB head moved during the turn, emit a session_info_update carrying
-        # _meta.hermes.sessionProvenance so ACP clients can render the boundary
-        # and keep old/new ids in lineage. The ACP session_id is unchanged.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
-        if (
-            conn
-            and post_turn_hermes_id
-            and pre_turn_hermes_id
-            and post_turn_hermes_id != pre_turn_hermes_id
-        ):
-            try:
-                await self._send_session_info_update(
-                    session_id,
-                    current_hermes_session_id=post_turn_hermes_id,
-                    previous_hermes_session_id=pre_turn_hermes_id,
-                )
-            except Exception:
-                logger.debug(
-                    "Could not emit ACP provenance update after rotation for %s",
-                    session_id,
-                    exc_info=True,
-                )
+            # Detect a compression-driven internal session rotation. If the agent's
+            # DB head moved during the turn, emit a session_info_update carrying
+            # _meta.hermes.sessionProvenance so ACP clients can render the boundary
+            # and keep old/new ids in lineage. The ACP session_id is unchanged.
+            post_turn_hermes_id = getattr(state.agent, "session_id", None)
+            if (
+                conn
+                and post_turn_hermes_id
+                and pre_turn_hermes_id
+                and post_turn_hermes_id != pre_turn_hermes_id
+            ):
+                try:
+                    await self._send_session_info_update(
+                        session_id,
+                        current_hermes_session_id=post_turn_hermes_id,
+                        previous_hermes_session_id=pre_turn_hermes_id,
+                    )
+                except Exception:
+                    logger.debug(
+                        "Could not emit ACP provenance update after rotation for %s",
+                        session_id,
+                        exc_info=True,
+                    )
 
-        final_response = result.get("final_response", "")
-        cancelled = bool(state.cancel_event and state.cancel_event.is_set())
-        interrupted = bool(result.get("interrupted")) or cancelled
-        # Hermes' local "waiting for model response" interrupt status is metadata,
-        # not assistant prose — clients get cancellation from stop_reason instead.
-        from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            # Use `or` (not .get default) so an explicit None value — e.g. a
+            # cancelled turn returns {"final_response": None} — is coerced to
+            # "", never left as None where the startswith below would crash
+            # (#86798). .get(key, "") only defaults when the KEY is absent.
+            final_response = result.get("final_response") or ""
+            cancelled = bool(state.cancel_event and state.cancel_event.is_set())
+            interrupted = bool(result.get("interrupted")) or cancelled
+            # Hermes' local "waiting for model response" interrupt status is metadata,
+            # not assistant prose — clients get cancellation from stop_reason instead.
+            from agent.conversation_loop import INTERRUPT_WAITING_FOR_MODEL_PREFIX
 
-        suppress_interrupt_response = interrupted and final_response.startswith(
-            INTERRUPT_WAITING_FOR_MODEL_PREFIX
-        )
-        if (
-            final_response
-            and conn
-            and not suppress_interrupt_response
-            and (not streamed_message or result.get("response_transformed"))
-        ):
-            # Deliver the final response when streaming did not already send it,
-            # or when a plugin hook transformed the response after streaming
-            # finished (e.g. transform_llm_output) — otherwise the appended /
-            # rewritten text never reaches the client.
-            update = acp.update_agent_message_text(final_response)
-            await conn.session_update(session_id, update)
-
-        # Mark this turn idle before draining queued work so recursive prompt()
-        # calls can acquire the session. Queued turns are intentionally run as
-        # normal follow-up user prompts, preserving role alternation and history.
-        with state.runtime_lock:
-            state.is_running = False
-            state.current_prompt_text = ""
+            suppress_interrupt_response = interrupted and final_response.startswith(
+                INTERRUPT_WAITING_FOR_MODEL_PREFIX
+            )
+            if (
+                final_response
+                and conn
+                and not suppress_interrupt_response
+                and (not streamed_message or result.get("response_transformed"))
+            ):
+                # Deliver the final response when streaming did not already send it,
+                # or when a plugin hook transformed the response after streaming
+                # finished (e.g. transform_llm_output) — otherwise the appended /
+                # rewritten text never reaches the client.
+                update = acp.update_agent_message_text(final_response)
+                await conn.session_update(session_id, update)
+        finally:
+            # Mark this turn idle before draining queued work so recursive prompt()
+            # calls can acquire the session. Runs on every exit (including when a
+            # mid-turn conn.session_update/etc. raises) so the session is never left
+            # permanently "running" with queued prompts bricked (#86798). Queued
+            # turns are intentionally run as normal follow-up user prompts below.
+            with state.runtime_lock:
+                state.is_running = False
+                state.current_prompt_text = ""
 
         while True:
             with state.runtime_lock:

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -726,3 +726,80 @@ class TestRegisterSessionMcpServers:
         with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])
+
+@pytest.mark.asyncio
+async def test_prompt_cancelled_turn_with_none_response_does_not_brick_session(agent):
+    """#86798: a cancelled turn whose final_response is None must not crash or
+    leave the session permanently running with prompts queued forever."""
+    new_resp = await agent.new_session(cwd=".")
+    state = agent.session_manager.get_session(new_resp.session_id)
+
+    def mock_run(*args, **kwargs):
+        state.cancel_event.set()
+        return {
+            "final_response": None,
+            "messages": [],
+            "interrupted": True,
+            "completed": False,
+        }
+
+    state.agent.run_conversation = mock_run
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    agent._conn = mock_conn
+
+    resp = await agent.prompt(
+        prompt=[TextContentBlock(type="text", text="do something slow")],
+        session_id=new_resp.session_id,
+    )
+
+    assert resp.stop_reason == "cancelled"
+    assert state.is_running is False
+    assert state.queued_prompts == []
+
+    # A follow-up prompt must actually run, not sit queued forever.
+    state.cancel_event.clear()
+    follow_up_ran = []
+
+    def mock_run_ok(*args, **kwargs):
+        follow_up_ran.append(True)
+        return {"final_response": "done", "messages": [], "completed": True}
+
+    state.agent.run_conversation = mock_run_ok
+    resp2 = await agent.prompt(
+        prompt=[TextContentBlock(type="text", text="follow up")],
+        session_id=new_resp.session_id,
+    )
+
+    assert resp2.stop_reason == "end_turn"
+    assert follow_up_ran, "follow-up prompt was queued instead of running"
+
+
+@pytest.mark.asyncio
+async def test_prompt_tail_exception_still_releases_session(agent):
+    """#86798: if the post-turn tail (save_session etc.) raises, is_running
+    must still be cleared via the finally so the session isn't bricked."""
+    new_resp = await agent.new_session(cwd=".")
+    state = agent.session_manager.get_session(new_resp.session_id)
+
+    def mock_run(*args, **kwargs):
+        return {
+            "final_response": "ok",
+            "messages": [{"role": "user", "content": "x"}],
+            "completed": True,
+        }
+
+    state.agent.run_conversation = mock_run
+    agent.session_manager.save_session = MagicMock(side_effect=RuntimeError("disk full"))
+    mock_conn = MagicMock(spec=acp.Client)
+    mock_conn.session_update = AsyncMock()
+    agent._conn = mock_conn
+
+    with pytest.raises(RuntimeError, match="disk full"):
+        await agent.prompt(
+            prompt=[TextContentBlock(type="text", text="hi")],
+            session_id=new_resp.session_id,
+        )
+
+    assert state.is_running is False
+    assert state.current_prompt_text == ""


### PR DESCRIPTION
## 问题

修复 #86798：ACP turn 被取消时，`HermesACPAgent.prompt()` 的 post-turn 尾部会崩。

取消的 turn 返回 `{"final_response": None}`。尾部代码在 `INTERRUPT_WAITING_FOR_MODEL_PREFIX` 检查处对 `final_response` 调 `.startswith(...)`，而 `result.get("final_response", "")` **只在 key 缺失时给默认值**——显式的 None 值会原样穿过，于是崩 `'NoneType' object has no attribute 'startswith'`。

崩溃发生在 `state.is_running = False` 复位**之前**（复位排在 session_update/尾部代码之后），所以会话永久卡在 `is_running=True`；之后每个 prompt 都只回 `"Queued for the next turn. (N queued)"`，直到进程被杀。任何在 running session 运行时发 system 消息的编排客户端都能复现，不止编辑器 cancel-and-resend。

## 修法

**1. coercion 用 `or ""` 而非 `.get(key, "")`**
`final_response = result.get("final_response") or ""` —— 把显式的 None（cancelled/interrupted turn）归一为 `""` 再做 `startswith`。这是 reporter 实测过的最小修复。

**2. 把 `is_running=False` 复位挪进 `finally`**
复位现在放进覆盖整个 post-turn 尾部（history save、provenance update、session_update 投递）的 `finally`，在任何退出路径上都执行——包括 `save_session` 或 `conn.session_update` 中途抛异常时。被 wedged/interrupted 的 turn 再也不可能把会话永久留在 running 态把 queued prompt 卡死。

## 测试

`tests/acp/test_server.py` 新增两个回归：
- 取消的 turn（final_response=None）以 `cancelled` 停止、释放会话、后续 follow-up 真正运行而非排队；
- 尾部抛异常（save_session RuntimeError）仍通过 finally 清掉 is_running。

本仓库 tests/acp + tests/acp_adapter 全绿（153 passed）。

Fixes #86798