### PR TITLE
fix(computer_use): recover coordinate scroll from driver schema

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -1822,9 +1822,7 @@ class TestClickButtonPassthrough:
 
     def test_coordinate_drag_and_scroll_keep_the_captured_window(self):
         backend = self._backend_with_active_target()
-        # Mock the capability check so x/y are included (they're gated
-        # behind the input.scroll.coordinates capability).
-        backend._session.supports_capability.return_value = True
+        cast(MagicMock, backend._session.supports_input_property).return_value = True
 
         backend.drag(from_xy=(10, 20), to_xy=(30, 40))
         drag_name, drag_args = backend._session.call_tool.call_args.args
@@ -1844,6 +1842,125 @@ class TestClickButtonPassthrough:
         assert scroll_name == "scroll"
         assert scroll_args["window_id"] == 222
         assert scroll_args["x"] == 50 and scroll_args["y"] == 60
+
+    def _backend_with_scroll_schema(
+            self, axis_schemas, *, capabilities=(), pid=111, window_id=222, replacement_axis_schemas=None,
+            schema_uri=None):
+        import asyncio
+        from types import SimpleNamespace
+
+        from jsonschema import Draft202012Validator
+        from tools.computer_use.cua_backend_session import _CuaDriverSession
+
+        def scroll_schema(axes):
+            properties = {
+                "pid": {"type": "integer"},
+                "window_id": {"type": "integer"},
+                "direction": {"enum": ["up", "down", "left", "right"]},
+                "amount": {"type": "integer"},
+                "session": {"type": "string"},
+                **axes,
+            }
+            return {**({"$schema": schema_uri} if schema_uri is not None else {}),
+                    "type": "object", "additionalProperties": False, "properties": properties,
+                    "required": ["pid", "window_id", "direction", "amount", "session"]}
+
+        class InlineBridge:
+            @staticmethod
+            def run(coro, timeout=30.0):
+                return asyncio.run(coro)
+
+        backend = self._backend_with_active_target()
+        backend._active_pid = pid
+        backend._active_window_id = window_id
+        session = _CuaDriverSession(cast(Any, InlineBridge()))
+        session._started = True
+        session._timeout_suspect = replacement_axis_schemas is not None
+        session._capabilities = {"scroll": set(capabilities)}
+        session._tool_schemas = {"scroll": scroll_schema(axis_schemas)}
+
+        class StrictMcpSession:
+            def __init__(self):
+                self.calls = []
+
+            async def call_tool(self, name, args):
+                self.calls.append((name, dict(args)))
+                Draft202012Validator(session._tool_schemas[name]).validate(args)
+                return SimpleNamespace(
+                    content=[SimpleNamespace(type="text", text="ok")],
+                    structured_content=None,
+                    is_error=False,
+                )
+
+        transport = StrictMcpSession()
+        session._session = cast(Any, transport)
+        if replacement_axis_schemas is not None:
+            def recreate(name, timeout, log_msg, *, restart=True, clear_timeout_suspect=False):
+                session._tool_schemas = {"scroll": scroll_schema(replacement_axis_schemas)}
+                session._tool_schema_validators = {}
+                session._started = True
+                if clear_timeout_suspect:
+                    session._timeout_suspect = False
+            session._recreate_session = recreate
+        backend._session = session
+        return backend, transport
+
+    @pytest.mark.parametrize(("coordinate", "axis_schemas", "element", "expected"), [
+        ([50, 60], {"x": {"type": "integer"}, "y": {"type": "integer"}}, None, {"x": 50, "y": 60}),
+        ([50, None], {"x": {"type": "integer"}}, None, {"x": 50}),
+        ([None, 60], {"y": {"type": "integer"}}, None, {"y": 60}),
+        ([50, 60], {"element_index": {"type": "integer"}}, 7, {"element_index": 7}),
+    ])
+    def test_scroll_preserves_the_schema_declared_target(self, coordinate, axis_schemas, element, expected):
+        """Use each declared coordinate axis, while a valid element target retains first precedence (#89527)."""
+        from tools.computer_use import tool as cu_tool
+
+        backend, transport = self._backend_with_scroll_schema(axis_schemas)
+        request = {"action": "scroll", "direction": "down", "coordinate": coordinate}
+        if element is not None:
+            request["element"] = element
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            result = json.loads(cu_tool.handle_computer_use(request))
+
+        assert result["ok"] is True
+        assert len(transport.calls) == 1
+        name, args = transport.calls[0]
+        assert name == "scroll"
+        assert {axis: args[axis] for axis in expected} == expected
+        assert not ({"x", "y"} - set(expected)) & set(args)
+
+    @pytest.mark.parametrize(
+        ("coordinate", "axis_schemas", "pid", "window_id", "capabilities", "replacement_axis_schemas",
+         "schema_uri"), [
+            ([50, 60], {"x": {"type": "integer"}}, 111, 222, {"input.scroll.coordinates"}, None, None),
+            ([50, None], {"x": False}, 111, 222, set(), None, None),
+            ([50, None], {"x": {"type": "integer", "maximum": 10}}, 111, 222, set(), None, None),
+            ([None, 60], {}, 111, 222, set(), None, None),
+            ([50, None], {"x": {"type": "integer"}}, 111, None, set(), None, None),
+            ([None, 60], {"y": {"type": "integer"}}, 111, None, set(), None, None),
+            ([50, None], {"x": {"type": "integer"}}, None, None, set(), None, None),
+            ([50, 60], {"x": {"type": "integer"}, "y": {"type": "integer"}}, 111, 222, set(), {}, None),
+            ([50, None], {"x": {"type": "integer"}}, 111, 222, set(), None,
+             "https://example.invalid/unknown-dialect"),
+        ])
+    def test_coordinate_scroll_refuses_when_target_cannot_be_preserved(
+            self, coordinate, axis_schemas, pid, window_id, capabilities, replacement_axis_schemas, schema_uri):
+        """Unsupported, stale-schema, or untargetable coordinates refuse before transport instead of widening."""
+        from tools.computer_use import tool as cu_tool
+
+        backend, transport = self._backend_with_scroll_schema(
+            axis_schemas, capabilities=capabilities, pid=pid, window_id=window_id,
+            replacement_axis_schemas=replacement_axis_schemas, schema_uri=schema_uri)
+
+        with patch.object(cu_tool, "_get_backend", return_value=backend):
+            result = json.loads(cu_tool.handle_computer_use({"action": "scroll", "direction": "down",
+                                                             "coordinate": coordinate}))
+
+        assert result["ok"] is False
+        assert result["action"] == "scroll"
+        assert result["code"] == "coordinate_scroll_unsupported"
+        assert transport.calls == []
 
     def test_coordinate_actions_without_window_id_fail_closed(self):
         backend = self._backend_with_active_target()

