### PR TITLE
fix(agent): isolate background review transcript snapshots

### DIFF
--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -933,8 +933,15 @@ def run_codex_app_server_turn(
         and (should_review_memory or should_review_skills)
     ):
         try:
+            # Keep the review fork's in-place transcript normalization from
+            # mutating the live foreground messages after persistence.  A
+            # shallow list copy still aliases nested tool-call/content data,
+            # which can make the next rebuilt request diverge from the cached
+            # prefix.
+            from agent.turn_finalizer import _clone_background_review_messages
+
             agent._spawn_background_review(
-                messages_snapshot=list(messages),
+                messages_snapshot=_clone_background_review_messages(messages),
                 review_memory=should_review_memory,
                 review_skills=should_review_skills,
             )

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -126,6 +126,15 @@ def _drop_verification_continuation_scaffolding(messages) -> None:
     ]
 
 
+def _clone_background_review_messages(messages):
+    """Copy the review input without aliasing the live transcript."""
+    # Import lazily: conversation_loop imports this module during turn
+    # finalization, so a module-level import would create a cycle.
+    from agent.conversation_loop import _clone_message_for_send
+
+    return [_clone_message_for_send(message) for message in messages]
+
+
 def finalize_turn(
     agent,
     *,
@@ -810,8 +819,14 @@ def finalize_turn(
         and (_should_review_memory or _should_review_skills)
     ):
         try:
+            # The review fork sanitizes and repairs its private transcript in
+            # place.  A shallow list copy would leave the message dicts (and
+            # nested tool-call/content containers) shared with the live
+            # foreground transcript, allowing the review to mutate the
+            # representation that was just persisted and break prefix-cache
+            # parity on the next turn.
             agent._spawn_background_review(
-                messages_snapshot=list(messages),
+                messages_snapshot=_clone_background_review_messages(messages),
                 review_memory=_should_review_memory,
                 review_skills=_should_review_skills,
             )

--- a/tests/run_agent/test_background_review.py
+++ b/tests/run_agent/test_background_review.py
@@ -461,6 +461,27 @@ def test_background_review_registers_before_start_runs_and_cleans_up(monkeypatch
     assert agent._active_children == []
 
 
+def test_background_review_snapshot_isolated_from_live_nested_messages():
+    """A review must not mutate the persisted/live transcript through aliases."""
+    original = [{
+        "role": "assistant",
+        "content": [{"type": "text", "text": "answer"}],
+        "tool_calls": [{
+            "id": "call-1",
+            "function": {"name": "read_file", "arguments": '{"path":"x"}'},
+        }],
+    }]
+
+    from agent.turn_finalizer import _clone_background_review_messages
+
+    snapshot = _clone_background_review_messages(original)
+    snapshot[0]["content"][0]["text"] = "review mutation"
+    snapshot[0]["tool_calls"][0]["function"]["arguments"] = "{}"
+
+    assert original[0]["content"][0]["text"] == "answer"
+    assert original[0]["tool_calls"][0]["function"]["arguments"] == '{"path":"x"}'
+
+
 def test_live_turn_waits_for_review_exit_before_relay_and_turn_context(monkeypatch):
     """The outer production wrapper waits before same-session instrumentation."""
     review_entered = threading.Event()


### PR DESCRIPTION
 ## What does this PR do?

  Prevents background-review agents from mutating the parent conversation transcript through shared nested message structures.

  The previous shallow snapshot copy could alias nested tool-call and content data. Review-time normalization could then change the live transcript after persistence, causing
  the next rebuilt API request to diverge from the prompt-cache prefix.

  This PR uses the existing recursive message clone for background-review snapshots in both standard and Codex runtime paths.

  ## Related Issue

  Fixes #100795

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)

  ## Changes Made

  - `agent/turn_finalizer.py`
    - Recursively clone messages before launching background review.
  - `agent/codex_runtime.py`
    - Apply the same transcript isolation to Codex background reviews.
  - `tests/run_agent/test_background_review.py`
    - Add regression coverage proving nested content and tool-call data are isolated.

  ## How to Test

  1. Run the focused regression suite:

     ```bash
     python -m pytest \
       tests/agent/test_system_prompt_restore.py \
       tests/run_agent/test_background_review.py \
       tests/agent/test_turn_overlap_tripwire.py -q

  2. Verify the result:

     35 passed

  3. Run static validation:

     ruff check agent/turn_finalizer.py agent/codex_runtime.py tests/run_agent/test_background_review.py
     git diff --check

  ## Checklist

  ### Code

  - [x] I've read the Contributing Guide (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow Conventional Commits (https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
  - [x] I searched for existing PRs (https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains only changes related to this fix/feature (no unrelated commits)
  - [x] I've run pytest tests/ -q and all tests pass
  - [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
  - [x] I've tested on my platform: Linux

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
  - [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
  - [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide
    (https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A

  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

  ## Screenshots / Logs

  N/A. Automated regression tests cover nested transcript isolation and prompt-cache-related restore behavior.