### PR TITLE
fix(installer): clone repository before managed Python setup

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -4733,11 +4733,15 @@ function Write-Completion {
 # or arrange to provide answers another way."
 $InstallStages = @(
     @{ Name = "uv";               Title = "Installing uv package manager";        Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Uv" }
-    @{ Name = "python";           Title = "Verifying Python $PythonVersion";      Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Python" }
     @{ Name = "git";              Title = "Installing Git";                       Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Git" }
     @{ Name = "node";             Title = "Detecting Node.js";                    Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Node" }
     @{ Name = "system-packages";  Title = "Installing ripgrep and ffmpeg";        Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-SystemPackages" }
     @{ Name = "repository";       Title = "Cloning Hermes repository";            Category = "install";      NeedsUserInput = $false; Worker = "Stage-Repository" }
+    # Managed Python lives under $InstallDir\.hermes-runtime, so the checkout
+    # must exist before this stage creates that directory. Otherwise the later
+    # repository stage treats the runtime-only directory as a broken checkout,
+    # parks it, and leaves Stage-Venv with no managed interpreter.
+    @{ Name = "python";           Title = "Verifying Python $PythonVersion";      Category = "prereqs";      NeedsUserInput = $false; Worker = "Stage-Python" }
     @{ Name = "venv";             Title = "Creating Python virtual environment";  Category = "install";      NeedsUserInput = $false; Worker = "Stage-Venv" }
     @{ Name = "dependencies";     Title = "Installing Python dependencies";       Category = "install";      NeedsUserInput = $false; Worker = "Stage-Dependencies" }
     @{ Name = "node-deps";        Title = "Installing Node.js dependencies";      Category = "install";      NeedsUserInput = $false; Worker = "Stage-NodeDeps" }

--- a/tests/test_install_ps1_managed_python_provenance.py
+++ b/tests/test_install_ps1_managed_python_provenance.py
@@ -18,6 +18,46 @@ pytestmark = pytest.mark.windows_only
 _INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
 
 
+def test_fresh_install_manifest_orders_repo_before_checkout_scoped_python(
+    tmp_path: Path,
+) -> None:
+    powershell = shutil.which("powershell")
+    if not powershell:
+        pytest.skip("Windows PowerShell is required")
+
+    install_dir = tmp_path / "install"
+    run = subprocess.run(
+        [
+            powershell,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(_INSTALL_PS1),
+            "-Manifest",
+            "-HermesHome",
+            str(tmp_path / "hermes-home"),
+            "-InstallDir",
+            str(install_dir),
+        ],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=45,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    manifest = json.loads(run.stdout)
+    stages = [stage["name"] for stage in manifest["stages"]]
+    assert (
+        stages.index("repository")
+        < stages.index("python")
+        < stages.index("venv")
+    )
+    assert not install_dir.exists(), "manifest lookup must remain read-only"
+
+
 def _run_venv_stage(
     powershell: str,
     tmp_path: Path,


### PR DESCRIPTION
## What does this PR do?

A fresh staged Windows install could provision checkout-scoped managed Python before the repository existed. That created `$InstallDir\.hermes-runtime\python` inside a non-Git install directory. The later repository stage then treated that directory as a broken checkout, parked it, cloned a fresh repository, and left the venv stage without the managed interpreter it had just provisioned.

This moves the existing `python` stage after `repository`, while preserving every stage name and worker. The checkout now exists before managed Python creates `.hermes-runtime\python`, and `venv` still immediately follows Python provisioning.

## Related Issue

No public issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Reorder `scripts/install.ps1` stages to `repository -> python -> venv`.
- Document why checkout-scoped Python must run after repository creation.
- Add a Windows behavioral regression that executes the public `-Manifest` contract and requires `repository < python < venv` without creating install state.

## How to Test

1. Run `powershell.exe -NoProfile -ExecutionPolicy Bypass -File scripts/install.ps1 -Manifest` and verify `repository` precedes `python`, which precedes `venv`.
2. Run `scripts/run_tests.sh tests/test_install_ps1_managed_python_provenance.py -q -j 4` on Windows.
3. From an empty install directory, run the staged installer and verify the repository exists before `.hermes-runtime\python` is provisioned and the venv stage resolves that checkout-scoped interpreter.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows, using PowerShell parser validation and real `-Manifest` execution

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings), or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys, or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows, or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility), or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior, or N/A

## Screenshots / Logs

Completed locally on Windows:

- `scripts/check-windows-footguns.py scripts/install.ps1 tests/test_install_ps1_managed_python_provenance.py`: passed
- PowerShell parser validation: passed
- Real manifest execution: `repository(4) < python(5) < venv(6)`
- Manifest side-effect check: no install state created
- `git diff --check`: passed

Not run locally: the focused Python test target above. The PR remains draft pending that verification.