--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -352,7 +352,8 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         payload.setdefault("session", self._session_id)
         return self._session.call_tool(name, payload, timeout=timeout)
 
-    def _action(self, name: str, args: Dict[str, Any], *, inject_session: bool = True) -> ActionResult:
+    def _action(self, name: str, args: Dict[str, Any], *, inject_session: bool = True,
+                schema_guard: Optional[tuple[tuple[str, ...], str, str]] = None) -> ActionResult:
         # Attach the snapshot's `element_token` to an `element_index` call so a superseded snapshot yields an explicit
         # 'stale' error. Gated on the per-tool capability: older drivers (`additionalProperties: false`) must never see it.
         idx = args.get("element_index")
@@ -362,7 +363,8 @@ class CuaDriverBackend(_CaptureMixin, _InputMixin, ComputerUseBackend):
         if inject_session:  # setdefault preserves any explicit session a caller already supplied
             args.setdefault("session", self._session_id)
         try:
-            out = self._session.call_tool(name, args)
+            out = (self._session.call_tool(name, args, schema_guard=schema_guard) if schema_guard is not None
+                   else self._session.call_tool(name, args))
         except Exception as e:
             logger.exception("cua-driver %s call failed", name)
             return ActionResult(ok=False, action=name, message=f"cua-driver error: {e}")

--- a/tools/computer_use/cua_backend_input.py
+++ b/tools/computer_use/cua_backend_input.py
@@ -13,6 +13,8 @@ _BTF_UNSUPPORTED_MSG = "The connected cua-driver does not advertise the standalo
 _FOREGROUND_UNSUPPORTED_MSG = ("The connected cua-driver action schema does not accept delivery_mode, so foreground "
                                "delivery is unavailable. Use another verified rung without assuming the reported "
                                "package version describes the live schema.")
+_COORDINATE_SCROLL_UNSUPPORTED_MSG = ("The connected cua-driver scroll schema cannot preserve the requested coordinate "
+                                      "target; retry without coordinates only if a window-wide scroll is intended.")
 # (what, extra args) pointer addressing form; ``extra`` is None when the caller did not supply that form and
 # may be a callable when computing it has side effects (capability probes) that must follow the refusal checks.
 _Variant = Tuple[str, Union[None, Dict[str, Any], Callable[[], Dict[str, Any]]]]
@@ -62,7 +64,8 @@ class _InputMixin:
         return None
 
     def _run_input_action(self, action: str, args: Dict[str, Any], delivery_mode: Optional[str],
-                          bring_to_front: bool) -> ActionResult:
+                          bring_to_front: bool,
+                          schema_guard: Optional[tuple[tuple[str, ...], str, str]] = None) -> ActionResult:
         """Apply one delivery rung, optionally focusing via its own tool. ``bring_to_front`` is never an
         input-action property: when requested, the separately approved standalone focus action runs first,
         then the original foreground input runs unchanged."""
@@ -81,7 +84,7 @@ class _InputMixin:
             focused = self.bring_to_front(pid=self._active_pid, window_id=self._active_window_id)
             if not focused.ok:
                 return focused
-        result = self._action(action, args)
+        result = self._action(action, args, schema_guard=schema_guard)
         if bring_to_front:
             result.meta["foreground_focus"] = {"invoked": True, "tool": "bring_to_front"}
         return result
@@ -128,22 +131,33 @@ class _InputMixin:
     def scroll(self, *, direction: str, amount: int = 3, element: Optional[int] = None,
                x: Optional[int] = None, y: Optional[int] = None, modifiers: Optional[List[str]] = None,
                delivery_mode: Optional[str] = None, bring_to_front: bool = False) -> ActionResult:
+        coordinate_target = x is not None or y is not None
         refusal, args = self._target_args("scroll")
         if refusal is not None:
-            return refusal
+            return (_refuse("scroll", "No active window_id for coordinate scroll.",
+                            code="coordinate_scroll_unsupported") if coordinate_target else refusal)
         args.update(direction=direction, amount=max(1, min(50, amount)))
-        # An element without a known window_id is not an addressing form here; scrolling then falls through
-        # to the coordinate form or the bare window. Some driver schemas reject x/y on scroll: only send
-        # coordinates when the driver advertises support; otherwise it scrolls the targeted window
-        # (window_id is still sent for routing).
-        xy = lambda: ({"x": x, "y": y}  # noqa: E731
-                      if self._session.supports_capability("input.scroll.coordinates", tool="scroll") else {})
+        # The raw input schema is authoritative: a capability token cannot make strict schemas accept x/y.
+        # Refuse rather than silently changing an explicit coordinate target into a window-wide scroll (#89527).
+        element_target = element is not None and self._active_window_id is not None
+        xy = None
+        if coordinate_target and not element_target:
+            if self._active_window_id is None:
+                return _refuse("scroll", "No active window_id for coordinate scroll.",
+                               code="coordinate_scroll_unsupported")
+            xy = {}
+            for axis, value in (("x", x), ("y", y)):
+                if value is not None:
+                    xy[axis] = value
         refusal = self._pointer_args("scroll", args, (
             ("element scroll", {"element_index": element}
-             if element is not None and self._active_window_id is not None else None),
-            ("coordinate scroll", xy if x is not None and y is not None else None),
+             if element_target else None),
+            ("coordinate scroll", xy),
         ), None)
-        return refusal if refusal is not None else self._run_input_action("scroll", args, delivery_mode, bring_to_front)
+        schema_guard = ((tuple(xy), "coordinate_scroll_unsupported", _COORDINATE_SCROLL_UNSUPPORTED_MSG)
+                        if xy is not None else None)
+        return refusal if refusal is not None else self._run_input_action(
+            "scroll", args, delivery_mode, bring_to_front, schema_guard=schema_guard)
 
     def type_text(self, text: str, *, delivery_mode: Optional[str] = None, bring_to_front: bool = False) -> ActionResult:
         refusal, args = self._target_args("type_text", need_window=True)

--- a/tools/computer_use/cua_backend_session.py
+++ b/tools/computer_use/cua_backend_session.py
@@ -12,7 +12,7 @@ import json
 import logging
 import os
 import threading
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, cast
 
 from hermes_cli._subprocess_compat import windows_hide_flags
 from tools.computer_use import cua_backend_driver as _driver
@@ -197,6 +197,7 @@ class _CuaDriverSession:
         # #47072.
         self._capabilities: Dict[str, set] = {}
         self._tool_schemas: Dict[str, Dict[str, Any]] = {}
+        self._tool_schema_validators: Dict[str, Any] = {}
         self._capability_version, self._ready_event = "", threading.Event()
         self._shutdown_event: Optional[asyncio.Event] = None  # created on bridge loop
         self._lifecycle_future = None  # concurrent.futures.Future
@@ -265,7 +266,7 @@ class _CuaDriverSession:
     async def _populate_capabilities(self, session: Any) -> None:
         """Cache per-tool capability sets, input schemas and capability_version from tools/list. Soft
         prerequisite: on failure the map stays empty (capability False)."""
-        self._capabilities, self._tool_schemas, self._capability_version = {}, {}, ""
+        self._capabilities, self._tool_schemas, self._tool_schema_validators, self._capability_version = {}, {}, {}, ""
         try:
             tools_list = await session.list_tools()
             for tool in getattr(tools_list, "tools", []) or []:
@@ -373,6 +374,34 @@ class _CuaDriverSession:
         properties = schema.get("properties") if isinstance(schema, dict) else None
         return isinstance(properties, dict) and property_name in properties
 
+    def _input_schema_accepts(self, tool: str, args: Dict[str, Any], required_properties: tuple[str, ...]) -> bool:
+        """The current live schema explicitly declares every required property and accepts the complete payload."""
+        schema = getattr(self, "_tool_schemas", {}).get(tool)
+        if not isinstance(schema, dict):
+            return False
+        properties = schema.get("properties")
+        if not isinstance(properties, dict) or any(name not in properties for name in required_properties):
+            return False
+        try:
+            from jsonschema.validators import validator_for
+            validators = getattr(self, "_tool_schema_validators", None)
+            if validators is None:
+                self._tool_schema_validators = validators = {}
+            validator = validators.get(tool)
+            if validator is None:
+                # validator_for otherwise falls back to the latest draft when an explicit dialect URI is unknown.
+                # Unknown keywords could then be treated as annotations, so an unrecognised declaration must refuse.
+                validator_cls = (validator_for(schema, default=cast(Any, None)) if "$schema" in schema
+                                 else validator_for(schema))
+                if validator_cls is None:
+                    return False
+                validator_cls.check_schema(schema)
+                validators[tool] = validator = validator_cls(schema)
+            return validator.is_valid(args)
+        except Exception:
+            logger.debug("cua-driver %s input schema could not validate guarded payload", tool, exc_info=True)
+            return False
+
     @property
     def capabilities_discovered(self) -> bool:
         """tools/list populated the map; when False ``_has_tool`` is untrustworthy."""
@@ -426,7 +455,7 @@ class _CuaDriverSession:
                 except Exception as e:
                     logger.debug("cua-driver session cleanup before reconnect failed: %s", e)
                 self._started = False
-                self._capabilities, self._tool_schemas, self._capability_version = {}, {}, ""
+                self._capabilities, self._tool_schemas, self._tool_schema_validators, self._capability_version = {}, {}, {}, ""
                 self._start_lifecycle_locked()
                 self._started = True
             if clear_timeout_suspect:
@@ -465,7 +494,8 @@ class _CuaDriverSession:
                 with contextlib.suppress(OSError):
                     os.remove(shot_file)
 
-    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
+    def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0,
+                  schema_guard: Optional[tuple[tuple[str, ...], str, str]] = None) -> Dict[str, Any]:
         if name not in self._LIFECYCLE_CALLS:
             # A prior MCP timeout marks the session suspect (possibly wedged): recreate it so one timeout never
             # poisons the run. Healthy sessions are never restarted here.
@@ -479,6 +509,12 @@ class _CuaDriverSession:
                     name, timeout, "cua-driver session not active on %s; (re)starting before call", restart=False)
         if not self._started:
             raise RuntimeError("cua-driver session not started")
+        if schema_guard is not None:
+            required_properties, code, message = schema_guard
+            if not self._input_schema_accepts(name, args, required_properties):
+                return _tool_envelope(message, [], {
+                    "ok": False, "code": code, "message": message, "operation": name,
+                }, True, [])
         try:
             result = self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
         except concurrent.futures.TimeoutError as e:


### PR DESCRIPTION
## Summary

- CUA Driver 0.23.x can omit the `input.scroll.coordinates` capability token while still declaring coordinate fields in the live `scroll` `inputSchema` (#89527).
- Make the current raw schema authoritative after any session recovery: every requested axis must be explicitly declared, and the complete payload must validate under a recognized JSON Schema dialect before transport.
- Preserve independent `x`/`y` semantics and element-first targeting. If an explicit coordinate target cannot be preserved—missing/asymmetric fields, a rejecting constraint, unavailable target, unknown schema dialect, or schema loss after reconnect—return `coordinate_scroll_unsupported` with zero scroll transport instead of silently widening to a window-level scroll.
- Capability tokens no longer override a strict raw schema. Window-only and valid element-addressed scrolls retain their existing behavior.

Complementary to #89531, which repairs capability discovery itself, and #106540, which applies the same strict-schema principle to other input actions.

## Verification

- [x] Production-dispatch matrix covers full, x-only, y-only, and element-first targets through the real session adapter and a strict MCP transport double.
- [x] Refusal matrix covers absent or asymmetric schemas, stale capability tokens, boolean-false fields, rejecting constraints, missing targets, reconnect schema replacement, and unknown schema dialects; every refusal asserts zero transport.
- [x] `scripts/run_tests.sh tests/tools/test_computer_use*.py -q --tb=short` — 257 passed.
- [x] `ruff check` on all four changed files, bytecode compilation, `git diff --check`, and the compatibility-pointer guard — clean.
- [x] Independent hash-pinned adversarial review — no logic or security blockers.

Refs #89527